### PR TITLE
Restore the global-footprint world map to the homepage

### DIFF
--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -236,6 +236,44 @@ const response = await client.chat.completions.create({
       </div>
     </section>
 
+    {# 6b. Global footprint map — visual proof of the multi-region scale
+       claimed in the reliability section above. Markup restored after the
+       2026-06 homepage redesign dropped it; the .regions-map CSS, the
+       data-regions-stage JS in dashboard.js, world-map.svg, and the
+       map_regions context (dashboard.py) were all left intact. #}
+    <section class="home-section">
+      <div class="home-wrap">
+        <section class="regions-map">
+          <div class="regions-map-head">
+            <h2>Global footprint: {{ map_regions|length }} regions</h2>
+            <p>Verified live gateways plus regional expansion points for lower latency and faster failover. Public status separates router health from provider health.</p>
+          </div>
+          <div class="regions-map-stage" data-regions-stage>
+            <svg viewBox="0 0 1000 500" class="regions-map-svg" role="img" aria-label="World map of TrustedRouter regions">
+              <image href="/static/world-map.svg" x="0" y="0" width="1000" height="500"/>
+              {% for region in map_regions %}
+              <g class="region-marker {{ 'is-primary' if region.primary else '' }} {{ 'is-serving' if region.serving else 'is-edge' }}" data-region-id="{{ region.id }}">
+                <circle cx="{{ '%.2f'|format(region.x) }}" cy="{{ '%.2f'|format(region.y) }}" r="{{ '20' if region.primary else '18' }}" class="region-pulse"/>
+                <circle cx="{{ '%.2f'|format(region.x) }}" cy="{{ '%.2f'|format(region.y) }}" r="{{ '10' if region.primary else '9' }}" class="region-dot"/>
+                <title>{{ region.id }} in {{ region.city }}. {{ region.status_label }}{% if region.primary %}. Primary{% endif %}</title>
+              </g>
+              {% endfor %}
+            </svg>
+            <ul class="region-list">
+              {% for region in map_regions %}
+              <li class="{{ 'is-primary' if region.primary else '' }} {{ 'is-serving' if region.serving else 'is-edge' }}" data-region-id="{{ region.id }}" tabindex="0" role="button" aria-label="Highlight region {{ region.id }}, {{ region.city }}">
+                <span class="region-list-id">{{ region.id }}</span>
+                <span class="region-list-city">{{ region.city }}</span>
+                {% if region.primary %}<span class="pill good">primary</span>{% endif %}
+                {% if not region.primary %}<span class="pill {{ 'good' if region.serving else '' }}">{{ region.status_label }}</span>{% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </section>
+      </div>
+    </section>
+
     {# 7. Privacy comparison #}
     <section class="home-section">
       <div class="home-wrap">


### PR DESCRIPTION
## Why

The 2026-06 homepage redesign (`14bd9ba`) dropped the world-map section. It's a key scale/credibility signal — it visually proves the multi-region footprint the page's reliability section claims ("Live regions: N"). Bringing it back.

## What

The redesign removed only the **markup** — everything that feeds the map survived:
- `.regions-map*` CSS (`dashboard.css`, 29 selectors, untouched)
- `data-regions-stage` interaction JS (`dashboard.js`, click-to-highlight)
- `world-map.svg` asset
- `map_regions` context (`dashboard.py:455`)

So this re-inserts the original markup verbatim (data-driven from `map_regions` — region count and marker coordinates stay correct), wrapped in the redesign's `home-section`/`home-wrap` so spacing/width match the new page. Placed right after the "Fallback when providers fail" reliability section.

## Also fixes a red smoke test

`test_marketing_page_advertises_production_not_alpha` asserts the homepage contains `world-map.svg`/`<svg` and has been failing since the redesign stripped the map. This re-greens it.

## Verification

Rendered `dashboard_html()` offline and screenshotted the isolated section:
- "Global footprint: N regions" heading
- 7 markers positioned **inside** the SVG (us-central1 = primary pulse; others serving/edge in correct geographic spots)
- Interactive region list with primary/live/edge pills alongside
- No Jinja errors; the marketing-smoke assertion now passes against the rendered output

![map renders correctly](confirmed via preview screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)