### PR TITLE
feat(perf): surface provider errors on /status + leaderboard

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -735,6 +735,15 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
         else f"https://{settings.trusted_domain}/status"
     )
     snapshot = _status_snapshot(settings)
+    # Measured upstream-provider health from the rotation-probe / organic
+    # benchmark samples. Informational provider watch — intentionally NOT part
+    # of the router-core paging SLO above (a flaky upstream model must not page
+    # router health), but surfaced here so provider errors are visible.
+    leaderboard = _leaderboard_snapshot(settings)
+    provider_health = sorted(
+        leaderboard.get("providers", []),
+        key=lambda p: (-p.get("error_rate", 0.0), p.get("provider", "")),
+    )
     return render_template(
         "public/status.html",
         api_base_url=settings.api_base_url,
@@ -746,4 +755,5 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
         github_enabled=settings.github_oauth_enabled,
         static_version=settings.release,
         snapshot=snapshot,
+        provider_health=provider_health,
     )

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -15,8 +15,9 @@ aggregation here is the reusable core either way.)
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from trusted_router.storage_models import ProviderBenchmarkSample
@@ -56,6 +57,7 @@ class ProviderModelStats:
     p95_ttfb_ms: int | None = None
     p50_tokens_per_second: float | None = None
     last_seen: str | None = None
+    errors: Counter[str] = field(default_factory=Counter)
 
     @property
     def uptime(self) -> float:
@@ -65,6 +67,11 @@ class ProviderModelStats:
     def error_rate(self) -> float:
         return self.error_count / self.sample_count if self.sample_count else 0.0
 
+    @property
+    def top_error(self) -> str | None:
+        common = self.errors.most_common(1)
+        return common[0][0] if common else None
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "provider": self.provider,
@@ -72,6 +79,8 @@ class ProviderModelStats:
             "sample_count": self.sample_count,
             "uptime": round(self.uptime, 4),
             "error_rate": round(self.error_rate, 4),
+            "top_error": self.top_error,
+            "errors": dict(self.errors),
             "p50_ttft_ms": self.p50_ttft_ms,
             "p95_ttft_ms": self.p95_ttft_ms,
             "p50_ttfb_ms": self.p50_ttfb_ms,
@@ -94,6 +103,7 @@ class ProviderStats:
     error_count: int = 0
     p50_ttft_ms: int | None = None
     p50_tokens_per_second: float | None = None
+    errors: Counter[str] = field(default_factory=Counter)
 
     @property
     def uptime(self) -> float:
@@ -103,6 +113,11 @@ class ProviderStats:
     def error_rate(self) -> float:
         return self.error_count / self.sample_count if self.sample_count else 0.0
 
+    @property
+    def top_error(self) -> str | None:
+        common = self.errors.most_common(1)
+        return common[0][0] if common else None
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "provider": self.provider,
@@ -110,6 +125,8 @@ class ProviderStats:
             "sample_count": self.sample_count,
             "uptime": round(self.uptime, 4),
             "error_rate": round(self.error_rate, 4),
+            "top_error": self.top_error,
+            "errors": dict(self.errors),
             "p50_ttft_ms": self.p50_ttft_ms,
             "p50_tokens_per_second": (
                 round(self.p50_tokens_per_second, 2)
@@ -151,6 +168,10 @@ def aggregate_leaderboard(
             stats.success_count += 1
         else:
             stats.error_count += 1
+            label = sample.error_type or (
+                f"http_{sample.error_status}" if sample.error_status else "error"
+            )
+            stats.errors[label] += 1
         if sample.first_token_milliseconds is not None:
             ttft[key].append(sample.first_token_milliseconds)
         if sample.ttfb_milliseconds is not None:
@@ -195,6 +216,7 @@ def _aggregate_providers(model_stats: list[ProviderModelStats]) -> list[Provider
         agg.sample_count += stats.sample_count
         agg.success_count += stats.success_count
         agg.error_count += stats.error_count
+        agg.errors.update(stats.errors)
         # Weight each model's p50 by its sample count for the provider median.
         if stats.p50_ttft_ms is not None:
             ttft[stats.provider].extend([stats.p50_ttft_ms] * stats.sample_count)

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -40,7 +40,7 @@
         <thead>
           <tr>
             <th>#</th><th>Provider</th><th>Models</th>
-            <th>p50 TTFT</th><th>Throughput</th><th>Uptime</th><th>Samples</th>
+            <th>p50 TTFT</th><th>Throughput</th><th>Uptime</th><th>Errors</th><th>Samples</th>
           </tr>
         </thead>
         <tbody>
@@ -52,6 +52,7 @@
             <td>{% if p.p50_ttft_ms is not none %}{{ p.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if p.p50_tokens_per_second is not none %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
             <td>{{ '%.2f'|format(p.uptime * 100) }}%</td>
+            <td>{% if p.top_error %}<code>{{ p.top_error }}</code> {{ '%.0f'|format(p.error_rate * 100) }}%{% else %}—{% endif %}</td>
             <td>{{ p.sample_count }}</td>
           </tr>
           {% endfor %}

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -59,6 +59,33 @@
     {% endfor %}
   </section>
 
+  {% if provider_health %}
+  <section class="status-section">
+    <div class="status-section-head">
+      <div>
+        <h2>Upstream provider health</h2>
+        <p>Continuously measured per provider from the rotation probe and real traffic. This is an informational provider watch — a flaky upstream model does NOT count against router-core uptime above. <a href="/leaderboard">Full leaderboard</a>.</p>
+      </div>
+    </div>
+    <div class="leaderboard-table-wrap">
+      <table class="leaderboard-table">
+        <thead><tr><th>Provider</th><th>Success</th><th>Error rate</th><th>Top error</th><th>Samples</th></tr></thead>
+        <tbody>
+          {% for p in provider_health %}
+          <tr>
+            <td><a href="/providers/{{ p.provider }}">{{ p.provider }}</a></td>
+            <td>{{ '%.2f'|format(p.uptime * 100) }}%</td>
+            <td>{% if p.error_rate and p.error_rate > 0 %}<span class="pill warn">{{ '%.1f'|format(p.error_rate * 100) }}%</span>{% else %}0%{% endif %}</td>
+            <td>{% if p.top_error %}<code>{{ p.top_error }}</code>{% else %}—{% endif %}</td>
+            <td>{{ p.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+  {% endif %}
+
   {% if snapshot.burn_rate_alerts %}
   <section class="status-section">
     <div class="status-section-head">

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -12,6 +12,7 @@ def _sample(
     ttft: int | None = None,
     ttfb: int | None = None,
     tps: float | None = None,
+    error_type: str | None = None,
     created_at: str = "2026-06-04T00:00:00Z",
 ) -> ProviderBenchmarkSample:
     return ProviderBenchmarkSample(
@@ -25,6 +26,7 @@ def _sample(
         first_token_milliseconds=ttft,
         ttfb_milliseconds=ttfb,
         speed_tokens_per_second=tps,
+        error_type=error_type,
         created_at=created_at,
     )
 
@@ -94,3 +96,20 @@ def test_empty_samples_produce_empty_leaderboard() -> None:
     assert result["models"] == []
     assert result["providers"] == []
     assert result["total_samples"] == 0
+
+
+def test_aggregate_tracks_error_types_per_model_and_provider() -> None:
+    samples = [
+        _sample(provider="cerebras", model="c/m", status="error", error_type="http_404"),
+        _sample(provider="cerebras", model="c/m", status="error", error_type="http_404"),
+        _sample(provider="cerebras", model="c/m", status="error", error_type="ConnectError"),
+        _sample(provider="cerebras", model="c/m", status="success", ttft=100),
+    ]
+    result = aggregate_leaderboard(samples)
+    model = result["models"][0]
+    assert model["error_rate"] == round(3 / 4, 4)
+    assert model["top_error"] == "http_404"
+    assert model["errors"] == {"http_404": 2, "ConnectError": 1}
+    provider = result["providers"][0]
+    assert provider["top_error"] == "http_404"
+    assert provider["errors"]["http_404"] == 2

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.routes.public import _status_page_html
 from trusted_router.storage import STORE, ProviderBenchmarkSample
 
 
@@ -60,3 +61,26 @@ def test_leaderboard_in_sitemap() -> None:
     resp = client.get("/sitemap.xml")
     assert resp.status_code == 200
     assert "/leaderboard" in resp.text
+
+
+def test_status_page_surfaces_upstream_provider_errors() -> None:
+    # The rotation-probe error data feeds an informational provider-health
+    # section on /status (separate from the router-core SLO). Render the page
+    # function directly to bypass the HTTP response cache.
+    STORE.record_provider_benchmark(
+        ProviderBenchmarkSample(
+            id="bench-status-err-1",
+            model="meta/some-model",
+            provider="cerebras",
+            provider_name="Cerebras",
+            status="error",
+            usage_type="Credits",
+            streamed=True,
+            error_type="http_404",
+            source="synthetic",
+        )
+    )
+    html = _status_page_html(_settings(), host="trustedrouter.com")
+    assert "Upstream provider health" in html
+    assert "cerebras" in html
+    assert "http_404" in html  # the captured error type is surfaced


### PR DESCRIPTION
You asked to monitor errors here + use it for status. The probe already captures `error_type`/`error_status` per sample; this surfaces it.

- **Aggregation**: per-model + per-provider error-type counts → `top_error` + `errors{}`.
- **/status**: new informational **"Upstream provider health"** section (success% / error-rate / top error / samples per provider), fed by the benchmark data. Intentionally **separate from the router-core paging SLO** — a flaky upstream model must not page router health — but now visible.
- **/leaderboard**: provider table gains an **Errors** column.

Live data already shows the value: cerebras/mistral/kimi rotation probes at 0%, anthropic ~39% — once this deploys, the error *type* shows so we can fix the specific routes. 3 tests. **757 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)