### PR TITLE
fix(privacy): set per-provider posture from researched policies

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -322,9 +322,12 @@ PROVIDERS: dict[str, Provider] = {
         supports_prepaid=True,
         provider_zero_data_retention=True,
         provider_policy=(
-            "Marked ZDR for direct Anthropic Messages API routing. Anthropic documents "
-            "zero data retention for appropriately configured API usage; non-message "
-            "features may have separate retention behavior."
+            "Marked ZDR via TrustedRouter's arrangement — zero retention is NOT "
+            "Anthropic's public default; it applies to contracted / approved API "
+            "usage, which TrustedRouter's deployed account is configured for. "
+            "Anthropic does not train on API content. (Flagged content may be "
+            "retained longer for Usage-Policy enforcement; non-Messages features "
+            "may differ.)"
         ),
         provider_policy_url="https://platform.claude.com/docs/en/api/data-retention",
     ),
@@ -419,9 +422,10 @@ PROVIDERS: dict[str, Provider] = {
         stores_content=False,
         provider_zero_data_retention=True,
         provider_policy=(
-            "Tracked as provider ZDR for TrustedRouter prepaid routes because the "
-            "deployed Together account has ZDR enabled. Together documents ZDR as "
-            "an account/privacy setting."
+            "Marked ZDR via TrustedRouter's arrangement — Together's ZDR is an "
+            "opt-in account/privacy setting, NOT the public default, and the "
+            "deployed Together account has it enabled. Together does not train "
+            "on content without opt-in."
         ),
         provider_policy_url="https://docs.together.ai/docs/privacy-and-security",
     ),
@@ -506,11 +510,13 @@ PROVIDERS: dict[str, Provider] = {
         supports_prepaid=True,
         stores_content=False,
         provider_zero_data_retention=True,
-        provider_confidential_compute=False,
-        provider_e2ee=False,
+        provider_confidential_compute=True,
+        provider_e2ee=True,
         provider_policy=(
-            "Tracked as a no-logs provider claim. This is not the same as "
-            "attested confidential compute."
+            "Tracked as confidential — Venice documents no logging or storage of "
+            "prompts/responses plus TEE-isolated, end-to-end-encrypted inference. "
+            "(Caveat: requests Venice proxies to external frontier models inherit "
+            "those providers' policies; TR routes Venice-native open models here.)"
         ),
         provider_policy_url="https://docs.venice.ai/overview/privacy",
     ),
@@ -554,10 +560,11 @@ PROVIDERS: dict[str, Provider] = {
         slug="gmi",
         name="GMI Cloud",
         supports_prepaid=True,
-        provider_confidential_compute=True,
         provider_policy=(
-            "Tracked as confidential-GPU provider compute. Zero-retention "
-            "and provider-side E2EE are not marked unless separately verified."
+            "GMI runs isolated/VPC GPU inference, but that is network isolation, "
+            "NOT an attested TEE — so no confidential-compute, zero-retention, or "
+            "E2EE claim is marked. Retention/training terms are unverified (the "
+            "published policy page is JavaScript-only and would not render)."
         ),
         provider_policy_url="https://gmicloud.ai/legal/privacy",
     ),
@@ -569,9 +576,13 @@ PROVIDERS: dict[str, Provider] = {
         slug="deepinfra",
         name="DeepInfra",
         supports_prepaid=True,
+        stores_content=False,
+        provider_zero_data_retention=True,
         provider_policy=(
-            "DeepInfra documents inference data handling and no training on submitted "
-            "API data, with provider-specific exceptions for some upstream model owners."
+            "Tracked as provider ZDR — DeepInfra documents memory-only handling "
+            "with no storage of API content and no training on submitted API data. "
+            "(Exception: requests to Google/Anthropic-backed models inherit those "
+            "vendors' policies.)"
         ),
         provider_policy_url="https://docs.deepinfra.com/account/data-privacy",
     ),
@@ -586,9 +597,10 @@ PROVIDERS: dict[str, Provider] = {
         stores_content=False,
         provider_zero_data_retention=True,
         provider_policy=(
-            "Tracked as provider ZDR for TrustedRouter prepaid routes because the "
-            "deployed Nebius account has ZDR enabled. Nebius documents no model "
-            "training on customer data and optional ZDR controls."
+            "Marked ZDR via TrustedRouter's arrangement — Nebius RETAINS inputs/"
+            "outputs by default (for speculative decoding); zero retention is an "
+            "opt-in control, which the deployed Nebius account has enabled. Nebius "
+            "does not train on customer data."
         ),
         provider_policy_url="https://docs.studio.nebius.com/legal/legal-quick-guide",
     ),

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -605,6 +605,13 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["together"]["provider_zero_data_retention"] is True
     assert provider_flags["nebius"]["provider_zero_data_retention"] is True
     assert provider_flags["venice"]["provider_zero_data_retention"] is True
+    # Venice runs TEE + E2EE inference — it's confidential, not merely no-logs.
+    assert provider_flags["venice"]["provider_confidential_compute"] is True
+    assert provider_flags["venice"]["provider_e2ee"] is True
+    # DeepInfra is memory-only / no-training — earns ZDR with a citation.
+    assert provider_flags["deepinfra"]["provider_zero_data_retention"] is True
+    # GMI runs VPC isolation, NOT an attested TEE — must NOT claim confidential.
+    assert provider_flags["gmi"]["provider_confidential_compute"] is None
     assert provider_flags["deepseek"]["provider_zero_data_retention"] is False
     assert "train or improve" in provider_flags["deepseek"]["provider_policy"]
     assert provider_flags["openai"]["provider_zero_data_retention"] is None
@@ -633,6 +640,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "trustedrouter",
         "anthropic",
         "cerebras",
+        "deepinfra",
         "nebius",
         "phala",
         "tinfoil",
@@ -641,6 +649,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     }.issubset(zdr_providers)
     assert "openai" not in zdr_providers
     assert "deepseek" not in zdr_providers
+    assert "gmi" not in zdr_providers
     credits = client.get("/v1/credits", headers=user_headers)
     assert credits.status_code == 200
     assert credits.json()["data"]["total_credits"] >= 0


### PR DESCRIPTION
Follow-up to the conservative-default flip (#31). A research pass against each provider's **published** data policy surfaced both overclaims and underclaims; this reconciles the catalog flags to what the docs actually say.

### Upgrades (high-confidence, cited)
| provider | change | basis |
|---|---|---|
| **Venice** | ZDR → **Confidential** (TEE + E2EE) | docs.venice.ai/overview/privacy — TEE-isolated, end-to-end-encrypted inference, no logging |
| **DeepInfra** | Standard → **Zero-retention** | docs.deepinfra.com/account/data-privacy — memory-only, no storage, no training on API data |

### De-risk (drop an overclaim)
- **GMI Cloud** — dropped `provider_confidential_compute`. GMI runs VPC/network isolation, **not** an attested TEE; its policy page is JS-only so retention is unverified. (Tier was already Standard since `e2ee` was never set, but the stray flag was misleading in the API/UI.)

### Scoped footnotes (keep the ZDR flag, make the basis explicit)
Per founder direction — these stay ZDR because TR's *deployed accounts* have zero-retention enabled, but the policy text now states plainly that it is **not** each provider's public default:
- **Anthropic** — ZDR is contract/approval-only; does not train on API content.
- **Together** — ZDR is an opt-in account setting.
- **Nebius** — retains by default for speculative decoding; ZDR is an opt-in control.

### Result
Tier distribution: **confidential 4** (phala, tinfoil, trustedrouter, venice), **zero-retention 5** (anthropic, cerebras, deepinfra, nebius, together), **standard 13**.

Tests lock in venice-confidential, deepinfra-ZDR, gmi-not-confidential, and add deepinfra to the `/v1/endpoints/zdr` set. **720 passed, 31 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)