### PR TITLE
Bill prompt-cache tokens at provider cache rates

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -218,6 +218,53 @@ def _customer_price(cost_microdollars_per_million: int) -> int:
     return max(marked_up, _PRICE_FLOOR_MICRODOLLARS_PER_M)
 
 
+# ---------------------------------------------------------------------------
+# Prompt-cache pricing
+#
+# The attested gateway reports cache_read_input_tokens /
+# cache_creation_input_tokens at settle. Cached tokens are billed as a
+# multiple of the endpoint's (already marked-up) prompt price, so the
+# uniform x1.10 margin structure is preserved: provider charges
+# cost x multiplier, we bill customer_price x multiplier.
+#
+# Multipliers mirror published provider pricing as of 2026-06:
+#   anthropic: cache read 0.1x, 5-minute cache write 1.25x
+#              (docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
+#   openai:    cached input 0.5x for the gpt-4o family; newer families
+#              are CHEAPER (0.1x), so 0.5x is the safe-side bound that
+#              never bills below our upstream cost. Tighten per-model
+#              when the pricing scrapers track cached rates.
+#   gemini/vertex: cached content 0.25x.
+# Providers absent from the read table get NO discount (1.0x) until
+# their cached pricing is verified — overcharging a discount we can't
+# confirm is the safe failure mode for margin, and those providers
+# rarely report cache fields anyway. Only Anthropic reports cache
+# WRITES; the 1.25x default keeps any future writer safe-side too.
+_CACHE_READ_PRICE_MULTIPLIER: dict[str, Decimal] = {
+    "anthropic": Decimal("0.1"),
+    "openai": Decimal("0.5"),
+    "gemini": Decimal("0.25"),
+    "vertex": Decimal("0.25"),
+}
+_CACHE_WRITE_PRICE_MULTIPLIER: dict[str, Decimal] = {
+    "anthropic": Decimal("1.25"),
+}
+_DEFAULT_CACHE_READ_MULTIPLIER = Decimal("1")
+_DEFAULT_CACHE_WRITE_MULTIPLIER = Decimal("1.25")
+
+
+def cache_token_prices_microdollars(provider: str, prompt_price_microdollars: int) -> tuple[int, int]:
+    """(cache-read, cache-write) customer price in microdollars per million
+    tokens for one endpoint's prompt price."""
+    prompt = Decimal(prompt_price_microdollars)
+    read = _CACHE_READ_PRICE_MULTIPLIER.get(provider, _DEFAULT_CACHE_READ_MULTIPLIER)
+    write = _CACHE_WRITE_PRICE_MULTIPLIER.get(provider, _DEFAULT_CACHE_WRITE_MULTIPLIER)
+    return (
+        int((prompt * read).to_integral_value()),
+        int((prompt * write).to_integral_value()),
+    )
+
+
 def _priced(cost_dollars_per_million: str | int | float) -> tuple[int, int, int]:
     """Return (prompt_price, published_price, cost_microdollars) for a
     dollars-per-million cost. prompt_price == published_price under the

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -25,6 +25,7 @@ from trusted_router.catalog import (
     PROVIDERS,
     Model,
     ModelEndpoint,
+    cache_token_prices_microdollars,
     default_endpoint_for_model,
     endpoint_for_id,
 )
@@ -480,7 +481,30 @@ def _settle_gateway_authorization(
 
     input_tokens = body.input_count
     output_tokens = body.output_count
-    actual_cost = _endpoint_cost_microdollars(selected_endpoint, input_tokens, output_tokens)
+    cache_read = body.cache_read_count
+    cache_creation = body.cache_creation_count
+    # Provider-dependent prompt accounting: Anthropic reports input_tokens
+    # EXCLUSIVE of cached tokens (input 14 + cache_read 6081 = 6095-token
+    # prompt), while OpenAI-compatible and Gemini prompt counts INCLUDE the
+    # cached subset. Normalize to (uncached, read, creation) for pricing
+    # and store the TOTAL prompt on the generation for honest dashboards.
+    if cache_read or cache_creation:
+        if selected_endpoint.provider == "anthropic":
+            uncached_input = input_tokens
+            total_input = input_tokens + cache_read + cache_creation
+        else:
+            uncached_input = max(input_tokens - cache_read - cache_creation, 0)
+            total_input = input_tokens
+    else:
+        uncached_input = total_input = input_tokens
+    actual_cost = _endpoint_cost_microdollars(
+        selected_endpoint,
+        uncached_input,
+        output_tokens,
+        cache_read_tokens=cache_read,
+        cache_creation_tokens=cache_creation,
+    )
+    input_tokens = total_input
     selected_usage_type = UsageType.for_endpoint(selected_endpoint)
 
     generation_id: str | None = None
@@ -665,13 +689,26 @@ def _endpoint_cost_microdollars(
     endpoint: ModelEndpoint,
     input_tokens: int,
     output_tokens: int,
+    *,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> int:
-    return token_cost_microdollars(
+    """input_tokens must be the UNCACHED prompt tokens when cache counts
+    are passed — cached reads/writes bill at the provider-specific
+    multiple of the prompt price (see catalog.cache_token_prices_microdollars)."""
+    cost = token_cost_microdollars(
         input_tokens, endpoint.prompt_price_microdollars_per_million_tokens
     ) + token_cost_microdollars(
         output_tokens,
         endpoint.completion_price_microdollars_per_million_tokens,
     )
+    if cache_read_tokens or cache_creation_tokens:
+        read_price, write_price = cache_token_prices_microdollars(
+            endpoint.provider, endpoint.prompt_price_microdollars_per_million_tokens
+        )
+        cost += token_cost_microdollars(cache_read_tokens, read_price)
+        cost += token_cost_microdollars(cache_creation_tokens, write_price)
+    return cost
 
 
 def _schedule_auto_refill(

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -195,6 +195,12 @@ class GatewaySettleRequest(_Lenient):
     actual_output_tokens: int | None = Field(default=None, ge=0)
     input_tokens: int | None = Field(default=None, ge=0)
     output_tokens: int | None = Field(default=None, ge=0)
+    # Prompt-cache accounting reported by the attested gateway. NOTE the
+    # provider-dependent semantics the settle handler normalizes:
+    # Anthropic's input_tokens EXCLUDE cached tokens; OpenAI-compatible
+    # and Gemini prompt counts INCLUDE the cached subset.
+    cache_read_input_tokens: int | None = Field(default=None, ge=0)
+    cache_creation_input_tokens: int | None = Field(default=None, ge=0)
     request_id: str | None = None
     finish_reason: str | None = None
     status: str | None = None
@@ -226,6 +232,14 @@ class GatewaySettleRequest(_Lenient):
         if self.actual_output_tokens is not None:
             return self.actual_output_tokens
         return self.output_tokens or 0
+
+    @property
+    def cache_read_count(self) -> int:
+        return self.cache_read_input_tokens or 0
+
+    @property
+    def cache_creation_count(self) -> int:
+        return self.cache_creation_input_tokens or 0
 
     @property
     def selected_model_id(self) -> str | None:

--- a/tests/test_gateway_cache_billing.py
+++ b/tests/test_gateway_cache_billing.py
@@ -1,0 +1,157 @@
+"""Cache-aware settle billing.
+
+The attested gateway reports cache_read_input_tokens /
+cache_creation_input_tokens. Two things must hold:
+
+1. Cached tokens are BILLED (pre-fix, Anthropic cache reads billed at
+   zero because Anthropic's input_tokens exclude them) — at the
+   provider's discounted multiple of the prompt price.
+2. Provider semantics are normalized: Anthropic input_tokens EXCLUDE
+   the cached tokens; OpenAI-compatible prompt counts INCLUDE them.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.catalog import cache_token_prices_microdollars, endpoint_for_id
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.money import token_cost_microdollars
+from trusted_router.storage import STORE
+
+
+def _client_and_key() -> tuple[TestClient, dict]:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    client = TestClient(app)
+    created = client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "cache-bill@example.com"},
+        json={"name": "cache billing"},
+    )
+    assert created.status_code == 201, created.text
+    return client, created.json()["data"]
+
+
+def _authorize(client: TestClient, key: dict, model: str) -> dict:
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": model,
+            "estimated_input_tokens": 8_000,
+            "max_output_tokens": 1_000,
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    return authorize.json()["data"]
+
+
+def test_anthropic_cache_read_and_write_tokens_are_billed() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(client, key, "anthropic/claude-haiku-4.5")
+    endpoint = endpoint_for_id(auth["endpoint_id"])
+    assert endpoint is not None and endpoint.provider == "anthropic"
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            # Anthropic semantics: input_tokens EXCLUDE the cached tokens.
+            "actual_input_tokens": 14,
+            "actual_output_tokens": 6,
+            "cache_read_input_tokens": 6081,
+            "cache_creation_input_tokens": 2000,
+            "request_id": "gw-cache-anthropic",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    data = settle.json()["data"]
+
+    prompt_price = endpoint.prompt_price_microdollars_per_million_tokens
+    completion_price = endpoint.completion_price_microdollars_per_million_tokens
+    read_price, write_price = cache_token_prices_microdollars("anthropic", prompt_price)
+    assert read_price < prompt_price, "anthropic cache reads must be discounted"
+    assert write_price > prompt_price, "anthropic cache writes cost more than raw input"
+    expected = (
+        token_cost_microdollars(14, prompt_price)
+        + token_cost_microdollars(6, completion_price)
+        + token_cost_microdollars(6081, read_price)
+        + token_cost_microdollars(2000, write_price)
+    )
+    assert data["cost_microdollars"] == expected
+
+    # Regression guard for the zero-billing bug: the cost must exceed what
+    # the uncached 14 input tokens alone would have produced.
+    uncached_only = token_cost_microdollars(14, prompt_price) + token_cost_microdollars(
+        6, completion_price
+    )
+    assert data["cost_microdollars"] > uncached_only
+
+    generation = STORE.get_generation(data["generation_id"])
+    assert generation is not None
+    # Dashboards see the TOTAL prompt, not Anthropic's exclusive count.
+    assert generation.tokens_prompt == 14 + 6081 + 2000
+
+
+def test_openai_compatible_cached_subset_is_normalized() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(client, key, "mistralai/mistral-small-3.2-24b-instruct")
+    endpoint = endpoint_for_id(auth["endpoint_id"])
+    assert endpoint is not None and endpoint.provider != "anthropic"
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            # OpenAI-compatible semantics: prompt count INCLUDES cached.
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 50,
+            "cache_read_input_tokens": 900,
+            "request_id": "gw-cache-openai-compat",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    data = settle.json()["data"]
+
+    prompt_price = endpoint.prompt_price_microdollars_per_million_tokens
+    completion_price = endpoint.completion_price_microdollars_per_million_tokens
+    read_price, _ = cache_token_prices_microdollars(endpoint.provider, prompt_price)
+    expected = (
+        token_cost_microdollars(100, prompt_price)  # 1000 - 900 cached
+        + token_cost_microdollars(50, completion_price)
+        + token_cost_microdollars(900, read_price)
+    )
+    assert data["cost_microdollars"] == expected
+
+    generation = STORE.get_generation(data["generation_id"])
+    assert generation is not None
+    assert generation.tokens_prompt == 1_000
+
+
+def test_settle_without_cache_fields_is_unchanged() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(client, key, "anthropic/claude-haiku-4.5")
+    endpoint = endpoint_for_id(auth["endpoint_id"])
+    assert endpoint is not None
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            "actual_input_tokens": 500,
+            "actual_output_tokens": 100,
+            "request_id": "gw-cache-none",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    data = settle.json()["data"]
+    expected = token_cost_microdollars(
+        500, endpoint.prompt_price_microdollars_per_million_tokens
+    ) + token_cost_microdollars(100, endpoint.completion_price_microdollars_per_million_tokens)
+    assert data["cost_microdollars"] == expected
+    generation = STORE.get_generation(data["generation_id"])
+    assert generation is not None
+    assert generation.tokens_prompt == 500


### PR DESCRIPTION
## Why now

The gateway began reporting cache tokens at settle today (quill-cloud-proxy `05c1d85`). Two money bugs follow without this PR:

1. **Anthropic cache reads bill at ZERO.** Anthropic's `input_tokens` EXCLUDE cached tokens (live smoke: `input_tokens: 14` + `cache_read_input_tokens: 6081` → we billed 14 tokens) while we pay Anthropic 0.1× input for every cached read. Revenue leak on exactly the traffic prompt caching attracts.
2. Customers get **no cache discount** on providers whose prompt counts include the cached subset.

## What

- `GatewaySettleRequest`: `cache_read_input_tokens` / `cache_creation_input_tokens`.
- `catalog.cache_token_prices_microdollars`: provider multipliers on the marked-up prompt price — anthropic read 0.1×/write 1.25× (published rates), openai 0.5× (safe-side bound; newer families are cheaper — tighten when scrapers track cached rates), gemini/vertex 0.25×, everyone else 1.0× (no discount until verified — never bill below upstream cost).
- Settle normalizes the two provider semantics (exclusive vs inclusive prompt counts), prices uncached/read/write components separately, and stores the **total** prompt on the generation for honest dashboards.

## Result

Cached Claude requests drop ~10× on the input side for customers, margins stay uniform (multiplier composes with the ×1.10 markup), and the zero-billing leak is closed.

Tests: 3 new (exclusive semantics + write billing, inclusive normalization, no-cache regression); full suite 823 passed, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)