### PR TITLE
feat(perf): provider/model rotation probe + TTFB/source telemetry

### DIFF
--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -9,7 +9,7 @@ from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
 from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
-from trusted_router.storage import STORE, SyntheticProbeSample
+from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
     gateway_fallback_probe,
@@ -39,6 +39,22 @@ def register(router: APIRouter) -> None:
         samples = [_sample_from_body(item) for item in raw_samples]
         for sample in samples:
             STORE.record_synthetic_probe_sample(sample)
+        return {"data": {"recorded": len(samples)}}
+
+    @router.post("/internal/synthetic/benchmark")
+    async def synthetic_benchmark(request: Request, settings: SettingsDep) -> dict[str, Any]:
+        # Ingest for provider/model rotation-probe samples. Distinct from
+        # /samples (which feeds the /status router-health SLO): these are
+        # ProviderBenchmarkSamples that join the same per-provider/model
+        # performance store as organic production traffic.
+        require_internal_gateway(request, settings)
+        body = await json_body(request)
+        raw_samples = body.get("samples", [body])
+        if not isinstance(raw_samples, list):
+            raise api_error(400, "samples must be an array", ErrorType.BAD_REQUEST)
+        samples = [_benchmark_from_body(item) for item in raw_samples]
+        for sample in samples:
+            STORE.record_provider_benchmark(sample)
         return {"data": {"recorded": len(samples)}}
 
     @router.post("/internal/synthetic/run")
@@ -118,6 +134,40 @@ def _sample_from_body(body: Any) -> SyntheticProbeSample:
     return SyntheticProbeSample(**kwargs)
 
 
+def _benchmark_from_body(body: Any) -> ProviderBenchmarkSample:
+    if not isinstance(body, dict):
+        raise api_error(400, "sample must be an object", ErrorType.BAD_REQUEST)
+    kwargs: dict[str, Any] = {
+        "id": str(body.get("id") or ""),
+        "model": str(body.get("model") or ""),
+        "provider": str(body.get("provider") or ""),
+        "provider_name": str(body.get("provider_name") or ""),
+        "status": str(body.get("status") or ""),
+        "usage_type": str(body.get("usage_type") or "Credits"),
+        "streamed": bool(body.get("streamed", False)),
+        "input_tokens": int(body.get("input_tokens") or 0),
+        "output_tokens": int(body.get("output_tokens") or 0),
+        "total_cost_microdollars": int(body.get("total_cost_microdollars") or 0),
+        "speed_tokens_per_second": _optional_float(body.get("speed_tokens_per_second")),
+        "elapsed_milliseconds": _optional_int(body.get("elapsed_milliseconds")),
+        "first_token_milliseconds": _optional_int(body.get("first_token_milliseconds")),
+        "ttfb_milliseconds": _optional_int(body.get("ttfb_milliseconds")),
+        "finish_reason": _optional_str(body.get("finish_reason")),
+        "error_type": _optional_str(body.get("error_type")),
+        "error_status": _optional_int(body.get("error_status")),
+        "region": _optional_str(body.get("region")),
+        # This ingest is the synthetic rotation path; default provenance is
+        # synthetic (the probe also sets it explicitly).
+        "source": str(body.get("source") or "synthetic"),
+    }
+    if body.get("created_at"):
+        kwargs["created_at"] = str(body["created_at"])
+    for field in ("id", "model", "provider", "provider_name", "status"):
+        if not kwargs[field]:
+            raise api_error(400, f"{field} is required", ErrorType.BAD_REQUEST)
+    return ProviderBenchmarkSample(**kwargs)
+
+
 def _optional_str(value: Any) -> str | None:
     if value is None:
         return None
@@ -129,3 +179,9 @@ def _optional_int(value: Any) -> int | None:
     if value is None or value == "":
         return None
     return int(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -243,6 +243,9 @@ class Generation:
     provider: str | None = None
     elapsed_milliseconds: int | None = None
     first_token_milliseconds: int | None = None
+    # Time to first response BYTE (headers / first SSE frame), distinct from
+    # first_token_milliseconds which is time to first CONTENT token (TTFT).
+    ttfb_milliseconds: int | None = None
     region: str | None = None
 
     def __post_init__(self) -> None:
@@ -266,6 +269,7 @@ class Generation:
     ) -> Generation:
         elapsed_ms = _seconds_to_milliseconds(getattr(result, "elapsed_seconds", 0.001))
         first_token_seconds = getattr(result, "first_token_seconds", None)
+        first_byte_seconds = getattr(result, "first_byte_seconds", None)
         return cls(
             id=f"gen-{uuid.uuid4().hex}",
             request_id=result.request_id,
@@ -288,6 +292,9 @@ class Generation:
             first_token_milliseconds=(
                 _seconds_to_milliseconds(first_token_seconds) if first_token_seconds is not None else None
             ),
+            ttfb_milliseconds=(
+                _seconds_to_milliseconds(first_byte_seconds) if first_byte_seconds is not None else None
+            ),
             region=region,
         )
 
@@ -308,6 +315,8 @@ class Generation:
         elapsed = max(float(body.get("elapsed_seconds") or 0.001), 0.001)
         first_token_raw = body.get("first_token_seconds") or body.get("time_to_first_token_seconds")
         first_token = max(float(first_token_raw), 0.001) if first_token_raw is not None else None
+        first_byte_raw = body.get("first_byte_seconds") or body.get("time_to_first_byte_seconds")
+        first_byte = max(float(first_byte_raw), 0.001) if first_byte_raw is not None else None
         return cls(
             id=f"gen-{uuid.uuid4().hex}",
             request_id=str(body.get("request_id") or f"req-{uuid.uuid4()}"),
@@ -329,6 +338,9 @@ class Generation:
             elapsed_milliseconds=_seconds_to_milliseconds(elapsed),
             first_token_milliseconds=(
                 _seconds_to_milliseconds(first_token) if first_token is not None else None
+            ),
+            ttfb_milliseconds=(
+                _seconds_to_milliseconds(first_byte) if first_byte is not None else None
             ),
             region=authorization.region,
         )
@@ -391,10 +403,16 @@ class ProviderBenchmarkSample:
     speed_tokens_per_second: float | None = None
     elapsed_milliseconds: int | None = None
     first_token_milliseconds: int | None = None
+    ttfb_milliseconds: int | None = None
     finish_reason: str | None = None
     error_type: str | None = None
     error_status: int | None = None
     region: str | None = None
+    # Internal-only provenance: "organic" (real production traffic) or
+    # "synthetic" (rotation-probe sample). Lets internal queries separate the
+    # two; public ranking pages intentionally combine them without surfacing
+    # this field.
+    source: str = "organic"
     created_at: str = field(default_factory=iso_now)
 
     def __post_init__(self) -> None:
@@ -417,6 +435,7 @@ class ProviderBenchmarkSample:
             speed_tokens_per_second=generation.speed_tokens_per_second,
             elapsed_milliseconds=generation.elapsed_milliseconds,
             first_token_milliseconds=generation.first_token_milliseconds,
+            ttfb_milliseconds=generation.ttfb_milliseconds,
             finish_reason=generation.finish_reason,
             region=generation.region,
             created_at=generation.created_at,

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import os
+import random
 import sys
 import time
+from dataclasses import asdict
 
 import httpx
 
 from trusted_router.config import Settings, get_settings
-from trusted_router.storage_models import SyntheticProbeSample
+from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.synthetic.probes import (
+    SyntheticTarget,
+    choose_rotation_target,
     gateway_billing_probe,
     gateway_fallback_probe,
+    provider_rotation_probe,
+    rotation_candidates,
     run_synthetic_once,
 )
 
@@ -31,6 +37,11 @@ from trusted_router.synthetic.probes import (
 # Override via TR_SYNTHETIC_RUNS_PER_INVOCATION (1 = old behaviour).
 _DEFAULT_RUNS_PER_INVOCATION = 2
 _DEFAULT_RUN_SPACING_SECONDS = 30.0
+
+# Provider/model rotation probe — how many random provider+model samples to
+# take per pass. Dark-launched: only runs when TR_SYNTHETIC_ROTATION_ENABLED is
+# truthy, so we can watch real token spend for ~24h before ramping.
+_DEFAULT_ROTATION_PER_PASS = 4
 
 
 async def _one_probe_pass(
@@ -66,6 +77,32 @@ async def _one_probe_pass(
     return samples
 
 
+async def _rotation_pass(
+    *, settings: Settings, monitor_region: str, api_key: str,
+    timeout: httpx.Timeout, count: int, rng: random.Random,
+) -> list[ProviderBenchmarkSample]:
+    pool = rotation_candidates()
+    target = SyntheticTarget("rotation", settings.api_base_url, monitor_region)
+    samples: list[ProviderBenchmarkSample] = []
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for _ in range(max(0, count)):
+            picked = choose_rotation_target(pool, rng)
+            if picked is None:
+                break
+            provider, model = picked
+            samples.append(
+                await provider_rotation_probe(
+                    client,
+                    target,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    provider=provider,
+                    model=model,
+                )
+            )
+    return samples
+
+
 async def run() -> int:
     settings = get_settings()
     monitor_region = (
@@ -92,8 +129,20 @@ async def run() -> int:
             str(_DEFAULT_RUN_SPACING_SECONDS),
         )
     )
+    rotation_enabled = os.environ.get("TR_SYNTHETIC_ROTATION_ENABLED", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    rotation_per_pass = max(
+        0,
+        int(os.environ.get("TR_SYNTHETIC_ROTATION_PER_PASS", str(_DEFAULT_ROTATION_PER_PASS))),
+    )
+    rotation_rng = random.Random()  # noqa: S311 - picks which model to probe, not cryptographic
 
     all_samples: list[SyntheticProbeSample] = []
+    rotation_samples: list[ProviderBenchmarkSample] = []
     pass_start_monotonic = time.monotonic()
     for pass_idx in range(runs_per_invocation):
         all_samples.extend(
@@ -106,6 +155,17 @@ async def run() -> int:
                 timeout=timeout,
             )
         )
+        if rotation_enabled and api_key:
+            rotation_samples.extend(
+                await _rotation_pass(
+                    settings=settings,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    timeout=timeout,
+                    count=rotation_per_pass,
+                    rng=rotation_rng,
+                )
+            )
         # Sleep until the next probe pass should start, but only if
         # there IS a next pass. Compensates for the time the probe
         # itself took so the spacing is between pass-starts, not
@@ -132,8 +192,21 @@ async def run() -> int:
             headers={"x-trustedrouter-internal-token": internal_token},
             json={"samples": [sample.public_dict() for sample in all_samples]},
         )
-    print(response.text)
-    return 0 if response.status_code == 200 else 1
+        print(response.text)
+        ok = response.status_code == 200
+        if rotation_samples:
+            benchmark_url = os.environ.get(
+                "TR_SYNTHETIC_BENCHMARK_INGEST_URL",
+                f"{control_plane.rstrip('/')}/v1/internal/synthetic/benchmark",
+            )
+            bench_response = await client.post(
+                benchmark_url,
+                headers={"x-trustedrouter-internal-token": internal_token},
+                json={"samples": [asdict(sample) for sample in rotation_samples]},
+            )
+            print(bench_response.text)
+            ok = ok and bench_response.status_code == 200
+    return 0 if ok else 1
 
 
 def main() -> int:

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import random
 import secrets
 import time
 import uuid
@@ -14,7 +15,7 @@ import httpx
 from trusted_router.config import Settings
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.security import lookup_hash_api_key
-from trusted_router.storage_models import SyntheticProbeSample
+from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
 
 
 @dataclass(frozen=True)
@@ -577,6 +578,190 @@ async def gateway_fallback_probe(
                 model=model,
             )
         ]
+
+
+# ---------------------------------------------------------------------------
+# Provider/model rotation probe — a synthetic "user" that exercises every
+# provider+model reachable via a prepaid endpoint, measuring TTFB (first byte)
+# and TTFT (first content token) from real streaming responses. Feeds the SAME
+# ProviderBenchmarkSample store as organic production traffic (tagged
+# source="synthetic"), so the public leaderboard and the measured-routing
+# snapshot get coverage for models with little/no organic traffic yet — and we
+# get a daily API-drift signal. Deliberately NOT a SyntheticProbeSample: it
+# never touches the /status router-health SLO or its burn-rate alerts.
+# ---------------------------------------------------------------------------
+
+
+def rotation_candidates() -> dict[str, list[str]]:
+    """Map each provider to the model IDs it serves via a prepaid (Credits)
+    endpoint. Iterates ENDPOINTS rather than Model.prepaid_available (a catalog
+    dedup marker) so supplemental provider-native models are covered too."""
+    from trusted_router.catalog import MODEL_ENDPOINTS
+
+    pool: dict[str, list[str]] = {}
+    for endpoint in MODEL_ENDPOINTS.values():
+        if endpoint.usage_type != "Credits":
+            continue
+        models = pool.setdefault(endpoint.provider, [])
+        if endpoint.model_id not in models:
+            models.append(endpoint.model_id)
+    return pool
+
+
+def choose_rotation_target(
+    pool: dict[str, list[str]], rng: random.Random
+) -> tuple[str, str] | None:
+    """Two-stage random pick: uniform over providers, then uniform over that
+    provider's models — equal airtime per provider regardless of catalog size."""
+    providers = sorted(provider for provider, models in pool.items() if models)
+    if not providers:
+        return None
+    provider = rng.choice(providers)
+    return provider, rng.choice(sorted(set(pool[provider])))
+
+
+def _provider_display_name(provider: str) -> str:
+    from trusted_router.catalog import PROVIDERS
+
+    entry = PROVIDERS.get(provider)
+    return entry.name if entry is not None else provider
+
+
+def _sse_line_has_content(line: str) -> bool:
+    """True if an SSE `data:` line carries a visible content/reasoning delta."""
+    line = line.strip()
+    if not line.startswith("data:"):
+        return False
+    payload = line[len("data:") :].strip()
+    if not payload or payload == "[DONE]":
+        return False
+    try:
+        data = json.loads(payload)
+    except ValueError:
+        return False
+    for choice in data.get("choices") or []:
+        delta = choice.get("delta") or {}
+        if delta.get("content") or delta.get("reasoning_content"):
+            return True
+        message = choice.get("message") or {}
+        if message.get("content"):
+            return True
+    return False
+
+
+async def provider_rotation_probe(
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    api_key: str,
+    provider: str,
+    model: str,
+) -> ProviderBenchmarkSample:
+    """Stream a tiny request to one provider+model and measure TTFB (first
+    byte) and TTFT (first content token). Pins `provider.only` so the sample is
+    attributed to the intended upstream; records the actually-served
+    provider/model from the provenance headers when present. max_tokens stays
+    tiny and we never assert the content — we measure token *flow*, not text."""
+    url = _api_url(target.api_base_url, "/chat/completions")
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": "reply exactly PONG"}],
+        "max_tokens": 16,
+        "temperature": 0,
+        "stream": True,
+        "provider": {"only": [provider]},
+        "metadata": {"trustedrouter_synthetic": "true"},
+    }
+    started = time.perf_counter()
+    ttfb_ms: int | None = None
+    ttft_ms: int | None = None
+    served_provider = provider
+    served_model = model
+    try:
+        async with client.stream(
+            "POST", url, json=body, headers=_auth_headers(api_key)
+        ) as response:
+            served_provider = response.headers.get("x-trustedrouter-provider") or provider
+            served_model = response.headers.get("x-trustedrouter-served-model") or model
+            if response.status_code != 200:
+                await response.aread()
+                return _rotation_error_sample(
+                    served_provider,
+                    served_model,
+                    region=monitor_region,
+                    elapsed_ms=_elapsed_ms(started),
+                    error_status=response.status_code,
+                    error_type=f"http_{response.status_code}",
+                )
+            tail = ""
+            async for chunk in response.aiter_bytes():
+                if not chunk:
+                    continue
+                now = _elapsed_ms(started)
+                if ttfb_ms is None:
+                    ttfb_ms = now
+                if ttft_ms is None:
+                    tail += chunk.decode("utf-8", "ignore")
+                    lines = tail.split("\n")
+                    tail = lines.pop()
+                    for line in lines:
+                        if _sse_line_has_content(line):
+                            ttft_ms = now
+                            break
+            elapsed_ms = _elapsed_ms(started)
+    except (httpx.HTTPError, ValueError) as exc:
+        return _rotation_error_sample(
+            served_provider,
+            served_model,
+            region=monitor_region,
+            elapsed_ms=_elapsed_ms(started),
+            error_status=None,
+            error_type=exc.__class__.__name__,
+        )
+    return ProviderBenchmarkSample(
+        id=f"bench-{uuid.uuid4().hex}",
+        model=served_model,
+        provider=served_provider,
+        provider_name=_provider_display_name(served_provider),
+        status="success",
+        usage_type="Credits",
+        streamed=True,
+        elapsed_milliseconds=elapsed_ms,
+        first_token_milliseconds=ttft_ms,
+        ttfb_milliseconds=ttfb_ms,
+        finish_reason="stop",
+        region=monitor_region,
+        source="synthetic",
+    )
+
+
+def _rotation_error_sample(
+    provider: str,
+    model: str,
+    *,
+    region: str,
+    elapsed_ms: int,
+    error_status: int | None,
+    error_type: str,
+) -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample(
+        id=f"bench-{uuid.uuid4().hex}",
+        model=model,
+        provider=provider,
+        provider_name=_provider_display_name(provider),
+        status="error",
+        usage_type="Credits",
+        streamed=True,
+        elapsed_milliseconds=elapsed_ms,
+        first_token_milliseconds=None,
+        ttfb_milliseconds=None,
+        finish_reason="error",
+        error_type=error_type,
+        error_status=error_status,
+        region=region,
+        source="synthetic",
+    )
 
 
 def _sample(

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -452,6 +452,67 @@ def test_gcp_provider_benchmark_write_uses_privacy_safe_indexes() -> None:
     assert b"key_" not in b"".join(table.committed)
 
 
+def test_gcp_provider_benchmark_round_trips_ttfb_and_source() -> None:
+    sample = ProviderBenchmarkSample(
+        id="bench_ttfb",
+        model="openai/gpt-5.4-nano",
+        provider="openai",
+        provider_name="OpenAI",
+        status="success",
+        usage_type="Credits",
+        streamed=True,
+        elapsed_milliseconds=300,
+        first_token_milliseconds=180,
+        ttfb_milliseconds=120,
+        source="synthetic",
+        created_at="2026-05-02T12:00:00Z",
+    )
+    table = _FakeBigtable([_FakeReadRow(sample)])
+
+    rows = _bt_provider_benchmark_samples(
+        table, "m", date="2026-05-02", provider="openai", model="openai/gpt-5.4-nano", limit=10
+    )
+
+    assert len(rows) == 1
+    # TTFB (first byte) is distinct from TTFT (first content token) and both
+    # survive the serialize/deserialize round trip, as does the internal source.
+    assert rows[0].ttfb_milliseconds == 120
+    assert rows[0].first_token_milliseconds == 180
+    assert rows[0].source == "synthetic"
+
+
+def test_provider_benchmark_from_generation_carries_ttfb_default_organic() -> None:
+    generation = Generation(
+        id="gen_1",
+        request_id="req_1",
+        workspace_id="ws_1",
+        key_hash="key_1",
+        model="anthropic/claude-opus-4.7",
+        provider_name="Anthropic",
+        app="TestApp",
+        tokens_prompt=10,
+        tokens_completion=5,
+        total_cost_microdollars=100,
+        usage_type="Credits",
+        speed_tokens_per_second=20.0,
+        finish_reason="stop",
+        status="success",
+        streamed=True,
+        provider="anthropic",
+        elapsed_milliseconds=250,
+        first_token_milliseconds=140,
+        ttfb_milliseconds=90,
+        region="us-east-1",
+    )
+
+    sample = ProviderBenchmarkSample.from_generation(generation)
+
+    assert sample.ttfb_milliseconds == 90
+    assert sample.first_token_milliseconds == 140
+    # Organic production traffic is the default provenance.
+    assert sample.source == "organic"
+
+
 def test_gcp_provider_benchmark_read_filters_without_workspace_scope() -> None:
     openai = ProviderBenchmarkSample(
         id="bench_openai",

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import datetime as dt
 import json
+import random
 from dataclasses import asdict
 from typing import Any
 
@@ -37,9 +38,13 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 from trusted_router.storage_models import iso_now, utcnow
 from trusted_router.synthetic.probes import (
     SyntheticTarget,
+    _sse_line_has_content,
     attestation_nonce_probe,
+    choose_rotation_target,
     openai_chat_pong_probe,
+    provider_rotation_probe,
     responses_pong_probe,
+    rotation_candidates,
     tls_health_probe,
 )
 from trusted_router.synthetic.rollups import (
@@ -1434,3 +1439,173 @@ class _FakeBigtable:
 
     def direct_row(self, key: bytes) -> _FakeDirectRow:
         return _FakeDirectRow(key, self)
+
+
+# ---------------------------------------------------------------------------
+# Provider/model rotation probe (Phase 1 of the performance-dataset effort).
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_candidates_cover_credits_endpoints() -> None:
+    pool = rotation_candidates()
+    assert pool, "expected at least one provider with a prepaid endpoint"
+    for provider, models in pool.items():
+        assert models, f"{provider} has no models"
+        assert len(models) == len(set(models)), f"{provider} has duplicate models"
+    # Both a snapshot provider and a supplemental-manifest provider are
+    # reachable — coverage is endpoint-driven, not the prepaid_available flag.
+    assert "openai" in pool
+    assert "novita" in pool
+
+
+def test_choose_rotation_target_two_stage_pick() -> None:
+    pool = {"openai": ["openai/gpt-5.4-nano"], "novita": ["novita/a", "novita/b"]}
+    rng = random.Random(0)  # noqa: S311 - deterministic test selection, not cryptographic
+    picks = {choose_rotation_target(pool, rng) for _ in range(50)}
+    for provider, model in picks:
+        assert model in pool[provider]
+    # Both providers get sampled despite novita having more models — equal
+    # airtime per provider, not per model.
+    assert {provider for provider, _ in picks} == {"openai", "novita"}
+
+
+def test_choose_rotation_target_empty_pool_is_none() -> None:
+    assert choose_rotation_target({}, random.Random(0)) is None  # noqa: S311 - test rng
+    assert (
+        choose_rotation_target({"openai": []}, random.Random(0)) is None  # noqa: S311 - test rng
+    )
+
+
+def test_sse_line_has_content_detects_visible_deltas() -> None:
+    assert _sse_line_has_content('data: {"choices":[{"delta":{"content":"PONG"}}]}')
+    assert _sse_line_has_content('data: {"choices":[{"delta":{"reasoning_content":"x"}}]}')
+    assert _sse_line_has_content('data: {"choices":[{"message":{"content":"PONG"}}]}')
+    # role-only opener, [DONE], and non-data lines are NOT first content.
+    assert not _sse_line_has_content('data: {"choices":[{"delta":{"role":"assistant"}}]}')
+    assert not _sse_line_has_content("data: [DONE]")
+    assert not _sse_line_has_content(": keep-alive")
+
+
+@pytest.mark.asyncio
+async def test_provider_rotation_probe_measures_ttfb_and_ttft() -> None:
+    body = (
+        b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+        b'data: {"choices":[{"delta":{"content":"PONG"}}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(
+            200,
+            headers={
+                "x-trustedrouter-provider": "openai",
+                "x-trustedrouter-served-model": "openai/gpt-5.4-nano",
+            },
+            content=body,
+        )
+
+    target = SyntheticTarget("rotation", "https://api.quillrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_rotation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="openai",
+            model="openai/gpt-5.4-nano",
+        )
+
+    assert sample.status == "success"
+    assert sample.source == "synthetic"
+    assert sample.provider == "openai"
+    assert sample.model == "openai/gpt-5.4-nano"
+    assert sample.streamed is True
+    assert sample.ttfb_milliseconds is not None
+    assert sample.first_token_milliseconds is not None
+    assert sample.elapsed_milliseconds is not None
+
+
+@pytest.mark.asyncio
+async def test_provider_rotation_probe_records_http_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    target = SyntheticTarget("rotation", "https://api.quillrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_rotation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="openai",
+            model="openai/gpt-5.4-nano",
+        )
+
+    assert sample.status == "error"
+    assert sample.error_type == "http_500"
+    assert sample.error_status == 500
+    assert sample.first_token_milliseconds is None
+    assert sample.source == "synthetic"
+
+
+def _benchmark_ingest_settings() -> Settings:
+    return Settings(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token="test-internal-secret",  # noqa: S106 - test fixture.
+        stripe_secret_key=None,
+        stripe_webhook_secret=None,
+        google_client_id=None,
+        google_client_secret=None,
+        google_oauth_redirect_url=None,
+        github_client_id=None,
+        github_client_secret=None,
+        github_oauth_redirect_url=None,
+    )
+
+
+def test_internal_benchmark_ingest_records_sample() -> None:
+    client = TestClient(create_app(_benchmark_ingest_settings(), init_observability=False))
+    payload = {
+        "samples": [
+            {
+                "id": "bench-ingest-test-1",
+                "model": "openai/gpt-5.4-nano",
+                "provider": "openai",
+                "provider_name": "OpenAI",
+                "status": "success",
+                "usage_type": "Credits",
+                "streamed": True,
+                "elapsed_milliseconds": 300,
+                "first_token_milliseconds": 150,
+                "ttfb_milliseconds": 90,
+                "source": "synthetic",
+                "created_at": "2026-06-04T00:00:00Z",
+            }
+        ]
+    }
+    resp = client.post(
+        "/v1/internal/synthetic/benchmark",
+        headers={"x-trustedrouter-internal-token": "test-internal-secret"},
+        json=payload,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["recorded"] == 1
+    rows = STORE.provider_benchmark_samples(
+        date=None, provider="openai", model="openai/gpt-5.4-nano", limit=50
+    )
+    matched = [row for row in rows if row.id == "bench-ingest-test-1"]
+    assert matched, "ingested benchmark sample not found in store"
+    assert matched[0].ttfb_milliseconds == 90
+    assert matched[0].source == "synthetic"
+
+
+def test_internal_benchmark_ingest_requires_token() -> None:
+    client = TestClient(create_app(_benchmark_ingest_settings(), init_observability=False))
+    resp = client.post(
+        "/v1/internal/synthetic/benchmark",
+        headers={"x-trustedrouter-internal-token": "wrong"},
+        json={"samples": []},
+    )
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
**Phase 1** of the measured-performance dataset (the OpenRouter-parity effort). Dark-launched — no behavior change until `TR_SYNTHETIC_ROTATION_ENABLED` is set.

### What
- **TTFB capture (was missing).** `ProviderBenchmarkSample` + `Generation` gain `ttfb_milliseconds` (time to first *byte*), distinct from `first_token_milliseconds` (TTFT). Populated from the enclave settle body (`first_byte_seconds`/`time_to_first_byte_seconds`) when the gateway emits it — field is ready ahead of that cross-repo change. Plus an internal `source` field (`organic`|`synthetic`).
- **`provider_rotation_probe()`** — a synthetic "user" that streams a tiny request to a random provider+model and measures real **TTFB + TTFT**. Two-stage uniform pick (provider → model) over **prepaid `Credits` endpoints** — iterates ENDPOINTS, not `Model.prepaid_available` (a dedup marker), so supplemental novita/nebius/minimax models are covered. Pins `provider.only`; `max_tokens=16`; never asserts content.
- **`POST /internal/synthetic/benchmark`** ingest → `record_provider_benchmark`. Separate from `/samples` so rotation traffic **never touches the `/status` router-health SLO** or burn-rate alerts.
- **CLI wiring** behind `TR_SYNTHETIC_ROTATION_ENABLED` (default OFF) + `TR_SYNTHETIC_ROTATION_PER_PASS` (default 4).

### Why
Surfaces will read this data (leaderboard, measured routing) in later phases. Probe-first so coverage accumulates across all providers while organic traffic is still thin, and we get a daily API-drift signal.

### Note for a later phase
When enabled, the probe's own inference settles as an *organic* benchmark sample too (monitor key). Phase 3 (leaderboard) will add a guard so monitor traffic isn't double-counted. No effect while dark.

730 passed, 31 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)