### PR TITLE
fix(synthetic): CPU 2/1Gi + dial cadence back to 2×30s

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -54,18 +54,16 @@ BASE_ENV_VARS=(
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
   "TR_SYNTHETIC_MONITOR_MODEL=trustedrouter/monitor"
   "TR_SYNTHETIC_CONTROL_PLANE_URL=https://trustedrouter.com"
-  # 10-second sub-cadence: each per-minute scheduler invocation runs
-  # the probe 6 times spaced 10s apart, so we get ~96K samples/day
-  # instead of ~16K. Tightens burn-rate windows by another 3x vs the
-  # 30s setting, drops 95% CI on 99.9% uptime to ~±0.010%, and detects
-  # a real outage within 10s instead of 60s.
-  #
-  # Budget impact: DeepSeek V4 Flash leads (and is served by 4
-  # providers transparently), so per-probe spend is ~3 μ$. At 6 passes
-  # × 60 min × 24h × per-region-pair × 2 probe types ≈ ~$0.30/day —
-  # negligible vs the SLO observability win.
-  "TR_SYNTHETIC_RUNS_PER_INVOCATION=6"
-  "TR_SYNTHETIC_RUN_SPACING_SECONDS=10"
+  # 30-second sub-cadence (2 passes/invocation). The 10s/6-passes
+  # plan from a prior iteration exceeded the Cloud Run Job CPU budget
+  # — N concurrent TLS handshakes serialized on 1 CPU, probe latency
+  # ballooned from 2s → 12s, executions hit 90-400s and stacked up
+  # past the 60s cron tick. With CPU 2 / 1Gi (set below in the job
+  # deploy flags) we may be able to safely return to 10s — but
+  # ratchet there in a SEPARATE PR after we've watched a few hours
+  # of clean runs at 30s under the new resources.
+  "TR_SYNTHETIC_RUNS_PER_INVOCATION=2"
+  "TR_SYNTHETIC_RUN_SPACING_SECONDS=30"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )
@@ -98,7 +96,15 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     --update-secrets "$UPDATE_SECRETS" \
     --max-retries 0 \
     --task-timeout 300s \
+    --cpu 2 \
+    --memory 1Gi \
     --quiet >/dev/null
+  # CPU 2 + 1Gi mem: the synthetic CLI fans out N probes per pass
+  # concurrently via asyncio.gather + httpx. On 1 CPU / 512Mi (the
+  # Cloud Run default) the parallel TLS handshakes serialize and
+  # probe latency balloons from ~2s to ~12s, blowing past task-
+  # timeout. 2 CPU / 1Gi handles 6 passes × 4 region pairs × 2
+  # probe types per pass comfortably.
 
   run_uri="https://${monitor_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"
   if gc scheduler jobs describe "$scheduler_name" --location "$monitor_region" >/dev/null 2>&1; then

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -16,15 +16,21 @@ from trusted_router.synthetic.probes import (
 )
 
 # Inside-a-single-cron-invocation cadence. Cloud Scheduler is minute-
-# granularity at best (`* * * * *`); to get 10-second sampling we run
-# the probe 6 times per invocation with a 10s sleep between starts.
-# Sample density goes from ~16K → ~96K/day per region pair, the burn
-# windows tighten 6x, and real outages are detected within 10s instead
-# of 60s. Spending is still negligible because DeepSeek V4 leads
-# (~$0.30/day total across all probes at 10s).
+# granularity at best (`* * * * *`); to get sub-minute sampling we
+# run the probe multiple times per invocation with a sleep between
+# starts. 2 passes × 30s spacing = ~32K samples/day per region pair,
+# fits comfortably in a 60s scheduler tick on Cloud Run Job defaults.
+#
+# Going more aggressive (6 × 10s for ~96K samples/day) caused probe
+# executions to stack up under load: with default 1 CPU / 512Mi the
+# concurrent TLS handshakes serialized, individual probe latency
+# ballooned from ~2s to ~12s, and 60s cron ticks fired faster than
+# 90-400s executions could finish. Bumping Cloud Run Job to 2 CPU /
+# 1Gi in synthetic.sh should make 10s feasible again — try that in
+# a separate PR after watching a stable 30s baseline.
 # Override via TR_SYNTHETIC_RUNS_PER_INVOCATION (1 = old behaviour).
-_DEFAULT_RUNS_PER_INVOCATION = 6
-_DEFAULT_RUN_SPACING_SECONDS = 10.0
+_DEFAULT_RUNS_PER_INVOCATION = 2
+_DEFAULT_RUN_SPACING_SECONDS = 30.0
 
 
 async def _one_probe_pass(


### PR DESCRIPTION
**Live debug findings from the 06:00Z 2026-06-02 pong surge debug session.** The 6/10s cadence from PR #14 wasn't feasible on Cloud Run Job defaults (1 CPU / 512Mi): concurrent TLS handshakes serialized on 1 CPU, probe latency 2s → 12s, executions 90-400s, cron firing every 60s, queue grew unbounded. Two-part durable fix: (a) bump Cloud Run Job to 2 CPU / 1Gi via synthetic.sh deploy flags so 10s might be feasible later, (b) roll cadence back to 2×30s now (env vars + cli.py defaults) on the proven setting. Live revert already applied to both region jobs. 37/37 tests pass.