### PR TITLE
feat(credits): add payment-history table on /console/credits

### DIFF
--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -24,6 +24,7 @@ from trusted_router.services.stripe_billing import (
     create_billing_portal_session,
     create_checkout_session,
     create_payment_method_session,
+    list_workspace_payments,
 )
 from trusted_router.storage import STORE
 
@@ -32,6 +33,19 @@ def register(app: FastAPI) -> None:
     @app.get("/console/credits")
     async def console_credits(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         credit = STORE.get_credit_account(ctx.workspace.id)
+        # Pull the last 20 Stripe checkout sessions tagged with this
+        # workspace_id from Stripe's Search API. Returns [] if Stripe is
+        # unreachable / not configured / there are no payments yet — all
+        # three collapse to the same "no payment history yet" copy on
+        # the template, so the rest of the page renders fine without
+        # being blocked on Stripe's API. See list_workspace_payments
+        # docstring for why we pull live instead of reading from a TR
+        # ledger (tr_entities doesn't store per-payment metadata today).
+        payments = list_workspace_payments(
+            workspace_id=ctx.workspace.id,
+            settings=settings,
+            limit=20,
+        )
         return HTMLResponse(render(
             "console/credits.html",
             settings=settings,
@@ -61,6 +75,7 @@ def register(app: FastAPI) -> None:
             last_auto_refill_at=credit.last_auto_refill_at if credit else None,
             last_auto_refill_status=credit.last_auto_refill_status if credit else None,
             paypal_enabled=settings.paypal_enabled or settings.environment.lower() in {"local", "test"},
+            payments=payments,
             api_base_url=settings.api_base_url,
         ))
 

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -152,3 +152,94 @@ def create_billing_portal_session(
         )
         return {"url": session["url"], "mode": "stripe"}
     return {"url": f"https://{settings.trusted_domain}/billing/mock-portal", "mode": "mock"}
+
+
+def list_workspace_payments(
+    *,
+    workspace_id: str,
+    settings: Settings,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Return the recent Stripe payments for this workspace.
+
+    Source of truth for "what did the user actually pay" is Stripe, not
+    TR — we don't track per-payment metadata in tr_entities today
+    (`stripe_event` rows only store `{"created_at": ...}` for
+    idempotency dedup). So this function pulls live from Stripe's
+    PaymentIntent Search API filtered by `metadata['workspace_id']:'...'`.
+
+    Why PaymentIntent search (not checkout.Session): Stripe's Search API
+    is only enabled on certain resources — PaymentIntent yes, Charge yes,
+    checkout.Session NO. Our `create_checkout_session()` stamps
+    `payment_intent_data.metadata.workspace_id` on every card-mode
+    checkout, so the resulting PaymentIntent IS searchable by workspace.
+
+    Returns up to `limit` rows newest-first, each with the shape:
+        {
+          "payment_intent": "pi_...",
+          "created_at": <unix ts>,
+          "amount_cents": int,
+          "currency": "usd",
+          "status": "succeeded" | "processing" | "requires_payment_method" | ...,
+          "receipt_url": str | None,
+          "card_brand": "visa" | "mastercard" | ... | None,
+          "card_last4": "4242" | None,
+        }
+
+    Failures (Stripe API down, missing key) return an empty list rather
+    than raising — the credits page falls back to "no payment history
+    yet" copy, which is the right UX in both legitimate-empty and
+    transient-failure cases. The page still renders the balance section
+    so the page isn't blocked on Stripe API uptime.
+    """
+    if not settings.stripe_secret_key:
+        return []
+    stripe.api_key = settings.stripe_secret_key
+    try:
+        # Search syntax: `metadata['workspace_id']:'<value>'` — single
+        # quotes around the UUID are required because dashes would
+        # otherwise be lexed as operator tokens. `expand` pulls the
+        # latest_charge inline so we don't need a second round-trip
+        # just to get card details and the hosted receipt URL.
+        results = stripe.PaymentIntent.search(
+            query=f"metadata['workspace_id']:'{workspace_id}'",
+            limit=min(limit, 100),
+            expand=["data.latest_charge"],
+        )
+    except Exception:
+        # Stripe down, search quota exceeded, or the workspace has
+        # never paid yet — all collapse to "no payments to show right
+        # now." Page still renders the rest of credits view.
+        return []
+
+    out: list[dict[str, Any]] = []
+    for pi in results.data[:limit]:
+        charge = pi.get("latest_charge") if hasattr(pi, "get") else None
+        if isinstance(charge, str):  # not expanded for some reason
+            charge = None
+        card_brand: str | None = None
+        card_last4: str | None = None
+        receipt_url: str | None = None
+        if isinstance(charge, dict):
+            receipt_url = charge.get("receipt_url")
+            pmd = charge.get("payment_method_details") or {}
+            card = pmd.get("card") if isinstance(pmd, dict) else None
+            if isinstance(card, dict):
+                card_brand = card.get("brand")
+                card_last4 = card.get("last4")
+        # PaymentIntent.amount is in cents already.
+        out.append({
+            "payment_intent": pi.get("id"),
+            "created_at": pi.get("created"),
+            "amount_cents": int(pi.get("amount") or 0),
+            "currency": pi.get("currency") or "usd",
+            "status": pi.get("status"),
+            # Display-shaped synonym so the template doesn't need to know
+            # the Stripe state machine — "succeeded" → "paid" reads
+            # natural alongside checkout-session-style status values.
+            "payment_status": "paid" if pi.get("status") == "succeeded" else pi.get("status"),
+            "receipt_url": receipt_url,
+            "card_brand": card_brand,
+            "card_last4": card_last4,
+        })
+    return out

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -95,4 +95,71 @@
     {% endif %}
   </div>
 </section>
+
+<section class="panel">
+  <div class="panel-head">
+    <h2>Payment history</h2>
+    <span class="pill">{{ payments|length }} recent</span>
+  </div>
+  <div class="panel-body">
+    {% if payments %}
+    <table class="data-table" style="width:100%;border-collapse:collapse">
+      <thead>
+        <tr style="text-align:left;border-bottom:1px solid var(--border)">
+          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Date</th>
+          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Amount</th>
+          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Payment</th>
+          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Status</th>
+          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Receipt</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for p in payments %}
+        <tr style="border-bottom:1px solid var(--border)">
+          <td style="padding:10px 6px;color:var(--muted);font-variant-numeric:tabular-nums">
+            {{ p.created_at | datetime_iso if p.created_at else '—' }}
+          </td>
+          <td style="padding:10px 6px;font-variant-numeric:tabular-nums">
+            ${{ '%.2f'|format((p.amount_cents or 0) / 100) }}
+            <span style="color:var(--muted);font-size:11px">{{ (p.currency or 'usd')|upper }}</span>
+          </td>
+          <td style="padding:10px 6px">
+            {% if p.card_brand and p.card_last4 %}
+              <span style="text-transform:capitalize">{{ p.card_brand }}</span> ····{{ p.card_last4 }}
+            {% else %}
+              <span style="color:var(--muted)">—</span>
+            {% endif %}
+          </td>
+          <td style="padding:10px 6px">
+            {% if p.payment_status == 'paid' %}
+              <span class="pill good">paid</span>
+            {% elif p.payment_status == 'unpaid' %}
+              <span class="pill warn">unpaid</span>
+            {% elif p.status == 'expired' %}
+              <span class="pill">expired</span>
+            {% else %}
+              <span class="pill">{{ p.payment_status or p.status or '—' }}</span>
+            {% endif %}
+          </td>
+          <td style="padding:10px 6px">
+            {% if p.receipt_url %}
+              <a href="{{ p.receipt_url }}" target="_blank" rel="noopener">Receipt ↗</a>
+            {% else %}
+              <span style="color:var(--muted)">—</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <p style="color:var(--muted);font-size:12px;margin-top:12px">
+      Source: Stripe. Showing up to the 20 most recent checkout sessions tagged with this workspace. Hosted receipts open in Stripe.
+    </p>
+    {% else %}
+    <p style="color:var(--muted);font-size:14px;margin:0">
+      No payments yet. Your purchases will show up here within a few seconds of Stripe completing the charge.
+    </p>
+    {% endif %}
+  </div>
+</section>
 {% endblock %}

--- a/src/trusted_router/views.py
+++ b/src/trusted_router/views.py
@@ -8,6 +8,7 @@ dropping a `.html` under templates/ — no per-module Jinja boilerplate.
 
 from __future__ import annotations
 
+import datetime as dt
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,26 @@ def _format_uptime(value: float | None, decimals: int = 4) -> str:
     return f"{value:.{decimals}f}%"
 
 
+def _format_datetime_iso(value: int | float | str | None) -> str:
+    """Render a Unix timestamp (or ISO string passthrough) as a compact
+    human-readable date. Used by the credits-page payment-history table
+    so a row like `created=1779582083` displays as `2026-05-24 01:01 UTC`.
+
+    Pass-through behavior for strings means we can wire this to anything
+    that's already iso-formatted server-side (e.g. last_auto_refill_at)
+    without converting first.
+    """
+    if value is None or value == "":
+        return "—"
+    if isinstance(value, str):
+        return value  # already iso-formatted
+    try:
+        ts = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    return dt.datetime.fromtimestamp(ts, tz=dt.UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+
 @lru_cache(maxsize=1)
 def _env() -> Environment:
     env = Environment(
@@ -42,6 +63,7 @@ def _env() -> Environment:
         keep_trailing_newline=True,
     )
     env.filters["uptime_pct"] = _format_uptime
+    env.filters["datetime_iso"] = _format_datetime_iso
     return env
 
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -647,3 +647,156 @@ def test_stripe_webhook_handles_stripe_object_from_construct_event(
     # that real Stripe payments grant credit again.
     after = STORE.credits[workspace_id].total_credits_microdollars
     assert after - before == 100 * 10000, f"expected +$1.00 in microdollars, got {after-before}"
+
+
+def test_list_workspace_payments_returns_empty_without_stripe_key() -> None:
+    """If the deployment has no Stripe secret configured (local/test
+    environments), the credits page must still render — return [] and
+    let the template show the 'no payments yet' fallback."""
+    from trusted_router.config import Settings
+    from trusted_router.services.stripe_billing import list_workspace_payments
+
+    result = list_workspace_payments(
+        workspace_id="ws-test",
+        settings=Settings(environment="local"),
+    )
+    assert result == []
+
+
+def test_list_workspace_payments_swallows_stripe_errors(monkeypatch) -> None:
+    """Stripe API failures must not block the credits page from rendering.
+    A 5xx from Stripe, a network blip, or a search-query quota hit all
+    collapse to an empty list — the rest of the page (balance, payment
+    methods, auto-refill) still renders. We deliberately don't surface
+    the Stripe error to the user; this is a read-only display panel and
+    they can refresh."""
+    from trusted_router.config import Settings
+    from trusted_router.services import stripe_billing
+
+    # `local` env has no fail-closed validator; setting stripe_secret_key
+    # is what makes list_workspace_payments take the Stripe-API code
+    # path rather than returning [] early.
+    settings = Settings(
+        environment="local",
+        stripe_secret_key="sk_test_dummy",  # noqa: S106
+    )
+
+    def explode(**_: Any) -> None:
+        raise RuntimeError("simulated Stripe outage")
+
+    monkeypatch.setattr(stripe_billing.stripe.PaymentIntent, "search", explode)
+    result = stripe_billing.list_workspace_payments(
+        workspace_id="ws-anything",
+        settings=settings,
+    )
+    assert result == []
+
+
+def _console_client_for_test() -> tuple[TestClient, str]:
+    """Build a TestClient with a real active console session cookie.
+
+    The default `client` fixture in conftest authenticates via API-key
+    Bearer headers, which the /console/* routes reject — they require
+    the SESSION COOKIE that OAuth sign-in mints. This helper stands up
+    a parallel client with a session cookie set, so server-rendered
+    console pages render their authenticated body instead of bouncing
+    to /?reason=signin."""
+    from trusted_router.config import Settings
+    from trusted_router.main import create_app
+
+    settings = Settings(environment="local")
+    app = create_app(settings, init_observability=False)
+    client = TestClient(app)
+    user = STORE.ensure_user("billing-test@example.com")
+    raw_token, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="billing-test@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+    return client, raw_token
+
+
+def test_credits_page_renders_payment_history_section(monkeypatch) -> None:
+    """The credits page must include a 'Payment history' section, even
+    when there are no payments yet. The 2026-05-24 user feedback was
+    'shouldn't the credits show a list of every payment I've made?' —
+    just showing a balance number isn't enough. Empty-state copy guides
+    them rather than silently omitting the section."""
+    from trusted_router.routes.console import credits as credits_module
+
+    monkeypatch.setattr(
+        credits_module,
+        "list_workspace_payments",
+        lambda **_: [],
+    )
+    client, _ = _console_client_for_test()
+    resp = client.get("/console/credits")
+    assert resp.status_code == 200, resp.text[:300]
+    assert "Payment history" in resp.text
+    assert "No payments yet" in resp.text
+
+
+def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
+    """When Stripe returns past payments, the credits page renders one
+    row per payment with date, amount, card brand+last4, status, and a
+    receipt link. This is what the user asked for after the $1 test —
+    'shouldn't the credits show a list of every payment I've made?'"""
+    # Patch on the credits route module (which imported the function at
+    # module load) — patching the services module is too late since the
+    # route already has its own reference.
+    from trusted_router.routes.console import credits as credits_module
+
+    fake_payments = [
+        {
+            "payment_intent": "pi_3TaPnB",
+            "created_at": 1779582083,  # 2026-05-24 01:01 UTC
+            "amount_cents": 100,
+            "currency": "usd",
+            "status": "succeeded",
+            "payment_status": "paid",
+            "receipt_url": "https://pay.stripe.com/receipts/test-receipt",
+            "card_brand": "visa",
+            "card_last4": "4242",
+        },
+        {
+            "payment_intent": "pi_5dollar",
+            "created_at": 1779561182,  # 2026-05-23 19:13 UTC
+            "amount_cents": 500,
+            "currency": "usd",
+            "status": "succeeded",
+            "payment_status": "paid",
+            "receipt_url": "https://pay.stripe.com/receipts/older-receipt",
+            "card_brand": "mastercard",
+            "card_last4": "8888",
+        },
+    ]
+    monkeypatch.setattr(
+        credits_module,
+        "list_workspace_payments",
+        lambda **_: fake_payments,
+    )
+
+    client, _ = _console_client_for_test()
+    resp = client.get("/console/credits")
+    assert resp.status_code == 200, resp.text[:300]
+    assert "Payment history" in resp.text
+    # Amount formatted as dollars
+    assert "$1.00" in resp.text
+    assert "$5.00" in resp.text
+    # Card brand + last4 displayed
+    assert "visa" in resp.text.lower()
+    assert "4242" in resp.text
+    assert "mastercard" in resp.text.lower()
+    assert "8888" in resp.text
+    # Receipt links rendered
+    assert "https://pay.stripe.com/receipts/test-receipt" in resp.text
+    # `paid` status pill
+    assert ">paid<" in resp.text or 'pill good">paid' in resp.text
+    # Date formatted (UTC)
+    assert "2026-05-24" in resp.text
+    assert "2026-05-23" in resp.text
+    # Empty-state copy NOT shown when payments exist
+    assert "No payments yet" not in resp.text


### PR DESCRIPTION
User feedback after the 2026-05-24 $1 test charge: "shouldn't the credits show a list of every payment I've made?". The credits page currently shows the running balance, payment-methods setup, and auto-refill config — but NOT a list of past payments. Users expect to see what they paid, when, on which card, and have a link to the hosted Stripe receipt. Adding that here closes the gap.

Source of truth: Stripe. We don't currently track per-payment metadata in tr_entities — `stripe_event` rows only store `{"created_at": ...}` purely for idempotency dedup. Rather than building a TR-side ledger (separate ~1 week project), this MVP queries Stripe live on every credits page load via the PaymentIntent Search API filtered by `metadata['workspace_id']:'<wid>'`. Every checkout we create via `create_checkout_session` stamps `payment_intent_data.metadata. workspace_id` so the resulting PaymentIntent is searchable by workspace exactly.

Why PaymentIntent.search not checkout.Session.search: Stripe's Search API is only enabled on certain resources. PaymentIntent yes, checkout.Session no (confirmed empirically with a 400 from Stripe).

Failure mode: if Stripe is unreachable, the search call errors, or the workspace simply has no payments yet, list_workspace_payments returns []. The credits page falls through to "No payments yet" empty-state copy — the rest of the page (balance, payment methods, auto-refill) still renders. Page never blocks on Stripe API uptime.

Template: new "Payment history" panel section with a table — Date, Amount, Payment method (card brand + last4), Status (pill), Receipt link. Hosted receipts open in a new tab. Empty-state copy on no payments.

Tests:
- list_workspace_payments returns [] without a stripe_secret_key
- list_workspace_payments returns [] on Stripe API failure
- credits page renders the section + empty-state copy
- credits page renders one table row per payment with all expected fields

Followup (not in this PR): record per-payment events in a tr_entities ledger so the page works offline-from-Stripe and can show a richer history (refunds, chargebacks, manual makeup grants from scripts/credit_makeup.py). The current MVP only sees what Stripe sees, not the manual_makeup_2026-05-22 grant for Gabriella's $107.