### PR TITLE
Add /choose — interactive "iron triangle" model picker

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -69,6 +69,7 @@ MODEL_COMPARE_URL_LIMIT = 2_600
 MODEL_COMPARE_MODEL_LIMIT = 73
 SEO_CORE_PATHS: tuple[str, ...] = (
     "/",
+    "/choose",
     "/models",
     "/providers",
     "/benchmarks",
@@ -240,6 +241,41 @@ class PublicPage:
 
 
 PUBLIC_PAGES: dict[str, PublicPage] = {
+    "choose": PublicPage(
+        template="public/choose.html",
+        title="Choose a Model — Smart, Cheap, Fast",
+        description=(
+            "Describe your task and privacy needs and we plot 220+ LLM routes on the "
+            "smart-cheap-fast triangle, then recommend the model. Open, zero-retention, or TEE."
+        ),
+        faq_items=(
+            (
+                "How do you decide which model fits?",
+                "Tell us the task and we estimate the intelligence it needs (simple to "
+                "frontier), the latency you can tolerate (real-time to overnight), and a "
+                "privacy floor. We keep only the routes that clear all three, then rank them "
+                "by the smart/cheap/fast tradeoff you set on the triangle.",
+            ),
+            (
+                "What do the privacy tiers mean?",
+                "Open routes any attested provider. Zero-retention (ZDR) only uses providers "
+                "that contractually keep nothing. Trusted Execution Environment (TEE) runs in "
+                "confidential compute with end-to-end encryption, so even the provider can't "
+                "read your prompt.",
+            ),
+            (
+                "Which models are fastest?",
+                "Cerebras-served gpt-oss, Xiaomi MiMo v2.5 Ultraspeed and GLM-4.7 Flash sit at "
+                "the fast tip of the triangle — hundreds to thousands of tokens per second.",
+            ),
+            (
+                "Do I have to pick one model?",
+                "No. trustedrouter/auto picks the best fit per request, trustedrouter/cheap "
+                "takes the cheapest capable route in a TEE, and trustedrouter/fusion combines "
+                "open models to beat any single frontier model — all through one OpenAI-shaped API.",
+            ),
+        ),
+    ),
     "compare/openrouter": PublicPage(
         template="public/compare_openrouter.html",
         title="TrustedRouter Compared With OpenRouter",

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -255,6 +255,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def pricing() -> str:
         return public_page_html(settings, "pricing")
 
+    @public_html_route("/choose")
+    async def choose() -> str:
+        return public_page_html(settings, "choose")
+
     @public_html_route("/docs")
     async def docs_hub() -> str:
         return public_page_html(settings, "docs")

--- a/src/trusted_router/static/choose-app.html
+++ b/src/trusted_router/static/choose-app.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>The Iron Triangle of LLMs · TrustedRouter</title>
+<meta name="description" content="Smart, cheap, fast — pick two. An interactive ternary chart of 220+ models. Tell it your problem and your privacy needs; it picks the model. Powered by the live TrustedRouter catalog.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#070b14; --bg2:#0b1220; --panel:#0e1626; --panel2:#121c30;
+  --line:#1c2942; --line2:#26354f;
+  --ink:#eaf0fb; --muted:#93a3c0; --muted2:#6477a0; --dim:#5b6b88;
+  --smart:#a78bfa;  /* violet  = intelligence */
+  --cheap:#34d399;  /* emerald = cheap */
+  --fast:#f59e0b;   /* amber   = fast */
+  --t0:#8aa0c4;     /* tier 0 open */
+  --t2:#22d3ee;     /* tier 2 zdr */
+  --t3:#22c55e;     /* tier 3 confidential */
+  --gold:#fbbf24;
+  --tr:#16a34a; --tr2:#22c55e;
+  --radius:16px;
+  --shadow:0 18px 50px -18px rgba(0,0,0,.7);
+  --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  color:var(--ink); background:
+    radial-gradient(1100px 700px at 18% -8%, #14223b 0%, transparent 55%),
+    radial-gradient(900px 650px at 105% 8%, #1a1330 0%, transparent 50%),
+    var(--bg);
+  -webkit-font-smoothing:antialiased; line-height:1.45; min-height:100vh;
+}
+a{color:inherit}
+.wrap{max-width:1280px;margin:0 auto;padding:22px clamp(14px,3vw,34px) 60px}
+
+/* ---------- header ---------- */
+header.top{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:14px}
+.brand{display:flex;align-items:center;gap:11px;font-weight:800;letter-spacing:-.02em}
+.brand .logo{width:30px;height:30px;display:grid;place-items:center;border-radius:9px;
+  background:linear-gradient(160deg,var(--tr2),#0e7a37);box-shadow:0 6px 18px -6px var(--tr)}
+.brand .logo svg{width:18px;height:18px}
+.brand b{font-size:16.5px}
+.brand span{color:var(--muted);font-weight:600;font-size:12.5px;display:block;margin-top:-3px;letter-spacing:0}
+.headstat{display:flex;gap:8px;align-items:center;font-size:12.5px;color:var(--muted)}
+.headstat .pill{display:inline-flex;gap:7px;align-items:center;background:var(--panel);border:1px solid var(--line);
+  padding:6px 11px;border-radius:999px}
+.dotlive{width:8px;height:8px;border-radius:50%;background:var(--tr2);box-shadow:0 0 0 0 var(--tr2);animation:pulse 2.4s infinite}
+@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(34,197,94,.55)}70%{box-shadow:0 0 0 8px rgba(34,197,94,0)}100%{box-shadow:0 0 0 0 rgba(34,197,94,0)}}
+
+.hero{margin:6px 0 22px}
+.hero h1{font-size:clamp(26px,4.4vw,46px);line-height:1.04;letter-spacing:-.03em;margin:0 0 8px;font-weight:900}
+.hero h1 .g{background:linear-gradient(100deg,var(--smart),var(--cheap) 55%,var(--fast));-webkit-background-clip:text;background-clip:text;color:transparent}
+.hero p{margin:0;color:var(--muted);font-size:clamp(14px,1.6vw,16.5px);max-width:70ch}
+
+/* ---------- layout ---------- */
+.grid{display:grid;grid-template-columns:1.32fr 1fr;gap:18px;align-items:start}
+@media(max-width:980px){.grid{grid-template-columns:1fr}}
+
+.card{background:linear-gradient(180deg,var(--panel),var(--bg2));border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+.stage{padding:14px 14px 8px;position:relative;overflow:hidden}
+.stage-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 10px;gap:10px;flex-wrap:wrap}
+.stage-head .t{font-weight:700;font-size:14px}
+.stage-head .t small{color:var(--muted);font-weight:500}
+.legend{display:flex;gap:13px;flex-wrap:wrap;font-size:11.5px;color:var(--muted)}
+.legend i{width:9px;height:9px;border-radius:50%;display:inline-block;margin-right:5px;vertical-align:middle}
+
+svg.tri{width:100%;height:auto;display:block;touch-action:none;cursor:crosshair;user-select:none}
+.vtx-label{font-weight:800;letter-spacing:-.01em}
+.vtx-sub{font-weight:500;}
+
+/* model dot tooltip */
+.tip{position:absolute;pointer-events:none;z-index:40;opacity:0;transform:translateY(4px);
+  transition:opacity .12s, transform .12s;background:#0b1322f2;border:1px solid var(--line2);
+  border-radius:12px;padding:11px 13px;width:248px;backdrop-filter:blur(8px);box-shadow:0 16px 40px -14px #000}
+.tip.show{opacity:1;transform:translateY(0)}
+.tip h4{margin:0 0 2px;font-size:13.5px;display:flex;align-items:center;gap:7px}
+.tip .prov{font-size:11px;color:var(--muted);font-family:var(--mono);margin-bottom:8px;word-break:break-all}
+.tip .bars{display:grid;gap:5px;margin:7px 0}
+.tip .bar{display:grid;grid-template-columns:46px 1fr 34px;align-items:center;gap:7px;font-size:10.5px;color:var(--muted)}
+.tip .bar .track{height:6px;border-radius:4px;background:#1b2740;overflow:hidden}
+.tip .bar .fill{height:100%;border-radius:4px}
+.tip .bar b{color:var(--ink);font-family:var(--mono);text-align:right;font-size:10px}
+.tip .meta{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px}
+.tag{font-size:10px;padding:2px 7px;border-radius:999px;background:#15203542;border:1px solid var(--line2);color:var(--muted)}
+.tip .tierbadge{font-size:10px;font-weight:700;padding:2px 7px;border-radius:6px}
+
+/* ---------- controls ---------- */
+.controls{display:flex;flex-direction:column;gap:14px}
+.block{padding:15px 16px}
+.block h3{margin:0 0 4px;font-size:12px;text-transform:uppercase;letter-spacing:.09em;color:var(--muted);font-weight:700;display:flex;align-items:center;gap:8px}
+.block h3 .n{width:18px;height:18px;border-radius:6px;background:var(--panel2);border:1px solid var(--line2);display:grid;place-items:center;font-size:10px;color:var(--ink)}
+.block .hint{font-size:11.5px;color:var(--dim);margin:0 0 11px}
+
+select.priv{width:100%;appearance:none;background:var(--panel2);border:1px solid var(--line2);color:var(--ink);
+  font:inherit;font-weight:600;font-size:14px;padding:11px 13px;border-radius:11px;cursor:pointer;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' stroke='%2393a3c0' stroke-width='2'%3E%3Cpath d='M3 5l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;background-position:right 14px center}
+.privnote{font-size:11.5px;color:var(--muted);margin-top:9px;display:flex;gap:8px;align-items:flex-start;line-height:1.4}
+.privnote svg{flex:0 0 auto;margin-top:1px}
+
+textarea#prob{width:100%;background:var(--panel2);border:1px solid var(--line2);color:var(--ink);font:inherit;font-size:14px;
+  padding:11px 13px;border-radius:11px;resize:vertical;min-height:64px}
+textarea#prob:focus,select.priv:focus{outline:none;border-color:#3a567f;box-shadow:0 0 0 3px #2a456e44}
+.exrow{display:flex;gap:7px;flex-wrap:wrap;margin-top:9px}
+.ex{font-size:11.5px;padding:6px 10px;border-radius:999px;background:#101a2e;border:1px solid var(--line2);color:var(--muted);cursor:pointer;transition:.15s}
+.ex:hover{color:var(--ink);border-color:#3a567f;background:#152138}
+.guessbtn{margin-top:10px;width:100%;padding:11px;border-radius:11px;border:1px solid #2a6b46;cursor:pointer;
+  background:linear-gradient(180deg,#13351f,#0e2a19);color:#bdf0cf;font:inherit;font-weight:700;font-size:13.5px;transition:.15s;display:flex;gap:8px;align-items:center;justify-content:center}
+.guessbtn:hover{border-color:var(--tr2);color:#eafff1}
+.rationale{font-size:12px;color:var(--cheap);margin-top:10px;min-height:0;line-height:1.45;opacity:0;transition:.2s}
+.rationale.show{opacity:1}
+.rationale b{color:#d6ffe7}
+
+.seg{display:grid;grid-template-columns:repeat(4,1fr);gap:7px}
+.seg.spd{grid-template-columns:repeat(4,1fr)}
+.opt{padding:9px 6px;border-radius:10px;border:1px solid var(--line2);background:var(--panel2);cursor:pointer;text-align:center;transition:.14s}
+.opt .lab{font-weight:700;font-size:12.5px}
+.opt .sub{font-size:9.5px;color:var(--dim);margin-top:2px;letter-spacing:.02em}
+.opt:hover{border-color:#3a567f}
+.opt.on{border-color:var(--accentc,#3a567f);background:var(--accentbg,#15233a)}
+.opt.on .lab{color:var(--accenti,#fff)}
+.seg.intel .opt.on{--accentc:var(--smart);--accentbg:#241a44;--accenti:#d9ccff}
+.seg.spd .opt.on{--accentc:var(--fast);--accentbg:#3a2a08;--accenti:#ffe2a6}
+
+.weights{display:flex;justify-content:space-between;gap:8px;margin-top:13px;padding-top:13px;border-top:1px solid var(--line)}
+.wt{flex:1;text-align:center}
+.wt .v{font-family:var(--mono);font-weight:700;font-size:18px}
+.wt .k{font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-top:2px}
+.wt.s .v{color:var(--smart)} .wt.c .v{color:var(--cheap)} .wt.f .v{color:var(--fast)}
+
+/* ---------- results ---------- */
+.results{margin-top:20px}
+.results>h2{font-size:13px;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);margin:0 0 12px;font-weight:700}
+.reslay{display:grid;grid-template-columns:1.5fr 1fr;gap:18px;align-items:start}
+@media(max-width:980px){.reslay{grid-template-columns:1fr}}
+.picks{display:flex;flex-direction:column;gap:11px}
+.pick{display:grid;grid-template-columns:auto 1fr auto;gap:14px;align-items:center;padding:14px 16px;border-radius:14px;
+  border:1px solid var(--line);background:linear-gradient(180deg,var(--panel),var(--bg2));transition:.2s}
+.pick.top{border-color:#5a4a12;background:linear-gradient(180deg,#1c1808,#0e1220);box-shadow:0 0 0 1px #6b560f44, var(--shadow)}
+.rank{width:34px;height:34px;border-radius:10px;display:grid;place-items:center;font-weight:800;font-family:var(--mono);font-size:14px;
+  background:var(--panel2);border:1px solid var(--line2);color:var(--muted)}
+.pick.top .rank{background:linear-gradient(180deg,var(--gold),#d99412);color:#231a02;border:none}
+.pick .nm{font-weight:700;font-size:15.5px;display:flex;align-items:center;gap:9px;flex-wrap:wrap}
+.pick .nm .why{font-size:10.5px;font-weight:700;color:var(--gold);background:#3a2e08;border:1px solid #6b560f;padding:2px 8px;border-radius:999px}
+.pick .sub{font-size:11.5px;color:var(--muted);font-family:var(--mono);margin-top:3px;word-break:break-all}
+.pick .tags{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px}
+.pick .price{text-align:right;font-family:var(--mono);font-size:12px;color:var(--muted);white-space:nowrap}
+.pick .price b{display:block;color:var(--ink);font-size:14.5px}
+.pick .price .tier{margin-top:5px;font-size:9.5px;font-weight:700;padding:2px 6px;border-radius:5px;display:inline-block}
+.minibars{display:flex;gap:4px;margin-top:9px}
+.minibars .mb{flex:1;height:5px;border-radius:3px;background:#1b2740;overflow:hidden}
+.minibars .mb i{display:block;height:100%}
+.empty{padding:22px;text-align:center;color:var(--muted);border:1px dashed var(--line2);border-radius:14px}
+
+/* TR pitch */
+.pitch{padding:18px;border-radius:16px;border:1px solid #1d5235;
+  background:linear-gradient(170deg,#0c2418,#0a1420 70%);position:relative;overflow:hidden}
+.pitch::before{content:"";position:absolute;inset:-40% -10% auto auto;width:240px;height:240px;border-radius:50%;
+  background:radial-gradient(circle,rgba(34,197,94,.18),transparent 70%);pointer-events:none}
+.pitch .kicker{font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--tr2);font-weight:700;display:flex;align-items:center;gap:8px}
+.pitch h3{margin:8px 0 6px;font-size:19px;letter-spacing:-.02em;line-height:1.2}
+.pitch p.lede{margin:0 0 14px;font-size:13px;color:#b9d4c4}
+.route{display:flex;gap:12px;align-items:center;padding:12px;border-radius:12px;background:#0c1b13aa;border:1px solid #1c4730;margin-bottom:9px}
+.route .ic{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;flex:0 0 auto;background:#11271a;border:1px solid #205237}
+.route .rn{font-family:var(--mono);font-weight:700;font-size:13px;color:#eafff1}
+.route .rd{font-size:11.5px;color:#9fc4ad;margin-top:2px}
+.route .rp{margin-left:auto;text-align:right;font-family:var(--mono);font-size:11px;color:#9fc4ad;white-space:nowrap}
+.route .rp b{display:block;color:#eafff1;font-size:13px}
+.route.primary{background:linear-gradient(180deg,#123a23,#0d2417);border-color:#2c7a4d}
+.cta{display:flex;gap:10px;margin-top:14px;flex-wrap:wrap}
+.cta a{flex:1;text-align:center;padding:12px;border-radius:11px;font-weight:700;font-size:13.5px;text-decoration:none;transition:.15s;white-space:nowrap}
+.cta a.go{background:linear-gradient(180deg,var(--tr2),#0e7a37);color:#04210f;box-shadow:0 8px 22px -8px var(--tr)}
+.cta a.go:hover{filter:brightness(1.07)}
+.cta a.ghost{border:1px solid #2c7a4d;color:#bdf0cf}
+.cta a.ghost:hover{background:#11271a}
+.trust{display:flex;align-items:center;gap:8px;margin-top:13px;font-size:11px;color:#86b89a;line-height:1.4}
+
+footer{margin-top:40px;padding-top:18px;border-top:1px solid var(--line);color:var(--dim);font-size:12px;
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap}
+footer a{color:var(--muted);text-decoration:none}
+footer a:hover{color:var(--ink)}
+.disc{font-size:10.5px;color:#46566f;max-width:58ch}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="top">
+    <div class="brand">
+      <div class="logo"><svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6z"/><path d="M9 12l2 2 4-4"/></svg></div>
+      <div><b>TrustedRouter</b><span>the attested LLM router</span></div>
+    </div>
+    <div class="headstat">
+      <span class="pill"><span class="dotlive"></span> live catalog · <b id="liveCount" style="color:var(--ink)">222</b>&nbsp;models</span>
+      <span class="pill">attested · stores&nbsp;no&nbsp;prompts</span>
+    </div>
+  </header>
+
+  <div class="hero">
+    <h1>The iron triangle of LLMs.<br><span class="g">Smart, cheap, fast — pick two.</span></h1>
+    <p>Every model is a tradeoff. Tell us your problem and how private it has to be; we'll plot where each model lives and pick the ones that fit. Then we'll show you the shortcut.</p>
+  </div>
+
+  <div class="grid">
+    <!-- ===================== TRIANGLE ===================== -->
+    <section class="card stage">
+      <div class="stage-head">
+        <div class="t">Where the models live <small>· drag the <b style="color:var(--ink)">YOU</b> dot to set your tradeoff</small></div>
+        <div class="legend">
+          <span><i style="background:var(--t0)"></i>Open</span>
+          <span><i style="background:var(--t2)"></i>Zero-retention</span>
+          <span><i style="background:var(--t3)"></i>Trusted Execution (TEE)</span>
+          <span><i style="background:var(--gold)"></i>your pick</span>
+        </div>
+      </div>
+      <svg class="tri" id="tri" viewBox="0 0 1000 940" aria-label="Ternary chart of models by intelligence, cost and speed"></svg>
+      <div class="tip" id="tip"></div>
+    </section>
+
+    <!-- ===================== CONTROLS ===================== -->
+    <aside class="controls">
+
+      <div class="card block">
+        <h3><span class="n">1</span> Privacy floor</h3>
+        <p class="hint">Every TrustedRouter route is attested. Choose how strict the upstream must be.</p>
+        <select class="priv" id="priv">
+          <option value="0">🌐 Open — any provider (most choice, best price)</option>
+          <option value="2" selected>🔒 Zero-retention (ZDR) — no prompt logging</option>
+          <option value="3">🛡️ Trusted Execution Environment (TEE) — confidential compute + E2EE</option>
+        </select>
+        <div class="privnote" id="privnote"></div>
+      </div>
+
+      <div class="card block">
+        <h3><span class="n">2</span> What's your problem?</h3>
+        <p class="hint">Describe the task. We'll guess how much intelligence it really needs.</p>
+        <textarea id="prob" placeholder="e.g. Refactor a gnarly React component and write tests…"></textarea>
+        <div class="exrow" id="examples"></div>
+        <button class="guessbtn" id="guess">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M18.4 5.6L17 7M7 17l-1.4 1.4"/><circle cx="12" cy="12" r="3.2"/></svg>
+          Guess what I need
+        </button>
+        <div class="rationale" id="rationale"></div>
+      </div>
+
+      <div class="card block">
+        <h3><span class="n">3</span> Intelligence needed</h3>
+        <p class="hint">The minimum brainpower. Smarter models still qualify — they just cost more.</p>
+        <div class="seg intel" id="intel"></div>
+      </div>
+
+      <div class="card block">
+        <h3><span class="n">4</span> How fast do you need it?</h3>
+        <p class="hint">Time-to-answer for your use case.</p>
+        <div class="seg spd" id="speed"></div>
+        <div class="weights">
+          <div class="wt s"><div class="v" id="wS">33</div><div class="k">Smart</div></div>
+          <div class="wt c"><div class="v" id="wC">33</div><div class="k">Cheap</div></div>
+          <div class="wt f"><div class="v" id="wF">33</div><div class="k">Fast</div></div>
+        </div>
+      </div>
+    </aside>
+  </div>
+
+  <!-- ===================== RESULTS ===================== -->
+  <section class="results">
+    <h2 id="resTitle">Your matches</h2>
+    <div class="reslay">
+      <div class="picks" id="picks"></div>
+      <div class="pitch" id="pitch"></div>
+    </div>
+  </section>
+
+  <footer>
+    <div>
+      <div>© TrustedRouter — one OpenAI-shaped client, every provider, <a href="https://trust.trustedrouter.com" target="_blank" rel="noopener">verifiable&nbsp;trust</a>.</div>
+      <div class="disc">Intelligence &amp; speed ratings are editorial estimates for relative comparison. Prices, context windows and privacy tiers are pulled from the live <span style="font-family:var(--mono)">/v1/models</span> catalog. Model versions shown reflect the current TrustedRouter panel.</div>
+    </div>
+    <div style="text-align:right;display:flex;flex-direction:column;gap:4px">
+      <a href="https://trustedrouter.com" target="_blank" rel="noopener">trustedrouter.com →</a>
+      <a href="https://github.com/Lore-Hex/trusted-router-js" target="_blank" rel="noopener">SDK on GitHub →</a>
+    </div>
+  </footer>
+</div>
+
+<script>
+/* =================================================================
+   DATA — real price / context / privacy tier from the live
+   TrustedRouter /v1/models catalog; intelligence & speed are
+   editorial 0–100 estimates for relative positioning.
+   ================================================================= */
+const TIER = {0:{k:'Open',full:'Open',c:'var(--t0)',bg:'#1b2740',fg:'#aebfd9'},
+              2:{k:'ZDR',full:'Zero-retention',c:'var(--t2)',bg:'#0c2c33',fg:'#7fe5f5'},
+              3:{k:'TEE',full:'Trusted Execution Environment (TEE)',c:'var(--t3)',bg:'#0d2a18',fg:'#7ee6a3'}};
+
+const MODELS = [
+ {id:'openai/gpt-5.5-pro',           n:'GPT-5.5 Pro',         intel:100, spd:22, pin:33,   pout:198,   ctx:1050000, tier:2, tags:['reasoning','math','research'], blurb:'Maximum-effort reasoning. Slow and costly — reserved for the hardest problems.'},
+ {id:'anthropic/claude-opus-4.8',    n:'Claude Opus 4.8',     intel:98,  spd:40, pin:4.95, pout:24.75, ctx:200000,  tier:2, tags:['reasoning','agentic','coding'], blurb:'The frontier default for hard, long-horizon agentic work.'},
+ {id:'openai/gpt-5.5',               n:'GPT-5.5',             intel:96,  spd:38, pin:5.5,  pout:33,    ctx:1050000, tier:2, tags:['reasoning','agentic','coding'], blurb:'Frontier generalist with a 1M-token window.'},
+ {id:'google/gemini-3.1-pro-preview',n:'Gemini 3.1 Pro',      intel:95,  spd:55, pin:2.2,  pout:13.2,  ctx:1048576, tier:2, tags:['reasoning','vision','long-context'], blurb:'Frontier multimodal, quick for its class, enormous context.'},
+ {id:'x-ai/grok-4.3',                n:'Grok 4.3',            intel:93,  spd:62, pin:1.375,pout:2.75,  ctx:1000000, tier:0, tags:['reasoning','agentic','realtime-knowledge'], blurb:'Frontier reasoning at a shockingly low price.'},
+ {id:'anthropic/claude-opus-4.7',    n:'Claude Opus 4.7',     intel:92,  spd:42, pin:5.5,  pout:27.5,  ctx:1000000, tier:2, tags:['reasoning','agentic','coding'], blurb:'Last-gen frontier Opus — still elite.'},
+ {id:'anthropic/claude-sonnet-4.6',  n:'Claude Sonnet 4.6',   intel:90,  spd:60, pin:3.3,  pout:16.5,  ctx:1000000, tier:2, tags:['coding','agentic','general'], blurb:'The workhorse: near-frontier quality at mid price and good speed.'},
+ {id:'openai/o3',                    n:'o3',                  intel:90,  spd:30, pin:2.2,  pout:8.8,   ctx:200000,  tier:2, tags:['reasoning','math','science'], blurb:'Deliberate step-by-step reasoner.'},
+ {id:'openai/gpt-5.4',               n:'GPT-5.4',             intel:89,  spd:55, pin:2.75, pout:16.5,  ctx:1050000, tier:2, tags:['reasoning','coding','general'], blurb:'Prior-gen frontier; balanced and dependable.'},
+ {id:'deepseek/deepseek-v4-pro',     n:'DeepSeek V4 Pro',     intel:89,  spd:58, pin:0.478,pout:0.957, ctx:1048576, tier:3, tags:['reasoning','coding','open-weight'], blurb:'Open-weight near-frontier at a fraction of the price — and confidential-tier.'},
+ {id:'moonshotai/kimi-k2-thinking',  n:'Kimi K2 Thinking',    intel:88,  spd:32, pin:0.66, pout:2.75,  ctx:262144,  tier:0, tags:['reasoning','math','agentic'], blurb:'Open-weight long-chain reasoner.'},
+ {id:'qwen/qwen3.5-397b-a17b',       n:'Qwen3.5 397B',        intel:88,  spd:55, pin:0.55, pout:3.85,  ctx:262144,  tier:3, tags:['reasoning','multilingual','open-weight'], blurb:'Huge open MoE, strong multilingual — confidential-tier.'},
+ {id:'z-ai/glm-5.2',                 n:'GLM-5.2',             intel:87,  spd:60, pin:1.54, pout:4.84,  ctx:1000000, tier:0, tags:['reasoning','coding','agentic','open-weight'], blurb:'Top-end open flagship, agentic and coding-strong.'},
+ {id:'moonshotai/kimi-k2.7-code',    n:'Kimi K2.7 Code',      intel:86,  spd:60, pin:1.045,pout:4.4,   ctx:262144,  tier:0, tags:['coding','agentic'], blurb:'Coding & tool-use specialist.'},
+ {id:'deepseek/deepseek-prover-v2-671b',n:'DeepSeek-Prover V2',intel:85, spd:40, pin:0.77, pout:2.75,  ctx:160000,  tier:0, tags:['math','proofs','reasoning'], blurb:'Formal-math / theorem-proving specialist.'},
+ {id:'qwen/qwen3-coder-480b-a35b-instruct',n:'Qwen3-Coder 480B',intel:84,spd:58, pin:0.418,pout:1.705, ctx:262144,  tier:0, tags:['coding','agentic','open-weight'], blurb:'Open coding workhorse with agentic chops.'},
+ {id:'deepseek/deepseek-r1-0528',    n:'DeepSeek R1',         intel:84,  spd:35, pin:0.77, pout:2.75,  ctx:163840,  tier:0, tags:['reasoning','math','open-weight'], blurb:'The open reasoning model that started the wave.'},
+ {id:'google/gemini-3.5-flash',      n:'Gemini 3.5 Flash',    intel:84,  spd:80, pin:1.65, pout:9.9,   ctx:1048576, tier:2, tags:['general','vision','fast'], blurb:'Fast, cheap, smart enough for most production traffic.'},
+ {id:'minimax/minimax-m3',           n:'MiniMax M3',          intel:83,  spd:65, pin:0.33, pout:1.32,  ctx:1048576, tier:0, tags:['general','long-context','cheap'], blurb:'Cheap long-context generalist.'},
+ {id:'qwen/qwen3-vl-235b-a22b-instruct',n:'Qwen3-VL 235B',    intel:82,  spd:60, pin:0.231,pout:2.09,  ctx:262144,  tier:0, tags:['vision','multimodal','open-weight'], blurb:'Open vision-language flagship — cheap multimodal.'},
+ {id:'openai/gpt-5.4-mini',          n:'GPT-5.4 mini',        intel:80,  spd:78, pin:0.825,pout:4.95,  ctx:400000,  tier:2, tags:['general','fast'], blurb:'Small frontier-family model, fast and private.'},
+ {id:'google/gemini-3-flash-preview',n:'Gemini 3 Flash',      intel:80,  spd:85, pin:0.55, pout:3.3,   ctx:1048576, tier:2, tags:['fast','vision','general'], blurb:'Quick multimodal at a low price.'},
+ {id:'deepseek/deepseek-v4-flash',   n:'DeepSeek V4 Flash',   intel:80,  spd:84, pin:0.143,pout:0.308, ctx:1048576, tier:0, tags:['general','cheap','fast'], blurb:'Absurdly cheap default for high-volume work.'},
+ {id:'minimax/minimax-m2.5-highspeed',n:'MiniMax M2.5 HS',    intel:79,  spd:92, pin:0.66, pout:2.64,  ctx:204800,  tier:0, tags:['realtime','fast'], blurb:'Tuned for low-latency serving.'},
+ {id:'anthropic/claude-haiku-4.5',   n:'Claude Haiku 4.5',    intel:78,  spd:84, pin:1.1,  pout:5.5,   ctx:200000,  tier:2, tags:['fast','general','agentic'], blurb:"Anthropic's fast, private small model."},
+ {id:'xiaomi/mimo-v2.5-pro-ultraspeed',n:'MiMo v2.5 Pro US',  intel:78,  spd:98, pin:1.435,pout:2.871, ctx:262144,  tier:0, tags:['realtime','blazing'], blurb:'Ultra-speed tuned MoE — one of the fastest models you can route to.'},
+ {id:'qwen/qwen3-next-80b-a3b-instruct',n:'Qwen3-Next 80B',   intel:77,  spd:80, pin:0.11, pout:1.21,  ctx:262144,  tier:0, tags:['fast','general','open-weight'], blurb:'Sparse MoE — big-model feel, small-model speed.'},
+ {id:'cerebras/gpt-oss-120b',        n:'gpt-oss-120B · Cerebras',intel:76,spd:100,pin:0.385,pout:0.825, ctx:131072,  tier:2, tags:['realtime','blazing','open-weight'], blurb:'Cerebras wafer-scale silicon: ~2,000 tok/s — the fastest route on the board.'},
+ {id:'z-ai/glm-4.7-flash',           n:'GLM-4.7 Flash',       intel:74,  spd:97, pin:0.11, pout:0.473, ctx:202752,  tier:3, tags:['realtime','blazing','cheap'], blurb:'Blazing fast, dirt cheap, and TEE-tier — a standout on latency.'},
+ {id:'google/gemini-3.1-flash-lite', n:'Gemini 3.1 Flash-Lite',intel:72, spd:90, pin:0.275,pout:1.65,  ctx:1048576, tier:2, tags:['realtime','cheap','vision'], blurb:'Real-time multimodal at rock-bottom price.'},
+ {id:'meta-llama/llama-3.3-70b-instruct',n:'Llama 3.3 70B',   intel:70,  spd:72, pin:0.242,pout:0.55,  ctx:131072,  tier:3, tags:['general','open-weight','private'], blurb:'Dependable open generalist — confidential-tier.'},
+ {id:'openai/gpt-oss-20b',           n:'gpt-oss 20B',         intel:68,  spd:88, pin:0.044,pout:0.165, ctx:131072,  tier:3, tags:['cheap','fast','private','edge'], blurb:'Tiny, private, nearly free.'},
+ {id:'openai/gpt-4.1-nano',          n:'GPT-4.1 nano',        intel:62,  spd:90, pin:0.11, pout:0.44,  ctx:1047576, tier:2, tags:['realtime','cheap','classify'], blurb:'Classify, extract, route — at scale, for cents.'},
+ {id:'mistralai/ministral-8b-2512',  n:'Ministral 8B',        intel:58,  spd:92, pin:0.165,pout:0.165, ctx:262144,  tier:0, tags:['realtime','cheap','edge'], blurb:'Edge-class workhorse for simple, instant tasks.'},
+];
+
+/* TrustedRouter virtual routes — the "don't pick a corner" payload (real catalog values). */
+const ROUTES = {
+ auto:  {id:'trustedrouter/auto',  n:'auto',  tier:2, pin:0.143, pout:0.308, desc:'Picks the best provider per request, fails over automatically. Zero-retention.'},
+ cheap: {id:'trustedrouter/cheap', n:'cheap', tier:3, pin:0.01,  pout:0.01,  desc:'Cheapest capable model, confidential compute + E2EE. ~$0.01 / Mtok.'},
+ fusion:{id:'trustedrouter/fusion',n:'fusion',tier:0, pin:0,     pout:0,     desc:'Fuses several open models into one answer — aims to beat any single frontier model.'},
+ zdr:   {id:'trustedrouter/zdr',   n:'zdr',   tier:3, pin:0.04,  pout:0.11,  desc:'Pool restricted to zero-retention + confidential providers only.'},
+ e2e:   {id:'trustedrouter/e2e',   n:'e2e',   tier:3, pin:0.04,  pout:0.11,  desc:'End-to-end encrypted open-weight pool.'},
+ free:  {id:'trustedrouter/free',  n:'free',  tier:0, pin:0.01,  pout:0.01,  desc:'Free tier for prototyping.'},
+};
+
+/* ---- requirement definitions ---- */
+const INTEL_TIERS = [
+ {key:'simple',  lab:'Simple',  sub:'extract · tag',     floor:0},
+ {key:'medium',  lab:'Medium',  sub:'rewrite · explain', floor:68},
+ {key:'smart',   lab:'Smart',   sub:'code · analyze',    floor:80},
+ {key:'frontier',lab:'Frontier',sub:'prove · architect', floor:90},
+];
+const SPEED_TIERS = [
+ {key:'realtime',lab:'Real-time',sub:'< 1s · chat',   floor:80},
+ {key:'seconds', lab:'Seconds',  sub:'live tools',     floor:48},
+ {key:'minutes', lab:'Minutes',  sub:'a workflow',     floor:28},
+ {key:'overnight',lab:'Overnight',sub:'batch · async', floor:0},
+];
+
+/* ---- example problems ---- */
+const EXAMPLES = [
+ 'Prove a lemma in number theory',
+ 'Refactor a React component + tests',
+ 'Real-time chat moderation at scale',
+ 'Summarize 5,000 support tickets overnight',
+ 'Extract dates & amounts from invoices',
+ 'Patient notes — must stay confidential',
+];
+
+/* =================================================================
+   STATE
+   ================================================================= */
+let state = {
+  priv: 2,
+  intel: 'smart',
+  speed: 'seconds',
+  pref: {s:1/3, c:1/3, f:1/3},   // barycentric preference weights
+  selected: null,
+  domain: null,                  // detected domain for boosting
+};
+
+/* derive cheapness 0..1 from blended price (log scale across panel) */
+const blended = m => m.pin*0.25 + m.pout*0.75;
+(function computeCheap(){
+  const vals = MODELS.map(m=>Math.log10(Math.max(blended(m),0.02)));
+  const lo=Math.min(...vals), hi=Math.max(...vals);
+  MODELS.forEach(m=>{ const v=Math.log10(Math.max(blended(m),0.02));
+    m.cheap = 1 - (v-lo)/(hi-lo); });            // cheapest -> 1
+})();
+const sc = m => ({s:m.intel/100, c:m.cheap, f:m.spd/100});
+
+/* =================================================================
+   TRIANGLE GEOMETRY  (barycentric <-> svg)
+   ================================================================= */
+const V = { s:{x:500,y:90}, c:{x:120,y:840}, f:{x:880,y:840} };  // Smart top, Cheap BL, Fast BR
+const bary2xy = (w)=>({ x:w.s*V.s.x + w.c*V.c.x + w.f*V.f.x,
+                        y:w.s*V.s.y + w.c*V.c.y + w.f*V.f.y });
+function xy2bary(px,py){
+  const d=(V.c.y-V.f.y)*(V.s.x-V.f.x)+(V.f.x-V.c.x)*(V.s.y-V.f.y);
+  let a=((V.c.y-V.f.y)*(px-V.f.x)+(V.f.x-V.c.x)*(py-V.f.y))/d;
+  let b=((V.f.y-V.s.y)*(px-V.f.x)+(V.s.x-V.f.x)*(py-V.f.y))/d;
+  let c=1-a-b;
+  a=Math.max(0,a); b=Math.max(0,b); c=Math.max(0,c);
+  const t=a+b+c; return {s:a/t,c:b/t,f:c/t};
+}
+/* model position: personality = normalized scores, with mild contrast */
+function modelPos(m){
+  const v=sc(m), k=1.35;
+  let s=Math.pow(v.s,k), c=Math.pow(v.c,k), f=Math.pow(v.f,k);
+  const t=s+c+f||1; return bary2xy({s:s/t,c:c/t,f:f/t});
+}
+
+const SVGNS='http://www.w3.org/2000/svg';
+const tri=document.getElementById('tri');
+const tip=document.getElementById('tip');
+const el=(t,a={})=>{const e=document.createElementNS(SVGNS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
+
+function drawScaffold(){
+  // glow defs
+  const defs=el('defs');
+  defs.innerHTML=`
+   <radialGradient id="floor" cx="50%" cy="62%" r="62%">
+     <stop offset="0%" stop-color="#16223b" stop-opacity=".9"/>
+     <stop offset="100%" stop-color="#0a1120" stop-opacity=".25"/>
+   </radialGradient>
+   <linearGradient id="edgeS" x1="0" y1="0" x2="1" y2="1">
+     <stop offset="0" stop-color="#a78bfa"/><stop offset="1" stop-color="#34d399"/>
+   </linearGradient>
+   <filter id="soft" x="-60%" y="-60%" width="220%" height="220%">
+     <feGaussianBlur stdDeviation="7" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+   </filter>
+   <filter id="dotglow" x="-150%" y="-150%" width="400%" height="400%">
+     <feGaussianBlur stdDeviation="4.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+   </filter>`;
+  tri.appendChild(defs);
+
+  // filled floor
+  tri.appendChild(el('polygon',{points:`${V.s.x},${V.s.y} ${V.c.x},${V.c.y} ${V.f.x},${V.f.y}`,fill:'url(#floor)',stroke:'none'}));
+
+  // internal ternary gridlines every 20%
+  const g=el('g',{stroke:'#1d2c47','stroke-width':'1','stroke-dasharray':'2 7',opacity:'.75'});
+  for(let i=1;i<5;i++){const t=i/5;
+    // lines parallel to each edge
+    let p1=bary2xy({s:t,c:1-t,f:0}), p2=bary2xy({s:t,c:0,f:1-t});
+    g.appendChild(el('line',{x1:p1.x,y1:p1.y,x2:p2.x,y2:p2.y}));
+    p1=bary2xy({s:0,c:t,f:1-t}); p2=bary2xy({s:1-t,c:t,f:0});
+    g.appendChild(el('line',{x1:p1.x,y1:p1.y,x2:p2.x,y2:p2.y}));
+    p1=bary2xy({s:0,c:1-t,f:t}); p2=bary2xy({s:1-t,c:0,f:t});
+    g.appendChild(el('line',{x1:p1.x,y1:p1.y,x2:p2.x,y2:p2.y}));
+  }
+  tri.appendChild(g);
+
+  // outer edges
+  tri.appendChild(el('polygon',{points:`${V.s.x},${V.s.y} ${V.c.x},${V.c.y} ${V.f.x},${V.f.y}`,
+    fill:'none',stroke:'url(#edgeS)','stroke-width':'2.4','stroke-linejoin':'round',opacity:'.85'}));
+
+  // vertex glyphs + labels
+  vertex(V.s.x, V.s.y-6, 'var(--smart)', 'SMART', 'best reasoning', 'up', '🧠');
+  vertex(V.c.x-4, V.c.y+8, 'var(--cheap)', 'CHEAP', 'lowest $/token', 'bl', '🪙');
+  vertex(V.f.x+4, V.f.y+8, 'var(--fast)', 'FAST', 'most tokens/sec', 'br', '⚡');
+}
+function vertex(x,y,color,lab,sub,pos,emoji){
+  const g=el('g');
+  const tx = pos==='bl'? x-2 : pos==='br'? x+2 : x;
+  const anchor = pos==='bl'?'start':pos==='br'?'end':'middle';
+  const ty = pos==='up'? y-26 : y+30;
+  const t1=el('text',{x:tx,y:ty,'text-anchor':anchor,fill:color,'font-size':'27','font-weight':'800','letter-spacing':'.5'});
+  t1.textContent=`${emoji} ${lab}`; t1.setAttribute('class','vtx-label');
+  const t2=el('text',{x:tx,y:ty+19,'text-anchor':anchor,fill:'var(--muted)','font-size':'14','font-weight':'500'});
+  t2.textContent=sub; t2.setAttribute('class','vtx-sub');
+  g.appendChild(t1);g.appendChild(t2);tri.appendChild(g);
+}
+
+/* ---- dot + preference layers (re-rendered) ---- */
+let dotLayer, prefLayer, linkLayer;
+function ensureLayers(){
+  linkLayer=el('g'); dotLayer=el('g'); prefLayer=el('g');
+  tri.appendChild(linkLayer); tri.appendChild(dotLayer); tri.appendChild(prefLayer);
+}
+
+function tierOf(m){return TIER[m.tier];}
+function passesFloors(m){
+  const it=INTEL_TIERS.find(t=>t.key===state.intel).floor;
+  const sp=SPEED_TIERS.find(t=>t.key===state.speed).floor;
+  return m.intel>=it && m.spd>=sp && m.tier>=state.priv;
+}
+function matchScore(m){
+  const v=sc(m); const p=state.pref;
+  let base = p.s*v.s + p.c*v.c + p.f*v.f;
+  if(state.domain && m.tags.includes(state.domain)) base += 0.10; // specialist nudge
+  return base;
+}
+
+function render(){
+  // weights readout
+  wS.textContent=Math.round(state.pref.s*100);
+  wC.textContent=Math.round(state.pref.c*100);
+  wF.textContent=Math.round(state.pref.f*100);
+
+  // rank qualifiers
+  const qual = MODELS.filter(passesFloors).sort((a,b)=>matchScore(b)-matchScore(a));
+  const topId = qual.length? qual[0].id : null;
+
+  // --- dots ---
+  dotLayer.innerHTML=''; linkLayer.innerHTML='';
+  // draw qualifiers last so they're on top
+  const order=[...MODELS].sort((a,b)=>(passesFloors(a)?1:0)-(passesFloors(b)?1:0));
+  for(const m of order){
+    const p=modelPos(m), ok=passesFloors(m), t=tierOf(m);
+    const isTop = m.id===topId;
+    const rank = qual.findIndex(x=>x.id===m.id);
+    let r = ok? (isTop?15: rank<3?12:9) : 6.5;
+    const sel = state.selected===m.id;
+    const gc=el('g',{class:'mdot',style:'cursor:pointer',transform:`translate(${p.x},${p.y})`});
+    gc.dataset.id=m.id;
+    if(ok){
+      gc.appendChild(el('circle',{r:r,fill:t.c,'fill-opacity':isTop?'1':'.92',
+        stroke:isTop?'var(--gold)':'#0a1120','stroke-width':isTop?'3':'1.4',
+        filter:(isTop||rank<3)?'url(#dotglow)':''}));
+      if(isTop) gc.appendChild(el('circle',{r:r+7,fill:'none',stroke:'var(--gold)','stroke-width':'1.5',opacity:'.6'}));
+    }else{
+      gc.appendChild(el('circle',{r:r,fill:t.c,'fill-opacity':'.16',stroke:'#26354f','stroke-width':'1'}));
+    }
+    if(sel) gc.appendChild(el('circle',{r:r+5,fill:'none',stroke:'#fff','stroke-width':'1.4',opacity:'.7'}));
+    dotLayer.appendChild(gc);
+  }
+  // link preference -> top pick
+  if(topId){
+    const tp=modelPos(MODELS.find(m=>m.id===topId)), pp=bary2xy(state.pref);
+    linkLayer.appendChild(el('line',{x1:pp.x,y1:pp.y,x2:tp.x,y2:tp.y,stroke:'var(--gold)',
+      'stroke-width':'1.4','stroke-dasharray':'4 5',opacity:'.45'}));
+  }
+  drawPref();
+  renderResults(qual);
+}
+
+function drawPref(){
+  prefLayer.innerHTML='';
+  const p=bary2xy(state.pref);
+  const g=el('g',{transform:`translate(${p.x},${p.y})`,style:'cursor:grab',id:'prefHandle'});
+  g.appendChild(el('circle',{r:22,fill:'var(--gold)','fill-opacity':'.10',stroke:'none'}));
+  g.appendChild(el('circle',{r:13,fill:'none',stroke:'var(--gold)','stroke-width':'2.4',filter:'url(#soft)'}));
+  g.appendChild(el('circle',{r:4.5,fill:'var(--gold)'}));
+  // crosshair
+  for(const [x1,y1,x2,y2] of [[-19,0,-13,0],[19,0,13,0],[0,-19,0,-13],[0,19,0,13]])
+    g.appendChild(el('line',{x1,y1,x2,y2,stroke:'var(--gold)','stroke-width':'2','stroke-linecap':'round'}));
+  const t=el('text',{x:0,y:-26,'text-anchor':'middle',fill:'var(--gold)','font-size':'13','font-weight':'800','letter-spacing':'1.5'});
+  t.textContent='YOU'; g.appendChild(t);
+  prefLayer.appendChild(g);
+}
+
+/* =================================================================
+   RESULTS + PITCH
+   ================================================================= */
+const fmt = n => n>=1? '$'+n.toFixed(2) : '$'+n.toFixed(3).replace(/0+$/,'').replace(/\.$/,'.0');
+const ctxFmt = c => c>=1e6? (c/1e6).toFixed(c%1e6?1:0)+'M' : Math.round(c/1000)+'K';
+
+function renderResults(qual){
+  const picks=document.getElementById('picks');
+  const title=document.getElementById('resTitle');
+  picks.innerHTML='';
+  if(!qual.length){
+    title.textContent='No single model fits that corner';
+    picks.innerHTML=`<div class="empty"><b style="color:var(--ink)">You're chasing the hard corner of the triangle.</b><br>
+      Frontier-smart, real-time-fast, dirt-cheap <i>and</i> confidential rarely coexist in one model.<br>
+      That's exactly the problem TrustedRouter solves &nbsp;👉</div>`;
+    renderPitch(null); return;
+  }
+  title.textContent = `Your matches · ${qual.length} model${qual.length>1?'s':''} qualify`;
+  qual.slice(0,3).forEach((m,i)=>{
+    const t=tierOf(m), v=sc(m);
+    const why = i===0 ? whyLabel(m,qual) : '';
+    const overkill = m.intel - INTEL_TIERS.find(x=>x.key===state.intel).floor > 22 && state.pref.c>0.4;
+    const div=document.createElement('div');
+    div.className='pick'+(i===0?' top':'');
+    div.innerHTML=`
+      <div class="rank">${i===0?'★':'#'+(i+1)}</div>
+      <div>
+        <div class="nm">${m.n}${why?`<span class="why">${why}</span>`:''}${overkill?`<span class="why" style="color:#9fb6d6;background:#1a2740;border-color:#2c3e5c">overkill — but cheap-leaning</span>`:''}</div>
+        <div class="sub">${m.id}</div>
+        <div class="tags">${m.tags.slice(0,4).map(x=>`<span class="tag">${x}</span>`).join('')}</div>
+        <div class="minibars">
+          <div class="mb" title="smart"><i style="width:${v.s*100}%;background:var(--smart)"></i></div>
+          <div class="mb" title="cheap"><i style="width:${v.c*100}%;background:var(--cheap)"></i></div>
+          <div class="mb" title="fast"><i style="width:${v.f*100}%;background:var(--fast)"></i></div>
+        </div>
+      </div>
+      <div class="price">
+        <b>${fmt(m.pout)}</b><span style="font-size:10px">/Mtok out</span>
+        <div style="margin-top:3px;opacity:.8">${fmt(m.pin)} in · ${ctxFmt(m.ctx)} ctx</div>
+        <span class="tier" style="background:${t.bg};color:${t.fg}">${t.k}</span>
+      </div>`;
+    div.onmouseenter=()=>{state.selected=m.id;render();};
+    picks.appendChild(div);
+  });
+  renderPitch(qual);
+}
+function whyLabel(m,qual){
+  if(state.domain && m.tags.includes(state.domain)) return 'great for '+state.domain;
+  const leads=f=>qual.reduce((a,b)=>f(b)>f(a)?b:a).id===m.id;
+  const p=state.pref;
+  if(p.s>=0.34 && leads(x=>x.intel)) return 'smartest that fits';
+  if(p.f>=0.34 && leads(x=>x.spd))   return 'fastest that fits';
+  if(leads(x=>x.cheap))              return 'best value';
+  return 'best balance for your mix';
+}
+
+function pickRoute(){
+  const p=state.pref;
+  if(state.priv>=3 && p.c>=0.4) return ROUTES.cheap;
+  if(state.priv>=3) return ROUTES.zdr;
+  if(p.s>=0.45 && state.intel==='frontier') return ROUTES.fusion;
+  if(p.c>=0.5) return ROUTES.cheap;
+  return ROUTES.auto;
+}
+function renderPitch(qual){
+  const primary=pickRoute();
+  const second = primary.id===ROUTES.auto.id ? ROUTES.fusion : ROUTES.auto;
+  const t1=TIER[primary.tier], t2=TIER[second.tier];
+  const noFit = !qual || !qual.length;
+  const pitch=document.getElementById('pitch');
+  pitch.innerHTML=`
+    <div class="kicker"><span class="dotlive"></span> the shortcut</div>
+    <h3>${noFit?"Stop juggling the triangle.":"Don't want to choose? Don't."}</h3>
+    <p class="lede">${noFit
+      ? "One endpoint that picks the right model per request — and proves it never logged your prompt."
+      : "Point one OpenAI-shaped client at <b>"+primary.n.toUpperCase()+"</b> and TrustedRouter handles the tradeoff for every request, with attestation."}</p>
+
+    <div class="route primary">
+      <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--tr2)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h6l2-4 3 8 2-4h3"/></svg></div>
+      <div><div class="rn">${primary.id}</div><div class="rd">${primary.desc}</div></div>
+      <div class="rp"><b>${primary.pin===0?'incl.':fmt(primary.pin)}</b>${primary.pin===0?'':'/Mtok in'}<div style="margin-top:3px"><span class="tier" style="background:${t1.bg};color:${t1.fg};font-size:9px;padding:2px 6px;border-radius:5px">${t1.k}</span></div></div>
+    </div>
+    <div class="route">
+      <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#7fd3a3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4v6c0 5-3.5 7-8 8-4.5-1-8-3-8-8V7z"/></svg></div>
+      <div><div class="rn">${second.id}</div><div class="rd">${second.desc}</div></div>
+      <div class="rp"><b>${second.pin===0?'incl.':fmt(second.pin)}</b>${second.pin===0?'':'/Mtok in'}</div>
+    </div>
+
+    <div class="cta">
+      <a class="go" href="https://trustedrouter.com" target="_blank" rel="noopener">Get an API key →</a>
+      <a class="ghost" href="https://trust.trustedrouter.com" target="_blank" rel="noopener">Verify the attestation</a>
+    </div>
+    <div class="trust">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6z"/><path d="M9 12l2 2 4-4"/></svg>
+      Attested gateway · stores no prompt or output content · one bill across Anthropic, OpenAI, Google, DeepSeek, Moonshot, Z.ai, MiniMax, Mistral &amp; more.
+    </div>`;
+}
+
+/* =================================================================
+   PROBLEM CLASSIFIER  (keyword heuristic)
+   ================================================================= */
+const KW = {
+  frontier:['prove','proof','theorem','lemma','research','novel','phd','olympiad','architect','design a system','distributed system','publishable','diagnos','strategy','derive','formal','agentic','multi-step','multi step','from scratch','optimi','algorithm','cryptograph','rigorous','hard'],
+  smart:['code','coding','program','debug','refactor','sql','analyze','analysis','reason','plan','essay','write a function','unit test','review','explain why','math','solve','financial model','build','implement'],
+  medium:['summar','rewrite','draft','email','translate','explain','rephrase','outline','blog','description','paraphrase','clean up','format nicely'],
+  simple:['classif','extract','tag','label','sentiment','yes/no','yes or no','spellcheck','spelling','format','parse','route','moderat','detect','flag','short reply','autocomplete','redact'],
+};
+const DOMAIN = {
+  coding:['code','coding','program','debug','refactor','python','react','javascript','typescript','rust','sql','function','unit test','api','bug'],
+  math:['math','theorem','lemma','proof','prove','algebra','calculus','equation','number theory','olympiad'],
+  vision:['image','photo','vision','ocr','screenshot','diagram','chart','visual','picture','scan'],
+  reasoning:['reason','logic','strategy','plan','analyze','diagnos','decision'],
+  multilingual:['translate','chinese','spanish','language','multilingual','french','japanese'],
+};
+const SPEED_HINT = {
+  realtime:['real-time','realtime','real time','chat','chatbot','live','instant','interactive','typeahead','autocomplete','moderat','voice','streaming'],
+  overnight:['overnight','batch','async','nightly','background','offline','bulk','thousands','millions','tickets','pipeline'],
+  minutes:['report','workflow','deep','thorough','agent'],
+};
+/* word-boundary prefix match: "\bsummar" hits "summarize" but "\bprove" skips "improve"/"invoices"→"voice" */
+const kwHit = (t,w)=> new RegExp('\\b'+w.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')).test(t);
+function classify(txt){
+  const t=' '+txt.toLowerCase()+' ';
+  const hit = obj => Object.entries(obj).map(([k,arr])=>[k,arr.reduce((n,w)=>n+(kwHit(t,w)?1:0),0)]);
+  // intelligence: highest tier with a hit, but require evidence
+  const order=['frontier','smart','medium','simple'];
+  const counts=Object.fromEntries(hit(KW));
+  let intel=null,intelHits=0;
+  for(const k of order){ if(counts[k]>0){intel=k;intelHits=counts[k];break;} }
+  if(!intel){ intel = txt.trim().length>140?'smart':'medium'; }
+  // domain
+  const dHits=hit(DOMAIN).filter(([,n])=>n>0).sort((a,b)=>b[1]-a[1]);
+  const domain=dHits.length?dHits[0][0]:null;
+  // speed
+  let speed=null;
+  for(const k of ['realtime','overnight','minutes']){ if(SPEED_HINT[k].some(w=>kwHit(t,w))){speed=k;break;} }
+  return {intel,domain,speed,counts};
+}
+
+/* =================================================================
+   UI WIRING
+   ================================================================= */
+function buildSeg(id, list, key, cls){
+  const wrap=document.getElementById(id); wrap.innerHTML='';
+  list.forEach(o=>{
+    const d=document.createElement('div');
+    d.className='opt'+(state[key]===o.key?' on':'');
+    d.innerHTML=`<div class="lab">${o.lab}</div><div class="sub">${o.sub}</div>`;
+    d.onclick=()=>{state[key]=o.key; buildSeg(id,list,key,cls); render();};
+    wrap.appendChild(d);
+  });
+}
+function buildExamples(){
+  const wrap=document.getElementById('examples');
+  EXAMPLES.forEach(x=>{
+    const b=document.createElement('div'); b.className='ex'; b.textContent=x;
+    b.onclick=()=>{document.getElementById('prob').value=x; doGuess();};
+    wrap.appendChild(b);
+  });
+}
+const PRIV_NOTE = {
+ 0:['#aebfd9','All 222 models, every provider. The gateway is still attested — but the upstream may retain prompts per its own policy.'],
+ 2:['#7fe5f5','~107 routes whose providers contractually retain nothing. The default for production.'],
+ 3:['#7ee6a3','~30 routes that run inside a Trusted Execution Environment (TEE) with end-to-end encryption — the hardware attests that even the provider can\'t read your prompt. For regulated / sensitive data.'],
+};
+function updatePrivNote(){
+  const [c,txt]=PRIV_NOTE[state.priv];
+  document.getElementById('privnote').innerHTML=
+    `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${c}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6z"/></svg><span style="color:${c}">${txt}</span>`;
+}
+
+function doGuess(){
+  const txt=document.getElementById('prob').value.trim();
+  const rat=document.getElementById('rationale');
+  if(!txt){ rat.className='rationale'; return; }
+  const r=classify(txt);
+  state.intel=r.intel; state.domain=r.domain;
+  if(r.speed) state.speed=r.speed;
+  buildSeg('intel',INTEL_TIERS,'intel'); buildSeg('speed',SPEED_TIERS,'speed');
+  // nudge preference toward the detected need
+  if(r.intel==='frontier'||r.intel==='smart') state.pref={s:0.5,c:0.22,f:0.28};
+  else state.pref={s:0.26,c:0.42,f:0.32};
+  if(state.speed==='realtime') state.pref={s:state.pref.s*0.7,c:state.pref.c,f:state.pref.f+0.18};
+  const tot=state.pref.s+state.pref.c+state.pref.f; state.pref={s:state.pref.s/tot,c:state.pref.c/tot,f:state.pref.f/tot};
+  const il=INTEL_TIERS.find(t=>t.key===r.intel).lab;
+  const sl=SPEED_TIERS.find(t=>t.key===state.speed).lab;
+  rat.innerHTML=`Detected ${r.domain?`<b>${r.domain}</b> · `:''}<b>${il}</b> intelligence${r.speed?` · <b>${sl}</b> latency`:''}. Adjusted the triangle — drag <b>YOU</b> to fine-tune.`;
+  rat.className='rationale show';
+  render();
+}
+
+/* ---- triangle dot hover/click + preference drag ---- */
+function svgPoint(evt){
+  const pt=tri.createSVGPoint();
+  const src=evt.touches?evt.touches[0]:evt;
+  pt.x=src.clientX; pt.y=src.clientY;
+  return pt.matrixTransform(tri.getScreenCTM().inverse());
+}
+let dragging=false;
+function startDrag(e){ dragging=true; document.getElementById('prefHandle')?.setAttribute('style','cursor:grabbing'); moveDrag(e); e.preventDefault?.(); }
+function moveDrag(e){
+  if(!dragging) return;
+  const p=svgPoint(e); state.pref=xy2bary(p.x,p.y); render();
+}
+function endDrag(){ dragging=false; }
+
+tri.addEventListener('pointerdown',e=>{
+  // if near the YOU handle OR anywhere inside, begin drag — but let dots take clicks
+  const target=e.target.closest('.mdot');
+  if(target){ state.selected=target.dataset.id; showTip(target,e); render(); return; }
+  startDrag(e);
+});
+window.addEventListener('pointermove',e=>{ moveDrag(e); });
+window.addEventListener('pointerup',endDrag);
+
+tri.addEventListener('pointermove',e=>{
+  if(dragging) return;
+  const target=e.target.closest('.mdot');
+  if(target) showTip(target,e); else hideTip();
+});
+tri.addEventListener('pointerleave',()=>{if(!dragging)hideTip();});
+
+function showTip(g,e){
+  const m=MODELS.find(x=>x.id===g.dataset.id); if(!m) return;
+  const t=tierOf(m), v=sc(m), ok=passesFloors(m);
+  tip.innerHTML=`
+    <h4>${m.n} <span class="tierbadge" style="background:${t.bg};color:${t.fg};margin-left:auto">${t.k}</span></h4>
+    <div class="prov">${m.id}</div>
+    <div style="font-size:11.5px;color:#c4d2ea;margin:-2px 0 4px">${m.blurb}</div>
+    <div class="bars">
+      ${bar('Smart',v.s,'var(--smart)',m.intel)}
+      ${bar('Cheap',v.c,'var(--cheap)',fmt(m.pout)+'/M')}
+      ${bar('Fast',v.f,'var(--fast)',m.spd+' tps≈')}
+    </div>
+    <div class="meta">${m.tags.map(x=>`<span class="tag">${x}</span>`).join('')}</div>
+    ${ok?'':'<div style="margin-top:8px;font-size:10.5px;color:#f0a">✕ below your current floor</div>'}`;
+  const rect=tri.getBoundingClientRect();
+  const src=e.touches?e.touches[0]:e;
+  let x=src.clientX-rect.left+14, y=src.clientY-rect.top+14;
+  if(x>rect.width-258) x=src.clientX-rect.left-262;
+  tip.style.left=x+'px'; tip.style.top=y+'px'; tip.classList.add('show');
+}
+function bar(lab,val,col,right){
+  return `<div class="bar"><span>${lab}</span><div class="track"><div class="fill" style="width:${val*100}%;background:${col}"></div></div><b>${right}</b></div>`;
+}
+function hideTip(){tip.classList.remove('show');}
+
+/* ---- privacy + guess wiring ---- */
+document.getElementById('priv').addEventListener('change',e=>{state.priv=+e.target.value;updatePrivNote();render();});
+document.getElementById('guess').addEventListener('click',doGuess);
+document.getElementById('prob').addEventListener('keydown',e=>{if((e.metaKey||e.ctrlKey)&&e.key==='Enter')doGuess();});
+
+/* try to refresh the live model count from the catalog (best-effort, no key needed for count) */
+fetch('https://trustedrouter.com/v1/models',{headers:{}}).then(r=>r.ok?r.json():null).then(d=>{
+  if(d&&d.data) document.getElementById('liveCount').textContent=d.data.length;
+}).catch(()=>{});
+
+/* ---- boot ---- */
+drawScaffold(); ensureLayers();
+buildSeg('intel',INTEL_TIERS,'intel'); buildSeg('speed',SPEED_TIERS,'speed');
+buildExamples(); updatePrivNote(); render();
+
+/* ---- embedded mode: when iframed into trustedrouter.com/choose, drop the
+   in-app brand header + hero (the page already shows the site nav + a hero),
+   and report height so the parent can size the frame. ---- */
+(function(){
+  if(window.self===window.top) return;          // standalone — leave as-is
+  document.documentElement.classList.add('embedded');
+  const hide=s=>{const e=document.querySelector(s); if(e) e.style.display='none';};
+  hide('header.top'); hide('.hero');
+  const wrap=document.querySelector('.wrap'); if(wrap){wrap.style.paddingTop='10px';}
+  const report=()=>{try{
+    const h=Math.ceil(document.body.scrollHeight);
+    parent.postMessage({type:'tr-choose-height',height:h},'*');
+  }catch(e){}};
+  new ResizeObserver(report).observe(document.body);
+  window.addEventListener('load',report); window.addEventListener('resize',report);
+  [120,400,900].forEach(t=>setTimeout(report,t)); report();
+})();
+</script>
+</body>
+</html>

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -46,6 +46,7 @@
     <nav class="nav">
       <a class="brand" href="/"><span class="mark">TR</span><span>TrustedRouter</span></a>
       <div class="links">
+        <a href="/choose">Choose</a>
         <a href="/models">Models</a>
         <a href="/providers">Providers</a>
         <a href="/eu">EU</a>

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -62,6 +62,7 @@
     <nav class="nav">
       <a class="brand" href="/"><span class="mark">TR</span><span>TrustedRouter</span></a>
       <div class="links">
+        <a href="/choose">Choose</a>
         <a href="/models">Models</a>
         <a href="/providers">Providers</a>
         <a href="/eu">EU</a>

--- a/src/trusted_router/templates/public/choose.html
+++ b/src/trusted_router/templates/public/choose.html
@@ -1,0 +1,96 @@
+{% extends "public/_base.html" %}
+{% block hero %}
+<section class="public-hero marketing-hero">
+  <div>
+    <span class="eyebrow">Smart · Cheap · Fast — pick two</span>
+    <h1>Choose the right model for the job.</h1>
+    <p class="lead">Describe your task and how private it has to be. We plot every route on the iron
+      triangle, keep the ones that fit, and recommend the model — then show you the one-line shortcut.</p>
+    <div class="hero-actions">
+      <button class="btn primary" type="button" data-action="open-signin">Create key</button>
+      <a class="btn" href="https://trust.trustedrouter.com">Verify gateway</a>
+    </div>
+  </div>
+  <div class="public-hero-metrics" aria-label="TrustedRouter quick facts">
+    <div><strong>220+</strong><span>models &amp; routes</span></div>
+    <div><strong>3 tiers</strong><span>Open · ZDR · TEE</span></div>
+    <div><strong>0</strong><span>prompt logs by default</span></div>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section aria-label="Interactive model picker" class="choose-embed">
+  <iframe id="tr-choose-frame"
+          title="Interactive model tradeoff explorer — smart, cheap, fast"
+          src="/static/choose-app.html?v={{ static_version|default('local') }}"
+          loading="eager"
+          referrerpolicy="same-origin"></iframe>
+</section>
+<style>
+  .choose-embed{margin:6px 0 30px;border-radius:18px;overflow:hidden;
+    border:1px solid var(--border, #1c2942);background:#070b14;box-shadow:0 18px 50px -22px rgba(0,0,0,.7)}
+  #tr-choose-frame{width:100%;border:0;display:block;min-height:1480px;background:#070b14}
+  @media(max-width:980px){ #tr-choose-frame{min-height:2200px} }
+</style>
+<script>
+  /* Same-origin iframe: size it to its content. Prefer the height the app
+     postMessages; fall back to reading the document directly. */
+  (function(){
+    var f = document.getElementById('tr-choose-frame');
+    function readFit(){
+      try{
+        var d = f.contentWindow.document;
+        var h = Math.max(d.documentElement.scrollHeight, d.body.scrollHeight);
+        if(h > 300) f.style.height = h + 'px';
+      }catch(e){ /* cross-origin or not ready — ignore */ }
+    }
+    window.addEventListener('message', function(ev){
+      if(ev.source === f.contentWindow && ev.data && ev.data.type === 'tr-choose-height'){
+        if(ev.data.height > 300) f.style.height = ev.data.height + 'px';
+      }
+    });
+    f.addEventListener('load', function(){
+      readFit();
+      [200, 600, 1300].forEach(function(t){ setTimeout(readFit, t); });
+    });
+    window.addEventListener('resize', function(){ setTimeout(readFit, 80); });
+  })();
+</script>
+
+<section class="marketing-split">
+  <div class="marketing-copy">
+    <span class="eyebrow">How the triangle works</span>
+    <h2>Three axes, one honest tradeoff.</h2>
+    <p><strong>Smart</strong> is reasoning quality. <strong>Cheap</strong> is dollars per million tokens,
+      straight from the live catalog. <strong>Fast</strong> is throughput — Cerebras-served gpt-oss,
+      MiMo Ultraspeed and GLM-4.7 Flash sit right at the tip.</p>
+    <p>Pick a privacy floor — <strong>Open</strong>, <strong>Zero-retention&nbsp;(ZDR)</strong>, or a
+      hardware <strong>Trusted Execution Environment&nbsp;(TEE)</strong> with end-to-end encryption — and the
+      board only keeps routes that clear it. Every route is attested at
+      <a href="https://trust.trustedrouter.com">trust.trustedrouter.com</a>.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Stop choosing</span><span>OpenAI SDK</span></div>
+    <pre><code>base_url="{{ api_base_url }}"
+
+# let the router pick, per request:
+model="trustedrouter/auto"     # best fit, zero-retention
+model="trustedrouter/cheap"    # cheapest capable, TEE
+model="trustedrouter/fusion"   # fuse open models &gt; frontier</code></pre>
+  </div>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">The shortcut</span>
+    <h2>The corner you actually want rarely exists in one model.</h2>
+  </div>
+  <div>
+    <p>Frontier-smart, real-time-fast, dirt-cheap and private almost never coexist in a single model.
+      TrustedRouter's <code>auto</code>, <code>cheap</code> and <code>fusion</code> routes dissolve the
+      tradeoff — one OpenAI-shaped endpoint that picks per request and proves it never logged your prompt.
+      <button class="btn primary" type="button" data-action="open-signin">Create a key</button></p>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -76,6 +76,39 @@ def test_revenue_pages_support_link_checkers(client: TestClient) -> None:
         assert slash_response.status_code == 200
 
 
+def test_choose_page_embeds_the_triangle_app(client: TestClient) -> None:
+    response = client.get("/choose")
+
+    assert response.status_code == 200
+    # Hero + the embedded interactive tool.
+    assert "Choose the right model for the job." in response.text
+    assert "/static/choose-app.html" in response.text  # iframe src
+    assert 'id="tr-choose-frame"' in response.text
+    # The renamed privacy tier and the router-route payload show up in copy.
+    assert "Trusted Execution Environment" in response.text
+    assert "trustedrouter/fusion" in response.text
+    # Must unfurl like every other public page.
+    assert 'property="og:title"' in response.text
+    assert 'property="og:image"' in response.text
+    # Trailing-slash + HEAD variants both resolve.
+    assert client.head("/choose").status_code == 200
+    assert client.get("/choose/", follow_redirects=False).status_code == 200
+
+
+def test_choose_app_static_asset_is_served(client: TestClient) -> None:
+    response = client.get("/static/choose-app.html")
+
+    assert response.status_code == 200
+    assert "iron triangle of LLMs" in response.text
+    # Embedded-mode hook that hides the in-app header inside the iframe.
+    assert "tr-choose-height" in response.text
+
+
+def test_homepage_and_nav_link_to_choose(client: TestClient) -> None:
+    assert 'href="/choose"' in client.get("/").text
+    assert 'href="/choose"' in client.get("/models").text  # _base nav
+
+
 def test_public_models_page_does_not_require_api_key(client: TestClient) -> None:
     response = client.get("/models")
 


### PR DESCRIPTION
A new public marketing page at **`trustedrouter.com/choose`** that plots the live model catalog on a **smart / cheap / fast** ternary chart ("the iron triangle of LLMs — pick two") and turns the tradeoff into a recommendation, ending in the `trustedrouter/auto · cheap · fusion` pitch.

### What it does
- Describe a task → a keyword classifier estimates the **intelligence** needed (simple → frontier).
- Set a **latency** need (real-time → overnight) and a **privacy floor**: Open · Zero-retention (ZDR) · **Trusted Execution Environment (TEE)**.
- Drag the **YOU** dot to weight the tradeoff; qualifying models rank live; non-qualifiers dim out.
- Output: ranked model cards (real price/context/tier) + the "don't pick a corner" TrustedRouter route pitch.

### How it's wired
- `static/choose-app.html` — self-contained app (vanilla SVG ternary chart, barycentric placement, classifier). Hides its own header/hero when iframed so it sits inside the site chrome.
- `templates/public/choose.html` — extends `public/_base.html` (real nav/footer/OG/SEO), embeds the app in a **self-sizing same-origin iframe**, adds indexable SEO copy + FAQ.
- `dashboard.py` — `PUBLIC_PAGES["choose"]` + `/choose` in the core sitemap.
- `routes/public.py` — `GET`/`HEAD /choose`.
- `_base.html` + `dashboard.html` — **Choose** nav link.
- Tests for the page render, the static asset, and the nav links.

### Data provenance
Prices, context windows and privacy tiers are pulled from the live `/v1/models` catalog. Intelligence and speed are editorial estimates for relative positioning (noted on-page in the footer).

### Verification
- `ruff` + `mypy` clean on changed modules.
- `pytest tests/test_public_seo_pages.py tests/test_public_revenue_pages.py` → 23 passed (incl. 3 new `/choose` tests).
- Rendered locally in the real site chrome (nav + hero + embedded triangle), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)