### PR TITLE
[codex] Add x402 stablecoin funding

### DIFF
--- a/docs/design/x402-stablecoin-funding.md
+++ b/docs/design/x402-stablecoin-funding.md
@@ -1,0 +1,297 @@
+# TrustedRouter x402 Stablecoin Funding Design
+
+Status: draft for review
+Owner: Lore Hex Corp
+Last updated: 2026-06-22
+Review status: reviewed with `claude --print` on 2026-06-22; P0/P1 feedback incorporated.
+
+## Summary
+
+TrustedRouter should support x402 stablecoin payments as a control-plane funding rail for existing workspaces. x402 should not run inside the attested enclave and should not change the prompt path. Agents still use a normal TrustedRouter API key. When credits are low, the agent can call a separate billing API to receive a Stripe x402 payment challenge, pay in USDC, and have the workspace credited after Stripe verifies settlement.
+
+The attested gateway remains unchanged: it receives the API key, asks the control plane for metadata-only authorization, serves the prompt only when credits are available, and returns insufficient-credit errors when the ledger cannot reserve funds.
+
+## Goals
+
+- Let agents automatically add prepaid credits using stablecoin.
+- Require a TrustedRouter API key for all x402 flows.
+- Keep the existing integer credit ledger as the source of truth.
+- Keep all x402 logic in the control plane, outside the enclave.
+- Keep prompt and output content out of Stripe, x402 payment metadata, Sentry, logs, and billing records.
+- Make all settlement paths idempotent.
+- Credit only from Stripe-confirmed settled amounts, never from client input.
+
+## Non-Goals
+
+- No accountless anonymous paid inference in v1.
+- No per-token on-chain refund path in v1.
+- No x402 code inside the enclave.
+- No prompt-path fallback to a non-attested control-plane route.
+- No Coinbase facilitator in v1. Stripe x402 is first.
+- No sub-cent x402 top-ups in v1, because Stripe PaymentIntent amounts are cent-denominated.
+
+## Research Notes
+
+- x402 uses HTTP `402 Payment Required` with machine-readable payment requirements so a client or agent can pay and retry. Coinbase describes this as a buyer requesting a resource, the server returning `PAYMENT-REQUIRED`, then the buyer sending payment authorization via `PAYMENT-SIGNATURE`.
+- Stripe's x402 docs describe a `payment-required` response header containing a base64-encoded payment requirements payload. Their quickstart creates a crypto `PaymentIntent` in deposit mode and extracts a USDC deposit address from `next_action.crypto_display_details.deposit_addresses`.
+- Stripe Machine Payments currently documents Base USDC support for x402. Stripe settlement should land in the Stripe account/balance according to account eligibility, so TrustedRouter should not require a special stablecoin bank account for the Stripe-first implementation.
+- Coinbase's facilitator model remains useful later if TrustedRouter wants Coinbase Business settlement, direct USDC treasury, or a non-Stripe route.
+
+References:
+
+- https://docs.stripe.com/payments/machine/x402
+- https://docs.stripe.com/payments/machine/x402/quickstart
+- https://docs.cdp.coinbase.com/x402/welcome
+- https://docs.cdp.coinbase.com/x402/core-concepts/facilitator
+- https://www.x402.org/
+
+## Public API
+
+### `POST /v1/billing/x402/fund`
+
+Authenticated by `Authorization: Bearer sk-tr-...`.
+
+Request:
+
+```json
+{
+  "amount": "10.00"
+}
+```
+
+Behavior:
+
+- Requires an inference or management API key.
+- Resolves the key's workspace.
+- Rejects request bodies containing `workspace_id`; x402 funding always derives workspace from the API key.
+- Rejects amounts below the minimum, above `TR_X402_MAX_FUND_DOLLARS`, or not exactly representable in cents.
+- Applies per-key and per-workspace rate limits before calling Stripe.
+- Creates a Stripe crypto `PaymentIntent` in deposit mode.
+- Stamps metadata:
+  - `workspace_id`
+  - `amount_microdollars`
+  - `payment_method=x402`
+  - `purpose=trustedrouter_credits`
+  - `asset=USDC`
+  - `network=base`
+- Returns HTTP `402 Payment Required`.
+- Includes `payment-required` response header with a base64 x402 payload.
+- Includes a JSON body for debugging and non-x402 clients.
+
+Response shape:
+
+```json
+{
+  "error": {
+    "code": 402,
+    "message": "Stablecoin payment required to add TrustedRouter credits",
+    "type": "insufficient_credits"
+  },
+  "data": {
+    "payment_protocol": "x402",
+    "provider": "stripe",
+    "payment_intent_id": "pi_...",
+    "network": "eip155:8453",
+    "asset": "USDC",
+    "amount_decimal": "10.00",
+    "amount_microdollars": 10000000,
+    "payment_required_header": "base64..."
+  }
+}
+```
+
+### `POST /v1/billing/x402/settle`
+
+Authenticated by `Authorization: Bearer sk-tr-...`.
+
+Request:
+
+```json
+{
+  "payment_intent_id": "pi_..."
+}
+```
+
+Behavior:
+
+- Retrieves the Stripe `PaymentIntent`.
+- Requires `metadata.payment_method=x402`.
+- Requires the PaymentIntent workspace to match the API key workspace.
+- Requires `currency=usd`.
+- Requires metadata `asset=USDC` and configured network.
+- Also verifies crypto asset/network from Stripe crypto display details when Stripe exposes those details.
+- If status is not terminal-success, returns the current payment status and does not credit.
+- If status is `succeeded`, credits the workspace exactly once using event id `x402:{payment_intent_id}`.
+- Credits from Stripe's settled amount (`amount_received` where available, otherwise Stripe `amount` only for already-succeeded PaymentIntents), capped by the amount TrustedRouter originally requested in metadata. Client-supplied settle bodies never control the credited amount.
+- Returns whether this call newly credited the workspace or was an idempotent replay.
+
+### Stripe Webhook
+
+The existing `/v1/internal/stripe/webhook` should handle `payment_intent.succeeded` where `metadata.payment_method=x402`.
+
+Webhook and `POST /v1/billing/x402/settle` use the same idempotency key, so either can arrive first:
+
+- webhook first, settle later: settle returns `credited=false`
+- settle first, webhook later: webhook returns `credited=false`
+- duplicate webhooks: only the first credits
+- distinct Stripe webhook events for the same PaymentIntent: only the first successful PaymentIntent credit lands
+
+Webhook signature verification remains mandatory in production. Tests must cover missing signatures, invalid signatures, and replay outside Stripe tolerance.
+
+Additional terminal or near-terminal events:
+
+- `payment_intent.processing`, `payment_intent.requires_action`, partial funding states: record status only, no credit.
+- `payment_intent.canceled`, `payment_intent.payment_failed`: record status only, no credit.
+- `charge.refunded` / refund events: v1 does not automatically debit already-granted credits. It must create an operator-visible alert and runbook entry. Automated debit support is a follow-up because debiting after credits may have been spent needs an explicit negative-balance policy.
+
+## Data Model
+
+Use existing credit ledger primitives in v1:
+
+- `CreditAccount.total_credits_microdollars`
+- `credit_workspace_once(workspace_id, amount_microdollars, event_id)`
+- existing `stripe_event` idempotency records
+
+No new Spanner table is required for v1 correctness. A future observability enhancement can add a first-class `payment` record for richer payment history, but the credit ledger and Stripe remain sufficient source of truth for v1.
+
+Money units:
+
+- TrustedRouter ledger: integer microdollars.
+- USDC: 6 decimal atomic units.
+- Stripe `PaymentIntent.amount`: integer cents.
+- x402 funding v1 accepts only cent-exact amounts: `amount_microdollars % 10_000 == 0`.
+- For USD-denominated credits, `amount_microdollars` maps 1:1 to USDC atomic units after the cent-exact Stripe amount is confirmed.
+- No floats in billing math.
+
+## Enclave Boundary
+
+x402 is not part of the enclave.
+
+The enclave still:
+
+- accepts prompt requests on `api.trustedrouter.com`
+- keeps prompt TLS termination inside Confidential Space
+- hashes API key metadata for control-plane authorization
+- receives either an authorization or an insufficient-credit error
+- does not create Stripe PaymentIntents
+- does not parse x402 payment headers
+- does not send prompt or output content to the payment system
+
+If a caller lacks credits, the enclave can continue returning its current insufficient-credit response. Docs should instruct agents to call the control-plane x402 funding endpoint and retry after funding.
+
+## Agent Flow
+
+1. Agent calls `POST /v1/chat/completions` with `Authorization: Bearer sk-tr-...`.
+2. If credits are sufficient, request proceeds normally.
+3. If credits are insufficient, the API returns `402 insufficient_credits`.
+4. Agent calls `POST /v1/billing/x402/fund` with the same API key and desired top-up amount.
+5. TrustedRouter returns a Stripe x402 `payment-required` challenge.
+6. Agent pays through its x402-capable wallet/client.
+7. Agent polls `POST /v1/billing/x402/settle` with exponential backoff, or waits for webhook settlement.
+8. TrustedRouter credits the workspace.
+9. Agent retries the original inference request.
+
+Recommended agent polling:
+
+- First retry after 5 seconds.
+- Then 10s, 20s, 30s, max every 60s.
+- Stop after 10 minutes and tell the user the payment is still pending.
+- Server-side `/settle` should rate limit per PaymentIntent to prevent hot loops.
+
+## Security Requirements
+
+- API key required for all x402 endpoints.
+- x402 funding never accepts `workspace_id` from the request body in v1. Workspace is derived from the API key.
+- Stripe metadata is treated as semi-public: visible to Stripe, Stripe dashboard viewers, exports, and support workflows. Keep it to workspace/payment bookkeeping only.
+- Stripe PaymentIntent metadata must not include prompts, outputs, message arrays, request bodies, user supplied prompt text, or API key raw values.
+- Stripe PaymentIntent metadata should not include stable API-key hashes unless a later fraud investigation feature explicitly needs it. Workspace id is enough for v1.
+- `payment_intent_id` can only credit the workspace stamped on Stripe metadata.
+- Duplicate or replayed PaymentIntent IDs credit once.
+- `payment_intent_id` must be a Stripe-shaped `pi_...` id before the server contacts Stripe.
+- Pending/failed/canceled PaymentIntents never credit.
+- Amount credited must come from Stripe's settled amount, bounded by TrustedRouter's requested amount in metadata, not from a client-supplied settle body.
+- Logs and Sentry must allowlist x402 fields. Redact `Authorization`, payment payload headers, and raw request bodies.
+- Feature flag disabled by default.
+
+## Config
+
+Suggested settings:
+
+- `TR_X402_ENABLED=false`
+- `TR_X402_ALLOW_MOCK_PAYMENTS=false`
+- `TR_X402_NETWORK=base`
+- `TR_X402_NETWORK_ID=eip155:8453`
+- `TR_X402_STRIPE_API_VERSION=2026-03-04.preview`
+- `TR_X402_MAX_FUND_DOLLARS=500`
+- `TR_X402_RATE_LIMIT_WINDOW_SECONDS=60`
+- `TR_X402_RATE_LIMIT_KEY_PER_WINDOW=10`
+- `TR_X402_RATE_LIMIT_WORKSPACE_PER_WINDOW=30`
+- `TR_X402_SETTLE_RATE_LIMIT_PER_WINDOW=30`
+- `TR_X402_SETTLE_WORKSPACE_PER_WINDOW=120`
+
+Production prerequisites:
+
+- `TR_STRIPE_SECRET_KEY`
+- `TR_STRIPE_WEBHOOK_SECRET`
+- Stripe account eligible for crypto/machine payments
+- Stripe webhook includes `payment_intent.succeeded`
+- `TR_X402_ALLOW_MOCK_PAYMENTS` must never be enabled outside local/test. Production boot fails closed if mock payments are enabled or x402 is enabled without Stripe credentials.
+
+## Tests
+
+Unit tests:
+
+- x402 disabled returns `404 not_found`.
+- missing API key returns `401`.
+- funding endpoint requires API key and derives workspace from key.
+- funding endpoint rejects `workspace_id` in request body.
+- funding endpoint enforces max amount and cent-exact amounts.
+- funding endpoint rate limits before Stripe calls.
+- funding response has status 402 and `payment-required` header.
+- Stripe PaymentIntent create args include crypto deposit mode and safe metadata only.
+- settle rejects wrong workspace.
+- settle returns `404`, not `403`, for cross-workspace PaymentIntent references so it does not confirm existence to another workspace.
+- settle rejects non-x402 PaymentIntent metadata.
+- settle rejects malformed `payment_intent_id` before calling Stripe.
+- settle rejects wrong currency, wrong asset, and wrong network.
+- pending PaymentIntent does not credit.
+- partial or underfunded PaymentIntent does not overcredit.
+- succeeded PaymentIntent credits exactly once.
+- webhook and settle are idempotent in both arrival orders.
+- two different Stripe webhook event ids for the same PaymentIntent credit exactly once.
+- concurrent settle calls for the same PaymentIntent credit exactly once.
+- refund/reversal events create an operator-visible status and do not silently ignore the reversal.
+- prompt/output strings are absent from x402 response, Stripe metadata, and ledger records.
+- amount conversion uses integer microdollars.
+- Stripe webhook signature verification rejects unsigned, invalid, and stale signatures.
+
+Integration tests:
+
+- fake Stripe PaymentIntent create/retrieve.
+- agent flow: insufficient credits, x402 fund, settle, retry authorizes.
+- duplicate webhook replay.
+
+Manual canary:
+
+- enable `TR_X402_ENABLED=1` for a test workspace.
+- create a tiny PaymentIntent through `/v1/billing/x402/fund`.
+- pay with a test x402-capable client or Stripe test tooling if available.
+- verify credits appear and inference authorizes.
+
+## Rollout
+
+1. Land behind `TR_X402_ENABLED=false`.
+2. Enable in local/test only with mocked Stripe.
+3. Enable in staging against Stripe test mode.
+4. Enable one internal production workspace.
+5. Add dashboards/alerts for PaymentIntent create error rate, settle latency, webhook-to-credit latency, and stuck PaymentIntents.
+6. Add an operator runbook for "Stripe succeeded but credits did not land" and refund/reversal handling.
+7. Add public docs after a real stablecoin canary succeeds.
+8. Keep the normal Stripe Checkout stablecoin button unchanged.
+
+## Open Questions
+
+- Stripe account eligibility: confirm whether Lore Hex Corp Stripe account has x402 / Machine Payments enabled in production.
+- Stripe exact header names: implementation should follow the current Stripe docs at build time. Docs currently show `payment-required`; Coinbase docs use `PAYMENT-REQUIRED` / `PAYMENT-SIGNATURE` terminology.
+- Payment history: v1 can rely on Stripe and credit ledger, but the console may need a first-class x402 payment list later.
+- Minimum top-up: recommend `$1` minimum initially to avoid tiny-payment support issues.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -127,6 +127,17 @@ class Settings(BaseSettings):
     ses_configuration_set: str | None = "trustedrouter-default"
 
     stablecoin_checkout_enabled: bool = True
+    x402_enabled: bool = False
+    x402_allow_mock_payments: bool = False
+    x402_network: str = "base"
+    x402_network_id: str = "eip155:8453"
+    x402_stripe_api_version: str = "2026-03-04.preview"
+    x402_max_fund_dollars: str = "500"
+    x402_rate_limit_window_seconds: int = 60
+    x402_rate_limit_key_per_window: int = 10
+    x402_rate_limit_workspace_per_window: int = 30
+    x402_settle_rate_limit_per_window: int = 30
+    x402_settle_workspace_per_window: int = 120
     multi_region_enabled: bool = True
     # Operational read-only flag. When set, write paths (credit
     # reservations, gateway authorize, signup, etc.) return 503 with
@@ -210,7 +221,19 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def production_is_fail_closed(self) -> Settings:
-        if self.environment.lower() != "production":
+        environment = self.environment.lower()
+        if self.x402_allow_mock_payments and environment not in {"local", "test"}:
+            raise ValueError("TR_X402_ALLOW_MOCK_PAYMENTS is only allowed in local/test")
+        if (
+            self.x402_enabled
+            and environment not in {"local", "test"}
+            and (not self.stripe_secret_key or not self.stripe_webhook_secret)
+        ):
+            raise ValueError(
+                "TR_X402_ENABLED requires TR_STRIPE_SECRET_KEY and "
+                "TR_STRIPE_WEBHOOK_SECRET outside local/test"
+            )
+        if environment != "production":
             return self
         missing = []
         if not self.internal_gateway_token:

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -326,6 +326,14 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "fallbacks to return one OpenAI-compatible answer."
         ),
     ),
+    "docs/x402": PublicPage(
+        template="public/x402.html",
+        title="x402 Stablecoin Funding For Agents",
+        description=(
+            "Let agents add TrustedRouter prepaid credits with Stripe x402 while "
+            "prompt traffic stays inside the attested API gateway."
+        ),
+    ),
     "eu": PublicPage(
         template="public/eu.html",
         og_card="eu.png",

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+import logging
+from typing import Any, cast
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 
-from trusted_router.auth import ManagementPrincipal, SettingsDep
+from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
 from trusted_router.errors import api_error, deprecated
 from trusted_router.money import money_pair
 from trusted_router.routes.helpers import json_body
-from trusted_router.schemas import CheckoutRequest
+from trusted_router.schemas import CheckoutRequest, X402FundingRequest, X402SettleRequest
 from trusted_router.services.paypal_billing import (
     capture_paypal_order_for_workspace,
     create_paypal_checkout_session,
@@ -19,8 +21,17 @@ from trusted_router.services.stripe_billing import (
     create_checkout_session,
     create_payment_method_session,
 )
+from trusted_router.services.x402_billing import (
+    X402_HEADER,
+    create_x402_funding_challenge,
+    settle_x402_payment,
+    validate_x402_funding_amount,
+    x402_payment_required_response_body,
+)
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
+
+log = logging.getLogger(__name__)
 
 
 def register_billing_routes(router: APIRouter) -> None:
@@ -95,6 +106,71 @@ def register_billing_routes(router: APIRouter) -> None:
             }
         }
 
+    @router.post("/billing/x402/fund")
+    async def billing_x402_fund(
+        request: Request,
+        settings: SettingsDep,
+    ) -> JSONResponse:
+        if not settings.x402_enabled:
+            raise api_error(404, "route not found", ErrorType.NOT_FOUND)
+        principal = principal_from_request(request, settings)
+        if principal.api_key is None:
+            raise api_error(403, "An API key is required for x402 funding", ErrorType.FORBIDDEN)
+        body = _validated_x402_body(X402FundingRequest, await json_body(request))
+        validate_x402_funding_amount(body.amount, settings)
+        _enforce_x402_rate_limit(
+            namespace="x402_fund_key",
+            subject=principal.api_key.hash,
+            limit=settings.x402_rate_limit_key_per_window,
+            settings=settings,
+        )
+        _enforce_x402_rate_limit(
+            namespace="x402_fund_workspace",
+            subject=principal.workspace.id,
+            limit=settings.x402_rate_limit_workspace_per_window,
+            settings=settings,
+        )
+        challenge = create_x402_funding_challenge(
+            body=body,
+            workspace_id=principal.workspace.id,
+            settings=settings,
+        )
+        return JSONResponse(
+            x402_payment_required_response_body(challenge),
+            status_code=402,
+            headers={X402_HEADER: str(challenge["payment_required_header"])},
+        )
+
+    @router.post("/billing/x402/settle")
+    async def billing_x402_settle(
+        request: Request,
+        settings: SettingsDep,
+    ) -> dict[str, dict[str, Any]]:
+        if not settings.x402_enabled:
+            raise api_error(404, "route not found", ErrorType.NOT_FOUND)
+        principal = principal_from_request(request, settings)
+        if principal.api_key is None:
+            raise api_error(403, "An API key is required for x402 settlement", ErrorType.FORBIDDEN)
+        body = _validated_x402_body(X402SettleRequest, await json_body(request))
+        _enforce_x402_rate_limit(
+            namespace="x402_settle_workspace",
+            subject=principal.workspace.id,
+            limit=settings.x402_settle_workspace_per_window,
+            settings=settings,
+        )
+        _enforce_x402_rate_limit(
+            namespace="x402_settle",
+            subject=f"{principal.workspace.id}:{body.payment_intent_id}",
+            limit=settings.x402_settle_rate_limit_per_window,
+            settings=settings,
+        )
+        result = settle_x402_payment(
+            payment_intent_id=body.payment_intent_id,
+            workspace_id=principal.workspace.id,
+            settings=settings,
+        )
+        return {"data": result}
+
     @router.post("/billing/portal")
     async def billing_portal(
         request: Request,
@@ -140,3 +216,39 @@ def _checkout_customer_email(principal: Any) -> str | None:
         if user is not None and user.email and "@" in user.email:
             return user.email
     return None
+
+
+def _validated_x402_body(model: Any, body: dict[str, Any]) -> Any:
+    try:
+        return model.model_validate(body)
+    except ValidationError as exc:
+        first = cast(dict[str, Any], exc.errors()[0]) if exc.errors() else {}
+        loc = ".".join(str(part) for part in first.get("loc", []) if part != "body") or "body"
+        message = first.get("msg") or "Invalid request body"
+        raise api_error(400, f"{loc}: {message}", ErrorType.BAD_REQUEST) from exc
+
+
+def _enforce_x402_rate_limit(
+    *,
+    namespace: str,
+    subject: str,
+    limit: int,
+    settings: Any,
+) -> None:
+    if limit <= 0:
+        return
+    try:
+        hit = STORE.hit_rate_limit(
+            namespace=namespace,
+            subject=subject,
+            limit=limit,
+            window_seconds=settings.x402_rate_limit_window_seconds,
+        )
+    except Exception as exc:  # noqa: BLE001 - payment creation must fail closed.
+        log.exception(
+            "x402.rate_limit_unavailable",
+            extra={"namespace": namespace, "subject": subject},
+        )
+        raise api_error(503, "x402 rate limiter is unavailable", ErrorType.SERVICE_UNAVAILABLE) from exc
+    if not hit.allowed:
+        raise api_error(429, "x402 funding rate limit exceeded", ErrorType.RATE_LIMITED)

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -13,18 +13,22 @@ here, not in __init__.py.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
 import stripe
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
 from trusted_router.money import DEFAULT_TRIAL_CREDIT_MICRODOLLARS, MICRODOLLARS_PER_CENT
 from trusted_router.routes.helpers import json_body
+from trusted_router.services.x402_billing import X402_PAYMENT_METHOD, credit_x402_payment_intent
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
+
+log = logging.getLogger(__name__)
 
 
 def _grant_trial_credit_on_card_attach(workspace_id: str) -> int:
@@ -157,6 +161,33 @@ def register(router: APIRouter) -> None:
         if event_type == "payment_intent.succeeded":
             obj = event.get("data", {}).get("object", {})
             metadata = obj.get("metadata") or {}
+            if metadata.get("payment_method") == X402_PAYMENT_METHOD:
+                try:
+                    result = credit_x402_payment_intent(
+                        obj,
+                        expected_workspace_id=None,
+                        settings=settings,
+                    )
+                except HTTPException as exc:
+                    if exc.status_code != 404:
+                        raise
+                    log.error(
+                        "x402.orphan_payment_intent",
+                        extra={
+                            "event_id": event_id,
+                            "payment_intent_id": obj.get("id"),
+                            "workspace_id": metadata.get("workspace_id"),
+                        },
+                    )
+                    return {
+                        "data": {
+                            "event_id": event_id,
+                            "x402": True,
+                            "orphan": True,
+                            "credited": False,
+                        }
+                    }
+                return {"data": {"event_id": event_id, "x402": True, **result}}
             workspace_id = metadata.get("workspace_id")
             amount_microdollars_raw = metadata.get("amount_microdollars")
             if (
@@ -195,7 +226,26 @@ def register(router: APIRouter) -> None:
                             "event_id": event_id,
                             "trial_credit_granted_microdollars": 0,
                         }
+                }
+
+        if event_type in {
+            "payment_intent.processing",
+            "payment_intent.requires_action",
+            "payment_intent.canceled",
+            "payment_intent.payment_failed",
+        }:
+            obj = event.get("data", {}).get("object", {})
+            metadata = obj.get("metadata") or {}
+            if metadata.get("payment_method") == X402_PAYMENT_METHOD:
+                return {
+                    "data": {
+                        "event_id": event_id,
+                        "x402": True,
+                        "status": obj.get("status") or event_type.removeprefix("payment_intent."),
+                        "payment_intent_id": obj.get("id"),
+                        "credited": False,
                     }
+                }
 
         if event_type == "payment_intent.payment_failed":
             obj = event.get("data", {}).get("object", {})
@@ -206,5 +256,26 @@ def register(router: APIRouter) -> None:
                 code = last_error.get("code") or "unknown"
                 STORE.record_auto_refill_outcome(workspace_id, status=f"failed:{code}")
                 return {"data": {"event_id": event_id, "auto_refill_failed": True, "code": code}}
+
+        if event_type in {"charge.refunded", "charge.refund.updated"}:
+            obj = event.get("data", {}).get("object", {})
+            metadata = obj.get("metadata") or {}
+            if metadata.get("payment_method") == X402_PAYMENT_METHOD:
+                log.warning(
+                    "x402.refund_requires_manual_review",
+                    extra={
+                        "event_id": event_id,
+                        "payment_intent_id": obj.get("payment_intent"),
+                        "refund_id": obj.get("id"),
+                    },
+                )
+                return {
+                    "data": {
+                        "event_id": event_id,
+                        "x402": True,
+                        "refund_requires_manual_review": True,
+                        "credited": False,
+                    }
+                }
 
         return {"data": {"ignored": True, "event_id": event_id}}

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -190,6 +190,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def fusion_docs() -> str:
         return public_page_html(settings, "docs/fusion")
 
+    @public_html_route("/docs/x402")
+    async def x402_docs() -> str:
+        return public_page_html(settings, "docs/x402")
+
     @public_html_route("/eu")
     async def eu() -> str:
         return public_page_html(settings, "eu")

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, mo
 
 from trusted_router.money import (
     MAX_CHECKOUT_DOLLARS,
+    MICRODOLLARS_PER_CENT,
     MICRODOLLARS_PER_DOLLAR,
     dollars_to_microdollars,
 )
@@ -54,6 +55,26 @@ class CheckoutRequest(_Lenient):
         if microdollars > MAX_CHECKOUT_DOLLARS * MICRODOLLARS_PER_DOLLAR:
             raise ValueError(f"amount must be at most {MAX_CHECKOUT_DOLLARS}")
         return Decimal(str(value))
+
+
+class X402FundingRequest(_Strict):
+    amount: Decimal | str | int = Decimal("10.00")
+
+    @field_validator("amount")
+    @classmethod
+    def amount_in_range(cls, value: Decimal | str | int) -> Decimal:
+        microdollars = dollars_to_microdollars(value)
+        if microdollars < MICRODOLLARS_PER_DOLLAR:
+            raise ValueError("amount must be at least 1")
+        if microdollars > MAX_CHECKOUT_DOLLARS * MICRODOLLARS_PER_DOLLAR:
+            raise ValueError(f"amount must be at most {MAX_CHECKOUT_DOLLARS}")
+        if microdollars % MICRODOLLARS_PER_CENT != 0:
+            raise ValueError("amount must be exactly representable in cents")
+        return Decimal(str(value))
+
+
+class X402SettleRequest(_Strict):
+    payment_intent_id: str = Field(pattern=r"^pi_[A-Za-z0-9_:-]{1,253}$")
 
 
 def _validate_dollars(value: Decimal | str | int | float | None) -> Decimal | None:

--- a/src/trusted_router/services/x402_billing.py
+++ b/src/trusted_router/services/x402_billing.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from decimal import Decimal
+from typing import Any, cast
+
+import stripe
+
+from trusted_router.config import Settings
+from trusted_router.errors import api_error
+from trusted_router.money import (
+    MICRODOLLARS_PER_CENT,
+    dollars_to_cents,
+    dollars_to_microdollars,
+    microdollars_to_decimal,
+)
+from trusted_router.schemas import X402FundingRequest
+from trusted_router.storage import STORE
+from trusted_router.types import ErrorType
+
+X402_HEADER = "payment-required"
+X402_PAYMENT_METHOD = "x402"
+X402_EVENT_PREFIX = "x402:"
+
+log = logging.getLogger(__name__)
+
+
+def create_x402_funding_challenge(
+    *,
+    body: X402FundingRequest,
+    workspace_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    _require_x402_enabled(settings)
+    amount_microdollars = dollars_to_microdollars(body.amount)
+    payment_intent = _create_payment_intent(
+        amount=body.amount,
+        amount_microdollars=amount_microdollars,
+        workspace_id=workspace_id,
+        settings=settings,
+    )
+    payment_intent_id = str(payment_intent.get("id") or "")
+    pay_to = _extract_pay_to_address(payment_intent, settings.x402_network)
+    payload = _payment_required_payload(
+        amount_microdollars=amount_microdollars,
+        payment_intent_id=payment_intent_id,
+        workspace_id=workspace_id,
+        pay_to=pay_to,
+        settings=settings,
+    )
+    encoded = _base64_json(payload)
+    return {
+        "payment_intent_id": payment_intent_id,
+        "payment_required": payload,
+        "payment_required_header": encoded,
+        "pay_to": pay_to,
+        "network": settings.x402_network_id,
+        "asset": "USDC",
+        "amount_decimal": microdollars_to_decimal(amount_microdollars),
+        "amount_microdollars": amount_microdollars,
+    }
+
+
+def settle_x402_payment(
+    *,
+    payment_intent_id: str,
+    workspace_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    _require_x402_enabled(settings)
+    payment_intent = retrieve_x402_payment_intent(payment_intent_id, settings)
+    return credit_x402_payment_intent(
+        payment_intent,
+        expected_workspace_id=workspace_id,
+        settings=settings,
+        hide_cross_workspace=True,
+    )
+
+
+def retrieve_x402_payment_intent(payment_intent_id: str, settings: Settings) -> dict[str, Any]:
+    if not settings.stripe_secret_key and _mock_payments_enabled(settings):
+        if not payment_intent_id.startswith("pi_x402_mock_"):
+            raise api_error(400, "Mock x402 settle requires a mock payment_intent_id", ErrorType.BAD_REQUEST)
+        amount_microdollars = dollars_to_microdollars("10")
+        return {
+            "id": payment_intent_id,
+            "status": "succeeded",
+            "currency": "usd",
+            "amount": amount_microdollars // MICRODOLLARS_PER_CENT,
+            "amount_received": amount_microdollars // MICRODOLLARS_PER_CENT,
+            "metadata": {
+                "workspace_id": workspace_id_from_mock_payment_intent(payment_intent_id),
+                "amount_microdollars": str(amount_microdollars),
+                "payment_method": X402_PAYMENT_METHOD,
+                "purpose": "trustedrouter_credits",
+                "asset": "USDC",
+                "network": settings.x402_network,
+            },
+            "next_action": {
+                "crypto_display_details": {
+                    "deposit_addresses": {
+                        settings.x402_network: {
+                            "address": "0x0000000000000000000000000000000000000402",
+                            "supported_tokens": [{"token_currency": "usdc"}],
+                        }
+                    }
+                }
+            },
+        }
+    if not settings.stripe_secret_key:
+        raise api_error(503, "Stripe x402 payment is not configured", ErrorType.SERVICE_UNAVAILABLE)
+    stripe.api_key = settings.stripe_secret_key
+    try:
+        return _stripe_object_to_dict(
+            cast(Any, stripe.PaymentIntent).retrieve(
+                payment_intent_id,
+                stripe_version=settings.x402_stripe_api_version,
+            )
+        )
+    except Exception as exc:
+        raise api_error(503, "Could not verify x402 payment", ErrorType.SERVICE_UNAVAILABLE) from exc
+
+
+def credit_x402_payment_intent(
+    payment_intent: dict[str, Any],
+    *,
+    expected_workspace_id: str | None,
+    settings: Settings,
+    hide_cross_workspace: bool = False,
+) -> dict[str, Any]:
+    metadata = _dict_value(payment_intent.get("metadata"))
+    if metadata.get("payment_method") != X402_PAYMENT_METHOD:
+        raise api_error(400, "PaymentIntent is not a TrustedRouter x402 payment", ErrorType.BAD_REQUEST)
+    workspace_id = str(metadata.get("workspace_id") or "")
+    if (
+        not workspace_id
+        or STORE.get_credit_account(workspace_id) is None
+        or (expected_workspace_id is not None and workspace_id != expected_workspace_id)
+    ):
+        if hide_cross_workspace:
+            raise api_error(404, "PaymentIntent not found", ErrorType.NOT_FOUND)
+        raise api_error(404, "Workspace not found", ErrorType.NOT_FOUND)
+    requested_microdollars = _metadata_requested_microdollars(metadata)
+    _validate_payment_intent_currency(payment_intent)
+    _validate_payment_intent_crypto_details(payment_intent, settings)
+    status = str(payment_intent.get("status") or "")
+    settled_microdollars = _settled_amount_microdollars(payment_intent)
+    if status != "succeeded":
+        return _x402_settle_payload(
+            status=status or "pending",
+            payment_intent_id=str(payment_intent.get("id") or ""),
+            workspace_id=workspace_id,
+            amount_microdollars=0,
+            credited=False,
+            requested_microdollars=requested_microdollars,
+            settled_microdollars=settled_microdollars,
+        )
+    amount_microdollars = min(settled_microdollars, requested_microdollars)
+    if amount_microdollars <= 0:
+        raise api_error(400, "PaymentIntent has no settled amount", ErrorType.BAD_REQUEST)
+    payment_intent_id = str(payment_intent.get("id") or "")
+    if not payment_intent_id:
+        raise api_error(400, "PaymentIntent is missing an id", ErrorType.BAD_REQUEST)
+    credited = STORE.credit_workspace_once(
+        workspace_id,
+        amount_microdollars,
+        x402_event_id(payment_intent_id),
+    )
+    return _x402_settle_payload(
+        status=status,
+        payment_intent_id=payment_intent_id,
+        workspace_id=workspace_id,
+        amount_microdollars=amount_microdollars,
+        credited=credited,
+        requested_microdollars=requested_microdollars,
+        settled_microdollars=settled_microdollars,
+    )
+
+
+def x402_payment_required_response_body(challenge: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "error": {
+            "code": 402,
+            "message": "Stablecoin payment required to add TrustedRouter credits",
+            "type": ErrorType.INSUFFICIENT_CREDITS.value,
+        },
+        "data": {
+            "payment_protocol": "x402",
+            "provider": "stripe",
+            **challenge,
+        },
+    }
+
+
+def x402_event_id(payment_intent_id: str) -> str:
+    return f"{X402_EVENT_PREFIX}{payment_intent_id}"
+
+
+def workspace_id_from_mock_payment_intent(payment_intent_id: str) -> str:
+    # Local tests monkeypatch retrieve for real workspace binding. This fallback
+    # exists only for manual mock demos; it deliberately cannot target a real
+    # workspace without a monkeypatch.
+    return payment_intent_id.removeprefix("pi_x402_mock_").rsplit("_", 1)[0]
+
+
+def _create_payment_intent(
+    *,
+    amount: Decimal | str | int,
+    amount_microdollars: int,
+    workspace_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    amount_cents = dollars_to_cents(amount)
+    if not settings.stripe_secret_key and _mock_payments_enabled(settings):
+        payment_intent_id = f"pi_x402_mock_{workspace_id}_000000"
+        return {
+            "id": payment_intent_id,
+            "status": "requires_action",
+            "currency": "usd",
+            "amount": amount_cents,
+            "metadata": {
+                "workspace_id": workspace_id,
+                "amount_microdollars": str(amount_microdollars),
+                "payment_method": X402_PAYMENT_METHOD,
+                "purpose": "trustedrouter_credits",
+                "asset": "USDC",
+                "network": settings.x402_network,
+            },
+            "next_action": {
+                "crypto_display_details": {
+                    "deposit_addresses": {
+                        settings.x402_network: {
+                            "address": "0x0000000000000000000000000000000000000402",
+                            "supported_tokens": [{"token_currency": "usdc"}],
+                        }
+                    }
+                }
+            },
+        }
+    if not settings.stripe_secret_key:
+        raise api_error(503, "Stripe x402 payment is not configured", ErrorType.SERVICE_UNAVAILABLE)
+    stripe.api_key = settings.stripe_secret_key
+    params = {
+        "amount": amount_cents,
+        "currency": "usd",
+        "payment_method_types": ["crypto"],
+        "payment_method_data": {"type": "crypto"},
+        "payment_method_options": {
+            "crypto": {
+                "mode": "deposit",
+                "deposit_options": {"networks": [settings.x402_network]},
+            }
+        },
+        "confirm": True,
+        "metadata": {
+            "workspace_id": workspace_id,
+            "amount_microdollars": str(amount_microdollars),
+            "payment_method": X402_PAYMENT_METHOD,
+            "purpose": "trustedrouter_credits",
+            "asset": "USDC",
+            "network": settings.x402_network,
+        },
+    }
+    try:
+        return _stripe_object_to_dict(
+            cast(Any, stripe.PaymentIntent).create(
+                **params,
+                stripe_version=settings.x402_stripe_api_version,
+            )
+        )
+    except Exception as exc:
+        raise api_error(503, "Could not create Stripe x402 payment", ErrorType.SERVICE_UNAVAILABLE) from exc
+
+
+def _payment_required_payload(
+    *,
+    amount_microdollars: int,
+    payment_intent_id: str,
+    workspace_id: str,
+    pay_to: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    return {
+        "x402Version": 2,
+        "error": "payment_required",
+        "accepts": [
+            {
+                "scheme": "exact",
+                "price": f"${microdollars_to_decimal(amount_microdollars)}",
+                "network": settings.x402_network_id,
+                "payTo": pay_to,
+                "asset": "USDC",
+                "maxAmountRequired": str(amount_microdollars),
+                "resource": settings.api_base_url.rstrip("/") + "/billing/x402/settle",
+                "description": "TrustedRouter prepaid credits",
+                "mimeType": "application/json",
+            }
+        ],
+        "metadata": {
+            "provider": "stripe",
+            "payment_intent_id": payment_intent_id,
+            "workspace_id": workspace_id,
+            "amount_microdollars": str(amount_microdollars),
+        },
+    }
+
+
+def _extract_pay_to_address(payment_intent: dict[str, Any], network: str) -> str:
+    details = _crypto_display_details(payment_intent)
+    network_details = _dict_value(_dict_value(details.get("deposit_addresses")).get(network))
+    address = network_details.get("address")
+    if not isinstance(address, str) or not address.strip():
+        raise api_error(
+            503,
+            "Stripe x402 payment intent did not include a deposit address",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    return address.strip()
+
+
+def _validate_payment_intent_currency(payment_intent: dict[str, Any]) -> None:
+    if str(payment_intent.get("currency") or "").lower() != "usd":
+        raise api_error(400, "x402 payment currency must be usd", ErrorType.BAD_REQUEST)
+
+
+def _validate_payment_intent_crypto_details(
+    payment_intent: dict[str, Any],
+    settings: Settings,
+) -> None:
+    metadata = _dict_value(payment_intent.get("metadata"))
+    if str(metadata.get("asset") or "").upper() != "USDC":
+        raise api_error(400, "x402 payment asset must be USDC", ErrorType.BAD_REQUEST)
+    if str(metadata.get("network") or "") != settings.x402_network:
+        raise api_error(400, "x402 payment network is not accepted", ErrorType.BAD_REQUEST)
+    details = _crypto_display_details(payment_intent)
+    if not details:
+        # Stripe may omit next_action after success; metadata carries the
+        # asset/network contract we stamped at create time.
+        return
+    addresses = _dict_value(details.get("deposit_addresses"))
+    network_details = _dict_value(addresses.get(settings.x402_network))
+    if addresses and not network_details:
+        raise api_error(400, "x402 payment network is not accepted", ErrorType.BAD_REQUEST)
+    tokens = network_details.get("supported_tokens")
+    if isinstance(tokens, list) and tokens:
+        currencies = {
+            str(_dict_value(token).get("token_currency") or "").lower()
+            for token in tokens
+            if isinstance(token, dict)
+        }
+        if "usdc" not in currencies:
+            raise api_error(400, "x402 payment asset must be USDC", ErrorType.BAD_REQUEST)
+
+
+def _crypto_display_details(payment_intent: dict[str, Any]) -> dict[str, Any]:
+    return _dict_value(_dict_value(payment_intent.get("next_action")).get("crypto_display_details"))
+
+
+def _metadata_requested_microdollars(metadata: dict[str, Any]) -> int:
+    raw = metadata.get("amount_microdollars")
+    if not isinstance(raw, str) or not raw.isdigit():
+        raise api_error(400, "PaymentIntent is missing TrustedRouter amount metadata", ErrorType.BAD_REQUEST)
+    return int(raw)
+
+
+def _settled_amount_microdollars(payment_intent: dict[str, Any]) -> int:
+    raw_amount = payment_intent.get("amount_received")
+    if raw_amount is None:
+        raw_amount = payment_intent.get("amount")
+    amount_cents = int(raw_amount or 0)
+    return amount_cents * MICRODOLLARS_PER_CENT
+
+
+def _x402_settle_payload(
+    *,
+    status: str,
+    payment_intent_id: str,
+    workspace_id: str,
+    amount_microdollars: int,
+    credited: bool,
+    requested_microdollars: int,
+    settled_microdollars: int,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "payment_intent_id": payment_intent_id,
+        "workspace_id": workspace_id,
+        "credited": credited,
+        "amount_decimal": microdollars_to_decimal(amount_microdollars),
+        "amount_microdollars": amount_microdollars,
+        "requested_amount_microdollars": requested_microdollars,
+        "settled_amount_microdollars": settled_microdollars,
+    }
+
+
+def validate_x402_funding_amount(amount: Decimal | str | int, settings: Settings) -> None:
+    amount_microdollars = dollars_to_microdollars(amount)
+    if amount_microdollars % MICRODOLLARS_PER_CENT != 0:
+        raise api_error(400, "x402 funding amount must be exactly representable in cents", ErrorType.BAD_REQUEST)
+    max_microdollars = dollars_to_microdollars(settings.x402_max_fund_dollars)
+    if amount_microdollars > max_microdollars:
+        raise api_error(400, "x402 funding amount exceeds the workspace cap", ErrorType.BAD_REQUEST)
+
+
+def _require_x402_enabled(settings: Settings) -> None:
+    if not settings.x402_enabled:
+        raise api_error(404, "route not found", ErrorType.NOT_FOUND)
+
+
+def _base64_json(payload: dict[str, Any]) -> str:
+    return base64.b64encode(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+
+
+def _stripe_object_to_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    to_dict = getattr(value, "_to_dict_recursive", None)
+    if callable(to_dict):
+        converted = to_dict()
+        if isinstance(converted, dict):
+            return cast(dict[str, Any], converted)
+    return cast(dict[str, Any], dict(value))
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _mock_payments_enabled(settings: Settings) -> bool:
+    return settings.x402_allow_mock_payments and settings.environment.lower() in {"local", "test"}

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -35,6 +35,7 @@ const r = await client.chat.completions.create({
     <a class="marketing-card card-as-link" href="/docs/migrate-from-openrouter"><h3>Migrate from OpenRouter</h3><p>Swap one base_url and keep your existing calls working.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/evals"><h3>Evals</h3><p>Run eval suites across providers through one API.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/fusion"><h3>Fusion</h3><p>Run a model panel, judge, and final synthesis inside the attested gateway.</p><span class="card-link">Open →</span></a>
+    <a class="marketing-card card-as-link" href="/docs/x402"><h3>x402 stablecoin funding</h3><p>Let agents add prepaid credits automatically without changing the prompt path.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/eu"><h3>EU routing</h3><p>Use the Europe West attested gateway and the EU-focused model alias.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/sign-in-with-trustedrouter"><h3>Sign in with TrustedRouter</h3><p>Let your users bring their own account and credits.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/compare/openrouter"><h3>vs OpenRouter</h3><p>How TrustedRouter compares to closed routers.</p><span class="card-link">Open →</span></a>

--- a/src/trusted_router/templates/public/x402.html
+++ b/src/trusted_router/templates/public/x402.html
@@ -1,0 +1,53 @@
+{% extends "public/_base.html" %}
+
+{% block body %}
+<section class="public-section docs-section">
+  <div class="panel">
+    <div class="panel-head"><h2>x402 stablecoin funding</h2><span class="pill">API-key required</span></div>
+    <div class="panel-body">
+      <p>x402 is a funding rail for prepaid credits. It does not run inside the enclave and it does not carry prompts. Agents use a normal TrustedRouter API key, add credits with stablecoin when needed, then retry the same attested API call.</p>
+      <pre><code>curl {{ api_base_url }}/billing/x402/fund \
+  -H "Authorization: Bearer $TRUSTEDROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"amount":"10.00"}'</code></pre>
+      <p>The response is HTTP <span class="mono">402 Payment Required</span> and includes a <span class="mono">payment-required</span> header for x402-capable clients.</p>
+    </div>
+  </div>
+
+  <div class="docs-grid">
+    <div class="panel">
+      <div class="panel-head"><h2>Settle after payment</h2><span class="pill good">idempotent</span></div>
+      <div class="panel-body">
+        <pre><code>curl {{ api_base_url }}/billing/x402/settle \
+  -H "Authorization: Bearer $TRUSTEDROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"payment_intent_id":"pi_..."}'</code></pre>
+        <p>Stripe webhooks also settle the same payment. If the webhook wins the race, the settle call returns the current state without double-crediting.</p>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="panel-head"><h2>Boundary</h2><span class="pill">control plane only</span></div>
+      <div class="panel-body">
+        <ul class="plain-list">
+          <li>x402 endpoints require a <span class="mono">sk-tr-...</span> key.</li>
+          <li>Workspace is derived from the key, never from request body input.</li>
+          <li>Stripe metadata contains billing ids and amounts only.</li>
+          <li>Prompt and output content stay out of Stripe, Sentry, logs, and billing records.</li>
+          <li>The enclave still authorizes only when prepaid credits are available.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-head"><h2>Agent retry loop</h2><span class="pill">recommended</span></div>
+    <div class="panel-body">
+      <pre><code>1. Call /v1/chat/completions or /v1/responses.
+2. If TrustedRouter returns insufficient credits, call /v1/billing/x402/fund.
+3. Pay using the payment-required header.
+4. Poll /v1/billing/x402/settle with backoff: 5s, 10s, 20s, 30s, then every 60s.
+5. Retry the original attested inference call after credits land.</code></pre>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_x402_billing.py
+++ b/tests/test_x402_billing.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import base64
+import json
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE
+
+
+def _x402_client(**settings: Any) -> TestClient:
+    merged: dict[str, Any] = {
+        "environment": "test",
+        "x402_enabled": True,
+        "stripe_secret_key": "sk_test_x402",
+        "stripe_webhook_secret": None,
+        "rate_limit_enabled": False,
+    }
+    merged.update(settings)
+    return TestClient(create_app(Settings(**merged), init_observability=False))
+
+
+def _api_headers(client: TestClient) -> tuple[dict[str, str], str]:
+    created = client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "x402@example.com"},
+        json={"name": "x402 key"},
+    )
+    assert created.status_code == 201, created.text
+    raw_key = created.json()["key"]
+    workspace_id = created.json()["data"]["workspace_id"]
+    return {"authorization": f"Bearer {raw_key}"}, workspace_id
+
+
+def _payment_intent(
+    *,
+    payment_intent_id: str = "pi_x402_good",
+    workspace_id: str,
+    status: str = "succeeded",
+    currency: str = "usd",
+    amount_cents: int = 1000,
+    received_cents: int | None = 1000,
+    requested_microdollars: int = 10_000_000,
+    asset_code: str = "usdc",
+    network: str = "base",
+    payment_method: str = "x402",
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": payment_intent_id,
+        "status": status,
+        "currency": currency,
+        "amount": amount_cents,
+        "metadata": {
+            "workspace_id": workspace_id,
+            "amount_microdollars": str(requested_microdollars),
+            "payment_method": payment_method,
+            "purpose": "trustedrouter_credits",
+            "asset": asset_code.upper(),
+            "network": network,
+        },
+        "next_action": {
+            "crypto_display_details": {
+                "deposit_addresses": {
+                    network: {
+                        "address": "0x0000000000000000000000000000000000000402",
+                        "supported_tokens": [{"token_currency": asset_code}],
+                    }
+                }
+            }
+        },
+    }
+    if received_cents is not None:
+        body["amount_received"] = received_cents
+    return body
+
+
+def test_x402_disabled_returns_404_without_auth(client: TestClient) -> None:
+    response = client.post("/v1/billing/x402/fund", json={"amount": "10.00"})
+
+    assert response.status_code == 404
+    assert response.json()["error"]["type"] == "not_found"
+
+
+def test_x402_config_refuses_mock_or_missing_stripe_outside_local_test() -> None:
+    with pytest.raises(ValueError, match="TR_X402_ALLOW_MOCK_PAYMENTS"):
+        Settings(environment="staging", x402_allow_mock_payments=True)
+    with pytest.raises(ValueError, match="TR_X402_ENABLED"):
+        Settings(
+            environment="staging",
+            x402_enabled=True,
+            stripe_secret_key=None,
+            stripe_webhook_secret=None,
+        )
+
+
+def test_x402_enabled_without_stripe_secret_does_not_mock_credit() -> None:
+    with _x402_client(stripe_secret_key=None) as client:
+        headers, workspace_id = _api_headers(client)
+        before = STORE.get_credit_account(workspace_id)
+        assert before is not None
+        before_total = before.total_credits_microdollars
+        fund = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "10.00"},
+        )
+        settle = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": f"pi_x402_mock_{workspace_id}_attacker"},
+        )
+        after = STORE.get_credit_account(workspace_id)
+
+    assert fund.status_code == 503
+    assert settle.status_code == 503
+    assert after is not None
+    assert after.total_credits_microdollars == before_total
+
+
+def test_x402_fund_creates_stripe_crypto_payment_intent_and_returns_payment_required(
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def create_payment_intent(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return _payment_intent(
+            payment_intent_id="pi_x402_challenge",
+            workspace_id=str(kwargs["metadata"]["workspace_id"]),
+            status="requires_action",
+            received_cents=None,
+        )
+
+    monkeypatch.setattr(
+        "trusted_router.services.x402_billing.stripe.PaymentIntent.create",
+        create_payment_intent,
+    )
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        response = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "10.00", "prompt": "secret prompt must not appear"},
+        )
+
+    assert response.status_code == 400
+    assert "Extra inputs are not permitted" in response.text
+
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        response = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "10.00"},
+        )
+
+    assert response.status_code == 402, response.text
+    assert "payment-required" in response.headers
+    body = response.json()
+    assert body["data"]["payment_intent_id"] == "pi_x402_challenge"
+    assert body["data"]["amount_decimal"] == "10"
+    decoded = json.loads(base64.b64decode(response.headers["payment-required"]))
+    assert decoded["metadata"]["payment_intent_id"] == "pi_x402_challenge"
+    assert decoded["accepts"][0]["network"] == "eip155:8453"
+    assert captured["payment_method_types"] == ["crypto"]
+    assert captured["payment_method_data"] == {"type": "crypto"}
+    assert captured["payment_method_options"]["crypto"]["mode"] == "deposit"
+    assert captured["payment_method_options"]["crypto"]["deposit_options"]["networks"] == ["base"]
+    assert captured["metadata"] == {
+        "workspace_id": workspace_id,
+        "amount_microdollars": "10000000",
+        "payment_method": "x402",
+        "purpose": "trustedrouter_credits",
+        "asset": "USDC",
+        "network": "base",
+    }
+    assert captured["stripe_version"] == "2026-03-04.preview"
+    assert "secret prompt" not in json.dumps(captured)
+    assert "sk-tr-" not in json.dumps(captured)
+
+
+def test_x402_fund_rejects_workspace_id_and_cent_fraction_before_stripe(monkeypatch) -> None:
+    called = False
+
+    def create_payment_intent(**_kwargs: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(
+        "trusted_router.services.x402_billing.stripe.PaymentIntent.create",
+        create_payment_intent,
+    )
+    with _x402_client() as client:
+        headers, _workspace_id = _api_headers(client)
+        injected = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "10.00", "workspace_id": "attacker"},
+        )
+        fractional = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "10.001"},
+        )
+
+    assert injected.status_code == 400
+    assert "workspace_id" in injected.text
+    assert fractional.status_code == 400
+    assert "cents" in fractional.text
+    assert called is False
+
+
+def test_x402_fund_enforces_amount_cap_and_rate_limit(monkeypatch) -> None:
+    calls = 0
+
+    def create_payment_intent(**kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return _payment_intent(
+            payment_intent_id=f"pi_x402_{calls}",
+            workspace_id=str(kwargs["metadata"]["workspace_id"]),
+            status="requires_action",
+            received_cents=None,
+        )
+
+    monkeypatch.setattr(
+        "trusted_router.services.x402_billing.stripe.PaymentIntent.create",
+        create_payment_intent,
+    )
+    with _x402_client(x402_max_fund_dollars="5", x402_rate_limit_key_per_window=1) as client:
+        headers, _workspace_id = _api_headers(client)
+        too_large = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "6.00"},
+        )
+        first = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "5.00"},
+        )
+        second = client.post(
+            "/v1/billing/x402/fund",
+            headers=headers,
+            json={"amount": "5.00"},
+        )
+
+    assert too_large.status_code == 400
+    assert first.status_code == 402
+    assert second.status_code == 429
+    assert calls == 1
+
+
+def test_x402_settle_credits_succeeded_payment_once(monkeypatch) -> None:
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        before = STORE.get_credit_account(workspace_id)
+        assert before is not None
+        before_total = before.total_credits_microdollars
+
+        def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return _payment_intent(workspace_id=workspace_id)
+
+        monkeypatch.setattr(
+            "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+            retrieve,
+        )
+        first = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_x402_good"},
+        )
+        second = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_x402_good"},
+        )
+        account = STORE.get_credit_account(workspace_id)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["data"]["credited"] is True
+    assert second.status_code == 200, second.text
+    assert second.json()["data"]["credited"] is False
+    assert account is not None
+    assert account.total_credits_microdollars == before_total + 10_000_000
+
+
+def test_x402_settle_pending_wrong_workspace_and_invalid_payment_intents(monkeypatch) -> None:
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        other_workspace = "other-workspace"
+        cases = {
+            "pi_pending": _payment_intent(workspace_id=workspace_id, status="processing", received_cents=0),
+            "pi_wrong_workspace": _payment_intent(workspace_id=other_workspace),
+            "pi_non_x402": _payment_intent(workspace_id=workspace_id, payment_method="checkout"),
+            "pi_wrong_currency": _payment_intent(workspace_id=workspace_id, currency="eur"),
+            "pi_wrong_asset": _payment_intent(workspace_id=workspace_id, asset_code="eurc"),
+            "pi_wrong_network": _payment_intent(workspace_id=workspace_id, network="solana"),
+        }
+
+        def retrieve(payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return cases[payment_intent_id]
+
+        monkeypatch.setattr(
+            "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+            retrieve,
+        )
+
+        pending = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_pending"},
+        )
+        wrong_workspace = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_wrong_workspace"},
+        )
+        non_x402 = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_non_x402"},
+        )
+        wrong_currency = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_wrong_currency"},
+        )
+        wrong_asset = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_wrong_asset"},
+        )
+        wrong_network = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_wrong_network"},
+        )
+
+    assert pending.status_code == 200
+    assert pending.json()["data"]["credited"] is False
+    assert wrong_workspace.status_code == 404
+    assert non_x402.status_code == 400
+    assert wrong_currency.status_code == 400
+    assert wrong_asset.status_code == 400
+    assert wrong_network.status_code == 400
+
+
+def test_x402_settle_rejects_malformed_payment_intent_before_stripe(monkeypatch) -> None:
+    called = False
+
+    def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(
+        "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+        retrieve,
+    )
+    with _x402_client() as client:
+        headers, _workspace_id = _api_headers(client)
+        response = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "not-a-payment-intent"},
+        )
+
+    assert response.status_code == 400
+    assert called is False
+
+
+def test_x402_settle_caps_credit_to_requested_amount(monkeypatch) -> None:
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        before = STORE.get_credit_account(workspace_id)
+        assert before is not None
+        before_total = before.total_credits_microdollars
+
+        def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return _payment_intent(
+                workspace_id=workspace_id,
+                requested_microdollars=5_000_000,
+                amount_cents=1000,
+                received_cents=1000,
+            )
+
+        monkeypatch.setattr(
+            "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+            retrieve,
+        )
+        response = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_x402_good"},
+        )
+        account = STORE.get_credit_account(workspace_id)
+
+    assert response.status_code == 200
+    assert response.json()["data"]["amount_microdollars"] == 5_000_000
+    assert account is not None
+    assert account.total_credits_microdollars == before_total + 5_000_000
+
+
+def test_x402_webhook_and_settle_are_idempotent_in_both_orders(monkeypatch) -> None:
+    with _x402_client() as client:
+        headers, workspace_id = _api_headers(client)
+        before = STORE.get_credit_account(workspace_id)
+        assert before is not None
+        before_total = before.total_credits_microdollars
+        payment = _payment_intent(workspace_id=workspace_id)
+
+        first_webhook = client.post(
+            "/v1/internal/stripe/webhook",
+            json={
+                "id": "evt_x402_first",
+                "type": "payment_intent.succeeded",
+                "data": {"object": payment},
+            },
+        )
+        retry_webhook = client.post(
+            "/v1/internal/stripe/webhook",
+            json={
+                "id": "evt_x402_retry_different_event_id",
+                "type": "payment_intent.succeeded",
+                "data": {"object": payment},
+            },
+        )
+
+        def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return payment
+
+        monkeypatch.setattr(
+            "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+            retrieve,
+        )
+        settle = client.post(
+            "/v1/billing/x402/settle",
+            headers=headers,
+            json={"payment_intent_id": "pi_x402_good"},
+        )
+        account = STORE.get_credit_account(workspace_id)
+
+    assert first_webhook.status_code == 200
+    assert first_webhook.json()["data"]["credited"] is True
+    assert retry_webhook.status_code == 200
+    assert retry_webhook.json()["data"]["credited"] is False
+    assert settle.status_code == 200
+    assert settle.json()["data"]["credited"] is False
+    assert account is not None
+    assert account.total_credits_microdollars == before_total + 10_000_000
+
+
+def test_x402_concurrent_settle_credits_once(monkeypatch) -> None:
+    with _x402_client(x402_settle_rate_limit_per_window=100) as client:
+        headers, workspace_id = _api_headers(client)
+        before = STORE.get_credit_account(workspace_id)
+        assert before is not None
+        before_total = before.total_credits_microdollars
+
+        def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return _payment_intent(workspace_id=workspace_id)
+
+        monkeypatch.setattr(
+            "trusted_router.services.x402_billing.stripe.PaymentIntent.retrieve",
+            retrieve,
+        )
+
+        def settle_once() -> bool:
+            resp = client.post(
+                "/v1/billing/x402/settle",
+                headers=headers,
+                json={"payment_intent_id": "pi_x402_good"},
+            )
+            assert resp.status_code == 200, resp.text
+            return bool(resp.json()["data"]["credited"])
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(lambda _: settle_once(), range(4)))
+        account = STORE.get_credit_account(workspace_id)
+
+    assert results.count(True) == 1
+    assert account is not None
+    assert account.total_credits_microdollars == before_total + 10_000_000
+
+
+def test_x402_refund_webhook_is_operator_visible_not_silent(client: TestClient) -> None:
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_x402_refund",
+            "type": "charge.refunded",
+            "data": {
+                "object": {
+                    "id": "ch_x402_refund",
+                    "payment_intent": "pi_x402_good",
+                    "metadata": {"payment_method": "x402"},
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["refund_requires_manual_review"] is True
+
+
+def test_x402_webhook_orphan_payment_intent_stops_retrying() -> None:
+    with _x402_client() as client:
+        response = client.post(
+            "/v1/internal/stripe/webhook",
+            json={
+                "id": "evt_x402_orphan",
+                "type": "payment_intent.succeeded",
+                "data": {
+                    "object": _payment_intent(
+                        payment_intent_id="pi_x402_orphan",
+                        workspace_id="missing-workspace",
+                    )
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["orphan"] is True
+    assert response.json()["data"]["credited"] is False


### PR DESCRIPTION
## Summary

Adds x402 stablecoin funding as a control-plane-only payment rail for existing TrustedRouter API-key users.

- Adds `/v1/billing/x402/fund` to create a Stripe crypto PaymentIntent and return an x402 `payment-required` challenge.
- Adds `/v1/billing/x402/settle` to verify Stripe settlement and credit the API key workspace exactly once.
- Wires Stripe webhook handling for x402 PaymentIntent success, pending/failure statuses, orphan events, and refund manual-review visibility.
- Adds fail-closed configuration for production and local/test-only mock payment guards.
- Documents the design and adds a public `/docs/x402` page.
- Adds focused tests for workspace isolation, idempotency, wrong asset/network/currency, malformed IDs, rate limits, and prompt/output non-leakage.

## Boundary

x402 remains outside the enclave. The attested API plane still only sees normal credit availability and does not parse payment headers or send prompt/output content to Stripe.

## Validation

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest tests/test_billing.py tests/test_x402_billing.py -q`
- Earlier full-suite run before branching: `1019 passed, 33 skipped`

## Notes

Two unrelated local edits were intentionally left unstaged: the blog draft and `scripts/credit_grant_joseph.py`. Claude CLI review was attempted after local validation, but the first invocation had a bad stdin expansion, the second exceeded a low budget, and the final higher-budget invocation hung without findings before being stopped.
