### PR TITLE
billing: keep manual credits mirrored during typed cutover

### DIFF
--- a/scripts/credit_grant_joseph.py
+++ b/scripts/credit_grant_joseph.py
@@ -23,6 +23,10 @@ os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
 os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
 os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
 os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+# Keep production manual credits safe during the typed-billing cutover. This
+# uses the normal STORE.credit_workspace_once path, but it must also update the
+# typed counter mirror that the cohort-enforced authorize path reads.
+os.environ["TR_TYPED_COUNTER_MIRROR"] = "1"
 
 from trusted_router.config import Settings
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR

--- a/scripts/credit_makeup.py
+++ b/scripts/credit_makeup.py
@@ -29,6 +29,10 @@ os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
 os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
 os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
 os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+# Keep production manual credits safe during the typed-billing cutover. This
+# uses the normal STORE.credit_workspace_once path, but it must also update the
+# typed counter mirror that the cohort-enforced authorize path reads.
+os.environ["TR_TYPED_COUNTER_MIRROR"] = "1"
 
 from trusted_router.config import Settings
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR

--- a/tests/test_operator_credit_scripts.py
+++ b/tests/test_operator_credit_scripts.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_manual_credit_scripts_enable_typed_counter_mirror_before_store_creation() -> None:
+    for relpath in ("scripts/credit_makeup.py", "scripts/credit_grant_joseph.py"):
+        source = (ROOT / relpath).read_text(encoding="utf-8")
+        assert 'setdefault("TR_TYPED_COUNTER_MIRROR"' not in source
+        mirror_pos = source.index('os.environ["TR_TYPED_COUNTER_MIRROR"] = "1"')
+        store_pos = source.index("create_store(Settings())")
+        assert mirror_pos < store_pos


### PR DESCRIPTION
## Summary\n- force typed counter mirroring on in manual production credit scripts\n- add a regression test that rejects setdefault and verifies mirror env is set before store construction\n\n## Verification\n- uv run ruff check scripts/credit_makeup.py scripts/credit_grant_joseph.py tests/test_operator_credit_scripts.py\n- uv run pytest tests/test_operator_credit_scripts.py tests/test_billing_typed_enforcement.py tests/test_billing_typed_counters.py -q\n- codex review: no blocking or high-confidence findings\n\n## Runtime note\nDuring synthetic typed-billing validation, the monitor workspace had JSON credits but a stale typed mirror. I repaired it via the application ledger path with TR_TYPED_COUNTER_MIRROR=1 and confirmed tr_reservation rows are now being created and settled for workspace 45819281-0ce9-4811-a0cd-c660ab3a116d.