### PR TITLE
feat(seo): 4 competitor/category landing pages + OG cards site-wide

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -71,6 +71,10 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/hipaa-llm-api",
     "/llm-zero-data-retention",
     "/claude-api-privacy",
+    "/litellm-alternative",
+    "/portkey-alternative",
+    "/confidential-computing-llm",
+    "/tinfoil-alternative",
     "/docs/migrate-from-openrouter",
 )
 _BENCHMARK_INDEX_LINKS: tuple[dict[str, str], ...] = (
@@ -269,6 +273,39 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "Anthropic's privacy posture plus a routing path you can verify."
         ),
     ),
+    # Competitor-alternative + category SEO pages (round 2).
+    "litellm-alternative": PublicPage(
+        template="public/seo_litellm_alternative.html",
+        title="LiteLLM Alternative — Self-Host and Verify It",
+        description=(
+            "A LiteLLM alternative that's self-hostable AND verifiable. "
+            "Hardware-attested gateway proves the no-logging guarantee."
+        ),
+    ),
+    "portkey-alternative": PublicPage(
+        template="public/seo_portkey_alternative.html",
+        title="Portkey Alternative — Routing Without Logging Every Prompt",
+        description=(
+            "A Portkey alternative for teams that can't store prompt content. "
+            "Usage metering without content logs, verifiable in source."
+        ),
+    ),
+    "confidential-computing-llm": PublicPage(
+        template="public/seo_confidential_computing_llm.html",
+        title="Confidential Computing for LLMs — TrustedRouter",
+        description=(
+            "Run LLM inference behind hardware attestation across every provider. "
+            "AWS Nitro Enclaves and GCP Confidential VMs, with remote attestation."
+        ),
+    ),
+    "tinfoil-alternative": PublicPage(
+        template="public/seo_tinfoil_alternative.html",
+        title="Tinfoil Alternative — Verifiable Privacy, Every Provider",
+        description=(
+            "Same verifiable-privacy bet as Tinfoil, applied as a router. "
+            "Attested, no-log gateway across 30+ providers with one API."
+        ),
+    ),
 }
 
 
@@ -355,6 +392,10 @@ def public_page_html(settings: Settings, page_key: str) -> str:
         title=f"{page.title} | TrustedRouter",
         heading=page.title,
         description=page.description,
+        # Absolute, environment-correct card URL so link unfurls work
+        # in staging/preview too; _base.html falls back to the prod
+        # card if this isn't passed.
+        og_image=f"https://{settings.trusted_domain}/og.png",
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,
         static_version=_static_version(settings),

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -172,6 +172,22 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def seo_claude_api_privacy() -> str:
         return public_page_html(settings, "claude-api-privacy")
 
+    @public_html_route("/litellm-alternative")
+    async def seo_litellm_alternative() -> str:
+        return public_page_html(settings, "litellm-alternative")
+
+    @public_html_route("/portkey-alternative")
+    async def seo_portkey_alternative() -> str:
+        return public_page_html(settings, "portkey-alternative")
+
+    @public_html_route("/confidential-computing-llm")
+    async def seo_confidential_computing_llm() -> str:
+        return public_page_html(settings, "confidential-computing-llm")
+
+    @public_html_route("/tinfoil-alternative")
+    async def seo_tinfoil_alternative() -> str:
+        return public_page_html(settings, "tinfoil-alternative")
+
     @public_html_route("/security")
     async def security() -> str:
         return public_page_html(settings, "security")

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -6,6 +6,27 @@
   <title>{{ title }}</title>
   <meta name="description" content="{{ description }}">
   <link rel="canonical" href="{{ site_url }}">
+  {# Open Graph + Twitter card so every public/SEO page unfurls with its
+     own title + description and the branded card image, instead of a
+     blank link preview on X / LinkedIn / Slack / iMessage. Uses the
+     per-page `title`/`description`/`site_url` already passed to every
+     template; `og_image` is threaded from public_page_html and falls
+     back to the prod card. #}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="TrustedRouter">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:url" content="{{ site_url }}">
+  <meta property="og:image" content="{{ og_image|default('https://trustedrouter.com/og.png') }}">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="TrustedRouter — verifiable, attested AI routing">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@jperla">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description }}">
+  <meta name="twitter:image" content="{{ og_image|default('https://trustedrouter.com/og.png') }}">
   <link rel="stylesheet" href="/static/dashboard.css?v={{ static_version|default('local') }}">
   {% if json_ld_blob %}
   {# Page-specific structured data (e.g. Product/Offer schema on the

--- a/src/trusted_router/templates/public/seo_confidential_computing_llm.html
+++ b/src/trusted_router/templates/public/seo_confidential_computing_llm.html
@@ -1,0 +1,64 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Confidential computing for LLMs">
+  <div class="marketing-copy">
+    <span class="eyebrow">Confidential computing for LLMs</span>
+    <h2>Run LLM inference behind hardware attestation — across every provider.</h2>
+    <p>Confidential computing has been deployable since 2018. The industry just never put inference behind it. TrustedRouter does: the gateway runs inside AWS Nitro Enclaves and GCP Confidential VMs, and signs the exact binary it's running.</p>
+    <p>You challenge it with a nonce, get a JWT signed by the CPU's hardware root key, and match the image digest to the open-source build. That's confidential computing applied to the one data path that's becoming the most sensitive: your prompts.</p>
+    <p>
+      <a class="btn primary" href="/security">See the attestation flow</a>
+      <a class="btn" href="/chat">Try the playground</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Challenge the enclave</span><span>curl</span></div>
+    <pre><code>NONCE=$(openssl rand -hex 16)
+curl -s "{{ api_base_url|replace('/v1', '') }}/attestation?nonce=$NONCE" | jq .
+
+# JWT signed by the hardware root key:
+#   eat_nonce     your nonce (replay-protected)
+#   image_digest  SHA-256 of the running container
+#   pcrs          boot-time platform measurements</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">TEE-backed</span>
+    <h3>Hardware root of trust.</h3>
+    <p>Nitro Enclaves and GCP Confidential VMs isolate the gateway from the host. Even the cloud operator can't read what's inside.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Cross-cloud</span>
+    <h3>No single-vendor dependency.</h3>
+    <p>Attested on both AWS and GCP. A single vendor's compromise is detectable by divergence, not silent.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Remote attestation</span>
+    <h3>Verify before you trust.</h3>
+    <p>The nonce-bound attestation endpoint lets any client confirm the running image on demand — not just at deploy, but per request.</p>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">Why this is the missing piece</span>
+    <h2>The overhead is gone. The excuse is gone.</h2>
+  </div>
+  <div>
+    <p>Nitro enclave overhead is single-digit milliseconds. GCP confidential VM overhead is the same. There's no longer a performance reason to run inference outside a TEE — only inertia.</p>
+    <p>TrustedRouter makes confidential inference a one-line base_url change, across 30+ providers, with the attestation exposed for you to check.</p>
+    <p>The full argument: <a href="https://jperla.com/blog/attestation-is-all-you-need">&ldquo;Attestation is All You Need&rdquo;</a>.</p>
+  </div>
+</section>
+
+<section class="limitation-band">
+  <span class="pill warn">Honest scope</span>
+  <div>
+    <p>Attestation proves the running binary is the published binary on hardware you can challenge. It does not defeat a nation-state with physical access to the host, and it does not prove the open-source binary is bug-free. The trust anchor is the chip vendor's root key. Cross-cloud narrows that dependency; it does not remove it.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_litellm_alternative.html
+++ b/src/trusted_router/templates/public/seo_litellm_alternative.html
@@ -1,0 +1,80 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="LiteLLM alternative">
+  <div class="marketing-copy">
+    <span class="eyebrow">LiteLLM alternative</span>
+    <h2>LiteLLM lets you self-host. TrustedRouter lets you self-host <em>and</em> prove it.</h2>
+    <p>LiteLLM is a great open-source proxy: one OpenAI-compatible API across 100+ models, runs in your own infra. The gap is verification — once it's deployed, nobody outside your ops team can confirm what the running proxy actually does with a prompt.</p>
+    <p>TrustedRouter closes that gap. The gateway runs in hardware enclaves and signs the exact binary it's running, so the no-logging guarantee is cryptographically checkable — by you, your auditors, or your customers.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try the playground</a>
+      <a class="btn" href="/security">How verification works</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Same OpenAI-compatible shape</span><span>Python</span></div>
+    <pre><code>client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-..."
+)
+# Drop-in for any LiteLLM proxy integration.
+# Self-host TR too — your built image hash is the
+# hash your enclave reports, so attestation holds.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Self-host</span>
+    <h3>Run it in your own VPC.</h3>
+    <p>Like LiteLLM, the full stack is open source and self-hostable. Unlike LiteLLM, the deployment is attestable end to end.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Verifiable</span>
+    <h3>Prove the no-log claim.</h3>
+    <p>Build the image, deploy to a confidential VM, and the attestation reports your hash. Your security team verifies instead of trusting your runbook.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Hosted option</span>
+    <h3>Or skip the ops entirely.</h3>
+    <p>Don't want to run a proxy? Use the hosted attested gateway at api.quillrouter.com — same verification, zero infra.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="LiteLLM vs TrustedRouter">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>LiteLLM</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Open source</span><span>Yes</span><span>Yes</span>
+  </div>
+  <div class="matrix-row">
+    <span>Self-host</span><span>Yes</span><span>Yes</span>
+  </div>
+  <div class="matrix-row">
+    <span>Hosted option</span><span>LiteLLM Cloud</span><span>Attested hosted gateway</span>
+  </div>
+  <div class="matrix-row">
+    <span>Verifiable runtime</span><span>No — trust your deploy</span><span>Yes — hardware attestation</span>
+  </div>
+  <div class="matrix-row">
+    <span>No-log guarantee</span><span>Configurable</span><span>Structural + verifiable in source</span>
+  </div>
+  <div class="matrix-row">
+    <span>Best fit</span><span>Teams that want a self-hosted proxy</span><span>Teams that must <em>prove</em> what the proxy does</span>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">When to choose TR over LiteLLM</span>
+    <h2>When "trust our deployment" isn't enough.</h2>
+  </div>
+  <div>
+    <p>If your security review, your customers, or your regulator needs evidence — not assurances — that prompts aren't logged, a self-hosted proxy alone doesn't get you there. Attestation does.</p>
+    <p>Read the full argument: <a href="https://jperla.com/blog/attestation-is-all-you-need">&ldquo;Attestation is All You Need&rdquo;</a>.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_portkey_alternative.html
+++ b/src/trusted_router/templates/public/seo_portkey_alternative.html
@@ -1,0 +1,83 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Portkey alternative">
+  <div class="marketing-copy">
+    <span class="eyebrow">Portkey alternative</span>
+    <h2>Portkey logs every request. TrustedRouter logs none of them — and proves it.</h2>
+    <p>Portkey is built around observability: it captures every request, response, and trace so you can monitor and govern AI usage. That's exactly what you want for some workloads — and exactly what you can't have for sensitive ones.</p>
+    <p>TrustedRouter takes the opposite stance. Prompt and output bodies are never persisted, the gateway is hardware-attested, and the whole thing is open source. You get routing, fallback, and usage metering without a copy of every prompt sitting in a logging backend.</p>
+    <p>
+      <a class="btn primary" href="/chat">Try the playground</a>
+      <a class="btn" href="/security">Trust surface</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Metadata only — the full log schema</span><span>open source</span></div>
+    <pre><code>{
+  "model_id": "anthropic/claude-sonnet-4.6",
+  "input_tokens": 12,
+  "output_tokens": 84,
+  "cost_microdollars": 218,
+  "provider": "anthropic",
+  "region": "us-central1"
+}
+# No prompt body. No response body. No content.
+# Verify the schema in the open-source code.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Usage tracking</span>
+    <h3>Metering without content.</h3>
+    <p>Token counts, cost, latency, model, region — everything you need for billing and capacity, none of the prompt content.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">No content logs</span>
+    <h3>By construction, not config.</h3>
+    <p>The attested binary never writes request or response bodies. It isn't a toggle you can forget to set; it's a property of the code you can verify.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Routing + fallback</span>
+    <h3>The gateway features you came for.</h3>
+    <p>30+ providers, automatic rollover on failure, BYOK, prepaid credits — the control-plane conveniences, minus the surveillance.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="Portkey vs TrustedRouter">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>Portkey</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Core stance</span><span>Log everything for control</span><span>Log nothing, prove it</span>
+  </div>
+  <div class="matrix-row">
+    <span>Prompt content</span><span>Captured + stored</span><span>Never persisted</span>
+  </div>
+  <div class="matrix-row">
+    <span>Source</span><span>Closed</span><span>Open</span>
+  </div>
+  <div class="matrix-row">
+    <span>Runtime trust</span><span>Hosted policy</span><span>Hardware attestation</span>
+  </div>
+  <div class="matrix-row">
+    <span>Usage metering</span><span>Yes (full content)</span><span>Yes (metadata only)</span>
+  </div>
+  <div class="matrix-row">
+    <span>Best fit</span><span>Teams that want full request observability</span><span>Teams that can't keep prompt copies</span>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">Two valid philosophies</span>
+    <h2>Pick by what you're allowed to store.</h2>
+  </div>
+  <div>
+    <p>If you need to replay and inspect every request, an observability-first gateway is the right tool. If a stored copy of a prompt is a liability — PHI, privileged material, proprietary code — you need the opposite: a path that provably keeps nothing.</p>
+    <p>Why we built around proof: <a href="https://jperla.com/blog/attestation-is-all-you-need">&ldquo;Attestation is All You Need&rdquo;</a>.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_tinfoil_alternative.html
+++ b/src/trusted_router/templates/public/seo_tinfoil_alternative.html
@@ -1,0 +1,86 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Tinfoil alternative">
+  <div class="marketing-copy">
+    <span class="eyebrow">Tinfoil alternative</span>
+    <h2>Same verifiable-privacy bet. TrustedRouter routes across every provider.</h2>
+    <p>Tinfoil pioneered verifiable confidential inference, and the thesis is right: attestation beats a privacy policy. TrustedRouter shares it — and applies it as a <em>router</em>, not a single inference endpoint.</p>
+    <p>That means you keep model choice. Route the same attested, no-log gateway to Claude, GPT, Gemini, DeepSeek, Kimi, Llama, Mistral and 20+ more, with automatic fallback, one OpenAI-compatible API, and one key.</p>
+    <p>
+      <a class="btn primary" href="/chat">Compare models in the playground</a>
+      <a class="btn" href="/security">How attestation works</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>One API, every provider</span><span>Python</span></div>
+    <pre><code>client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-..."
+)
+
+# Same attested gateway, any model:
+for model in ["anthropic/claude-sonnet-4.6",
+              "openai/gpt-5.5",
+              "deepseek/deepseek-v4-flash"]:
+    client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+    )</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Shared thesis</span>
+    <h3>Verify, don't trust.</h3>
+    <p>Hardware attestation + open source. We agree with Tinfoil on the principle — privacy you can check beats privacy you're promised.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Router, not endpoint</span>
+    <h3>30+ providers, one key.</h3>
+    <p>Don't pick a single confidential model — route the attested gateway to the best model for each job, with fallback when one is down.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Drop-in</span>
+    <h3>OpenAI-compatible.</h3>
+    <p>Change one base_url and keep your existing SDK, model IDs, and code. Migrate an existing OpenRouter or OpenAI integration in minutes.</p>
+  </div>
+</section>
+
+<section class="compare-matrix" aria-label="Tinfoil vs TrustedRouter">
+  <div class="matrix-row matrix-head">
+    <span></span><strong>Tinfoil</strong><strong>TrustedRouter</strong>
+  </div>
+  <div class="matrix-row">
+    <span>Attestation</span><span>Yes</span><span>Yes</span>
+  </div>
+  <div class="matrix-row">
+    <span>Open source</span><span>Yes</span><span>Yes</span>
+  </div>
+  <div class="matrix-row">
+    <span>Shape</span><span>Confidential inference</span><span>Multi-provider router</span>
+  </div>
+  <div class="matrix-row">
+    <span>Model choice</span><span>Hosted model set</span><span>30+ providers, switchable per call</span>
+  </div>
+  <div class="matrix-row">
+    <span>Provider fallback</span><span>n/a</span><span>Automatic rollover</span>
+  </div>
+  <div class="matrix-row">
+    <span>Best fit</span><span>A confidential endpoint for chosen models</span><span>Verifiable routing across the whole model market</span>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">Same destination, wider road</span>
+    <h2>Attestation should cover the whole market, not one endpoint.</h2>
+  </div>
+  <div>
+    <p>The future where every prompt goes through an attested path shouldn't require giving up model choice. TrustedRouter is the bet that you can have both: verifiable privacy <em>and</em> the full provider market behind one API.</p>
+    <p>The argument in full: <a href="https://jperla.com/blog/attestation-is-all-you-need">&ldquo;Attestation is All You Need&rdquo;</a>.</p>
+  </div>
+</section>
+
+{% endblock %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -22,6 +22,11 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         "/hipaa-llm-api": "The LLM API whose privacy posture is verifiable",
         "/llm-zero-data-retention": "Zero data retention as a verifiable property",
         "/claude-api-privacy": "Call Claude through a prompt path you can verify.",
+        # Round-2 competitor-alternative + category pages.
+        "/litellm-alternative": "LiteLLM lets you self-host.",
+        "/portkey-alternative": "Portkey logs every request.",
+        "/confidential-computing-llm": "Run LLM inference behind hardware attestation",
+        "/tinfoil-alternative": "Same verifiable-privacy bet.",
     }
 
     for path, marker in markers.items():
@@ -32,6 +37,10 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         assert "OpenAI compatible API" in response.text
         assert "Invalid API key" not in response.text
         assert "Continue with MetaMask" in response.text
+        # Every public page must unfurl: og:title + a card image.
+        assert 'property="og:title"' in response.text, f"{path} missing og:title"
+        assert 'property="og:image"' in response.text, f"{path} missing og:image"
+        assert 'name="twitter:card"' in response.text, f"{path} missing twitter:card"
 
 
 def test_revenue_pages_support_link_checkers(client: TestClient) -> None:


### PR DESCRIPTION
Continues the marketing push.

**4 new SEO landing pages** (top-level slugs, in sitemap):
- `/litellm-alternative` — self-host AND verify
- `/portkey-alternative` — log-nothing vs log-everything
- `/confidential-computing-llm` — the TEE/attestation category query
- `/tinfoil-alternative` — honest 'same bet, but a router' framing (closest comp)

**OG cards site-wide**: `_base.html` had zero og:/twitter: tags, so all 14+ public/SEO pages + /chat unfurled blank on social. Added an Open Graph + Twitter summary_large_image block driven by per-page title/description + the branded og.png. Now every share looks professional.

7/7 revenue-page tests pass (extended to assert OG tags on every public page); 27 public/seo/dashboard tests green.