### PR TITLE
Label the /choose hero metric "3 privacy tiers"

### DIFF
--- a/src/trusted_router/templates/public/choose.html
+++ b/src/trusted_router/templates/public/choose.html
@@ -13,7 +13,7 @@
   </div>
   <div class="public-hero-metrics" aria-label="TrustedRouter quick facts">
     <div><strong>220+</strong><span>models &amp; routes</span></div>
-    <div><strong>3 tiers</strong><span>Open · ZDR · TEE</span></div>
+    <div><strong>3 privacy tiers</strong><span>Open · ZDR · TEE</span></div>
     <div><strong>0</strong><span>prompt logs by default</span></div>
   </div>
 </section>


### PR DESCRIPTION
Small copy fix: the hero metric on `/choose` said "3 tiers" — now "3 privacy tiers (Open · ZDR · TEE)" so it's clear what the three are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)