### PR TITLE
chore(monitor): launch provider/model rotation probe

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -64,6 +64,16 @@ BASE_ENV_VARS=(
   # of clean runs at 30s under the new resources.
   "TR_SYNTHETIC_RUNS_PER_INVOCATION=2"
   "TR_SYNTHETIC_RUN_SPACING_SECONDS=30"
+  # Provider/model rotation probe — LAUNCHED (2026-06-04). Each pass takes
+  # TR_SYNTHETIC_ROTATION_PER_PASS random provider+model samples (two-stage),
+  # streams a tiny max_tokens=16 request, and records measured TTFB/TTFT into
+  # the benchmark store that feeds /leaderboard + the per-model/provider pages
+  # + API-drift detection. To control spend: lower PER_PASS or set ENABLED to
+  # false. Watch the monitor workspace's credit burn (these spend prepaid
+  # credits on the synthetic-monitor key). At 4/pass × 2 passes × 2 regions
+  # that's ~16 probes/min (~$30-50/mo at max_tokens=16).
+  "TR_SYNTHETIC_ROTATION_ENABLED=true"
+  "TR_SYNTHETIC_ROTATION_PER_PASS=4"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )


### PR DESCRIPTION
Flips the rotation probe ON (config-as-code) — `TR_SYNTHETIC_ROTATION_ENABLED=true`, `TR_SYNTHETIC_ROTATION_PER_PASS=4` on the synthetic monitor jobs. Starts populating the measured-performance dataset behind /leaderboard + the per-model/provider pages + drift detection.

~16 probes/min across 2 regions (~$30-50/mo at max_tokens=16). Throttle via PER_PASS or ENABLED=false. Spends prepaid credits on the synthetic-monitor key — watch that workspace balance. Also flipping live via gcloud so it starts before the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)