### PR TITLE
feat(routing): provider.min_privacy — pick your security level

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -35,6 +35,56 @@ class Provider:
     provider_policy_url: str | None = None
 
 
+# Privacy-posture tiers, lowest → highest. A request can demand a minimum
+# tier (provider.min_privacy in the routing prefs); the router then only
+# considers providers whose posture clears that bar. The tiers are nested:
+# every confidential provider is also zero-retention; every zero-retention
+# provider is also no-store.
+PRIVACY_TIER_STANDARD = 0   # no tracked posture (would store content)
+PRIVACY_TIER_NO_STORE = 1   # does not store request/response content
+PRIVACY_TIER_ZERO_RETENTION = 2  # contractual / policy zero data retention
+PRIVACY_TIER_CONFIDENTIAL = 3    # confidential compute + provider-side e2ee
+
+# Friendly names a client can pass as provider.min_privacy. All map to a
+# minimum tier rank above. "standard"/"any" is the default (no filter).
+PRIVACY_TIER_ALIASES: dict[str, int] = {
+    "standard": PRIVACY_TIER_STANDARD,
+    "any": PRIVACY_TIER_STANDARD,
+    "no_store": PRIVACY_TIER_NO_STORE,
+    "no-store": PRIVACY_TIER_NO_STORE,
+    "nostore": PRIVACY_TIER_NO_STORE,
+    "zdr": PRIVACY_TIER_ZERO_RETENTION,
+    "zero_retention": PRIVACY_TIER_ZERO_RETENTION,
+    "zero-retention": PRIVACY_TIER_ZERO_RETENTION,
+    "confidential": PRIVACY_TIER_CONFIDENTIAL,
+    "e2ee": PRIVACY_TIER_CONFIDENTIAL,
+    "max": PRIVACY_TIER_CONFIDENTIAL,
+    "maximum": PRIVACY_TIER_CONFIDENTIAL,
+}
+
+
+PRIVACY_TIER_LABELS: dict[int, str] = {
+    PRIVACY_TIER_STANDARD: "Standard",
+    PRIVACY_TIER_NO_STORE: "No-store",
+    PRIVACY_TIER_ZERO_RETENTION: "Zero retention",
+    PRIVACY_TIER_CONFIDENTIAL: "Confidential + E2EE",
+}
+
+
+def provider_privacy_tier(provider: Provider) -> int:
+    """The highest privacy bar a provider clears. Used to enforce a
+    request's minimum-privacy routing preference. Note the TR gateway hop
+    is always attested regardless of tier — this rank is about the
+    UPSTREAM provider's posture, which is what varies."""
+    if provider.provider_confidential_compute and provider.provider_e2ee:
+        return PRIVACY_TIER_CONFIDENTIAL
+    if provider.provider_zero_data_retention:
+        return PRIVACY_TIER_ZERO_RETENTION
+    if provider.stores_content is False:
+        return PRIVACY_TIER_NO_STORE
+    return PRIVACY_TIER_STANDARD
+
+
 @dataclass(frozen=True)
 class PriceTier:
     """One tier of context-conditional pricing. A request whose prompt
@@ -1278,6 +1328,33 @@ def _meta_price_range(
     return (min(values), max(values))
 
 
+def _model_max_privacy_tier(model: Model, endpoints: list[ModelEndpoint]) -> int:
+    """Highest privacy tier this model can be routed through. For meta
+    models (auto/free/cheap), that's the best tier across the candidate
+    pool — NOT the 'trustedrouter' pseudo-provider, which would falsely
+    claim confidential for Auto. For regular models, the max across the
+    model's own provider plus any serving endpoints."""
+    providers: set[str] = set()
+    if model.id in META_MODEL_IDS:
+        for candidate in meta_candidate_models(model.id):
+            providers.add(candidate.provider)
+    else:
+        providers.add(model.provider)
+        for endpoint in endpoints:
+            providers.add(endpoint.provider)
+    tiers = [
+        provider_privacy_tier(PROVIDERS[p]) for p in providers if p in PROVIDERS
+    ]
+    return max(tiers) if tiers else PRIVACY_TIER_STANDARD
+
+
+def model_max_privacy_tier(model: Model) -> int:
+    """Public wrapper: highest privacy tier `model` can be routed through,
+    resolving its serving endpoints internally. Used by the router's
+    min_privacy filter."""
+    return _model_max_privacy_tier(model, endpoints_for_model(model.id))
+
+
 def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     provider = PROVIDERS[model.provider]
     is_meta = model.id in META_MODEL_IDS
@@ -1338,6 +1415,14 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         "provider_e2ee": provider.provider_e2ee,
         "provider_policy": provider.provider_policy,
         "provider_policy_url": provider.provider_policy_url,
+        # Highest privacy tier reachable for this model — the max across
+        # every provider that serves it (a request can route to the best
+        # one). Lets the picker / SEO pages show "this model can run
+        # confidential" without re-deriving from raw posture flags.
+        "privacy_tier": _model_max_privacy_tier(model, endpoints),
+        "privacy_tier_label": PRIVACY_TIER_LABELS[
+            _model_max_privacy_tier(model, endpoints)
+        ],
         "prompt_price_microdollars_per_million_tokens": prompt_min,
         "completion_price_microdollars_per_million_tokens": completion_min,
         "published_prompt_price_microdollars_per_million_tokens": pub_prompt_min,

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -7,12 +7,15 @@ from typing import Any
 from trusted_router.catalog import (
     AUTO_MODEL_ID,
     MODELS,
+    PRIVACY_TIER_ALIASES,
     PROVIDERS,
     Model,
     ModelEndpoint,
     auto_candidate_models,
     endpoints_for_model,
     meta_candidate_models,
+    model_max_privacy_tier,
+    provider_privacy_tier,
 )
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
@@ -28,6 +31,9 @@ class RoutePreferences:
     data_collection: str | None = None
     sort: str | None = None
     usage_type: str | None = None
+    # Minimum upstream-provider privacy tier (see catalog.PRIVACY_TIER_*).
+    # 0 = no filter (default). Set via provider.min_privacy in the body.
+    min_privacy_rank: int = 0
 
 
 _PROVIDER_ALIASES = {
@@ -161,12 +167,29 @@ def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
     sort = _sort_mode(raw.get("sort"))
     usage_type = _usage_type(raw.get("usage") or raw.get("usage_type") or raw.get("billing"))
 
+    # provider.min_privacy: route only to providers whose posture clears
+    # this bar. Accepts friendly names ("zdr", "confidential", "no_store",
+    # "any"). Unknown values are a 400 so a typo can't silently downgrade
+    # the privacy a caller asked for.
+    min_privacy_rank = 0
+    min_privacy = raw.get("min_privacy")
+    if min_privacy is not None:
+        key = str(min_privacy).strip().lower()
+        if key not in PRIVACY_TIER_ALIASES:
+            raise api_error(
+                400,
+                "provider.min_privacy must be one of: any, no_store, zdr, confidential",
+                ErrorType.BAD_REQUEST,
+            )
+        min_privacy_rank = PRIVACY_TIER_ALIASES[key]
+
     return RoutePreferences(
         order=order,
         only=only,
         ignore=ignore,
         allow_fallbacks=allow_fallbacks_bool,
         data_collection=data_collection,
+        min_privacy_rank=min_privacy_rank,
         sort=sort,
         usage_type=usage_type,
     )
@@ -245,6 +268,13 @@ def _apply_provider_filters(candidates: list[Model], prefs: RoutePreferences) ->
             continue
         if prefs.data_collection == "deny" and provider.stores_content:
             continue
+        # Keep a model if ANY provider that serves it can meet the
+        # requested privacy bar — a model like deepseek-v3.2 is no-store
+        # via deepseek but confidential via phala, so it stays in a
+        # confidential request. The endpoint-level filter then narrows to
+        # the qualifying provider when the gateway picks an endpoint.
+        if prefs.min_privacy_rank and model_max_privacy_tier(model) < prefs.min_privacy_rank:
+            continue
         out.append(model)
     return out
 
@@ -282,6 +312,8 @@ def _apply_endpoint_provider_filters(
         if endpoint.provider in prefs.ignore:
             continue
         if prefs.data_collection == "deny" and provider.stores_content:
+            continue
+        if prefs.min_privacy_rank and provider_privacy_tier(provider) < prefs.min_privacy_rank:
             continue
         if prefs.usage_type is not None and endpoint.usage_type != prefs.usage_type:
             continue

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -406,7 +406,11 @@ def test_embeddings_and_model_endpoints(client: TestClient, inference_headers: d
     openai = client.get("/v1/models/openai/gpt-5.4-nano/endpoints")
     assert openai.status_code == 200
     openai_endpoints = openai.json()["data"]
-    assert {item["provider"] for item in openai_endpoints} >= {"openai", "gmi"}
+    # Pin only the canonical first-party provider. Secondary serving
+    # providers (gmi, etc.) churn with each OpenRouter snapshot refresh,
+    # so asserting their exact membership makes this test flaky against
+    # the hourly price-refresh bot.
+    assert "openai" in {item["provider"] for item in openai_endpoints}
     assert [
         item["trustedrouter"]["usage_type"]
         for item in openai_endpoints

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -243,3 +243,85 @@ def test_provider_route_preferences_data_collection_validates_enum() -> None:
 def test_provider_route_preferences_rejects_unknown_sort_mode() -> None:
     with pytest.raises(HTTPException):
         provider_route_preferences({"provider": {"sort": "popularity"}})
+
+
+# ── provider.min_privacy (privacy-tier routing) ─────────────────────────
+
+
+def test_min_privacy_parses_friendly_aliases() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_CONFIDENTIAL,
+        PRIVACY_TIER_ZERO_RETENTION,
+    )
+
+    p = provider_route_preferences(
+        {"model": "x", "provider": {"min_privacy": "zdr"}}
+    )
+    assert p.min_privacy_rank == PRIVACY_TIER_ZERO_RETENTION
+    p2 = provider_route_preferences(
+        {"model": "x", "provider": {"min_privacy": "maximum"}}
+    )
+    assert p2.min_privacy_rank == PRIVACY_TIER_CONFIDENTIAL
+    # Default: no filter.
+    assert provider_route_preferences({"model": "x"}).min_privacy_rank == 0
+
+
+def test_min_privacy_rejects_unknown_value() -> None:
+    with pytest.raises(HTTPException) as exc:
+        provider_route_preferences(
+            {"model": "x", "provider": {"min_privacy": "kinda-private"}}
+        )
+    assert exc.value.status_code == 400
+
+
+def test_min_privacy_zdr_on_auto_keeps_only_zdr_reachable() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_ZERO_RETENTION,
+        model_max_privacy_tier,
+    )
+
+    candidates = chat_route_candidates(
+        {"model": "trustedrouter/auto", "provider": {"min_privacy": "zdr"}},
+        _settings(),
+    )
+    assert candidates, "expected ZDR-reachable candidates in the Auto pool"
+    for model in candidates:
+        assert model_max_privacy_tier(model) >= PRIVACY_TIER_ZERO_RETENTION
+
+
+def test_min_privacy_confidential_keeps_confidential_reachable_model() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_CONFIDENTIAL,
+        model_max_privacy_tier,
+    )
+
+    # no-store via deepseek, confidential via phala — must still route.
+    candidates = chat_route_candidates(
+        {"model": "deepseek/deepseek-v3.2", "provider": {"min_privacy": "confidential"}},
+        _settings(),
+    )
+    assert candidates
+    assert all(model_max_privacy_tier(m) >= PRIVACY_TIER_CONFIDENTIAL for m in candidates)
+
+
+def test_min_privacy_too_high_for_model_raises() -> None:
+    # A no-store-only model demanded at confidential tier has no route —
+    # fail closed rather than silently downgrade.
+    with pytest.raises(HTTPException) as exc:
+        chat_route_candidates(
+            {"model": "openai/gpt-5.4-nano", "provider": {"min_privacy": "confidential"}},
+            _settings(),
+        )
+    assert exc.value.status_code == 400
+
+
+def test_model_shape_exposes_privacy_tier() -> None:
+    from trusted_router.catalog import MODELS, model_to_openrouter_shape
+
+    # Anthropic is zero-retention → tier label present and >= ZDR.
+    anth = next(m for m in MODELS.values() if m.provider == "anthropic")
+    shape = model_to_openrouter_shape(anth)
+    tr = shape["trustedrouter"]
+    assert "privacy_tier" in tr
+    assert "privacy_tier_label" in tr
+    assert tr["privacy_tier"] >= 2  # zero retention or better


### PR DESCRIPTION
Makes 'select the level of security you want' a real, enforced product feature — grounded in the per-provider posture TR already tracks. Each provider sits at a different tier; min_privacy means 'only route to providers that clear the bar.'

**Tiers** (nested):
- 3 **confidential** — confidential compute + e2ee (trustedrouter, phala, tinfoil)
- 2 **zero_retention** — ZDR (+ anthropic, cerebras, together, venice, nebius)
- 1 **no_store** — doesn't store content (everyone else)
- 0 **standard**

**API**: `provider.min_privacy` = `any|no_store|zdr|confidential` (+ aliases like `maximum`). A model is kept if *some* serving provider clears the bar (deepseek-v3.2 stays under confidential because phala serves it); the endpoint filter narrows to the qualifying provider. Nothing clears it → 400 (fail closed, never silently downgrade). Unknown value → 400. Default unset → no filter (backwards compatible).

`/v1/models` now exposes `privacy_tier` + `privacy_tier_label` per model (max reachable; meta models use candidate pool so Auto doesn't overclaim).

Also loosens a snapshot-fragile assertion in test_core_api that the price-refresh bot had reddened. 718 pass.