### PR TITLE
feat(perf): provider/model API-drift detection

### DIFF
--- a/scripts/detect_provider_drift.py
+++ b/scripts/detect_provider_drift.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Detect day-over-day provider/model API drift from benchmark samples.
+
+Aggregates a recent window of ProviderBenchmarkSamples (organic + rotation
+probe) and compares it against a committed baseline, flagging undocumented
+upstream changes: a model that started erroring/404ing, a brand-new error
+shape, a TTFT regression, or a newly-appeared model.
+
+Usage:
+    python scripts/detect_provider_drift.py                  # report drift
+    python scripts/detect_provider_drift.py --check          # exit 1 if drift found (for CI / alerts)
+    python scripts/detect_provider_drift.py --update-baseline  # rewrite the committed baseline
+
+Reads the live store (prod GCP env) for the recent window. The committed
+baseline lives at src/trusted_router/data/provider_drift_baseline.json; refresh
+it deliberately via --update-baseline and review the diff in a PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from trusted_router.synthetic.drift import aggregate, baseline_from_stats, detect_drift
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_BASELINE = REPO_ROOT / "src" / "trusted_router" / "data" / "provider_drift_baseline.json"
+BASELINE_PATH = Path(os.environ.get("TR_DRIFT_BASELINE_PATH", str(_DEFAULT_BASELINE)))
+
+
+def _load_baseline() -> dict:
+    if not BASELINE_PATH.exists():
+        return {}
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def _recent_samples(limit: int) -> list:
+    from trusted_router.storage import STORE
+
+    return STORE.provider_benchmark_samples(date=None, limit=limit)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect provider/model API drift.")
+    parser.add_argument("--limit", type=int, default=5000, help="recent samples to scan")
+    parser.add_argument("--check", action="store_true", help="exit 1 if any drift is found")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the committed baseline from the current window",
+    )
+    parser.add_argument("--min-samples", type=int, default=5)
+    args = parser.parse_args(argv)
+
+    current = aggregate(_recent_samples(args.limit))
+    total = sum(stats.sample_count for stats in current.values())
+
+    if args.update_baseline:
+        baseline = baseline_from_stats(current)
+        BASELINE_PATH.write_text(
+            json.dumps(baseline, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"wrote baseline for {len(baseline)} models ({total} samples) -> {BASELINE_PATH}")
+        return 0
+
+    findings = detect_drift(current, _load_baseline(), min_samples=args.min_samples)
+    if not findings:
+        print(f"no drift across {len(current)} models ({total} samples)")
+        return 0
+    print(f"DRIFT: {len(findings)} finding(s):")
+    for finding in findings:
+        print(f"  [{finding.kind}] {finding.provider}/{finding.model}: {finding.detail}")
+    return 1 if args.check else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/synthetic/drift.py
+++ b/src/trusted_router/synthetic/drift.py
@@ -1,0 +1,184 @@
+"""Day-over-day API-drift detection from provider benchmark samples.
+
+The rotation probe (and organic traffic) continuously record
+``ProviderBenchmarkSample`` rows per provider+model. Comparing a recent window
+against a committed baseline surfaces *undocumented* upstream API changes that
+no changelog would tell us about:
+
+* a model that started 404ing or erroring (deprecated / renamed upstream),
+* a brand-new error shape (``error_type`` / ``error_status``) we've never seen,
+* a latency cliff (p50 TTFT regressed well past its historical value),
+* a model that newly appeared.
+
+The logic here is pure and store-agnostic so it is trivially testable; the
+``scripts/detect_provider_drift.py`` CLI wires it to the real store + a
+committed baseline JSON.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.storage_models import ProviderBenchmarkSample
+
+
+def _model_key(provider: str, model: str) -> str:
+    return f"{provider}/{model}"
+
+
+@dataclass
+class ModelStats:
+    """Aggregated performance for one (provider, model) over a window."""
+
+    provider: str
+    model: str
+    sample_count: int = 0
+    error_count: int = 0
+    p50_ttft_ms: int | None = None
+    error_types: list[str] = field(default_factory=list)
+
+    @property
+    def key(self) -> str:
+        return _model_key(self.provider, self.model)
+
+    @property
+    def error_rate(self) -> float:
+        return self.error_count / self.sample_count if self.sample_count else 0.0
+
+    def to_baseline(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "sample_count": self.sample_count,
+            "error_rate": round(self.error_rate, 4),
+            "p50_ttft_ms": self.p50_ttft_ms,
+            "error_types": sorted(set(self.error_types)),
+        }
+
+
+def _median(values: Sequence[int]) -> int | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) // 2
+
+
+def aggregate(samples: Iterable[ProviderBenchmarkSample]) -> dict[str, ModelStats]:
+    """Group samples by (provider, model) into ``ModelStats``."""
+    grouped: dict[str, ModelStats] = {}
+    ttfts: dict[str, list[int]] = {}
+    for sample in samples:
+        key = _model_key(sample.provider, sample.model)
+        stats = grouped.get(key)
+        if stats is None:
+            stats = ModelStats(provider=sample.provider, model=sample.model)
+            grouped[key] = stats
+            ttfts[key] = []
+        stats.sample_count += 1
+        if sample.status != "success":
+            stats.error_count += 1
+            if sample.error_type:
+                stats.error_types.append(sample.error_type)
+            elif sample.error_status:
+                stats.error_types.append(f"http_{sample.error_status}")
+        # TTFT only meaningful on successful streamed responses.
+        if sample.first_token_milliseconds is not None:
+            ttfts[key].append(sample.first_token_milliseconds)
+    for key, stats in grouped.items():
+        stats.p50_ttft_ms = _median(ttfts[key])
+    return grouped
+
+
+@dataclass
+class DriftFinding:
+    kind: str  # appeared | error_spike | new_error_type | ttft_regression
+    provider: str
+    model: str
+    detail: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "provider": self.provider,
+            "model": self.model,
+            "detail": self.detail,
+        }
+
+
+def detect_drift(
+    current: dict[str, ModelStats],
+    baseline: dict[str, dict[str, Any]],
+    *,
+    min_samples: int = 5,
+    error_rate_jump: float = 0.2,
+    ttft_regression_ratio: float = 1.5,
+) -> list[DriftFinding]:
+    """Compare a current window's aggregates against the committed baseline.
+
+    Only models with at least ``min_samples`` in the current window are judged
+    (random rotation makes a thin window noisy). Disappearance is intentionally
+    NOT flagged on absence — a deprecated/renamed model instead shows up as an
+    ``error_spike`` + ``new_error_type`` (e.g. ``http_404``), which is a far
+    less noisy signal than "we happened not to sample it."
+    """
+    findings: list[DriftFinding] = []
+    for key, stats in sorted(current.items()):
+        if stats.sample_count < min_samples:
+            continue
+        prior = baseline.get(key)
+        if prior is None:
+            findings.append(
+                DriftFinding(
+                    "appeared",
+                    stats.provider,
+                    stats.model,
+                    f"new model not in baseline ({stats.sample_count} samples)",
+                )
+            )
+            continue
+        prior_error_rate = float(prior.get("error_rate") or 0.0)
+        if stats.error_rate - prior_error_rate >= error_rate_jump:
+            findings.append(
+                DriftFinding(
+                    "error_spike",
+                    stats.provider,
+                    stats.model,
+                    f"error rate {prior_error_rate:.0%} -> {stats.error_rate:.0%}",
+                )
+            )
+        prior_errors = set(prior.get("error_types") or [])
+        new_errors = sorted(set(stats.error_types) - prior_errors)
+        if new_errors:
+            findings.append(
+                DriftFinding(
+                    "new_error_type",
+                    stats.provider,
+                    stats.model,
+                    f"unseen error(s): {', '.join(new_errors)}",
+                )
+            )
+        prior_ttft = prior.get("p50_ttft_ms")
+        if (
+            prior_ttft
+            and stats.p50_ttft_ms is not None
+            and stats.p50_ttft_ms >= prior_ttft * ttft_regression_ratio
+        ):
+            findings.append(
+                DriftFinding(
+                    "ttft_regression",
+                    stats.provider,
+                    stats.model,
+                    f"p50 TTFT {prior_ttft}ms -> {stats.p50_ttft_ms}ms",
+                )
+            )
+    return findings
+
+
+def baseline_from_stats(current: dict[str, ModelStats]) -> dict[str, dict[str, Any]]:
+    """Serialize a current aggregate into the committed baseline shape."""
+    return {key: stats.to_baseline() for key, stats in sorted(current.items())}

--- a/tests/test_provider_drift.py
+++ b/tests/test_provider_drift.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.drift import (
+    aggregate,
+    baseline_from_stats,
+    detect_drift,
+)
+
+
+def _sample(
+    *,
+    provider: str = "openai",
+    model: str = "openai/gpt-5.4-nano",
+    status: str = "success",
+    ttft: int | None = 100,
+    error_type: str | None = None,
+    error_status: int | None = None,
+) -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample(
+        id="b",
+        model=model,
+        provider=provider,
+        provider_name=provider,
+        status=status,
+        usage_type="Credits",
+        streamed=True,
+        first_token_milliseconds=ttft,
+        error_type=error_type,
+        error_status=error_status,
+        source="synthetic",
+    )
+
+
+def test_aggregate_counts_errors_and_median_ttft() -> None:
+    samples = [
+        _sample(ttft=100),
+        _sample(ttft=200),
+        _sample(ttft=300),
+        _sample(status="error", ttft=None, error_status=500),
+    ]
+    stats = aggregate(samples)["openai/openai/gpt-5.4-nano"]
+    assert stats.sample_count == 4
+    assert stats.error_count == 1
+    assert stats.error_rate == 0.25
+    assert stats.p50_ttft_ms == 200  # median of [100,200,300]
+    assert stats.error_types == ["http_500"]
+
+
+def test_detect_drift_flags_error_spike() -> None:
+    current = aggregate([_sample(status="error", error_status=503) for _ in range(10)])
+    baseline = {"openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}}
+    findings = detect_drift(current, baseline)
+    kinds = {f.kind for f in findings}
+    assert "error_spike" in kinds
+    assert "new_error_type" in kinds  # http_503 unseen in baseline
+
+
+def test_detect_drift_flags_ttft_regression() -> None:
+    current = aggregate([_sample(ttft=400) for _ in range(10)])
+    baseline = {
+        "openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}
+    }
+    findings = [f for f in detect_drift(current, baseline) if f.kind == "ttft_regression"]
+    assert findings and "100ms -> 400ms" in findings[0].detail
+
+
+def test_detect_drift_flags_new_model_appearance() -> None:
+    current = aggregate([_sample() for _ in range(10)])
+    findings = detect_drift(current, baseline={})
+    assert [f.kind for f in findings] == ["appeared"]
+
+
+def test_detect_drift_respects_min_samples() -> None:
+    # Only 3 samples — below the default min_samples=5 — so no judgment.
+    current = aggregate([_sample(status="error", error_status=500) for _ in range(3)])
+    baseline = {"openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}}
+    assert detect_drift(current, baseline) == []
+
+
+def test_detect_drift_quiet_when_stable() -> None:
+    current = aggregate([_sample(ttft=110) for _ in range(10)])
+    baseline = {
+        "openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}
+    }
+    assert detect_drift(current, baseline) == []
+
+
+def test_baseline_round_trips_through_detect() -> None:
+    current = aggregate([_sample(ttft=120) for _ in range(10)])
+    baseline = baseline_from_stats(current)
+    # A baseline minted from the current window should show no drift against it.
+    assert detect_drift(current, baseline) == []
+    assert baseline["openai/openai/gpt-5.4-nano"]["p50_ttft_ms"] == 120
+
+
+def test_drift_cli_update_then_check(tmp_path, monkeypatch) -> None:
+    import scripts.detect_provider_drift as cli
+
+    baseline_file = tmp_path / "baseline.json"
+    monkeypatch.setattr(cli, "BASELINE_PATH", baseline_file)
+
+    healthy = [_sample(ttft=100) for _ in range(10)]
+    monkeypatch.setattr(cli, "_recent_samples", lambda limit: healthy)
+    # Mint a baseline from a healthy window.
+    assert cli.main(["--update-baseline"]) == 0
+    assert baseline_file.exists()
+    # Same window → no drift → --check passes.
+    assert cli.main(["--check"]) == 0
+
+    # Upstream starts erroring → --check fails (exit 1) so an alert can fire.
+    broken = [_sample(status="error", error_status=500) for _ in range(10)]
+    monkeypatch.setattr(cli, "_recent_samples", lambda limit: broken)
+    assert cli.main(["--check"]) == 1


### PR DESCRIPTION
**Completes Phase 1.** Pure drift logic in `synthetic/drift.py` + a thin `scripts/detect_provider_drift.py` CLI.

Aggregates a recent window of `ProviderBenchmarkSample`s per (provider, model) vs a committed baseline and flags undocumented upstream changes:
- **error_spike** — error rate jumped vs baseline
- **new_error_type** — an `error_type`/`error_status` (e.g. `http_404`) never seen before
- **ttft_regression** — p50 TTFT past a regression ratio
- **appeared** — a new model not in the baseline

Disappearance is deliberately NOT flagged on absence (random rotation makes a thin window noisy) — a deprecated/renamed model surfaces instead as `error_spike` + `new_error_type(http_404)`, a much cleaner signal.

CLI: `--check` (exit 1 on drift → alert/CI), `--update-baseline` (rewrite the committed baseline; review the diff in a PR). Baseline path env-overridable for tests.

8 new tests (aggregation, every drift kind, min-samples gating, stable-quiet, baseline round-trip, CLI update→check glue). **738 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)