### PR TITLE
billing(cutover ramp 1): add real workspace 063e9fb9 to typed enforcement cohort

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -115,7 +115,10 @@ ENV_VARS=(
   # prod-smoke gateway_authorize_settle). DDL applied, mirror live, drift
   # comparator CLEAN before this. Empty = no enforcement; add to a denylist env
   # to kill-switch a workspace. Ramp by appending more workspace IDs.
-  "TR_TYPED_BILLING_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d"
+  # Ramp 1 (2026-06-21): +063e9fb9 — the most active REAL workspace (live
+  # in-flight reservations, funded), pre-flight comparator CLEAN + available>0.
+  # First real (non-synthetic, real-model CREDITS) traffic on the typed path.
+  "TR_TYPED_BILLING_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,063e9fb9-880b-41f6-a122-b141e52ed4bb"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 


### PR DESCRIPTION
## What
Appends the first **real** workspace (`063e9fb9-880b-41f6-a122-b141e52ed4bb`) to `TR_TYPED_BILLING_WORKSPACE_IDS`, so its gateway authorize/settle run the typed conditional-DML path (the deadlock fix). Config-only change to `rollout.sh`.

## Why this workspace
Most active real workspace — live in-flight reservations (typed reserved=3.8M), funded (available=30M). Exercises the typed path on real (non-synthetic, real-model CREDITS) traffic.

## Pre-flight (all verified)
- Drift comparator **CLEAN** for 063e9fb9 and its keys (only the synthetic 45819281 shows the expected post-flip drift).
- Typed `available` = 30,125,008 (>0); mirror fresh (source_updated_at 14:12Z).
- Gate verified with the 2-entry CSV: 45819281→True, 063e9fb9→True, others→False, denylist kill-switch→False.
- `bash -n rollout.sh` OK.

## Context
Deadlocks were dominated by the synthetic monitor (the only workspace appearing in deadlock payloads; ~8000x the traffic of any real ws). **0 deadlocks service-wide since its cutover.** So this ramp is real-traffic validation + de-risking future growth, not active fire-fighting.

## Rollback
Fast kill-switch: `gcloud run services update --update-env-vars TR_TYPED_BILLING_WORKSPACE_DENYLIST=063e9fb9-...` (denylist wins, ~minutes), or revert this PR. In-flight typed reservations still finalize (settle routes by reservation origin).