### PR TITLE
billing(cutover): universal typed-billing default (deadlock fix fleet-wide)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -109,18 +109,22 @@ ENV_VARS=(
   # typed tables before the enforcement cohort flag. The typed tables already
   # exist (migrate_typed_counters.sh). Remove to revert the dual-write.
   "TR_TYPED_COUNTER_MIRROR=1"
-  # Billing typed-counter migration cutover, step 5 — ENFORCEMENT cohort. Each
-  # listed workspace's gateway authorize/settle flows go through the typed
-  # conditional-DML path (the deadlock fix). Settle/refund route by reservation
-  # ORIGIN, so straddling requests stay matched. First cohort = the internal
-  # synthetic-monitor workspace (highest-concurrency, validated continuously by
-  # prod-smoke gateway_authorize_settle). DDL applied, mirror live, drift
-  # comparator CLEAN before this. Empty = no enforcement; add to a denylist env
-  # to kill-switch a workspace. Ramp by appending more workspace IDs.
-  # Ramp 1 (2026-06-21): +063e9fb9 — the most active REAL workspace (live
-  # in-flight reservations, funded), pre-flight comparator CLEAN + available>0.
-  # First real (non-synthetic, real-model CREDITS) traffic on the typed path.
-  "TR_TYPED_BILLING_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,063e9fb9-880b-41f6-a122-b141e52ed4bb"
+  # Billing typed-counter migration cutover — ENFORCEMENT. A workspace's gateway
+  # authorize/settle goes through the typed conditional-DML path (the deadlock
+  # fix) when this gate passes. Settle/refund route by reservation ORIGIN, so
+  # straddling requests stay matched. The denylist env
+  # (TR_TYPED_BILLING_WORKSPACE_DENYLIST) ALWAYS wins → per-workspace emergency
+  # kill switch (revert one workspace to legacy without a code change).
+  #
+  # 2026-06-25: UNIVERSAL DEFAULT. "*" = every existing AND new workspace runs
+  # the typed path, retiring the legacy read-modify-write counters that caused
+  # the per-tenant Spanner deadlock. Gated on a clean fleet pre-flight sweep —
+  # all 51 credit workspaces + 89 active keys have funded, JSON-consistent typed
+  # rows (0 missing, drift only on the two already-migrated). Prior ramp:
+  # 45819281 (synthetic, ~250K reservations) + 063e9fb9 (first real), both
+  # clean, 0 Deadlock/Aborted since cutover. Roll back via the denylist, not by
+  # editing this line under load.
+  "TR_TYPED_BILLING_WORKSPACE_IDS=*"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 


### PR DESCRIPTION
## What
Sets `TR_TYPED_BILLING_WORKSPACE_IDS=*` — every existing **and new** workspace runs the typed conditional-DML billing path, retiring the legacy read-modify-write counters that caused the recurring per-tenant Spanner `Aborted: Deadlock`. Config-only: the gate already supports `*`=all (engine commit 3f74d24, live in the deployed image); the denylist stays as the per-workspace emergency kill switch (always wins).

## Why now / safety
The deadlock fix has been live + validated; this completes it by getting the whole fleet off the deadlock-prone path. Gated on a **clean fleet pre-flight sweep** (read-only, today):
- **51 credit workspaces** — 0 missing typed `tr_credit_balance` rows; typed counters == JSON for all 49 non-cohort (drift only on the 2 already-migrated, expected).
- **89 active API keys** — 0 missing typed `tr_key_limit` rows (a missing typed row is the one thing that 402s real traffic — none exist).
- Prior cohort: 45819281 (synthetic, ~250K reservations) + 063e9fb9 (first real) — both clean, **0 Deadlock/Aborted since cutover**.

So the one risk class that bit us before (a stale/missing typed counter 402-ing real traffic) is eliminated fleet-wide.

## Rollout plan (after merge)
Flip **region-by-region via env-update** (fast, reversible) watching the authorize-402 rate, denylist staged; this PR makes it durable so the next pipeline deploy keeps it.

## Rollback
Per-workspace: add to `TR_TYPED_BILLING_WORKSPACE_DENYLIST` (no code change). Global: revert this line. JSON mirror stays on as the safety net.