### PR TITLE
fix(synthetic): 10s cadence + V4 Pro tier (more provider diversity)

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -54,13 +54,18 @@ BASE_ENV_VARS=(
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
   "TR_SYNTHETIC_MONITOR_MODEL=trustedrouter/monitor"
   "TR_SYNTHETIC_CONTROL_PLANE_URL=https://trustedrouter.com"
-  # 30-second sub-cadence: each per-minute scheduler invocation runs
-  # the probe twice with a 30s gap, so we get ~32K samples/day instead
-  # of ~16K. Tighter burn-rate windows, faster real-outage detection.
-  # DeepSeek V4 Flash leads the rollover pool so the extra spend is
-  # ~$0.10/day vs ~$0.05/day at 1× — well inside the synthetic budget.
-  "TR_SYNTHETIC_RUNS_PER_INVOCATION=2"
-  "TR_SYNTHETIC_RUN_SPACING_SECONDS=30"
+  # 10-second sub-cadence: each per-minute scheduler invocation runs
+  # the probe 6 times spaced 10s apart, so we get ~96K samples/day
+  # instead of ~16K. Tightens burn-rate windows by another 3x vs the
+  # 30s setting, drops 95% CI on 99.9% uptime to ~±0.010%, and detects
+  # a real outage within 10s instead of 60s.
+  #
+  # Budget impact: DeepSeek V4 Flash leads (and is served by 4
+  # providers transparently), so per-probe spend is ~3 μ$. At 6 passes
+  # × 60 min × 24h × per-region-pair × 2 probe types ≈ ~$0.30/day —
+  # negligible vs the SLO observability win.
+  "TR_SYNTHETIC_RUNS_PER_INVOCATION=6"
+  "TR_SYNTHETIC_RUN_SPACING_SECONDS=10"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )
@@ -92,7 +97,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     --set-env-vars "$set_env_vars" \
     --update-secrets "$UPDATE_SECRETS" \
     --max-retries 0 \
-    --task-timeout 150s \
+    --task-timeout 300s \
     --quiet >/dev/null
 
   run_uri="https://${monitor_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -1162,21 +1162,21 @@ def cheap_candidate_models(limit: int = 8) -> list[Model]:
     return sorted(by_provider.values(), key=_price_sort_key)[:limit]
 
 
-def monitor_candidate_models(limit: int = 10) -> list[Model]:
+def monitor_candidate_models(limit: int = 12) -> list[Model]:
     # Order is ASCENDING by cost-per-probe so the steady-state synthetic
     # spend hits the cheapest reliable model first; rollover only
     # escalates to pricier models when the cheap path fails. This keeps
     # the rollover-resilience signal AND cuts steady-state probe cost
     # ~12x vs. anthropic/claude-haiku-4.5 leading.
     #
-    # Tier 1 + tier 2 are BOTH DeepSeek-family non-reasoning models —
-    # v4-flash and v3.2. When v4-flash has a bad minute the rollover
-    # immediately retries on v3.2 (same provider API path), which is
-    # still cheap and proven; only after BOTH DeepSeek tiers fail do
-    # we cross to a different provider. The intent is fastest possible
-    # rollover for the common case (a single model glitching) without
-    # losing the multi-provider resilience signal for full-provider
-    # outages.
+    # Tiers 1-3 are ALL DeepSeek-family non-reasoning models —
+    # v4-flash, v3.2, v4-pro. The lead (v4-flash) is served by 4
+    # providers (deepseek, parasail, siliconflow, novita) so TR's
+    # within-model routing already fans across providers transparently.
+    # Tier 2 (v3.2) is same-family fallback for the cheap path; tier 3
+    # (v4-pro) brings 2 ADDITIONAL providers (tinfoil + gmi) so a 6th
+    # and 7th provider show up in the rollover ladder before crossing
+    # to Mistral / OpenAI / etc.
     #
     # Leading with non-reasoning models (DeepSeek V4/V3.2, Mistral
     # Small, GPT-5.4 nano) avoids the reasoning_content failure mode
@@ -1184,9 +1184,10 @@ def monitor_candidate_models(limit: int = 10) -> list[Model]:
     # stay in the rollover tail but won't be hit in steady state.
     #
     # Costs at 2026-06 prices ($/M tokens, in / out):
-    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← cheapest, lead
+    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← lead (4 providers)
     #   deepseek/deepseek-v3.2        0.308 / 0.495   ← same-family backup
-    #   mistralai/mistral-small-2603  0.165 / 0.660
+    #   deepseek/deepseek-v4-pro      0.478 / 0.957   ← +tinfoil +gmi
+    #   mistralai/mistral-small-2603  0.165 / 0.660   ← cross-provider
     #   openai/gpt-5.4-nano           0.176 / 1.100
     #   z-ai/glm-4.5-air              0.220 / 1.210
     #   google/gemini-2.5-flash       0.330 / 2.750
@@ -1196,6 +1197,7 @@ def monitor_candidate_models(limit: int = 10) -> list[Model]:
     preferred_ids = [
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v3.2",
+        "deepseek/deepseek-v4-pro",
         "mistralai/mistral-small-2603",
         "openai/gpt-5.4-nano",
         "z-ai/glm-4.5-air",

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -15,13 +15,15 @@ from trusted_router.synthetic.probes import (
 )
 
 # Inside-a-single-cron-invocation cadence. Cloud Scheduler is minute-
-# granularity at best (`* * * * *`); to get 30-second sampling we run
-# the probe twice per invocation with a sleep in between. Doubles the
-# sample density (~16K → ~32K samples/day) so the burn-rate windows
-# tighten faster after a real outage. Default 2 sub-runs spaced 30s.
+# granularity at best (`* * * * *`); to get 10-second sampling we run
+# the probe 6 times per invocation with a 10s sleep between starts.
+# Sample density goes from ~16K → ~96K/day per region pair, the burn
+# windows tighten 6x, and real outages are detected within 10s instead
+# of 60s. Spending is still negligible because DeepSeek V4 leads
+# (~$0.30/day total across all probes at 10s).
 # Override via TR_SYNTHETIC_RUNS_PER_INVOCATION (1 = old behaviour).
-_DEFAULT_RUNS_PER_INVOCATION = 2
-_DEFAULT_RUN_SPACING_SECONDS = 30.0
+_DEFAULT_RUNS_PER_INVOCATION = 6
+_DEFAULT_RUN_SPACING_SECONDS = 10.0
 
 
 async def _one_probe_pass(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -78,23 +78,24 @@ def test_monitor_alias_expands_to_paid_rollover_candidates() -> None:
         Settings(environment="test"),
     )
 
-    assert len(candidates) >= 3
-    # Tier 1 + tier 2 are both DeepSeek-family non-reasoning models so
-    # a single-model glitch on v4-flash rolls over INSTANTLY to v3.2
-    # within the same provider API path (still cheap, still non-
-    # reasoning). Mistral Small follows at tier 3 as cross-provider
-    # fallback for a full DeepSeek outage. See monitor_candidate_models
-    # for the full cost-ordered list.
-    assert [candidate.id for candidate in candidates[:3]] == [
+    assert len(candidates) >= 4
+    # Tiers 1-3 are all DeepSeek-family non-reasoning models:
+    #   1. v4-flash (cheapest, 4 providers: deepseek/parasail/siliconflow/novita)
+    #   2. v3.2     (same-family backup if v4-flash misbehaves)
+    #   3. v4-pro   (+tinfoil +gmi providers — total of ~7 routes before
+    #                we cross to a different model)
+    # Mistral Small comes at tier 4 as the first cross-MODEL fallback.
+    assert [candidate.id for candidate in candidates[:4]] == [
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v3.2",
+        "deepseek/deepseek-v4-pro",
         "mistralai/mistral-small-2603",
     ]
     assert all(not candidate.id.endswith(":free") for candidate in candidates)
     # Reasoning-by-default models (kimi-k2.6, glm-4.6) are kept in the
     # rollover tail but not at the head, so the steady-state probe
     # path is reasoning-content-free and pong_mismatch noise stays low.
-    head = [c.id for c in candidates[:4]]
+    head = [c.id for c in candidates[:5]]
     assert "moonshotai/kimi-k2.6" not in head
     assert "z-ai/glm-4.6" not in head
 


### PR DESCRIPTION
## Summary

Two further tightening passes per your suggestion.

### 1. DeepSeek V4 Pro inserted as tier-3 backup

V4 Pro brings two providers V4 Flash doesn't have — **tinfoil + gmi** — so the rollover ladder now picks up 7 distinct provider routes before crossing model families:

\`\`\`
tier 1: deepseek/deepseek-v4-flash  (deepseek, parasail, siliconflow, novita)
tier 2: deepseek/deepseek-v3.2      (deepseek)
tier 3: deepseek/deepseek-v4-pro    (+ tinfoil, gmi)
tier 4: mistralai/mistral-small-2603 (first cross-MODEL fallback)
...
\`\`\`

### 2. 10-second cadence

Bumped \`runs_per_invocation\` 2 → 6 and \`spacing\` 30s → 10s. Effect on the numbers:

| metric | 60s (start) | 30s (last) | 10s (now) |
|---|---|---|---|
| samples/day | ~16K | ~32K | **~96K** |
| 95% CI on 99.9% uptime | ±0.024% | ±0.017% | **±0.010%** |
| outage detection lag | 60s | 30s | **10s** |
| spend/day | ~\$0.05 | ~\$0.10 | **~\$0.30** |

Cloud Run Job task-timeout bumped 150s → 300s for headroom (worst-case 5 × 10s spacing + 6 × ~15s probe = ~140s, so ~2x margin).

## Tests

- Updated monitor-pool test pin to assert new top-4 (V4 Flash, V3.2, V4 Pro, Mistral Small)
- 37/37 synthetic-monitoring tests pass
- Monitor candidate limit bumped 10 → 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)