### PR TITLE
feat(perf): leaderboard aggregation from benchmark samples

### DIFF
--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -1,0 +1,208 @@
+"""Aggregate ProviderBenchmarkSamples into leaderboard statistics.
+
+Pure, store-agnostic aggregation: given a window of samples (organic
+production traffic + synthetic rotation-probe samples, combined — the `source`
+field is internal-only and intentionally NOT surfaced here), compute per-model
+and per-provider performance: p50/p95 TTFT and TTFB, median throughput,
+uptime %, error rate, and sample counts.
+
+This is the data layer behind the public ``/leaderboard`` page and the per-model
+performance subpages. The page builds it from a recent window of samples behind
+the same short cache the status page uses, so there is no per-view store read.
+(A future scale optimization can precompute these as Bigtable rollups; the
+aggregation here is the reusable core either way.)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from trusted_router.storage_models import ProviderBenchmarkSample
+
+
+def _percentile(values: Sequence[int], percentile: int) -> int | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    # Nearest-rank: smallest value at or above the percentile position.
+    rank = max(1, -(-percentile * len(ordered) // 100))  # ceil(p*n/100)
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def _median_float(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+@dataclass
+class ProviderModelStats:
+    provider: str
+    model: str
+    sample_count: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    p50_ttft_ms: int | None = None
+    p95_ttft_ms: int | None = None
+    p50_ttfb_ms: int | None = None
+    p95_ttfb_ms: int | None = None
+    p50_tokens_per_second: float | None = None
+    last_seen: str | None = None
+
+    @property
+    def uptime(self) -> float:
+        return self.success_count / self.sample_count if self.sample_count else 0.0
+
+    @property
+    def error_rate(self) -> float:
+        return self.error_count / self.sample_count if self.sample_count else 0.0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "sample_count": self.sample_count,
+            "uptime": round(self.uptime, 4),
+            "error_rate": round(self.error_rate, 4),
+            "p50_ttft_ms": self.p50_ttft_ms,
+            "p95_ttft_ms": self.p95_ttft_ms,
+            "p50_ttfb_ms": self.p50_ttfb_ms,
+            "p95_ttfb_ms": self.p95_ttfb_ms,
+            "p50_tokens_per_second": (
+                round(self.p50_tokens_per_second, 2)
+                if self.p50_tokens_per_second is not None
+                else None
+            ),
+            "last_seen": self.last_seen,
+        }
+
+
+@dataclass
+class ProviderStats:
+    provider: str
+    model_count: int = 0
+    sample_count: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    p50_ttft_ms: int | None = None
+    p50_tokens_per_second: float | None = None
+
+    @property
+    def uptime(self) -> float:
+        return self.success_count / self.sample_count if self.sample_count else 0.0
+
+    @property
+    def error_rate(self) -> float:
+        return self.error_count / self.sample_count if self.sample_count else 0.0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "model_count": self.model_count,
+            "sample_count": self.sample_count,
+            "uptime": round(self.uptime, 4),
+            "error_rate": round(self.error_rate, 4),
+            "p50_ttft_ms": self.p50_ttft_ms,
+            "p50_tokens_per_second": (
+                round(self.p50_tokens_per_second, 2)
+                if self.p50_tokens_per_second is not None
+                else None
+            ),
+        }
+
+
+def _sort_key(p50_ttft_ms: int | None) -> tuple[int, int]:
+    # Fastest measured TTFT first; un-measured (None) sink to the bottom.
+    return (0 if p50_ttft_ms is not None else 1, p50_ttft_ms or 0)
+
+
+def aggregate_leaderboard(
+    samples: Iterable[ProviderBenchmarkSample], *, min_samples: int = 1
+) -> dict[str, Any]:
+    """Aggregate samples into ranked per-model and per-provider stats.
+
+    Models/providers with fewer than ``min_samples`` are excluded from the
+    ranked lists (callers surface a "limited data" note for thin coverage).
+    """
+    by_model: dict[tuple[str, str], ProviderModelStats] = {}
+    ttft: dict[tuple[str, str], list[int]] = {}
+    ttfb: dict[tuple[str, str], list[int]] = {}
+    tps: dict[tuple[str, str], list[float]] = {}
+
+    for sample in samples:
+        key = (sample.provider, sample.model)
+        stats = by_model.get(key)
+        if stats is None:
+            stats = ProviderModelStats(provider=sample.provider, model=sample.model)
+            by_model[key] = stats
+            ttft[key] = []
+            ttfb[key] = []
+            tps[key] = []
+        stats.sample_count += 1
+        if sample.status == "success":
+            stats.success_count += 1
+        else:
+            stats.error_count += 1
+        if sample.first_token_milliseconds is not None:
+            ttft[key].append(sample.first_token_milliseconds)
+        if sample.ttfb_milliseconds is not None:
+            ttfb[key].append(sample.ttfb_milliseconds)
+        if sample.speed_tokens_per_second:
+            tps[key].append(sample.speed_tokens_per_second)
+        if stats.last_seen is None or sample.created_at > stats.last_seen:
+            stats.last_seen = sample.created_at
+
+    for key, stats in by_model.items():
+        stats.p50_ttft_ms = _percentile(ttft[key], 50)
+        stats.p95_ttft_ms = _percentile(ttft[key], 95)
+        stats.p50_ttfb_ms = _percentile(ttfb[key], 50)
+        stats.p95_ttfb_ms = _percentile(ttfb[key], 95)
+        stats.p50_tokens_per_second = _median_float(tps[key])
+
+    models = [s for s in by_model.values() if s.sample_count >= min_samples]
+    models.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
+
+    providers = _aggregate_providers(models)
+    return {
+        "models": [s.as_dict() for s in models],
+        "providers": [s.as_dict() for s in providers],
+        "model_count": len(models),
+        "provider_count": len(providers),
+        "total_samples": sum(s.sample_count for s in models),
+    }
+
+
+def _aggregate_providers(model_stats: list[ProviderModelStats]) -> list[ProviderStats]:
+    by_provider: dict[str, ProviderStats] = {}
+    ttft: dict[str, list[int]] = {}
+    tps: dict[str, list[float]] = {}
+    for stats in model_stats:
+        agg = by_provider.get(stats.provider)
+        if agg is None:
+            agg = ProviderStats(provider=stats.provider)
+            by_provider[stats.provider] = agg
+            ttft[stats.provider] = []
+            tps[stats.provider] = []
+        agg.model_count += 1
+        agg.sample_count += stats.sample_count
+        agg.success_count += stats.success_count
+        agg.error_count += stats.error_count
+        # Weight each model's p50 by its sample count for the provider median.
+        if stats.p50_ttft_ms is not None:
+            ttft[stats.provider].extend([stats.p50_ttft_ms] * stats.sample_count)
+        if stats.p50_tokens_per_second is not None:
+            tps[stats.provider].extend([stats.p50_tokens_per_second] * stats.sample_count)
+    providers = list(by_provider.values())
+    for agg in providers:
+        agg.p50_ttft_ms = _percentile(ttft[agg.provider], 50)
+        agg.p50_tokens_per_second = _median_float(tps[agg.provider])
+    providers.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
+    return providers

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+
+
+def _sample(
+    *,
+    provider: str,
+    model: str,
+    status: str = "success",
+    ttft: int | None = None,
+    ttfb: int | None = None,
+    tps: float | None = None,
+    created_at: str = "2026-06-04T00:00:00Z",
+) -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample(
+        id="b",
+        model=model,
+        provider=provider,
+        provider_name=provider,
+        status=status,
+        usage_type="Credits",
+        streamed=True,
+        first_token_milliseconds=ttft,
+        ttfb_milliseconds=ttfb,
+        speed_tokens_per_second=tps,
+        created_at=created_at,
+    )
+
+
+def test_aggregate_computes_per_model_metrics() -> None:
+    samples = [
+        _sample(provider="cerebras", model="c/m", ttft=100, ttfb=80, tps=300.0),
+        _sample(provider="cerebras", model="c/m", ttft=200, ttfb=120, tps=320.0),
+        _sample(provider="cerebras", model="c/m", ttft=300, ttfb=160, tps=280.0),
+        _sample(provider="cerebras", model="c/m", status="error", ttft=None),
+    ]
+    result = aggregate_leaderboard(samples)
+    model = result["models"][0]
+    assert model["provider"] == "cerebras"
+    assert model["sample_count"] == 4
+    assert model["uptime"] == 0.75
+    assert model["error_rate"] == 0.25
+    assert model["p50_ttft_ms"] == 200  # median of [100,200,300]
+    assert model["p50_ttfb_ms"] == 120
+    assert model["p50_tokens_per_second"] == 300.0  # median of [280,300,320]
+    assert result["total_samples"] == 4
+
+
+def test_models_sorted_fastest_first_unmeasured_last() -> None:
+    samples = [
+        _sample(provider="slow", model="slow/m", ttft=500),
+        _sample(provider="fast", model="fast/m", ttft=90),
+        # No TTFT measured at all -> should sink below measured models.
+        _sample(provider="unknown", model="unknown/m", status="error", ttft=None),
+    ]
+    result = aggregate_leaderboard(samples)
+    ordered = [m["model"] for m in result["models"]]
+    assert ordered[0] == "fast/m"
+    assert ordered[1] == "slow/m"
+    assert ordered[2] == "unknown/m"  # un-measured at the bottom
+
+
+def test_min_samples_filters_thin_models() -> None:
+    samples = [
+        _sample(provider="a", model="a/keep", ttft=100),
+        _sample(provider="a", model="a/keep", ttft=110),
+        _sample(provider="a", model="a/drop", ttft=100),  # only 1 sample
+    ]
+    result = aggregate_leaderboard(samples, min_samples=2)
+    models = [m["model"] for m in result["models"]]
+    assert models == ["a/keep"]
+
+
+def test_provider_rollup_aggregates_models() -> None:
+    samples = [
+        _sample(provider="p", model="p/m1", ttft=100, tps=200.0),
+        _sample(provider="p", model="p/m1", ttft=100, tps=200.0),
+        _sample(provider="p", model="p/m2", status="error", ttft=None),
+    ]
+    result = aggregate_leaderboard(samples)
+    assert result["provider_count"] == 1
+    provider = result["providers"][0]
+    assert provider["provider"] == "p"
+    assert provider["model_count"] == 2
+    assert provider["sample_count"] == 3
+    # 2 success / 3 total.
+    assert provider["uptime"] == round(2 / 3, 4)
+
+
+def test_empty_samples_produce_empty_leaderboard() -> None:
+    result = aggregate_leaderboard([])
+    assert result["models"] == []
+    assert result["providers"] == []
+    assert result["total_samples"] == 0


### PR DESCRIPTION
**Phase 2.** Pure, store-agnostic aggregation in `synthetic/leaderboard.py` — the data layer for the upcoming `/leaderboard` page and per-model performance subpages.

Given a window of `ProviderBenchmarkSample`s (organic + synthetic combined; the internal `source` field is **not** surfaced publicly), computes per-model and per-provider: **p50/p95 TTFT + TTFB**, median **throughput**, **uptime %**, **error rate**, sample counts, last-seen. Ranks fastest-measured-TTFT first; un-measured models sink to the bottom.

**Design note — Bigtable rollups deferred (on purpose).** The page will build this from the already-indexed raw samples behind the same short cache `/status` uses (so no per-view store read, consistent with "no hot-path live reads"). A precomputed-rollup write path would add a write to the billing hot path and is premature at current volume — this aggregation is the reusable core if/when we precompute for scale.

5 tests (per-model metrics + percentiles, ordering, min-samples filter, provider rollup, empty). **743 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)