### PR TITLE
catalog: add Xiaomi MiMo-V2.5-Pro-UltraSpeed (1T, ~1000 tok/s)

### DIFF
--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -2,8 +2,8 @@
   "provider": "xiaomi",
   "source": "https://api.xiaomimimo.com/v1/models",
   "generated_at": "2026-06-09T00:00:00Z",
-  "model_count": 4,
-  "_note": "Xiaomi MiMo. OpenAI-compatible chat at api.xiaomimimo.com/v1 (Bearer auth). Model ids verified live against /v1/models 2026-06-09; prices from platform.xiaomimimo.com (provider cost, marked up by the catalog). Context set to the documented MiMo-V2 256K window. /v1/models does not expose context/price, so these are hand-maintained.",
+  "model_count": 5,
+  "_note": "Xiaomi MiMo. OpenAI-compatible chat at api.xiaomimimo.com/v1 (Bearer auth). Model ids verified live against /v1/models 2026-06-09; prices from platform.xiaomimimo.com (provider cost, marked up by the catalog). Context set to the documented MiMo-V2 256K window. /v1/models does not expose context/price, so these are hand-maintained. mimo-v2.5-pro-ultraspeed: 1T-param speed-serving tier (up to ~1000 tok/s), id + pricing + 131072 max_completion_tokens from platform.xiaomimimo.com/docs/.../mimo-v2.5-pro-ultraspeed (added 2026-06-09 on beta access).",
   "models": [
     {
       "id": "xiaomi/mimo-v2-flash",
@@ -63,6 +63,22 @@
       "max_output_tokens": 65536,
       "input_token_price_per_m": 1000000,
       "output_token_price_per_m": 3000000,
+      "model_type": "chat",
+      "endpoints": ["chat/completions"],
+      "features": ["function-calling", "serverless"],
+      "input_modalities": ["text"],
+      "output_modalities": ["text"]
+    },
+    {
+      "id": "xiaomi/mimo-v2.5-pro-ultraspeed",
+      "upstream_id": "mimo-v2.5-pro-ultraspeed",
+      "display_name": "Xiaomi MiMo V2.5 Pro UltraSpeed",
+      "title": "MiMo-V2.5-Pro-UltraSpeed",
+      "created": 1781000000,
+      "context_length": 262144,
+      "max_output_tokens": 131072,
+      "input_token_price_per_m": 1305000,
+      "output_token_price_per_m": 2610000,
       "model_type": "chat",
       "endpoints": ["chat/completions"],
       "features": ["function-calling", "serverless"],

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -400,7 +400,7 @@ def test_route_candidate_validation_errors_are_specific(body: dict, message: str
 
 
 def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
-    """Xiaomi MiMo onboarding: the 4 chat models load from the static manifest,
+    """Xiaomi MiMo onboarding: the 5 chat models load from the static manifest,
     map to the right upstream ids, and have a prepaid (Credits) xiaomi endpoint
     the attested gateway can dispatch."""
     from trusted_router.catalog import PROVIDERS, endpoints_for_model
@@ -412,6 +412,7 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
         "xiaomi/mimo-v2-pro": "mimo-v2-pro",
         "xiaomi/mimo-v2.5": "mimo-v2.5",
         "xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
+        "xiaomi/mimo-v2.5-pro-ultraspeed": "mimo-v2.5-pro-ultraspeed",
     }
     for model_id, upstream in expected.items():
         model = MODELS.get(model_id)
@@ -426,3 +427,17 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
             if str(e.usage_type) == "Credits" and e.provider == "xiaomi"
         ]
         assert credits, f"{model_id} has no xiaomi prepaid endpoint"
+
+    # UltraSpeed is the 1T-param speed-serving tier with its own ¥9/¥18
+    # ($1.305/$2.61) cost, marked up by the manifest loader (cost x 1.10,
+    # $0.01/M floor). Guard the exact prices so a regen can't silently
+    # collapse them onto the regular v2.5-pro numbers ($1.10/$3.30 customer).
+    ultraspeed = MODELS["xiaomi/mimo-v2.5-pro-ultraspeed"]
+    assert ultraspeed.prompt_price_microdollars_per_million_tokens == 1_435_500
+    assert ultraspeed.completion_price_microdollars_per_million_tokens == 2_871_000
+    # ...and that it is genuinely a distinct row from regular v2.5-pro.
+    pro = MODELS["xiaomi/mimo-v2.5-pro"]
+    assert (
+        ultraspeed.completion_price_microdollars_per_million_tokens
+        != pro.completion_price_microdollars_per_million_tokens
+    )


### PR DESCRIPTION
Adds the new **MiMo-V2.5-Pro-UltraSpeed** beta model to the existing `xiaomi` provider.

| id | upstream | in $/M | out $/M | ctx | max out |
|---|---|---|---|---|---|
| `xiaomi/mimo-v2.5-pro-ultraspeed` | mimo-v2.5-pro-ultraspeed | **1.4355** | **2.8710** | 262144 | 131072 |

(Customer prices — cost $1.305 / $2.61 per 1M = ¥9 / ¥18, marked up ×1.10 by the manifest loader.)

**1T-parameter speed-serving tier** generating at up to ~1000 tok/s, for high-concurrency real-time conversation / live large-project edits. Function-calling + streaming, OpenAI-shaped at `api.xiaomimimo.com/v1`. Spec from [platform.xiaomimimo.com docs](https://platform.xiaomimimo.com/docs/en-US/model-intro/mimo-v2.5-pro-ultraspeed).

## Scope
**Catalog-only.** The attested enclave already dispatches every `xiaomi/*` model by provider (shipped `77567e1`, GCP canary green), so no enclave change is required — this just makes the new id routable.

## Tests
`test_xiaomi_mimo_provider_models_present_and_routable` extended to 5 models; guards the distinct UltraSpeed pricing so a manifest regen can't silently collapse it onto regular v2.5-pro. Full local CI green (ruff/mypy/pytest/coverage/browser).