### PR TITLE
billing(incident): ownership-split the JSON->typed mirror (stop reserved clobber)

### DIFF
--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -134,11 +134,20 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
 
 
 def backfill(store: Any, *, dry_run: bool = False) -> dict[str, int]:
-    """Mirror the typed row for every JSON credit/api_key row. Idempotent.
+    """Mirror the JSON-owned columns of the typed row for every JSON credit/
+    api_key row. Idempotent; safe to run repeatedly.
 
-    Each row is re-read and mirrored inside one transaction so it commits a
-    json-consistent typed row atomically (no stale-read clobber). Safe to run
-    repeatedly; run until ``compare`` is clean.
+    OWNERSHIP SPLIT (2026-06-25 incident) — READ BEFORE USING AS A FLIP GATE:
+    this delegates to ``mirror_write``, which now writes ONLY JSON-owned columns
+    (total_credits; key limit_micro/include_byok). It therefore does NOT seed the
+    typed-DML-owned reserved / total_usage / usage / byok_usage, and a clean
+    ``compare`` (which now audits only those JSON-owned columns) does NOT mean a
+    workspace is safe to flip to typed enforcement. Flipping requires a SEPARATE
+    ledger-derived reconciliation that computes reserved from open holds (legacy +
+    typed) and seeds total_usage, atomic with the gate flip — otherwise the typed
+    reserve gate over-admits by the sum of open/historical holds (silent
+    overspend). Do NOT "fix" this by re-adding reserved/usage to the mirror: that
+    full-row copy WAS the clobber.
     """
     counts = {"credit": 0, "api_key": 0}
     spanner_module = store._spanner

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -28,23 +28,27 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 # Long tail lives entirely on shard 0; sharding a whale is a data change later.
 UNSHARDED = 0
 
+# OWNERSHIP SPLIT (2026-06-25 incident). The JSON->typed mirror writes ONLY the
+# columns JSON owns. `total_credits` is set by credit events (top-ups / grants /
+# refunds-as-credit, all via credit_workspace_once). `reserved` + `total_usage`
+# are owned by the typed authorize/finalize DML, so the mirror must NOT write
+# them — a full-row mirror clobbers an in-flight typed hold and the next finalize
+# fails "release row-count != 1". Columns dropped from the mirror keep their
+# NOT NULL DEFAULT(0), so a first-write insert still lands reserved/total_usage=0.
 CREDIT_BALANCE_COLUMNS = (
     "workspace_id",
     "shard",
     "total_credits",
-    "total_usage",
-    "reserved",
     "source_updated_at",
     "updated_at",
 )
 
+# Same split for keys: JSON owns config (limit_micro, include_byok); the typed
+# DML owns usage / byok_usage / reserved. Mirror config only.
 KEY_LIMIT_COLUMNS = (
     "key_hash",
     "shard",
     "limit_micro",
-    "usage",
-    "byok_usage",
-    "reserved",
     "include_byok",
     "source_updated_at",
     "updated_at",
@@ -59,28 +63,27 @@ def _field(value: Any, name: str, default: Any = None) -> Any:
 
 
 def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> tuple:
-    """Exact post-write mirror of a `credit` row into tr_credit_balance."""
+    """Mirror the JSON-owned `total_credits` of a `credit` row into
+    tr_credit_balance. reserved + total_usage are typed-DML-owned and are
+    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS)."""
     return (
         workspace_id,
         UNSHARDED,
         int(_field(value, "total_credits_microdollars", 0)),
-        int(_field(value, "total_usage_microdollars", 0)),
-        int(_field(value, "reserved_microdollars", 0)),
         commit_ts,  # source_updated_at — the JSON row's updated_at, same commit
         commit_ts,  # this mirror's updated_at
     )
 
 
 def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:
-    """Exact post-write mirror of an `api_key` row into tr_key_limit."""
+    """Mirror the JSON-owned config (limit_micro, include_byok) of an `api_key`
+    row into tr_key_limit. usage / byok_usage / reserved are typed-DML-owned and
+    are deliberately NOT mirrored (see KEY_LIMIT_COLUMNS)."""
     limit = _field(value, "limit_microdollars", None)
     return (
         key_hash,
         UNSHARDED,
         None if limit is None else int(limit),
-        int(_field(value, "usage_microdollars", 0)),
-        int(_field(value, "byok_usage_microdollars", 0)),
-        int(_field(value, "reserved_microdollars", 0)),
         bool(_field(value, "include_byok_in_limit", True)),
         commit_ts,
         commit_ts,
@@ -141,18 +144,16 @@ def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module:
 
 # (json body field, typed column, default-when-the-json-field-is-absent).
 # Defaults MUST match the model + the mirror writer so legacy JSON rows that
-# omit a field don't read as false drift: int counters -> 0, an uncapped key's
-# limit -> None, include_byok -> True.
+# omit a field don't read as false drift.
+# OWNERSHIP SPLIT (2026-06-25): only the JSON-owned columns are comparable. The
+# typed DML owns reserved/total_usage (credit) and usage/byok_usage/reserved
+# (key); JSON is intentionally stale for those after typed enforcement, so they
+# are NOT drift-checked (and the mirror/backfill no longer write them).
 CREDIT_DRIFT_FIELDS = (
     ("total_credits_microdollars", "total_credits", 0),
-    ("total_usage_microdollars", "total_usage", 0),
-    ("reserved_microdollars", "reserved", 0),
 )
 KEY_DRIFT_FIELDS = (
     ("limit_microdollars", "limit_micro", None),
-    ("usage_microdollars", "usage", 0),
-    ("byok_usage_microdollars", "byok_usage", 0),
-    ("reserved_microdollars", "reserved", 0),
     ("include_byok_in_limit", "include_byok", True),
 )
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -13,6 +13,41 @@ class _ParamTypes:
     TIMESTAMP = "TIMESTAMP"
 
 
+# Real Spanner column DEFAULTs for the typed counter tables (every counter is
+# NOT NULL DEFAULT(0) in the DDL). The fake fills these on INSERT so a
+# subset-column insert_or_update — which is what the ownership-split mirror does
+# now, writing only the JSON-owned columns — still yields a complete row whose
+# typed-DML-owned counters start at 0.
+_TYPED_DEFAULTS: dict[str, dict[str, Any]] = {
+    "tr_credit_balance": {"total_credits": 0, "total_usage": 0, "reserved": 0},
+    "tr_key_limit": {
+        "limit_micro": None,
+        "usage": 0,
+        "byok_usage": 0,
+        "reserved": 0,
+        "include_byok": True,
+    },
+}
+
+
+def _apply_upsert_typed(
+    typed: dict, versions: dict, table: str, columns: Any, value_tuple: tuple, version: int
+) -> None:
+    """Model real Spanner insert_or_update on a typed counter table: on INSERT
+    fill the NOT NULL DEFAULT columns the write omitted; on UPDATE touch ONLY
+    the supplied columns and leave the rest intact. Shared by the transaction
+    and batch commit paths so the ownership-split mirror behaves identically
+    through either writer (a partial mirror must never clobber typed counters)."""
+    pk = (value_tuple[0], value_tuple[1])
+    incoming = dict(zip(columns, value_tuple, strict=True))
+    table_rows = typed.setdefault(table, {})
+    existing = table_rows.get(pk)
+    row = dict(existing) if existing is not None else dict(_TYPED_DEFAULTS.get(table, {}))
+    row.update(incoming)
+    table_rows[pk] = row
+    versions[(table, pk)] = version
+
+
 @dataclass
 class _KeySet:
     keys: list[tuple]
@@ -129,11 +164,9 @@ class FakeSpannerDatabase:
                     self.rows.pop((kind, entity_id), None)
                 elif op[0] == "upsert_typed":
                     _, table, columns, value_tuple = op
-                    pk = (value_tuple[0], value_tuple[1])
-                    self.typed.setdefault(table, {})[pk] = dict(
-                        zip(columns, value_tuple, strict=True)
+                    _apply_upsert_typed(
+                        self.typed, self.typed_versions, table, columns, value_tuple, new_version
                     )
-                    self.typed_versions[(table, pk)] = new_version
                 elif op[0] == "update_typed":  # conditional-DML write
                     _, table, pk, record = op
                     self.typed.setdefault(table, {})[pk] = record
@@ -410,11 +443,9 @@ class _FakeBatch:
                     self.db.rows.pop((kind, entity_id), None)
                 elif op[0] == "upsert_typed":
                     _, table, columns, value_tuple = op
-                    pk = (value_tuple[0], value_tuple[1])
-                    self.db.typed.setdefault(table, {})[pk] = dict(
-                        zip(columns, value_tuple, strict=True)
+                    _apply_upsert_typed(
+                        self.db.typed, self.db.typed_versions, table, columns, value_tuple, new_version
                     )
-                    self.db.typed_versions[(table, pk)] = new_version
                 elif op[0] == "delete_typed":
                     _, table, pk = op
                     self.db.typed.get(table, {}).pop(pk, None)

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -1,9 +1,14 @@
-"""Step 1 of the billing typed-column migration: exact-mirror dual-write.
+"""Billing typed-column migration: the JSON->typed mirror and its OWNERSHIP SPLIT.
 
-Verifies that every JSON `credit` / `api_key` write also lands an exact mirror
-row on the typed tables (tr_credit_balance / tr_key_limit) in the SAME
-transaction, so the typed row can never tear from the authoritative JSON row.
-Enforcement is unchanged in Step 1 — this only proves the mirror tracks truth.
+The mirror propagates only the columns JSON owns — total_credits (credit) and
+limit_micro / include_byok (key config). reserved + total_usage (credit) and
+usage / byok_usage / reserved (key) are owned by the typed authorize/finalize
+DML; the mirror must NOT write them or it clobbers an in-flight typed hold (the
+2026-06-25 "typed finalize failed: release row-count != 1" incident).
+
+These tests prove total_credits/config still track JSON, that a JSON write can
+never clobber a typed-DML-owned hold, and that the drift comparator only flags
+JSON-owned columns.
 
 See docs/design/billing-typed-counters.md.
 """
@@ -13,7 +18,12 @@ from __future__ import annotations
 import json
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount, GatewayAuthorization
+from trusted_router.storage import CreditAccount
+from trusted_router.storage_gcp_counter_dml import (
+    release_credit,
+    reserve_credit,
+    reserve_key,
+)
 from trusted_router.storage_gcp_counter_reconcile import backfill, compare
 from trusted_router.storage_gcp_counters import (
     CREDIT_BALANCE_TABLE,
@@ -39,125 +49,113 @@ def _typed_key(db, key_hash: str) -> dict:
     return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
 
 
-def assert_credit_mirror_matches(db, workspace_id: str) -> None:
-    """The typed credit row must equal the authoritative JSON counters (drift 0)."""
+def assert_credit_total_mirrored(db, workspace_id: str) -> None:
+    """The mirror propagates ONLY the JSON-owned total_credits. reserved +
+    total_usage are typed-DML-owned and are deliberately NOT sourced from JSON."""
     j = _json_credit(db, workspace_id)
     t = _typed_credit(db, workspace_id)
     assert t["total_credits"] == j["total_credits_microdollars"], (j, t)
-    assert t["total_usage"] == j["total_usage_microdollars"], (j, t)
-    assert t["reserved"] == j["reserved_microdollars"], (j, t)
     assert t["shard"] == 0
 
 
-def assert_key_mirror_matches(db, key_hash: str) -> None:
+def assert_key_config_mirrored(db, key_hash: str) -> None:
+    """The mirror propagates ONLY the JSON-owned config (limit_micro,
+    include_byok). usage / byok_usage / reserved are typed-DML-owned."""
     j = _json_key(db, key_hash)
     t = _typed_key(db, key_hash)
     assert t["limit_micro"] == j["limit_microdollars"], (j, t)
-    assert t["usage"] == j["usage_microdollars"], (j, t)
-    assert t["byok_usage"] == j["byok_usage_microdollars"], (j, t)
-    assert t["reserved"] == j["reserved_microdollars"], (j, t)
     assert t["include_byok"] == j["include_byok_in_limit"], (j, t)
     assert t["shard"] == 0
 
 
-def test_credit_seed_and_reserve_mirror_tracks_json() -> None:
+def test_credit_total_credits_is_mirrored() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_mirror"
     store._write_entity(
         "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
     )
-    assert_credit_mirror_matches(db, ws)
+    assert_credit_total_mirrored(db, ws)
+    assert _typed_credit(db, ws)["total_credits"] == 1_000_000
+    # A later credit event (top-up) re-mirrors the new total_credits.
+    store.credit_workspace_once(ws, 500_000, "evt_topup")
+    assert _typed_credit(db, ws)["total_credits"] == 1_500_000
 
+
+def test_json_credit_reserve_does_not_propagate_to_typed_reserved() -> None:
+    """A legacy JSON-path reserve updates JSON.reserved, but the mirror does NOT
+    carry it into the typed-DML-owned tr_credit_balance.reserved."""
+    store, db, _ = make_fake_store()
+    ws = "ws_legacy_reserve"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
     store.reserve(ws, "key_1", 250_000)
     assert _json_credit(db, ws)["reserved_microdollars"] == 250_000
-    assert_credit_mirror_matches(db, ws)
-    assert _typed_credit(db, ws)["reserved"] == 250_000
+    # total_credits still mirrored; reserved stays at the typed default (0).
+    assert_credit_total_mirrored(db, ws)
+    assert _typed_credit(db, ws)["reserved"] == 0
 
 
-def test_credit_settle_mirror_tracks_json() -> None:
+def test_json_credit_write_does_not_clobber_typed_hold() -> None:
+    """THE 2026-06-25 incident reproduction. A typed-DML hold sits in
+    tr_credit_balance.reserved; a JSON credit write (top-up) fires the mirror.
+    Before the ownership split the mirror overwrote reserved with the stale JSON
+    value (0), so the next typed finalize failed 'release row-count != 1'. Now
+    the hold is untouched and the release succeeds."""
     store, db, _ = make_fake_store()
-    ws = "ws_settle_mirror"
+    ws = "ws_clobber"
     store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=2_000_000)
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
     )
-    reservation = store.reserve(ws, "key_1", 500_000)
-    assert_credit_mirror_matches(db, ws)
+    pt = store._param_types
+    # take a typed hold via the conditional-DML path
+    assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 300_000))
+    assert _typed_credit(db, ws)["reserved"] == 300_000
 
-    store.settle(reservation.id, 480_000)
-    j = _json_credit(db, ws)
-    assert j["reserved_microdollars"] == 0
-    assert j["total_usage_microdollars"] == 480_000
-    assert_credit_mirror_matches(db, ws)
+    # a JSON credit top-up (mirror fires) must NOT clobber the in-flight hold
+    store.credit_workspace_once(ws, 500_000, "evt_topup")
+    assert _typed_credit(db, ws)["total_credits"] == 1_500_000  # credit applied
+    assert _typed_credit(db, ws)["reserved"] == 300_000  # hold preserved
+
+    # the typed release still finds its hold: row-count == 1, NOT the incident's 0
+    assert store._database.run_in_transaction(
+        lambda t: release_credit(t, pt, ws, 300_000, 290_000)
+    ) == 1
+    assert _typed_credit(db, ws)["reserved"] == 0
+    assert _typed_credit(db, ws)["total_usage"] == 290_000
 
 
-def test_api_key_create_update_and_limit_mirror_tracks_json() -> None:
+def test_api_key_config_is_mirrored_usage_is_not() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_key_mirror"
     _raw, key = store.api_keys.create(
         workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
     )
-    assert_key_mirror_matches(db, key.hash)
-
-    store.reserve_key_limit(key.hash, 400_000, usage_type="Credits")
-    assert _json_key(db, key.hash)["reserved_microdollars"] == 400_000
-    assert_key_mirror_matches(db, key.hash)
-
+    assert_key_config_mirrored(db, key.hash)
+    # A legacy JSON usage write updates JSON but not the typed-owned usage.
     store.api_keys.add_usage(key.hash, 120_000, is_byok=False)
     assert _json_key(db, key.hash)["usage_microdollars"] == 120_000
-    assert_key_mirror_matches(db, key.hash)
+    assert_key_config_mirrored(db, key.hash)
+    assert _typed_key(db, key.hash)["usage"] == 0
 
 
-def test_finalize_mirrors_both_credit_and_key() -> None:
+def test_json_key_write_does_not_clobber_typed_key_hold() -> None:
+    """Key-side analogue of the incident: a typed key hold must survive a JSON
+    api_key write (here a usage write, which also fires the mirror)."""
     store, db, _ = make_fake_store()
-    ws = "ws_finalize_mirror"
-    store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=5_000_000)
-    )
+    ws = "ws_key_clobber"
     _raw, key = store.api_keys.create(
-        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=5_000_000
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=2_000_000
     )
-    store.reserve_key_limit(key.hash, 1_000_000, usage_type="Credits")
-    reservation = store.reserve(ws, key.hash, 1_000_000)
-    auth = GatewayAuthorization(
-        id="gwa_m",
-        workspace_id=ws,
-        key_hash=key.hash,
-        model_id="openai/gpt-5.4-nano",
-        provider="openai",
-        usage_type="Credits",
-        estimated_microdollars=1_000_000,
-        credit_reservation_id=reservation.id,
+    pt = store._param_types
+    store._database.run_in_transaction(
+        lambda t: reserve_key(t, pt, key.hash, 600_000, is_byok=False)
     )
-    store._write_entity("gateway_authorization", auth.id, auth)
-
-    from trusted_router.storage import Generation
-
-    generation = Generation(
-        id="gen_m",
-        request_id="req_m",
-        workspace_id=ws,
-        key_hash=key.hash,
-        model="openai/gpt-5.4-nano",
-        provider_name="OpenAI",
-        app="typed-mirror-test",
-        tokens_prompt=100,
-        tokens_completion=50,
-        total_cost_microdollars=900_000,
-        usage_type="Credits",
-        speed_tokens_per_second=10.0,
-        finish_reason="stop",
-        status="success",
-        streamed=False,
-    )
-    ok = store.finalize_gateway_authorization(
-        auth.id, success=True, actual_microdollars=900_000,
-        selected_usage_type="Credits", generation=generation,
-    )
-    assert ok is True
-    assert _json_credit(db, ws)["reserved_microdollars"] == 0
-    assert _json_credit(db, ws)["total_usage_microdollars"] == 900_000
-    assert_credit_mirror_matches(db, ws)
-    assert_key_mirror_matches(db, key.hash)
+    assert _typed_key(db, key.hash)["reserved"] == 600_000
+    # a JSON api_key write fires the mirror; the typed hold must be untouched
+    store.api_keys.add_usage(key.hash, 100_000, is_byok=False)
+    assert _typed_key(db, key.hash)["reserved"] == 600_000  # hold preserved
+    assert _typed_key(db, key.hash)["limit_micro"] == 2_000_000  # config still mirrored
 
 
 def test_api_key_delete_removes_typed_mirror_row() -> None:
@@ -199,7 +197,7 @@ def test_uncapped_key_mirrors_null_limit() -> None:
         workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=None
     )
     assert _typed_key(db, key.hash)["limit_micro"] is None
-    assert_key_mirror_matches(db, key.hash)
+    assert_key_config_mirrored(db, key.hash)
 
 
 # ── Step 2: backfill + drift comparator ─────────────────────────────────────
@@ -212,10 +210,14 @@ def test_credit_drift_pure() -> None:
     }
     match = {"total_credits": 1_000_000, "total_usage": 200_000, "reserved": 50_000}
     assert credit_drift(body, match) == {}
-    assert credit_drift(body, None)  # missing mirror = drift on all fields
-    bad = dict(match, reserved=49_999)
-    drift = credit_drift(body, bad)
-    assert drift == {"reserved": (50_000, 49_999)}
+    assert credit_drift(body, None)  # missing mirror = drift on the owned field
+    # reserved + total_usage are typed-owned now: a mismatch there is NOT drift.
+    assert credit_drift(body, dict(match, reserved=49_999)) == {}
+    assert credit_drift(body, dict(match, total_usage=199_999)) == {}
+    # but a JSON-owned total_credits mismatch IS drift.
+    assert credit_drift(body, dict(match, total_credits=999_999)) == {
+        "total_credits": (1_000_000, 999_999)
+    }
 
 
 def test_key_drift_pure_handles_null_limit_and_bool() -> None:
@@ -229,6 +231,8 @@ def test_key_drift_pure_handles_null_limit_and_bool() -> None:
     typed = {"limit_micro": None, "usage": 10, "byok_usage": 0, "reserved": 0, "include_byok": True}
     assert key_drift(body, typed) == {}
     assert "include_byok" in key_drift(body, dict(typed, include_byok=False))
+    # typed-owned usage mismatch is NOT drift.
+    assert key_drift(body, dict(typed, usage=999)) == {}
 
 
 def test_compare_clean_after_mirror() -> None:
@@ -249,15 +253,21 @@ def test_compare_clean_after_mirror() -> None:
     assert report.key_rows == 1
 
 
-def test_compare_detects_corrupted_typed_row() -> None:
+def test_compare_ignores_typed_owned_columns_flags_json_owned() -> None:
+    """The comparator only audits JSON-owned columns. Corrupting the typed-owned
+    reserved is expected divergence (typed owns it); corrupting the JSON-owned
+    total_credits is real drift."""
     store, db, _ = make_fake_store()
     ws = "ws_corrupt"
     store._write_entity(
         "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
     )
     assert compare(store).clean
-    # Corrupt the typed mirror out from under the JSON authority.
+    # Typed-owned reserved diverging is NOT drift.
     db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] = 999_999
+    assert compare(store).clean
+    # JSON-owned total_credits diverging IS drift.
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_credits"] = 12_345
     report = compare(store)
     assert not report.clean
     assert report.credit_drift == 1

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -268,9 +268,12 @@ def test_release_key_settles_usage_and_byok() -> None:
 
 def test_reserve_key_include_byok_true_counts_byok_usage() -> None:
     """With include_byok=true, prior BYOK usage consumes the cap headroom."""
-    store, _db, _ = make_fake_store()
+    store, db, _ = make_fake_store()
     key = _make_key(store, "ws_ib", limit=1_000_000, include_byok=True)
-    store.api_keys.add_usage(key.hash, 400_000, is_byok=True)  # byok_usage=400k
+    # BYOK usage is typed-DML-owned; the legacy JSON add_usage no longer
+    # propagates into the typed row after the ownership split, so seed the typed
+    # byok_usage directly (this is what reserve_key reads for the cap math).
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["byok_usage"] = 400_000
     pt = store._param_types
     # available = 1_000_000 - 0 - 400_000 - 0 = 600_000
     assert store._database.run_in_transaction(


### PR DESCRIPTION
## Incident
Production `typed finalize failed: release row-count != 1` in gateway settle (settle fails internally, that request's usage goes unbilled). Triggered when the universal `*` typed-billing flip put every workspace on the typed path.

## Root cause (confirmed with prod data)
The one-way JSON→typed mirror (`storage_gcp_counters.mirror_write`) did an **exact full-row copy**, including `reserved`/`total_usage` (credit) and `usage`/`byok_usage`/`reserved` (key). Those columns are owned by the typed authorize/finalize **DML**, and their JSON copy is **stale** for a typed workspace (the typed path never writes JSON). So any JSON credit/key write — a top-up, grant, refund, key-limit change, or a legacy settle straddling the flip — re-fired the mirror and overwrote the live typed hold → the next typed release matched 0 rows → the error. A flipped workspace had `typed.reserved == json.reserved == 8079` while its 17 open typed holds summed to 46,864.

## Fix — ownership split
The mirror now writes **only JSON-owned columns**: credit `total_credits`; key `limit_micro`/`include_byok` (+ timestamps). It never writes the typed-DML-owned counters. Subset-column `insert_or_update` is safe because every dropped column is `NOT NULL DEFAULT(0)` (new row → 0; existing row → untouched, Spanner merge). Drift comparator narrowed to the JSON-owned columns.

- **Fake fidelity** (`tests/fakes/spanner.py`): models real `insert_or_update` — default-fill on insert, supplied-column merge on update — on **both** the txn and batch commit paths. The prior full-row replace modeled neither and would have hidden the clobber.
- **Tests**: rewritten to the ownership-split contract + **incident reproductions** (a typed hold survives a subsequent JSON credit/key write; the typed release still gets row-count `== 1`). 64 typed + 200 broader billing tests pass; lint clean.
- **`backfill()` guard**: docstring states it is **not** a flip gate — it no longer seeds typed `reserved`/`usage`, so a (re-)flip needs a separate ledger-derived reconciliation, and a clean `compare()` does not mean flip-safe.

## Architecture review (codex + independent multi-lens, both converged)
Approach **A (unconditional ownership split) is the correct steady-state design** and the smallest change that stops the clobber. Gate-aware **B was rejected** (threads routing policy into storage + races the flip = fail-quiet under-seed). Dual-write **C** rejected (reintroduces the deadlock). codex line-level pass: **PASS, no blocking bug**.

## Scope / safety
- **Safe to operate the current cohort now**: both cohort workspaces were seeded under the old full-row backfill (their typed counters are correct), are continuously typed, and the new mirror no longer touches typed-owned columns. The one live risk (auto-refill reading stale JSON balance → underbill) **does not fire** — both cohort workspaces have auto-refill disabled.
- **NOT flip-ready**: the universal re-flip is a separate follow-up effort — a ledger-derived reconciliation (seed `typed.reserved` from open holds + `total_usage`, atomic with the gate flip), a fail-closed post-seed verification, a typed-side invariant auditor, and typed-aware reads (auto-refill/console/invoicing). Companion config revert: #78 keeps `rollout.sh` off `*`.

Stops the bleeding + protects the cohort; does not attempt the re-flip.