### PR TITLE
feat(perf): public /leaderboard page

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -59,6 +59,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/providers",
     "/benchmarks",
     "/rankings",
+    "/leaderboard",
     "/status",
     "/security",
     "/chat",
@@ -454,6 +455,30 @@ def public_benchmarks_html(settings: Settings) -> str:
         models=_seo_model_rows(),
         providers=[_provider_view(provider) for provider in providers_for_display()],
         benchmark_links=list(_BENCHMARK_INDEX_LINKS),
+        google_enabled=settings.google_oauth_enabled,
+        github_enabled=settings.github_oauth_enabled,
+        static_version=_static_version(settings),
+    )
+
+
+def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> str:
+    """Render the public performance leaderboard from a precomputed snapshot.
+
+    `snapshot` is the output of `aggregate_leaderboard()` plus a `generated_at`
+    timestamp — built (and cached) by the route so this stays render-only.
+    """
+    return _env().get_template("public/leaderboard.html").render(
+        api_base_url=settings.api_base_url,
+        site_url=f"https://{settings.trusted_domain}/leaderboard",
+        title="LLM Provider & Model Speed Leaderboard | TrustedRouter",
+        heading="Provider & model performance",
+        description=(
+            "Measured time-to-first-token, time-to-first-byte, throughput, and "
+            "uptime for every LLM provider and model TrustedRouter routes to — "
+            "continuously sampled, not vendor-claimed."
+        ),
+        page_kind="leaderboard",
+        snapshot=snapshot,
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,
         static_version=_static_version(settings),

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -25,6 +25,7 @@ from trusted_router.dashboard import (
     llms_txt,
     public_benchmarks_html,
     public_chat_html,
+    public_leaderboard_html,
     public_model_compare_html,
     public_model_detail_html,
     public_model_not_found_html,
@@ -40,6 +41,7 @@ from trusted_router.dashboard import (
 from trusted_router.og import OG_PNG_PATH
 from trusted_router.storage import STORE
 from trusted_router.storage_models import utcnow
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 from trusted_router.synthetic.status import history_payload, status_snapshot
 from trusted_router.trust import gcp_release, trust_html
 from trusted_router.views import render_template
@@ -55,7 +57,12 @@ STATUS_RESPONSE_CACHE_SECONDS = 60
 STATUS_RESPONSE_STALE_SECONDS = 600
 STATUS_HISTORY_CACHE_SECONDS = 300
 STATUS_HISTORY_STALE_SECONDS = 1_800
+LEADERBOARD_SAMPLE_LIMIT = 8_000
+LEADERBOARD_MIN_SAMPLES = 1
+LEADERBOARD_RESPONSE_CACHE_SECONDS = 60
+LEADERBOARD_RESPONSE_STALE_SECONDS = 900
 _STATUS_CACHE: tuple[float, dict[str, Any]] | None = None
+_LEADERBOARD_CACHE: tuple[float, dict[str, Any]] | None = None
 _STATUS_RESPONSE_CACHE: dict[str, _CachedPublicBody] = {}
 _STATUS_RESPONSE_REFRESHING: set[str] = set()
 _STATUS_RESPONSE_CACHE_LOCK = threading.RLock()
@@ -246,6 +253,20 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             settings,
             host=request.headers.get("host", ""),
             background_tasks=background_tasks,
+        )
+
+    @public_html_route("/leaderboard")
+    async def leaderboard_page(request: Request, background_tasks: BackgroundTasks) -> Response:
+        return _cached_public_response(
+            settings,
+            key=f"leaderboard:page:{request.headers.get('host', '')}",
+            media_type="text/html",
+            ttl_seconds=LEADERBOARD_RESPONSE_CACHE_SECONDS,
+            stale_seconds=LEADERBOARD_RESPONSE_STALE_SECONDS,
+            background_tasks=background_tasks,
+            build=lambda: public_leaderboard_html(
+                settings, _leaderboard_snapshot(settings)
+            ).encode(),
         )
 
     @app.get("/status.json")
@@ -594,6 +615,21 @@ def _status_history_page_html(
         window=window,
         json_url=f"/status/history?window={window}&format=json",
     )
+
+
+def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
+    global _LEADERBOARD_CACHE
+    now = time.monotonic()
+    if settings.environment != "test" and _LEADERBOARD_CACHE is not None:
+        cached_at, payload = _LEADERBOARD_CACHE
+        if now - cached_at < STATUS_SNAPSHOT_CACHE_SECONDS:
+            return payload
+    samples = STORE.provider_benchmark_samples(date=None, limit=LEADERBOARD_SAMPLE_LIMIT)
+    payload = aggregate_leaderboard(samples, min_samples=LEADERBOARD_MIN_SAMPLES)
+    payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
+    if settings.environment != "test":
+        _LEADERBOARD_CACHE = (now, payload)
+    return payload
 
 
 def _status_snapshot(settings: Settings) -> dict[str, Any]:

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -482,3 +482,14 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
   .regions-map-stage { grid-template-columns:1fr; }
   .region-list { max-height:none; }
 }
+
+/* Performance leaderboard tables */
+.leaderboard-page .status-section + .status-section { margin-top:18px; }
+.leaderboard-table-wrap { overflow-x:auto; }
+.leaderboard-table { width:100%; border-collapse:collapse; font-size:13px; }
+.leaderboard-table th, .leaderboard-table td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--line2); white-space:nowrap; }
+.leaderboard-table th { color:var(--muted); font-weight:650; background:#fbfcfd; }
+.leaderboard-table tbody tr:hover { background:var(--soft); }
+.leaderboard-table td a { color:var(--blue); text-decoration:none; }
+.leaderboard-table td a:hover { text-decoration:underline; }
+.lb-badge { display:inline-block; margin-left:8px; padding:1px 7px; border-radius:999px; font-size:11px; color:var(--muted); background:var(--line2); border:1px solid var(--line); }

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -47,6 +47,7 @@
         <a href="/models">Models</a>
         <a href="/providers">Providers</a>
         <a href="/benchmarks">Benchmarks</a>
+        <a href="/leaderboard">Leaderboard</a>
         <a href="/chat">Chat</a>
         <a href="/status">Status</a>
         <a href="https://trust.trustedrouter.com">Trust</a>

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -1,0 +1,102 @@
+{% extends "public/_base.html" %}
+
+{% block hero %}
+<section class="status-hero">
+  <div>
+    <span class="eyebrow">Measured performance</span>
+    <h1>{{ heading }}</h1>
+    <p class="lead">{{ description }}</p>
+  </div>
+  <div class="status-updated">
+    <span>Last updated</span>
+    <strong>{{ snapshot.generated_at }}</strong>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section class="status-page leaderboard-page">
+  <div class="status-note">
+    Continuously sampled from TrustedRouter's monitor regions — time-to-first-token (TTFT),
+    time-to-first-byte (TTFB), throughput, and success rate measured on real streaming
+    requests, not vendor-claimed. No prompt or output content is ever stored.
+  </div>
+
+  {% if not snapshot.models %}
+  <div class="status-note status-note-warning">
+    Measurements are warming up — performance data will appear here shortly. Check back soon.
+  </div>
+  {% else %}
+  <section class="status-section">
+    <div class="status-section-head">
+      <div>
+        <h2>Providers</h2>
+        <p>Ranked by measured p50 time-to-first-token across all of a provider's models
+          ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} samples).</p>
+      </div>
+    </div>
+    <div class="leaderboard-table-wrap">
+      <table class="leaderboard-table">
+        <thead>
+          <tr>
+            <th>#</th><th>Provider</th><th>Models</th>
+            <th>p50 TTFT</th><th>Throughput</th><th>Uptime</th><th>Samples</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for p in snapshot.providers %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td><a href="/providers/{{ p.provider }}">{{ p.provider }}</a></td>
+            <td>{{ p.model_count }}</td>
+            <td>{% if p.p50_ttft_ms is not none %}{{ p.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if p.p50_tokens_per_second is not none %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
+            <td>{{ '%.2f'|format(p.uptime * 100) }}%</td>
+            <td>{{ p.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="status-section">
+    <div class="status-section-head">
+      <div>
+        <h2>Models</h2>
+        <p>Every model TrustedRouter routes to, fastest measured TTFT first.
+          Rows with few samples are marked — more data sharpens the numbers.</p>
+      </div>
+    </div>
+    <div class="leaderboard-table-wrap">
+      <table class="leaderboard-table">
+        <thead>
+          <tr>
+            <th>#</th><th>Model</th><th>Provider</th>
+            <th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th>
+            <th>Throughput</th><th>Uptime</th><th>Samples</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for m in snapshot.models %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a>
+              {% if m.sample_count < 20 %}<span class="lb-badge">limited data</span>{% endif %}
+            </td>
+            <td>{{ m.provider }}</td>
+            <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if m.p95_ttft_ms is not none %}{{ m.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
+            <td>{{ '%.2f'|format(m.uptime * 100) }}%</td>
+            <td>{{ m.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, ProviderBenchmarkSample
+
+
+def _settings() -> Settings:
+    return Settings(
+        environment="test",
+        sentry_dsn=None,
+        stripe_secret_key=None,
+        stripe_webhook_secret=None,
+        google_client_id=None,
+        google_client_secret=None,
+        google_oauth_redirect_url=None,
+        github_client_id=None,
+        github_client_secret=None,
+        github_oauth_redirect_url=None,
+    )
+
+
+def _seed(provider: str, model: str, ttft: int, ttfb: int) -> None:
+    for _ in range(3):
+        STORE.record_provider_benchmark(
+            ProviderBenchmarkSample(
+                id=f"bench-page-{provider}-{model}-{ttft}",
+                model=model,
+                provider=provider,
+                provider_name=provider.title(),
+                status="success",
+                usage_type="Credits",
+                streamed=True,
+                first_token_milliseconds=ttft,
+                ttfb_milliseconds=ttfb,
+                speed_tokens_per_second=250.0,
+                source="synthetic",
+            )
+        )
+
+
+def test_leaderboard_page_renders_measurements() -> None:
+    client = TestClient(create_app(_settings(), init_observability=False))
+    # Seed after app creation: the route reads STORE at request time, and app
+    # construction may reset the in-memory store.
+    _seed("cerebras", "meta/llama-3.3-70b", ttft=120, ttfb=80)
+    resp = client.get("/leaderboard")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Measured performance" in body  # hero eyebrow
+    assert "p50 TTFT" in body  # table header
+    assert "cerebras" in body  # seeded provider row
+    assert "meta/llama-3.3-70b" in body  # seeded model row
+
+
+def test_leaderboard_in_sitemap() -> None:
+    client = TestClient(create_app(_settings(), init_observability=False))
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+    assert "/leaderboard" in resp.text

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -331,7 +331,7 @@ def test_data_collection_deny_keeps_zdr_drops_standard() -> None:
     # deny == "no data collection" → require >= no-store tier. ZDR
     # providers (anthropic) carry the conservative stores_content=True
     # default but must NOT be dropped; standard providers must be.
-    from trusted_router.catalog import model_max_privacy_tier, PRIVACY_TIER_NO_STORE
+    from trusted_router.catalog import PRIVACY_TIER_NO_STORE, model_max_privacy_tier
 
     kept = chat_route_candidates(
         {"model": "anthropic/claude-sonnet-4.6", "provider": {"data_collection": "deny"}},
@@ -350,7 +350,7 @@ def test_data_collection_deny_keeps_zdr_drops_standard() -> None:
 def test_unverified_provider_defaults_to_stores_content() -> None:
     # Conservative default: a provider with no explicit posture is assumed
     # to store content (tier STANDARD), never silently "no-store".
-    from trusted_router.catalog import PROVIDERS, provider_privacy_tier, PRIVACY_TIER_STANDARD
+    from trusted_router.catalog import PRIVACY_TIER_STANDARD, PROVIDERS, provider_privacy_tier
 
     assert provider_privacy_tier(PROVIDERS["openai"]) == PRIVACY_TIER_STANDARD
     assert PROVIDERS["openai"].stores_content is True


### PR DESCRIPTION
**Phase 3.** A public `/leaderboard` ranking providers & models by **measured** p50/p95 **TTFT + TTFB**, throughput, and uptime — from the `ProviderBenchmarkSample`s we already collect (organic + synthetic combined; `source` not surfaced). Fastest TTFT first; thin-data rows flagged "limited data"; graceful empty state while measurements warm up.

- `public_leaderboard_html()` render-only; route + `_leaderboard_snapshot()` fetch recent samples → `aggregate_leaderboard` → served via the shared `_cached_public_response` (60s TTL / 900s stale) so **no per-view store read**.
- `/leaderboard` in `SEO_CORE_PATHS` (sitemap) + nav link; template + table CSS matching the status-page theme.
- Rows deep-link to `/providers/{slug}` and `/models/{id}/performance` — **enriching those existing pages with measured numbers is the next follow-up**.

Until the rotation probe is enabled it shows organic data + the warming-up state. 2 page tests + a stray-import sort. **745 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)