### PR TITLE
mktg: hero leads with 'tell your agent to move you over' flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,55 @@
 
 # End-to-end encrypted LLMs. One API. Provable privacy.
 
-Point your coding agent — Codex, Claude Code, Cursor, anything OpenAI- or
-Anthropic-compatible — at TrustedRouter and stop worrying about who can see
-your prompts. Same API, 30+ models, one key. The gateway runs in hardware
+Stop worrying about who can see your prompts. Tell your coding agent to move
+your project over, pick how private you want to be, pick a model, drop in a
+key — done. Same API, 30+ models, one key. The gateway runs in hardware
 enclaves and you can cryptographically verify it never logs you.
 
-### Switch your coding agent (10 seconds)
+### Move your project over in one prompt
 
-**Codex**
+Paste this into Codex, Claude Code, or Cursor — it does the migration for you:
+
+```text
+Migrate this project to TrustedRouter, a privacy-first LLM router
+(https://trustedrouter.com). Repoint my LLM client to base_url
+"https://api.quillrouter.com/v1" (or "https://api.quillrouter.com" for the
+Anthropic SDK), read the key from the TRUSTEDROUTER_API_KEY env var, and keep
+all my existing calls working.
+
+For maximum privacy, add the routing preference
+{"provider": {"data_collection": "deny"}} so only zero-retention providers
+are used.
+
+Then tell me to sign up at trustedrouter.com, add a card, and paste my sk-tr
+key into TRUSTEDROUTER_API_KEY.
+```
+
+Then:
+
+1. **Pick your privacy level** — end-to-end attested (default), or restrict to
+   zero-retention providers with `{"provider": {"data_collection": "deny"}}`.
+2. **Pick a model** — any of 30+, or `trustedrouter/auto` for automatic fallback.
+3. **Sign up, add a card, get your key** at https://trustedrouter.com.
+4. **Ship** — your prompts now run through a path you can verify.
+
+<details>
+<summary>Prefer to wire it by hand?</summary>
+
 ```bash
+# Codex
 export OPENAI_BASE_URL="https://api.quillrouter.com/v1"
-export OPENAI_API_KEY="sk-tr-v1-..."     # get one at trustedrouter.com
-```
+export OPENAI_API_KEY="sk-tr-v1-..."
 
-**Claude Code**
-```bash
+# Claude Code
 export ANTHROPIC_BASE_URL="https://api.quillrouter.com"
-export ANTHROPIC_API_KEY="sk-tr-v1-..."  # get one at trustedrouter.com
+export ANTHROPIC_API_KEY="sk-tr-v1-..."
 ```
-
-**Anything else (OpenAI SDK)**
 ```python
-client = OpenAI(
-    base_url="https://api.quillrouter.com/v1",  # ← the only change
-    api_key="sk-tr-v1-...",
-)
+# Any OpenAI SDK
+client = OpenAI(base_url="https://api.quillrouter.com/v1", api_key="sk-tr-v1-...")
 ```
-
-That's it. Your agent keeps working; your prompts now run through an attested,
-no-log path across every major provider.
+</details>
 
 - **Get a key / take my money:** https://trustedrouter.com
 - **Try it first (no signup):** https://trustedrouter.com/chat

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -78,6 +78,10 @@ code, .mono { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospa
 .code-strip pre { background:#0b121a; border:1px solid #263644; border-radius:8px; color:#d8e6f3; }
 .code-strip pre code { white-space:pre-wrap; overflow-wrap:anywhere; }
 .code-strip .pill { background:rgba(255,255,255,.08); color:#c8d7e5; border-color:rgba(255,255,255,.16); }
+.code-strip .sdk-links { display:flex; flex-direction:column; gap:8px; align-items:flex-start; }
+.switch-steps { margin:12px 0 0; padding-left:20px; display:grid; gap:7px; color:#c3d2df; font-size:13px; line-height:1.4; }
+.switch-steps li { padding-left:2px; }
+.switch-steps li::marker { color:#7be0b1; font-weight:750; }
 .wrap { max-width:1180px; margin:0 auto; padding:20px 22px 42px; display:grid; gap:18px; }
 .public-wrap { padding-top:28px; }
 .public-hero { background:#fff; border:1px solid var(--line); border-radius:8px; padding:28px; }

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -76,24 +76,34 @@
     </div>
   </section>
   <main class="wrap">
-    <section class="code-strip" aria-label="Switch your coding agent">
+    <section class="code-strip" aria-label="Move your project over in one prompt">
       <div>
-        <span class="eyebrow">Switch in 10 seconds</span>
-        <h2>Point Codex or Claude Code at TrustedRouter.</h2>
+        <span class="eyebrow">Move over in one prompt</span>
+        <h2>Tell your agent. Pick privacy + model. Get a key.</h2>
+        <ol class="switch-steps">
+          <li>Paste the prompt into Codex, Claude Code, or Cursor — it migrates your project.</li>
+          <li>Pick your privacy level: end-to-end attested (default) or zero-retention providers only.</li>
+          <li>Pick a model, or use <span class="mono">trustedrouter/auto</span> for automatic fallback.</li>
+          <li>Sign up, add a card, get your <span class="mono">sk-tr</span> key.</li>
+        </ol>
       </div>
-      <pre><code># Codex
-export OPENAI_BASE_URL="{{ api_base_url }}"
-export OPENAI_API_KEY="sk-tr-v1-..."
+      <pre><code># Paste into your coding agent:
+Migrate this project to TrustedRouter, a privacy-first
+LLM router (https://trustedrouter.com). Repoint my LLM
+client to base_url "{{ api_base_url }}" (or
+"https://api.quillrouter.com" for the Anthropic SDK),
+read the key from TRUSTEDROUTER_API_KEY, and keep all
+my existing calls working.
 
-# Claude Code
-export ANTHROPIC_BASE_URL="https://api.quillrouter.com"
-export ANTHROPIC_API_KEY="sk-tr-v1-..."
+For maximum privacy, add the routing preference
+{"provider": {"data_collection": "deny"}} so only
+zero-retention providers are used.
 
-# Any OpenAI SDK
-client = OpenAI(base_url="{{ api_base_url }}",
-                api_key="sk-tr-v1-...")</code></pre>
+Then tell me to sign up at trustedrouter.com, add a
+card, and paste my sk-tr key into TRUSTEDROUTER_API_KEY.</code></pre>
       <div class="sdk-links">
-        <button class="btn primary" type="button" data-action="open-signin">Get a key</button>
+        <button class="btn primary" type="button" data-action="open-signin">Sign up &amp; get a key</button>
+        <a class="pill" href="/chat">Try it free</a>
         <a class="pill" href="/security">Technical details</a>
         <a class="pill" href="https://github.com/Lore-Hex/trusted-router-py">trusted-router-py</a>
         <a class="pill" href="https://github.com/Lore-Hex/trusted-router-js">trusted-router-js</a>

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -114,10 +114,11 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "Public status separates router health from provider health" in response.text
     assert "/static/hero-router-scene.js" in response.text
     assert "data-router-scene" in response.text
-    # Hero leads with the coding-agent switch (Codex + Claude Code).
-    assert "Point Codex or Claude Code at TrustedRouter" in response.text
-    assert "OPENAI_BASE_URL" in response.text
-    assert "ANTHROPIC_BASE_URL" in response.text
+    # Hero leads with the "tell your agent to move you over" prompt flow.
+    assert "Move over in one prompt" in response.text
+    assert "Migrate this project to TrustedRouter" in response.text
+    assert "data_collection" in response.text  # privacy-level routing pref
+    assert "Sign up &amp; get a key" in response.text
 
 
 def test_console_credit_note_is_manual(client: TestClient) -> None:


### PR DESCRIPTION
Refined per founder feedback: the hook isn't 'export env vars,' it's **'paste one prompt and your agent migrates your project.'**

Homepage hero + README now lead with a paste-into-your-agent prompt that repoints the project to TrustedRouter, optionally pins zero-retention providers via `{"provider": {"data_collection": "deny"}}`, and tells the user to sign up + add a card + drop in their sk-tr key. A 4-step numbered flow sits beside it: pick privacy level (end-to-end / ZDR) → pick model → get key → ship. Manual env-var setup demoted to a 'wire it by hand' details block.

712 tests pass.