### PR TITLE
fix(catalog): stop routing models Cerebras can't serve (502 root cause)

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -1174,6 +1174,45 @@ MODEL_ENDPOINTS: dict[str, ModelEndpoint] = _build_endpoints(MODELS)
 MODEL_ENDPOINTS.update(_INGESTED_ENDPOINTS)
 MODEL_ENDPOINTS.update(_SUPPLEMENTAL_ENDPOINTS)
 
+# --- Provider served-model allowlist -------------------------------------
+# Our upstream accounts don't always match OpenRouter's provider→model map.
+# Routing a model a provider doesn't actually host on our account returns an
+# upstream error (the gateway surfaces it as a 502). When an allowlist is set
+# for a provider, ONLY its listed models keep that provider's endpoints; routes
+# for any other model on that provider are dropped before serving/routing.
+#
+# Cerebras (the key wired into the enclave) serves only gpt-oss-120b and
+# glm-4.7 on our account — verified 2026-06-04 from the Cerebras dashboard —
+# NOT the Llama models OpenRouter lists for Cerebras's GA tier. Without this
+# filter every Llama-via-Cerebras route 502s, and because Cerebras is rank-0
+# ("fastest") it gets tried first for those models. (Adding Cerebras endpoints
+# for the two served models with verified Cerebras pricing is a follow-up; for
+# now those model ids simply have no Cerebras endpoint to keep.)
+_PROVIDER_SERVED_MODEL_ALLOWLIST: dict[str, frozenset[str]] = {
+    "cerebras": frozenset({"openai/gpt-oss-120b", "z-ai/glm-4.7"}),
+}
+
+
+def _filter_unserved_provider_endpoints(
+    endpoints: dict[str, ModelEndpoint],
+) -> dict[str, ModelEndpoint]:
+    """Drop a provider's prepaid (Credits) endpoints for models it doesn't
+    serve on our account. Only Credits routes use OUR provider key, so only
+    those 502 on an account mismatch — BYOK routes use the customer's own key
+    (their account may serve a different model set), so they're left intact.
+    """
+    allow = _PROVIDER_SERVED_MODEL_ALLOWLIST
+    return {
+        endpoint_id: endpoint
+        for endpoint_id, endpoint in endpoints.items()
+        if endpoint.usage_type != "Credits"
+        or endpoint.provider not in allow
+        or endpoint.model_id in allow[endpoint.provider]
+    }
+
+
+MODEL_ENDPOINTS = _filter_unserved_provider_endpoints(MODEL_ENDPOINTS)
+
 
 def endpoints_for_model(model_id: str) -> list[ModelEndpoint]:
     return [endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.model_id == model_id]

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from trusted_router.catalog import MODELS, endpoints_for_model
+from trusted_router.catalog import (
+    _PROVIDER_SERVED_MODEL_ALLOWLIST,
+    MODEL_ENDPOINTS,
+    MODELS,
+    endpoints_for_model,
+)
 from trusted_router.dashboard import _model_detail_view
 
 
@@ -36,3 +41,30 @@ def test_byok_only_model_stays_not_prepaid() -> None:
             return
     # If every non-prepaid model has a Credits endpoint, there's nothing to
     # assert — not a failure.
+
+
+def test_cerebras_only_credits_serves_allowlisted_models() -> None:
+    # The Cerebras account serves only a small set of models on OUR key;
+    # routing a Credits request for any other model 502s. Credits endpoints
+    # must never include a non-allowlisted model. (BYOK uses the customer's
+    # own key and is intentionally left untouched.)
+    allow = _PROVIDER_SERVED_MODEL_ALLOWLIST["cerebras"]
+    cerebras_credits = {
+        e.model_id
+        for e in MODEL_ENDPOINTS.values()
+        if e.provider == "cerebras" and e.usage_type == "Credits"
+    }
+    assert cerebras_credits <= allow
+
+
+def test_llama_33_70b_no_longer_credits_routes_to_cerebras() -> None:
+    # Regression for the cerebras 502s: this model's Credits route used to
+    # include cerebras (which can't serve it) and fail. Its prepaid routing
+    # must now use only providers that actually serve it.
+    credits_providers = {
+        e.provider
+        for e in endpoints_for_model("meta-llama/llama-3.3-70b-instruct")
+        if e.usage_type == "Credits"
+    }
+    assert "cerebras" not in credits_providers
+    assert credits_providers & {"novita", "parasail", "tinfoil", "together"}

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -28,7 +28,7 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
         ("google/gemini-2.5-flash", "gemini"),
         ("deepseek/deepseek-v4-flash", "deepseek"),
         ("mistralai/mistral-small-2603", "mistral"),
-        ("meta-llama/llama-3.1-8b-instruct", "cerebras"),
+        ("meta-llama/llama-3.1-8b-instruct", "novita"),
         ("moonshotai/kimi-k2.6", "kimi"),
     ]:
         assert f"{model_id}@{provider}/prepaid" in MODEL_ENDPOINTS
@@ -60,7 +60,6 @@ def test_every_prepaid_endpoint_is_backed_by_attested_gateway_dispatch() -> None
         "anthropic",
         "openai",
         "gemini",
-        "cerebras",
         "deepseek",
         "mistral",
         "kimi",
@@ -230,7 +229,7 @@ def test_route_candidates_honor_models_provider_order_sort_and_dedupe() -> None:
         ("openai/gpt-5.4-nano", "openai"),
         ("mistralai/mistral-small-2603", "mistral"),
         ("deepseek/deepseek-v4-flash", "deepseek"),
-        ("meta-llama/llama-3.1-8b-instruct", "cerebras"),
+        ("meta-llama/llama-3.1-8b-instruct", "novita"),
         ("google/gemini-2.5-flash", "gemini"),
         ("anthropic/claude-sonnet-4.6", "anthropic"),
     ],
@@ -240,18 +239,23 @@ def test_endpoint_candidates_make_dual_mode_models_explicit(model_id: str, provi
         {"model": model_id},
         Settings(environment="test"),
     )
-    expected = [
-        f"{model_id}@{provider}/prepaid",
-        f"{model_id}@{provider}/byok",
-    ]
-    assert [endpoint.id for _model, endpoint in endpoints][:2] == expected
+    prepaid = f"{model_id}@{provider}/prepaid"
+    byok = f"{model_id}@{provider}/byok"
+    # Dual-mode is explicit: a provider's prepaid endpoint is immediately
+    # followed by its BYOK twin. We check adjacency rather than absolute
+    # position, since the full candidate list is ordered by provider rank and
+    # a BYOK-only provider (e.g. Cerebras for Llama) can sort ahead.
+    route_ids = [endpoint.id for _model, endpoint in endpoints]
+    assert prepaid in route_ids
+    assert route_ids[route_ids.index(prepaid) + 1] == byok
 
     byok_only = chat_route_endpoint_candidates(
         {"model": model_id, "provider": {"usage": "byok"}},
         Settings(environment="test"),
     )
     assert [endpoint.usage_type for _model, endpoint in byok_only] == ["BYOK"] * len(byok_only)
-    assert [endpoint.id for endpoint in endpoints_for_model(model_id)][:2] == expected
+    catalog_ids = [endpoint.id for endpoint in endpoints_for_model(model_id)]
+    assert catalog_ids[catalog_ids.index(prepaid) + 1] == byok
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -393,7 +393,18 @@ def test_embeddings_and_model_endpoints(client: TestClient, inference_headers: d
 
     endpoint = client.get("/v1/models/meta-llama/llama-3.1-8b-instruct/endpoints")
     assert endpoint.status_code == 200
-    assert endpoint.json()["data"][0]["provider_name"] == "Cerebras"
+    endpoint_rows = endpoint.json()["data"]
+    # Cerebras no longer serves Llama via Credits on our account (catalog
+    # corrected after the dashboard showed it only hosts gpt-oss-120b +
+    # glm-4.7). It may still appear as a BYOK route (customer's own key), but
+    # must NOT be a prepaid option our key would 502 on.
+    assert not [
+        row
+        for row in endpoint_rows
+        if row["provider_name"] == "Cerebras" and row["trustedrouter"]["prepaid_available"]
+    ]
+    # The model still has working prepaid providers.
+    assert any(row["trustedrouter"]["prepaid_available"] for row in endpoint_rows)
 
     kimi = client.get("/v1/models/moonshotai/kimi-k2.6/endpoints")
     assert kimi.status_code == 200


### PR DESCRIPTION
**Root cause of the cerebras 502s** (from your dashboard screenshot): the Cerebras account serves only **gpt-oss-120b + glm-4.7**, but our catalog routed **Llama** models to Cerebras's Credits endpoints → Cerebras rejects them → gateway 502. Cerebras is rank-0 "fastest", so the auto-router tried it first → real `llama-3.3-70b` traffic 502'd.

**Fix:** a per-provider served-model allowlist that drops a provider's **prepaid (Credits)** endpoints for models it doesn't serve on our account. Only Credits uses OUR key (only those 502); **BYOK is left intact** (customer's own key/account). Llama now routes to novita/parasail/tinfoil/together; Cerebras BYOK preserved.

Verified parasail/novita/tinfoil serve llama-3.3-70b fine. Tests updated to the corrected catalog. **759 passed.**

Follow-ups: add Cerebras's real models (gpt-oss-120b/glm-4.7) with verified pricing; the enclave failover-on-error fix (separate repo) so a provider blip fails over instead of 502ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)