### PR TITLE
fix(synthetic): monitor pool cheapest-first — DeepSeek V4 leads (~12x cost cut)

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -1085,14 +1085,35 @@ def cheap_candidate_models(limit: int = 8) -> list[Model]:
 
 
 def monitor_candidate_models(limit: int = 8) -> list[Model]:
+    # Order is ASCENDING by cost-per-probe so the steady-state synthetic
+    # spend hits the cheapest reliable model first; rollover only
+    # escalates to pricier models when the cheap path fails. This keeps
+    # the rollover-resilience signal AND cuts steady-state probe cost
+    # ~12x vs. anthropic/claude-haiku-4.5 leading.
+    #
+    # Bonus: leading with non-reasoning models (DeepSeek V4, Mistral
+    # Small, GPT-5.4 nano) avoids the reasoning_content failure mode
+    # that drove the 2026-05 pong_mismatch surge — kimi-k2.6 / glm-4.6
+    # stay in the rollover tail but won't be hit in steady state.
+    #
+    # Costs at 2026-06 prices ($/M tokens, in / out):
+    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← cheapest
+    #   mistralai/mistral-small-2603  0.165 / 0.660
+    #   openai/gpt-5.4-nano           0.176 / 1.100
+    #   z-ai/glm-4.5-air              0.220 / 1.210
+    #   google/gemini-2.5-flash       0.330 / 2.750
+    #   z-ai/glm-4.6                  0.660 / 2.420   ← reasoning, tail
+    #   moonshotai/kimi-k2.6          0.880 / 3.850   ← reasoning, tail
+    #   anthropic/claude-haiku-4.5    1.100 / 5.500   ← most expensive
     preferred_ids = [
-        "anthropic/claude-haiku-4.5",
+        "deepseek/deepseek-v4-flash",
+        "mistralai/mistral-small-2603",
+        "openai/gpt-5.4-nano",
         "z-ai/glm-4.5-air",
+        "google/gemini-2.5-flash",
         "z-ai/glm-4.6",
         "moonshotai/kimi-k2.6",
-        "google/gemini-2.5-flash",
-        "mistralai/mistral-small-2603",
-        "deepseek/deepseek-v4-flash",
+        "anthropic/claude-haiku-4.5",
     ]
     candidates: list[Model] = []
     seen: set[str] = set()

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -79,11 +79,21 @@ def test_monitor_alias_expands_to_paid_rollover_candidates() -> None:
     )
 
     assert len(candidates) >= 2
+    # Cheapest-first ordering: DeepSeek V4 Flash leads (~0.154/0.308 $/M),
+    # then Mistral Small. Steady-state probe cost is ~12x lower than the
+    # previous claude-haiku-4.5 leader. See monitor_candidate_models
+    # docstring for the full cost-ordered list.
     assert [candidate.id for candidate in candidates[:2]] == [
-        "anthropic/claude-haiku-4.5",
-        "z-ai/glm-4.5-air",
+        "deepseek/deepseek-v4-flash",
+        "mistralai/mistral-small-2603",
     ]
     assert all(not candidate.id.endswith(":free") for candidate in candidates)
+    # Reasoning-by-default models (kimi-k2.6, glm-4.6) are kept in the
+    # rollover tail but not at the head, so the steady-state probe
+    # path is reasoning-content-free and pong_mismatch noise stays low.
+    head = [c.id for c in candidates[:3]]
+    assert "moonshotai/kimi-k2.6" not in head
+    assert "z-ai/glm-4.6" not in head
 
 
 def test_monitor_alias_is_marked_internal_only() -> None:


### PR DESCRIPTION
## Summary

You called it — the pong probes were using the most *expensive* model in the pool, not the cheapest.

\`trustedrouter/monitor\` is a meta-route that fans across 7 models with rollover. The pool was led by \`anthropic/claude-haiku-4.5\` at \$1.10/M in + \$5.50/M out. Every successful steady-state probe was spending ~38μ\$ where \`deepseek/deepseek-v4-flash\` would have spent ~3μ\$.

Reordered the pool to cheapest-first:

| | model | \$/M in | \$/M out |
|---|---|---|---|
| 1 | deepseek/deepseek-v4-flash    | 0.154 | 0.308 ← cheapest |
| 2 | mistralai/mistral-small-2603  | 0.165 | 0.660 |
| 3 | openai/gpt-5.4-nano           | 0.176 | 1.100 |
| 4 | z-ai/glm-4.5-air              | 0.220 | 1.210 |
| 5 | google/gemini-2.5-flash       | 0.330 | 2.750 |
| 6 | z-ai/glm-4.6                  | 0.660 | 2.420 ← reasoning, tail |
| 7 | moonshotai/kimi-k2.6          | 0.880 | 3.850 ← reasoning, tail |
| 8 | anthropic/claude-haiku-4.5    | 1.100 | 5.500 ← most expensive |

## Wins

1. **~12x synthetic spend reduction.** At ~16,700 probes/day across region pairs (per current \`/status\` sample count), monitor cost drops from ~\$0.63/day → ~\$0.05/day.
2. **Reasoning models move to tail.** Kimi K2.6 and GLM-4.6 — the two reasoning-by-default models that drove the May pong_mismatch surge — stay in the rollover ladder but no longer get hit in the steady state. The pong_mismatch noise tail that's been dragging the 24h burn back to 100% should close faster.
3. **Rollover-resilience preserved.** When DeepSeek V4 misbehaves, the meta-route still escalates through the ladder. The "TR can route around a single-provider outage" SLO signal is intact.

## Tests

- Updated \`test_monitor_alias_expands_to_paid_rollover_candidates\` to pin the new head (DeepSeek V4, Mistral Small) and assert the top-3 is reasoning-free.
- 37/37 synthetic-monitoring tests pass
- 59/59 monitor + catalog tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)