### PR TITLE
fix(scripts): credit_grant_joseph uses correct CreditAccount fields

### DIFF
--- a/scripts/credit_grant_joseph.py
+++ b/scripts/credit_grant_joseph.py
@@ -55,11 +55,16 @@ def main() -> int:
     workspace = workspaces[0]
     print(f"granting ${AMOUNT_DOLLARS} ({AMOUNT_MICRODOLLARS} μ$) to workspace {workspace.id}")
 
+    def _avail(acct) -> float:
+        # Available credit = total deposited - total burned - currently reserved
+        net = acct.total_credits_microdollars - acct.total_usage_microdollars - acct.reserved_microdollars
+        return net / MICRODOLLARS_PER_DOLLAR
+
     before = STORE.get_credit_account(workspace.id)
     if before is None:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
-    print(f"  balance before: ${before.balance_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}")
+    print(f"  available before: ${_avail(before):.4f}  (deposited=${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}, used=${before.total_usage_microdollars / MICRODOLLARS_PER_DOLLAR:.4f})")
 
     granted = STORE.credit_workspace_once(
         workspace.id, AMOUNT_MICRODOLLARS, EVENT_ID
@@ -70,7 +75,7 @@ def main() -> int:
         print("  credit applied")
 
     after = STORE.get_credit_account(workspace.id)
-    print(f"  balance after:  ${after.balance_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}")
+    print(f"  available after:  ${_avail(after):.4f}  (deposited=${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}, used=${after.total_usage_microdollars / MICRODOLLARS_PER_DOLLAR:.4f})")
     return 0
 
 


### PR DESCRIPTION
Display step errored on first run because CreditAccount has no single balance field — it tracks total_credits / total_usage / reserved separately. Replaced with _avail() that computes available = total_credits - total_usage - reserved and prints all three components. Grant itself worked; this is purely the display fix.