### PR TITLE
Billing Step 3: flip enforcement to conditional DML (kills the reserve/settle deadlock)

### DIFF
--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -111,6 +111,7 @@ if table_exists tr_reservation; then log "tr_reservation exists, skip"; else
     actual_micro INT64,
     hold_usage_type STRING(16),
     settled_usage_type STRING(16),
+    authorization_id STRING(64),
     settled BOOL NOT NULL DEFAULT (false),
     idempotency_scope STRING(256),
     idempotency_fingerprint STRING(64),

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -41,6 +41,14 @@ class Settings(BaseSettings):
     bigtable_instance_id: str | None = None
     bigtable_generation_table: str = "trustedrouter-generations"
 
+    # Typed-column billing enforcement cutover (docs/design/billing-typed-counters).
+    # Per-workspace allowlist (CSV) that authorize uses the typed conditional-DML
+    # path for; settle/refund route by reservation ORIGIN, not this flag. Default
+    # empty = legacy path everywhere (zero behavior change). "*" = all workspaces.
+    # The denylist is an emergency kill switch that always wins.
+    typed_billing_workspace_ids: str = ""
+    typed_billing_workspace_denylist: str = ""
+
     sentry_dsn: str | None = None
     sentry_traces_sample_rate: float = 0.05
     sentry_local_enabled: bool = False

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -193,49 +193,107 @@ def register(router: APIRouter) -> None:
                 idempotent_replay=True,
             )
         credit_reservation_id: str | None = None
-        try:
-            STORE.reserve_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
-        except ValueError as exc:
-            raise api_error(
-                402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED
-            ) from exc
+        idempotent_replay = False
+        # Typed-column billing cutover: when this workspace is in the cohort AND
+        # the store supports it (Spanner), authorize via the atomic conditional-DML
+        # path (the deadlock fix). Default-off -> the legacy path below, unchanged.
+        _typed_authz = getattr(STORE, "authorize_gateway_typed", None)
+        _typed_cohort = False
+        if _typed_authz is not None:
+            from trusted_router.storage_gcp_authorize import (
+                typed_billing_enabled_for_workspace,
+            )
 
-        if has_credit_candidate:
-            try:
-                credit_reservation = STORE.reserve(
-                    workspace.id,
-                    api_key.hash,
-                    estimate,
-                    idempotency_key=request_idempotency_key,
-                )
-                credit_reservation_id = credit_reservation.id
-            except ValueError as exc:
-                STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            _typed_cohort = typed_billing_enabled_for_workspace(
+                workspace.id,
+                allowlist_csv=settings.typed_billing_workspace_ids,
+                denylist_csv=settings.typed_billing_workspace_denylist,
+            )
+        if _typed_authz is not None and _typed_cohort:
+            import datetime as _dt
+
+            from trusted_router.storage_gcp_authorize import AuthorizeOutcome
+
+            # expires_at = generous execution deadline (> max stream + settle
+            # retry window) so the reaper only reclaims genuinely-abandoned holds.
+            expires_at = _dt.datetime.now(_dt.UTC) + _dt.timedelta(seconds=7200)
+            outcome, authorization = _typed_authz(
+                workspace_id=workspace.id,
+                key_hash=api_key.hash,
+                estimate=estimate,
+                has_credit_candidate=has_credit_candidate,
+                reservation_usage_type=reservation_usage_type,
+                model_id=model.id,
+                provider=endpoint.provider,
+                requested_model_id=requested_model_id,
+                candidate_model_ids=[m.id for m, _e in endpoint_candidates],
+                region=region,
+                endpoint_id=endpoint.id,
+                candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
+                idempotency_key=request_idempotency_key,
+                idempotency_fingerprint=request_fingerprint,
+                expires_at=expires_at,
+            )
+            if outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS:
+                raise api_error(402, "Insufficient credits", ErrorType.INSUFFICIENT_CREDITS)
+            if outcome in (AuthorizeOutcome.KEY_LIMIT_EXCEEDED, AuthorizeOutcome.KEY_MISSING):
                 raise api_error(
-                    402, "Insufficient credits", ErrorType.INSUFFICIENT_CREDITS
+                    402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED
+                )
+            if outcome == AuthorizeOutcome.IDEMPOTENCY_MISMATCH:
+                raise api_error(
+                    409,
+                    "Idempotency key was already used for a different gateway request",
+                    ErrorType.CONFLICT,
+                )
+            if authorization is None:
+                raise api_error(500, "gateway authorize failed", ErrorType.INTERNAL_ERROR)
+            credit_reservation_id = authorization.credit_reservation_id
+            idempotent_replay = outcome == AuthorizeOutcome.REPLAY
+        else:
+            try:
+                STORE.reserve_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            except ValueError as exc:
+                raise api_error(
+                    402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED
                 ) from exc
 
-        authorization = STORE.create_gateway_authorization(
-            workspace_id=workspace.id,
-            key_hash=api_key.hash,
-            model_id=model.id,
-            provider=endpoint.provider,
-            usage_type=reservation_usage_type,
-            estimated_microdollars=estimate,
-            credit_reservation_id=credit_reservation_id,
-            requested_model_id=requested_model_id,
-            candidate_model_ids=[
-                candidate_model.id for candidate_model, _endpoint in endpoint_candidates
-            ],
-            region=region,
-            endpoint_id=endpoint.id,
-            candidate_endpoint_ids=[
-                candidate_endpoint.id
-                for _candidate_model, candidate_endpoint in endpoint_candidates
-            ],
-            idempotency_key=request_idempotency_key,
-            idempotency_fingerprint=request_fingerprint,
-        )
+            if has_credit_candidate:
+                try:
+                    credit_reservation = STORE.reserve(
+                        workspace.id,
+                        api_key.hash,
+                        estimate,
+                        idempotency_key=request_idempotency_key,
+                    )
+                    credit_reservation_id = credit_reservation.id
+                except ValueError as exc:
+                    STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+                    raise api_error(
+                        402, "Insufficient credits", ErrorType.INSUFFICIENT_CREDITS
+                    ) from exc
+
+            authorization = STORE.create_gateway_authorization(
+                workspace_id=workspace.id,
+                key_hash=api_key.hash,
+                model_id=model.id,
+                provider=endpoint.provider,
+                usage_type=reservation_usage_type,
+                estimated_microdollars=estimate,
+                credit_reservation_id=credit_reservation_id,
+                requested_model_id=requested_model_id,
+                candidate_model_ids=[
+                    candidate_model.id for candidate_model, _endpoint in endpoint_candidates
+                ],
+                region=region,
+                endpoint_id=endpoint.id,
+                candidate_endpoint_ids=[
+                    candidate_endpoint.id
+                    for _candidate_model, candidate_endpoint in endpoint_candidates
+                ],
+                idempotency_key=request_idempotency_key,
+                idempotency_fingerprint=request_fingerprint,
+            )
         byok_config = (
             STORE.get_byok_provider(workspace.id, endpoint.provider)
             if model_usage_type.is_byok()
@@ -262,7 +320,7 @@ def register(router: APIRouter) -> None:
             settings=settings,
             broadcast_destinations=broadcast_destinations,
             endpoint_candidates=endpoint_candidates,
-            idempotent_replay=False,
+            idempotent_replay=idempotent_replay,
         )
 
     @router.post("/internal/gateway/settle")
@@ -523,13 +581,29 @@ def _settle_gateway_authorization(
         )
         generation_id = generation.id
 
-    finalized = STORE.finalize_gateway_authorization(
-        authorization.id,
-        success=success,
-        actual_microdollars=actual_cost,
-        selected_usage_type=selected_usage_type,
-        generation=generation,
-    )
+    # Typed-column billing cutover: settle by reservation ORIGIN, not the cohort
+    # flag, so a request that reserved typed settles typed and a JSON one settles
+    # JSON (codex 3e). Default: no typed reservation (or InMemory store) -> legacy
+    # path unchanged.
+    _is_typed = getattr(STORE, "is_typed_reservation", None)
+    if _is_typed is not None and _is_typed(
+        authorization.credit_reservation_id, authorization.id
+    ):
+        finalized = STORE.typed_finalize_gateway_authorization(
+            authorization.id,
+            success=success,
+            actual_microdollars=actual_cost,
+            selected_usage_type=selected_usage_type,
+            generation=generation,
+        )
+    else:
+        finalized = STORE.finalize_gateway_authorization(
+            authorization.id,
+            success=success,
+            actual_microdollars=actual_cost,
+            selected_usage_type=selected_usage_type,
+            generation=generation,
+        )
     if not finalized:
         return {
             "data": {

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -149,16 +149,10 @@ def register(router: APIRouter) -> None:
             key_hash=api_key.hash,
             body=body_dict,
         )
-        existing_authorization = STORE.get_gateway_authorization_by_idempotency_key(
-            workspace.id, api_key.hash, request_idempotency_key
-        )
-        if existing_authorization is not None:
-            if existing_authorization.idempotency_fingerprint != request_fingerprint:
-                raise api_error(
-                    409,
-                    "Idempotency key was already used for a different gateway request",
-                    ErrorType.CONFLICT,
-                )
+        def _replay_response(existing_authorization: Any) -> dict[str, Any]:
+            # Build the replay response from the STORED authorization (NOT current
+            # routing), so a replay across catalog/pricing/BYOK drift advertises
+            # the endpoint that was actually authorized (codex 3e route review #1).
             existing_candidates = _authorization_endpoint_candidates(
                 existing_authorization, endpoint_candidates
             )
@@ -192,6 +186,27 @@ def register(router: APIRouter) -> None:
                 endpoint_candidates=existing_candidates,
                 idempotent_replay=True,
             )
+
+        existing_authorization = STORE.get_gateway_authorization_by_idempotency_key(
+            workspace.id, api_key.hash, request_idempotency_key
+        )
+        if existing_authorization is None:
+            # Typed authorizations have no JSON idempotency index; look them up
+            # INDEPENDENT of the cohort flag so a retry after a cohort flag-off /
+            # denylist rollback still replays (codex 3e route review #2).
+            _typed_idem = getattr(STORE, "get_typed_authorization_by_idempotency", None)
+            if _typed_idem is not None:
+                existing_authorization = _typed_idem(
+                    workspace.id, api_key.hash, request_idempotency_key
+                )
+        if existing_authorization is not None:
+            if existing_authorization.idempotency_fingerprint != request_fingerprint:
+                raise api_error(
+                    409,
+                    "Idempotency key was already used for a different gateway request",
+                    ErrorType.CONFLICT,
+                )
+            return _replay_response(existing_authorization)
         credit_reservation_id: str | None = None
         idempotent_replay = False
         # Typed-column billing cutover: when this workspace is in the cohort AND
@@ -248,8 +263,10 @@ def register(router: APIRouter) -> None:
                 )
             if authorization is None:
                 raise api_error(500, "gateway authorize failed", ErrorType.INTERNAL_ERROR)
+            if outcome == AuthorizeOutcome.REPLAY:
+                # concurrent-race replay: respond from the STORED authorization
+                return _replay_response(authorization)
             credit_reservation_id = authorization.credit_reservation_id
-            idempotent_replay = outcome == AuthorizeOutcome.REPLAY
         else:
             try:
                 STORE.reserve_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -603,10 +603,13 @@ def _settle_gateway_authorization(
     # JSON (codex 3e). Default: no typed reservation (or InMemory store) -> legacy
     # path unchanged.
     _is_typed = getattr(STORE, "is_typed_reservation", None)
-    if _is_typed is not None and _is_typed(
-        authorization.credit_reservation_id, authorization.id
+    _typed_finalize = getattr(STORE, "typed_finalize_gateway_authorization", None)
+    if (
+        _is_typed is not None
+        and _typed_finalize is not None
+        and _is_typed(authorization.credit_reservation_id, authorization.id)
     ):
-        finalized = STORE.typed_finalize_gateway_authorization(
+        finalized = _typed_finalize(
             authorization.id,
             success=success,
             actual_microdollars=actual_cost,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -937,6 +937,132 @@ class SpannerBigtableStore:
 
         return typed_finalize_atomic(self._database, self._param_types, **kwargs)
 
+    def typed_finalize_gateway_authorization(
+        self,
+        authorization_id: str,
+        *,
+        success: bool,
+        actual_microdollars: int,
+        selected_usage_type: UsageType | str,
+        generation: Generation | None = None,
+    ) -> bool:
+        """Route-facing typed settle: same contract as
+        finalize_gateway_authorization (returns False on replay/already-settled)
+        but via the DML-only typed_finalize_atomic. Builds the generation entity
+        bodies + the settled gateway_authorization body, then indexes Bigtable
+        after commit (NOT generation_store.add — that would double-book key usage
+        the typed settle already booked)."""
+        from trusted_router.storage_gcp_authorize import SettleOutcome, typed_finalize_atomic
+
+        authorization = self.get_gateway_authorization(authorization_id)
+        if authorization is None or authorization.credit_reservation_id is None:
+            return False
+        actual_usage_type = UsageType.coerce(selected_usage_type)
+        generation_writes: list[tuple[str, str, str]] = []
+        if success and generation is not None:
+            generation_writes = [
+                ("generation", generation.id, _json_body(generation)),
+                (
+                    "generation_by_workspace",
+                    _generation_workspace_id(generation),
+                    _json_body({"generation_id": generation.id}),
+                ),
+            ]
+        authorization.settled = True
+        result = typed_finalize_atomic(
+            self._database,
+            self._param_types,
+            reservation_id=authorization.credit_reservation_id,
+            authorization_id=authorization_id,
+            success=success,
+            actual_micro=actual_microdollars,
+            settled_usage_type=str(actual_usage_type),
+            now=dt.datetime.now(dt.UTC),
+            auth_body_settled=_json_body(authorization),
+            generation_writes=generation_writes,
+        )
+        if result["outcome"] == SettleOutcome.ERROR:
+            raise RuntimeError("typed finalize failed: release row-count != 1")
+        if result["outcome"] == SettleOutcome.SETTLED:
+            if success and generation is not None:
+                self.generation_store.index_after_commit(generation)
+            return True
+        return False  # already_settled / not_found
+
+    def authorize_gateway_typed(
+        self,
+        *,
+        workspace_id: str,
+        key_hash: str,
+        estimate: int,
+        has_credit_candidate: bool,
+        reservation_usage_type: UsageType | str,
+        model_id: str,
+        provider: str,
+        requested_model_id: str | None,
+        candidate_model_ids: list[str],
+        region: str | None,
+        endpoint_id: str | None,
+        candidate_endpoint_ids: list[str],
+        idempotency_key: str | None,
+        idempotency_fingerprint: str | None,
+        expires_at: Any,
+    ) -> tuple[str, GatewayAuthorization | None]:
+        """Route-facing typed authorize. Runs the atomic conditional-DML authorize
+        (holds + reservation + gateway_authorization DML-insert) and returns
+        (outcome, authorization). outcome in accepted/replay/insufficient_credits/
+        key_limit_exceeded/key_missing/idempotency_mismatch."""
+        from trusted_router.storage_gcp_authorize import AuthorizeOutcome, authorize_atomic
+        from trusted_router.storage_gcp_keys import (
+            _gateway_authorization_idempotency_index_id,
+        )
+
+        usage = UsageType.coerce(reservation_usage_type)
+        scope = (
+            _gateway_authorization_idempotency_index_id(workspace_id, key_hash, idempotency_key)
+            if idempotency_key is not None
+            else None
+        )
+
+        def build_body(authorization_id: str, reservation_id: str) -> str:
+            auth = GatewayAuthorization(
+                id=authorization_id,
+                workspace_id=workspace_id,
+                key_hash=key_hash,
+                model_id=model_id,
+                provider=provider,
+                usage_type=usage,
+                estimated_microdollars=estimate,
+                credit_reservation_id=reservation_id,
+                requested_model_id=requested_model_id,
+                candidate_model_ids=list(candidate_model_ids or []),
+                region=region,
+                endpoint_id=endpoint_id,
+                candidate_endpoint_ids=list(candidate_endpoint_ids or []),
+                idempotency_key=idempotency_key,
+                idempotency_fingerprint=idempotency_fingerprint,
+            )
+            return _json_body(auth)
+
+        result = authorize_atomic(
+            self._database,
+            self._param_types,
+            workspace_id=workspace_id,
+            key_hash=key_hash,
+            estimate=estimate,
+            has_credit_candidate=has_credit_candidate,
+            reservation_usage_type=str(usage),
+            idempotency_scope=scope,
+            idempotency_fingerprint=idempotency_fingerprint,
+            expires_at=expires_at,
+            build_auth_body=build_body,
+        )
+        outcome = result["outcome"]
+        authorization: GatewayAuthorization | None = None
+        if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
+            authorization = self.get_gateway_authorization(result["authorization_id"])
+        return outcome, authorization
+
     def reap_expired_reservations(self, *, now: Any, limit: int = 100) -> int:
         from trusted_router.storage_gcp_authorize import (
             reap_expired_reservations as _reap,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1074,14 +1074,44 @@ class SpannerBigtableStore:
         """Settle/refund origin detection (codex 3e): typed iff a tr_reservation
         row exists for this reservation id AND its authorization_id matches — so a
         request that reserved typed settles typed, and a JSON one settles JSON,
-        regardless of the current cohort flag."""
-        if not reservation_id:
+        regardless of the current cohort flag.
+
+        Guarded by the mirror flag: when off, no typed tables/reservations exist
+        (the cutover turns the mirror on, after the DDL, before any typed
+        authorize), so we never query tr_reservation before it exists — avoiding a
+        flag-off settle 500 if the route deploys ahead of the schema (codex 3e
+        route review #3)."""
+        if not getattr(self, "_counter_mirror_enabled", False) or not reservation_id:
             return False
         from trusted_router.storage_gcp_counter_dml import read_reservation
 
         with self._database.snapshot() as snapshot:
             res = read_reservation(snapshot, self._param_types, reservation_id)
         return res is not None and res.get("authorization_id") == authorization_id
+
+    def get_typed_authorization_by_idempotency(
+        self, workspace_id: str, key_hash: str, idempotency_key: str
+    ) -> GatewayAuthorization | None:
+        """Find a typed authorization by its scoped idempotency key, INDEPENDENT
+        of the current cohort flag, so a retry after a cohort flag-off/denylist
+        rollback still replays the typed authorization instead of falling to the
+        legacy path and creating a second hold (codex 3e route review #2). Returns
+        None when the mirror is off (no typed tables yet)."""
+        if not getattr(self, "_counter_mirror_enabled", False):
+            return None
+        from trusted_router.storage_gcp_counter_dml import read_reservation_by_idempotency
+        from trusted_router.storage_gcp_keys import (
+            _gateway_authorization_idempotency_index_id,
+        )
+
+        scope = _gateway_authorization_idempotency_index_id(
+            workspace_id, key_hash, idempotency_key
+        )
+        with self._database.snapshot() as snapshot:
+            existing = read_reservation_by_idempotency(snapshot, self._param_types, scope)
+        if existing is None:
+            return None
+        return self.get_gateway_authorization(existing["authorization_id"])
 
     def reserve_key_limit(
         self,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -924,6 +924,39 @@ class SpannerBigtableStore:
             self.generation_store.index_after_commit(generation)
         return bool(finalized)
 
+    # ── Typed-column billing (Step 3): thin wrappers over storage_gcp_authorize.
+    # The atomic conditional-DML authorize/settle engine. Gated by the route on
+    # the cohort flag (authorize) and reservation origin (settle/refund).
+    def authorize_gateway_atomic(self, **kwargs: Any) -> dict:
+        from trusted_router.storage_gcp_authorize import authorize_atomic
+
+        return authorize_atomic(self._database, self._param_types, **kwargs)
+
+    def typed_finalize_gateway(self, **kwargs: Any) -> dict:
+        from trusted_router.storage_gcp_authorize import typed_finalize_atomic
+
+        return typed_finalize_atomic(self._database, self._param_types, **kwargs)
+
+    def reap_expired_reservations(self, *, now: Any, limit: int = 100) -> int:
+        from trusted_router.storage_gcp_authorize import (
+            reap_expired_reservations as _reap,
+        )
+
+        return _reap(self._database, self._param_types, now=now, limit=limit)
+
+    def is_typed_reservation(self, reservation_id: str | None, authorization_id: str) -> bool:
+        """Settle/refund origin detection (codex 3e): typed iff a tr_reservation
+        row exists for this reservation id AND its authorization_id matches — so a
+        request that reserved typed settles typed, and a JSON one settles JSON,
+        regardless of the current cohort flag."""
+        if not reservation_id:
+            return False
+        from trusted_router.storage_gcp_counter_dml import read_reservation
+
+        with self._database.snapshot() as snapshot:
+            res = read_reservation(snapshot, self._param_types, reservation_id)
+        return res is not None and res.get("authorization_id") == authorization_id
+
     def reserve_key_limit(
         self,
         key_hash: str,

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -267,3 +267,91 @@ def reap_expired_reservations(
         if result["outcome"] == SettleOutcome.SETTLED:
             reaped += 1
     return reaped
+
+
+def typed_finalize_atomic(
+    database: Any,
+    param_types: Any,
+    *,
+    reservation_id: str,
+    authorization_id: str,
+    success: bool,
+    actual_micro: int,
+    settled_usage_type: str,
+    now: Any,
+    auth_body_settled: str,
+    generation_writes: list | None = None,
+) -> dict:
+    """Full DML-only finalize for the typed path (codex 3e, Option B).
+
+    ONE transaction reproduces legacy finalize_gateway_authorization's whole
+    behavior so a crash can't leave counters charged but the generation missing /
+    auth unsettled: claim the reservation -> release the EXACT holds (key then
+    credit) and book actual -> on success DML-insert the generation entities ->
+    DML-mark the gateway_authorization settled. All writes use a client `now`
+    timestamp (NOT PENDING_COMMIT_TIMESTAMP) so the multiple tr_entities DML
+    statements don't hit the PCT same-table trap. The caller does the Bigtable
+    index AFTER commit (like legacy index_after_commit), and must NOT use
+    SpannerGenerations.add() (it would double-book key usage already booked here).
+
+    `generation_writes` = [(kind, entity_id, body_json), ...] inserted only on
+    success. `auth_body_settled` = the gateway_authorization JSON body with
+    settled=true. Returns {outcome: settled|already_settled|not_found|error}.
+    """
+    from trusted_router.storage_gcp_counter_dml import (
+        claim_reservation,
+        insert_entity_dml_at,
+        read_reservation,
+        release_credit,
+        release_key,
+        update_entity_body_dml,
+    )
+
+    pt = param_types
+    book_actual = actual_micro if success else 0
+    book_to_byok = settled_usage_type == "BYOK"
+    writes = generation_writes or []
+
+    def txn(transaction: Any) -> dict:
+        res = read_reservation(transaction, pt, reservation_id)
+        if res is None:
+            return {"outcome": SettleOutcome.NOT_FOUND}
+        won = claim_reservation(
+            transaction, pt, reservation_id,
+            actual_micro=book_actual, settled_usage_type=settled_usage_type,
+        )
+        if not won:
+            return {"outcome": SettleOutcome.ALREADY_SETTLED}
+
+        key_count = release_key(
+            transaction, pt, res["key_hash"], res["key_reserved_micro"],
+            book_actual, book_to_byok=book_to_byok,
+        )
+        if res["key_reserved_micro"] > 0 and key_count != 1:
+            raise _SettleError("key release row-count != 1")
+
+        if res["credit_reserved_micro"] > 0:
+            credit_actual = book_actual if settled_usage_type == "Credits" else 0
+            credit_count = release_credit(
+                transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
+                credit_actual,
+            )
+            if credit_count != 1:
+                raise _SettleError("credit release row-count != 1")
+
+        if success:
+            for kind, entity_id, body_json in writes:
+                insert_entity_dml_at(transaction, pt, kind, entity_id, body_json, now)
+
+        marked = update_entity_body_dml(
+            transaction, pt, "gateway_authorization", authorization_id,
+            auth_body_settled, now,
+        )
+        if marked != 1:
+            raise _SettleError("gateway_authorization update row-count != 1")
+        return {"outcome": SettleOutcome.SETTLED}
+
+    try:
+        return run_in_transaction_with_retry(database, txn)
+    except _SettleError:
+        return {"outcome": SettleOutcome.ERROR}

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -136,8 +136,12 @@ def authorize_atomic(
     except AlreadyExists:
         # Concurrent first-call lost the unique-idempotency-index race: the winner
         # committed; re-read and replay (codex Step-3 #4) — never a second debit.
+        # The conflict was on idempotency_scope, so it is necessarily non-None.
+        assert idempotency_scope is not None
+        conflict_scope: str = idempotency_scope
+
         def replay_txn(transaction: Any) -> dict:
-            existing = read_reservation_by_idempotency(transaction, pt, idempotency_scope)
+            existing = read_reservation_by_idempotency(transaction, pt, conflict_scope)
             if existing is None:  # pragma: no cover - winner must exist post-conflict
                 raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
             # Same fingerprint check as the normal replay path (codex keystone

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -140,6 +140,11 @@ def authorize_atomic(
             existing = read_reservation_by_idempotency(transaction, pt, idempotency_scope)
             if existing is None:  # pragma: no cover - winner must exist post-conflict
                 raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
+            # Same fingerprint check as the normal replay path (codex keystone
+            # review): a concurrent same-scope but DIFFERENT-body loser must get
+            # IDEMPOTENCY_MISMATCH, not the winner's authorization as a replay.
+            if existing["idempotency_fingerprint"] != idempotency_fingerprint:
+                raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
             return _replay(existing)
 
         try:
@@ -224,3 +229,41 @@ def settle_atomic(
         return run_in_transaction_with_retry(database, txn)
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
+
+
+def reap_expired_reservations(
+    database: Any, param_types: Any, *, now: Any, limit: int = 100
+) -> int:
+    """Reclaim crashed-before-settle reservations (settled=false AND expires_at<now).
+
+    Releases each stranded reservation's holds via the SAME claim-gated settle
+    path (success=False = refund, books nothing), so a late settle racing the
+    reaper is safe — whoever claims the row first wins, the other no-ops.
+
+    `expires_at` is set at authorize to the EXECUTION DEADLINE (max stream
+    duration + settle-retry window + margin), so a reaped reservation is genuinely
+    abandoned; releasing without a charge is the bounded-loss accept (red-team P1).
+    A durable settle outbox (gateway persists actuals on response) is the planned
+    enhancement to recover the rare completed-but-settle-lost charge instead of
+    releasing it free; until then, keep `expires_at` generous. Returns the count
+    reaped.
+    """
+    pt = param_types
+    with database.snapshot() as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT reservation_id FROM tr_reservation "
+                "WHERE settled=false AND expires_at < @now LIMIT @limit",
+                params={"now": now, "limit": int(limit)},
+                param_types={"now": pt.TIMESTAMP, "limit": pt.INT64},
+            )
+        )
+    reaped = 0
+    for (reservation_id,) in rows:
+        result = settle_atomic(
+            database, pt, reservation_id=reservation_id, actual_micro=0,
+            settled_usage_type="Credits", success=False,
+        )
+        if result["outcome"] == SettleOutcome.SETTLED:
+            reaped += 1
+    return reaped

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -1,0 +1,148 @@
+"""Step 3b-3: the atomic gateway-authorize transaction (DML-only).
+
+See docs/design/billing-typed-counters.md.
+
+ONE Spanner read-write transaction (no mutation mixing) owns the whole authorize
+decision, so a crash can never leak a hold (codex#1 #1):
+
+  scoped idempotency read (+ fingerprint) ->
+  conditional key-cap DML -> conditional credit DML ->
+  tr_reservation INSERT (exact holds + hold usage type + authorization_id) ->
+  gateway_authorization DML INSERT.
+
+A rejection (insufficient credits / key cap) raises inside the callback, which
+rolls the whole transaction back — releasing any hold already taken atomically,
+no compensation needed. A duplicate idempotency_scope (concurrent first-call
+loser) surfaces ALREADY_EXISTS (NOT retried); we re-read and REPLAY — no second
+debit. Replay is resume/no-execute: the caller must NOT re-run the LLM call
+(codex#2 #4).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from google.api_core.exceptions import AlreadyExists
+
+from trusted_router.storage_gcp_counter_dml import (
+    KEY_ACCEPTED,
+    KEY_INSUFFICIENT,
+    KEY_MISSING,
+    insert_entity_dml,
+    insert_reservation,
+    read_reservation_by_idempotency,
+    reserve_credit,
+    reserve_key,
+)
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+
+
+class AuthorizeOutcome:
+    ACCEPTED = "accepted"
+    REPLAY = "replay"  # idempotent replay: resume, do NOT re-execute
+    INSUFFICIENT_CREDITS = "insufficient_credits"
+    KEY_LIMIT_EXCEEDED = "key_limit_exceeded"
+    KEY_MISSING = "key_missing"  # typed key row absent -> fail closed
+    IDEMPOTENCY_MISMATCH = "idempotency_mismatch"  # same key, different request body
+
+
+class _Reject(Exception):
+    """Roll the authorize transaction back with a terminal outcome (not retried)."""
+
+    def __init__(self, outcome: str) -> None:
+        self.outcome = outcome
+
+
+def authorize_atomic(
+    database: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int,
+    has_credit_candidate: bool,
+    reservation_usage_type: str,
+    idempotency_scope: str | None,
+    idempotency_fingerprint: str | None,
+    expires_at: Any,
+    build_auth_body: Callable[[str, str], str],
+) -> dict:
+    """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
+
+    `build_auth_body(authorization_id, reservation_id) -> json str` lets the caller
+    construct the gateway_authorization body once the ids are known.
+    `reservation_usage_type` is the HOLD usage type (Credits if any credit
+    candidate, else BYOK). `has_credit_candidate` gates the credit hold.
+    """
+    pt = param_types
+    is_byok = not has_credit_candidate
+    # Stable ids across ABORTED retries (only the committed attempt persists).
+    reservation_id = str(uuid.uuid4())
+    authorization_id = f"gwa-{uuid.uuid4().hex}"
+
+    def _replay(existing: dict) -> dict:
+        return {
+            "outcome": AuthorizeOutcome.REPLAY,
+            "reservation_id": existing["reservation_id"],
+            "authorization_id": existing["authorization_id"],
+        }
+
+    def txn(transaction: Any) -> dict:
+        if idempotency_scope is not None:
+            existing = read_reservation_by_idempotency(transaction, pt, idempotency_scope)
+            if existing is not None:
+                if existing["idempotency_fingerprint"] != idempotency_fingerprint:
+                    raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
+                return _replay(existing)
+
+        key_result = reserve_key(transaction, pt, key_hash, estimate, is_byok=is_byok)
+        if key_result == KEY_INSUFFICIENT:
+            raise _Reject(AuthorizeOutcome.KEY_LIMIT_EXCEEDED)
+        if key_result == KEY_MISSING:
+            raise _Reject(AuthorizeOutcome.KEY_MISSING)
+        key_hold = estimate if key_result == KEY_ACCEPTED else 0
+
+        credit_hold = 0
+        if has_credit_candidate:
+            if not reserve_credit(transaction, pt, workspace_id, estimate):
+                raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
+            credit_hold = estimate
+
+        insert_reservation(
+            transaction, pt,
+            reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
+            ws_shard=0, key_shard=0,
+            credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
+            hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
+            idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
+            expires_at=expires_at,
+        )
+        insert_entity_dml(
+            transaction, pt, "gateway_authorization", authorization_id,
+            build_auth_body(authorization_id, reservation_id),
+        )
+        return {
+            "outcome": AuthorizeOutcome.ACCEPTED,
+            "reservation_id": reservation_id,
+            "authorization_id": authorization_id,
+        }
+
+    try:
+        return run_in_transaction_with_retry(database, txn)
+    except _Reject as reject:
+        return {"outcome": reject.outcome}
+    except AlreadyExists:
+        # Concurrent first-call lost the unique-idempotency-index race: the winner
+        # committed; re-read and replay (codex Step-3 #4) — never a second debit.
+        def replay_txn(transaction: Any) -> dict:
+            existing = read_reservation_by_idempotency(transaction, pt, idempotency_scope)
+            if existing is None:  # pragma: no cover - winner must exist post-conflict
+                raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
+            return _replay(existing)
+
+        try:
+            return run_in_transaction_with_retry(database, replay_txn)
+        except _Reject as reject:
+            return {"outcome": reject.outcome}

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -146,3 +146,81 @@ def authorize_atomic(
             return run_in_transaction_with_retry(database, replay_txn)
         except _Reject as reject:
             return {"outcome": reject.outcome}
+
+
+class SettleOutcome:
+    SETTLED = "settled"  # this caller claimed + released the holds
+    ALREADY_SETTLED = "already_settled"  # replay: another caller already settled
+    NOT_FOUND = "not_found"  # no such reservation
+    ERROR = "error"  # a release row-count != 1 -> rolled back, re-drive/alarm
+
+
+class _SettleError(Exception):
+    """A release returned row-count != 1 — roll the settle back (don't leave the
+    reservation claimed with the hold unreleased / charge unbooked)."""
+
+
+def settle_atomic(
+    database: Any,
+    param_types: Any,
+    *,
+    reservation_id: str,
+    actual_micro: int,
+    settled_usage_type: str,
+    success: bool,
+) -> dict:
+    """Claim-gated settle/refund in ONE transaction (key then credit lock order).
+
+    Claim flips settled false->true (first-writer-wins); only the winner releases
+    the EXACT recorded holds and books `actual`. `success=False` is a refund:
+    release the holds, book nothing. Booking matches the legacy finalize: key
+    usage by settled usage type (usage vs byok_usage); credit total_usage only
+    when the settled usage type is Credits.
+    """
+    from trusted_router.storage_gcp_counter_dml import (
+        claim_reservation,
+        read_reservation,
+        release_credit,
+        release_key,
+    )
+
+    pt = param_types
+    book_actual = actual_micro if success else 0
+    book_to_byok = settled_usage_type == "BYOK"
+
+    def txn(transaction: Any) -> dict:
+        res = read_reservation(transaction, pt, reservation_id)
+        if res is None:
+            return {"outcome": SettleOutcome.NOT_FOUND}
+        won = claim_reservation(
+            transaction, pt, reservation_id,
+            actual_micro=book_actual, settled_usage_type=settled_usage_type,
+        )
+        if not won:
+            return {"outcome": SettleOutcome.ALREADY_SETTLED}  # replay, no double-apply
+
+        # key first, then credit (single lock order everywhere — codex#2 #2).
+        key_actual = book_actual  # key usage counts under both Credits and BYOK
+        key_count = release_key(
+            transaction, pt, res["key_hash"], res["key_reserved_micro"],
+            key_actual, book_to_byok=book_to_byok,
+        )
+        # A recorded hold MUST release; an uncapped/no-hold row (key_reserved==0)
+        # may 0-row and is tolerated (best-effort usage tracking).
+        if res["key_reserved_micro"] > 0 and key_count != 1:
+            raise _SettleError("key release row-count != 1")
+
+        if res["credit_reserved_micro"] > 0:
+            credit_actual = book_actual if settled_usage_type == "Credits" else 0
+            credit_count = release_credit(
+                transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
+                credit_actual,
+            )
+            if credit_count != 1:
+                raise _SettleError("credit release row-count != 1")
+        return {"outcome": SettleOutcome.SETTLED}
+
+    try:
+        return run_in_transaction_with_retry(database, txn)
+    except _SettleError:
+        return {"outcome": SettleOutcome.ERROR}

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -355,3 +355,16 @@ def typed_finalize_atomic(
         return run_in_transaction_with_retry(database, txn)
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
+
+
+def typed_billing_enabled_for_workspace(
+    workspace_id: str, *, allowlist_csv: str, denylist_csv: str
+) -> bool:
+    """Cohort gate for the typed AUTHORIZE path. Default-off; the denylist is an
+    emergency kill switch that always wins; "*" in the allowlist = all. Settle/
+    refund route by reservation ORIGIN, not this gate (codex 3e)."""
+    deny = {w.strip() for w in denylist_csv.split(",") if w.strip()}
+    if workspace_id in deny:
+        return False
+    allow = {w.strip() for w in allowlist_csv.split(",") if w.strip()}
+    return "*" in allow or workspace_id in allow

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -201,7 +201,7 @@ def release_key(
 RESERVATION_COLUMNS = (
     "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
     "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
-    "idempotency_scope", "idempotency_fingerprint", "expires_at",
+    "authorization_id", "idempotency_scope", "idempotency_fingerprint", "expires_at",
 )
 
 
@@ -216,7 +216,7 @@ def read_reservation_by_idempotency(
     rows = list(
         transaction.execute_sql(
             "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
-            "hold_usage_type, idempotency_fingerprint, settled "
+            "hold_usage_type, authorization_id, idempotency_fingerprint, settled "
             "FROM tr_reservation WHERE idempotency_scope=@scope",
             params={"scope": idempotency_scope},
             param_types={"scope": param_types.STRING},
@@ -230,8 +230,9 @@ def read_reservation_by_idempotency(
         "credit_reserved_micro": r[1],
         "key_reserved_micro": r[2],
         "hold_usage_type": r[3],
-        "idempotency_fingerprint": r[4],
-        "settled": r[5],
+        "authorization_id": r[4],
+        "idempotency_fingerprint": r[5],
+        "settled": r[6],
     }
 
 
@@ -266,8 +267,9 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
         "reservation_id": pt.STRING, "workspace_id": pt.STRING, "key_hash": pt.STRING,
         "ws_shard": pt.INT64, "key_shard": pt.INT64,
         "credit_reserved_micro": pt.INT64, "key_reserved_micro": pt.INT64,
-        "hold_usage_type": pt.STRING, "idempotency_scope": pt.STRING,
-        "idempotency_fingerprint": pt.STRING, "expires_at": pt.TIMESTAMP,
+        "hold_usage_type": pt.STRING, "authorization_id": pt.STRING,
+        "idempotency_scope": pt.STRING, "idempotency_fingerprint": pt.STRING,
+        "expires_at": pt.TIMESTAMP,
     }
     cols = ", ".join(RESERVATION_COLUMNS)
     binds = ", ".join(f"@{c}" for c in RESERVATION_COLUMNS)
@@ -304,3 +306,22 @@ def claim_reservation(
         },
     )
     return count == 1
+
+
+def insert_entity_dml(
+    transaction: Any, param_types: Any, kind: str, entity_id: str, body_json: str
+) -> None:
+    """DML INSERT of a tr_entities JSON row (e.g. gateway_authorization), so it
+    composes into the DML-only authorize transaction instead of a mutation.
+    PENDING_COMMIT_TIMESTAMP() is the last touch of the row; raises ALREADY_EXISTS
+    on a duplicate (kind,id)."""
+    transaction.execute_update(
+        "INSERT INTO tr_entities (kind, id, body, updated_at) "
+        "VALUES (@kind, @id, @body, PENDING_COMMIT_TIMESTAMP())",
+        params={"kind": kind, "id": entity_id, "body": body_json},
+        param_types={
+            "kind": param_types.STRING,
+            "id": param_types.STRING,
+            "body": param_types.STRING,
+        },
+    )

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -66,11 +66,15 @@ def release_credit(
     For refund pass actual=0 (releases the hold, books no usage). Returns the
     modified-row count; the caller asserts == 1 (a 0-row release must not be
     silently accepted — it strands the hold and loses the charge).
+
+    The `reserved >= @hold` guard makes a stale/double release a 0-row no-op
+    instead of driving `reserved` negative (which would inflate apparent
+    availability) — row-count 0 trips the caller's assert/alarm.
     """
     sql = (
         "UPDATE tr_credit_balance "
         "SET reserved = reserved - @hold, total_usage = total_usage + @actual "
-        "WHERE workspace_id=@ws AND shard=@shard"
+        "WHERE workspace_id=@ws AND shard=@shard AND reserved >= @hold"
     )
     return transaction.execute_update(
         sql,

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -325,3 +325,37 @@ def insert_entity_dml(
             "body": param_types.STRING,
         },
     )
+
+
+def insert_entity_dml_at(
+    transaction: Any, param_types: Any, kind: str, entity_id: str, body_json: str, now: Any
+) -> None:
+    """DML INSERT a tr_entities row with a client `updated_at` (NOT
+    PENDING_COMMIT_TIMESTAMP), so MULTIPLE tr_entities DML statements can run in
+    one transaction without the PCT same-table trap (codex 3e). Raises
+    ALREADY_EXISTS on duplicate (kind,id)."""
+    transaction.execute_update(
+        "INSERT INTO tr_entities (kind, id, body, updated_at) "
+        "VALUES (@kind, @id, @body, @now)",
+        params={"kind": kind, "id": entity_id, "body": body_json, "now": now},
+        param_types={
+            "kind": param_types.STRING, "id": param_types.STRING,
+            "body": param_types.STRING, "now": param_types.TIMESTAMP,
+        },
+    )
+
+
+def update_entity_body_dml(
+    transaction: Any, param_types: Any, kind: str, entity_id: str, body_json: str, now: Any
+) -> int:
+    """DML UPDATE a tr_entities row's body (e.g. mark gateway_authorization
+    settled) with a client `updated_at`. Returns the modified-row count."""
+    return transaction.execute_update(
+        "UPDATE tr_entities SET body=@body, updated_at=@now "
+        "WHERE kind=@kind AND id=@id",
+        params={"kind": kind, "id": entity_id, "body": body_json, "now": now},
+        param_types={
+            "kind": param_types.STRING, "id": param_types.STRING,
+            "body": param_types.STRING, "now": param_types.TIMESTAMP,
+        },
+    )

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -26,6 +26,12 @@ from typing import Any
 
 from trusted_router.storage_gcp_counters import UNSHARDED
 
+# reserve_key outcomes (the per-key spend-cap counterpart of reserve_credit).
+KEY_ACCEPTED = "accepted"  # hold taken (row-count 1)
+KEY_NO_HOLD = "no_hold"  # uncapped key, or BYOK excluded from the cap: proceed
+KEY_INSUFFICIENT = "insufficient"  # capped and over the cap -> 402
+KEY_MISSING = "missing"  # typed row absent -> fail closed (drift / not backfilled)
+
 
 def reserve_credit(
     transaction: Any, param_types: Any, workspace_id: str, amount: int, *, shard: int = UNSHARDED
@@ -83,6 +89,103 @@ def release_credit(
             "hold": param_types.INT64,
             "actual": param_types.INT64,
             "ws": param_types.STRING,
+            "shard": param_types.INT64,
+        },
+    )
+
+
+def reserve_key(
+    transaction: Any,
+    param_types: Any,
+    key_hash: str,
+    amount: int,
+    *,
+    is_byok: bool,
+    shard: int = UNSHARDED,
+) -> str:
+    """Atomically reserve `amount` against the per-key spend cap.
+
+    Single conditional UPDATE: it matches (and holds) only a capped key whose
+    available headroom covers `amount`, AND only when the cap applies to this
+    usage type (BYOK is skipped when the key excludes BYOK). On row-count 0 we
+    classify with a point-read IN THE SAME TRANSACTION (codex#2 #3) so the 0 is
+    not ambiguous: missing row vs uncapped vs BYOK-excluded vs truly insufficient.
+
+    Returns one of KEY_ACCEPTED / KEY_NO_HOLD / KEY_INSUFFICIENT / KEY_MISSING.
+    """
+    sql = (
+        "UPDATE tr_key_limit SET reserved = reserved + @est "
+        "WHERE key_hash=@kh AND shard=@shard AND limit_micro IS NOT NULL "
+        "AND (@is_byok = FALSE OR include_byok = TRUE) "
+        "AND (limit_micro - usage - IF(include_byok, byok_usage, 0) - reserved) >= @est"
+    )
+    count = transaction.execute_update(
+        sql,
+        params={"est": int(amount), "kh": key_hash, "shard": shard, "is_byok": bool(is_byok)},
+        param_types={
+            "est": param_types.INT64,
+            "kh": param_types.STRING,
+            "shard": param_types.INT64,
+            "is_byok": param_types.BOOL,
+        },
+    )
+    if count == 1:
+        return KEY_ACCEPTED
+    rows = list(
+        transaction.execute_sql(
+            "SELECT limit_micro, include_byok FROM tr_key_limit "
+            "WHERE key_hash=@kh AND shard=@shard",
+            params={"kh": key_hash, "shard": shard},
+            param_types={"kh": param_types.STRING, "shard": param_types.INT64},
+        )
+    )
+    if not rows:
+        return KEY_MISSING
+    limit_micro, include_byok = rows[0][0], rows[0][1]
+    if limit_micro is None:
+        return KEY_NO_HOLD  # uncapped
+    if is_byok and not include_byok:
+        return KEY_NO_HOLD  # BYOK excluded from this key's cap
+    return KEY_INSUFFICIENT  # capped and over the cap
+
+
+def release_key(
+    transaction: Any,
+    param_types: Any,
+    key_hash: str,
+    hold: int,
+    actual: int,
+    *,
+    book_to_byok: bool,
+    shard: int = UNSHARDED,
+) -> int:
+    """Release the EXACT recorded key hold and book `actual` to usage/byok_usage.
+
+    `hold` is the exact amount taken at reserve (0 if no hold was taken — uncapped
+    or BYOK-excluded); `book_to_byok` selects the usage column by the SETTLED
+    usage type. Refund = actual 0. The `reserved >= @hold` guard makes a
+    stale/double release a 0-row no-op rather than driving reserved negative.
+    Returns the modified-row count (caller asserts == 1).
+    """
+    if book_to_byok:
+        sql = (
+            "UPDATE tr_key_limit "
+            "SET reserved = reserved - @hold, byok_usage = byok_usage + @actual "
+            "WHERE key_hash=@kh AND shard=@shard AND reserved >= @hold"
+        )
+    else:
+        sql = (
+            "UPDATE tr_key_limit "
+            "SET reserved = reserved - @hold, usage = usage + @actual "
+            "WHERE key_hash=@kh AND shard=@shard AND reserved >= @hold"
+        )
+    return transaction.execute_update(
+        sql,
+        params={"hold": int(hold), "actual": int(actual), "kh": key_hash, "shard": shard},
+        param_types={
+            "hold": param_types.INT64,
+            "actual": param_types.INT64,
+            "kh": param_types.STRING,
             "shard": param_types.INT64,
         },
     )

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -189,3 +189,107 @@ def release_key(
             "shard": param_types.INT64,
         },
     )
+
+
+# ── tr_reservation: durable hold record + scoped idempotency + settle claim ──
+# The reservation row records the EXACT holds taken at authorize (so settle
+# releases exactly those, codex#1 #5), the resolved usage types (hold vs settled,
+# codex#2 #2), and the scoped idempotency key. The atomic authorize INSERTs it;
+# settle/refund CLAIM it (first-writer-wins). All DML so it composes into the
+# DML-only authorize/settle transactions (no mutation mixing).
+
+RESERVATION_COLUMNS = (
+    "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+    "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
+    "idempotency_scope", "idempotency_fingerprint", "expires_at",
+)
+
+
+def read_reservation_by_idempotency(
+    transaction: Any, param_types: Any, idempotency_scope: str
+) -> dict | None:
+    """Point-read the existing reservation for a scoped idempotency key (replay).
+
+    Returns the row (incl. fingerprint + the exact holds) or None. The caller
+    verifies the fingerprint and replays without re-debiting.
+    """
+    rows = list(
+        transaction.execute_sql(
+            "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
+            "hold_usage_type, idempotency_fingerprint, settled "
+            "FROM tr_reservation WHERE idempotency_scope=@scope",
+            params={"scope": idempotency_scope},
+            param_types={"scope": param_types.STRING},
+        )
+    )
+    if not rows:
+        return None
+    r = rows[0]
+    return {
+        "reservation_id": r[0],
+        "credit_reserved_micro": r[1],
+        "key_reserved_micro": r[2],
+        "hold_usage_type": r[3],
+        "idempotency_fingerprint": r[4],
+        "settled": r[5],
+    }
+
+
+def read_reservation(transaction: Any, param_types: Any, reservation_id: str) -> dict | None:
+    """Point-read a reservation by id (for settle/refund and the reaper)."""
+    rows = list(
+        transaction.execute_sql(
+            "SELECT reservation_id, workspace_id, key_hash, ws_shard, key_shard, "
+            "credit_reserved_micro, key_reserved_micro, hold_usage_type, "
+            "settled_usage_type, settled "
+            "FROM tr_reservation WHERE reservation_id=@rid",
+            params={"rid": reservation_id},
+            param_types={"rid": param_types.STRING},
+        )
+    )
+    if not rows:
+        return None
+    r = rows[0]
+    keys = (
+        "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+        "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
+        "settled_usage_type", "settled",
+    )
+    return dict(zip(keys, r, strict=True))
+
+
+def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> None:
+    """INSERT a reservation row. Raises ALREADY_EXISTS (NOT retried) on a scoped
+    idempotency-key conflict — the caller converts that to the replay path."""
+    pt = param_types
+    types = {
+        "reservation_id": pt.STRING, "workspace_id": pt.STRING, "key_hash": pt.STRING,
+        "ws_shard": pt.INT64, "key_shard": pt.INT64,
+        "credit_reserved_micro": pt.INT64, "key_reserved_micro": pt.INT64,
+        "hold_usage_type": pt.STRING, "idempotency_scope": pt.STRING,
+        "idempotency_fingerprint": pt.STRING, "expires_at": pt.TIMESTAMP,
+    }
+    cols = ", ".join(RESERVATION_COLUMNS)
+    binds = ", ".join(f"@{c}" for c in RESERVATION_COLUMNS)
+    transaction.execute_update(
+        f"INSERT INTO tr_reservation ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
+        params={c: fields.get(c) for c in RESERVATION_COLUMNS},
+        param_types={c: types[c] for c in RESERVATION_COLUMNS},
+    )
+
+
+def claim_reservation(
+    transaction: Any, param_types: Any, reservation_id: str, *, settled_usage_type: str
+) -> bool:
+    """Claim a reservation for settle/refund: first caller wins.
+
+    True = this caller won the claim (row-count 1, settled flipped false->true);
+    False = already settled (row-count 0, a replay) -> do NOT touch counters.
+    """
+    count = transaction.execute_update(
+        "UPDATE tr_reservation SET settled=true, settled_usage_type=@sut "
+        "WHERE reservation_id=@rid AND settled=false",
+        params={"rid": reservation_id, "sut": settled_usage_type},
+        param_types={"rid": param_types.STRING, "sut": param_types.STRING},
+    )
+    return count == 1

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -241,7 +241,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
         transaction.execute_sql(
             "SELECT reservation_id, workspace_id, key_hash, ws_shard, key_shard, "
             "credit_reserved_micro, key_reserved_micro, hold_usage_type, "
-            "settled_usage_type, settled "
+            "settled_usage_type, actual_micro, settled "
             "FROM tr_reservation WHERE reservation_id=@rid",
             params={"rid": reservation_id},
             param_types={"rid": param_types.STRING},
@@ -253,7 +253,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
     keys = (
         "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
         "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
-        "settled_usage_type", "settled",
+        "settled_usage_type", "actual_micro", "settled",
     )
     return dict(zip(keys, r, strict=True))
 
@@ -279,17 +279,28 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
 
 
 def claim_reservation(
-    transaction: Any, param_types: Any, reservation_id: str, *, settled_usage_type: str
+    transaction: Any,
+    param_types: Any,
+    reservation_id: str,
+    *,
+    actual_micro: int,
+    settled_usage_type: str,
 ) -> bool:
     """Claim a reservation for settle/refund: first caller wins.
 
     True = this caller won the claim (row-count 1, settled flipped false->true);
     False = already settled (row-count 0, a replay) -> do NOT touch counters.
+    Persists `actual_micro` + `settled_usage_type` so the durable reservation
+    records the exact settled amount for audit / reaper reconciliation.
     """
     count = transaction.execute_update(
-        "UPDATE tr_reservation SET settled=true, settled_usage_type=@sut "
-        "WHERE reservation_id=@rid AND settled=false",
-        params={"rid": reservation_id, "sut": settled_usage_type},
-        param_types={"rid": param_types.STRING, "sut": param_types.STRING},
+        "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "
+        "settled_usage_type=@sut WHERE reservation_id=@rid AND settled=false",
+        params={"rid": reservation_id, "actual": int(actual_micro), "sut": settled_usage_type},
+        param_types={
+            "rid": param_types.STRING,
+            "actual": param_types.INT64,
+            "sut": param_types.STRING,
+        },
     )
     return count == 1

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -242,7 +242,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
         transaction.execute_sql(
             "SELECT reservation_id, workspace_id, key_hash, ws_shard, key_shard, "
             "credit_reserved_micro, key_reserved_micro, hold_usage_type, "
-            "settled_usage_type, actual_micro, settled "
+            "settled_usage_type, actual_micro, authorization_id, settled "
             "FROM tr_reservation WHERE reservation_id=@rid",
             params={"rid": reservation_id},
             param_types={"rid": param_types.STRING},
@@ -254,7 +254,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
     keys = (
         "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
         "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
-        "settled_usage_type", "actual_micro", "settled",
+        "settled_usage_type", "actual_micro", "authorization_id", "settled",
     )
     return dict(zip(keys, r, strict=True))
 

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -1,0 +1,84 @@
+"""Step 3: conditional-DML enforcement on the typed counter tables.
+
+See docs/design/billing-typed-counters.md.
+
+This is the deadlock fix. Instead of read-modify-write (a shared read lock that
+upgrades to exclusive -> wound-wait deadlock under per-tenant concurrency), each
+reserve is a SINGLE conditional UPDATE that takes the row write lock directly and
+atomically checks-and-decrements:
+
+    UPDATE tr_credit_balance SET reserved = reserved + @est
+     WHERE workspace_id=@ws AND shard=@shard
+       AND (total_credits - total_usage - reserved) >= @est
+
+``execute_update()`` returns the modified-row count: 1 = accepted, 0 = rejected
+(insufficient). Concurrent reservers serialize on the row write lock instead of
+deadlocking; the predicate re-evaluates against committed state.
+
+Standard DML only (NOT partitioned DML); these run inside ``run_in_transaction``
+so ABORTED is retried. They must NOT be mixed with Spanner mutations in the same
+transaction (docs §5) — the authorize/settle transactions are DML-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.storage_gcp_counters import UNSHARDED
+
+
+def reserve_credit(
+    transaction: Any, param_types: Any, workspace_id: str, amount: int, *, shard: int = UNSHARDED
+) -> bool:
+    """Atomically reserve `amount` against the workspace credit balance.
+
+    True = accepted (row-count 1); False = insufficient credits (row-count 0).
+    """
+    # Static table name (literal, not interpolated) + bound params only.
+    sql = (
+        "UPDATE tr_credit_balance SET reserved = reserved + @est "
+        "WHERE workspace_id=@ws AND shard=@shard "
+        "AND (total_credits - total_usage - reserved) >= @est"
+    )
+    count = transaction.execute_update(
+        sql,
+        params={"est": int(amount), "ws": workspace_id, "shard": shard},
+        param_types={
+            "est": param_types.INT64,
+            "ws": param_types.STRING,
+            "shard": param_types.INT64,
+        },
+    )
+    return count == 1
+
+
+def release_credit(
+    transaction: Any,
+    param_types: Any,
+    workspace_id: str,
+    hold: int,
+    actual: int,
+    *,
+    shard: int = UNSHARDED,
+) -> int:
+    """Release the EXACT recorded credit hold and book `actual` usage.
+
+    For refund pass actual=0 (releases the hold, books no usage). Returns the
+    modified-row count; the caller asserts == 1 (a 0-row release must not be
+    silently accepted — it strands the hold and loses the charge).
+    """
+    sql = (
+        "UPDATE tr_credit_balance "
+        "SET reserved = reserved - @hold, total_usage = total_usage + @actual "
+        "WHERE workspace_id=@ws AND shard=@shard"
+    )
+    return transaction.execute_update(
+        sql,
+        params={"hold": int(hold), "actual": int(actual), "ws": workspace_id, "shard": shard},
+        param_types={
+            "hold": param_types.INT64,
+            "actual": param_types.INT64,
+            "ws": param_types.STRING,
+            "shard": param_types.INT64,
+        },
+    )

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -9,6 +9,7 @@ from typing import Any
 class _ParamTypes:
     STRING = "STRING"
     INT64 = "INT64"
+    BOOL = "BOOL"
 
 
 @dataclass
@@ -195,6 +196,30 @@ class _FakeTransaction:
             )
             self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
             return 1
+        if "UPDATE tr_key_limit SET reserved = reserved + @est" in sql:
+            pk = (p["kh"], p["shard"])
+            rec = self._typed_current("tr_key_limit", pk)
+            if rec is None or rec["limit_micro"] is None:
+                return 0  # missing or uncapped (limit_micro IS NOT NULL fails)
+            if p["is_byok"] and not rec["include_byok"]:
+                return 0  # BYOK excluded from the cap
+            included_byok = rec["byok_usage"] if rec["include_byok"] else 0
+            avail = rec["limit_micro"] - rec["usage"] - included_byok - rec["reserved"]
+            if avail >= p["est"]:
+                new = dict(rec, reserved=rec["reserved"] + p["est"])
+                self.pending_writes.append(("update_typed", "tr_key_limit", pk, new))
+                return 1
+            return 0
+        if "UPDATE tr_key_limit " in sql and "reserved = reserved - @hold" in sql:
+            pk = (p["kh"], p["shard"])
+            rec = self._typed_current("tr_key_limit", pk)
+            if rec is None or rec["reserved"] < p["hold"]:
+                return 0
+            col = "byok_usage" if "byok_usage = byok_usage + @actual" in sql else "usage"
+            new = dict(rec, reserved=rec["reserved"] - p["hold"])
+            new[col] = rec[col] + p["actual"]
+            self.pending_writes.append(("update_typed", "tr_key_limit", pk, new))
+            return 1
         raise NotImplementedError(sql)
 
     def insert_or_update(
@@ -308,6 +333,19 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # Typed key-limit point-read (reserve_key 0-row classification). Honors the
+    # WHERE, so it must precede the full-scan branch below.
+    if "FROM tr_key_limit WHERE key_hash=@kh" in sql:
+        pk = (params["kh"], params["shard"])
+        rec = (
+            txn._typed_current("tr_key_limit", pk)
+            if txn is not None
+            else db.typed.get("tr_key_limit", {}).get(pk)
+        )
+        if rec is None:
+            return []
+        cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+        return [[rec.get(c) for c in cols]]
     # Typed counter tables (Step 2 reconcile scans): SELECT <cols> FROM <table>.
     for typed_table in ("tr_credit_balance", "tr_key_limit"):
         if f"FROM {typed_table}" in sql:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -10,6 +10,7 @@ class _ParamTypes:
     STRING = "STRING"
     INT64 = "INT64"
     BOOL = "BOOL"
+    TIMESTAMP = "TIMESTAMP"
 
 
 @dataclass
@@ -35,6 +36,12 @@ class FakeAborted(Exception):
     pass
 
 
+class FakeAlreadyExists(Exception):
+    """Unique-index violation (e.g. duplicate idempotency_scope). Unlike Aborted,
+    run_in_transaction does NOT retry this — the caller must convert it to the
+    replay path (codex Step-3 #4)."""
+
+
 class FakeSpannerDatabase:
     """In-process Spanner replacement that simulates snapshot-isolation
     conflict-abort. Implements only the surface used by SpannerBigtableStore:
@@ -54,6 +61,11 @@ class FakeSpannerDatabase:
         # concurrent execute_update reservers serialize via abort-retry (the fake
         # analogue of the real row write lock).
         self.typed_versions: dict[tuple, int] = {}
+        # tr_reservation: 1-col PK (reservation_id) + a UNIQUE index on
+        # idempotency_scope. Modeled separately from the 2-col typed counters.
+        self.reservations: dict[str, dict] = {}
+        self.reservation_versions: dict[str, int] = {}
+        self.reservation_idemp: dict[str, str] = {}  # idempotency_scope -> reservation_id
         self._global_version = 0
         self._commit_lock = threading.Lock()
         self._ready_barrier = ready_barrier
@@ -84,6 +96,12 @@ class FakeSpannerDatabase:
             for key, observed in txn.read_versions.items():
                 if isinstance(key, tuple) and len(key) == 3 and key[0] == "typed":
                     current_version = self.typed_versions.get((key[1], key[2]), 0)
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "res":
+                    current_version = self.reservation_versions.get(key[1], 0)
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "idemp":
+                    # presence-based: a same-scope insert committed since our read
+                    # flips this, aborting the loser so its retry raises ALREADY_EXISTS
+                    current_version = 1 if key[1] in self.reservation_idemp else 0
                 else:
                     current = self.rows.get(key)
                     current_version = current.version if current is not None else 0
@@ -113,6 +131,18 @@ class FakeSpannerDatabase:
                     _, table, pk = op
                     self.typed.get(table, {}).pop(pk, None)
                     self.typed_versions.pop((table, pk), None)
+                elif op[0] == "insert_reservation":
+                    _, record = op
+                    rid = record["reservation_id"]
+                    self.reservations[rid] = record
+                    self.reservation_versions[rid] = new_version
+                    scope = record.get("idempotency_scope")
+                    if scope is not None:
+                        self.reservation_idemp[scope] = rid
+                elif op[0] == "update_reservation":
+                    _, rid, record = op
+                    self.reservations[rid] = record
+                    self.reservation_versions[rid] = new_version
             return True
 
     def snapshot(self, **_kwargs: Any) -> _FakeSnapshot:
@@ -142,6 +172,19 @@ class _FakeTransaction:
         param_types: Any = None,
     ) -> list[list[str]]:
         return _execute_sql(self.db, self, sql, params or {})
+
+    def _reservation_current(self, rid: str) -> dict | None:
+        """In-txn view of a reservation (read-your-writes) + record read version."""
+        for op in reversed(self.pending_writes):
+            if op[0] == "update_reservation" and op[1] == rid:
+                return dict(op[2])
+            if op[0] == "insert_reservation" and op[1]["reservation_id"] == rid:
+                return dict(op[1])
+        version_key = ("res", rid)
+        if version_key not in self.read_versions:
+            self.read_versions[version_key] = self.db.reservation_versions.get(rid, 0)
+        rec = self.db.reservations.get(rid)
+        return dict(rec) if rec is not None else None
 
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
         """In-txn view of a typed row for DML: sees prior DML writes
@@ -219,6 +262,27 @@ class _FakeTransaction:
             new = dict(rec, reserved=rec["reserved"] - p["hold"])
             new[col] = rec[col] + p["actual"]
             self.pending_writes.append(("update_typed", "tr_key_limit", pk, new))
+            return 1
+        if sql.startswith("INSERT INTO tr_reservation"):
+            scope = p.get("idempotency_scope")
+            if scope is not None:
+                if scope in self.db.reservation_idemp:
+                    raise FakeAlreadyExists(scope)  # unique-index conflict (committed)
+                idemp_key = ("idemp", scope)
+                if idemp_key not in self.read_versions:
+                    self.read_versions[idemp_key] = 0  # observed absent
+            record = dict(p)
+            record["settled"] = False
+            record["settled_usage_type"] = None
+            record["actual_micro"] = None
+            self.pending_writes.append(("insert_reservation", record))
+            return 1
+        if "UPDATE tr_reservation SET settled=true" in sql:
+            rec = self._reservation_current(p["rid"])
+            if rec is None or rec["settled"]:
+                return 0  # missing or already-claimed (replay)
+            new = dict(rec, settled=True, settled_usage_type=p["sut"])
+            self.pending_writes.append(("update_reservation", p["rid"], new))
             return 1
         raise NotImplementedError(sql)
 
@@ -333,6 +397,36 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # tr_reservation reads (idempotency replay + by-id for settle/reaper).
+    if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
+        scope = params["scope"]
+        rid = None
+        if txn is not None:
+            for op in reversed(txn.pending_writes):
+                if op[0] == "insert_reservation" and op[1].get("idempotency_scope") == scope:
+                    rid = op[1]["reservation_id"]
+                    break
+            if rid is None:
+                rid = db.reservation_idemp.get(scope)
+            idemp_key = ("idemp", scope)
+            if idemp_key not in txn.read_versions:
+                txn.read_versions[idemp_key] = 1 if scope in db.reservation_idemp else 0
+        else:
+            rid = db.reservation_idemp.get(scope)
+        if rid is None:
+            return []
+        rec = txn._reservation_current(rid) if txn is not None else db.reservations.get(rid)
+        if rec is None:
+            return []
+        cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+        return [[rec.get(c) for c in cols]]
+    if "FROM tr_reservation WHERE reservation_id=@rid" in sql:
+        rid = params["rid"]
+        rec = txn._reservation_current(rid) if txn is not None else db.reservations.get(rid)
+        if rec is None:
+            return []
+        cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+        return [[rec.get(c) for c in cols]]
     # Typed key-limit point-read (reserve_key 0-row classification). Honors the
     # WHERE, so it must precede the full-scan branch below.
     if "FROM tr_key_limit WHERE key_hash=@kh" in sql:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -49,6 +49,10 @@ class FakeSpannerDatabase:
         # Typed counter tables (tr_credit_balance, tr_key_limit): table ->
         # (pk col0, pk col1) -> {column: value}. PK is the first two columns.
         self.typed: dict[str, dict[tuple, dict]] = {}
+        # Per typed-row version for conditional-DML conflict detection, so two
+        # concurrent execute_update reservers serialize via abort-retry (the fake
+        # analogue of the real row write lock).
+        self.typed_versions: dict[tuple, int] = {}
         self._global_version = 0
         self._commit_lock = threading.Lock()
         self._ready_barrier = ready_barrier
@@ -77,8 +81,11 @@ class FakeSpannerDatabase:
     def _try_commit(self, txn: _FakeTransaction) -> bool:
         with self._commit_lock:
             for key, observed in txn.read_versions.items():
-                current = self.rows.get(key)
-                current_version = current.version if current is not None else 0
+                if isinstance(key, tuple) and len(key) == 3 and key[0] == "typed":
+                    current_version = self.typed_versions.get((key[1], key[2]), 0)
+                else:
+                    current = self.rows.get(key)
+                    current_version = current.version if current is not None else 0
                 if current_version != observed:
                     return False
             self._global_version += 1
@@ -92,12 +99,19 @@ class FakeSpannerDatabase:
                     self.rows.pop((kind, entity_id), None)
                 elif op[0] == "upsert_typed":
                     _, table, columns, value_tuple = op
-                    self.typed.setdefault(table, {})[
-                        (value_tuple[0], value_tuple[1])
-                    ] = dict(zip(columns, value_tuple, strict=True))
+                    pk = (value_tuple[0], value_tuple[1])
+                    self.typed.setdefault(table, {})[pk] = dict(
+                        zip(columns, value_tuple, strict=True)
+                    )
+                    self.typed_versions[(table, pk)] = new_version
+                elif op[0] == "update_typed":  # conditional-DML write
+                    _, table, pk, record = op
+                    self.typed.setdefault(table, {})[pk] = record
+                    self.typed_versions[(table, pk)] = new_version
                 elif op[0] == "delete_typed":
                     _, table, pk = op
                     self.typed.get(table, {}).pop(pk, None)
+                    self.typed_versions.pop((table, pk), None)
             return True
 
     def snapshot(self, **_kwargs: Any) -> _FakeSnapshot:
@@ -123,6 +137,55 @@ class _FakeTransaction:
         param_types: Any = None,
     ) -> list[list[str]]:
         return _execute_sql(self.db, self, sql, params or {})
+
+    def _typed_current(self, table: str, pk: tuple) -> dict | None:
+        """In-txn view of a typed row (read-your-writes) + record read version."""
+        for op in reversed(self.pending_writes):
+            if op[0] == "update_typed" and op[1] == table and op[2] == pk:
+                return dict(op[3])
+            if op[0] == "upsert_typed" and op[1] == table and (op[3][0], op[3][1]) == pk:
+                return dict(zip(op[2], op[3], strict=True))
+            if op[0] == "delete_typed" and op[1] == table and op[2] == pk:
+                return None
+        version_key = ("typed", table, pk)
+        if version_key not in self.read_versions:
+            self.read_versions[version_key] = self.db.typed_versions.get((table, pk), 0)
+        rec = self.db.typed.get(table, {}).get(pk)
+        return dict(rec) if rec is not None else None
+
+    def execute_update(
+        self, sql: str, *, params: dict[str, Any] | None = None, param_types: Any = None
+    ) -> int:
+        """Model the conditional-DML statements used by storage_gcp_counter_dml.
+
+        Reads the typed row into the read-set (so concurrent reservers conflict
+        and serialize via abort-retry), evaluates the WHERE predicate, and
+        conditionally buffers the SET. Returns the modified-row count.
+        """
+        p = params or {}
+        if "UPDATE tr_credit_balance SET reserved = reserved + @est" in sql:
+            pk = (p["ws"], p["shard"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            if rec is None:
+                return 0
+            if (rec["total_credits"] - rec["total_usage"] - rec["reserved"]) >= p["est"]:
+                new = dict(rec, reserved=rec["reserved"] + p["est"])
+                self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+                return 1
+            return 0
+        if "UPDATE tr_credit_balance SET reserved = reserved - @hold" in sql:
+            pk = (p["ws"], p["shard"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            if rec is None:
+                return 0
+            new = dict(
+                rec,
+                reserved=rec["reserved"] - p["hold"],
+                total_usage=rec["total_usage"] + p["actual"],
+            )
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
+        raise NotImplementedError(sql)
 
     def insert_or_update(
         self, *, table: str, columns: tuple[str, ...], values: list[tuple]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -157,6 +157,9 @@ class FakeSpannerDatabase:
                 elif op[0] == "insert_entity_dml":  # DML INSERT into tr_entities
                     _, kind, entity_id, body = op
                     self.rows[(kind, entity_id)] = _Row(body=body, version=new_version)
+                elif op[0] == "update_entity_dml":  # DML UPDATE tr_entities body
+                    _, kind, entity_id, body = op
+                    self.rows[(kind, entity_id)] = _Row(body=body, version=new_version)
             return True
 
     def snapshot(self, **_kwargs: Any) -> _FakeSnapshot:
@@ -313,6 +316,23 @@ class _FakeTransaction:
             if entity_key not in self.read_versions:
                 self.read_versions[entity_key] = 0  # observed absent
             self.pending_writes.append(("insert_entity_dml", p["kind"], p["id"], p["body"]))
+            return 1
+        if sql.startswith("UPDATE tr_entities SET body=@body"):
+            entity_key = (p["kind"], p["id"])
+            # read-your-writes within the txn, else committed
+            pending = None
+            for op in reversed(self.pending_writes):
+                if op[0] in ("insert_entity_dml", "update_entity_dml") and (op[1], op[2]) == entity_key:
+                    pending = op
+                    break
+            if pending is None:
+                if entity_key not in self.read_versions:
+                    self.read_versions[entity_key] = (
+                        self.db.rows[entity_key].version if entity_key in self.db.rows else 0
+                    )
+                if entity_key not in self.db.rows:
+                    return 0  # no such row
+            self.pending_writes.append(("update_entity_dml", p["kind"], p["id"], p["body"]))
             return 1
         raise NotImplementedError(sql)
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -427,6 +427,18 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # Reaper scan: expired unsettled reservations.
+    if "FROM tr_reservation WHERE settled=false AND expires_at" in sql:
+        now = params["now"]
+        limit = int(params.get("limit", 100))
+        out: list[list] = []
+        for rid, rec in db.reservations.items():
+            exp = rec.get("expires_at")
+            if not rec.get("settled") and exp is not None and exp < now:
+                out.append([rid])
+                if len(out) >= limit:
+                    break
+        return out
     # tr_reservation reads (idempotency replay + by-id for settle/reaper).
     if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
         scope = params["scope"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -36,10 +36,21 @@ class FakeAborted(Exception):
     pass
 
 
-class FakeAlreadyExists(Exception):
-    """Unique-index violation (e.g. duplicate idempotency_scope). Unlike Aborted,
-    run_in_transaction does NOT retry this — the caller must convert it to the
-    replay path (codex Step-3 #4)."""
+try:  # subclass the real exception so production `except AlreadyExists` catches it
+    from google.api_core.exceptions import AlreadyExists as _AlreadyExists
+except ImportError:  # pragma: no cover - google always present in the test venv
+    _AlreadyExists = Exception  # type: ignore[assignment,misc]
+
+
+class FakeAlreadyExists(_AlreadyExists):
+    """Unique-index / duplicate-PK violation (e.g. duplicate idempotency_scope or
+    reservation_id). Unlike Aborted, run_in_transaction does NOT retry this — the
+    caller must convert it to the replay path (codex Step-3 #4). Subclasses the
+    real google.api_core.exceptions.AlreadyExists so the same `except AlreadyExists`
+    works in prod and tests."""
+
+    def __init__(self, detail: str = "already exists") -> None:
+        super().__init__(detail)
 
 
 class FakeSpannerDatabase:
@@ -264,6 +275,12 @@ class _FakeTransaction:
             self.pending_writes.append(("update_typed", "tr_key_limit", pk, new))
             return 1
         if sql.startswith("INSERT INTO tr_reservation"):
+            rid = p["reservation_id"]
+            if rid in self.db.reservations:
+                raise FakeAlreadyExists(rid)  # duplicate PK
+            res_key = ("res", rid)
+            if res_key not in self.read_versions:
+                self.read_versions[res_key] = self.db.reservation_versions.get(rid, 0)
             scope = p.get("idempotency_scope")
             if scope is not None:
                 if scope in self.db.reservation_idemp:
@@ -281,7 +298,9 @@ class _FakeTransaction:
             rec = self._reservation_current(p["rid"])
             if rec is None or rec["settled"]:
                 return 0  # missing or already-claimed (replay)
-            new = dict(rec, settled=True, settled_usage_type=p["sut"])
+            new = dict(
+                rec, settled=True, settled_usage_type=p["sut"], actual_micro=p["actual"]
+            )
             self.pending_writes.append(("update_reservation", p["rid"], new))
             return 1
         raise NotImplementedError(sql)

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -128,6 +128,10 @@ class _FakeTransaction:
         self.read_versions: dict[tuple[str, str], int] = {}
         self.read_snapshots: dict[tuple[str, str], str | None] = {}
         self.pending_writes: list[tuple] = []
+        # DML+mutation mixing is forbidden in one transaction (real Spanner
+        # buffers mutations after DML and DML can't see them); fail fast if both.
+        self._did_mutation = False
+        self._did_dml = False
 
     def execute_sql(
         self,
@@ -139,14 +143,13 @@ class _FakeTransaction:
         return _execute_sql(self.db, self, sql, params or {})
 
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
-        """In-txn view of a typed row (read-your-writes) + record read version."""
+        """In-txn view of a typed row for DML: sees prior DML writes
+        (update_typed = read-your-writes) but NOT buffered mutations (real Spanner
+        DML can't see mutations; mixing is rejected in execute_update). Records
+        the read version on first read for conflict detection."""
         for op in reversed(self.pending_writes):
             if op[0] == "update_typed" and op[1] == table and op[2] == pk:
                 return dict(op[3])
-            if op[0] == "upsert_typed" and op[1] == table and (op[3][0], op[3][1]) == pk:
-                return dict(zip(op[2], op[3], strict=True))
-            if op[0] == "delete_typed" and op[1] == table and op[2] == pk:
-                return None
         version_key = ("typed", table, pk)
         if version_key not in self.read_versions:
             self.read_versions[version_key] = self.db.typed_versions.get((table, pk), 0)
@@ -162,6 +165,12 @@ class _FakeTransaction:
         and serialize via abort-retry), evaluates the WHERE predicate, and
         conditionally buffers the SET. Returns the modified-row count.
         """
+        if self._did_mutation:
+            raise RuntimeError(
+                "DML after a mutation in the same transaction — DML+mutation "
+                "mixing is forbidden (see docs §5)"
+            )
+        self._did_dml = True
         p = params or {}
         if "UPDATE tr_credit_balance SET reserved = reserved + @est" in sql:
             pk = (p["ws"], p["shard"])
@@ -176,7 +185,8 @@ class _FakeTransaction:
         if "UPDATE tr_credit_balance SET reserved = reserved - @hold" in sql:
             pk = (p["ws"], p["shard"])
             rec = self._typed_current("tr_credit_balance", pk)
-            if rec is None:
+            # mirrors the `AND reserved >= @hold` guard: underflow = 0-row no-op
+            if rec is None or rec["reserved"] < p["hold"]:
                 return 0
             new = dict(
                 rec,
@@ -190,6 +200,12 @@ class _FakeTransaction:
     def insert_or_update(
         self, *, table: str, columns: tuple[str, ...], values: list[tuple]
     ) -> None:
+        if self._did_dml:
+            raise RuntimeError(
+                "mutation after DML in the same transaction — DML+mutation "
+                "mixing is forbidden (see docs §5)"
+            )
+        self._did_mutation = True
         for value_tuple in values:
             if table == "tr_entities":
                 kind, entity_id, body = value_tuple[0], value_tuple[1], value_tuple[2]
@@ -198,6 +214,12 @@ class _FakeTransaction:
                 self.pending_writes.append(("upsert_typed", table, columns, value_tuple))
 
     def delete(self, table: str, keyset: _KeySet) -> None:
+        if self._did_dml:
+            raise RuntimeError(
+                "mutation after DML in the same transaction — DML+mutation "
+                "mixing is forbidden (see docs §5)"
+            )
+        self._did_mutation = True
         for entry in keyset.keys:
             if table == "tr_entities":
                 kind, entity_id = entry[0], entry[1]
@@ -249,12 +271,15 @@ class _FakeBatch:
                     self.db.rows.pop((kind, entity_id), None)
                 elif op[0] == "upsert_typed":
                     _, table, columns, value_tuple = op
-                    self.db.typed.setdefault(table, {})[
-                        (value_tuple[0], value_tuple[1])
-                    ] = dict(zip(columns, value_tuple, strict=True))
+                    pk = (value_tuple[0], value_tuple[1])
+                    self.db.typed.setdefault(table, {})[pk] = dict(
+                        zip(columns, value_tuple, strict=True)
+                    )
+                    self.db.typed_versions[(table, pk)] = new_version
                 elif op[0] == "delete_typed":
                     _, table, pk = op
                     self.db.typed.get(table, {}).pop(pk, None)
+                    self.db.typed_versions.pop((table, pk), None)
         return None
 
     def insert_or_update(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -154,6 +154,9 @@ class FakeSpannerDatabase:
                     _, rid, record = op
                     self.reservations[rid] = record
                     self.reservation_versions[rid] = new_version
+                elif op[0] == "insert_entity_dml":  # DML INSERT into tr_entities
+                    _, kind, entity_id, body = op
+                    self.rows[(kind, entity_id)] = _Row(body=body, version=new_version)
             return True
 
     def snapshot(self, **_kwargs: Any) -> _FakeSnapshot:
@@ -302,6 +305,14 @@ class _FakeTransaction:
                 rec, settled=True, settled_usage_type=p["sut"], actual_micro=p["actual"]
             )
             self.pending_writes.append(("update_reservation", p["rid"], new))
+            return 1
+        if sql.startswith("INSERT INTO tr_entities"):
+            entity_key = (p["kind"], p["id"])
+            if entity_key in self.db.rows:
+                raise FakeAlreadyExists(f"{p['kind']}/{p['id']}")  # duplicate PK
+            if entity_key not in self.read_versions:
+                self.read_versions[entity_key] = 0  # observed absent
+            self.pending_writes.append(("insert_entity_dml", p["kind"], p["id"], p["body"]))
             return 1
         raise NotImplementedError(sql)
 

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -1,0 +1,129 @@
+"""Step 3 of the billing typed-column migration: conditional-DML enforcement.
+
+These tests drive the conditional-DML reserve/release primitives against the
+in-process Spanner fake, which models per-typed-row versioning so concurrent
+``execute_update`` reservers serialize via conflict-abort (the fake analogue of
+the real row write lock). The headline test proves the deadlock-fix property:
+concurrent reservers on one hot workspace never overspend and resolve via
+retry — no shared-read->exclusive-upgrade deadlock.
+
+See docs/design/billing-typed-counters.md.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount
+from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+
+def _seed_credit(store, ws: str, total: int) -> None:
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=total)
+    )
+
+
+def _typed(db, ws: str) -> dict:
+    return db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]
+
+
+def _run_workers(workers: list[threading.Thread], barrier: threading.Barrier) -> None:
+    for t in workers:
+        t.start()
+    try:
+        barrier.wait(timeout=10)
+    except threading.BrokenBarrierError:
+        pass
+    for t in workers:
+        t.join(timeout=10)
+    assert all(not t.is_alive() for t in workers), "worker hang"
+
+
+def test_conditional_reserve_accepts_until_exhausted() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_seq"
+    _seed_credit(store, ws, 1_000_000)
+    pt = store._param_types
+
+    def reserve(amount: int) -> bool:
+        return store._database.run_in_transaction(
+            lambda t: reserve_credit(t, pt, ws, amount)
+        )
+
+    assert reserve(600_000) is True
+    assert reserve(300_000) is True
+    assert reserve(200_000) is False  # only 100k left
+    assert reserve(100_000) is True
+    assert _typed(db, ws)["reserved"] == 1_000_000
+
+
+def test_conditional_reserve_no_overspend_under_concurrency() -> None:
+    """The deadlock fix: N concurrent reservers on ONE hot workspace accept
+    exactly floor(available/amount), never overspend, and resolve via
+    conflict-retry (no deadlock)."""
+    ws = "ws_hot"
+    n = 8
+    amount = 250_000  # 4 of 8 fit in 1_000_000
+    barrier = threading.Barrier(n + 1)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 1_000_000)
+    pt = store._param_types
+
+    results: list[bool] = []
+    lock = threading.Lock()
+
+    def reserve_once() -> None:
+        ok = store._database.run_in_transaction(
+            lambda t: reserve_credit(t, pt, ws, amount)
+        )
+        with lock:
+            results.append(ok)
+
+    _run_workers(
+        [threading.Thread(target=reserve_once, daemon=True) for _ in range(n)], barrier
+    )
+
+    assert results.count(True) == 4, results
+    assert results.count(False) == 4, results
+    typed = _typed(db, ws)
+    assert typed["reserved"] == 1_000_000  # exactly the balance, never more
+    # Resolved by conflict-retry (the serialization), not deadlock.
+    assert db.aborts >= n - 1, f"expected contention retries, got {db.aborts}"
+
+
+def test_conditional_reserve_rejects_when_insufficient() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_poor"
+    _seed_credit(store, ws, 100_000)
+    pt = store._param_types
+    ok = store._database.run_in_transaction(
+        lambda t: reserve_credit(t, pt, ws, 250_000)
+    )
+    assert ok is False
+
+
+def test_release_credit_settles_and_refunds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_rel"
+    _seed_credit(store, ws, 1_000_000)
+    pt = store._param_types
+    assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 500_000))
+
+    # settle: release the 500k hold, book 480k actual
+    count = store._database.run_in_transaction(
+        lambda t: release_credit(t, pt, ws, 500_000, 480_000)
+    )
+    assert count == 1
+    typed = _typed(db, ws)
+    assert typed["reserved"] == 0
+    assert typed["total_usage"] == 480_000
+
+    # a second hold, then refund (actual=0): release hold, book nothing
+    assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 200_000))
+    store._database.run_in_transaction(lambda t: release_credit(t, pt, ws, 200_000, 0))
+    typed = _typed(db, ws)
+    assert typed["reserved"] == 0
+    assert typed["total_usage"] == 480_000  # unchanged by the refund

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -165,3 +165,102 @@ def test_dml_after_mutation_is_rejected() -> None:
 
     with pytest.raises(RuntimeError, match="DML.*mutation"):
         store._database.run_in_transaction(mix)
+
+
+# ── key-limit conditional DML (the second hot row) ──────────────────────────
+
+from trusted_router.storage_gcp_counter_dml import (  # noqa: E402
+    KEY_ACCEPTED,
+    KEY_INSUFFICIENT,
+    KEY_MISSING,
+    KEY_NO_HOLD,
+    release_key,
+    reserve_key,
+)
+from trusted_router.storage_gcp_counters import KEY_LIMIT_TABLE  # noqa: E402
+
+
+def _make_key(store, ws: str, *, limit, include_byok=True):
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None,
+        limit_microdollars=limit, include_byok_in_limit=include_byok,
+    )
+    return key
+
+
+def test_reserve_key_capped_no_overcap_under_concurrency() -> None:
+    ws = "ws_keyhot"
+    n = 8
+    amount = 250_000  # 4 of 8 fit in a 1_000_000 cap
+    barrier = threading.Barrier(n + 1)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    key = _make_key(store, ws, limit=1_000_000)
+    pt = store._param_types
+
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def reserve_once() -> None:
+        r = store._database.run_in_transaction(
+            lambda t: reserve_key(t, pt, key.hash, amount, is_byok=False)
+        )
+        with lock:
+            results.append(r)
+
+    _run_workers(
+        [threading.Thread(target=reserve_once, daemon=True) for _ in range(n)], barrier
+    )
+    assert results.count(KEY_ACCEPTED) == 4, results
+    assert results.count(KEY_INSUFFICIENT) == 4, results
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 1_000_000
+
+
+def test_reserve_key_uncapped_is_no_hold() -> None:
+    store, _db, _ = make_fake_store()
+    key = _make_key(store, "ws_unc", limit=None)
+    pt = store._param_types
+    r = store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 999_999, is_byok=False)
+    )
+    assert r == KEY_NO_HOLD
+
+
+def test_reserve_key_byok_excluded_is_no_hold() -> None:
+    store, db, _ = make_fake_store()
+    key = _make_key(store, "ws_byok", limit=1_000_000, include_byok=False)
+    pt = store._param_types
+    r = store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 100_000, is_byok=True)
+    )
+    assert r == KEY_NO_HOLD
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0  # no hold taken
+
+
+def test_reserve_key_insufficient_and_missing() -> None:
+    store, _db, _ = make_fake_store()
+    key = _make_key(store, "ws_ins", limit=100_000)
+    pt = store._param_types
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 250_000, is_byok=False)
+    ) == KEY_INSUFFICIENT
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, "nonexistent_key", 1, is_byok=False)
+    ) == KEY_MISSING
+
+
+def test_release_key_settles_usage_and_byok() -> None:
+    store, db, _ = make_fake_store()
+    key = _make_key(store, "ws_krel", limit=2_000_000)
+    pt = store._param_types
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 500_000, is_byok=False)
+    ) == KEY_ACCEPTED
+    # settle as Credits usage
+    count = store._database.run_in_transaction(
+        lambda t: release_key(t, pt, key.hash, 500_000, 480_000, book_to_byok=False)
+    )
+    assert count == 1
+    row = db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    assert row["reserved"] == 0
+    assert row["usage"] == 480_000
+    assert row["byok_usage"] == 0

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -890,3 +890,62 @@ def test_typed_finalize_race_books_once() -> None:
     _run_workers([threading.Thread(target=go, daemon=True) for _ in range(6)], barrier)
     assert outcomes.count(SettleOutcome.SETTLED) == 1, outcomes
     assert _typed(db, ws)["total_usage"] == 900_000  # charged exactly once
+
+
+# ── 3e-2: cohort gate + store wrappers + origin detection ───────────────────
+
+from trusted_router.storage_gcp_authorize import typed_billing_enabled_for_workspace  # noqa: E402
+
+
+def test_cohort_gate_allowlist_denylist_wildcard() -> None:
+    f = typed_billing_enabled_for_workspace
+    assert f("ws1", allowlist_csv="ws1,ws2", denylist_csv="") is True
+    assert f("ws3", allowlist_csv="ws1,ws2", denylist_csv="") is False
+    assert f("ws9", allowlist_csv="*", denylist_csv="") is True
+    assert f("ws1", allowlist_csv="*", denylist_csv="ws1") is False  # denylist wins
+    assert f("ws1", allowlist_csv="", denylist_csv="") is False  # default off
+
+
+def test_store_authorize_wrapper_and_origin_detection() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_wrap"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    res = store.authorize_gateway_atomic(
+        workspace_id=ws, key_hash=key.hash, estimate=1_000_000,
+        has_credit_candidate=True, reservation_usage_type="Credits",
+        idempotency_scope=None, idempotency_fingerprint=None,
+        expires_at="2026-01-01T00:00:00Z", build_auth_body=_auth_body,
+    )
+    assert res["outcome"] == AuthorizeOutcome.ACCEPTED
+    rid, aid = res["reservation_id"], res["authorization_id"]
+    # origin detection: this reservation is typed and matches its authorization
+    assert store.is_typed_reservation(rid, aid) is True
+    # a JSON-origin (no tr_reservation) or mismatched auth is not typed
+    assert store.is_typed_reservation(rid, "gwa-someone-else") is False
+    assert store.is_typed_reservation("json-reservation-id", aid) is False
+    assert store.is_typed_reservation(None, aid) is False
+
+
+def test_store_typed_finalize_wrapper_and_reaper_wrapper() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_wrap2"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    res = store.authorize_gateway_atomic(
+        workspace_id=ws, key_hash=key.hash, estimate=1_000_000,
+        has_credit_candidate=True, reservation_usage_type="Credits",
+        idempotency_scope=None, idempotency_fingerprint=None,
+        expires_at="2026-01-01T00:00:00Z", build_auth_body=_auth_body,
+    )
+    rid, aid = res["reservation_id"], res["authorization_id"]
+    out = store.typed_finalize_gateway(
+        reservation_id=rid, authorization_id=aid, success=True, actual_micro=900_000,
+        settled_usage_type="Credits", now=_TS,
+        auth_body_settled=_json.dumps({"id": aid, "settled": True}),
+        generation_writes=[("generation", f"g-{rid}", "{}")],
+    )
+    assert out["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["total_usage"] == 900_000
+    # reaper wrapper: nothing expired+unsettled now
+    assert store.reap_expired_reservations(now=_NOW) == 0

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -580,3 +580,104 @@ def test_authorize_atomic_concurrent_same_scope_one_debit() -> None:
     assert outcomes.count(AuthorizeOutcome.REPLAY) == 1, outcomes
     assert len(db.reservations) == 1  # exactly one reservation
     assert _typed(db, ws)["reserved"] == 1_000_000  # one debit
+
+
+# ── 3c: claim-gated settle ──────────────────────────────────────────────────
+
+from trusted_router.storage_gcp_authorize import SettleOutcome, settle_atomic  # noqa: E402
+
+
+def _settle(store, *, rid, actual, settled_ut="Credits", success=True):
+    return settle_atomic(
+        store._database, store._param_types,
+        reservation_id=rid, actual_micro=actual,
+        settled_usage_type=settled_ut, success=success,
+    )
+
+
+def test_settle_end_to_end_books_actual_on_both() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_e2e"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    assert auth["outcome"] == AuthorizeOutcome.ACCEPTED
+
+    res = _settle(store, rid=auth["reservation_id"], actual=900_000)
+    assert res["outcome"] == SettleOutcome.SETTLED
+    credit = _typed(db, ws)
+    assert credit["reserved"] == 0
+    assert credit["total_usage"] == 900_000  # available now 4.1M
+    krow = db.typed[_KLT][(key.hash, 0)]
+    assert krow["reserved"] == 0
+    assert krow["usage"] == 900_000
+    assert krow["byok_usage"] == 0
+
+
+def test_settle_refund_releases_without_booking() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_refund"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    res = _settle(store, rid=auth["reservation_id"], actual=0, success=False)
+    assert res["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 0  # refund books nothing
+    assert db.typed[_KLT][(key.hash, 0)]["usage"] == 0
+
+
+def test_settle_replay_does_not_double_apply() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_settle_replay"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    first = _settle(store, rid=auth["reservation_id"], actual=900_000)
+    second = _settle(store, rid=auth["reservation_id"], actual=900_000)
+    assert first["outcome"] == SettleOutcome.SETTLED
+    assert second["outcome"] == SettleOutcome.ALREADY_SETTLED
+    assert _typed(db, ws)["total_usage"] == 900_000  # booked exactly once
+
+
+def test_settle_race_settles_once() -> None:
+    ws = "ws_settle_race"
+    barrier = threading.Barrier(7)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid = auth["reservation_id"]
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def go() -> None:
+        r = _settle(store, rid=rid, actual=900_000)
+        with lock:
+            outcomes.append(r["outcome"])
+
+    _run_workers([threading.Thread(target=go, daemon=True) for _ in range(6)], barrier)
+    assert outcomes.count(SettleOutcome.SETTLED) == 1, outcomes
+    assert _typed(db, ws)["total_usage"] == 900_000  # charged exactly once
+    assert _typed(db, ws)["reserved"] == 0
+
+
+def test_settle_byok_books_byok_usage_only() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_settle_byok"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000, include_byok=True)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, has_credit=False)
+    res = _settle(store, rid=auth["reservation_id"], actual=800_000, settled_ut="BYOK")
+    assert res["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["total_usage"] == 0  # no credit usage for BYOK
+    krow = db.typed[_KLT][(key.hash, 0)]
+    assert krow["byok_usage"] == 800_000
+    assert krow["usage"] == 0
+    assert krow["reserved"] == 0
+
+
+def test_settle_not_found() -> None:
+    store, _db, _ = make_fake_store()
+    res = _settle(store, rid="nonexistent", actual=100)
+    assert res["outcome"] == SettleOutcome.NOT_FOUND

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -466,14 +466,15 @@ def _auth_body(aid, rid):
     return _json.dumps({"id": aid, "credit_reservation_id": rid, "model": "m"})
 
 
-def _authorize(store, *, ws, key_hash, estimate, has_credit=True, scope=None, fp=None):
+def _authorize(store, *, ws, key_hash, estimate, has_credit=True, scope=None, fp=None,
+               expires="2026-01-01T00:00:00Z"):
     return authorize_atomic(
         store._database, store._param_types,
         workspace_id=ws, key_hash=key_hash, estimate=estimate,
         has_credit_candidate=has_credit,
         reservation_usage_type=("Credits" if has_credit else "BYOK"),
         idempotency_scope=scope, idempotency_fingerprint=fp,
-        expires_at="2026-01-01T00:00:00Z", build_auth_body=_auth_body,
+        expires_at=expires, build_auth_body=_auth_body,
     )
 
 
@@ -681,3 +682,116 @@ def test_settle_not_found() -> None:
     store, _db, _ = make_fake_store()
     res = _settle(store, rid="nonexistent", actual=100)
     assert res["outcome"] == SettleOutcome.NOT_FOUND
+
+
+# ── 3d: crash reaper ────────────────────────────────────────────────────────
+
+from trusted_router.storage_gcp_authorize import reap_expired_reservations  # noqa: E402
+
+_NOW = "2026-06-01T00:00:00Z"  # after the default authorize expiry, before 2027
+
+
+def test_reaper_reclaims_expired_unsettled_holds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_reap"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)  # expires 2026-01-01
+    assert _typed(db, ws)["reserved"] == 1_000_000
+
+    reaped = reap_expired_reservations(store._database, store._param_types, now=_NOW)
+    assert reaped == 1
+    assert _typed(db, ws)["reserved"] == 0  # hold released
+    assert _typed(db, ws)["total_usage"] == 0  # no charge (abandoned)
+    assert db.typed[_KLT][(key.hash, 0)]["reserved"] == 0
+    # reservation now settled -> a second reap is a no-op
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+
+
+def test_reaper_skips_not_yet_expired() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_reap_future"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, expires="2027-01-01T00:00:00Z")
+    reaped = reap_expired_reservations(store._database, store._param_types, now=_NOW)
+    assert reaped == 0
+    assert _typed(db, ws)["reserved"] == 1_000_000  # hold preserved
+
+
+def test_reaper_skips_already_settled() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_reap_settled"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    _settle(store, rid=auth["reservation_id"], actual=900_000)  # settled before reap
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+
+
+def test_reaper_vs_late_settle_one_wins() -> None:
+    """A real settle landing as the reaper runs must not double-apply: the claim
+    makes exactly one of {settle, reap} win."""
+    ws = "ws_reap_race"
+    barrier = threading.Barrier(3)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid = auth["reservation_id"]
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def settler() -> None:
+        r = _settle(store, rid=rid, actual=900_000)
+        with lock:
+            results.append(("settle", r["outcome"]))
+
+    def reaper() -> None:
+        try:
+            barrier.wait(timeout=10)
+        except threading.BrokenBarrierError:
+            pass
+        reap_expired_reservations(store._database, store._param_types, now=_NOW)
+
+    t_settle = threading.Thread(target=settler, daemon=True)
+    t_reap = threading.Thread(target=reaper, daemon=True)
+    t_settle.start()
+    t_reap.start()
+    try:
+        barrier.wait(timeout=10)
+    except threading.BrokenBarrierError:
+        pass
+    t_settle.join(timeout=10)
+    t_reap.join(timeout=10)
+
+    # The reservation is settled exactly once; usage is either the real charge
+    # (settle won) or 0 (reaper won) — never both, never negative.
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] in (0, 900_000)
+    assert db.reservations[rid]["settled"] is True
+
+
+def test_authorize_atomic_concurrent_same_scope_different_fingerprint() -> None:
+    """Concurrent same-scope but DIFFERENT-body calls: the winner is ACCEPTED, the
+    loser hits the unique-index conflict and must get IDEMPOTENCY_MISMATCH (NOT a
+    replay of the winner's authorization) — codex keystone review."""
+    ws = "ws_auth_race_mm"
+    barrier = threading.Barrier(3)
+    store, _db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def go(fp: str) -> None:
+        r = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="rscope", fp=fp)
+        with lock:
+            outcomes.append(r["outcome"])
+
+    _run_workers(
+        [threading.Thread(target=go, args=(f"fp{i}",), daemon=True) for i in range(2)],
+        barrier,
+    )
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1, outcomes
+    assert outcomes.count(AuthorizeOutcome.IDEMPOTENCY_MISMATCH) == 1, outcomes

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -412,16 +412,24 @@ def test_reservation_claim_first_writer_wins() -> None:
     _insert_res(store, rid="rc", credit_hold=100_000)
     pt = store._param_types
     first = store._database.run_in_transaction(
-        lambda t: claim_reservation(t, pt, "rc", settled_usage_type="Credits")
+        lambda t: claim_reservation(t, pt, "rc", actual_micro=95_000, settled_usage_type="Credits")
     )
     second = store._database.run_in_transaction(
-        lambda t: claim_reservation(t, pt, "rc", settled_usage_type="Credits")
+        lambda t: claim_reservation(t, pt, "rc", actual_micro=99_000, settled_usage_type="Credits")
     )
     assert first is True
     assert second is False  # already settled -> replay no-op
     row = store._database.run_in_transaction(lambda t: read_reservation(t, pt, "rc"))
     assert row["settled"] is True
     assert row["settled_usage_type"] == "Credits"
+    assert row["actual_micro"] == 95_000  # first claim's actual, durably recorded
+
+
+def test_reservation_duplicate_id_raises_already_exists() -> None:
+    store, _db, _ = make_fake_store()
+    _insert_res(store, rid="dupid")
+    with pytest.raises(FakeAlreadyExists):
+        _insert_res(store, rid="dupid", scope="different")  # same PK -> conflict
 
 
 def test_reservation_claim_race_settles_once() -> None:
@@ -434,7 +442,7 @@ def test_reservation_claim_race_settles_once() -> None:
 
     def claim() -> None:
         w = store._database.run_in_transaction(
-            lambda t: claim_reservation(t, pt, "rr", settled_usage_type="Credits")
+            lambda t: claim_reservation(t, pt, "rr", actual_micro=90_000, settled_usage_type="Credits")
         )
         with lock:
             wins.append(w)

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -795,3 +795,98 @@ def test_authorize_atomic_concurrent_same_scope_different_fingerprint() -> None:
     )
     assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1, outcomes
     assert outcomes.count(AuthorizeOutcome.IDEMPOTENCY_MISMATCH) == 1, outcomes
+
+
+# ── 3e-1: full-DML typed finalize (reproduces legacy finalize) ──────────────
+
+from trusted_router.storage_gcp_authorize import typed_finalize_atomic  # noqa: E402
+
+_TS = "2026-02-01T00:00:00Z"
+
+
+def _typed_finalize(store, *, rid, aid, actual, settled_ut="Credits", success=True, gen=True):
+    writes = []
+    if gen and success:
+        writes = [
+            ("generation", f"gen-{rid}", _json.dumps({"id": f"gen-{rid}", "cost": actual})),
+            ("generation_by_workspace", f"genidx-{rid}", _json.dumps({"generation_id": f"gen-{rid}"})),
+        ]
+    auth_settled = _json.dumps({"id": aid, "settled": True})
+    return typed_finalize_atomic(
+        store._database, store._param_types,
+        reservation_id=rid, authorization_id=aid, success=success,
+        actual_micro=actual, settled_usage_type=settled_ut, now=_TS,
+        auth_body_settled=auth_settled, generation_writes=writes,
+    )
+
+
+def test_typed_finalize_full_success() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_tf"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+
+    res = _typed_finalize(store, rid=rid, aid=aid, actual=900_000)
+    assert res["outcome"] == SettleOutcome.SETTLED
+    # counters
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 900_000
+    assert db.typed[_KLT][(key.hash, 0)]["usage"] == 900_000
+    # generation entities written in the same txn
+    assert ("generation", f"gen-{rid}") in db.rows
+    assert ("generation_by_workspace", f"genidx-{rid}") in db.rows
+    # auth marked settled
+    assert _json.loads(db.rows[("gateway_authorization", aid)].body)["settled"] is True
+
+
+def test_typed_finalize_refund_no_generation_no_booking() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_tf_refund"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+
+    res = _typed_finalize(store, rid=rid, aid=aid, actual=0, success=False)
+    assert res["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 0  # refund books nothing
+    assert ("generation", f"gen-{rid}") not in db.rows  # no generation on failure
+    assert _json.loads(db.rows[("gateway_authorization", aid)].body)["settled"] is True
+
+
+def test_typed_finalize_replay_books_once() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_tf_replay"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    first = _typed_finalize(store, rid=rid, aid=aid, actual=900_000)
+    second = _typed_finalize(store, rid=rid, aid=aid, actual=900_000)
+    assert first["outcome"] == SettleOutcome.SETTLED
+    assert second["outcome"] == SettleOutcome.ALREADY_SETTLED
+    assert _typed(db, ws)["total_usage"] == 900_000  # booked once
+
+
+def test_typed_finalize_race_books_once() -> None:
+    ws = "ws_tf_race"
+    barrier = threading.Barrier(7)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def go() -> None:
+        r = _typed_finalize(store, rid=rid, aid=aid, actual=900_000)
+        with lock:
+            outcomes.append(r["outcome"])
+
+    _run_workers([threading.Thread(target=go, daemon=True) for _ in range(6)], barrier)
+    assert outcomes.count(SettleOutcome.SETTLED) == 1, outcomes
+    assert _typed(db, ws)["total_usage"] == 900_000  # charged exactly once

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -123,7 +123,45 @@ def test_release_credit_settles_and_refunds() -> None:
 
     # a second hold, then refund (actual=0): release hold, book nothing
     assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 200_000))
-    store._database.run_in_transaction(lambda t: release_credit(t, pt, ws, 200_000, 0))
+    refund_count = store._database.run_in_transaction(
+        lambda t: release_credit(t, pt, ws, 200_000, 0)
+    )
+    assert refund_count == 1
     typed = _typed(db, ws)
     assert typed["reserved"] == 0
     assert typed["total_usage"] == 480_000  # unchanged by the refund
+
+
+def test_release_underflow_is_noop_not_negative() -> None:
+    """A stale/double release of more than `reserved` must be a 0-row no-op, not
+    drive reserved negative (which would inflate apparent availability)."""
+    store, db, _ = make_fake_store()
+    ws = "ws_underflow"
+    _seed_credit(store, ws, 1_000_000)
+    pt = store._param_types
+    assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 200_000))
+
+    count = store._database.run_in_transaction(
+        lambda t: release_credit(t, pt, ws, 500_000, 0)  # more than the 200k held
+    )
+    assert count == 0  # trips the caller's must-be-1 assert/alarm
+    assert _typed(db, ws)["reserved"] == 200_000  # unchanged, never negative
+
+
+def test_dml_after_mutation_is_rejected() -> None:
+    """The fake fails fast on DML+mutation mixing (forbidden, docs §5), so future
+    authorize/settle code that accidentally mixes is caught in tests."""
+    import pytest
+
+    store, _db, _ = make_fake_store()
+    ws = "ws_mix"
+    _seed_credit(store, ws, 1_000_000)
+    pt = store._param_types
+
+    def mix(transaction) -> None:
+        store._write_entity_tx(transaction, "credit", ws, CreditAccount(
+            workspace_id=ws, total_credits_microdollars=1_000_000))  # mutation
+        reserve_credit(transaction, pt, ws, 100_000)  # DML -> must raise
+
+    with pytest.raises(RuntimeError, match="DML.*mutation"):
+        store._database.run_in_transaction(mix)

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage import CreditAccount
 from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
@@ -151,8 +153,6 @@ def test_release_underflow_is_noop_not_negative() -> None:
 def test_dml_after_mutation_is_rejected() -> None:
     """The fake fails fast on DML+mutation mixing (forbidden, docs §5), so future
     authorize/settle code that accidentally mixes is caught in tests."""
-    import pytest
-
     store, _db, _ = make_fake_store()
     ws = "ws_mix"
     _seed_credit(store, ws, 1_000_000)
@@ -324,3 +324,120 @@ def test_reserve_key_uncapped_concurrent_no_aborts() -> None:
     _run_workers([threading.Thread(target=once, daemon=True) for _ in range(n)], barrier)
     assert results == [KEY_NO_HOLD] * n, results
     assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+
+
+# ── tr_reservation: durable hold + scoped idempotency + settle claim ─────────
+
+from tests.fakes.spanner import FakeAlreadyExists  # noqa: E402
+from trusted_router.storage_gcp_counter_dml import (  # noqa: E402
+    claim_reservation,
+    insert_reservation,
+    read_reservation,
+    read_reservation_by_idempotency,
+)
+
+
+def _insert_res(store, *, rid, scope=None, fingerprint=None, credit_hold=0, key_hold=0):
+    def txn(t):
+        insert_reservation(
+            t, store._param_types,
+            reservation_id=rid, workspace_id="ws", key_hash="kh",
+            ws_shard=0, key_shard=0, credit_reserved_micro=credit_hold,
+            key_reserved_micro=key_hold, hold_usage_type="Credits",
+            idempotency_scope=scope, idempotency_fingerprint=fingerprint,
+            expires_at="2026-01-01T00:00:00Z",
+        )
+    store._database.run_in_transaction(txn)
+
+
+def test_reservation_insert_and_reads() -> None:
+    store, _db, _ = make_fake_store()
+    _insert_res(store, rid="r1", scope="ws#kh#abc", fingerprint="fp1", credit_hold=500_000)
+    pt = store._param_types
+
+    by_idem = store._database.run_in_transaction(
+        lambda t: read_reservation_by_idempotency(t, pt, "ws#kh#abc")
+    )
+    assert by_idem["reservation_id"] == "r1"
+    assert by_idem["credit_reserved_micro"] == 500_000
+    assert by_idem["idempotency_fingerprint"] == "fp1"
+    assert by_idem["settled"] is False
+
+    by_id = store._database.run_in_transaction(lambda t: read_reservation(t, pt, "r1"))
+    assert by_id["workspace_id"] == "ws"
+    assert by_id["credit_reserved_micro"] == 500_000
+
+    miss = store._database.run_in_transaction(
+        lambda t: read_reservation_by_idempotency(t, pt, "nope")
+    )
+    assert miss is None
+
+
+def test_reservation_duplicate_idempotency_scope_raises_already_exists() -> None:
+    store, _db, _ = make_fake_store()
+    _insert_res(store, rid="r1", scope="dup")
+    with pytest.raises(FakeAlreadyExists):
+        _insert_res(store, rid="r2", scope="dup")  # same scope -> unique conflict
+
+
+def test_reservation_concurrent_same_scope_one_wins() -> None:
+    """Two concurrent first-calls with the same idempotency scope: exactly one
+    INSERT commits, the other raises ALREADY_EXISTS (codex Step-3 #4) — the loser
+    is NOT silently retried into a second debit."""
+    barrier = threading.Barrier(3)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def insert(rid: str) -> None:
+        try:
+            _insert_res(store, rid=rid, scope="race")
+            with lock:
+                outcomes.append("ok")
+        except FakeAlreadyExists:
+            with lock:
+                outcomes.append("already_exists")
+
+    _run_workers(
+        [threading.Thread(target=insert, args=(f"r{i}",), daemon=True) for i in range(2)],
+        barrier,
+    )
+    assert outcomes.count("ok") == 1, outcomes
+    assert outcomes.count("already_exists") == 1, outcomes
+    assert len(db.reservation_idemp) == 1
+
+
+def test_reservation_claim_first_writer_wins() -> None:
+    store, _db, _ = make_fake_store()
+    _insert_res(store, rid="rc", credit_hold=100_000)
+    pt = store._param_types
+    first = store._database.run_in_transaction(
+        lambda t: claim_reservation(t, pt, "rc", settled_usage_type="Credits")
+    )
+    second = store._database.run_in_transaction(
+        lambda t: claim_reservation(t, pt, "rc", settled_usage_type="Credits")
+    )
+    assert first is True
+    assert second is False  # already settled -> replay no-op
+    row = store._database.run_in_transaction(lambda t: read_reservation(t, pt, "rc"))
+    assert row["settled"] is True
+    assert row["settled_usage_type"] == "Credits"
+
+
+def test_reservation_claim_race_settles_once() -> None:
+    barrier = threading.Barrier(7)
+    store, _db, _ = make_fake_store(ready_barrier=barrier)
+    _insert_res(store, rid="rr", credit_hold=100_000)
+    pt = store._param_types
+    wins: list[bool] = []
+    lock = threading.Lock()
+
+    def claim() -> None:
+        w = store._database.run_in_transaction(
+            lambda t: claim_reservation(t, pt, "rr", settled_usage_type="Credits")
+        )
+        with lock:
+            wins.append(w)
+
+    _run_workers([threading.Thread(target=claim, daemon=True) for _ in range(6)], barrier)
+    assert wins.count(True) == 1, wins  # exactly one claim wins

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -949,3 +949,34 @@ def test_store_typed_finalize_wrapper_and_reaper_wrapper() -> None:
     assert _typed(db, ws)["total_usage"] == 900_000
     # reaper wrapper: nothing expired+unsettled now
     assert store.reap_expired_reservations(now=_NOW) == 0
+
+
+def test_typed_idempotency_lookup_survives_cohort_rollback() -> None:
+    """get_typed_authorization_by_idempotency finds a typed auth INDEPENDENT of
+    the cohort flag, so a retry after rollback replays (codex 3e route #2)."""
+    store, _db, _ = make_fake_store()
+    ws = "ws_idem_rollback"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    res = store.authorize_gateway_typed(
+        workspace_id=ws, key_hash=key.hash, estimate=1_000_000,
+        has_credit_candidate=True, reservation_usage_type="Credits",
+        model_id="m", provider="openai", requested_model_id=None,
+        candidate_model_ids=["m"], region="us", endpoint_id="e",
+        candidate_endpoint_ids=["e"], idempotency_key="idem-1",
+        idempotency_fingerprint="fp1", expires_at="2026-01-01T00:00:00Z",
+    )
+    assert res[0] == AuthorizeOutcome.ACCEPTED
+    found = store.get_typed_authorization_by_idempotency(ws, key.hash, "idem-1")
+    assert found is not None
+    assert found.id == res[1].id  # same authorization, regardless of cohort flag
+    assert store.get_typed_authorization_by_idempotency(ws, key.hash, "other") is None
+
+
+def test_typed_origin_and_idempotency_guarded_by_mirror_flag() -> None:
+    """With the mirror off (no typed tables yet) the origin/idempotency lookups
+    short-circuit to legacy without querying tr_reservation (codex 3e route #3)."""
+    store, _db, _ = make_fake_store()
+    store._counter_mirror_enabled = False
+    assert store.is_typed_reservation("any", "auth") is False
+    assert store.get_typed_authorization_by_idempotency("ws", "kh", "k") is None

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -264,3 +264,63 @@ def test_release_key_settles_usage_and_byok() -> None:
     assert row["reserved"] == 0
     assert row["usage"] == 480_000
     assert row["byok_usage"] == 0
+
+
+def test_reserve_key_include_byok_true_counts_byok_usage() -> None:
+    """With include_byok=true, prior BYOK usage consumes the cap headroom."""
+    store, _db, _ = make_fake_store()
+    key = _make_key(store, "ws_ib", limit=1_000_000, include_byok=True)
+    store.api_keys.add_usage(key.hash, 400_000, is_byok=True)  # byok_usage=400k
+    pt = store._param_types
+    # available = 1_000_000 - 0 - 400_000 - 0 = 600_000
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 700_000, is_byok=False)
+    ) == KEY_INSUFFICIENT
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 500_000, is_byok=False)
+    ) == KEY_ACCEPTED
+
+
+def test_release_key_book_to_byok_and_underflow() -> None:
+    store, db, _ = make_fake_store()
+    key = _make_key(store, "ws_kb", limit=2_000_000)
+    pt = store._param_types
+    assert store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 300_000, is_byok=False)
+    ) == KEY_ACCEPTED
+    # settle as BYOK usage -> books byok_usage, not usage
+    assert store._database.run_in_transaction(
+        lambda t: release_key(t, pt, key.hash, 300_000, 250_000, book_to_byok=True)
+    ) == 1
+    row = db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    assert row["reserved"] == 0
+    assert row["byok_usage"] == 250_000
+    assert row["usage"] == 0
+    # underflow: releasing more than held is a 0-row no-op (never negative)
+    assert store._database.run_in_transaction(
+        lambda t: release_key(t, pt, key.hash, 500_000, 0, book_to_byok=False)
+    ) == 0
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+
+
+def test_reserve_key_uncapped_concurrent_no_aborts() -> None:
+    """Concurrent reservers on an UNCAPPED key all get no-hold and the 0-row
+    classification path does not introduce lock-upgrade contention."""
+    n = 6
+    barrier = threading.Barrier(n + 1)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    key = _make_key(store, "ws_uncc", limit=None)
+    pt = store._param_types
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def once() -> None:
+        r = store._database.run_in_transaction(
+            lambda t: reserve_key(t, pt, key.hash, 100_000, is_byok=False)
+        )
+        with lock:
+            results.append(r)
+
+    _run_workers([threading.Thread(target=once, daemon=True) for _ in range(n)], barrier)
+    assert results == [KEY_NO_HOLD] * n, results
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -449,3 +449,134 @@ def test_reservation_claim_race_settles_once() -> None:
 
     _run_workers([threading.Thread(target=claim, daemon=True) for _ in range(6)], barrier)
     assert wins.count(True) == 1, wins  # exactly one claim wins
+
+
+# ── 3b-3: the atomic authorize transaction (keystone) ───────────────────────
+
+import json as _json  # noqa: E402
+
+from trusted_router.storage_gcp_authorize import (  # noqa: E402
+    AuthorizeOutcome,
+    authorize_atomic,
+)
+from trusted_router.storage_gcp_counters import KEY_LIMIT_TABLE as _KLT  # noqa: E402
+
+
+def _auth_body(aid, rid):
+    return _json.dumps({"id": aid, "credit_reservation_id": rid, "model": "m"})
+
+
+def _authorize(store, *, ws, key_hash, estimate, has_credit=True, scope=None, fp=None):
+    return authorize_atomic(
+        store._database, store._param_types,
+        workspace_id=ws, key_hash=key_hash, estimate=estimate,
+        has_credit_candidate=has_credit,
+        reservation_usage_type=("Credits" if has_credit else "BYOK"),
+        idempotency_scope=scope, idempotency_fingerprint=fp,
+        expires_at="2026-01-01T00:00:00Z", build_auth_body=_auth_body,
+    )
+
+
+def test_authorize_atomic_accepts_and_holds_both() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_auth"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    res = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    assert res["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert _typed(db, ws)["reserved"] == 1_000_000  # credit hold
+    assert db.typed[_KLT][(key.hash, 0)]["reserved"] == 1_000_000  # key hold
+    # reservation + auth entity written atomically
+    assert res["reservation_id"] in db.reservations
+    assert ("gateway_authorization", res["authorization_id"]) in db.rows
+    resv = db.reservations[res["reservation_id"]]
+    assert resv["credit_reserved_micro"] == 1_000_000
+    assert resv["key_reserved_micro"] == 1_000_000
+    assert resv["authorization_id"] == res["authorization_id"]
+
+
+def test_authorize_atomic_insufficient_credits_leaks_no_hold() -> None:
+    """THE atomicity test (codex#1 #1): credit reject must roll back the key hold
+    taken earlier in the same transaction — no leaked reserved."""
+    store, db, _ = make_fake_store()
+    ws = "ws_auth_poor"
+    _seed_credit(store, ws, 500_000)  # less than the estimate
+    key = _make_key(store, ws, limit=5_000_000)  # key has plenty
+    res = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    assert res["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert _typed(db, ws)["reserved"] == 0  # credit untouched
+    assert db.typed[_KLT][(key.hash, 0)]["reserved"] == 0  # KEY HOLD ROLLED BACK
+    assert db.reservations == {}  # nothing persisted
+
+
+def test_authorize_atomic_key_limit_exceeded() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_auth_cap"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=100_000)  # tiny cap
+    res = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    assert res["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+    assert _typed(db, ws)["reserved"] == 0  # credit never touched (key checked first)
+    assert db.reservations == {}
+
+
+def test_authorize_atomic_idempotent_replay() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_auth_idem"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    first = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="s1", fp="fp1")
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    reserved_after_first = _typed(db, ws)["reserved"]
+
+    replay = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="s1", fp="fp1")
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["authorization_id"] == first["authorization_id"]
+    assert replay["reservation_id"] == first["reservation_id"]
+    assert _typed(db, ws)["reserved"] == reserved_after_first  # NO second debit
+    assert len(db.reservations) == 1
+
+
+def test_authorize_atomic_idempotency_fingerprint_mismatch() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_auth_mm"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="s2", fp="fpA")
+    mism = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="s2", fp="fpB")
+    assert mism["outcome"] == AuthorizeOutcome.IDEMPOTENCY_MISMATCH
+
+
+def test_authorize_atomic_byok_no_credit_hold() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_auth_byok"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000, include_byok=True)
+    res = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, has_credit=False)
+    assert res["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert _typed(db, ws)["reserved"] == 0  # no credit hold for BYOK
+    assert db.typed[_KLT][(key.hash, 0)]["reserved"] == 1_000_000  # key hold (include_byok)
+    assert db.reservations[res["reservation_id"]]["credit_reserved_micro"] == 0
+
+
+def test_authorize_atomic_concurrent_same_scope_one_debit() -> None:
+    """Two concurrent first-calls, same idempotency scope: exactly one debits,
+    the other replays (ALREADY_EXISTS -> replay) — never a double reservation."""
+    ws = "ws_auth_race"
+    barrier = threading.Barrier(3)
+    store, db, _ = make_fake_store(ready_barrier=barrier)
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def go() -> None:
+        r = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000, scope="race", fp="fp")
+        with lock:
+            outcomes.append(r["outcome"])
+
+    _run_workers([threading.Thread(target=go, daemon=True) for _ in range(2)], barrier)
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1, outcomes
+    assert outcomes.count(AuthorizeOutcome.REPLAY) == 1, outcomes
+    assert len(db.reservations) == 1  # exactly one reservation
+    assert _typed(db, ws)["reserved"] == 1_000_000  # one debit


### PR DESCRIPTION
**Stacked on #64** (Steps 1+2). Base is `billing-typed-counters` so this PR's diff
is ONLY the Step 3 enforcement change. Rebase onto main once #64 merges.

## What this does

Step 3 is the flip that actually fixes the production deadlock
(`Aborted: Deadlock with higher priority transaction` on
gateway_authorize→reserve). It replaces the read-modify-write of the hot
credit/api_key counters with a **single conditional DML** on the typed tables:

```sql
UPDATE tr_credit_balance SET reserved = reserved + @est
 WHERE workspace_id=@ws AND shard=@shard
   AND (total_credits - total_usage - reserved) >= @est
```

The conditional UPDATE takes the row write lock directly — the shared-read →
exclusive-upgrade cycle that deadlocks today **cannot form**. `execute_update()`
row-count is the accept(1)/reject(0) signal. Still exact, still strongly
consistent.

## Landing incrementally (this PR grows)

- [x] **3a — conditional-DML primitives + deadlock-fix proof** (this commit):
  `reserve_credit` / `release_credit`; fake `execute_update` with per-row
  versioning; concurrency test showing N reservers on one hot workspace accept
  exactly `floor(available/amount)`, never overspend, resolve via retry (no
  deadlock).
- [ ] 3b — one-transaction atomic authorize (scoped idempotency → conditional
  key DML → conditional credit DML → reservation/auth writes with exact holds)
- [ ] 3c — claim-gated settle/finalize (exact hold release, hold-vs-settled
  usage-type, row-count==1 assertion)
- [ ] 3d — typed reservations + scoped idempotency index + crash reaper +
  durable settle outbox
- [ ] 3e — gateway.py route changes (replay = resume/no-execute); cohort flag
- [ ] pre-cutover: comparator-gate at flip, `ALREADY_EXISTS`→replay, PCT
  single-touch

Enforcement is **unchanged** until 3e wires it in behind a cohort flag, and the
**production flip is gated on Joseph's explicit go**. Each chunk is codex-reviewed
(matching the Step 1/2 workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)