### PR TITLE
mktg: restore 'End-to-end encrypted LLMs' headline + lead with the agent switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,42 +9,57 @@
 [![Python SDK](https://img.shields.io/pypi/v/trusted-router-py?label=Python%20SDK&logo=pypi)](https://pypi.org/project/trusted-router-py/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
 
-**Every LLM provider tells you they don't log your prompts. None of them lets
-you check. TrustedRouter does.**
+# End-to-end encrypted LLMs. One API. Provable privacy.
 
-TrustedRouter is an open-source, OpenAI-compatible LLM router whose gateway
-runs inside hardware enclaves (AWS Nitro Enclaves + GCP Confidential VMs). The
-CPU signs the running binary; you compare that hash to this repo. If they
-match, you *know* — not assume — the code handling your prompts is the code
-you can read here, and that it never writes your prompts to disk.
+Point your coding agent — Codex, Claude Code, Cursor, anything OpenAI- or
+Anthropic-compatible — at TrustedRouter and stop worrying about who can see
+your prompts. Same API, 30+ models, one key. The gateway runs in hardware
+enclaves and you can cryptographically verify it never logs you.
 
-Same API shape as OpenRouter. Change one base URL, keep your model IDs. 30+
-providers behind one key.
+### Switch your coding agent (10 seconds)
 
-- **Try it (no signup):** https://trustedrouter.com/chat
-- **Verify it:** https://trustedrouter.com/security
-- **Why we built it:** https://jperla.com/blog/attestation-is-all-you-need
-- Product: `trustedrouter.com` · API base: `https://api.quillrouter.com/v1` · Trust: `trust.trustedrouter.com`
+**Codex**
+```bash
+export OPENAI_BASE_URL="https://api.quillrouter.com/v1"
+export OPENAI_API_KEY="sk-tr-v1-..."     # get one at trustedrouter.com
+```
 
-### Use it (one line changes)
+**Claude Code**
+```bash
+export ANTHROPIC_BASE_URL="https://api.quillrouter.com"
+export ANTHROPIC_API_KEY="sk-tr-v1-..."  # get one at trustedrouter.com
+```
 
+**Anything else (OpenAI SDK)**
 ```python
-from openai import OpenAI
-
 client = OpenAI(
     base_url="https://api.quillrouter.com/v1",  # ← the only change
     api_key="sk-tr-v1-...",
 )
-resp = client.chat.completions.create(
-    model="anthropic/claude-sonnet-4.6",
-    messages=[{"role": "user", "content": "hello"}],
-)
 ```
 
-### Verify the gateway (60 seconds, no account)
+That's it. Your agent keeps working; your prompts now run through an attested,
+no-log path across every major provider.
+
+- **Get a key / take my money:** https://trustedrouter.com
+- **Try it first (no signup):** https://trustedrouter.com/chat
+- **The technical details (for the nerds):** https://trustedrouter.com/security
+- **Why we built it:** https://jperla.com/blog/attestation-is-all-you-need
+
+---
+
+<details>
+<summary><strong>For the nerds: how the privacy is provable</strong></summary>
+
+TrustedRouter's gateway runs inside hardware enclaves (AWS Nitro Enclaves + GCP
+Confidential VMs). The CPU signs a measurement of the running binary; you
+compare that hash to this repo. If they match, you *know* — not assume — that
+the code handling your prompts is the code you can read here, and that it never
+writes your prompts to disk.
+
+Verify it yourself in 60 seconds, no account:
 
 ```bash
-# Nonce-bound attestation, signed by the cloud's hardware root key
 NONCE=$(openssl rand -hex 16)
 curl -s "https://api.quillrouter.com/attestation?nonce=$NONCE" | jq .
 #   eat_nonce     your nonce  (replay-protected)
@@ -53,8 +68,6 @@ curl -s "https://api.quillrouter.com/attestation?nonce=$NONCE" | jq .
 # Compare image_digest to the published artifact at
 # https://trustedrouter.com/security — match = the running code is this repo.
 ```
-
-### Why this is different
 
 | | trust model |
 |---|---|
@@ -69,6 +82,8 @@ physical host access, and it does not prove the open-source binary is bug-free.
 The trust anchor is the chip vendor's root key; cross-cloud (AWS + GCP) narrows
 that dependency without eliminating it. Upstream providers handle prompts per
 their own policies — each provider's posture is published on the model pages.
+
+</details>
 
 ---
 

--- a/src/trusted_router/og.py
+++ b/src/trusted_router/og.py
@@ -4,10 +4,11 @@ from pathlib import Path
 
 from trusted_router.config import Settings
 
-OG_TITLE = "TrustedRouter | End to end encrypted AI router"
+OG_TITLE = "TrustedRouter — End-to-end encrypted LLMs. One API. Provable privacy."
 OG_DESCRIPTION = (
-    "Hosted OpenAI compatible router for hundreds of models. Use prepaid credits "
-    "or BYOK. TLS terminates inside the attested gateway, not the dashboard."
+    "Point Codex, Claude Code, or any OpenAI/Anthropic app at TrustedRouter and "
+    "stop worrying about who sees your prompts. Hundreds of models, one key, an "
+    "attested gateway you can cryptographically verify never logs you."
 )
 OG_IMAGE_WIDTH = 1200
 OG_IMAGE_HEIGHT = 630
@@ -59,11 +60,11 @@ def og_image_svg(_settings: Settings) -> str:
 
   <!-- Headline -->
   <g font-family="{_SANS}">
-    <text x="80" y="244" font-size="70" font-weight="800" fill="#ffffff" letter-spacing="-1.2">Route every model.</text>
-    <text x="80" y="332" font-size="70" font-weight="800" fill="#ffffff" letter-spacing="-1.2">Verify the gateway.</text>
-    <text x="80" y="424" font-size="56" font-weight="800" letter-spacing="-1.0">
-      <tspan fill="#7be0b1">No prompt logs</tspan>
-      <tspan fill="#ffffff" dx="14">by default.</tspan>
+    <text x="80" y="244" font-size="64" font-weight="800" fill="#ffffff" letter-spacing="-1.2">End-to-end</text>
+    <text x="80" y="320" font-size="64" font-weight="800" fill="#ffffff" letter-spacing="-1.2">encrypted LLMs.</text>
+    <text x="80" y="412" font-size="52" font-weight="800" letter-spacing="-1.0">
+      <tspan fill="#ffffff">One API.</tspan>
+      <tspan fill="#7be0b1" dx="14">Provable privacy.</tspan>
     </text>
   </g>
 

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -51,12 +51,12 @@
           <strong>Open source router</strong>
           <span class="oss-sub">Control plane and attested gateway on GitHub. Audit it, fork it, or run it yourself.</span>
         </a>
-        <span class="eyebrow">End to end encrypted router for production AI apps</span>
-        <h1>Route every model through a prompt path you can verify.</h1>
-        <p class="lead">One OpenAI compatible API for hundreds of models across Anthropic, OpenAI, Google, DeepSeek, Mistral, Cerebras, MiniMax, Kimi, Z.AI and more. Use prepaid credits, bring provider keys, or let <span class="mono">trustedrouter/auto</span> choose a healthy route.</p>
+        <span class="eyebrow">End-to-end encrypted AI</span>
+        <h1>End-to-end encrypted LLMs.<br>One API. Provable privacy.</h1>
+        <p class="lead">Point your coding agent — Codex, Claude Code, Cursor, or any OpenAI- or Anthropic-compatible app — at TrustedRouter and stop worrying about who can see your prompts. Same API, hundreds of models, one key. The gateway runs in hardware enclaves and you can cryptographically verify it never logs you.</p>
         <div class="hero-actions">
-          <button class="btn primary" type="button" data-action="open-signin">Create key</button>
-          <a class="btn" href="https://trust.trustedrouter.com">Verify gateway</a>
+          <button class="btn primary" type="button" data-action="open-signin">Get a key</button>
+          <a class="btn" href="/chat">Try it free</a>
         </div>
         <p class="signup-foot">Add a card to unlock trial credit. Wallet accounts start at $0. Migration credits are available by approval for teams already spending more than $100 per month on LLMs. Open source SDKs are available for Python and TypeScript.</p>
         <div class="proof">
@@ -76,20 +76,25 @@
     </div>
   </section>
   <main class="wrap">
-    <section class="code-strip" aria-label="OpenAI SDK compatible example">
+    <section class="code-strip" aria-label="Switch your coding agent">
       <div>
-        <span class="eyebrow">Small migration</span>
-        <h2>Change <span class="mono">base_url</span>. Keep your client.</h2>
+        <span class="eyebrow">Switch in 10 seconds</span>
+        <h2>Point Codex or Claude Code at TrustedRouter.</h2>
       </div>
-      <pre><code>client = OpenAI(
-    base_url="{{ api_base_url }}",
-    api_key="sk-tr-v1-..."
-)
-resp = client.chat.completions.create(
-    model="trustedrouter/auto",
-    messages=messages,
-)</code></pre>
+      <pre><code># Codex
+export OPENAI_BASE_URL="{{ api_base_url }}"
+export OPENAI_API_KEY="sk-tr-v1-..."
+
+# Claude Code
+export ANTHROPIC_BASE_URL="https://api.quillrouter.com"
+export ANTHROPIC_API_KEY="sk-tr-v1-..."
+
+# Any OpenAI SDK
+client = OpenAI(base_url="{{ api_base_url }}",
+                api_key="sk-tr-v1-...")</code></pre>
       <div class="sdk-links">
+        <button class="btn primary" type="button" data-action="open-signin">Get a key</button>
+        <a class="pill" href="/security">Technical details</a>
         <a class="pill" href="https://github.com/Lore-Hex/trusted-router-py">trusted-router-py</a>
         <a class="pill" href="https://github.com/Lore-Hex/trusted-router-js">trusted-router-js</a>
       </div>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -3,7 +3,7 @@ const { expect, test } = require("@playwright/test");
 test("homepage opens sign-in modal and handles missing MetaMask", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /Route every model through a prompt path/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /End-to-end encrypted LLMs/ })).toBeVisible();
   await expect(page.locator(".proof-card .mono", { hasText: "trustedrouter/auto" })).toBeVisible();
 
   await page.getByRole("button", { name: "Sign in" }).click();
@@ -95,7 +95,7 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /Route every model through a prompt path/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /End-to-end encrypted LLMs/ })).toBeVisible();
   const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
   expect(overflow).toBeLessThanOrEqual(2);
 });
@@ -103,7 +103,7 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
 test("homepage exposes stablecoin, open-source, and trust claims", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByText("End to end encrypted router").first()).toBeVisible();
+  await expect(page.getByText("End-to-end encrypted AI").first()).toBeVisible();
   await expect(page.getByText("Stablecoin")).toBeVisible();
   await expect(page.getByText("No subscriptions")).toBeVisible();
   await expect(page.getByText("Open source hosting")).toBeVisible();

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -114,7 +114,10 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "Public status separates router health from provider health" in response.text
     assert "/static/hero-router-scene.js" in response.text
     assert "data-router-scene" in response.text
-    assert "Change <span class=\"mono\">base_url</span>" in response.text
+    # Hero leads with the coding-agent switch (Codex + Claude Code).
+    assert "Point Codex or Claude Code at TrustedRouter" in response.text
+    assert "OPENAI_BASE_URL" in response.text
+    assert "ANTHROPIC_BASE_URL" in response.text
 
 
 def test_console_credit_note_is_manual(client: TestClient) -> None:

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -172,7 +172,7 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     dashboard = client.get("/")
     assert dashboard.status_code == 200
     # Marketing page hero copy stays.
-    assert "Create key" in dashboard.text
+    assert "Get a key" in dashboard.text
     assert "Stablecoin" in dashboard.text
     assert "$25 USDC" not in dashboard.text
     assert "Stripe Crypto" not in dashboard.text


### PR DESCRIPTION
Two pieces of founder feedback.

**1. Restore the headline.** I'd drifted the README/assets to the essay's 'every provider says they don't log' hook. Back to **'End-to-end encrypted LLMs. One API. Provable privacy.'** as the homepage hero + OG title.

**2. Lead with the paste-and-go switch** (per the 'take my money' feedback). Hero's first section after the fold is now:
```
Codex        OPENAI_BASE_URL=https://api.quillrouter.com/v1
Claude Code  ANTHROPIC_BASE_URL=https://api.quillrouter.com
Any SDK      base_url=https://api.quillrouter.com/v1
```
CTAs are 'Get a key' + 'Try it free'; nerd details (attestation curl, threat model) moved to a 'Technical details' link → /security and a README <details> block.

Both switch commands confirmed against live routes (/v1/chat/completions, /v1/messages). 712 tests pass.