### PR TITLE
feat(seo): measured perf on model /performance + provider pages

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -29,6 +29,7 @@ from trusted_router.catalog import (
     providers_for_display,
 )
 from trusted_router.config import Settings
+from trusted_router.measured import measured_for_model, measured_for_provider
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR
 from trusted_router.og import OG_DESCRIPTION, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, OG_TITLE
 from trusted_router.regions import configured_regions, region_map_payload
@@ -572,6 +573,7 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
         ),
         provider=_provider_detail_view(provider, served_models=served_models),
         served_models=served_models,
+        measured=measured_for_provider(provider.slug, test_mode=settings.environment == "test"),
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,
         static_version=_static_version(settings),
@@ -650,6 +652,7 @@ def public_model_section_html(settings: Settings, model_id: str, section: str) -
         section_label=label,
         benchmark_links=_benchmark_links(model),
         benchmark_scores=scores_for_model(model.id),
+        measured=measured_for_model(model.id, test_mode=settings.environment == "test"),
         json_ld_blob=_model_json_ld(settings, model, f"https://{settings.trusted_domain}/models/{model_id}"),
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,

--- a/src/trusted_router/measured.py
+++ b/src/trusted_router/measured.py
@@ -1,0 +1,52 @@
+"""Cached measured-performance accessors for the per-model and per-provider
+public pages.
+
+The /leaderboard route has its own cached snapshot; these accessors give the
+render-only dashboard functions the same measured data (p50/p95 TTFT/TTFB,
+throughput, uptime) sliced per model or per provider — behind a short TTL so a
+model/provider page view never triggers a live store scan. Pass
+`test_mode=True` (settings.environment == "test") to bypass the cache so the
+per-test STORE reset isn't masked by a stale snapshot.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from trusted_router.storage import STORE
+from trusted_router.storage_models import utcnow
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+
+_SAMPLE_LIMIT = 8_000
+_TTL_SECONDS = 60
+_CACHE: tuple[float, dict[str, Any]] | None = None
+
+
+def measured_snapshot(*, test_mode: bool = False) -> dict[str, Any]:
+    global _CACHE
+    now = time.monotonic()
+    if not test_mode and _CACHE is not None and now - _CACHE[0] < _TTL_SECONDS:
+        return _CACHE[1]
+    samples = STORE.provider_benchmark_samples(date=None, limit=_SAMPLE_LIMIT)
+    payload = aggregate_leaderboard(samples, min_samples=1)
+    payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
+    if not test_mode:
+        _CACHE = (now, payload)
+    return payload
+
+
+def measured_for_model(model_id: str, *, test_mode: bool = False) -> list[dict[str, Any]]:
+    """Per-provider measured rows for one model (a model can be served by more
+    than one provider; each is a distinct sample group)."""
+    snapshot = measured_snapshot(test_mode=test_mode)
+    return [row for row in snapshot["models"] if row["model"] == model_id]
+
+
+def measured_for_provider(provider: str, *, test_mode: bool = False) -> dict[str, Any]:
+    snapshot = measured_snapshot(test_mode=test_mode)
+    provider_row = next(
+        (row for row in snapshot["providers"] if row["provider"] == provider), None
+    )
+    models = [row for row in snapshot["models"] if row["provider"] == provider]
+    return {"provider_row": provider_row, "models": models}

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -84,6 +84,29 @@
       </tbody>
     </table>
     {% elif section == "performance" %}
+    {% if measured %}
+    <h3>Measured performance</h3>
+    <p class="muted-copy">Continuously sampled p50/p95 time-to-first-token (TTFT), time-to-first-byte (TTFB), throughput, and success rate for {{ model.name }} — real measurements from TrustedRouter's monitor, no prompt or output content stored.</p>
+    <div class="leaderboard-table-wrap">
+      <table class="leaderboard-table">
+        <thead><tr><th>Provider</th><th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th><th>Throughput</th><th>Uptime</th><th>Samples</th></tr></thead>
+        <tbody>
+          {% for r in measured %}
+          <tr>
+            <td><a href="/providers/{{ r.provider }}">{{ r.provider }}</a></td>
+            <td>{% if r.p50_ttft_ms is not none %}{{ r.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if r.p95_ttft_ms is not none %}{{ r.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if r.p50_ttfb_ms is not none %}{{ r.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if r.p50_tokens_per_second is not none %}{{ '%.0f'|format(r.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
+            <td>{{ '%.2f'|format(r.uptime * 100) }}%</td>
+            <td>{{ r.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p class="muted-copy" style="margin-top:10px">Full <a href="/leaderboard">provider &amp; model leaderboard</a>.</p>
+    {% endif %}
     <div class="marketing-grid three">
       <div class="marketing-card">
         <span class="card-label">Provider diversity</span>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -22,6 +22,45 @@
   </div>
 </section>
 
+{% if measured.provider_row %}
+<section class="panel">
+  <div class="panel-head">
+    <h2>Measured performance</h2>
+    <span class="pill good">{{ measured.provider_row.sample_count }} samples</span>
+  </div>
+  <div class="panel-body">
+    <p class="muted-copy">Continuously sampled across {{ provider.name }}'s routed models — p50 TTFT, throughput, and success rate. No prompt or output content stored.</p>
+    <table>
+      <tbody>
+        <tr><th>p50 TTFT</th><td>{% if measured.provider_row.p50_ttft_ms is not none %}{{ measured.provider_row.p50_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
+        <tr><th>Throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td></tr>
+        <tr><th>Uptime</th><td>{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%</td></tr>
+      </tbody>
+    </table>
+    {% if measured.models %}
+    <div class="leaderboard-table-wrap" style="margin-top:12px">
+      <table class="leaderboard-table">
+        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Throughput</th><th>Uptime</th><th>Samples</th></tr></thead>
+        <tbody>
+          {% for m in measured.models %}
+          <tr>
+            <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a></td>
+            <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
+            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
+            <td>{{ '%.2f'|format(m.uptime * 100) }}%</td>
+            <td>{{ m.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+    <p class="muted-copy" style="margin-top:10px"><a href="/leaderboard">Full provider &amp; model leaderboard</a>.</p>
+  </div>
+</section>
+{% endif %}
+
 <section class="model-catalog">
   <div class="model-catalog-head">
     <div>

--- a/tests/test_measured_pages.py
+++ b/tests/test_measured_pages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, ProviderBenchmarkSample
+
+
+def _settings() -> Settings:
+    return Settings(
+        environment="test",
+        sentry_dsn=None,
+        stripe_secret_key=None,
+        stripe_webhook_secret=None,
+        google_client_id=None,
+        google_client_secret=None,
+        google_oauth_redirect_url=None,
+        github_client_id=None,
+        github_client_secret=None,
+        github_oauth_redirect_url=None,
+    )
+
+
+def _seed(provider: str, model: str, *, ttft: int, ttfb: int) -> None:
+    for i in range(4):
+        STORE.record_provider_benchmark(
+            ProviderBenchmarkSample(
+                id=f"bench-measured-{provider}-{model}-{i}",
+                model=model,
+                provider=provider,
+                provider_name=provider.title(),
+                status="success",
+                usage_type="Credits",
+                streamed=True,
+                first_token_milliseconds=ttft,
+                ttfb_milliseconds=ttfb,
+                speed_tokens_per_second=120.0,
+                source="synthetic",
+            )
+        )
+
+
+def test_model_performance_page_shows_measured() -> None:
+    client = TestClient(create_app(_settings(), init_observability=False))
+    _seed("deepinfra", "meta-llama/llama-3.3-70b-instruct", ttft=150, ttfb=90)
+    resp = client.get("/models/meta-llama/llama-3.3-70b-instruct/performance")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Measured performance" in body
+    assert "deepinfra" in body
+    assert "150 ms" in body
+
+
+def test_provider_detail_page_shows_measured() -> None:
+    client = TestClient(create_app(_settings(), init_observability=False))
+    _seed("cerebras", "meta-llama/llama-3.3-70b-instruct", ttft=110, ttfb=70)
+    resp = client.get("/providers/cerebras")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Measured performance" in body
+    assert "110 ms" in body
+
+
+def test_model_performance_page_without_data_still_renders() -> None:
+    # No seeded samples for this model → no measured table, page still 200.
+    client = TestClient(create_app(_settings(), init_observability=False))
+    resp = client.get("/models/openai/gpt-5.4-nano/performance")
+    assert resp.status_code == 200


### PR DESCRIPTION
Phase 3 (cont). Surfaces the measured leaderboard data on the per-model **/performance** subpage and the **/providers/{slug}** page — OpenRouter's "per-provider latency/throughput/uptime" view, cited to our own continuous measurement.

- `measured.py`: 60s-TTL cached `measured_for_model()` / `measured_for_provider()` over the benchmark aggregation → a per-view page render never triggers a live store scan (consistent with "no hot-path reads"). `test_mode` bypasses cache so per-test STORE resets aren't masked.
- `/models/{id}/performance`: per-provider table (p50/p95 TTFT, TTFB, throughput, uptime, samples).
- `/providers/{slug}`: provider-aggregate panel + per-model table.
- Both gate on data presence (graceful while the probe is still dark).

3 page tests. **753 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)