### PR TITLE
catalog: add Xiaomi MiMo provider (OpenAI-compatible chat)

### DIFF
--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -64,6 +64,9 @@ ensure_secret_from_env_file "COHERE_API_KEY" "trustedrouter-cohere-api-key"
 # Reads VOYAGE_API_KEY from ~/.quill_cloud_keys.private. Same project-level
 # secretAccessor binding as every other provider secret.
 ensure_secret_from_env_file "VOYAGE_API_KEY" "trustedrouter-voyage-api-key"
+# Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1). Reads
+# XIAOMI_API_KEY from ~/.quill_cloud_keys.private.
+ensure_secret_from_env_file "XIAOMI_API_KEY" "trustedrouter-xiaomi-api-key"
 # 2026-05 — six new backend providers. All OpenAI-compatible chat
 # completions; the existing enclave OpenAI-shape adapter dispatches
 # to whichever base URL the catalog selects per model.

--- a/src/trusted_router/apps.py
+++ b/src/trusted_router/apps.py
@@ -44,13 +44,18 @@ def aggregate_apps(
         requests[name] += 1
         tokens[name] += toks
 
+    # Rank off the typed `requests` counter (most-used first, stable
+    # tie-break on name) BEFORE projecting into the public dict shape, so
+    # the sort key stays `tuple[int, str]` rather than indexing into the
+    # heterogeneous {str|int} result dict.
+    ordered_names = sorted(
+        (name for name in requests if requests[name] >= min_requests),
+        key=lambda name: (-requests[name], name),
+    )
     apps = [
         {"name": name, "requests": requests[name], "tokens": tokens[name]}
-        for name in requests
-        if requests[name] >= min_requests
+        for name in ordered_names
     ]
-    # Most-used first; stable tie-break on name.
-    apps.sort(key=lambda a: (-a["requests"], a["name"]))
 
     return {
         "apps": apps,

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -621,6 +621,18 @@ PROVIDERS: dict[str, Provider] = {
         ),
         provider_policy_url="https://www.minimax.io/privacy-policy-v2.html",
     ),
+    # Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1). MiMo-V2 /
+    # V2.5 agent models. Models + prices are in data/provider_models/xiaomi.json.
+    "xiaomi": Provider(
+        slug="xiaomi",
+        name="Xiaomi MiMo",
+        supports_prepaid=True,
+        provider_policy=(
+            "No provider-ZDR claim is tracked here. Xiaomi MiMo's open-platform "
+            "terms are linked for users who need to review API data handling."
+        ),
+        provider_policy_url="https://platform.xiaomimimo.com/",
+    ),
     # Cohere — first-party embeddings (embed-v4.0, embed-*-v3.0) plus
     # Command chat models. Embeddings are Cohere's flagship retrieval
     # product; chat is registered but TR currently only catalogs Cohere
@@ -717,6 +729,8 @@ GATEWAY_PREPAID_PROVIDER_SLUGS = frozenset(
         "cohere",
         # Voyage — embeddings only (OpenAI-shaped /v1/embeddings in the enclave).
         "voyage",
+        # Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1).
+        "xiaomi",
     }
 )
 
@@ -1180,6 +1194,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "anthropic",
         "cerebras",
         "gemini",
+        "xiaomi",
     ):
         path = _PROVIDER_MODELS_DIR / f"{provider_slug}.json"
         if not path.exists() or provider_slug not in PROVIDERS:

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -1,0 +1,73 @@
+{
+  "provider": "xiaomi",
+  "source": "https://api.xiaomimimo.com/v1/models",
+  "generated_at": "2026-06-09T00:00:00Z",
+  "model_count": 4,
+  "_note": "Xiaomi MiMo. OpenAI-compatible chat at api.xiaomimimo.com/v1 (Bearer auth). Model ids verified live against /v1/models 2026-06-09; prices from platform.xiaomimimo.com (provider cost, marked up by the catalog). Context set to the documented MiMo-V2 256K window. /v1/models does not expose context/price, so these are hand-maintained.",
+  "models": [
+    {
+      "id": "xiaomi/mimo-v2-flash",
+      "upstream_id": "mimo-v2-flash",
+      "display_name": "Xiaomi MiMo V2 Flash",
+      "title": "MiMo-V2-Flash",
+      "created": 1781000000,
+      "context_length": 262144,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 90000,
+      "output_token_price_per_m": 290000,
+      "model_type": "chat",
+      "endpoints": ["chat/completions"],
+      "features": ["function-calling", "serverless"],
+      "input_modalities": ["text"],
+      "output_modalities": ["text"]
+    },
+    {
+      "id": "xiaomi/mimo-v2-pro",
+      "upstream_id": "mimo-v2-pro",
+      "display_name": "Xiaomi MiMo V2 Pro",
+      "title": "MiMo-V2-Pro",
+      "created": 1781000000,
+      "context_length": 262144,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 3000000,
+      "model_type": "chat",
+      "endpoints": ["chat/completions"],
+      "features": ["function-calling", "serverless"],
+      "input_modalities": ["text"],
+      "output_modalities": ["text"]
+    },
+    {
+      "id": "xiaomi/mimo-v2.5",
+      "upstream_id": "mimo-v2.5",
+      "display_name": "Xiaomi MiMo V2.5",
+      "title": "MiMo-V2.5",
+      "created": 1781000000,
+      "context_length": 262144,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 400000,
+      "output_token_price_per_m": 2000000,
+      "model_type": "chat",
+      "endpoints": ["chat/completions"],
+      "features": ["function-calling", "serverless"],
+      "input_modalities": ["text"],
+      "output_modalities": ["text"]
+    },
+    {
+      "id": "xiaomi/mimo-v2.5-pro",
+      "upstream_id": "mimo-v2.5-pro",
+      "display_name": "Xiaomi MiMo V2.5 Pro",
+      "title": "MiMo-V2.5-Pro",
+      "created": 1781000000,
+      "context_length": 262144,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 3000000,
+      "model_type": "chat",
+      "endpoints": ["chat/completions"],
+      "features": ["function-calling", "serverless"],
+      "input_modalities": ["text"],
+      "output_modalities": ["text"]
+    }
+  ]
+}

--- a/src/trusted_router/providers.py
+++ b/src/trusted_router/providers.py
@@ -50,6 +50,8 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, tuple[tuple[str, ...], str]] = {
     "deepinfra": (("DEEPINFRA_API_KEY",), "https://api.deepinfra.com/v1/openai"),
     # Voyage AI — OpenAI-shaped embeddings (voyage-3-large).
     "voyage": (("VOYAGE_API_KEY",), "https://api.voyageai.com/v1"),
+    # Xiaomi MiMo — OpenAI-compatible chat (MiMo-V2 / V2.5).
+    "xiaomi": (("XIAOMI_API_KEY",), "https://api.xiaomimimo.com/v1"),
 }
 
 __all__ = [

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -4,7 +4,7 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: /Private, reliable LLM routing/ })).toBeVisible();
-  await expect(page.getByText("ATTESTED GATEWAY")).toBeVisible();
+  await expect(page.getByText("ATTESTED GATEWAY", { exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.locator("#signinModal")).toBeVisible();
@@ -106,7 +106,7 @@ test("homepage exposes privacy, no-subscription, and open-source claims", async 
   await expect(page.getByText("Privacy-first AI gateway").first()).toBeVisible();
   await expect(page.getByText("No subscription required")).toBeVisible();
   await expect(page.getByText("inspect, fork, or run yourself")).toBeVisible();
-  await expect(page.getByText("ATTESTED GATEWAY")).toBeVisible();
+  await expect(page.getByText("ATTESTED GATEWAY", { exact: true })).toBeVisible();
   await expect(
     page.locator('a[href="https://github.com/Lore-Hex/trusted-router-py"]').first(),
   ).toBeVisible();

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -397,3 +397,32 @@ def test_route_candidate_validation_errors_are_specific(body: dict, message: str
     with pytest.raises(Exception) as exc_info:
         chat_route_candidates(body, Settings(environment="test"))
     assert message in str(exc_info.value)
+
+
+def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
+    """Xiaomi MiMo onboarding: the 4 chat models load from the static manifest,
+    map to the right upstream ids, and have a prepaid (Credits) xiaomi endpoint
+    the attested gateway can dispatch."""
+    from trusted_router.catalog import PROVIDERS, endpoints_for_model
+
+    assert "xiaomi" in PROVIDERS
+    assert "xiaomi" in GATEWAY_PREPAID_PROVIDER_SLUGS
+    expected = {
+        "xiaomi/mimo-v2-flash": "mimo-v2-flash",
+        "xiaomi/mimo-v2-pro": "mimo-v2-pro",
+        "xiaomi/mimo-v2.5": "mimo-v2.5",
+        "xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
+    }
+    for model_id, upstream in expected.items():
+        model = MODELS.get(model_id)
+        assert model is not None, f"{model_id} missing from catalog"
+        assert model.supports_chat, f"{model_id} not chat"
+        assert model.provider == "xiaomi"
+        assert model.upstream_id == upstream
+        assert model.prompt_price_microdollars_per_million_tokens > 0
+        credits = [
+            e
+            for e in endpoints_for_model(model_id)
+            if str(e.usage_type) == "Credits" and e.provider == "xiaomi"
+        ]
+        assert credits, f"{model_id} has no xiaomi prepaid endpoint"

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -767,8 +767,9 @@ def test_byok_provider_config_returns_503_when_kms_encrypt_denied(
     # encrypt with the byok-envelope KMS key (e.g. the AWS/cross-cloud SA is
     # decrypt-only by design). That must return a clean 503 — never an
     # unhandled 500 + KMS stack trace (prod 2026-06-08).
-    import trusted_router.routes.byok as byok_routes
     from google.api_core import exceptions as gcp_exceptions
+
+    import trusted_router.routes.byok as byok_routes
 
     def _denied(*_args: object, **_kwargs: object) -> object:
         raise gcp_exceptions.PermissionDenied("useToEncrypt denied on byok-envelope")


### PR DESCRIPTION
Adds **Xiaomi MiMo** as a prepaid (gateway-keyed) provider — OpenAI-compatible `/v1/chat/completions` at `api.xiaomimimo.com/v1`.

## Models (4, chat)
| id | upstream | in $/M | out $/M | ctx |
|---|---|---|---|---|
| `xiaomi/mimo-v2-flash` | mimo-v2-flash | 0.10 | 0.32 | 262144 |
| `xiaomi/mimo-v2-pro` | mimo-v2-pro | 1.10 | 3.30 | 262144 |
| `xiaomi/mimo-v2.5` | mimo-v2.5 | 0.44 | 2.20 | 262144 |
| `xiaomi/mimo-v2.5-pro` | mimo-v2.5-pro | 1.10 | 3.30 | 262144 |

(Customer prices shown — cost × 1.10 markup applied by the manifest loader.)

## Changes
- `data/provider_models/xiaomi.json` — 4-model manifest (microdollars/1M cost, marked up by loader).
- `catalog.py` — register `xiaomi` Provider (prepaid, conservative no-ZDR policy), add to supplemental loader + `GATEWAY_PREPAID_PROVIDER_SLUGS`.
- `providers.py` — `OPENAI_COMPATIBLE_PROVIDERS["xiaomi"]`.
- `scripts/deploy/secrets.sh` — `XIAOMI_API_KEY` → `trustedrouter-xiaomi-api-key`.
- `tests/test_catalog_routing_contracts.py` — contract test asserting 4 models present, chat, routable to the prepaid endpoints.

## Enclave (already merged + rolled)
quill-cloud-proxy main `77567e1` — GCP canary roll green (us-central1 + europe-west4). Enclave dispatch/BYOK/bootstrap + `XiaomiAPIKey` wired; `QUILL_XIAOMI_SECRET` (→ `trustedrouter-xiaomi-api-key`) provisioned + IAM verified.

## Privacy
Conservative posture — **no ZDR claim** pending confirmation of Xiaomi's terms.