### PR TITLE
fix(synthetic): revert pong prompt — 100% failure surge

### DIFF
--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -266,13 +266,19 @@ async def openai_chat_pong_probe(
     url = _api_url(target.api_base_url, "/chat/completions")
     body = {
         "model": model,
-        "messages": [{"role": "user", "content": "Respond with only the word PONG."}],
-        # Bumped from 4 → 128 so reasoning models (kimi-k2.6, glm-4.6,
-        # deepseek-v4) can finish their thinking phase and still emit
-        # the visible token. At 4 tokens with temperature=0 every
-        # thinking token was consumed BEFORE the model wrote "PONG",
-        # so message.content arrived empty and the matcher flagged
-        # pong_mismatch even though the model behaved correctly.
+        # Reverted from "Respond with only the word PONG." back to
+        # "reply exactly PONG" — the original phrasing worked at
+        # 99.97% uptime for ~24h on the same monitor pool, then the
+        # rephrase coincided with a surge to 100% pong_mismatch at
+        # 06:00Z 2026-06-02. DeepSeek V4 Flash (current pool leader)
+        # appears to interpret the new phrasing differently — maybe
+        # refusing, maybe wrapping in markdown the extractor doesn't
+        # reach. Reverting to the known-good prompt while we
+        # investigate the underlying response shape.
+        "messages": [{"role": "user", "content": "reply exactly PONG"}],
+        # max_tokens stays at 128 so reasoning models (kimi-k2.6,
+        # glm-4.6) in the rollover tail still finish their thinking
+        # phase if they're ever reached.
         "max_tokens": 128,
         "temperature": 0,
         "metadata": {"trustedrouter_synthetic": "true"},
@@ -321,7 +327,10 @@ async def responses_pong_probe(
     url = _api_url(target.api_base_url, "/responses")
     body = {
         "model": model,
-        "input": "Respond with only the word PONG.",
+        # Same prompt as chat-completions — see that probe's revert
+        # comment. Original phrasing worked, rephrase coincided with
+        # 100% failure surge on 2026-06-02.
+        "input": "reply exactly PONG",
         # See chat-completions probe — same reason: reasoning models in
         # the monitor pool need headroom past their thinking phase.
         "max_output_tokens": 128,


### PR DESCRIPTION
Live status surge: provider_effective 6h burn went from 26x → 25,090x at 06:00Z 2026-06-02. Pong probes 100% failure across every region pair. HTTP 200 + normal latency + body without 'pong'. Reverting prompt to original phrasing that worked at 99.97% for 24h before the rephrase. 37/37 tests pass.