### PR TITLE
pricing: stop a spurious provider $0 from freezing the hourly refresh (+ fix self-heal)

### DIFF
--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -57,6 +57,13 @@ PARSER_IMPORT_WHITELIST = frozenset(
         "json",
         "typing",
         "dataclasses",
+        # `from __future__ import annotations` is a compile-time directive,
+        # not a runtime import — it can't pull in executable code. The
+        # self-heal LLM emits it (it's idiomatic and present in every
+        # committed parser), and rejecting it made EVERY self-heal attempt
+        # fail the whitelist, so venice/novita/mistral could never recover
+        # from a deterministic-parse failure and went stale hourly.
+        "__future__",
     }
 )
 
@@ -574,7 +581,12 @@ def ast_whitelist_check(source: str) -> list[str]:
         errors.append("missing top-level function `parse`")
         return errors
 
-    # Validate parse(html: str) -> dict signature.
+    # Validate the parse() signature: exactly one positional arg. The arg
+    # NAME is not constrained — sandbox_run_parser invokes `parse(html)`
+    # positionally (the value is the captured page source regardless of the
+    # parameter's name), and the self-heal LLM frequently names it `text`/
+    # `markdown`/`source`. Requiring the literal name `html` rejected
+    # otherwise-valid self-heal output and was a no-op for safety.
     args = parse_func_node.args
     if (
         len(args.args) != 1
@@ -583,9 +595,7 @@ def ast_whitelist_check(source: str) -> list[str]:
         or args.kwonlyargs
         or args.posonlyargs
     ):
-        errors.append("parse() must take exactly one positional arg `html`")
-    elif args.args[0].arg != "html":
-        errors.append("parse() first arg must be named `html`")
+        errors.append("parse() must take exactly one positional arg")
 
     # Walk the entire AST once for blacklisted name references.
     for sub in ast.walk(tree):

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -449,6 +449,24 @@ def _cross_check_ids(
     return notes
 
 
+def _is_unpriced(price: ModelPrice) -> bool:
+    """A provider-direct ModelPrice whose headline tier is $0 prompt AND
+    $0 completion is treated as UNPRICED, not as a genuinely free model.
+
+    Keyed providers in this catalog do not serve free models; a $0/$0 row
+    is always a feed/parse artifact — a `:free`/preview variant that
+    collapsed onto the paid id, a /v1/models row listed without pricing
+    (coerced to 0), or an intermittent omission. Letting such a $0 into
+    the `cheapest`-tier selection zeroes the model's headline, trips
+    check_price_spike's both-prices-to-zero guard, and freezes the entire
+    hourly refresh (observed: a ~2-week stall, last good commit 2026-06-07,
+    over 6 popular open models like gemma-3-4b-it / llama-3.3-70b that are
+    in fact served at real prices). If a genuinely-free model is ever
+    needed, add it to an explicit allowlist rather than trusting a 0."""
+    headline = price.tiers[0]
+    return headline.prompt_micro_per_m <= 0 and headline.completion_micro_per_m <= 0
+
+
 def _price_to_pricing_block(price: ModelPrice) -> dict[str, Any]:
     """Render a ModelPrice into the snapshot's `pricing` block. The
     headline (low-tier) rate is exposed as `pricing.prompt` /
@@ -544,19 +562,61 @@ def _merge_snapshot(
             # this case ("parser found N models OR doesn't list").
             continue
         new_model = dict(or_model)
-        # Model-level headline pricing = the cheapest provider-direct
-        # tier across all endpoints (matches OR's convention and what
-        # /v1/models top-level pricing should show).
-        cheapest = min(by_slug.values(), key=lambda p: p.tiers[0].prompt_micro_per_m)
+        # Drop $0/$0 provider tiers BEFORE selecting the headline. A zero
+        # price from a keyed provider is a feed artifact, not a free model
+        # (see _is_unpriced) — and because the headline is the *cheapest*
+        # tier, a single spurious $0 would otherwise win `min()` and zero
+        # the model, freezing the whole refresh via the spike watchdog.
+        priced_by_slug = {
+            slug: price for slug, price in by_slug.items() if not _is_unpriced(price)
+        }
         new_pricing = dict(new_model.get("pricing") or {})
-        new_pricing.update(_price_to_pricing_block(cheapest))
-        new_model["pricing"] = new_pricing
-        # Tag pricing_source as self-healed if ANY of the slugs that
-        # priced this model went through the LLM rewrite.
-        if any(slug in healed_slugs for slug in by_slug):
-            new_model["pricing_source"] = "self_healed_provider"
+        if priced_by_slug:
+            # Model-level headline pricing = the cheapest *positively-priced*
+            # provider-direct tier (matches OR's convention and what
+            # /v1/models top-level pricing should show).
+            cheapest = min(
+                priced_by_slug.values(), key=lambda p: p.tiers[0].prompt_micro_per_m
+            )
+            new_pricing.update(_price_to_pricing_block(cheapest))
+            new_model["pricing"] = new_pricing
+            # Tag pricing_source as self-healed if ANY of the slugs that
+            # priced this model went through the LLM rewrite.
+            if any(slug in healed_slugs for slug in priced_by_slug):
+                new_model["pricing_source"] = "self_healed_provider"
+            else:
+                new_model["pricing_source"] = "provider_direct"
         else:
-            new_model["pricing_source"] = "provider_direct"
+            # Every keyed provider returned $0 for a model that OR prices
+            # above $0 — a feed glitch across all of them at once. Fall
+            # back to OR's cross-check price (the one place OR is used as a
+            # billing source, by explicit design, as a last resort) rather
+            # than emitting $0 (freezes the refresh) or dropping a model we
+            # actually serve. If OR has no usable price either, skip it.
+            or_price = _or_pricing_to_micro_per_m(or_model.get("pricing") or {})
+            if or_price is None or _is_unpriced(or_price):
+                continue
+            new_pricing.update(_price_to_pricing_block(or_price))
+            new_model["pricing"] = new_pricing
+            new_model["pricing_source"] = "openrouter_fallback"
+            # Keep OR's endpoints (with their OR pricing) so the model
+            # stays routable — rebuilding from priced_by_slug would drop
+            # every endpoint (it's empty here) and the no-endpoints guard
+            # below would then delete a model we actually serve.
+            or_endpoints: list[dict[str, Any]] = []
+            for ep in new_model.get("endpoints") or []:
+                if not isinstance(ep, dict) or not isinstance(
+                    ep.get("tr_provider_slug"), str
+                ):
+                    continue
+                or_ep = dict(ep)
+                or_ep["pricing_source"] = "openrouter_fallback"
+                or_endpoints.append(or_ep)
+            if not or_endpoints:
+                continue
+            new_model["endpoints"] = or_endpoints
+            merged_models.append(new_model)
+            continue
 
         new_endpoints: list[dict[str, Any]] = []
         seen_slugs: set[str] = set()
@@ -565,11 +625,11 @@ def _merge_snapshot(
             ep_slug = new_ep.get("tr_provider_slug")
             if not isinstance(ep_slug, str):
                 continue
-            ep_price = by_slug.get(ep_slug)
+            ep_price = priced_by_slug.get(ep_slug)
             if ep_price is None:
-                # Drop non-priced endpoints — without provider-direct
-                # pricing we can't bill the route, so listing it is
-                # misleading.
+                # Drop non-priced AND $0-priced endpoints — without a real
+                # provider-direct price we can't bill the route, so listing
+                # it is misleading (and a $0 here would understate cost).
                 continue
             new_ep_pricing = dict(new_ep.get("pricing") or {})
             new_ep_pricing.update(_price_to_pricing_block(ep_price))
@@ -596,7 +656,7 @@ def _merge_snapshot(
         # it into the catalog — OR's /endpoints feed lags or omits them
         # entirely, but we still bill correctly because the parser pulled
         # the price straight off the provider's own pricing page / API.
-        for missing_slug, missing_price in by_slug.items():
+        for missing_slug, missing_price in priced_by_slug.items():
             if missing_slug in seen_slugs:
                 continue
             synth_slug_map = upstream_id_maps.get(missing_slug) or {}

--- a/tests/test_pricing_base.py
+++ b/tests/test_pricing_base.py
@@ -123,6 +123,22 @@ def test_ast_whitelist_passes_clean_parser() -> None:
     assert ast_whitelist_check(_VALID_PARSER) == []
 
 
+def test_ast_whitelist_allows_future_import_and_any_arg_name() -> None:
+    """Regression for the self-heal freeze: the LLM-rewritten parsers emit
+    `from __future__ import annotations` (idiomatic, present in every
+    committed parser) and often name the arg `text`/`markdown` instead of
+    `html`. Both used to fail the whitelist, so venice/novita/mistral could
+    never self-heal and went stale hourly. `__future__` is a compile-time
+    directive (no runtime import) and parse() is called positionally."""
+    src = (
+        "from __future__ import annotations\n"
+        "import re\n\n"
+        "def parse(markdown: str) -> dict:\n"
+        '    return {"x/y": {"prompt_micro_per_m": 1, "completion_micro_per_m": 2}}\n'
+    )
+    assert ast_whitelist_check(src) == []
+
+
 def test_ast_whitelist_rejects_subprocess_import() -> None:
     src = "import subprocess\n\ndef parse(html: str) -> dict:\n    return {}\n"
     errors = ast_whitelist_check(src)

--- a/tests/test_pricing_zero_guard.py
+++ b/tests/test_pricing_zero_guard.py
@@ -1,0 +1,115 @@
+"""Regression tests for the 2026-06 price-refresh freeze.
+
+A single provider returning $0 for a popular open model (a `:free`/preview
+variant, a /v1/models row listed without pricing, or an intermittent
+omission) used to win `_merge_snapshot`'s cheapest-tier selection, zero the
+model's headline, trip check_price_spike's both-prices-to-zero guard, and
+freeze the ENTIRE hourly refresh — the committed snapshot went stale for
+~2 weeks while ~6 models (gemma-3-4b-it, llama-3.3-70b, ...) were in fact
+served at real prices the whole time.
+"""
+from __future__ import annotations
+
+from scripts.pricing import refresh as R
+from scripts.pricing.base import ModelPrice, PriceTier
+
+
+def _mp(prompt_micro: int, completion_micro: int) -> ModelPrice:
+    return ModelPrice(
+        tiers=[
+            PriceTier(
+                max_prompt_tokens=None,
+                prompt_micro_per_m=prompt_micro,
+                completion_micro_per_m=completion_micro,
+            )
+        ]
+    )
+
+
+def _or_snapshot(model_id: str, slugs: list[str], pricing: dict[str, str]) -> dict:
+    return {
+        "models": [
+            {
+                "id": model_id,
+                "name": model_id,
+                "context_length": 131072,
+                "pricing": pricing,
+                "endpoints": [
+                    {
+                        "name": f"{s} | {model_id}",
+                        "model_id": model_id,
+                        "tr_provider_slug": s,
+                        "context_length": 131072,
+                        "pricing": pricing,
+                    }
+                    for s in slugs
+                ],
+            }
+        ],
+        "tr_keyed_providers": slugs,
+    }
+
+
+def test_zero_priced_provider_does_not_win_cheapest() -> None:
+    """deepinfra prices gemma-3-4b-it for real; a second provider returns
+    $0 (free-tier artifact). The headline must be deepinfra's real price,
+    NOT $0 — this is the exact shape that froze the refresh."""
+    mid = "google/gemma-3-4b-it"
+    or_snap = _or_snapshot(
+        mid, ["deepinfra"], {"prompt": "0.00000005", "completion": "0.0000001"}
+    )
+    provider_index = {
+        mid: {
+            "deepinfra": _mp(50_000, 100_000),  # real $0.05/$0.10 per M
+            "novita": _mp(0, 0),  # spurious free-tier $0 row
+        }
+    }
+    merged = R._merge_snapshot(or_snap, provider_index, set())
+    model = next(m for m in merged["models"] if m["id"] == mid)
+    assert model["pricing"]["prompt"] == "0.00000005", model["pricing"]
+    assert model["pricing"]["completion"] == "0.0000001", model["pricing"]
+    assert model["pricing_source"] == "provider_direct"
+    # the $0 endpoint must not appear; deepinfra must.
+    slugs = {e["tr_provider_slug"] for e in model["endpoints"]}
+    assert slugs == {"deepinfra"}, slugs
+
+
+def test_all_zero_falls_back_to_openrouter_not_zero() -> None:
+    """If EVERY keyed provider returns $0 for a model OR prices > $0 (a
+    feed glitch across all of them), fall back to OR's price rather than
+    emitting $0 (which freezes the refresh) or dropping a served model."""
+    mid = "meta-llama/llama-3.3-70b-instruct"
+    or_snap = _or_snapshot(
+        mid, ["parasail", "tinfoil"], {"prompt": "0.0000001", "completion": "0.00000032"}
+    )
+    provider_index = {mid: {"parasail": _mp(0, 0), "tinfoil": _mp(0, 0)}}
+    merged = R._merge_snapshot(or_snap, provider_index, set())
+    model = next(m for m in merged["models"] if m["id"] == mid)
+    assert model["pricing"]["prompt"] == "0.0000001", model["pricing"]
+    assert model["pricing_source"] == "openrouter_fallback"
+    assert model["endpoints"], "OR-fallback model must keep its endpoints"
+
+
+def test_positive_price_path_unchanged() -> None:
+    """No $0 anywhere → behaves exactly as before (cheapest positive tier)."""
+    mid = "google/gemma-3-27b-it"
+    or_snap = _or_snapshot(
+        mid,
+        ["deepinfra", "parasail"],
+        {"prompt": "0.00000008", "completion": "0.00000016"},
+    )
+    provider_index = {
+        mid: {"deepinfra": _mp(80_000, 160_000), "parasail": _mp(120_000, 450_000)}
+    }
+    merged = R._merge_snapshot(or_snap, provider_index, set())
+    model = next(m for m in merged["models"] if m["id"] == mid)
+    # cheapest prompt tier = deepinfra 80_000
+    assert model["pricing"]["prompt"] == "0.00000008", model["pricing"]
+    assert model["pricing_source"] == "provider_direct"
+
+
+def test_is_unpriced_helper() -> None:
+    assert R._is_unpriced(_mp(0, 0))
+    assert not R._is_unpriced(_mp(1, 0))
+    assert not R._is_unpriced(_mp(0, 1))
+    assert not R._is_unpriced(_mp(50_000, 100_000))


### PR DESCRIPTION
## Symptom
The hourly **Refresh upstream prices** workflow has failed **60+ runs in a row** — the last committed `[bot] price refresh` was **2026-06-07**, so catalog prices have been frozen ~2 weeks. No *wrong* price went live (the watchdog blocked each bad snapshot), but every price update stalled and the gap grows hourly.

## Root cause — two bugs
**1. A spurious provider `$0` wins "cheapest" and zeroes the model.**
`_merge_snapshot` sets a model's headline to the *cheapest* provider tier, and `MIN_PRICE_MICRO_PER_M = 0` makes `$0` a valid tier. So a single `$0` from any keyed provider — a `:free`/preview variant collapsed onto the paid id, a `/v1/models` row listed without pricing, or an intermittent omission — wins `min()`, zeroes the headline, trips `check_price_spike`'s both-prices-to-zero guard, and blocks the commit. Six popular open models (`gemma-3-4b-it`, `llama-3.3-70b`, `gemma-3-27b-it`, `gemma-4-26b-a4b-it`, `qwen3.5-35b-a3b`, `glm-4.5v`) were hit **despite being served at real prices the whole time** — confirmed live: deepinfra returns `gemma-3-4b-it` at `$0.05/$0.10`, and in isolation the merge produces the correct price; the `$0` only appears when an *extra* provider contributes `$0` to `by_slug`.

**2. Self-heal was completely broken.** `ast_whitelist_check` rejected `from __future__ import annotations` (`__future__` wasn't whitelisted) and required `parse()`'s arg be named `html` — but the self-heal LLM emits both. So `venice`/`novita`/`mistral` could never recover from a deterministic-parse failure and went stale every hour.

## Fix
- `_is_unpriced()` drops `$0/$0` tiers **before** cheapest-selection and endpoint construction (a `$0` from a keyed provider is a feed artifact, not a free model).
- If **every** provider is `$0` for a model OR prices `>$0` (a glitch across all of them), fall back to **OpenRouter's price** (`pricing_source="openrouter_fallback"`) — OR as the explicit last-resort cross-check — rather than emitting `$0` or dropping a served model.
- Whitelist `__future__` (compile-time directive, no runtime import) and drop the cosmetic `html` arg-name requirement (`parse()` is invoked positionally). Self-heal can run again.

## Proof
- New `tests/test_pricing_zero_guard.py` reproduces the exact failure shape (real price + spurious `$0` → headline stays real; all-zero → OR fallback, never `$0`).
- New whitelist regression test in `test_pricing_base.py`.
- **End-to-end:** the real pipeline (live fetch + stale-fallback + merge) now prices all six and **would commit** — 0 would-freeze models.
- Full suite: **1002 passed**, ruff + mypy clean.

## After merge
The refresh will commit a fresh snapshot for the first time in ~2 weeks; it deploys via the normal `src/**` trigger. **Eyeball the first auto-commit's diff** before it ships, since ~2 weeks of real provider price movement lands at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)