### PR TITLE
Billing: typed-column conditional-DML counters (fixes Spanner reserve/settle deadlock)

### DIFF
--- a/docs/design/billing-typed-counters.md
+++ b/docs/design/billing-typed-counters.md
@@ -1,0 +1,412 @@
+# Billing / Metering / Quota plane — typed-column conditional DML
+
+Status: **design, reviewed** (panel synthesis + 2× codex adversarial review)
+Owner: billing critical path. Changes ship incrementally; each step is
+independently revertible and gated on tests + codex review (+ Joseph's go for
+any cutover that changes live enforcement).
+
+## 1. Problem
+
+Per request the control plane synchronously does:
+
+- **authorize** → reserve estimated credit: read-modify-write the per-workspace
+  `credit:{workspace_id}` row *and* the per-key `api_key:{key_hash}` row;
+- run the LLM call;
+- **settle** → `finalize_gateway_authorization`: RMW the same two rows with the
+  actual cost (plus reservation / generation / auth rows).
+
+Every entity is a JSON blob in one Spanner table `tr_entities(kind,id,body)`.
+The RMW pattern takes a shared read lock on the counter row, then upgrades to an
+exclusive write lock. Two concurrent requests for the same hot workspace/key
+both hold the shared lock and both try to upgrade → **wound-wait deadlock**
+(`Aborted: Deadlock with higher priority transaction`). An 8-attempt retry
+wrapper (`storage_gcp_io.run_in_transaction_with_retry`) absorbs normal
+contention but a sustained hot tenant exhausts it, and the retries add latency
+on the user-blocking authorize path.
+
+## 2. Decision
+
+Adopt the **typed-column atomic conditional-DML** design. Move the four hot
+counters out of the JSON blob into native `INT64` columns on dedicated tables,
+and replace each read-modify-write with a **single conditional DML**:
+
+```sql
+UPDATE tr_credit_balance
+   SET reserved = reserved + @est
+ WHERE workspace_id=@ws AND shard=0
+   AND (total_credits - total_usage - reserved) >= @est
+```
+
+`transaction.execute_update()` returns the exact modified-row count
+(verified on `google-cloud-spanner==3.65.0`): **1 = accepted, 0 = rejected**
+(insufficient) — disambiguated from "no such row / uncapped" by a cheap
+point-read only on the `0` path. The conditional UPDATE takes the row write
+lock **directly**, so the shared-read→exclusive-upgrade cycle that deadlocks
+today *cannot form*. Concurrent reservers serialize in microseconds; the loser
+re-evaluates the predicate against committed state.
+
+### Why this over leases / ledger
+
+Considered: lease/token-bucket quota, async-metering + soft limit, event-sourced
+ledger, sharded counters. The lease/ledger family scales a single key past the
+single-row write ceiling, but pays for it by demoting Spanner from
+system-of-record on the hot path, adding a second authoritative store (Redis) +
+async reconciliation + bounded-overshoot reasoning — buying throughput we do not
+yet have, at the cost of the two higher-ranked priorities (exact correctness,
+simplicity). Typed-column DML fixes the deadlock at the root, keeps **exact,
+strongly-consistent, multi-region** enforcement with **no new datastore**, and
+is the shared foundation those designs need anyway. The door stays open:
+per-whale sharding (built in, dormant) and a change-stream audit ledger are
+additive, non-load-bearing escalations if a tenant ever proves it needs them.
+
+## 3. Data model
+
+Three typed tables. `shard` is in the PK from day one with `DEFAULT(0)` — the
+long tail lives entirely on shard 0 (one row, exact, zero scan), and turning a
+whale into N shards is a *data* change, not a schema migration.
+
+```sql
+CREATE TABLE tr_credit_balance (
+  workspace_id      STRING(64) NOT NULL,
+  shard             INT64 NOT NULL DEFAULT (0),
+  total_credits     INT64 NOT NULL DEFAULT (0),
+  total_usage       INT64 NOT NULL DEFAULT (0),
+  reserved          INT64 NOT NULL DEFAULT (0),
+  source_updated_at TIMESTAMP,   -- the JSON row's updated_at this mirror reflects
+  updated_at        TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (workspace_id, shard);
+
+CREATE TABLE tr_key_limit (
+  key_hash          STRING(64) NOT NULL,
+  shard             INT64 NOT NULL DEFAULT (0),
+  limit_micro       INT64,                 -- NULL = uncapped key
+  usage             INT64 NOT NULL DEFAULT (0),
+  byok_usage        INT64 NOT NULL DEFAULT (0),
+  reserved          INT64 NOT NULL DEFAULT (0),
+  include_byok      BOOL  NOT NULL DEFAULT (true),
+  source_updated_at TIMESTAMP,
+  updated_at        TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (key_hash, shard);
+
+CREATE TABLE tr_reservation (
+  reservation_id        STRING(64) NOT NULL,
+  workspace_id          STRING(64),
+  key_hash              STRING(64),
+  ws_shard              INT64,
+  key_shard             INT64,
+  credit_reserved_micro INT64,   -- EXACT credit hold taken at reserve
+  key_reserved_micro    INT64,   -- EXACT key hold taken at reserve (0 if none)
+  actual_micro          INT64,   -- booked at settle
+  hold_usage_type       STRING(16),  -- usage_type the HOLD was taken under (Credits if any credit candidate)
+  settled_usage_type    STRING(16),  -- usage_type the ACTUAL selected endpoint resolved to, set at settle
+  settled               BOOL NOT NULL DEFAULT (false),
+  idempotency_scope     STRING(256), -- workspace#key#sha256(idem) ; NULL if none
+  idempotency_fingerprint STRING(64),
+  created_at            TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+  expires_at            TIMESTAMP,   -- for the crash reaper
+) PRIMARY KEY (reservation_id);
+
+-- scoped idempotency: NOT a global UNIQUE(idempotency_key)
+CREATE UNIQUE NULL_FILTERED INDEX tr_reservation_by_idemp
+  ON tr_reservation (idempotency_scope);
+CREATE INDEX tr_reservation_by_expiry ON tr_reservation (settled, expires_at);
+```
+
+`tr_entities` stays the home of everything else; Bigtable generation rows are
+unchanged. No Redis on the enforcement path.
+
+## 4. Flows (final enforcement shape — Step 3+)
+
+### Lock order — ONE order everywhere: **key, then credit**
+
+codex finding #2: the panel had authorize=key→credit but settle=credit→key,
+which still deadlocks. Both authorize and settle acquire **key first, then
+credit**.
+
+### authorize — ONE atomic read-write transaction
+
+codex finding #1: today key reserve, credit reserve, and auth-create are three
+separate operations; a crash between them leaks a hold. The typed design does
+the whole authorize decision in one transaction:
+
+1. **Idempotency (scoped):** point-read `tr_reservation_by_idemp` on
+   `idempotency_scope = workspace#key#sha256(idem)`. On hit, verify
+   `idempotency_fingerprint` matches the request; mismatch → reject (body
+   changed under same key); match → replay the existing authorization, **no
+   second debit**. (Preserves the current `(workspace_id, key_hash,
+   hash(idempotency_key))` scope; does **not** use a global unique key, and does
+   not `insert_or_update`-overwrite an existing mapping.)
+   - **Concurrent first calls** (codex#2 #4 / red-team P4): two requests with the
+     same key may both miss the index read before either commits; the
+     `UNIQUE NULL_FILTERED` index makes the second committer's INSERT fail. The
+     conflict surfaces as **`ALREADY_EXISTS` (an IntegrityError), which
+     `run_in_transaction` does NOT retry — it only retries `Aborted`.** So the
+     code must **explicitly catch `ALREADY_EXISTS`** on the reservation INSERT
+     and convert it to the **replay path** (re-read by `idempotency_scope`, now
+     guaranteed to hit the committed winner, run the fingerprint check → return
+     the winner's auth on match, deterministic 4xx on mismatch). It must **never
+     surface a 500**. (The loser's own holds rolled back with its aborted txn, so
+     money-safety already holds; this closes the API contract.)
+   - **Replay is resume / no-execute** (codex#2 #4): a replay returns the same
+     authorization but the gateway must **not re-run the LLM call** — the
+     reservation already holds budget and claim-gated settle charges exactly
+     once, so a second provider call would be uncharged (we eat its cost).
+     `idempotent_replay=True` means "resume the in-flight/finished
+     authorization," not "execute again." (The route already returns
+     `idempotent_replay`; the contract is that the caller resumes, not
+     re-executes.)
+2. **Key cap** (only if the key is capped and the hold applies — see BYOK):
+   `UPDATE tr_key_limit SET reserved = reserved + @est
+      WHERE key_hash=@kh AND shard=@ks AND limit_micro IS NOT NULL
+        AND (limit_micro - usage - IF(include_byok, byok_usage, 0) - reserved) >= @est`.
+   On **row-count 0**, classify with a point-read **inside the same
+   transaction** after the failed DML (codex#2 #3) — do NOT decide from the
+   pre-authorize `ApiKey` read:
+   - typed row **missing** → fail closed (drift/not-yet-backfilled; alarm);
+   - `limit_micro IS NULL` → uncapped → no hold, proceed;
+   - BYOK-excluded (`usage_type==BYOK AND include_byok=false`) → no hold (the
+     statement is skipped up front for this case);
+   - capped & insufficient → 402.
+3. **Credit balance** (CREDITS usage only):
+   `UPDATE tr_credit_balance SET reserved = reserved + @est
+      WHERE workspace_id=@ws AND shard=@ws_shard
+        AND (total_credits - total_usage - reserved) >= @est`.
+   row-count 0 → insufficient credits → 402. (We already grabbed the key hold in
+   the SAME transaction, so a credit reject simply aborts the txn and releases
+   the key hold atomically — no compensation DML needed.)
+4. Insert `tr_reservation` recording **the exact holds taken** (`credit_reserved_micro`,
+   `key_reserved_micro`), the resolved `usage_type`, shards, `expires_at`, and
+   the idempotency scope/fingerprint; insert the `gateway_authorization`.
+5. Commit. Run the LLM call.
+
+All five steps commit in one `run_in_transaction` callback → atomic across both
+counters; the ABORTED-retry wrapper still wraps it for the (now rare) genuine
+contention.
+
+### settle / refund — claim-gated, exact release
+
+codex findings #4 & #5:
+
+1. **Claim:** `UPDATE tr_reservation SET settled=true, actual_micro=@actual,
+      settled_usage_type=@settled_ut
+      WHERE reservation_id=@rid AND settled=false`. row-count **1 = this caller
+   won**, **0 = already settled (replay) → return without touching counters.**
+   First-writer-wins, preserved from today's `reservation.settled` /
+   `authorization.settled` contract.
+2. Winner releases **the exact recorded holds** (never `GREATEST(0, reserved -
+   est)`, which masks double-release/drift):
+   - key: `UPDATE tr_key_limit SET reserved = reserved - @key_reserved_micro
+       [, usage += @actual | byok_usage += @actual]  WHERE key_hash=@kh AND shard=@ks`
+   - credit: `UPDATE tr_credit_balance SET reserved = reserved - @credit_reserved_micro
+       [, total_usage += @actual]  WHERE workspace_id=@ws AND shard=@ws_shard`
+   Release the hold using the recorded **`hold_usage_type`** (so the exact
+   key/credit holds taken at reserve are released even if the selected endpoint
+   differs); book the **actual** to the column chosen by **`settled_usage_type`**
+   (codex#2 #2: a request may take a CREDITS hold — because a credit candidate
+   existed — yet actually run a BYOK endpoint; the hold must be released as
+   CREDITS while the actual is bucketed as BYOK `byok_usage`, and credit
+   `total_usage` is incremented only when `settled_usage_type == CREDITS`).
+   key first, then credit; usage increment only on `success`.
+   **Assert each release UPDATE returns row-count == 1** (red-team polish): a
+   0-row release (e.g. the recorded shard no longer exists after a future Step-4
+   rebalance, or a missing counter row) must **not** silently commit
+   `settled=true` while booking nothing — that strands the hold *and* loses the
+   charge. On a 0-row release, abort the settle txn (so the claim rolls back and
+   the reaper/outbox re-drives it) and alarm. At N=1 (shard 0 always exists) this
+   never fires, but landing the assertion now hardens the reaper and the Step-4
+   sharding cutover.
+3. refund = same claim, then release holds with **no** usage increment.
+
+### Overdraft semantics (codex finding #6) — explicit decision
+
+Conditional reserve guarantees accepted *estimates* never exceed available. It
+does **not** prevent the final balance going slightly negative when the
+**actual** cost of a request exceeds its estimate (streaming output longer than
+predicted). We **preserve today's behavior**: settle books `actual` via
+`total_usage += actual` and **permits bounded overdraft** of at most one
+in-flight request's (actual − estimate) per concurrent request. For prepaid
+credit this is a tiny, bounded, self-liquidating loss — acceptable, and what the
+system already does. (Alternative — reserve a true upper bound from
+`max_output_tokens` — over-reserves and rejects more; not adopted. Revisit only
+if overdraft is observed to matter.)
+
+The same bounded-overdraft acceptance covers **cache tokens** (codex#2 #5):
+authorize estimates only normal input/output cost, but settle may add
+provider-specific cache read/write charges (`gateway.py` settle pricing) that the
+estimate did not predict. We explicitly **accept and bound** cache-token
+overdraft on the same terms as output overdraft, rather than adding cache-token
+estimate fields. (If cache charges ever dominate, add an estimate term then.)
+
+### BYOK (codex finding #7)
+
+The key hold is **skipped** when `usage_type == BYOK AND include_byok=false`
+(no `tr_key_limit` reserve statement issued). At settle, actual BYOK usage is
+still recorded to `byok_usage` (it counts toward the cap for keys with
+`include_byok=true`). The SQL therefore needs a **usage-type predicate at
+reserve** (skip the statement), and **usage-column selection by usage_type at
+settle** (`byok_usage` vs `usage`), not merely `IF(include_byok, byok_usage,0)`
+inside the available expression.
+
+## 5. Spanner mechanics (verified on 3.65.0)
+
+- `transaction.execute_update(dml, params, param_types)` returns the exact
+  affected row count — the accept/reject signal. Use **standard DML**, not
+  partitioned DML, on the hot authorize path.
+- Multiple DML statements in one `run_in_transaction` callback are fine; the
+  client retries `ABORTED` by re-invoking the callback (our wrapper adds more
+  attempts of that same safe re-run).
+- **Do not mix DML and mutations in the same transaction.** Spanner executes DML
+  before buffered mutations, and mutations are invisible to later SQL/DML in the
+  same txn (Google DML best-practices). The authorize/settle transactions
+  therefore do **all** writes as DML (`INSERT`/`UPDATE` via `execute_update`),
+  not `transaction.insert_or_update`. (Non-counter JSON writers elsewhere keep
+  their mutation path.)
+- Do not set `last_statement=True` unless it is genuinely the last statement and
+  there are no mutations.
+- **`PENDING_COMMIT_TIMESTAMP()` poisons the WHOLE table + its indexes**, not
+  just the column (red-team P3): after a statement writes PCT to a table, *any*
+  later SQL in the same transaction that touches that table (SELECT/INSERT/
+  UPDATE/DELETE) fails the transaction. So the PCT-writing statement must be the
+  **last touch of that table** in the txn. Since each authorize/settle txn
+  already touches each counter table exactly once, this is a guardrail: add a
+  review/CI invariant "no two same-table SQL statements in one txn when the first
+  wrote PCT." (Alternatively skip PCT on the hot counter `updated_at` and set it
+  from a read-free expression, keeping the single-touch rule simplest.)
+
+## 6. Migration — incremental, each step revertible
+
+**Step 0 — skipped.** The retry wrapper holds; "conditional JSON DML" isn't real
+on a STRING body; async settle without a durable outbox/reaper risks lost
+charges. Go straight to schema → exact dual-write → backfill → typed
+enforcement.
+
+**Step 1 — typed tables + EXACT-MIRROR dual-write.** `update_ddl` the three
+tables. Every JSON writer of these counters (key create/update, credit grants,
+reserve, settle, refund, finalize) additionally writes the typed rows. The JSON
+path stays **authoritative**. Critical correction (codex): the shadow writes
+mirror the **exact post-transaction counter values + `source_updated_at`** — they
+do **not** run conditional accept/reject predicates (a shadow predicate would
+manufacture drift by design). Emit a divergence metric (typed value vs JSON
+value per write). Zero behavior change.
+
+**Step 2 — backfill + reconcile to zero drift.** One-shot, **idempotent**,
+guarded by source `updated_at` (never overwrite a newer dual-write). Hold until
+drift is zero. Critical (red-team P2): the per-write divergence metric is
+**structurally blind to a torn dual-write** — if the JSON leg commits but the
+typed-mirror write aborts/OOMs, no sample is emitted, so "flat at zero" can pass
+over real drift that then enforces real money at the flip. So add an
+**independent periodic full-row comparator** (scan typed vs JSON with
+`updated_at`-staleness tolerance), and **re-scan each cohort at flip time**
+(not just the one-shot backfill); gate the Step-3 flip for a cohort on *that
+comparator* reading zero, not on the per-write metric alone.
+
+**Step 3 — flip enforcement to conditional DML (the deadlock fix). Includes
+typed reservations + scoped idempotency index + reaper** (codex#2 #1: these
+cannot lag behind the live cutover, or crash-after-authorize holds strand with
+nothing to reclaim them). The cutover ships together:
+- the one-shot atomic `gateway_authorize` and claim-gated `finalize` transactions
+  (conditional-UPDATE row-count = authoritative accept/reject);
+- `tr_reservation` + the scoped `tr_reservation_by_idemp` unique index (collapses
+  the three JSON idempotency entities into one indexed point-read);
+- the Cloud Scheduler **reaper** over `tr_reservation_by_expiry`, racing late
+  settles safely via the `settled` claim (one wins, the other no-ops), claim +
+  release in **one transaction**.
+  **`expires_at` is an execution deadline = max stream duration + settle-retry
+  window + margin** — it MUST be beyond the longest legitimate run, or the reaper
+  could win the `settled=false` claim and leave a successful LLM call uncharged
+  (codex#2 #1 / red-team P1).
+  The reaper must distinguish **crashed-before-completion** (no provider cost →
+  release the hold, book nothing — correct) from **completed-but-settle-lost**
+  (a real provider call whose settle never landed → must book actual, not free).
+  To make the latter recoverable, settle actuals are written to a **durable
+  outbox** when the gateway receives the response, so a lost settle is re-driven
+  from the outbox rather than silently reaped to zero. (This is the one piece
+  that must exist before the reaper can safely release holds.)
+
+Cutover flips **reserve and settle together, per cohort** (typed-reserve +
+JSON-settle leaks holds; JSON-reserve + typed-settle invents refunds). An
+in-flight request that reserved under JSON must settle under JSON — gate on the
+reservation's own origin (a flag/marker on the reservation), not the cohort's
+current state, so a request straddling the flip settles where it reserved. Keep a
+lazy exact JSON mirror for ≥1 release so rollback is a flag flip, not a repair.
+Ramp by workspace cohort; credit first, then key cap. The ABORTED-retry should
+now essentially never fire.
+
+**Step 4 — per-whale shard fan-out (DEFERRED, metrics-driven).** Only when a
+specific key/workspace demonstrates the single-row ceiling. Reserve targets
+`hash(request_id) % N`; settle hits the recorded shard; available *display* is a
+lock-free `SUM` over shards; on a per-shard `0`-row deny, do an exact
+sum-on-deny read before rejecting. A single-writer-per-tenant,
+conservation-invariant rebalancer (`SUM(slices) == total_credits`, moved in one
+txn) ships **observe-only** first; enable apply only with the invariant auditor
+green. Everyone else stays N=1/exact.
+
+**Step 5 — (optional) change streams for audit + soft display cache.** Spanner
+change streams on the counter tables give a native ordered audit ledger; an
+optional Redis cache may serve available-balance *display* reads (never the
+gate).
+
+Rollback at any step = flip the enforcement source back to the dual-written JSON
+path.
+
+## 7. Single-row write ceiling — measure, don't assume
+
+Typed DML removes the *deadlock*, not physics: one row tops out at
+~hundreds–low-thousands of conditional-UPDATE commits/sec (single-writer-per-
+commit + cross-region Paxos). One request ≈ two writes to the key row and (for
+credit routes) two to the credit row (reserve + settle/refund). **Before/after
+Step 3, measure hot `(workspace_id, shard=0)` and `(key_hash, shard=0)` commit
+QPS + the abort-rate metric.** If the production hot key is already several
+hundred req/s, build Step 5 sooner; if the incident is abort storms at lower QPS,
+Step 3 alone fixes it. The shard flag is pre-wired so a whale can be sharded
+*before* it saturates.
+
+## 8. Test plan (must pass before each cutover)
+
+Concurrency + correctness (extend `tests/test_storage_gcp_concurrency.py`,
+`test_credit_ledger_idempotency*.py`, `test_billing.py`,
+`test_storage_gcp_features.py`):
+
+- N concurrent reserves on one workspace: exactly `floor(available/est)` accept,
+  rest 402; `reserved` never exceeds available; **no deadlock / no ABORTED
+  surfaced**.
+- Concurrent same-idempotency-key authorize → one reservation, one debit.
+- Idempotency-key body mismatch → rejected.
+- settle/refund race (half each) → first-writer-wins, charged exactly once,
+  ledger never negative beyond bounded overdraft, never double-applied.
+- BYOK with `include_byok=false` → no key hold at reserve, `byok_usage` recorded
+  at settle; with `include_byok=true` → counts toward cap.
+- Key limit removed/changed between reserve and settle → releases the **exact**
+  recorded hold (no leak, no phantom refund).
+- actual > estimate → bounded overdraft booked, accounted once.
+- Step 1/2: per-write divergence metric == 0 AND the independent full-row
+  comparator == 0 across a replay of recorded traffic; a deliberately torn
+  dual-write (typed leg skipped) is caught by the comparator, not the per-write
+  metric.
+- Concurrent same-key first calls: the index loser hits `ALREADY_EXISTS` and is
+  converted to a successful replay (never a 500); fingerprint mismatch → 4xx.
+- N concurrent same-key+same-workspace reserves on the uncapped 0-row path raise
+  **no ABORTED** (the disambiguation read must not introduce a lock-upgrade).
+
+InMemory store mirrors the same contracts so the suite runs without Spanner.
+
+## 9. Review log
+
+- **Design panel** (5 architects + synthesis): chose typed-column conditional DML
+  over lease/ledger/sharded/async for a high-scale router at current scale.
+- **codex review #1** (REVISE): 7 money-safety findings (atomic authorize;
+  single key→credit lock order; scoped idempotency+fingerprint; claim-gated
+  settle; exact recorded-hold release; explicit overdraft decision; BYOK
+  predicate) + Spanner mechanics (execute_update row-count; no DML/mutation
+  mixing; exact-mirror dual-write not shadow-conditional). All folded in.
+- **codex review #2** (REVISE): 5 specs — merge reaper/idempotency into the Step-3
+  gate + define `expires_at`; split hold-usage-type vs settled-usage-type;
+  stricter 0-row key classification; replay = resume/no-execute + concurrent
+  unique-conflict→replay; cache-token overdraft. All folded in.
+- **Money-safety red team** (7 attackers + synthesis): **no blockers** — Step 1
+  ready now; double-charge and deadlock-reintroduction are FALSE alarms (claim +
+  releases in one atomic txn = exactly-once; key→credit order holds). Pre-cutover
+  fixes P1 (reaper books actual + durable outbox), P2 (independent comparator +
+  flip-time rescan), P3 (PCT poisons whole table), P4 (`ALREADY_EXISTS` not
+  retried → catch→replay), plus row-count==1 on releases. All folded in.
+```

--- a/docs/design/billing-typed-counters.md
+++ b/docs/design/billing-typed-counters.md
@@ -72,7 +72,8 @@ CREATE TABLE tr_credit_balance (
   total_credits     INT64 NOT NULL DEFAULT (0),
   total_usage       INT64 NOT NULL DEFAULT (0),
   reserved          INT64 NOT NULL DEFAULT (0),
-  source_updated_at TIMESTAMP,   -- the JSON row's updated_at this mirror reflects
+  -- both timestamps take the COMMIT_TIMESTAMP sentinel, so both need the option
+  source_updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
   updated_at        TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY (workspace_id, shard);
 
@@ -84,7 +85,7 @@ CREATE TABLE tr_key_limit (
   byok_usage        INT64 NOT NULL DEFAULT (0),
   reserved          INT64 NOT NULL DEFAULT (0),
   include_byok      BOOL  NOT NULL DEFAULT (true),
-  source_updated_at TIMESTAMP,
+  source_updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
   updated_at        TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY (key_hash, shard);
 

--- a/scripts/cleanup_smoke_signups.py
+++ b/scripts/cleanup_smoke_signups.py
@@ -124,8 +124,12 @@ def main() -> int:
             from google.cloud.spanner_v1 import KeySet
             for ak_id in _ak_ids:
                 transaction.delete("tr_entities", KeySet(keys=[("api_key", ak_id)]))
+                # Keep the typed counter mirror in sync (Step 1 migration): a
+                # leftover tr_key_limit row would be exact-mirror drift.
+                transaction.delete("tr_key_limit", KeySet(keys=[(ak_id, 0)]))
             for wsid in _ws_ids:
                 transaction.delete("tr_entities", KeySet(keys=[("credit", wsid)]))
+                transaction.delete("tr_credit_balance", KeySet(keys=[(wsid, 0)]))
                 transaction.delete("tr_entities", KeySet(keys=[("workspace", wsid)]))
             for m_id in _member_ids:
                 transaction.delete("tr_entities", KeySet(keys=[("member", m_id)]))

--- a/scripts/deploy/backfill_typed_counters.py
+++ b/scripts/deploy/backfill_typed_counters.py
@@ -1,0 +1,60 @@
+"""Step 2 CLI: backfill the typed counter mirror and report drift.
+
+See docs/design/billing-typed-counters.md.
+
+  # report drift only (read-only); exit 1 if any drift
+  python scripts/deploy/backfill_typed_counters.py --compare
+
+  # backfill missing/stale typed rows, then report
+  python scripts/deploy/backfill_typed_counters.py --backfill
+
+Run --backfill until --compare is CLEAN; the Step 3 enforcement flip is gated on
+a clean comparator. Requires the typed tables to exist
+(scripts/deploy/migrate_typed_counters.sh) and is safe to re-run (idempotent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_gcp_counter_reconcile import backfill, compare
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backfill", action="store_true", help="write missing/stale typed rows")
+    parser.add_argument("--dry-run", action="store_true", help="with --backfill, count only")
+    parser.add_argument("--compare", action="store_true", help="report drift (default)")
+    args = parser.parse_args()
+
+    store = create_store(Settings())
+
+    if args.backfill:
+        counts = backfill(store, dry_run=args.dry_run)
+        verb = "would mirror" if args.dry_run else "mirrored"
+        print(f"backfill: {verb} credit={counts['credit']} api_key={counts['api_key']}")
+
+    # Always finish with a comparator reading unless a pure dry-run backfill.
+    if not (args.backfill and args.dry_run):
+        report = compare(store)
+        print(report.summary())
+        for entity_id, drift in report.samples.items():
+            print(f"  DRIFT {entity_id}: {drift}")
+        if not report.clean:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy/backfill_typed_counters.py
+++ b/scripts/deploy/backfill_typed_counters.py
@@ -43,17 +43,17 @@ def main() -> int:
     if args.backfill:
         counts = backfill(store, dry_run=args.dry_run)
         verb = "would mirror" if args.dry_run else "mirrored"
-        print(f"backfill: {verb} credit={counts['credit']} api_key={counts['api_key']}")
+        # NOTE: this counts every JSON row that would be (re)mirrored, not only
+        # missing/stale ones — it is NOT a drift signal. The comparator below is.
+        print(f"backfill: {verb} credit={counts['credit']} api_key={counts['api_key']} rows")
 
-    # Always finish with a comparator reading unless a pure dry-run backfill.
-    if not (args.backfill and args.dry_run):
-        report = compare(store)
-        print(report.summary())
-        for entity_id, drift in report.samples.items():
-            print(f"  DRIFT {entity_id}: {drift}")
-        if not report.clean:
-            return 1
-    return 0
+    # ALWAYS finish with the comparator — including after --dry-run — so the exit
+    # code can never be mistaken for a clean-gate signal (codex Step-2 #4).
+    report = compare(store)
+    print(report.summary())
+    for entity_id, drift in report.samples.items():
+        print(f"  DRIFT {entity_id}: {drift}")
+    return 0 if report.clean else 1
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -45,6 +45,25 @@ apply_ddl() {
     --instance="$INSTANCE" "${PROJECT_ARG[@]}" --ddl="$1"
 }
 
+# Idempotent guard: ensure a timestamp column carries allow_commit_timestamp=true.
+# Needed because the mirror writes the COMMIT_TIMESTAMP sentinel into
+# source_updated_at; without the option the first mirrored write fails the txn.
+# Covers tables created by an earlier version of this script without the option.
+ensure_commit_ts_col() {
+  local table="$1" col="$2" n
+  n=$(gcloud spanner databases execute-sql "$DATABASE" \
+        --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+        --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMN_OPTIONS
+               WHERE table_name='${table}' AND column_name='${col}'
+                 AND option_name='allow_commit_timestamp' AND option_value='TRUE'" \
+        --format='value(rows[0])' 2>/dev/null || echo 0)
+  if [ "${n:-0}" = "0" ]; then
+    apply_ddl "ALTER TABLE ${table} ALTER COLUMN ${col} TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
+  else
+    log "${table}.${col} already has allow_commit_timestamp, skip"
+  fi
+}
+
 # shard is in the PK from day one (DEFAULT 0): the long tail lives on shard 0;
 # sharding a whale later is a data change, not a schema migration.
 if table_exists tr_credit_balance; then log "tr_credit_balance exists, skip"; else
@@ -54,7 +73,7 @@ if table_exists tr_credit_balance; then log "tr_credit_balance exists, skip"; el
     total_credits INT64 NOT NULL DEFAULT (0),
     total_usage INT64 NOT NULL DEFAULT (0),
     reserved INT64 NOT NULL DEFAULT (0),
-    source_updated_at TIMESTAMP,
+    source_updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
     updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
   ) PRIMARY KEY (workspace_id, shard)"
 fi
@@ -68,10 +87,15 @@ if table_exists tr_key_limit; then log "tr_key_limit exists, skip"; else
     byok_usage INT64 NOT NULL DEFAULT (0),
     reserved INT64 NOT NULL DEFAULT (0),
     include_byok BOOL NOT NULL DEFAULT (true),
-    source_updated_at TIMESTAMP,
+    source_updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
     updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
   ) PRIMARY KEY (key_hash, shard)"
 fi
+
+# Backfill the commit-timestamp option on source_updated_at for tables that may
+# predate the option being added to the CREATE statements above.
+ensure_commit_ts_col tr_credit_balance source_updated_at
+ensure_commit_ts_col tr_key_limit source_updated_at
 
 # tr_reservation + its indexes are used at the Step 3 enforcement flip; created
 # now so the schema is in place ahead of cutover.

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Apply the typed-counter DDL (Step 1 of the billing typed-column migration).
+# See docs/design/billing-typed-counters.md.
+#
+# Idempotent: checks INFORMATION_SCHEMA and only creates objects that are
+# missing, so it is safe to re-run and safe on both fresh and existing
+# databases. Apply this BEFORE deploying the mirror code with
+# TR_TYPED_COUNTER_MIRROR=1 — the dual-write writes to these tables.
+#
+# Usage:
+#   SPANNER_INSTANCE_ID=... SPANNER_DATABASE_ID=... [GCP_PROJECT_ID=...] \
+#     scripts/deploy/migrate_typed_counters.sh
+set -euo pipefail
+
+INSTANCE="${SPANNER_INSTANCE_ID:?set SPANNER_INSTANCE_ID}"
+DATABASE="${SPANNER_DATABASE_ID:?set SPANNER_DATABASE_ID}"
+PROJECT_ARG=()
+[ -n "${GCP_PROJECT_ID:-}" ] && PROJECT_ARG=(--project "${GCP_PROJECT_ID}")
+
+log() { printf '%s %s\n' "[migrate_typed_counters]" "$*"; }
+
+table_exists() {
+  local name="$1"
+  local n
+  n=$(gcloud spanner databases execute-sql "$DATABASE" \
+        --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+        --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='${name}'" \
+        --format='value(rows[0])' 2>/dev/null || echo 0)
+  [ "${n:-0}" != "0" ]
+}
+
+index_exists() {
+  local name="$1"
+  local n
+  n=$(gcloud spanner databases execute-sql "$DATABASE" \
+        --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+        --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE index_name='${name}'" \
+        --format='value(rows[0])' 2>/dev/null || echo 0)
+  [ "${n:-0}" != "0" ]
+}
+
+apply_ddl() {
+  log "applying: $1"
+  gcloud spanner databases ddl update "$DATABASE" \
+    --instance="$INSTANCE" "${PROJECT_ARG[@]}" --ddl="$1"
+}
+
+# shard is in the PK from day one (DEFAULT 0): the long tail lives on shard 0;
+# sharding a whale later is a data change, not a schema migration.
+if table_exists tr_credit_balance; then log "tr_credit_balance exists, skip"; else
+  apply_ddl "CREATE TABLE tr_credit_balance (
+    workspace_id STRING(64) NOT NULL,
+    shard INT64 NOT NULL DEFAULT (0),
+    total_credits INT64 NOT NULL DEFAULT (0),
+    total_usage INT64 NOT NULL DEFAULT (0),
+    reserved INT64 NOT NULL DEFAULT (0),
+    source_updated_at TIMESTAMP,
+    updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+  ) PRIMARY KEY (workspace_id, shard)"
+fi
+
+if table_exists tr_key_limit; then log "tr_key_limit exists, skip"; else
+  apply_ddl "CREATE TABLE tr_key_limit (
+    key_hash STRING(64) NOT NULL,
+    shard INT64 NOT NULL DEFAULT (0),
+    limit_micro INT64,
+    usage INT64 NOT NULL DEFAULT (0),
+    byok_usage INT64 NOT NULL DEFAULT (0),
+    reserved INT64 NOT NULL DEFAULT (0),
+    include_byok BOOL NOT NULL DEFAULT (true),
+    source_updated_at TIMESTAMP,
+    updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+  ) PRIMARY KEY (key_hash, shard)"
+fi
+
+# tr_reservation + its indexes are used at the Step 3 enforcement flip; created
+# now so the schema is in place ahead of cutover.
+if table_exists tr_reservation; then log "tr_reservation exists, skip"; else
+  apply_ddl "CREATE TABLE tr_reservation (
+    reservation_id STRING(64) NOT NULL,
+    workspace_id STRING(64),
+    key_hash STRING(64),
+    ws_shard INT64,
+    key_shard INT64,
+    credit_reserved_micro INT64,
+    key_reserved_micro INT64,
+    actual_micro INT64,
+    hold_usage_type STRING(16),
+    settled_usage_type STRING(16),
+    settled BOOL NOT NULL DEFAULT (false),
+    idempotency_scope STRING(256),
+    idempotency_fingerprint STRING(64),
+    created_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+    expires_at TIMESTAMP,
+  ) PRIMARY KEY (reservation_id)"
+fi
+
+if index_exists tr_reservation_by_idemp; then log "tr_reservation_by_idemp exists, skip"; else
+  apply_ddl "CREATE UNIQUE NULL_FILTERED INDEX tr_reservation_by_idemp
+    ON tr_reservation (idempotency_scope)"
+fi
+
+if index_exists tr_reservation_by_expiry; then log "tr_reservation_by_expiry exists, skip"; else
+  apply_ddl "CREATE INDEX tr_reservation_by_expiry ON tr_reservation (settled, expires_at)"
+fi
+
+log "done"

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -58,7 +58,7 @@ ensure_commit_ts_col() {
                  AND option_name='allow_commit_timestamp' AND option_value='TRUE'" \
         --format='value(rows[0])' 2>/dev/null || echo 0)
   if [ "${n:-0}" = "0" ]; then
-    apply_ddl "ALTER TABLE ${table} ALTER COLUMN ${col} TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
+    apply_ddl "ALTER TABLE ${table} ALTER COLUMN ${col} SET OPTIONS (allow_commit_timestamp=true)"
   else
     log "${table}.${col} already has allow_commit_timestamp, skip"
   fi

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -47,6 +47,7 @@ from trusted_router.storage_gcp_codec import (
 from trusted_router.storage_gcp_codec import (
     normalize_email as _normalize_email,
 )
+from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
 from trusted_router.storage_gcp_generations import SpannerGenerations
@@ -1241,9 +1242,15 @@ class SpannerBigtableStore:
                 self.entity_table,
                 self._spanner.KeySet(keys=[(kind, entity_id) for entity_id in entity_ids]),
             )
+            # Step 1: mirror credit/api_key deletes onto the typed table so a
+            # deleted row never leaves a stale typed mirror (drift).
+            if getattr(self, "_counter_mirror_enabled", False):
+                mirror_counter_delete(batch, kind, entity_ids, self._spanner)
 
     def _delete_entities_tx(self, transaction: Any, kind: str, entity_ids: list[str]) -> None:
         transaction.delete(
             self.entity_table,
             self._spanner.KeySet(keys=[(kind, entity_id) for entity_id in entity_ids]),
         )
+        if getattr(self, "_counter_mirror_enabled", False):
+            mirror_counter_delete(transaction, kind, entity_ids, self._spanner)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -47,6 +47,7 @@ from trusted_router.storage_gcp_codec import (
 from trusted_router.storage_gcp_codec import (
     normalize_email as _normalize_email,
 )
+from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
 from trusted_router.storage_gcp_generations import SpannerGenerations
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
@@ -181,6 +182,14 @@ class SpannerBigtableStore:
         # Composed feature stores. Each owns its own logic and is importable
         # on its own — keeps the core SpannerBigtableStore body focused on
         # identity + credit ledger. Mirrors the InMemoryStore pattern.
+
+        # Step 1 of the typed-counter migration: when enabled, every credit /
+        # api_key write also mirrors exact values onto the typed tables in the
+        # same transaction (see storage_gcp_counters + docs). Default OFF so the
+        # code is safe to deploy BEFORE the DDL is applied; flip
+        # TR_TYPED_COUNTER_MIRROR=1 only once tr_credit_balance / tr_key_limit
+        # exist, or the mirror writes would fail the billing transactions.
+        self._counter_mirror_enabled = os.environ.get("TR_TYPED_COUNTER_MIRROR", "") == "1"
         io = SpannerIO(
             database=self._database,
             write_entity_batch=self._write_entity_batch,
@@ -1211,6 +1220,10 @@ class SpannerBigtableStore:
             columns=("kind", "id", "body", "updated_at"),
             values=[(kind, entity_id, _json_body(value), self._spanner.COMMIT_TIMESTAMP)],
         )
+        # Step 1: mirror hot counters (credit / api_key) onto typed tables in the
+        # SAME batch so they commit atomically with the authoritative JSON row.
+        if getattr(self, "_counter_mirror_enabled", False):
+            mirror_counter_write(batch, kind, entity_id, value, self._spanner.COMMIT_TIMESTAMP)
 
     def _write_entity_tx(self, transaction: Any, kind: str, entity_id: str, value: Any) -> None:
         transaction.insert_or_update(
@@ -1218,6 +1231,9 @@ class SpannerBigtableStore:
             columns=("kind", "id", "body", "updated_at"),
             values=[(kind, entity_id, _json_body(value), self._spanner.COMMIT_TIMESTAMP)],
         )
+        # Step 1: mirror hot counters in the SAME transaction (atomic, no tear).
+        if getattr(self, "_counter_mirror_enabled", False):
+            mirror_counter_write(transaction, kind, entity_id, value, self._spanner.COMMIT_TIMESTAMP)
 
     def _delete_entities(self, kind: str, entity_ids: list[str]) -> None:
         with self._database.batch() as batch:

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -1,0 +1,136 @@
+"""Step 2 of the billing typed-column migration: backfill + drift comparator.
+
+See docs/design/billing-typed-counters.md.
+
+- ``compare`` is the INDEPENDENT full-row comparator (red-team P2): it scans both
+  the authoritative JSON rows and the typed mirror and reports any row whose
+  counters diverge (or whose typed mirror is missing). The per-write mirror is
+  atomic so it cannot tear, but this comparator is the defense-in-depth that the
+  Step 3 enforcement flip is gated on — flip only when it reports zero drift.
+
+- ``backfill`` writes the typed mirror for pre-flag JSON rows (rows that existed
+  before TR_TYPED_COUNTER_MIRROR was turned on). Each row is mirrored inside a
+  transaction that re-reads the authoritative JSON row, so it writes a
+  json-consistent typed row atomically and cannot clobber a concurrent
+  dual-write with a stale read. Idempotent and re-runnable to convergence.
+
+Both operate on a live SpannerBigtableStore (``store``), using its existing JSON
+scan plus a direct typed-table scan.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.storage_gcp_counters import (
+    credit_drift,
+    key_drift,
+    mirror_write,
+)
+
+_CREDIT_TYPED_SCAN = (
+    "SELECT workspace_id, total_credits, total_usage, reserved FROM tr_credit_balance"
+)
+_KEY_TYPED_SCAN = (
+    "SELECT key_hash, limit_micro, usage, byok_usage, reserved, include_byok "
+    "FROM tr_key_limit"
+)
+
+
+@dataclass
+class DriftReport:
+    credit_rows: int = 0
+    key_rows: int = 0
+    credit_drift: int = 0
+    key_drift: int = 0
+    # up to a few examples for triage: {id: {col: (json, typed)}}
+    samples: dict[str, dict] = field(default_factory=dict)
+
+    @property
+    def clean(self) -> bool:
+        return self.credit_drift == 0 and self.key_drift == 0
+
+    def summary(self) -> str:
+        return (
+            f"credit: {self.credit_drift}/{self.credit_rows} drift | "
+            f"key: {self.key_drift}/{self.key_rows} drift | "
+            f"{'CLEAN' if self.clean else 'DRIFT'}"
+        )
+
+
+def _scan_typed(store: Any, sql: str, key_col: str, value_cols: list[str]) -> dict[str, dict]:
+    with store._database.snapshot() as snapshot:
+        rows = list(snapshot.execute_sql(sql))
+    out: dict[str, dict] = {}
+    for row in rows:
+        record = dict(zip([key_col, *value_cols], row, strict=True))
+        out[record[key_col]] = record
+    return out
+
+
+def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
+    """Scan JSON vs typed and report per-row counter drift. Read-only."""
+    report = DriftReport()
+
+    json_credit = {b["workspace_id"]: b for b in store._list_entities("credit", cls=dict)}
+    typed_credit = _scan_typed(
+        store, _CREDIT_TYPED_SCAN, "workspace_id",
+        ["total_credits", "total_usage", "reserved"],
+    )
+    report.credit_rows = len(json_credit)
+    for ws_id, body in json_credit.items():
+        drift = credit_drift(body, typed_credit.get(ws_id))
+        if drift:
+            report.credit_drift += 1
+            if len(report.samples) < max_samples:
+                report.samples[f"credit:{ws_id}"] = drift
+
+    json_key = {b["hash"]: b for b in store._list_entities("api_key", cls=dict)}
+    typed_key = _scan_typed(
+        store, _KEY_TYPED_SCAN, "key_hash",
+        ["limit_micro", "usage", "byok_usage", "reserved", "include_byok"],
+    )
+    report.key_rows = len(json_key)
+    for key_hash, body in json_key.items():
+        drift = key_drift(body, typed_key.get(key_hash))
+        if drift:
+            report.key_drift += 1
+            if len(report.samples) < max_samples:
+                report.samples[f"api_key:{key_hash}"] = drift
+
+    return report
+
+
+def backfill(store: Any, *, dry_run: bool = False) -> dict[str, int]:
+    """Mirror the typed row for every JSON credit/api_key row. Idempotent.
+
+    Each row is re-read and mirrored inside one transaction so it commits a
+    json-consistent typed row atomically (no stale-read clobber). Safe to run
+    repeatedly; run until ``compare`` is clean.
+    """
+    counts = {"credit": 0, "api_key": 0}
+    spanner_module = store._spanner
+
+    plan: list[tuple[str, str]] = []
+    plan += [("credit", b["workspace_id"]) for b in store._list_entities("credit", cls=dict)]
+    plan += [("api_key", b["hash"]) for b in store._list_entities("api_key", cls=dict)]
+
+    for kind, entity_id in plan:
+        if dry_run:
+            counts[kind] += 1
+            continue
+
+        def _txn(transaction: Any, _kind: str = kind, _id: str = entity_id) -> bool:
+            body = store._read_entity_tx(transaction, _kind, _id, dict)
+            if body is None:
+                return False
+            mirror_write(
+                transaction, _kind, _id, body, spanner_module.COMMIT_TIMESTAMP
+            )
+            return True
+
+        if store._run_in_transaction(_txn):
+            counts[kind] += 1
+
+    return counts

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -20,6 +20,7 @@ scan plus a direct typed-table scan.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -44,60 +45,90 @@ class DriftReport:
     key_rows: int = 0
     credit_drift: int = 0
     key_drift: int = 0
+    credit_orphans: int = 0  # typed rows with no JSON authority
+    key_orphans: int = 0
     # up to a few examples for triage: {id: {col: (json, typed)}}
     samples: dict[str, dict] = field(default_factory=dict)
 
     @property
     def clean(self) -> bool:
-        return self.credit_drift == 0 and self.key_drift == 0
+        return (
+            self.credit_drift == 0
+            and self.key_drift == 0
+            and self.credit_orphans == 0
+            and self.key_orphans == 0
+        )
 
     def summary(self) -> str:
         return (
-            f"credit: {self.credit_drift}/{self.credit_rows} drift | "
-            f"key: {self.key_drift}/{self.key_rows} drift | "
+            f"credit: {self.credit_drift}/{self.credit_rows} drift, "
+            f"{self.credit_orphans} orphan | "
+            f"key: {self.key_drift}/{self.key_rows} drift, {self.key_orphans} orphan | "
             f"{'CLEAN' if self.clean else 'DRIFT'}"
         )
 
 
-def _scan_typed(store: Any, sql: str, key_col: str, value_cols: list[str]) -> dict[str, dict]:
-    with store._database.snapshot() as snapshot:
-        rows = list(snapshot.execute_sql(sql))
+def _scan_json(snapshot: Any, kind: str, id_field: str, pt: Any) -> dict[str, dict]:
     out: dict[str, dict] = {}
-    for row in rows:
-        record = dict(zip([key_col, *value_cols], row, strict=True))
-        out[record[key_col]] = record
+    for row in snapshot.execute_sql(
+        "SELECT body FROM tr_entities WHERE kind=@kind",
+        params={"kind": kind},
+        param_types={"kind": pt.STRING},
+    ):
+        body = json.loads(row[0])
+        out[body[id_field]] = body
     return out
 
 
 def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
-    """Scan JSON vs typed and report per-row counter drift. Read-only."""
-    report = DriftReport()
+    """Scan JSON vs typed in ONE consistent snapshot and report drift + orphans.
 
-    json_credit = {b["workspace_id"]: b for b in store._list_entities("credit", cls=dict)}
-    typed_credit = _scan_typed(
-        store, _CREDIT_TYPED_SCAN, "workspace_id",
-        ["total_credits", "total_usage", "reserved"],
-    )
+    Read-only. A single multi-use snapshot reads JSON and typed at the same
+    timestamp, so a live dual-write in flight cannot produce a transient false
+    positive (codex Step-2 #3). Reports value drift, missing mirrors, AND orphan
+    typed rows that have no JSON authority (codex Step-2 #1).
+    """
+    report = DriftReport()
+    pt = store._param_types
+
+    with store._database.snapshot(multi_use=True) as snapshot:
+        json_credit = _scan_json(snapshot, "credit", "workspace_id", pt)
+        json_key = _scan_json(snapshot, "api_key", "hash", pt)
+        typed_credit = {
+            r[0]: {"total_credits": r[1], "total_usage": r[2], "reserved": r[3]}
+            for r in snapshot.execute_sql(_CREDIT_TYPED_SCAN)
+        }
+        typed_key = {
+            r[0]: {
+                "limit_micro": r[1], "usage": r[2], "byok_usage": r[3],
+                "reserved": r[4], "include_byok": r[5],
+            }
+            for r in snapshot.execute_sql(_KEY_TYPED_SCAN)
+        }
+
+    def _sample(key: str, value: dict) -> None:
+        if len(report.samples) < max_samples:
+            report.samples[key] = value
+
     report.credit_rows = len(json_credit)
     for ws_id, body in json_credit.items():
         drift = credit_drift(body, typed_credit.get(ws_id))
         if drift:
             report.credit_drift += 1
-            if len(report.samples) < max_samples:
-                report.samples[f"credit:{ws_id}"] = drift
+            _sample(f"credit:{ws_id}", drift)
+    for ws_id in typed_credit.keys() - json_credit.keys():
+        report.credit_orphans += 1
+        _sample(f"credit-orphan:{ws_id}", {"orphan_typed_row": True})
 
-    json_key = {b["hash"]: b for b in store._list_entities("api_key", cls=dict)}
-    typed_key = _scan_typed(
-        store, _KEY_TYPED_SCAN, "key_hash",
-        ["limit_micro", "usage", "byok_usage", "reserved", "include_byok"],
-    )
     report.key_rows = len(json_key)
     for key_hash, body in json_key.items():
         drift = key_drift(body, typed_key.get(key_hash))
         if drift:
             report.key_drift += 1
-            if len(report.samples) < max_samples:
-                report.samples[f"api_key:{key_hash}"] = drift
+            _sample(f"api_key:{key_hash}", drift)
+    for key_hash in typed_key.keys() - json_key.keys():
+        report.key_orphans += 1
+        _sample(f"api_key-orphan:{key_hash}", {"orphan_typed_row": True})
 
     return report
 

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -130,3 +130,55 @@ def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module:
         table,
         spanner_module.KeySet(keys=[(entity_id, UNSHARDED) for entity_id in entity_ids]),
     )
+
+
+# ── Step 2: reconciliation (pure drift detection) ───────────────────────────
+# The per-write mirror is atomic (same txn) so it cannot tear, but an INDEPENDENT
+# full-row comparator is the red-team P2 defense: it catches a missing typed row
+# (pre-flag rows not yet backfilled) or any value divergence, which the per-write
+# path is structurally blind to. The flip to typed enforcement (Step 3) is gated
+# on this comparator reading zero across production.
+
+# JSON body field  ->  typed-table column
+CREDIT_DRIFT_FIELDS = {
+    "total_credits_microdollars": "total_credits",
+    "total_usage_microdollars": "total_usage",
+    "reserved_microdollars": "reserved",
+}
+KEY_DRIFT_FIELDS = {
+    "limit_microdollars": "limit_micro",
+    "usage_microdollars": "usage",
+    "byok_usage_microdollars": "byok_usage",
+    "reserved_microdollars": "reserved",
+    "include_byok_in_limit": "include_byok",
+}
+
+
+def _drift(json_body: dict, typed_row: dict | None, fields: dict[str, str]) -> dict:
+    """Return {field: (json_value, typed_value)} for every mismatch.
+
+    typed_row None (missing mirror) reports every field as drift. A normalized
+    int/bool/None compare avoids false positives from JSON 0-vs-missing.
+    """
+    out: dict[str, tuple] = {}
+    for json_field, typed_col in fields.items():
+        jv = json_body.get(json_field, 0)
+        tv = None if typed_row is None else typed_row.get(typed_col)
+        # default-0 for int counters when the JSON omits the field
+        if jv is None and typed_col != "limit_micro":
+            jv = 0
+        if not isinstance(jv, bool) and isinstance(jv, int | type(None)) and tv is not None:
+            tv = int(tv) if not isinstance(tv, bool) and tv is not None else tv
+        if jv != tv:
+            out[typed_col] = (jv, tv)
+    return out
+
+
+def credit_drift(json_body: dict, typed_row: dict | None) -> dict:
+    """Mismatched credit counters between the authoritative JSON and typed row."""
+    return _drift(json_body, typed_row, CREDIT_DRIFT_FIELDS)
+
+
+def key_drift(json_body: dict, typed_row: dict | None) -> dict:
+    """Mismatched api_key counters between the authoritative JSON and typed row."""
+    return _drift(json_body, typed_row, KEY_DRIFT_FIELDS)

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -139,36 +139,47 @@ def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module:
 # path is structurally blind to. The flip to typed enforcement (Step 3) is gated
 # on this comparator reading zero across production.
 
-# JSON body field  ->  typed-table column
-CREDIT_DRIFT_FIELDS = {
-    "total_credits_microdollars": "total_credits",
-    "total_usage_microdollars": "total_usage",
-    "reserved_microdollars": "reserved",
-}
-KEY_DRIFT_FIELDS = {
-    "limit_microdollars": "limit_micro",
-    "usage_microdollars": "usage",
-    "byok_usage_microdollars": "byok_usage",
-    "reserved_microdollars": "reserved",
-    "include_byok_in_limit": "include_byok",
-}
+# (json body field, typed column, default-when-the-json-field-is-absent).
+# Defaults MUST match the model + the mirror writer so legacy JSON rows that
+# omit a field don't read as false drift: int counters -> 0, an uncapped key's
+# limit -> None, include_byok -> True.
+CREDIT_DRIFT_FIELDS = (
+    ("total_credits_microdollars", "total_credits", 0),
+    ("total_usage_microdollars", "total_usage", 0),
+    ("reserved_microdollars", "reserved", 0),
+)
+KEY_DRIFT_FIELDS = (
+    ("limit_microdollars", "limit_micro", None),
+    ("usage_microdollars", "usage", 0),
+    ("byok_usage_microdollars", "byok_usage", 0),
+    ("reserved_microdollars", "reserved", 0),
+    ("include_byok_in_limit", "include_byok", True),
+)
 
 
-def _drift(json_body: dict, typed_row: dict | None, fields: dict[str, str]) -> dict:
-    """Return {field: (json_value, typed_value)} for every mismatch.
+def _norm(value: Any, default: Any) -> Any:
+    """Normalize a value to its default's type for an apples-to-apples compare.
 
-    typed_row None (missing mirror) reports every field as drift. A normalized
-    int/bool/None compare avoids false positives from JSON 0-vs-missing.
+    bool default -> bool; int default -> int; None-default (nullable limit) keeps
+    None or coerces to int. A None json value falls back to the field default.
+    """
+    if isinstance(default, bool):
+        return default if value is None else bool(value)
+    if value is None:
+        return None if default is None else int(default)
+    return int(value)
+
+
+def _drift(json_body: dict, typed_row: dict | None, fields: tuple) -> dict:
+    """Return {typed_col: (json_value, typed_value)} for every mismatch.
+
+    typed_row None (missing mirror) reports drift on every field whose default is
+    not None (so a missing mirror is always flagged via at least one field).
     """
     out: dict[str, tuple] = {}
-    for json_field, typed_col in fields.items():
-        jv = json_body.get(json_field, 0)
-        tv = None if typed_row is None else typed_row.get(typed_col)
-        # default-0 for int counters when the JSON omits the field
-        if jv is None and typed_col != "limit_micro":
-            jv = 0
-        if not isinstance(jv, bool) and isinstance(jv, int | type(None)) and tv is not None:
-            tv = int(tv) if not isinstance(tv, bool) and tv is not None else tv
+    for json_field, typed_col, default in fields:
+        jv = _norm(json_body.get(json_field, default), default)
+        tv = None if typed_row is None else _norm(typed_row.get(typed_col), default)
         if jv != tv:
             out[typed_col] = (jv, tv)
     return out

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -106,3 +106,27 @@ def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: 
             columns=KEY_LIMIT_COLUMNS,
             values=[key_limit_mirror_row(entity_id, value, commit_ts)],
         )
+
+
+def _typed_table_for(kind: str) -> str | None:
+    if kind == "credit":
+        return CREDIT_BALANCE_TABLE
+    if kind == "api_key":
+        return KEY_LIMIT_TABLE
+    return None
+
+
+def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module: Any) -> None:
+    """Mirror a credit/api_key delete onto its typed table on the same writer.
+
+    Without this, deleting the authoritative JSON row leaves a stale typed row
+    behind — exact-mirror drift that would poison Step 2 reconciliation. No-op
+    for non-counter kinds.
+    """
+    table = _typed_table_for(kind)
+    if table is None:
+        return
+    writer.delete(
+        table,
+        spanner_module.KeySet(keys=[(entity_id, UNSHARDED) for entity_id in entity_ids]),
+    )

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -1,0 +1,108 @@
+"""Typed-counter mirror — Step 1 of the billing typed-column migration.
+
+See docs/design/billing-typed-counters.md.
+
+During Step 1 the JSON ``tr_entities`` rows for kind ``credit`` and ``api_key``
+stay **authoritative**. Every write of one of those rows ALSO mirrors the exact
+post-write counter values into typed Spanner tables (``tr_credit_balance`` /
+``tr_key_limit``) as a **mutation in the SAME transaction/batch** as the JSON
+write. Same-transaction mutation + mutation (never DML here) means the typed row
+can never *tear* from the JSON row — they commit atomically or not at all.
+
+Deliberately there are **no conditional predicates** in this mirror: a shadow
+that ran accept/reject logic would manufacture drift by design (red-team P2).
+The mirror writes absolute post-transaction values (idempotent under the JSON
+RMW retry), so re-running the transaction yields the same typed row.
+
+Enforcement stays on the JSON path until Step 3 flips it to conditional DML on
+these same typed tables.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CREDIT_BALANCE_TABLE = "tr_credit_balance"
+KEY_LIMIT_TABLE = "tr_key_limit"
+
+# Long tail lives entirely on shard 0; sharding a whale is a data change later.
+UNSHARDED = 0
+
+CREDIT_BALANCE_COLUMNS = (
+    "workspace_id",
+    "shard",
+    "total_credits",
+    "total_usage",
+    "reserved",
+    "source_updated_at",
+    "updated_at",
+)
+
+KEY_LIMIT_COLUMNS = (
+    "key_hash",
+    "shard",
+    "limit_micro",
+    "usage",
+    "byok_usage",
+    "reserved",
+    "include_byok",
+    "source_updated_at",
+    "updated_at",
+)
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    """Read a field from either a dataclass (CreditAccount/ApiKey) or a dict."""
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> tuple:
+    """Exact post-write mirror of a `credit` row into tr_credit_balance."""
+    return (
+        workspace_id,
+        UNSHARDED,
+        int(_field(value, "total_credits_microdollars", 0)),
+        int(_field(value, "total_usage_microdollars", 0)),
+        int(_field(value, "reserved_microdollars", 0)),
+        commit_ts,  # source_updated_at — the JSON row's updated_at, same commit
+        commit_ts,  # this mirror's updated_at
+    )
+
+
+def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:
+    """Exact post-write mirror of an `api_key` row into tr_key_limit."""
+    limit = _field(value, "limit_microdollars", None)
+    return (
+        key_hash,
+        UNSHARDED,
+        None if limit is None else int(limit),
+        int(_field(value, "usage_microdollars", 0)),
+        int(_field(value, "byok_usage_microdollars", 0)),
+        int(_field(value, "reserved_microdollars", 0)),
+        bool(_field(value, "include_byok_in_limit", True)),
+        commit_ts,
+        commit_ts,
+    )
+
+
+def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: Any) -> None:
+    """If `kind` is a hot counter, mirror it onto its typed table via `writer`.
+
+    `writer` is a Spanner transaction or batch exposing ``insert_or_update``.
+    Called immediately after the authoritative ``tr_entities`` write on the same
+    writer, so the mirror commits atomically with it. No-op for other kinds.
+    """
+    if kind == "credit":
+        writer.insert_or_update(
+            table=CREDIT_BALANCE_TABLE,
+            columns=CREDIT_BALANCE_COLUMNS,
+            values=[credit_balance_mirror_row(entity_id, value, commit_ts)],
+        )
+    elif kind == "api_key":
+        writer.insert_or_update(
+            table=KEY_LIMIT_TABLE,
+            columns=KEY_LIMIT_COLUMNS,
+            values=[key_limit_mirror_row(entity_id, value, commit_ts)],
+        )

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -95,6 +95,9 @@ class FakeSpannerDatabase:
                     self.typed.setdefault(table, {})[
                         (value_tuple[0], value_tuple[1])
                     ] = dict(zip(columns, value_tuple, strict=True))
+                elif op[0] == "delete_typed":
+                    _, table, pk = op
+                    self.typed.get(table, {}).pop(pk, None)
             return True
 
     def snapshot(self) -> _FakeSnapshot:
@@ -132,8 +135,11 @@ class _FakeTransaction:
 
     def delete(self, table: str, keyset: _KeySet) -> None:
         for entry in keyset.keys:
-            kind, entity_id = entry[0], entry[1]
-            self.pending_writes.append(("delete", table, kind, entity_id))
+            if table == "tr_entities":
+                kind, entity_id = entry[0], entry[1]
+                self.pending_writes.append(("delete", table, kind, entity_id))
+            else:
+                self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
 
 
 class _FakeSnapshot:
@@ -182,6 +188,9 @@ class _FakeBatch:
                     self.db.typed.setdefault(table, {})[
                         (value_tuple[0], value_tuple[1])
                     ] = dict(zip(columns, value_tuple, strict=True))
+                elif op[0] == "delete_typed":
+                    _, table, pk = op
+                    self.db.typed.get(table, {}).pop(pk, None)
         return None
 
     def insert_or_update(
@@ -196,8 +205,11 @@ class _FakeBatch:
 
     def delete(self, table: str, keyset: _KeySet) -> None:
         for entry in keyset.keys:
-            kind, entity_id = entry[0], entry[1]
-            self.pending_writes.append(("delete", table, kind, entity_id))
+            if table == "tr_entities":
+                kind, entity_id = entry[0], entry[1]
+                self.pending_writes.append(("delete", table, kind, entity_id))
+            else:
+                self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
 
 
 def _execute_sql(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -219,6 +219,14 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # Typed counter tables (Step 2 reconcile scans): SELECT <cols> FROM <table>.
+    for typed_table in ("tr_credit_balance", "tr_key_limit"):
+        if f"FROM {typed_table}" in sql:
+            cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+            return [
+                [rec.get(c) for c in cols]
+                for rec in db.typed.get(typed_table, {}).values()
+            ]
     if "AND id=@id" in sql:
         entity_id = params["id"]
         if txn is not None:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -46,6 +46,9 @@ class FakeSpannerDatabase:
 
     def __init__(self, *, ready_barrier: threading.Barrier | None = None) -> None:
         self.rows: dict[tuple[str, str], _Row] = {}
+        # Typed counter tables (tr_credit_balance, tr_key_limit): table ->
+        # (pk col0, pk col1) -> {column: value}. PK is the first two columns.
+        self.typed: dict[str, dict[tuple, dict]] = {}
         self._global_version = 0
         self._commit_lock = threading.Lock()
         self._ready_barrier = ready_barrier
@@ -87,6 +90,11 @@ class FakeSpannerDatabase:
                 elif op[0] == "delete":
                     _, _table, kind, entity_id = op
                     self.rows.pop((kind, entity_id), None)
+                elif op[0] == "upsert_typed":
+                    _, table, columns, value_tuple = op
+                    self.typed.setdefault(table, {})[
+                        (value_tuple[0], value_tuple[1])
+                    ] = dict(zip(columns, value_tuple, strict=True))
             return True
 
     def snapshot(self) -> _FakeSnapshot:
@@ -116,8 +124,11 @@ class _FakeTransaction:
         self, *, table: str, columns: tuple[str, ...], values: list[tuple]
     ) -> None:
         for value_tuple in values:
-            kind, entity_id, body = value_tuple[0], value_tuple[1], value_tuple[2]
-            self.pending_writes.append(("upsert", table, kind, entity_id, body))
+            if table == "tr_entities":
+                kind, entity_id, body = value_tuple[0], value_tuple[1], value_tuple[2]
+                self.pending_writes.append(("upsert", table, kind, entity_id, body))
+            else:
+                self.pending_writes.append(("upsert_typed", table, columns, value_tuple))
 
     def delete(self, table: str, keyset: _KeySet) -> None:
         for entry in keyset.keys:
@@ -166,14 +177,22 @@ class _FakeBatch:
                 elif op[0] == "delete":
                     _, _table, kind, entity_id = op
                     self.db.rows.pop((kind, entity_id), None)
+                elif op[0] == "upsert_typed":
+                    _, table, columns, value_tuple = op
+                    self.db.typed.setdefault(table, {})[
+                        (value_tuple[0], value_tuple[1])
+                    ] = dict(zip(columns, value_tuple, strict=True))
         return None
 
     def insert_or_update(
         self, *, table: str, columns: tuple[str, ...], values: list[tuple]
     ) -> None:
         for value_tuple in values:
-            kind, entity_id, body = value_tuple[0], value_tuple[1], value_tuple[2]
-            self.pending_writes.append(("upsert", table, kind, entity_id, body))
+            if table == "tr_entities":
+                kind, entity_id, body = value_tuple[0], value_tuple[1], value_tuple[2]
+                self.pending_writes.append(("upsert", table, kind, entity_id, body))
+            else:
+                self.pending_writes.append(("upsert_typed", table, columns, value_tuple))
 
     def delete(self, table: str, keyset: _KeySet) -> None:
         for entry in keyset.keys:
@@ -280,6 +299,7 @@ def make_fake_store(
     store._param_types = _ParamTypes
     store._database = db
     store._bt_table = bt
+    store._counter_mirror_enabled = True  # exercise the Step-1 typed-counter mirror
     io = SpannerIO(
         database=db,
         write_entity_batch=store._write_entity_batch,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -100,7 +100,8 @@ class FakeSpannerDatabase:
                     self.typed.get(table, {}).pop(pk, None)
             return True
 
-    def snapshot(self) -> _FakeSnapshot:
+    def snapshot(self, **_kwargs: Any) -> _FakeSnapshot:
+        # accepts multi_use=True etc.; the fake allows repeated reads regardless
         return _FakeSnapshot(self)
 
     def batch(self) -> _FakeBatch:

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -154,6 +154,21 @@ def test_finalize_mirrors_both_credit_and_key() -> None:
     assert_key_mirror_matches(db, key.hash)
 
 
+def test_api_key_delete_removes_typed_mirror_row() -> None:
+    """Deleting the authoritative JSON api_key must also drop the typed mirror,
+    or Step 2 reconciliation sees a phantom typed row (drift)."""
+    store, db, _ = make_fake_store()
+    ws = "ws_delete"
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    assert (key.hash, 0) in db.typed[KEY_LIMIT_TABLE]
+
+    assert store.api_keys.delete(key.hash) is True
+    assert ("api_key", key.hash) not in db.rows
+    assert (key.hash, 0) not in db.typed.get(KEY_LIMIT_TABLE, {})
+
+
 def test_mirror_disabled_writes_no_typed_rows() -> None:
     """Default-off safety: with the flag off, no typed rows are written, so the
     code is safe to deploy before the DDL exists."""

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -1,0 +1,181 @@
+"""Step 1 of the billing typed-column migration: exact-mirror dual-write.
+
+Verifies that every JSON `credit` / `api_key` write also lands an exact mirror
+row on the typed tables (tr_credit_balance / tr_key_limit) in the SAME
+transaction, so the typed row can never tear from the authoritative JSON row.
+Enforcement is unchanged in Step 1 — this only proves the mirror tracks truth.
+
+See docs/design/billing-typed-counters.md.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount, GatewayAuthorization
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _json_credit(db, workspace_id: str) -> dict:
+    return json.loads(db.rows[("credit", workspace_id)].body)
+
+
+def _json_key(db, key_hash: str) -> dict:
+    return json.loads(db.rows[("api_key", key_hash)].body)
+
+
+def _typed_credit(db, workspace_id: str) -> dict:
+    return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+
+
+def _typed_key(db, key_hash: str) -> dict:
+    return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
+
+
+def assert_credit_mirror_matches(db, workspace_id: str) -> None:
+    """The typed credit row must equal the authoritative JSON counters (drift 0)."""
+    j = _json_credit(db, workspace_id)
+    t = _typed_credit(db, workspace_id)
+    assert t["total_credits"] == j["total_credits_microdollars"], (j, t)
+    assert t["total_usage"] == j["total_usage_microdollars"], (j, t)
+    assert t["reserved"] == j["reserved_microdollars"], (j, t)
+    assert t["shard"] == 0
+
+
+def assert_key_mirror_matches(db, key_hash: str) -> None:
+    j = _json_key(db, key_hash)
+    t = _typed_key(db, key_hash)
+    assert t["limit_micro"] == j["limit_microdollars"], (j, t)
+    assert t["usage"] == j["usage_microdollars"], (j, t)
+    assert t["byok_usage"] == j["byok_usage_microdollars"], (j, t)
+    assert t["reserved"] == j["reserved_microdollars"], (j, t)
+    assert t["include_byok"] == j["include_byok_in_limit"], (j, t)
+    assert t["shard"] == 0
+
+
+def test_credit_seed_and_reserve_mirror_tracks_json() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_mirror"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    assert_credit_mirror_matches(db, ws)
+
+    store.reserve(ws, "key_1", 250_000)
+    assert _json_credit(db, ws)["reserved_microdollars"] == 250_000
+    assert_credit_mirror_matches(db, ws)
+    assert _typed_credit(db, ws)["reserved"] == 250_000
+
+
+def test_credit_settle_mirror_tracks_json() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_settle_mirror"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=2_000_000)
+    )
+    reservation = store.reserve(ws, "key_1", 500_000)
+    assert_credit_mirror_matches(db, ws)
+
+    store.settle(reservation.id, 480_000)
+    j = _json_credit(db, ws)
+    assert j["reserved_microdollars"] == 0
+    assert j["total_usage_microdollars"] == 480_000
+    assert_credit_mirror_matches(db, ws)
+
+
+def test_api_key_create_update_and_limit_mirror_tracks_json() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_key_mirror"
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    assert_key_mirror_matches(db, key.hash)
+
+    store.reserve_key_limit(key.hash, 400_000, usage_type="Credits")
+    assert _json_key(db, key.hash)["reserved_microdollars"] == 400_000
+    assert_key_mirror_matches(db, key.hash)
+
+    store.api_keys.add_usage(key.hash, 120_000, is_byok=False)
+    assert _json_key(db, key.hash)["usage_microdollars"] == 120_000
+    assert_key_mirror_matches(db, key.hash)
+
+
+def test_finalize_mirrors_both_credit_and_key() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_finalize_mirror"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=5_000_000)
+    )
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=5_000_000
+    )
+    store.reserve_key_limit(key.hash, 1_000_000, usage_type="Credits")
+    reservation = store.reserve(ws, key.hash, 1_000_000)
+    auth = GatewayAuthorization(
+        id="gwa_m",
+        workspace_id=ws,
+        key_hash=key.hash,
+        model_id="openai/gpt-5.4-nano",
+        provider="openai",
+        usage_type="Credits",
+        estimated_microdollars=1_000_000,
+        credit_reservation_id=reservation.id,
+    )
+    store._write_entity("gateway_authorization", auth.id, auth)
+
+    from trusted_router.storage import Generation
+
+    generation = Generation(
+        id="gen_m",
+        request_id="req_m",
+        workspace_id=ws,
+        key_hash=key.hash,
+        model="openai/gpt-5.4-nano",
+        provider_name="OpenAI",
+        app="typed-mirror-test",
+        tokens_prompt=100,
+        tokens_completion=50,
+        total_cost_microdollars=900_000,
+        usage_type="Credits",
+        speed_tokens_per_second=10.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+    )
+    ok = store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=900_000,
+        selected_usage_type="Credits", generation=generation,
+    )
+    assert ok is True
+    assert _json_credit(db, ws)["reserved_microdollars"] == 0
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 900_000
+    assert_credit_mirror_matches(db, ws)
+    assert_key_mirror_matches(db, key.hash)
+
+
+def test_mirror_disabled_writes_no_typed_rows() -> None:
+    """Default-off safety: with the flag off, no typed rows are written, so the
+    code is safe to deploy before the DDL exists."""
+    store, db, _ = make_fake_store()
+    store._counter_mirror_enabled = False
+    ws = "ws_flag_off"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    store.reserve(ws, "key_1", 100_000)
+    assert CREDIT_BALANCE_TABLE not in db.typed or (ws, 0) not in db.typed.get(
+        CREDIT_BALANCE_TABLE, {}
+    )
+    # JSON path unaffected.
+    assert _json_credit(db, ws)["reserved_microdollars"] == 100_000
+
+
+def test_uncapped_key_mirrors_null_limit() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_uncapped"
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=None
+    )
+    assert _typed_key(db, key.hash)["limit_micro"] is None
+    assert_key_mirror_matches(db, key.hash)

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -296,3 +296,46 @@ def test_backfill_is_idempotent() -> None:
     backfill(store)
     backfill(store)  # second run must not corrupt anything
     assert compare(store).clean
+
+
+def test_compare_detects_orphan_typed_row() -> None:
+    """A typed row with no JSON authority (e.g. missed delete) must be flagged,
+    not silently CLEAN (codex Step-2 #1)."""
+    store, db, _ = make_fake_store()
+    ws = "ws_orphan"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    assert compare(store).clean
+    # Authoritative JSON row vanishes but the typed mirror lingers.
+    del db.rows[("credit", ws)]
+    report = compare(store)
+    assert not report.clean
+    assert report.credit_orphans == 1
+    assert f"credit-orphan:{ws}" in report.samples
+
+
+def test_drift_no_false_positive_on_omitted_legacy_fields() -> None:
+    """Legacy JSON bodies that omit limit_microdollars / include_byok_in_limit
+    must not read as drift against a correctly-defaulted typed row."""
+    # Uncapped, include_byok defaulted true, counters absent.
+    legacy_key = {"hash": "k", "usage_microdollars": 0}
+    typed = {"limit_micro": None, "usage": 0, "byok_usage": 0, "reserved": 0, "include_byok": True}
+    assert key_drift(legacy_key, typed) == {}
+    # bool vs int representation of include_byok must compare equal.
+    assert key_drift(legacy_key, dict(typed, include_byok=1)) == {}
+
+
+def test_backfill_dry_run_still_compares_and_signals_drift() -> None:
+    """--dry-run must not look like a clean gate: compare still runs (codex #4)."""
+    store, db, _ = make_fake_store()
+    store._counter_mirror_enabled = False
+    ws = "ws_dry"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    # dry-run plans the row but writes nothing -> drift remains.
+    counts = backfill(store, dry_run=True)
+    assert counts["credit"] == 1
+    assert CREDIT_BALANCE_TABLE not in db.typed
+    assert not compare(store).clean

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -14,7 +14,13 @@ import json
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage import CreditAccount, GatewayAuthorization
-from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_counter_reconcile import backfill, compare
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    KEY_LIMIT_TABLE,
+    credit_drift,
+    key_drift,
+)
 
 
 def _json_credit(db, workspace_id: str) -> dict:
@@ -194,3 +200,99 @@ def test_uncapped_key_mirrors_null_limit() -> None:
     )
     assert _typed_key(db, key.hash)["limit_micro"] is None
     assert_key_mirror_matches(db, key.hash)
+
+
+# ── Step 2: backfill + drift comparator ─────────────────────────────────────
+
+def test_credit_drift_pure() -> None:
+    body = {
+        "total_credits_microdollars": 1_000_000,
+        "total_usage_microdollars": 200_000,
+        "reserved_microdollars": 50_000,
+    }
+    match = {"total_credits": 1_000_000, "total_usage": 200_000, "reserved": 50_000}
+    assert credit_drift(body, match) == {}
+    assert credit_drift(body, None)  # missing mirror = drift on all fields
+    bad = dict(match, reserved=49_999)
+    drift = credit_drift(body, bad)
+    assert drift == {"reserved": (50_000, 49_999)}
+
+
+def test_key_drift_pure_handles_null_limit_and_bool() -> None:
+    body = {
+        "limit_microdollars": None,
+        "usage_microdollars": 10,
+        "byok_usage_microdollars": 0,
+        "reserved_microdollars": 0,
+        "include_byok_in_limit": True,
+    }
+    typed = {"limit_micro": None, "usage": 10, "byok_usage": 0, "reserved": 0, "include_byok": True}
+    assert key_drift(body, typed) == {}
+    assert "include_byok" in key_drift(body, dict(typed, include_byok=False))
+
+
+def test_compare_clean_after_mirror() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_cmp"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=3_000_000)
+    )
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=2_000_000
+    )
+    store.reserve(ws, key.hash, 400_000)
+    store.reserve_key_limit(key.hash, 400_000, usage_type="Credits")
+
+    report = compare(store)
+    assert report.clean, report.summary() + f" {report.samples}"
+    assert report.credit_rows == 1
+    assert report.key_rows == 1
+
+
+def test_compare_detects_corrupted_typed_row() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_corrupt"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    assert compare(store).clean
+    # Corrupt the typed mirror out from under the JSON authority.
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] = 999_999
+    report = compare(store)
+    assert not report.clean
+    assert report.credit_drift == 1
+    assert f"credit:{ws}" in report.samples
+
+
+def test_backfill_fills_pre_flag_rows() -> None:
+    """Rows written before the flag was on have no typed mirror; backfill adds
+    them and compare goes clean."""
+    store, db, _ = make_fake_store()
+    store._counter_mirror_enabled = False  # simulate pre-flag writes (JSON only)
+    ws = "ws_backfill"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=2_500_000)
+    )
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    # No typed rows yet -> compare sees missing-mirror drift.
+    assert CREDIT_BALANCE_TABLE not in db.typed
+    assert not compare(store).clean
+
+    counts = backfill(store)
+    assert counts == {"credit": 1, "api_key": 1}
+    report = compare(store)
+    assert report.clean, report.summary() + f" {report.samples}"
+
+
+def test_backfill_is_idempotent() -> None:
+    store, _db, _ = make_fake_store()
+    store._counter_mirror_enabled = False
+    ws = "ws_idem"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    backfill(store)
+    backfill(store)  # second run must not corrupt anything
+    assert compare(store).clean


### PR DESCRIPTION
## Why

Production is throwing `Aborted: Deadlock with higher priority transaction` on
`gateway_authorize` → `reserve` (and the settle path). Root cause: per-request
**read-modify-write** of the per-workspace `credit` row and per-key `api_key`
row, stored as JSON blobs in `tr_entities`. Two concurrent requests for one hot
tenant each take a shared read lock then upgrade to exclusive → wound-wait
deadlock. The 8-attempt retry wrapper absorbs normal contention but a sustained
hot tenant exhausts it, and retries add latency on the user-blocking authorize
path.

Patching with more locks/retries treats the symptom. This redesigns the
billing/metering/quota plane properly.

## What

Move the four hot counters out of the JSON blob into **typed Spanner columns**
(`tr_credit_balance`, `tr_key_limit`, `tr_reservation`, `shard` in PK = 0) and
replace each RMW with a **single conditional DML**:

```sql
UPDATE tr_credit_balance SET reserved = reserved + @est
 WHERE workspace_id=@ws AND shard=0
   AND (total_credits - total_usage - reserved) >= @est
```

`execute_update()` row-count = accept(1)/reject(0). The conditional UPDATE takes
the write lock directly → **the shared→exclusive upgrade cycle cannot form.**
Still exact, strongly-consistent across all 3 regions, **no new datastore**.
Per-whale sharding is built in but dormant (activates as a *data* change, not a
migration) if a single tenant ever saturates one row.

Considered and rejected for current scale: lease/token-bucket, async-metering +
soft limits, event-sourced ledger (all add a second authoritative store +
eventual consistency for throughput we don't yet need). See the design doc.

## Review provenance

This PR (so far) is the **design doc**. It was hardened by:
- a 5-architect design panel (chose typed-DML over lease/ledger/sharded/async),
- **2 codex adversarial review passes** (12 money-safety findings — atomic
  authorize, single key→credit lock order, scoped idempotency+fingerprint,
  claim-gated settle, exact recorded-hold release, BYOK predicate, overdraft
  decision, DML/mutation mixing, `PENDING_COMMIT_TIMESTAMP` table-poisoning, …),
- a **7-agent money-safety red team** (no blockers; confirmed double-charge and
  deadlock-reintroduction are false alarms; surfaced P1–P4 pre-cutover fixes).

All folded in — see `## 9. Review log` in the doc.

## Incremental rollout (each step independently revertible; no big-bang)

1. **Step 1** — typed tables + **exact-mirror dual-write** (JSON stays
   authoritative) + per-write divergence metric + independent full-row
   comparator. *Zero behavior change.* ← lands on this PR next.
2. **Step 2** — idempotent backfill + reconcile to zero drift.
3. **Step 3** — flip enforcement to conditional DML (**the deadlock fix**);
   one-shot atomic authorize, claim-gated settle, typed reservations + scoped
   idempotency index + crash reaper, all in the cutover. Ramp by cohort behind a
   flag; keep JSON mirror ≥1 release for flag-flip rollback. *(Billing-critical:
   gated on Joseph's go.)*
4. **Step 4** (deferred) — per-whale sharding, only when metrics prove it.
5. **Step 5** (optional) — change-streams audit ledger.

Draft until Step 1 code + concurrency tests are in and codex has reviewed the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)