### PR TITLE
billing: log typed gateway decision for synthetic cutover

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import uuid
 from typing import Any
 
@@ -52,6 +53,8 @@ from trusted_router.services.broadcast import (
 )
 from trusted_router.storage import STORE, Generation, ProviderBenchmarkSample
 from trusted_router.types import ErrorType, UsageType
+
+logger = logging.getLogger("trusted_router")
 
 
 def register(router: APIRouter) -> None:
@@ -224,6 +227,13 @@ def register(router: APIRouter) -> None:
                 allowlist_csv=settings.typed_billing_workspace_ids,
                 denylist_csv=settings.typed_billing_workspace_denylist,
             )
+        _log_typed_billing_decision(
+            body=body,
+            workspace_id=workspace.id,
+            settings=settings,
+            typed_authz_available=_typed_authz is not None,
+            typed_cohort=_typed_cohort,
+        )
         if _typed_authz is not None and _typed_cohort:
             import datetime as _dt
 
@@ -413,6 +423,48 @@ def _gateway_authorize_fingerprint(
     material["key_hash"] = key_hash
     encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _log_typed_billing_decision(
+    *,
+    body: GatewayAuthorizeRequest,
+    workspace_id: str,
+    settings: Settings,
+    typed_authz_available: bool,
+    typed_cohort: bool,
+) -> None:
+    """Emit a narrow prod breadcrumb for the typed billing cutover.
+
+    This intentionally logs only synthetic-monitor or explicitly configured cutover
+    workspaces, and never logs prompts, API keys, or raw request metadata.
+    """
+    metadata = body.metadata if isinstance(body.metadata, dict) else {}
+    is_synthetic = str(metadata.get("trustedrouter_synthetic", "")).lower() == "true"
+    allowlist = settings.typed_billing_workspace_ids or ""
+    denylist = settings.typed_billing_workspace_denylist or ""
+    allowlist_ids = {item.strip() for item in allowlist.split(",") if item.strip()}
+    denylist_ids = {item.strip() for item in denylist.split(",") if item.strip()}
+    workspace_allowlisted = workspace_id in allowlist_ids
+    workspace_denylisted = workspace_id in denylist_ids
+    if not is_synthetic and not workspace_allowlisted and not workspace_denylisted:
+        return
+
+    store_target = getattr(STORE, "target", STORE)
+    logger.warning(
+        "typed_billing_decision ws=%s synthetic=%s typed_authz=%s cohort=%s "
+        "workspace_allowlisted=%s workspace_denylisted=%s allowlist_count=%s "
+        "denylist_count=%s settings=%s store=%s",
+        workspace_id,
+        is_synthetic,
+        typed_authz_available,
+        typed_cohort,
+        workspace_allowlisted,
+        workspace_denylisted,
+        len(allowlist_ids),
+        len(denylist_ids),
+        type(settings).__name__,
+        type(store_target).__name__,
+    )
 
 
 def _authorization_endpoint_candidates(

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -17,6 +17,9 @@ import threading
 import pytest
 
 from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.routes.internal.gateway import _log_typed_billing_decision
+from trusted_router.schemas import GatewayAuthorizeRequest
 from trusted_router.storage import CreditAccount
 from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
@@ -980,3 +983,49 @@ def test_typed_origin_and_idempotency_guarded_by_mirror_flag() -> None:
     store._counter_mirror_enabled = False
     assert store.is_typed_reservation("any", "auth") is False
     assert store.get_typed_authorization_by_idempotency("ws", "kh", "k") is None
+
+
+def test_typed_billing_decision_log_is_scoped_to_synthetic(caplog) -> None:
+    settings = Settings(
+        environment="test",
+        typed_billing_workspace_ids="ws_synthetic",
+    )
+    body = GatewayAuthorizeRequest(
+        api_key_lookup_hash="lookup",
+        model="trustedrouter/monitor",
+        metadata={"trustedrouter_synthetic": "true"},
+    )
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        _log_typed_billing_decision(
+            body=body,
+            workspace_id="ws_synthetic",
+            settings=settings,
+            typed_authz_available=True,
+            typed_cohort=False,
+        )
+
+    assert "typed_billing_decision" in caplog.text
+    assert "ws=ws_synthetic" in caplog.text
+    assert "synthetic=True" in caplog.text
+    assert "typed_authz=True" in caplog.text
+    assert "cohort=False" in caplog.text
+    assert "workspace_allowlisted=True" in caplog.text
+    assert "workspace_denylisted=False" in caplog.text
+    assert "allowlist_count=1" in caplog.text
+
+
+def test_typed_billing_decision_log_ignores_unrelated_authorizes(caplog) -> None:
+    settings = Settings(environment="test", typed_billing_workspace_ids="ws_synthetic")
+    body = GatewayAuthorizeRequest(api_key_lookup_hash="lookup", model="trustedrouter/auto")
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        _log_typed_billing_decision(
+            body=body,
+            workspace_id="ws_other",
+            settings=settings,
+            typed_authz_available=True,
+            typed_cohort=True,
+        )
+
+    assert "typed_billing_decision" not in caplog.text


### PR DESCRIPTION
## Summary
- add a scoped typed_billing_decision warning for synthetic/cutover workspaces at the internal gateway authorize branch
- include only non-sensitive branch inputs: workspace id, synthetic flag, typed method availability, cohort result, allow/denylist strings, settings/store class names
- add tests proving synthetic logs and unrelated authorizes stay quiet

## Tests
- uv run ruff check src/trusted_router/routes/internal/gateway.py tests/test_billing_typed_enforcement.py
- uv run pytest tests/test_billing_typed_enforcement.py -q
- uv run pytest tests/test_billing.py::test_internal_gateway_authorize_and_settle_records_metadata tests/test_billing.py::test_internal_gateway_authorize_replays_same_idempotency_key_once tests/test_auth_and_routing.py::test_regions_endpoint_and_gateway_authorize_include_routing_metadata tests/test_gateway_fallback_billing.py -q
- uv run mypy src/trusted_router/routes/internal/gateway.py

## Operational intent
This is a temporary cutover breadcrumb. After one synthetic probe identifies whether `typed_authz` or `cohort` is false at runtime, remove this log in a follow-up.