### PR TITLE
catalog: add Claude Fable 5 (anthropic/claude-fable-5)

### DIFF
--- a/src/trusted_router/data/provider_models/anthropic.json
+++ b/src/trusted_router/data/provider_models/anthropic.json
@@ -1,5 +1,5 @@
 {
-  "_about": "Provider-native supplement for Anthropic-direct models released after the OpenRouter snapshot. Claude Opus 4.8 is the latest Claude (verified live via the Anthropic /v1/models API as claude-opus-4-8). The attested gateway maps anthropic/claude-opus-4.8 -> claude-opus-4-8 algorithmically (internal/llm/anthropic.go mapModelID), so no enclave change is needed. Pricing matches the Opus 4.7 tier: provider cost x1.10 -> $4.95/$24.75 per M customer.",
+  "_about": "Provider-native supplement for Anthropic-direct models released after the OpenRouter snapshot. The attested gateway maps the dotted catalog id -> Anthropic's dashed id algorithmically (internal/llm/anthropic.go mapModelID: strip 'anthropic/' prefix, then ReplaceAll('.', '-')), so adding a Claude model here needs NO enclave change. Pricing fields are PROVIDER COST in microdollars/M; the loader applies x1.10 to get the customer price. Claude Opus 4.8: cost x1.10 -> $4.95/$24.75 per M. Claude Fable 5 (claude-fable-5): Anthropic's most capable widely-released model, GA 2026-06-09; cost $10/$50 -> customer $11.00/$55.00 per M; 1M context, 128k max output, adaptive-thinking-always-on (no extended thinking). Verified vs platform.claude.com models overview 2026-06-09. (Claude Mythos 5 is invitation-only Project Glasswing -> intentionally NOT listed.)",
   "models": [
     {
       "id": "anthropic/claude-opus-4.8",
@@ -15,6 +15,22 @@
       "output_modalities": ["text"],
       "endpoints": ["chat/completions"],
       "upstream_id": "anthropic/claude-opus-4.8",
+      "status": 1
+    },
+    {
+      "id": "anthropic/claude-fable-5",
+      "display_name": "Claude Fable 5",
+      "title": "anthropic/claude-fable-5",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "input_token_price_per_m": 10000000,
+      "output_token_price_per_m": 50000000,
+      "model_type": "chat",
+      "features": ["function-calling"],
+      "input_modalities": ["text", "image"],
+      "output_modalities": ["text"],
+      "endpoints": ["chat/completions"],
+      "upstream_id": "anthropic/claude-fable-5",
       "status": 1
     }
   ]

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -441,3 +441,26 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
         ultraspeed.completion_price_microdollars_per_million_tokens
         != pro.completion_price_microdollars_per_million_tokens
     )
+
+
+def test_anthropic_claude_fable_5_present_and_routable() -> None:
+    """Claude Fable 5 (GA 2026-06-09) loads from the anthropic manifest, maps
+    to the anthropic provider, prices at cost x1.10 ($10/$50 -> $11/$55), and
+    has a prepaid (Credits) anthropic endpoint the attested gateway can
+    dispatch. The enclave resolves the dotted id -> `claude-fable-5` via the
+    mapModelID dot->dash fallback, so no enclave change is required."""
+    from trusted_router.catalog import endpoints_for_model
+
+    model = MODELS.get("anthropic/claude-fable-5")
+    assert model is not None, "anthropic/claude-fable-5 missing from catalog"
+    assert model.supports_chat
+    assert model.provider == "anthropic"
+    # cost $10/$50 per M -> microdollars 10_000_000 / 50_000_000, x1.10 markup
+    assert model.prompt_price_microdollars_per_million_tokens == 11_000_000
+    assert model.completion_price_microdollars_per_million_tokens == 55_000_000
+    credits = [
+        e
+        for e in endpoints_for_model("anthropic/claude-fable-5")
+        if str(e.usage_type) == "Credits" and e.provider == "anthropic"
+    ]
+    assert credits, "claude-fable-5 has no anthropic prepaid endpoint"


### PR DESCRIPTION
Adds **Claude Fable 5** — Anthropic's most capable widely-released model, GA **2026-06-09** (verified against platform.claude.com models overview).

| id | upstream | in $/M | out $/M | ctx | max out |
|---|---|---|---|---|---|
| `anthropic/claude-fable-5` | claude-fable-5 | **11.00** | **55.00** | 1,000,000 | 128,000 |

(Customer prices — provider cost $10/$50 per M, ×1.10 markup. Adaptive-thinking-always-on, no extended thinking, vision, function-calling.)

## Scope
**Catalog-only.** The enclave's `mapModelID` resolves `anthropic/claude-fable-5` → `claude-fable-5` via the dot→dash fallback, so **no enclave change** — same path as Opus 4.8.

## Deliberately *not* done
- **`DEFAULT_AUTO_MODEL_ORDER` unchanged** — Fable 5 is the priciest model; making it the default auto-route is a separate decision. Routable on explicit request.
- **Claude Mythos 5 not added** — invitation-only (Project Glasswing), not GA.

## Tests
`test_anthropic_claude_fable_5_present_and_routable` asserts presence, `anthropic` provider, exact $11/$55 price, and a prepaid endpoint. Full local CI green.