### PR TITLE
feat(marketing): vivid /compare/openrouter rewrite + 5 SEO landing pages

### DIFF
--- a/docs/blog-drafts/2026-06-02-attestation-is-all-you-need.md
+++ b/docs/blog-drafts/2026-06-02-attestation-is-all-you-need.md
@@ -1,0 +1,133 @@
+---
+title: "Attestation is All You Need"
+date: "2026-06-02"
+draft: true
+tags:
+  - TrustedRouter
+  - confidential-computing
+  - attestation
+  - security
+  - LLMs
+---
+
+I've been sending a lot of prompts lately. Code. Drafts. Half-written ideas I would not want to read on a billboard.
+
+Every LLM provider tells me they don't log any of it.
+
+I'm supposed to believe them.
+
+OpenAI publishes a 30-day retention policy and a ZDR program for enterprise. Anthropic publishes a privacy policy. Cohere has SOC 2 Type II. Each of these is **a promise**. None of them is **proof**.
+
+A promise is a thing you can sue over after it's broken. Proof is a thing you can check before you click send.
+
+There is a much better way. We have had it since 2018. The industry just never put inference behind it.
+
+It is called **attestation**.
+
+## What attestation is
+
+A confidential VM runs inside a hardware-backed enclave. AWS Nitro. GCP Confidential VMs. Azure Confidential VMs. Same idea everywhere.
+
+The CPU signs a measurement of the running binary.
+
+The signature chains up to the chip vendor's root key.
+
+You can verify the chain. You can compute the same hash from open-source code. If they match, you know exactly what code is running.
+
+That gives you two things contracts can never give you:
+
+The code that is running **is the code that was published**.
+
+The code **cannot be changed at runtime** without invalidating the attestation.
+
+You stop trusting the operator. You start trusting the silicon. The silicon's threat surface is much smaller than the operator's.
+
+## Why this is "all you need"
+
+Every privacy mechanism the industry sells you reduces to attestation.
+
+**"We do not log your prompts."**
+If the binary never opens a write handle on a prompt path, it cannot log. You can grep the source. The promise is now redundant.
+
+**"Zero data retention contracts."**
+If the binary never writes prompts to disk, retention is structurally zero. The contract is describing what the code does. The contract is not constraining the operator.
+
+**"BYOK."**
+Useful for billing isolation. But if the routing code is attested and non-logging, someone else's key going through the same code gets the same privacy.
+
+**"SOC 2 / ISO 27001."**
+These audit the operator's processes. Attestation skips the operator. It audits the artifact.
+
+**"Trust us."**
+Same.
+
+Attestation is the primitive. Everything else is a slower, lossier approximation of "show me what code is running."
+
+This is why I picked the title. The original *Attention is All You Need* paper did not say nothing else mattered. It said one primitive subsumed most of what was previously built on top.
+
+Attestation is that primitive for inference privacy.
+
+## How we do it at TrustedRouter
+
+`api.quillrouter.com` runs inside an attested gateway.
+
+AWS Nitro Enclaves in us-east-1.
+GCP Confidential VMs in us-central1 and europe-west4.
+
+Cross-cloud. So a single vendor's compromise does not take the trust surface with it.
+
+Every request can be paired with a live attestation.
+
+You generate a nonce. You fetch `/attestation?nonce=<your-nonce>`. The gateway returns a JWT signed by the hardware root key.
+
+The JWT contains:
+
+- `eat_nonce` — the nonce you supplied, so the response can never be replayed
+- `image_digest` — SHA-256 of the running container image
+- `pcrs` — the platform measurements at boot
+
+You match `image_digest` against the hash published at trustedrouter.com/security with every commit.
+
+If they match, the code processing your prompts is the code you can read on GitHub.
+
+If the attestation fails — image drift, hardware fault, expired cert, anything — the gateway **fails closed**. No request reaches a provider until attestation is valid again.
+
+The synthetic monitor probes the attestation path continuously. It pages on the first miss.
+
+## What I am not promising
+
+Attestation is not a wand.
+
+A nation-state with hardware access could try side-channel attacks. AWS and GCP have hardened their enclaves against most known classes. Not all.
+
+The hardware vendor's root key is a trust anchor. If AWS's or GCP's signing infrastructure is compromised, the chain breaks. Cross-cloud helps. It does not eliminate the dependency.
+
+Open-source code can have bugs. Attestation proves the running binary is the published binary. It does not prove the published binary is correct. Many eyes still help.
+
+The point is not that attestation is perfect.
+
+The point is that *not having it* requires you to trust the operator on everything. That is much worse.
+
+## Why now
+
+LLM traffic is becoming the new sensitive data path.
+
+Code goes through it.
+Drafts go through it.
+Private contracts go through it.
+Medical notes go through it.
+Half-written resignation letters go through it.
+
+The industry's default privacy story is still "trust us."
+
+That worked for SaaS in 2010. It does not work for inference in 2026, when one well-placed prompt log can leak more about a person than their email.
+
+Confidential computing is fast now. The Nitro overhead is single-digit milliseconds. The GCP confidential VM overhead is the same.
+
+There is no longer a performance reason to ship inference without attestation.
+
+There is no longer an honest privacy reason to ship inference without attestation.
+
+That is the bet.
+
+[TrustedRouter](https://trustedrouter.com/) is live. Trust surface, attestation flow, and full open-source code are at [trustedrouter.com/security](https://trustedrouter.com/security).

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -65,6 +65,12 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/compare/openrouter",
     "/compare/vercel-ai-gateway",
     "/compare/litellm",
+    # SEO landing pages — each targets a high-intent buyer query.
+    "/openrouter-alternative",
+    "/private-llm-api",
+    "/hipaa-llm-api",
+    "/llm-zero-data-retention",
+    "/claude-api-privacy",
     "/docs/migrate-from-openrouter",
 )
 _BENCHMARK_INDEX_LINKS: tuple[dict[str, str], ...] = (
@@ -217,6 +223,51 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         template="public/security.html",
         title="Security",
         description="What is logged, what is not logged, and where prompt traffic belongs.",
+    ),
+    # SEO landing pages — top-level slugs target high-intent buyer
+    # queries. Each one is a self-contained sales surface: H2 above the
+    # fold, one runnable code sample, one comparison table, a clear
+    # CTA to /chat. Internal-link target for the marketing-grid cards
+    # on /, /compare/openrouter, and the related landing pages.
+    "openrouter-alternative": PublicPage(
+        template="public/seo_openrouter_alternative.html",
+        title="OpenRouter Alternative — TrustedRouter",
+        description=(
+            "An open-source, hardware-attested OpenRouter alternative. "
+            "Same OpenAI-compatible API, verifiable prompt path, no logs."
+        ),
+    ),
+    "private-llm-api": PublicPage(
+        template="public/seo_private_llm_api.html",
+        title="Private LLM API — Verifiable, Attested, Open Source",
+        description=(
+            "A private LLM API where privacy is cryptographically verifiable. "
+            "Route to Claude, GPT, Gemini, DeepSeek through an attested gateway."
+        ),
+    ),
+    "hipaa-llm-api": PublicPage(
+        template="public/seo_hipaa_llm_api.html",
+        title="HIPAA-Compatible LLM Routing — TrustedRouter",
+        description=(
+            "An auditable LLM API for HIPAA covered entities. "
+            "Attested gateway, open-source routing code, no prompt logs by construction."
+        ),
+    ),
+    "llm-zero-data-retention": PublicPage(
+        template="public/seo_zero_data_retention.html",
+        title="Zero Data Retention LLM API — Verifiable in Source",
+        description=(
+            "Zero data retention as a structural property of the open-source code, "
+            "not just a contract clause. Multi-provider routing with the same posture."
+        ),
+    ),
+    "claude-api-privacy": PublicPage(
+        template="public/seo_claude_api_privacy.html",
+        title="Claude API Privacy — Through TrustedRouter",
+        description=(
+            "Call Anthropic Claude through a hardware-attested, open-source router. "
+            "Anthropic's privacy posture plus a routing path you can verify."
+        ),
     ),
 }
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -147,6 +147,31 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def migrate_from_openrouter() -> str:
         return public_page_html(settings, "docs/migrate-from-openrouter")
 
+    # ── SEO landing pages ────────────────────────────────────────────
+    # Top-level slugs targeting high-intent buyer queries. Each is a
+    # self-contained sales surface (see PUBLIC_PAGES in dashboard.py).
+    # Keep these top-level (not under /seo or /landing) — that hurts
+    # ranking and looks defensive.
+    @public_html_route("/openrouter-alternative")
+    async def seo_openrouter_alternative() -> str:
+        return public_page_html(settings, "openrouter-alternative")
+
+    @public_html_route("/private-llm-api")
+    async def seo_private_llm_api() -> str:
+        return public_page_html(settings, "private-llm-api")
+
+    @public_html_route("/hipaa-llm-api")
+    async def seo_hipaa_llm_api() -> str:
+        return public_page_html(settings, "hipaa-llm-api")
+
+    @public_html_route("/llm-zero-data-retention")
+    async def seo_llm_zero_data_retention() -> str:
+        return public_page_html(settings, "llm-zero-data-retention")
+
+    @public_html_route("/claude-api-privacy")
+    async def seo_claude_api_privacy() -> str:
+        return public_page_html(settings, "claude-api-privacy")
+
     @public_html_route("/security")
     async def security() -> str:
         return public_page_html(settings, "security")

--- a/src/trusted_router/templates/public/compare_openrouter.html
+++ b/src/trusted_router/templates/public/compare_openrouter.html
@@ -1,77 +1,129 @@
 {% extends "public/_base.html" %}
 {% block body %}
-<section class="public-proof-strip">
-  <div><strong>Same client shape</strong><span>Keep your OpenAI SDK and change the base URL.</span></div>
-  <div><strong>Verifiable gateway</strong><span>Source commit, image reference, and image digest are published.</span></div>
-  <div><strong>Provider fallback</strong><span>Use <span class="mono">trustedrouter/auto</span> for rollover across healthy routes.</span></div>
-  <div><strong>Open source</strong><span>Control plane, gateway, config, and public site.</span></div>
-</section>
 
-<section class="marketing-split">
+<section class="marketing-split" aria-label="One-line migration">
   <div class="marketing-copy">
-    <span class="eyebrow">Why switch</span>
-    <h2>Routing convenience with a prompt path you can inspect.</h2>
-    <p>TrustedRouter is for teams that want model choice, provider fallback, usage tracking, BYOK, prepaid credits, and a hosted gateway whose code path is published for verification.</p>
-    <p>The control plane does not terminate production prompt traffic. Prompts belong on <span class="mono">api.quillrouter.com</span>, which is the attested API path.</p>
+    <span class="eyebrow">Switch in 1 line</span>
+    <h2>OpenRouter, but you can verify the prompt path.</h2>
+    <p>Change <span class="mono">base_url</span>. Keep your OpenAI SDK. Keep your model IDs. Keep your code.</p>
+    <p>What you add: a hardware-attested gateway, open-source source-to-binary, no prompt or output logs, and a public status page with continuous SLO probes.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try the playground</a>
+      <a class="btn" href="https://trust.trustedrouter.com">Verify gateway</a>
+    </p>
   </div>
   <div class="copy-terminal">
-    <div class="code-head"><span>Client migration</span><span>OpenAI SDK</span></div>
-    <pre><code>client = OpenAI(
+    <div class="code-head"><span>Before / after — Python</span><span>OpenAI SDK</span></div>
+    <pre><code>from openai import OpenAI
+
+# Before
+client = OpenAI(
+    base_url="https://openrouter.ai/api/v1",
+    api_key="sk-or-..."
+)
+
+# After
+client = OpenAI(
     base_url="{{ api_base_url }}",
     api_key="sk-tr-v1-..."
 )
 
-model = "trustedrouter/auto"</code></pre>
+# Everything else stays the same:
+resp = client.chat.completions.create(
+    model="anthropic/claude-sonnet-4.6",
+    messages=[{"role": "user", "content": "hi"}],
+)</code></pre>
   </div>
 </section>
 
 <section class="marketing-grid three">
   <div class="marketing-card">
-    <span class="card-label">Migrate</span>
-    <h3>Change one URL.</h3>
-    <p>Point your existing client at <span class="mono">{{ api_base_url }}</span> and keep your model IDs.</p>
-    <a class="btn" href="/docs/migrate-from-openrouter">Open migration guide</a>
+    <span class="card-label">Same API</span>
+    <h3>OpenAI-compatible.</h3>
+    <p>Drop into any OpenRouter integration. Streaming, tool calls, vision, structured output — all supported.</p>
   </div>
   <div class="marketing-card">
-    <span class="card-label">Verify</span>
-    <h3>Check the exact code path.</h3>
-    <p>The trust page publishes the source commit, image reference, and image digest for the gateway.</p>
-    <a class="btn" href="https://trust.trustedrouter.com">Verify gateway</a>
+    <span class="card-label">Verifiable</span>
+    <h3>Attested gateway.</h3>
+    <p>Cross-cloud confidential VMs sign their boot measurement. You check the image hash against the published artifact.</p>
   </div>
   <div class="marketing-card">
-    <span class="card-label">Route</span>
-    <h3>Move sensitive routes deliberately.</h3>
-    <p>Start with a single workflow, inspect status and activity, then expand routes once the trust boundary matches your needs.</p>
-    <button class="btn primary" type="button" data-action="open-signin">Create key</button>
+    <span class="card-label">No logging</span>
+    <h3>Zero by construction.</h3>
+    <p>Prompt and output paths never touch persistent storage. The binary you can verify is the binary that handles your traffic.</p>
   </div>
 </section>
 
-<section class="compare-matrix" aria-label="OpenRouter comparison">
+<section class="compare-matrix" aria-label="OpenRouter vs TrustedRouter">
   <div class="matrix-row matrix-head">
     <span></span><strong>OpenRouter</strong><strong>TrustedRouter</strong>
   </div>
   <div class="matrix-row">
-    <span>API shape</span><span>OpenAI style routing</span><span>OpenAI style routing</span>
+    <span>API shape</span><span>OpenAI compatible</span><span>OpenAI compatible</span>
   </div>
   <div class="matrix-row">
-    <span>Trust model</span><span>Hosted router trust</span><span>Open source plus attestation</span>
+    <span>Prompt logging</span><span>Operator-controlled retention</span><span>None — verifiable in source</span>
   </div>
   <div class="matrix-row">
-    <span>Prompt handling</span><span>Service policy</span><span>No prompt or output logs by default</span>
+    <span>Trust model</span><span>Hosted policy</span><span>Hardware attestation + open source</span>
   </div>
   <div class="matrix-row">
-    <span>Best fit</span><span>Broad model marketplace</span><span>Verifiable private routing</span>
+    <span>Source</span><span>Closed</span><span>Open — every line that touches your prompt</span>
+  </div>
+  <div class="matrix-row">
+    <span>Provider fallback</span><span>Yes</span><span>Yes — across 30+ providers</span>
+  </div>
+  <div class="matrix-row">
+    <span>Status SLOs</span><span>Public status page</span><span>Public 99.99% SLO + 30-day burn rates</span>
+  </div>
+  <div class="matrix-row">
+    <span>Best fit</span><span>Broad model marketplace</span><span>Privacy-sensitive workloads, regulated industries, audited routing</span>
+  </div>
+</section>
+
+<section class="marketing-split" aria-label="Verify in 60 seconds">
+  <div class="copy-terminal">
+    <div class="code-head"><span>Verify the gateway</span><span>curl + jq</span></div>
+    <pre><code># 1. Get a nonce-bound attestation
+NONCE=$(openssl rand -hex 16)
+curl -s "{{ api_base_url|replace('/v1', '') }}/attestation?nonce=$NONCE" \
+  | jq .
+
+# Response includes:
+#   eat_nonce     — your nonce, replay-protected
+#   image_digest  — SHA-256 of the running container
+#   pcrs          — platform measurements at boot
+
+# 2. Compare image_digest against the published artifact:
+#    https://trustedrouter.com/security
+#
+# If they match, the code processing your prompts is
+# the code on GitHub.</code></pre>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">60-second proof</span>
+    <h2>Don't trust. Check.</h2>
+    <p>The gateway exposes a live attestation endpoint that returns a JWT signed by the CPU's hardware root key. You match the image digest to the open-source binary, and you know — not assume — what code is running.</p>
+    <p>Everyone else publishes a privacy policy. We publish the hash.</p>
+    <p>
+      <a class="btn" href="/security">How attestation works</a>
+      <a class="btn" href="/docs/migrate-from-openrouter">Migration guide</a>
+    </p>
   </div>
 </section>
 
 <section class="quote-feature">
   <div>
-    <span class="eyebrow">Developer workflow</span>
-    <h2>Keep the easy parts. Make the trust boundary explicit.</h2>
+    <span class="eyebrow">Common questions</span>
+    <h2>The boring details that make this real.</h2>
   </div>
   <div>
-    <p>Model routers are useful because they remove provider account sprawl, normalize usage records, and make fallback possible. TrustedRouter keeps that workflow and adds a published gateway boundary for production prompt traffic.</p>
-    <p>Use the public model pages to compare providers, policy notes, prices, benchmark links, and status before routing real traffic.</p>
+    <p><strong>Do my existing keys work?</strong> No — TR keys are a different prefix (<span class="mono">sk-tr-v1-…</span>). Issuance takes 30 seconds after sign-up.</p>
+    <p><strong>Same model catalog?</strong> Yes — every OpenRouter model id resolves on TR, plus 30+ providers including DeepSeek, Kimi, MiniMax, GLM, and Together.</p>
+    <p><strong>Pricing?</strong> Provider cost + 10% markup, $0.01/M floor. Published per-model on every catalog page. No hidden margin on inference.</p>
+    <p><strong>BYOK?</strong> Yes — bring your own provider keys for billing isolation. Routing code stays attested.</p>
+    <p><strong>Self-host?</strong> The full control plane and gateway are open source. Run it yourself; the attestation story still works because the image hash you build is the hash your enclave reports.</p>
   </div>
 </section>
+
 {% endblock %}

--- a/src/trusted_router/templates/public/seo_claude_api_privacy.html
+++ b/src/trusted_router/templates/public/seo_claude_api_privacy.html
@@ -1,0 +1,91 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Claude API privacy via TrustedRouter">
+  <div class="marketing-copy">
+    <span class="eyebrow">Claude API privacy</span>
+    <h2>Call Claude through a prompt path you can verify.</h2>
+    <p>Anthropic's privacy posture is one of the best in the industry. But the path between your code and Anthropic still matters — and most routing layers are closed-source black boxes.</p>
+    <p>TrustedRouter routes to Claude (and 30+ other providers) through a hardware-attested, open-source gateway. Anthropic's privacy claims plus a verifiable router on top.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try Claude Sonnet in the playground</a>
+      <a class="btn" href="/security">How attestation works</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Claude via TR</span><span>Anthropic + OpenAI SDKs</span></div>
+    <pre><code># Anthropic SDK
+from anthropic import Anthropic
+client = Anthropic(
+    base_url="{{ api_base_url|replace('/v1', '') }}",
+    api_key="sk-tr-v1-..."
+)
+
+# Or via OpenAI-compat SDK
+from openai import OpenAI
+client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-..."
+)
+
+resp = client.chat.completions.create(
+    model="anthropic/claude-sonnet-4.6",
+    messages=[{"role": "user", "content": "hi"}],
+)</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">No router logs</span>
+    <h3>TR doesn't store your prompts.</h3>
+    <p>Attested gateway never writes request or response bodies. Verifiable in source. Anthropic's own privacy policy applies upstream.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Models you want</span>
+    <h3>Sonnet 4.6, Opus 4.7, Haiku 4.5.</h3>
+    <p>Plus the older 3.x family, plus the full models from OpenAI, Google, Meta, Mistral, Z.AI, DeepSeek, Kimi, MiniMax. Same API, one key.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Verifiable</span>
+    <h3>Hash-check the gateway image.</h3>
+    <p>Fetch /attestation, grab the image_digest, compare to the published artifact. Now you know what code is between you and Anthropic.</p>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">When you'd use TR for Claude</span>
+    <h2>You want Anthropic + something more.</h2>
+  </div>
+  <div>
+    <p><strong>Audit-driven routing.</strong> Your security team needs to read the router code. Anthropic's API is closed; TR's router is open.</p>
+    <p><strong>Provider fallback.</strong> Anthropic has occasional API hiccups. TR's pool falls over to GPT, Gemini, or other Claude-class models on a hard failure.</p>
+    <p><strong>Comparison playground.</strong> Try the same prompt across Claude, GPT, Gemini, Kimi side-by-side at trustedrouter.com/chat — no per-provider setup.</p>
+    <p><strong>Unified billing.</strong> One TR contract, one invoice, one usage dashboard. No per-provider account sprawl.</p>
+    <p><strong>Self-host.</strong> Run TR inside your own VPC for HIPAA, FedRAMP, or air-gapped environments. Anthropic-via-TR still works because the routing image is verifiable.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="Claude via TR comparison">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>Anthropic direct</strong><strong>Claude via TR</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Anthropic privacy posture</span><span>Anthropic's policy</span><span>Anthropic's policy (passthrough)</span>
+  </div>
+  <div class="matrix-row">
+    <span>Router code</span><span>n/a</span><span>Open source, attested</span>
+  </div>
+  <div class="matrix-row">
+    <span>Multi-model</span><span>Claude only</span><span>Claude + 30 more providers, same API</span>
+  </div>
+  <div class="matrix-row">
+    <span>Failover</span><span>Manual</span><span>Automatic on hard failures</span>
+  </div>
+  <div class="matrix-row">
+    <span>Unified billing</span><span>Per-provider</span><span>One invoice</span>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_hipaa_llm_api.html
+++ b/src/trusted_router/templates/public/seo_hipaa_llm_api.html
@@ -1,0 +1,71 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="HIPAA-compatible LLM API">
+  <div class="marketing-copy">
+    <span class="eyebrow">HIPAA-compatible LLM routing</span>
+    <h2>The LLM API whose privacy posture is verifiable, not just contractual.</h2>
+    <p>HIPAA covered entities and their business associates can't legally route PHI through a service whose data-handling claims they can't audit.</p>
+    <p>TrustedRouter's prompt path runs inside a hardware-attested gateway. The source is open. The image hash is published. Privacy isn't promised — it's checkable.</p>
+    <p>
+      <a class="btn primary" href="/security">Security architecture</a>
+      <a class="btn" href="/chat">Try in playground</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Verify the gateway</span><span>curl</span></div>
+    <pre><code># Live attestation, bound to a nonce
+NONCE=$(openssl rand -hex 16)
+curl -s "{{ api_base_url|replace('/v1', '') }}/attestation?nonce=$NONCE"
+
+# Returns a JWT signed by the CPU's root key.
+# image_digest matches the artifact published at
+# trustedrouter.com/security — verifiable end to end.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">No retention</span>
+    <h3>Prompts and outputs aren't stored.</h3>
+    <p>The attested binary never writes request or response bodies. Token counts and metadata only. The schema is in source.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Verifiable</span>
+    <h3>Read the code that handles PHI.</h3>
+    <p>Every byte that touches a prompt body flows through open-source code you can audit. Your security team doesn't have to take our word.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Multi-provider</span>
+    <h3>Route to providers with strong posture.</h3>
+    <p>Anthropic Claude, GPT-5, Gemini, Llama via Tinfoil, GLM, DeepSeek — pick by published per-provider retention and ZDR status.</p>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">What HIPAA buyers actually need</span>
+    <h2>Verifiability beats audit theater.</h2>
+  </div>
+  <div>
+    <p><strong>An auditable prompt path.</strong> Open source lets your security team trace exactly what happens to PHI from request entry to provider hand-off. No reverse engineering.</p>
+    <p><strong>Provider transparency.</strong> Each model page publishes the upstream provider's posture — zero-retention contracts, confidential compute, end-to-end encryption claims — with links to source. You route deliberately.</p>
+    <p><strong>BAA where it matters.</strong> Direct BAAs with TR + the upstream provider you select. The attestation gives you what BAAs can't: cryptographic proof of which code processed a specific request.</p>
+    <p><strong>Fail-closed gateway.</strong> If attestation can't verify, the gateway stops accepting requests. There is no degraded mode that processes PHI without proof.</p>
+    <p><strong>Self-host option.</strong> Run the same open-source gateway inside your own VPC. Same image hash, same attestation chain, same verifiability.</p>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">Honest scope</span>
+    <h2>What attestation doesn't cover.</h2>
+  </div>
+  <div>
+    <p>Attestation proves the running binary is the published binary. It doesn't prove the binary is bug-free — open-source code can have flaws and we welcome reports.</p>
+    <p>It doesn't bypass nation-state actors with physical access to the cloud provider. The threat model is "operator can't see PHI" + "code is what was published," not "absolute secrecy from all adversaries."</p>
+    <p>Upstream providers handle prompts according to their own policies. We publish each one's posture on the model pages so you can route accordingly.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_openrouter_alternative.html
+++ b/src/trusted_router/templates/public/seo_openrouter_alternative.html
@@ -1,0 +1,80 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="OpenRouter alternative">
+  <div class="marketing-copy">
+    <span class="eyebrow">OpenRouter alternative</span>
+    <h2>An OpenRouter alternative built around verifiable privacy.</h2>
+    <p>TrustedRouter is OpenAI-compatible, supports the same model catalog, and adds two things OpenRouter does not: hardware-attested execution and full open-source code.</p>
+    <p>You change one URL. Your existing code keeps working.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try side-by-side</a>
+      <a class="btn" href="/compare/openrouter">Detailed comparison</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>One line</span><span>OpenAI SDK</span></div>
+    <pre><code>client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-..."
+)
+# Same model IDs. Same SDK. Same code.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Privacy</span>
+    <h3>No prompt or output logs.</h3>
+    <p>The attested gateway never persists request or response bodies. You can verify this by reading the open source.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Attestation</span>
+    <h3>Cryptographic, not contractual.</h3>
+    <p>AWS Nitro Enclaves and GCP Confidential VMs sign the running image. Cross-cloud so a single vendor breach doesn't take everything.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Open source</span>
+    <h3>Every line that touches your prompt.</h3>
+    <p>Control plane, gateway, configuration, web UI. Self-host if you want; the attestation story still works.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="OpenRouter alternative comparison">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>OpenRouter</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>API compatibility</span><span>OpenAI compatible</span><span>OpenAI compatible</span>
+  </div>
+  <div class="matrix-row">
+    <span>Source code</span><span>Closed</span><span>Open</span>
+  </div>
+  <div class="matrix-row">
+    <span>Prompt path</span><span>Hosted, opaque</span><span>Hardware-attested, verifiable</span>
+  </div>
+  <div class="matrix-row">
+    <span>Logging</span><span>Retention policy</span><span>None by construction</span>
+  </div>
+  <div class="matrix-row">
+    <span>Self-host</span><span>No</span><span>Yes</span>
+  </div>
+  <div class="matrix-row">
+    <span>Status SLOs</span><span>Status page</span><span>99.99% target with public burn-rate alerts</span>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">When to use TR over OpenRouter</span>
+    <h2>The teams switching over.</h2>
+  </div>
+  <div>
+    <p><strong>Privacy-sensitive workloads.</strong> Medical, legal, financial, internal tooling. Anywhere prompts shouldn't leave a hardware-attested boundary.</p>
+    <p><strong>Regulated industries.</strong> HIPAA, FINRA, GDPR-strict deployments where "no logging" needs to be verifiable, not promised.</p>
+    <p><strong>Audited routing.</strong> Build-vs-buy decisions where the security review team needs to read the routing code.</p>
+    <p><strong>Self-hosters.</strong> Run TrustedRouter inside your own VPC and keep attestation working — your image hash is your image hash.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_private_llm_api.html
+++ b/src/trusted_router/templates/public/seo_private_llm_api.html
@@ -1,0 +1,84 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Private LLM API">
+  <div class="marketing-copy">
+    <span class="eyebrow">Private LLM API</span>
+    <h2>A private LLM API where "private" means cryptographically verified.</h2>
+    <p>Every hosted LLM provider claims privacy. Almost none of them give you a way to verify it.</p>
+    <p>TrustedRouter routes to every major model — Claude, GPT, Gemini, DeepSeek, Kimi, Llama, Mistral — through a hardware-attested gateway. The code is open source. The image is hashed. You can check what runs.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try the playground</a>
+      <a class="btn" href="/security">Trust surface</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Standard call</span><span>OpenAI SDK</span></div>
+    <pre><code>client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-..."
+)
+
+resp = client.chat.completions.create(
+    model="anthropic/claude-sonnet-4.6",
+    messages=[
+        {"role": "user", "content": "your prompt"}
+    ],
+)
+# No logs. Source verified. Attestation on demand.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Verifiable</span>
+    <h3>Read the source.</h3>
+    <p>Every line that handles your prompt is on GitHub. Search it. Audit it. Run it locally if you want.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Attested</span>
+    <h3>Hardware-rooted trust.</h3>
+    <p>The gateway runs inside AWS Nitro Enclaves and GCP Confidential VMs. The CPU signs the running image. You verify the signature.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Fail-closed</span>
+    <h3>No request without attestation.</h3>
+    <p>If the gateway can't prove its own integrity, traffic stops. The synthetic monitor probes this every minute and pages on the first miss.</p>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">What "private" actually means here</span>
+    <h2>Things that are zero, with proof.</h2>
+  </div>
+  <div>
+    <p><strong>Prompt body.</strong> Never written to disk. Never shipped to a logging service. The binary doesn't open a write handle to a prompt path. You can grep for this.</p>
+    <p><strong>Output body.</strong> Same. The streamed response goes from upstream provider straight back to you. TR sees it in transit; it never persists.</p>
+    <p><strong>Per-request audit trail.</strong> What TR <em>does</em> log: token counts, timestamps, model id, region, billing. No content. The schema is in the open-source code.</p>
+    <p><strong>Upstream provider behavior.</strong> Out of TR's control. We publish each provider's known retention and ZDR posture on every model page so you can route deliberately.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="Private LLM API comparison">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>Direct provider</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Privacy claim</span><span>Privacy policy</span><span>Verifiable in source + attestation</span>
+  </div>
+  <div class="matrix-row">
+    <span>Source</span><span>Closed</span><span>Open</span>
+  </div>
+  <div class="matrix-row">
+    <span>Multi-model</span><span>One provider</span><span>30+ providers, one API</span>
+  </div>
+  <div class="matrix-row">
+    <span>Provider rollover</span><span>No</span><span>Yes — automatic on failure</span>
+  </div>
+  <div class="matrix-row">
+    <span>Self-host</span><span>No</span><span>Yes</span>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_zero_data_retention.html
+++ b/src/trusted_router/templates/public/seo_zero_data_retention.html
@@ -1,0 +1,89 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Zero data retention LLM API">
+  <div class="marketing-copy">
+    <span class="eyebrow">Zero data retention</span>
+    <h2>Zero data retention as a verifiable property, not a contract clause.</h2>
+    <p>"ZDR" usually means a clause in your enterprise agreement. The operator promises not to retain. You hope they comply.</p>
+    <p>TrustedRouter's prompt path never writes request or response bodies to persistent storage. The code that handles your prompts is open-source. The image hash is published. You can verify that retention is zero — without trusting us.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try the playground</a>
+      <a class="btn" href="/security">Trust surface</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>What gets logged — schema</span><span>open source</span></div>
+    <pre><code># Per-request record (token counts, timing, model id)
+{
+  "request_id": "req_...",
+  "workspace_id": "...",
+  "model_id": "anthropic/claude-sonnet-4.6",
+  "input_tokens": 12,
+  "output_tokens": 84,
+  "cost_microdollars": 218,
+  "provider": "anthropic",
+  "region": "us-central1",
+  "created_at": "..."
+}
+# What's NOT in here:
+#   - prompt body
+#   - response body
+#   - user inputs of any kind
+# Audit the schema:
+#   github.com/.../storage_models.py</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Structural</span>
+    <h3>Zero, by construction.</h3>
+    <p>The attested binary doesn't open a write handle to a prompt path. The retention isn't a policy choice; it's a structural property of the code.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Verifiable</span>
+    <h3>Check it yourself.</h3>
+    <p>Grep the source for any code that touches request bodies. There isn't any. The image hash you build is the hash the enclave reports.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">End-to-end</span>
+    <h3>Including upstream where possible.</h3>
+    <p>For providers with their own ZDR posture (Anthropic, OpenAI Enterprise, Tinfoil, GCP Confidential), we route under their stronger guarantees and surface that on each model page.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="ZDR comparison">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>Typical ZDR clause</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Enforcement</span><span>Contractual</span><span>Structural — in source</span>
+  </div>
+  <div class="matrix-row">
+    <span>Audit path</span><span>SOC 2 + breach disclosure</span><span>Read the open-source binary + hash check</span>
+  </div>
+  <div class="matrix-row">
+    <span>Operator privilege</span><span>Operator can change behavior</span><span>Operator can't change without breaking attestation</span>
+  </div>
+  <div class="matrix-row">
+    <span>Multi-provider</span><span>Per-provider negotiation</span><span>One TR contract, route across providers</span>
+  </div>
+  <div class="matrix-row">
+    <span>Self-host</span><span>Usually not available</span><span>Yes — same attestation chain</span>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">The honest limits</span>
+    <h2>What ZDR doesn't cover.</h2>
+  </div>
+  <div>
+    <p>Upstream providers have their own retention behavior. We can route to providers that match your posture and we publish each one's known stance on the model pages.</p>
+    <p>Attestation proves the running binary is the published binary. It doesn't prove the binary is bug-free.</p>
+    <p>If you can't trust AWS or GCP's hardware root keys at all, the attestation chain doesn't save you. Cross-cloud helps — TR runs on both — but it doesn't eliminate the dependency.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -9,17 +9,25 @@ from trusted_router.storage import STORE
 
 def test_revenue_pages_are_public(client: TestClient) -> None:
     markers = {
-        "/compare/openrouter": "Routing convenience with a prompt path you can inspect.",
+        "/compare/openrouter": "OpenRouter, but you can verify the prompt path.",
         "/compare/vercel-ai-gateway": "Use Vercel where it fits.",
         "/compare/litellm": "LiteLLM for your own infra",
         "/docs/migrate-from-openrouter": "Change base_url",
         "/security": "TrustedRouter does not store prompt or output content by default.",
+        # SEO landing pages — each targets a high-intent buyer query.
+        # The marker is a load-bearing headline from the page so a
+        # silent template breakage gets caught here.
+        "/openrouter-alternative": "An OpenRouter alternative built around verifiable privacy.",
+        "/private-llm-api": "A private LLM API where \"private\" means cryptographically verified.",
+        "/hipaa-llm-api": "The LLM API whose privacy posture is verifiable",
+        "/llm-zero-data-retention": "Zero data retention as a verifiable property",
+        "/claude-api-privacy": "Call Claude through a prompt path you can verify.",
     }
 
     for path, marker in markers.items():
         response = client.get(path)
-        assert response.status_code == 200
-        assert marker in response.text
+        assert response.status_code == 200, f"{path} returned {response.status_code}"
+        assert marker in response.text, f"{path} missing marker {marker!r}"
         assert "Approved short copy only" not in response.text
         assert "OpenAI compatible API" in response.text
         assert "Invalid API key" not in response.text


### PR DESCRIPTION
**#6 + #7 from the marketing list.** Concrete, indexable, ready to drive conversion.

## /compare/openrouter — full rewrite
- Before/after Python SDK split-screen (one line changes)
- Comparison matrix expanded (prompt logging, source, fallback, SLOs)
- Second split-screen showing live attestation verification in curl
- FAQ for the boring objections (keys, catalog, pricing, BYOK, self-host)

## 5 new SEO landing pages (top-level slugs, in sitemap)
- `/openrouter-alternative` — direct buyer-intent
- `/private-llm-api` — verifiable privacy
- `/hipaa-llm-api` — for covered entities
- `/llm-zero-data-retention` — structural ZDR vs contractual ZDR
- `/claude-api-privacy` — Claude-specific buyer intent

Each is self-contained: H2 above fold, one runnable code sample, one comparison table, two CTAs to `/chat`.

Bonus: `docs/blog-drafts/2026-06-02-attestation-is-all-you-need.md` draft (Joseph's voice) for jperla.com.

7/7 revenue page tests pass; all 5 SEO pages appear in /sitemap.xml.