### PR TITLE
billing(incident): revert universal typed-billing flip (settle row-count errors)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -116,15 +116,16 @@ ENV_VARS=(
   # (TR_TYPED_BILLING_WORKSPACE_DENYLIST) ALWAYS wins → per-workspace emergency
   # kill switch (revert one workspace to legacy without a code change).
   #
-  # 2026-06-25: UNIVERSAL DEFAULT. "*" = every existing AND new workspace runs
-  # the typed path, retiring the legacy read-modify-write counters that caused
-  # the per-tenant Spanner deadlock. Gated on a clean fleet pre-flight sweep —
-  # all 51 credit workspaces + 89 active keys have funded, JSON-consistent typed
-  # rows (0 missing, drift only on the two already-migrated). Prior ramp:
-  # 45819281 (synthetic, ~250K reservations) + 063e9fb9 (first real), both
-  # clean, 0 Deadlock/Aborted since cutover. Roll back via the denylist, not by
-  # editing this line under load.
-  "TR_TYPED_BILLING_WORKSPACE_IDS=*"
+  # 2026-06-25: REVERTED from the universal "*" default back to the validated
+  # cohort. The "*" flip exposed a latent bug — the one-way JSON->typed exact
+  # mirror (storage_gcp_counters.credit_balance_mirror_row) writes `reserved`,
+  # but for a typed workspace `tr_credit_balance.reserved` is owned by the typed
+  # authorize/finalize DML. Any JSON credit-entity write on a typed workspace
+  # (top-up, grant, refund, or a legacy settle straddling the flip) clobbered
+  # the in-flight typed hold -> release_credit row-count 0 -> "typed finalize
+  # failed: release row-count != 1". DO NOT set this to "*" again until the
+  # mirror is fixed to stop writing reserved/total_usage (typed owns them).
+  "TR_TYPED_BILLING_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,063e9fb9-880b-41f6-a122-b141e52ed4bb"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -118,13 +118,16 @@ ENV_VARS=(
   #
   # 2026-06-25: REVERTED from the universal "*" default back to the validated
   # cohort. The "*" flip exposed a latent bug — the one-way JSON->typed exact
-  # mirror (storage_gcp_counters.credit_balance_mirror_row) writes `reserved`,
-  # but for a typed workspace `tr_credit_balance.reserved` is owned by the typed
-  # authorize/finalize DML. Any JSON credit-entity write on a typed workspace
-  # (top-up, grant, refund, or a legacy settle straddling the flip) clobbered
-  # the in-flight typed hold -> release_credit row-count 0 -> "typed finalize
-  # failed: release row-count != 1". DO NOT set this to "*" again until the
-  # mirror is fixed to stop writing reserved/total_usage (typed owns them).
+  # mirror copied reserved/total_usage, which the typed DML owns; any JSON write
+  # on a typed workspace clobbered the in-flight hold -> "typed finalize failed:
+  # release row-count != 1". The mirror itself is fixed by the ownership-split PR
+  # (#79: mirror only JSON-owned columns). BUT THE MIRROR FIX ALONE DOES NOT MAKE
+  # "*" SAFE. After the split, backfill() no longer seeds typed reserved/usage,
+  # so flipping a not-yet-typed workspace would leave typed.reserved blind to its
+  # open holds -> SILENT OVERSPEND (no row-count error). Re-enabling "*" requires
+  # the separate ledger-derived flip reconciliation + fail-closed seed
+  # verification (the "Step 6" safe-cutover effort). DO NOT set this to "*" until
+  # that lands and you have re-validated, no matter how green CI looks.
   "TR_TYPED_BILLING_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,063e9fb9-880b-41f6-a122-b141e52ed4bb"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"


### PR DESCRIPTION
## Incident
The universal `TR_TYPED_BILLING_WORKSPACE_IDS=*` flip caused production `typed finalize failed: release row-count != 1` errors in gateway settle (settle 500s internally, usage unbilled).

## Root cause
The one-way JSON→typed exact mirror (`storage_gcp_counters.credit_balance_mirror_row`) writes `reserved`. For a **typed** workspace, `tr_credit_balance.reserved` is owned by the typed authorize/finalize DML. Any JSON credit-entity write on a typed workspace (top-up / grant / refund / a legacy settle straddling the flip) fires the mirror and overwrites `reserved` with the stale JSON value, wiping the in-flight typed hold → `release_credit` (`WHERE reserved >= @hold`) row-count 0 → the RuntimeError. Latent with 2 controlled workspaces; the flip put everyone on typed and exposed it.

## Status
Gate already reverted live via env-update (us-central1/eu → synthetic-only, us-east4 → cohort); errors stopped. **This makes the revert durable** so a future deploy doesn't re-apply `*`.

## Follow-up (separate PR)
Fix the mirror to stop writing `reserved`/`total_usage` (only `total_credits`, which JSON legitimately owns). Then re-flip universal. **Please merge promptly** to prevent an accidental re-flip.