### PR TITLE
billing: no free trial credit for new users (default $0, config-toggleable)

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -49,6 +49,12 @@ class Settings(BaseSettings):
     typed_billing_workspace_ids: str = ""
     typed_billing_workspace_denylist: str = ""
 
+    # Free "trial" credit granted to a new workspace the first time a valid
+    # payment card is attached (routes/internal/webhook.py). Default 0 = NO free
+    # credit for new users (policy as of 2026-06-25); a card attach saves the
+    # method but grants nothing. Set to e.g. 10_000_000 ($10) to re-enable.
+    signup_trial_credit_microdollars: int = 0
+
     sentry_dsn: str | None = None
     sentry_traces_sample_rate: float = 0.05
     sentry_local_enabled: bool = False

--- a/src/trusted_router/money.py
+++ b/src/trusted_router/money.py
@@ -6,7 +6,9 @@ MICRODOLLARS_PER_DOLLAR = 1_000_000
 MICRODOLLARS_PER_CENT = 10_000
 TOKENS_PER_MILLION = 1_000_000
 
-# Default trial credit granted to a new workspace ($10).
+# Standard trial-credit amount ($10). As of 2026-06-25 this is NOT granted by
+# default — new users get no free credit (config.signup_trial_credit_microdollars
+# defaults to 0). Kept as the amount to re-enable with + for test fixtures.
 DEFAULT_TRIAL_CREDIT_MICRODOLLARS = 10 * MICRODOLLARS_PER_DOLLAR
 
 # Stripe checkout cap ($10,000).

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
-from trusted_router.money import DEFAULT_TRIAL_CREDIT_MICRODOLLARS, MICRODOLLARS_PER_CENT
+from trusted_router.money import MICRODOLLARS_PER_CENT
 from trusted_router.routes.helpers import json_body
 from trusted_router.services.x402_billing import X402_PAYMENT_METHOD, credit_x402_payment_intent
 from trusted_router.storage import STORE
@@ -31,26 +31,31 @@ from trusted_router.types import ErrorType
 log = logging.getLogger(__name__)
 
 
-def _grant_trial_credit_on_card_attach(workspace_id: str) -> int:
+def _grant_trial_credit_on_card_attach(
+    workspace_id: str, amount_microdollars: int
+) -> int:
     """First time a valid card is attached to this workspace, grant the
-    standard trial credit. Idempotent across webhook replays + repeat
-    setup_intents (e.g. user adds a second card later) by using a
-    deterministic per-workspace event_id — credit_workspace_once dedupes
-    via the stripe_events ledger so the trial only ever lands once.
+    configured trial credit (settings.signup_trial_credit_microdollars).
+    Idempotent across webhook replays + repeat setup_intents (e.g. user adds a
+    second card later) by using a deterministic per-workspace event_id —
+    credit_workspace_once dedupes via the stripe_events ledger so the trial only
+    ever lands once.
 
-    Returns the amount actually credited (0 if already granted previously,
-    or DEFAULT_TRIAL_CREDIT_MICRODOLLARS on the first attach).
+    Returns the amount actually credited: 0 if already granted previously, if
+    the grant is disabled (amount_microdollars <= 0 — the default policy as of
+    2026-06-25: NO free credit for new users), else the configured amount on
+    the first attach.
 
-    Trial credit was previously granted at signup; it now requires a
-    Stripe-validated card to defend against throwaway-email farming.
-    See storage.py / storage_gcp.py create_workspace for the matching
-    "$0 at creation" change.
+    Trial credit was previously granted at signup; it then required a
+    Stripe-validated card to defend against throwaway-email farming, and now
+    defaults to $0. See storage.py / storage_gcp.py create_workspace for the
+    matching "$0 at creation" change.
     """
+    if amount_microdollars <= 0:
+        return 0
     event_id = f"trial:{workspace_id}"
-    if STORE.credit_workspace_once(
-        workspace_id, DEFAULT_TRIAL_CREDIT_MICRODOLLARS, event_id
-    ):
-        return DEFAULT_TRIAL_CREDIT_MICRODOLLARS
+    if STORE.credit_workspace_once(workspace_id, amount_microdollars, event_id):
+        return amount_microdollars
     return 0
 
 
@@ -123,7 +128,9 @@ def register(router: APIRouter) -> None:
                 # card-validation signal — Stripe just successfully charged
                 # the card. Grant the trial credit too if it hasn't been
                 # granted yet (idempotent via the per-workspace event_id).
-                granted = _grant_trial_credit_on_card_attach(workspace_id)
+                granted = _grant_trial_credit_on_card_attach(
+                    workspace_id, settings.signup_trial_credit_microdollars
+                )
                 return {
                     "data": {
                         "credited": credited,
@@ -149,7 +156,9 @@ def register(router: APIRouter) -> None:
                     customer_id=customer_id,
                     payment_method_id=payment_method,
                 )
-                granted = _grant_trial_credit_on_card_attach(workspace_id)
+                granted = _grant_trial_credit_on_card_attach(
+                    workspace_id, settings.signup_trial_credit_microdollars
+                )
                 return {
                     "data": {
                         "setup_saved": True,

--- a/src/trusted_router/templates/console/welcome.html
+++ b/src/trusted_router/templates/console/welcome.html
@@ -7,10 +7,10 @@
     <div class="signup-reveal">
       <div class="signup-reveal-head">Your TrustedRouter API key</div>
       <div class="secret-row"><code>{{ revealed_key }}</code></div>
-      <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span> · Trial <span class="mono">{{ trial_credit }}</span></div>
+      <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span></div>
     </div>
     {% if trial_credit_microdollars == 0 %}
-    <p class="microcopy">Trial credit unlocks once you add a valid card on the <a href="/console/credits">Credits</a> page. No charge. Stripe just verifies the card.</p>
+    <p class="microcopy">Add a card on the <a href="/console/credits">Credits</a> page to start routing — prepaid, you pay only for what you use. No charge to add it; Stripe just verifies the card.</p>
     {% endif %}
     <p>Use this key in the OpenAI SDK by setting <code>base_url={{ api_base_url }}</code>.</p>
     {% else %}

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -201,6 +201,71 @@ def test_setup_intent_without_customer_does_not_grant_trial_or_save_method(
     assert account.stripe_payment_method_id is None
 
 
+def test_setup_intent_grants_no_trial_credit_by_default(
+    user_headers: dict[str, str], client
+) -> None:
+    """New policy (2026-06-25): attaching a valid card saves the payment method
+    but grants NO free credit — signup_trial_credit_microdollars defaults to 0."""
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    # Undo the conftest auto-credit so a grant *would* fire if it were enabled.
+    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.stripe_events.discard(f"trial:{workspace_id}")
+    event = {
+        "id": "evt_setup_intent_no_trial",
+        "type": "setup_intent.succeeded",
+        "data": {
+            "object": {
+                "customer": "cus_no_trial",
+                "payment_method": "pm_no_trial",
+                "metadata": {"workspace_id": workspace_id},
+            }
+        },
+    }
+
+    resp = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["data"]
+    assert body["setup_saved"] is True
+    assert body["trial_credit_granted_microdollars"] == 0
+    account = STORE.get_credit_account(workspace_id)
+    assert account is not None
+    assert account.total_credits_microdollars == 0
+    assert account.stripe_payment_method_id == "pm_no_trial"
+
+
+def test_setup_intent_grants_configured_trial_credit_when_enabled(
+    user_headers: dict[str, str], client, monkeypatch
+) -> None:
+    """Setting signup_trial_credit_microdollars > 0 re-enables the grant."""
+    monkeypatch.setattr(
+        client.app.state.settings, "signup_trial_credit_microdollars", 5_000_000
+    )
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.stripe_events.discard(f"trial:{workspace_id}")
+    event = {
+        "id": "evt_setup_intent_enabled_trial",
+        "type": "setup_intent.succeeded",
+        "data": {
+            "object": {
+                "customer": "cus_enabled_trial",
+                "payment_method": "pm_enabled_trial",
+                "metadata": {"workspace_id": workspace_id},
+            }
+        },
+    }
+
+    resp = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["data"]
+    assert body["trial_credit_granted_microdollars"] == 5_000_000
+    account = STORE.get_credit_account(workspace_id)
+    assert account is not None
+    assert account.total_credits_microdollars == 5_000_000
+
+
 def test_payment_intent_succeeded_from_checkout_saves_payment_method_without_crediting(
     user_headers: dict[str, str], client
 ) -> None:


### PR DESCRIPTION
## What
New-user policy: **no more free credit**. Attaching a payment card still saves the method, but grants $0.

The first-card-attach trial credit (`webhook.py::_grant_trial_credit_on_card_attach`) is now driven by a config setting **`signup_trial_credit_microdollars` (default 0 = off)** instead of the hardcoded $10 `DEFAULT_TRIAL_CREDIT_MICRODOLLARS`. Workspace creation already granted $0; this closes the only remaining free-credit path.

## Reversible
Set `TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=10000000` ($10) to re-enable — no code change.

## Tests
- New: card-attach grants **$0** by default (the policy).
- New: setting the config > 0 still grants the configured amount (re-enable wiring).
- Existing no-grant cases (no customer, checkout-only) unchanged. **27 billing tests pass**; ruff + mypy clean.