### PR TITLE
billing: revert #68 diagnostic logger (fixes AxiomError spam on cohort authorize)

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import uuid
 from typing import Any
 
@@ -53,8 +52,6 @@ from trusted_router.services.broadcast import (
 )
 from trusted_router.storage import STORE, Generation, ProviderBenchmarkSample
 from trusted_router.types import ErrorType, UsageType
-
-logger = logging.getLogger("trusted_router")
 
 
 def register(router: APIRouter) -> None:
@@ -227,13 +224,6 @@ def register(router: APIRouter) -> None:
                 allowlist_csv=settings.typed_billing_workspace_ids,
                 denylist_csv=settings.typed_billing_workspace_denylist,
             )
-        _log_typed_billing_decision(
-            body=body,
-            workspace_id=workspace.id,
-            settings=settings,
-            typed_authz_available=_typed_authz is not None,
-            typed_cohort=_typed_cohort,
-        )
         if _typed_authz is not None and _typed_cohort:
             import datetime as _dt
 
@@ -423,48 +413,6 @@ def _gateway_authorize_fingerprint(
     material["key_hash"] = key_hash
     encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
-
-
-def _log_typed_billing_decision(
-    *,
-    body: GatewayAuthorizeRequest,
-    workspace_id: str,
-    settings: Settings,
-    typed_authz_available: bool,
-    typed_cohort: bool,
-) -> None:
-    """Emit a narrow prod breadcrumb for the typed billing cutover.
-
-    This intentionally logs only synthetic-monitor or explicitly configured cutover
-    workspaces, and never logs prompts, API keys, or raw request metadata.
-    """
-    metadata = body.metadata if isinstance(body.metadata, dict) else {}
-    is_synthetic = str(metadata.get("trustedrouter_synthetic", "")).lower() == "true"
-    allowlist = settings.typed_billing_workspace_ids or ""
-    denylist = settings.typed_billing_workspace_denylist or ""
-    allowlist_ids = {item.strip() for item in allowlist.split(",") if item.strip()}
-    denylist_ids = {item.strip() for item in denylist.split(",") if item.strip()}
-    workspace_allowlisted = workspace_id in allowlist_ids
-    workspace_denylisted = workspace_id in denylist_ids
-    if not is_synthetic and not workspace_allowlisted and not workspace_denylisted:
-        return
-
-    store_target = getattr(STORE, "target", STORE)
-    logger.warning(
-        "typed_billing_decision ws=%s synthetic=%s typed_authz=%s cohort=%s "
-        "workspace_allowlisted=%s workspace_denylisted=%s allowlist_count=%s "
-        "denylist_count=%s settings=%s store=%s",
-        workspace_id,
-        is_synthetic,
-        typed_authz_available,
-        typed_cohort,
-        workspace_allowlisted,
-        workspace_denylisted,
-        len(allowlist_ids),
-        len(denylist_ids),
-        type(settings).__name__,
-        type(store_target).__name__,
-    )
 
 
 def _authorization_endpoint_candidates(

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -17,9 +17,6 @@ import threading
 import pytest
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.config import Settings
-from trusted_router.routes.internal.gateway import _log_typed_billing_decision
-from trusted_router.schemas import GatewayAuthorizeRequest
 from trusted_router.storage import CreditAccount
 from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
@@ -983,49 +980,3 @@ def test_typed_origin_and_idempotency_guarded_by_mirror_flag() -> None:
     store._counter_mirror_enabled = False
     assert store.is_typed_reservation("any", "auth") is False
     assert store.get_typed_authorization_by_idempotency("ws", "kh", "k") is None
-
-
-def test_typed_billing_decision_log_is_scoped_to_synthetic(caplog) -> None:
-    settings = Settings(
-        environment="test",
-        typed_billing_workspace_ids="ws_synthetic",
-    )
-    body = GatewayAuthorizeRequest(
-        api_key_lookup_hash="lookup",
-        model="trustedrouter/monitor",
-        metadata={"trustedrouter_synthetic": "true"},
-    )
-
-    with caplog.at_level("WARNING", logger="trusted_router"):
-        _log_typed_billing_decision(
-            body=body,
-            workspace_id="ws_synthetic",
-            settings=settings,
-            typed_authz_available=True,
-            typed_cohort=False,
-        )
-
-    assert "typed_billing_decision" in caplog.text
-    assert "ws=ws_synthetic" in caplog.text
-    assert "synthetic=True" in caplog.text
-    assert "typed_authz=True" in caplog.text
-    assert "cohort=False" in caplog.text
-    assert "workspace_allowlisted=True" in caplog.text
-    assert "workspace_denylisted=False" in caplog.text
-    assert "allowlist_count=1" in caplog.text
-
-
-def test_typed_billing_decision_log_ignores_unrelated_authorizes(caplog) -> None:
-    settings = Settings(environment="test", typed_billing_workspace_ids="ws_synthetic")
-    body = GatewayAuthorizeRequest(api_key_lookup_hash="lookup", model="trustedrouter/auto")
-
-    with caplog.at_level("WARNING", logger="trusted_router"):
-        _log_typed_billing_decision(
-            body=body,
-            workspace_id="ws_other",
-            settings=settings,
-            typed_authz_available=True,
-            typed_cohort=True,
-        )
-
-    assert "typed_billing_decision" not in caplog.text


### PR DESCRIPTION
## Problem
Production alert: `AxiomError: ingestion only supported for logs and events datasets` firing ~50×/hr on `gateway_authorize` (issue ef443a1d).

Root cause: the #68 diagnostic (`_log_typed_billing_decision`) calls `logger.warning(...)` on every synthetic/cohort authorize for workspace `45819281`. The service's Axiom logging handler tries to ingest that record into a dataset that doesn't support ingestion → `AxiomError`.

## Severity
**Non-fatal.** Zero 5xx on `/internal/gateway/authorize` in the trailing hour — Python's `logging.handleError` swallows the handler exception, so the request still returns 200 and typed reservations keep being created. It's pure error-tracker spam, but it's noisy and the diagnostic never produced useful Cloud Logging lines anyway (per the #68 author's own note in the handoff doc).

## Fix
Revert #68 in full (`3c92420`): removes `_log_typed_billing_decision`, the `logger`/`import logging` it added, and its tests. **The typed-billing cohort branch logic (`if _typed_authz is not None and _typed_cohort:`) is untouched** — only the breadcrumb log call before it is removed.

## Verification
- `grep`: diagnostic + logger fully gone; cohort branch intact (gateway.py:215–227).
- `ruff` + `mypy` clean on the changed file.
- Billing suite green: `88 passed` (test_billing_typed_enforcement / _counters / test_billing).

## Note (separate, pre-existing)
The underlying Axiom misconfig (a configured dataset that rejects ingestion) is latent and pre-existing — this revert just stops the path that triggers it. Worth a separate look at `init_axiom` dataset config.