### PR TITLE
fix(synthetic): DeepSeek V3.2 backup + 30s sub-cadence (2x sampling)

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -54,6 +54,13 @@ BASE_ENV_VARS=(
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
   "TR_SYNTHETIC_MONITOR_MODEL=trustedrouter/monitor"
   "TR_SYNTHETIC_CONTROL_PLANE_URL=https://trustedrouter.com"
+  # 30-second sub-cadence: each per-minute scheduler invocation runs
+  # the probe twice with a 30s gap, so we get ~32K samples/day instead
+  # of ~16K. Tighter burn-rate windows, faster real-outage detection.
+  # DeepSeek V4 Flash leads the rollover pool so the extra spend is
+  # ~$0.10/day vs ~$0.05/day at 1× — well inside the synthetic budget.
+  "TR_SYNTHETIC_RUNS_PER_INVOCATION=2"
+  "TR_SYNTHETIC_RUN_SPACING_SECONDS=30"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )
@@ -85,7 +92,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     --set-env-vars "$set_env_vars" \
     --update-secrets "$UPDATE_SECRETS" \
     --max-retries 0 \
-    --task-timeout 120s \
+    --task-timeout 150s \
     --quiet >/dev/null
 
   run_uri="https://${monitor_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -1162,20 +1162,30 @@ def cheap_candidate_models(limit: int = 8) -> list[Model]:
     return sorted(by_provider.values(), key=_price_sort_key)[:limit]
 
 
-def monitor_candidate_models(limit: int = 8) -> list[Model]:
+def monitor_candidate_models(limit: int = 10) -> list[Model]:
     # Order is ASCENDING by cost-per-probe so the steady-state synthetic
     # spend hits the cheapest reliable model first; rollover only
     # escalates to pricier models when the cheap path fails. This keeps
     # the rollover-resilience signal AND cuts steady-state probe cost
     # ~12x vs. anthropic/claude-haiku-4.5 leading.
     #
-    # Bonus: leading with non-reasoning models (DeepSeek V4, Mistral
+    # Tier 1 + tier 2 are BOTH DeepSeek-family non-reasoning models —
+    # v4-flash and v3.2. When v4-flash has a bad minute the rollover
+    # immediately retries on v3.2 (same provider API path), which is
+    # still cheap and proven; only after BOTH DeepSeek tiers fail do
+    # we cross to a different provider. The intent is fastest possible
+    # rollover for the common case (a single model glitching) without
+    # losing the multi-provider resilience signal for full-provider
+    # outages.
+    #
+    # Leading with non-reasoning models (DeepSeek V4/V3.2, Mistral
     # Small, GPT-5.4 nano) avoids the reasoning_content failure mode
     # that drove the 2026-05 pong_mismatch surge — kimi-k2.6 / glm-4.6
     # stay in the rollover tail but won't be hit in steady state.
     #
     # Costs at 2026-06 prices ($/M tokens, in / out):
-    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← cheapest
+    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← cheapest, lead
+    #   deepseek/deepseek-v3.2        0.308 / 0.495   ← same-family backup
     #   mistralai/mistral-small-2603  0.165 / 0.660
     #   openai/gpt-5.4-nano           0.176 / 1.100
     #   z-ai/glm-4.5-air              0.220 / 1.210
@@ -1185,6 +1195,7 @@ def monitor_candidate_models(limit: int = 8) -> list[Model]:
     #   anthropic/claude-haiku-4.5    1.100 / 5.500   ← most expensive
     preferred_ids = [
         "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v3.2",
         "mistralai/mistral-small-2603",
         "openai/gpt-5.4-nano",
         "z-ai/glm-4.5-air",

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import time
 
 import httpx
 
@@ -13,15 +14,24 @@ from trusted_router.synthetic.probes import (
     run_synthetic_once,
 )
 
+# Inside-a-single-cron-invocation cadence. Cloud Scheduler is minute-
+# granularity at best (`* * * * *`); to get 30-second sampling we run
+# the probe twice per invocation with a sleep in between. Doubles the
+# sample density (~16K → ~32K samples/day) so the burn-rate windows
+# tighten faster after a real outage. Default 2 sub-runs spaced 30s.
+# Override via TR_SYNTHETIC_RUNS_PER_INVOCATION (1 = old behaviour).
+_DEFAULT_RUNS_PER_INVOCATION = 2
+_DEFAULT_RUN_SPACING_SECONDS = 30.0
 
-async def run() -> int:
-    settings = get_settings()
-    monitor_region = os.environ.get("TR_SYNTHETIC_MONITOR_REGION") or settings.synthetic_monitor_region
-    control_plane = os.environ.get("TR_SYNTHETIC_CONTROL_PLANE_URL", "https://trustedrouter.com")
-    internal_token = settings.internal_gateway_token
-    api_key = settings.synthetic_monitor_api_key
-    timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
-    samples = await run_synthetic_once(settings, monitor_region=monitor_region, api_key=api_key)
+
+async def _one_probe_pass(
+    *, settings, monitor_region: str, control_plane: str,
+    internal_token: str | None, api_key: str | None,
+    timeout: httpx.Timeout,
+) -> list:
+    samples = await run_synthetic_once(
+        settings, monitor_region=monitor_region, api_key=api_key,
+    )
     if api_key and internal_token:
         async with httpx.AsyncClient(timeout=timeout) as client:
             samples.extend(
@@ -44,13 +54,62 @@ async def run() -> int:
                     model=settings.synthetic_monitor_model,
                 )
             )
+    return samples
+
+
+async def run() -> int:
+    settings = get_settings()
+    monitor_region = os.environ.get("TR_SYNTHETIC_MONITOR_REGION") or settings.synthetic_monitor_region
+    control_plane = os.environ.get("TR_SYNTHETIC_CONTROL_PLANE_URL", "https://trustedrouter.com")
+    internal_token = settings.internal_gateway_token
+    api_key = settings.synthetic_monitor_api_key
+    timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
+    runs_per_invocation = max(
+        1,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_RUNS_PER_INVOCATION",
+                str(_DEFAULT_RUNS_PER_INVOCATION),
+            )
+        ),
+    )
+    run_spacing_seconds = float(
+        os.environ.get(
+            "TR_SYNTHETIC_RUN_SPACING_SECONDS",
+            str(_DEFAULT_RUN_SPACING_SECONDS),
+        )
+    )
+
+    all_samples: list = []
+    pass_start_monotonic = time.monotonic()
+    for pass_idx in range(runs_per_invocation):
+        all_samples.extend(
+            await _one_probe_pass(
+                settings=settings,
+                monitor_region=monitor_region,
+                control_plane=control_plane,
+                internal_token=internal_token,
+                api_key=api_key,
+                timeout=timeout,
+            )
+        )
+        # Sleep until the next probe pass should start, but only if
+        # there IS a next pass. Compensates for the time the probe
+        # itself took so the spacing is between pass-starts, not
+        # pass-ends.
+        if pass_idx + 1 < runs_per_invocation:
+            target = (pass_idx + 1) * run_spacing_seconds
+            elapsed = time.monotonic() - pass_start_monotonic
+            to_sleep = target - elapsed
+            if to_sleep > 0:
+                await asyncio.sleep(to_sleep)
 
     ingest_url = os.environ.get(
         "TR_SYNTHETIC_INGEST_URL",
         f"{control_plane.rstrip('/')}/v1/internal/synthetic/samples",
     )
     if not internal_token:
-        for sample in samples:
+        for sample in all_samples:
             print(sample.public_dict())
         print("TR_INTERNAL_GATEWAY_TOKEN is required to ingest samples", file=sys.stderr)
         return 2
@@ -58,7 +117,7 @@ async def run() -> int:
         response = await client.post(
             ingest_url,
             headers={"x-trustedrouter-internal-token": internal_token},
-            json={"samples": [sample.public_dict() for sample in samples]},
+            json={"samples": [sample.public_dict() for sample in all_samples]},
         )
     print(response.text)
     return 0 if response.status_code == 200 else 1

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -78,20 +78,23 @@ def test_monitor_alias_expands_to_paid_rollover_candidates() -> None:
         Settings(environment="test"),
     )
 
-    assert len(candidates) >= 2
-    # Cheapest-first ordering: DeepSeek V4 Flash leads (~0.154/0.308 $/M),
-    # then Mistral Small. Steady-state probe cost is ~12x lower than the
-    # previous claude-haiku-4.5 leader. See monitor_candidate_models
-    # docstring for the full cost-ordered list.
-    assert [candidate.id for candidate in candidates[:2]] == [
+    assert len(candidates) >= 3
+    # Tier 1 + tier 2 are both DeepSeek-family non-reasoning models so
+    # a single-model glitch on v4-flash rolls over INSTANTLY to v3.2
+    # within the same provider API path (still cheap, still non-
+    # reasoning). Mistral Small follows at tier 3 as cross-provider
+    # fallback for a full DeepSeek outage. See monitor_candidate_models
+    # for the full cost-ordered list.
+    assert [candidate.id for candidate in candidates[:3]] == [
         "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v3.2",
         "mistralai/mistral-small-2603",
     ]
     assert all(not candidate.id.endswith(":free") for candidate in candidates)
     # Reasoning-by-default models (kimi-k2.6, glm-4.6) are kept in the
     # rollover tail but not at the head, so the steady-state probe
     # path is reasoning-content-free and pong_mismatch noise stays low.
-    head = [c.id for c in candidates[:3]]
+    head = [c.id for c in candidates[:4]]
     assert "moonshotai/kimi-k2.6" not in head
     assert "z-ai/glm-4.6" not in head
 


### PR DESCRIPTION
## Summary

Two complementary tightening passes per your suggestion.

### 1. DeepSeek V3.2 inserted as tier-2 backup

When v4-flash glitches on a single request, the rollover now retries **instantly** on v3.2 — same DeepSeek provider API path, still cheap, still non-reasoning. Only after BOTH DeepSeek tiers fail does the meta-route cross to Mistral / OpenAI / etc.

| | model | \$/M in | \$/M out |
|---|---|---|---|
| 1 | deepseek/deepseek-v4-flash    | 0.154 | 0.308 ← lead |
| 2 | deepseek/deepseek-v3.2        | 0.308 | 0.495 ← same-family backup |
| 3 | mistralai/mistral-small-2603  | 0.165 | 0.660 ← cross-provider tier |
| 4 | openai/gpt-5.4-nano           | 0.176 | 1.100 |
| 5 | z-ai/glm-4.5-air              | 0.220 | 1.210 |
| 6 | google/gemini-2.5-flash       | 0.330 | 2.750 |
| 7 | z-ai/glm-4.6                  | 0.660 | 2.420 ← reasoning, tail |
| 8 | moonshotai/kimi-k2.6          | 0.880 | 3.850 ← reasoning, tail |
| 9 | anthropic/claude-haiku-4.5    | 1.100 | 5.500 ← most expensive |

Rationale: single-model 5xxs are far more common than full provider outages, so optimizing the **inner** rollover for "same provider, different model" recovers faster without losing the cross-provider resilience signal. Limit bumped 8 → 10 to fit.

### 2. 30-second sub-cadence (2× sample density)

Cloud Scheduler is minute-granularity at best, so the CLI now runs the probe **twice per invocation** with a 30s gap. Spacing computed against pass-start with \`time.monotonic()\` so probe duration doesn't drift the second pass off-cadence. Cloud Run Job timeout bumped 120s → 150s for headroom.

Effect on the numbers:

| metric | before | after |
|---|---|---|
| samples/day | ~16K | ~32K |
| 95% CI on 99.9% uptime | ±0.024% | ±0.017% |
| burn-window detection lag | 60s grain | 30s grain |
| spend/day at DSv4 prices | ~\$0.05 | ~\$0.10 |

Even at 2×, monitor spend stays inside the synthetic budget. Tighter SLO numbers, faster real-outage detection.

Both env-var driven (\`TR_SYNTHETIC_RUNS_PER_INVOCATION\` defaults 2, \`TR_SYNTHETIC_RUN_SPACING_SECONDS\` defaults 30) — set in the deploy script.

## Tests
- 37/37 synthetic-monitoring tests pass
- Existing monitor test asserts the new top-3 ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)