### PR TITLE
test: fix stale synth preset assertions (unblocks main CI)

### DIFF
--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -130,8 +130,8 @@ def test_synth_page_renders_raw_thinking_hooks_and_valid_defaults(client: TestCl
     assert "raw thinking when returned" in body
     assert "data-fusion-details" in body
     assert 'data-action="toggle-fusion-detail-layout"' in body
-    assert '<option value="budget" selected>Budget panel</option>' in body
-    assert '<option value="frontier">Frontier panel</option>' in body
+    assert '<option value="budget" selected>Iris 1.0 &mdash; budget</option>' in body
+    assert '<option value="frontier">Zeus 1.0 &mdash; frontier</option>' in body
     assert "Panel models" in body
     assert 'data-fusion-model-cards="panel"' in body
     assert "/static/model_catalog.js" in body


### PR DESCRIPTION
main CI has been red since `913fc0e` relabeled the /synth preset dropdown (Budget/Quality/Frontier → Iris 1.0/Prometheus 1.0/Zeus 1.0, option **values** unchanged) without updating `test_synth_page_renders_raw_thinking_hooks_and_valid_defaults`, which still asserted the old labels. The last several main runs (blog/synth commits) all fail on this one assertion.

This updates the two assertions to the current rendered markup. Labels only — no behavior change. Unblocks main + the blog/synth deploys + the billing PR (#75).