### PR TITLE
fix(privacy): assume providers store content until verified

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -24,7 +24,13 @@ class Provider:
     supports_prepaid: bool = False
     supports_byok: bool = True
     attested_gateway: bool = True
-    stores_content: bool = False
+    # Conservative default: assume an upstream provider stores request /
+    # response content unless we've VERIFIED otherwise from its published
+    # policy. Overclaiming privacy (labelling a storing/training provider
+    # as "no-store") is the one thing a verifiable-privacy product must
+    # never do — so the floor is "assume stored", and providers earn a
+    # higher tier only with an explicit, cited flag below.
+    stores_content: bool = True
     provider_zero_data_retention: bool | None = None
     provider_confidential_compute: bool | None = None
     provider_e2ee: bool | None = None

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -8,6 +8,7 @@ from trusted_router.catalog import (
     AUTO_MODEL_ID,
     MODELS,
     PRIVACY_TIER_ALIASES,
+    PRIVACY_TIER_NO_STORE,
     PROVIDERS,
     Model,
     ModelEndpoint,
@@ -266,7 +267,14 @@ def _apply_provider_filters(candidates: list[Model], prefs: RoutePreferences) ->
             continue
         if model.provider in prefs.ignore:
             continue
-        if prefs.data_collection == "deny" and provider.stores_content:
+        # "deny" = no data collection — require at least the no-store
+        # tier. Keyed off the privacy tier (not raw stores_content) so
+        # ZDR/confidential providers, which carry the conservative
+        # stores_content=True default, are correctly kept.
+        if (
+            prefs.data_collection == "deny"
+            and provider_privacy_tier(provider) < PRIVACY_TIER_NO_STORE
+        ):
             continue
         # Keep a model if ANY provider that serves it can meet the
         # requested privacy bar — a model like deepseek-v3.2 is no-store
@@ -311,7 +319,14 @@ def _apply_endpoint_provider_filters(
             continue
         if endpoint.provider in prefs.ignore:
             continue
-        if prefs.data_collection == "deny" and provider.stores_content:
+        # "deny" = no data collection — require at least the no-store
+        # tier. Keyed off the privacy tier (not raw stores_content) so
+        # ZDR/confidential providers, which carry the conservative
+        # stores_content=True default, are correctly kept.
+        if (
+            prefs.data_collection == "deny"
+            and provider_privacy_tier(provider) < PRIVACY_TIER_NO_STORE
+        ):
             continue
         if prefs.min_privacy_rank and provider_privacy_tier(provider) < prefs.min_privacy_rank:
             continue

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -325,3 +325,32 @@ def test_model_shape_exposes_privacy_tier() -> None:
     assert "privacy_tier" in tr
     assert "privacy_tier_label" in tr
     assert tr["privacy_tier"] >= 2  # zero retention or better
+
+
+def test_data_collection_deny_keeps_zdr_drops_standard() -> None:
+    # deny == "no data collection" → require >= no-store tier. ZDR
+    # providers (anthropic) carry the conservative stores_content=True
+    # default but must NOT be dropped; standard providers must be.
+    from trusted_router.catalog import model_max_privacy_tier, PRIVACY_TIER_NO_STORE
+
+    kept = chat_route_candidates(
+        {"model": "anthropic/claude-sonnet-4.6", "provider": {"data_collection": "deny"}},
+        _settings(),
+    )
+    assert kept and all(model_max_privacy_tier(m) >= PRIVACY_TIER_NO_STORE for m in kept)
+
+    with pytest.raises(HTTPException) as exc:
+        chat_route_candidates(
+            {"model": "openai/gpt-5.4-nano", "provider": {"data_collection": "deny"}},
+            _settings(),
+        )
+    assert exc.value.status_code == 400
+
+
+def test_unverified_provider_defaults_to_stores_content() -> None:
+    # Conservative default: a provider with no explicit posture is assumed
+    # to store content (tier STANDARD), never silently "no-store".
+    from trusted_router.catalog import PROVIDERS, provider_privacy_tier, PRIVACY_TIER_STANDARD
+
+    assert provider_privacy_tier(PROVIDERS["openai"]) == PRIVACY_TIER_STANDARD
+    assert PROVIDERS["openai"].stores_content is True


### PR DESCRIPTION
**Founder flag: 'many providers do store and train, and say so.'** The catalog defaulted every Provider to `stores_content=False`, so the new privacy tiers labeled 14 unverified providers 'No-store' purely by omission. For a verifiable-privacy product that's the cardinal sin.

Flip the default to `stores_content=True` (assume stored until verified). Honest distribution now:
| | before | after |
|---|---|---|
| confidential | 3 | 3 |
| zero_retention | 5 | 5 |
| no_store | 14 | **0** |
| standard (assume stored) | 0 | **14** |

Also fixes `data_collection: "deny"` to key off the privacy **tier** (≥ no-store) instead of raw `stores_content` — otherwise ZDR providers (which now carry the conservative default) would be wrongly dropped. `deny` and `min_privacy: no_store` are now consistent.

A research pass (in flight) will set accurate per-provider flags from each provider's published policy + citations, earning verified providers back up to no-store/ZDR. 720 tests pass.