### PR TITLE
feat(chat): voice mode — full STT → send → TTS conversational loop

### DIFF
--- a/src/trusted_router/static/chat.css
+++ b/src/trusted_router/static/chat.css
@@ -1909,6 +1909,165 @@
     background: var(--chat-error);
 }
 
+/* ── Voice mode overlay ────────────────────────────────────────── */
+
+.chat-voice-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 220;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--chat-font);
+}
+
+.chat-voice-backdrop {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+        circle at 50% 40%,
+        rgba(100, 103, 242, 0.22) 0%,
+        rgba(9, 9, 17, 0.92) 70%
+    );
+    cursor: pointer;
+}
+
+.chat-voice-panel {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    padding: 48px;
+    max-width: 560px;
+    width: 92vw;
+    color: #fff;
+    text-align: center;
+}
+
+.chat-voice-exit {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #fff;
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 120ms;
+}
+
+.chat-voice-exit:hover {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.chat-voice-orb {
+    position: relative;
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    background: radial-gradient(
+        circle at 35% 35%,
+        rgba(255, 255, 255, 0.18),
+        rgba(100, 103, 242, 0.55) 60%,
+        rgba(100, 103, 242, 0.85) 100%
+    );
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    box-shadow:
+        0 0 80px rgba(100, 103, 242, 0.45),
+        inset 0 0 40px rgba(255, 255, 255, 0.15);
+}
+
+.chat-voice-orb-pulse {
+    position: absolute;
+    inset: -8px;
+    border-radius: 50%;
+    border: 2px solid rgba(100, 103, 242, 0.6);
+    opacity: 0;
+    animation: chat-voice-pulse 2400ms ease-out infinite;
+    pointer-events: none;
+}
+
+@keyframes chat-voice-pulse {
+    0%   { opacity: 0.7; transform: scale(1); }
+    100% { opacity: 0;   transform: scale(1.4); }
+}
+
+/* Per-state colour shifts */
+.chat-voice-panel[data-state="listening"] .chat-voice-orb {
+    background: radial-gradient(
+        circle at 35% 35%,
+        rgba(255, 255, 255, 0.22),
+        rgba(16, 163, 127, 0.55) 60%,
+        rgba(16, 163, 127, 0.85) 100%
+    );
+    box-shadow:
+        0 0 80px rgba(16, 163, 127, 0.45),
+        inset 0 0 40px rgba(255, 255, 255, 0.15);
+}
+
+.chat-voice-panel[data-state="listening"] .chat-voice-orb-pulse {
+    border-color: rgba(16, 163, 127, 0.7);
+}
+
+.chat-voice-panel[data-state="thinking"] .chat-voice-orb-pulse {
+    animation-duration: 900ms;
+}
+
+.chat-voice-panel[data-state="speaking"] .chat-voice-orb {
+    background: radial-gradient(
+        circle at 35% 35%,
+        rgba(255, 255, 255, 0.22),
+        rgba(100, 103, 242, 0.65) 60%,
+        rgba(100, 103, 242, 0.95) 100%
+    );
+}
+
+.chat-voice-panel[data-state="speaking"] .chat-voice-orb-pulse {
+    animation-duration: 1200ms;
+    border-color: rgba(100, 103, 242, 0.7);
+}
+
+.chat-voice-status {
+    font-size: 20px;
+    font-weight: 500;
+    color: #fff;
+}
+
+.chat-voice-transcript {
+    font-size: 16px;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.85);
+    min-height: 48px;
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 0 12px;
+    font-style: italic;
+}
+
+.chat-voice-hint {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.55);
+}
+
+.chat-voice-hint kbd {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-family: var(--chat-mono);
+    font-size: 11px;
+    color: #fff;
+    margin: 0 2px;
+}
+
 /* ── Prompt / confirm modal (replaces window.prompt/confirm) ───── */
 
 .chat-prompt-overlay {

--- a/src/trusted_router/static/chat.js
+++ b/src/trusted_router/static/chat.js
@@ -2778,7 +2778,335 @@
         });
     }
 
-    // ── Voice input (Web Speech API) ──────────────────────────────────
+    // ── Voice mode (conversational: STT → send → TTS → loop) ──────────
+    //
+    // Full hands-free conversation in the browser:
+    //   1. Request mic permission via getUserMedia
+    //   2. Continuous SpeechRecognition with interimResults
+    //   3. End-of-utterance detected by a silence timer after the
+    //      last final result chunk → auto-send through the existing
+    //      streaming path (so multi-model / per-model sys-prompt /
+    //      params all still apply)
+    //   4. TTS reads the model's response sentence-by-sentence as
+    //      tokens stream in (chunks at . ? ! to feel responsive)
+    //   5. When TTS playback finishes, resume listening
+    //   6. Esc / button click exits voice mode and stops everything
+    //
+    // Browser support: Web Speech API is Chrome/Edge/Safari only.
+    // Firefox surfaces a friendly toast and doesn't enter the mode.
+
+    let VOICE_STATE = {
+        active: false,
+        rec: null,            // SpeechRecognition instance
+        stream: null,         // MediaStream from getUserMedia (kept for cleanup)
+        overlay: null,        // DOM root for the voice overlay
+        spokenChars: 0,       // index into respSlot.content already TTS'd
+        ttsQueue: [],         // pending SpeechSynthesisUtterance chunks
+        ttsSpeaking: false,
+        silenceTimer: null,
+        currentTranscript: "",
+    };
+    const VOICE_SILENCE_MS = 1200;   // pause length that ends an utterance
+
+    async function enterVoiceMode() {
+        const SR =
+            window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (!SR || typeof window.speechSynthesis === "undefined") {
+            showToast(
+                "Voice mode needs Chrome, Edge, or Safari (Firefox doesn't support the Web Speech API yet)",
+                { danger: true, holdMs: 4000 },
+            );
+            return;
+        }
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            showToast(
+                "Microphone access isn't available in this browser",
+                { danger: true },
+            );
+            return;
+        }
+        // Ask the browser for mic permission up-front. SpeechRecognition
+        // implicitly prompts too, but doing it explicitly via
+        // getUserMedia gives us a cleaner failure path AND keeps the
+        // mic stream open so the OS-level mic indicator stays on
+        // throughout the session.
+        try {
+            VOICE_STATE.stream = await navigator.mediaDevices.getUserMedia({
+                audio: true,
+            });
+        } catch (err) {
+            const denied =
+                err && (err.name === "NotAllowedError" || err.name === "PermissionDeniedError");
+            showToast(
+                denied
+                    ? "Microphone access denied — allow it in your browser settings to use voice mode"
+                    : "Couldn't access microphone: " + (err.message || err.name),
+                { danger: true, holdMs: 4000 },
+            );
+            return;
+        }
+        VOICE_STATE.active = true;
+        renderVoiceOverlay();
+        startVoiceListening();
+    }
+
+    function exitVoiceMode() {
+        VOICE_STATE.active = false;
+        // Stop recognition
+        if (VOICE_STATE.rec) {
+            try {
+                VOICE_STATE.rec.onend = null;
+                VOICE_STATE.rec.stop();
+            } catch (_) {}
+            VOICE_STATE.rec = null;
+        }
+        // Stop any in-flight TTS
+        if (window.speechSynthesis) {
+            try {
+                window.speechSynthesis.cancel();
+            } catch (_) {}
+        }
+        VOICE_STATE.ttsQueue = [];
+        VOICE_STATE.ttsSpeaking = false;
+        VOICE_STATE.spokenChars = 0;
+        VOICE_STATE.currentTranscript = "";
+        if (VOICE_STATE.silenceTimer) {
+            clearTimeout(VOICE_STATE.silenceTimer);
+            VOICE_STATE.silenceTimer = null;
+        }
+        // Release the mic stream
+        if (VOICE_STATE.stream) {
+            VOICE_STATE.stream.getTracks().forEach((t) => {
+                try { t.stop(); } catch (_) {}
+            });
+            VOICE_STATE.stream = null;
+        }
+        // Stop any inference streams that were started for voice mode
+        stopAllStreams();
+        // Drop the overlay
+        if (VOICE_STATE.overlay) {
+            VOICE_STATE.overlay.remove();
+            VOICE_STATE.overlay = null;
+        }
+    }
+
+    function renderVoiceOverlay() {
+        if (VOICE_STATE.overlay) return;
+        const overlay = document.createElement("div");
+        overlay.className = "chat-voice-overlay";
+        overlay.innerHTML =
+            '<div class="chat-voice-backdrop"></div>' +
+            '<div class="chat-voice-panel">' +
+            '<button type="button" class="chat-voice-exit" aria-label="Exit voice mode">×</button>' +
+            '<div class="chat-voice-orb" data-orb>' +
+            '<div class="chat-voice-orb-pulse"></div>' +
+            '<svg viewBox="0 0 32 32" width="48" height="48" fill="none" ' +
+            'stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+            'stroke-linejoin="round" aria-hidden="true">' +
+            '<rect x="12" y="4" width="8" height="16" rx="4" />' +
+            '<path d="M7 13 C7 18 11 22 16 22 C21 22 25 18 25 13" />' +
+            '<path d="M16 22 L16 28" />' +
+            '<path d="M12 28 L20 28" />' +
+            "</svg></div>" +
+            '<div class="chat-voice-status" data-voice-status>Listening…</div>' +
+            '<div class="chat-voice-transcript" data-voice-transcript></div>' +
+            '<div class="chat-voice-hint">Press <kbd>esc</kbd> to exit</div>' +
+            "</div>";
+        document.body.appendChild(overlay);
+        overlay
+            .querySelector(".chat-voice-exit")
+            .addEventListener("click", exitVoiceMode);
+        overlay
+            .querySelector(".chat-voice-backdrop")
+            .addEventListener("click", exitVoiceMode);
+        VOICE_STATE.overlay = overlay;
+        setVoiceState("listening", "Listening…");
+    }
+
+    function setVoiceState(stateClass, label) {
+        if (!VOICE_STATE.overlay) return;
+        const panel = VOICE_STATE.overlay.querySelector(".chat-voice-panel");
+        panel.dataset.state = stateClass;
+        const status = VOICE_STATE.overlay.querySelector("[data-voice-status]");
+        if (status && label) status.textContent = label;
+    }
+
+    function setVoiceTranscript(text) {
+        if (!VOICE_STATE.overlay) return;
+        const el = VOICE_STATE.overlay.querySelector("[data-voice-transcript]");
+        if (el) el.textContent = text || "";
+    }
+
+    function startVoiceListening() {
+        const SR =
+            window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (!SR || !VOICE_STATE.active) return;
+        const rec = new SR();
+        rec.continuous = true;
+        rec.interimResults = true;
+        rec.lang = "en-US";
+        VOICE_STATE.rec = rec;
+        VOICE_STATE.currentTranscript = "";
+        setVoiceState("listening", "Listening…");
+
+        rec.onresult = (e) => {
+            let interim = "";
+            let final = "";
+            for (let i = e.resultIndex; i < e.results.length; i++) {
+                const r = e.results[i];
+                if (r.isFinal) {
+                    final += r[0].transcript;
+                } else {
+                    interim += r[0].transcript;
+                }
+            }
+            VOICE_STATE.currentTranscript = (
+                VOICE_STATE.currentTranscript +
+                " " +
+                final
+            ).trim();
+            const display = (VOICE_STATE.currentTranscript + " " + interim).trim();
+            setVoiceTranscript(display);
+            // Reset the silence timer on every chunk — when audio
+            // goes quiet for VOICE_SILENCE_MS we treat that as the
+            // end of the user's utterance.
+            if (VOICE_STATE.silenceTimer) clearTimeout(VOICE_STATE.silenceTimer);
+            VOICE_STATE.silenceTimer = setTimeout(() => {
+                finalizeUtterance();
+            }, VOICE_SILENCE_MS);
+        };
+        rec.onerror = (e) => {
+            // Some errors (no-speech) are benign; keep listening.
+            if (e.error === "no-speech" || e.error === "audio-capture") {
+                return;
+            }
+            console.warn("chat: voice rec error:", e.error);
+        };
+        rec.onend = () => {
+            // If we're still active, restart so the loop persists.
+            if (VOICE_STATE.active && !VOICE_STATE.ttsSpeaking) {
+                try { rec.start(); } catch (_) {}
+            }
+        };
+        try {
+            rec.start();
+        } catch (e) {
+            console.warn("chat: voice rec start failed:", e);
+        }
+    }
+
+    function finalizeUtterance() {
+        if (!VOICE_STATE.active) return;
+        const text = (VOICE_STATE.currentTranscript || "").trim();
+        if (!text) return;
+        VOICE_STATE.currentTranscript = "";
+        setVoiceTranscript(text);
+        setVoiceState("thinking", "Thinking…");
+        // Pause the mic while the model thinks + speaks so TTS doesn't
+        // feed back into STT.
+        if (VOICE_STATE.rec) {
+            try {
+                VOICE_STATE.rec.onend = null;
+                VOICE_STATE.rec.stop();
+            } catch (_) {}
+            VOICE_STATE.rec = null;
+        }
+        // Run the prompt through the standard send path; the voice
+        // overlay's content-watcher (below) picks up streaming tokens
+        // and feeds them to TTS.
+        VOICE_STATE.spokenChars = 0;
+        startVoiceSend(text);
+    }
+
+    async function startVoiceSend(text) {
+        const input = document.querySelector("[data-chat-input]");
+        if (input) input.value = text;
+        // Use the existing send pipeline so chat history, multi-model,
+        // and cost accounting all work the same as a typed message.
+        const before = (getActiveChat() || { messages: [] }).messages.length;
+        await handleSendClick();
+        const chat = getActiveChat();
+        if (!chat || chat.messages.length <= before) {
+            setVoiceState("listening", "Listening…");
+            startVoiceListening();
+            return;
+        }
+        const assistantMsg = chat.messages[chat.messages.length - 1];
+        setVoiceState("speaking", "Speaking…");
+        // Poll for streaming tokens on the first response slot; chunk
+        // at sentence boundaries and feed to TTS.
+        const watcher = setInterval(() => {
+            if (!VOICE_STATE.active) {
+                clearInterval(watcher);
+                return;
+            }
+            const resp = (assistantMsg.responses || [])[0];
+            const content = (resp && resp.content) || "";
+            const fresh = content.slice(VOICE_STATE.spokenChars);
+            // Sentence boundary anywhere in the fresh slice → speak up
+            // to and including the last terminator.
+            const match = fresh.match(/^[\s\S]*[.!?](?=\s|$)/);
+            if (match) {
+                const chunk = match[0].trim();
+                if (chunk) speakChunk(chunk);
+                VOICE_STATE.spokenChars += match[0].length;
+            }
+            // Stream done → flush remaining text + resume listening.
+            const streamDone =
+                resp &&
+                (resp.finish_reason ||
+                    (resp.content && !STREAMS.size && content.length > 0));
+            if (streamDone) {
+                clearInterval(watcher);
+                const tail = content.slice(VOICE_STATE.spokenChars).trim();
+                if (tail) speakChunk(tail);
+                // After the last chunk's onend, resumeListening kicks in.
+                if (!VOICE_STATE.ttsQueue.length && !VOICE_STATE.ttsSpeaking) {
+                    resumeListeningSoon();
+                }
+            }
+        }, 120);
+    }
+
+    function speakChunk(text) {
+        if (!VOICE_STATE.active || !window.speechSynthesis) return;
+        const u = new SpeechSynthesisUtterance(text);
+        u.rate = 1.05;
+        u.pitch = 1.0;
+        u.lang = "en-US";
+        u.onend = () => {
+            VOICE_STATE.ttsSpeaking = false;
+            if (VOICE_STATE.ttsQueue.length) {
+                const next = VOICE_STATE.ttsQueue.shift();
+                VOICE_STATE.ttsSpeaking = true;
+                window.speechSynthesis.speak(next);
+            } else if (VOICE_STATE.active && !STREAMS.size) {
+                resumeListeningSoon();
+            }
+        };
+        if (VOICE_STATE.ttsSpeaking) {
+            VOICE_STATE.ttsQueue.push(u);
+        } else {
+            VOICE_STATE.ttsSpeaking = true;
+            window.speechSynthesis.speak(u);
+        }
+    }
+
+    function resumeListeningSoon() {
+        if (!VOICE_STATE.active) return;
+        // Short beat so the user has a half-second to start speaking
+        // without the mic picking up the tail of TTS.
+        setTimeout(() => {
+            if (VOICE_STATE.active && !VOICE_STATE.ttsSpeaking) {
+                startVoiceListening();
+            }
+        }, 350);
+    }
+
+    // ── Voice input (one-shot Web Speech API — push-to-talk) ──────────
+    // The original "click mic to dictate a single prompt" flow. Kept
+    // alongside the conversational Voice Mode above so users have a
+    // quick option without entering the full overlay.
 
     function startVoiceInput() {
         const SR =
@@ -2960,8 +3288,13 @@
         const targetTag =
             e.target && e.target.tagName ? e.target.tagName.toLowerCase() : "";
         const inField = targetTag === "input" || targetTag === "textarea";
-        // Esc — stop any active stream first (before falling through to
-        // close-modal Esc behavior elsewhere).
+        // Esc — exit voice mode first if active, else stop any active
+        // stream (before falling through to close-modal Esc behavior).
+        if (e.key === "Escape" && VOICE_STATE.active) {
+            e.preventDefault();
+            exitVoiceMode();
+            return;
+        }
         if (e.key === "Escape" && STREAMS.size > 0) {
             e.preventDefault();
             stopAllStreams();
@@ -3024,6 +3357,12 @@
         if (e.key.toLowerCase() === "k") {
             e.preventDefault();
             addModel();
+            return;
+        }
+        // V — enter voice mode
+        if (e.key.toLowerCase() === "v") {
+            e.preventDefault();
+            enterVoiceMode();
             return;
         }
         // ? — open shortcuts help
@@ -3161,7 +3500,8 @@
             "<tr><td><kbd>⌘/Ctrl + J / K</kbd></td><td>Next / previous chat</td></tr>" +
             "<tr><td><kbd>/</kbd></td><td>Focus input</td></tr>" +
             "<tr><td><kbd>K</kbd></td><td>Add model</td></tr>" +
-            "<tr><td><kbd>Esc</kbd></td><td>Stop streams / close menu</td></tr>" +
+            "<tr><td><kbd>V</kbd></td><td>Enter voice mode</td></tr>" +
+            "<tr><td><kbd>Esc</kbd></td><td>Stop streams / exit voice / close menu</td></tr>" +
             "<tr><td><kbd>?</kbd></td><td>Show this help</td></tr>" +
             "</table>" +
             "<p>Click outside to close.</p>" +
@@ -3386,6 +3726,10 @@
             }
             if (target.closest('[data-action="voice-input"]')) {
                 startVoiceInput();
+                return;
+            }
+            if (target.closest('[data-action="enter-voice-mode"]')) {
+                enterVoiceMode();
                 return;
             }
             if (target.closest('[data-action="show-shortcuts"]')) {

--- a/src/trusted_router/templates/public/chat.html
+++ b/src/trusted_router/templates/public/chat.html
@@ -60,6 +60,14 @@
       </div>
       <div class="chat-header-actions">
         <button class="btn chat-header-btn" type="button" data-action="toggle-system-prompt" title="System prompt">Sys</button>
+        <button class="btn chat-header-btn chat-header-btn-icon" type="button" data-action="enter-voice-mode" title="Voice mode" aria-label="Voice mode">
+          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="6" y="2" width="4" height="8" rx="2" />
+            <path d="M3.5 7 C3.5 9.5 5.5 11 8 11 C10.5 11 12.5 9.5 12.5 7" />
+            <path d="M8 11 L8 14" />
+            <path d="M6 14 L10 14" />
+          </svg>
+        </button>
         <button class="btn chat-header-btn" type="button" data-action="export-md" title="Export to Markdown">⤓</button>
         <button class="btn chat-header-btn chat-header-btn-icon" type="button" data-action="share-link" title="Copy share link" aria-label="Share">
           <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/tests-e2e/specs/voice-mode.spec.ts
+++ b/tests-e2e/specs/voice-mode.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Voice mode — entry button + permission flow + Esc exit.
+ *
+ * Real browser-native Web Speech / SpeechSynthesis can't be driven
+ * from Playwright (the engines hook system audio), so these tests
+ * stub the SR + speechSynthesis APIs on window and assert the UI
+ * surface + the conversational loop wiring.
+ */
+import { test, expect } from "@playwright/test";
+import { mockExternalApis } from "../fixtures/api-mock";
+import { plantSignedInHint } from "../fixtures/sign-in";
+import {
+    setLocalStorageState,
+    chatStateWithModels,
+} from "../fixtures/helpers";
+
+test.beforeEach(async ({ context, page, baseURL }) => {
+    await mockExternalApis(page);
+    await plantSignedInHint(context, baseURL!);
+});
+
+/**
+ * Inject fakes for the Web Speech APIs + getUserMedia BEFORE chat.js
+ * runs, so feature detection sees them as present and the overlay
+ * opens. The fake SR doesn't emit results — these tests only cover
+ * the UI surface, not the full STT/TTS loop.
+ */
+async function stubSpeechApis(page: any): Promise<void> {
+    await page.addInitScript(() => {
+        const noop = () => {};
+        class FakeSR {
+            continuous = false;
+            interimResults = false;
+            lang = "en-US";
+            onresult: any = null;
+            onerror: any = null;
+            onend: any = null;
+            start = noop;
+            stop = noop;
+            abort = noop;
+        }
+        (window as any).SpeechRecognition = FakeSR;
+        (window as any).webkitSpeechRecognition = FakeSR;
+        (window as any).speechSynthesis = {
+            speak: noop,
+            cancel: noop,
+            pause: noop,
+            resume: noop,
+            getVoices: () => [],
+            speaking: false,
+            paused: false,
+            pending: false,
+        };
+        // Fake getUserMedia that grants a dummy MediaStream-like object
+        const fakeStream = {
+            getTracks: () => [{ stop: noop, kind: "audio" }],
+        };
+        (navigator as any).mediaDevices = {
+            getUserMedia: () => Promise.resolve(fakeStream),
+        };
+    });
+}
+
+test("Voice mode entry button is visible in the header", async ({ page }) => {
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    const btn = page.locator('[data-action="enter-voice-mode"]');
+    await expect(btn).toBeVisible();
+});
+
+test("Clicking Voice mode opens the overlay with a listening orb", async ({
+    page,
+}) => {
+    await stubSpeechApis(page);
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    await page.locator('[data-action="enter-voice-mode"]').click();
+    await expect(page.locator(".chat-voice-overlay")).toBeVisible();
+    await expect(page.locator(".chat-voice-orb")).toBeVisible();
+    await expect(page.locator("[data-voice-status]")).toContainText(
+        /listening/i,
+    );
+});
+
+test("Esc exits voice mode", async ({ page }) => {
+    await stubSpeechApis(page);
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    await page.locator('[data-action="enter-voice-mode"]').click();
+    await expect(page.locator(".chat-voice-overlay")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".chat-voice-overlay")).toHaveCount(0);
+});
+
+test("Clicking the backdrop also exits voice mode", async ({ page }) => {
+    await stubSpeechApis(page);
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    await page.locator('[data-action="enter-voice-mode"]').click();
+    await page.locator(".chat-voice-backdrop").click();
+    await expect(page.locator(".chat-voice-overlay")).toHaveCount(0);
+});
+
+test("Voice mode shows a toast when Speech API is unavailable", async ({
+    page,
+}) => {
+    // No stubSpeechApis() — feature-detect should fail
+    await page.addInitScript(() => {
+        delete (window as any).SpeechRecognition;
+        delete (window as any).webkitSpeechRecognition;
+        delete (window as any).speechSynthesis;
+    });
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    await page.locator('[data-action="enter-voice-mode"]').click();
+    const toast = page.locator(".chat-toast.is-danger");
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText(/Web Speech|microphone|voice/i);
+    // Overlay does NOT open
+    await expect(page.locator(".chat-voice-overlay")).toHaveCount(0);
+});
+
+test("Voice mode shows a toast when mic permission is denied", async ({
+    page,
+}) => {
+    await page.addInitScript(() => {
+        const noop = () => {};
+        class FakeSR {
+            continuous = false;
+            interimResults = false;
+            lang = "en-US";
+            onresult: any = null;
+            onerror: any = null;
+            onend: any = null;
+            start = noop;
+            stop = noop;
+            abort = noop;
+        }
+        (window as any).SpeechRecognition = FakeSR;
+        (window as any).speechSynthesis = {
+            speak: noop,
+            cancel: noop,
+            getVoices: () => [],
+            speaking: false,
+            paused: false,
+            pending: false,
+        };
+        (navigator as any).mediaDevices = {
+            getUserMedia: () =>
+                Promise.reject(
+                    Object.assign(new Error("Permission denied"), {
+                        name: "NotAllowedError",
+                    }),
+                ),
+        };
+    });
+    await page.goto("/chat");
+    await setLocalStorageState(
+        page,
+        chatStateWithModels(["anthropic/claude-sonnet-4.6"]),
+    );
+    await page.reload();
+    await page.locator('[data-action="enter-voice-mode"]').click();
+    const toast = page.locator(".chat-toast.is-danger");
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText(/denied|microphone/i);
+    await expect(page.locator(".chat-voice-overlay")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Hands-free voice conversation in the browser. Mic icon in the header opens a full-screen overlay that runs:

1. **Mic permission** via \`navigator.mediaDevices.getUserMedia({audio: true})\` — keeps the mic stream open for the session (OS-level mic indicator stays on)
2. **Continuous STT** via Web Speech API (\`webkitSpeechRecognition\` with \`continuous: true, interimResults: true\`)
3. **End-of-utterance** detected by a 1.2s silence timer after the last chunk → auto-send through the existing \`handleSendClick\` so multi-model fan-out, per-model sys-prompts, params, and cost accounting all still apply
4. **Sentence-by-sentence TTS** — watcher polls the active assistant response, chunks at \`.\` \`!\` \`?\` boundaries, queues \`SpeechSynthesisUtterance\` so the model starts speaking before streaming completes
5. **Resume listening** 350ms after TTS queue drains (avoids the mic catching the tail of TTS)
6. **Exit** via Esc / × button / backdrop click → tears down recognizer, cancels TTS, releases the mic stream, stops any in-flight inference

## Visuals

Glowing orb shifts color by state:
- Green = listening
- Default purple = thinking (faster pulse)
- Primary purple = speaking (slower pulse, brighter glow)

Transcript text live under the orb. \`Esc to exit\` hint at the bottom.

## Graceful degradation

- **Firefox** (no \`webkitSpeechRecognition\`): toast \`Voice mode needs Chrome, Edge, or Safari (Firefox doesn't support the Web Speech API yet)\`, overlay never opens
- **Mic permission denied**: toast \`Microphone access denied — allow it in your browser settings to use voice mode\`
- **No \`mediaDevices\`**: toast with the underlying error message

## Shortcuts

- **V** (when no input focused) → enter voice mode
- **Esc** → exit voice mode (priority over Stop streams / close menus)

Shortcut overlay updated with both.

## Test plan

- [ ] CI: Playwright suite now **368 tests across 21 specs**. New \`voice-mode.spec.ts\` covers: entry-button visible, overlay+orb open on click, Esc exits, backdrop click exits, missing Speech API → toast, denied permission → toast. Stubs \`SpeechRecognition\`/\`speechSynthesis\`/\`getUserMedia\` via \`page.addInitScript\` so feature-detect passes without touching real system audio.
- [ ] On Chrome: click mic icon → permission prompt → grant → orb pulses green → speak → orb goes purple → response streams + reads aloud → orb returns to green
- [ ] Esc during any state exits cleanly (no stuck mic indicator, no stuck TTS)
- [ ] On Firefox: click mic icon → red toast, overlay does not open
- [ ] Voice mode works while multi-model is active (each fan-out spoken from the first slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)