### PR TITLE
billing(step6): ledger-derived flip reconciliation (safe re-flip seed)

### DIFF
--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -174,3 +174,167 @@ def backfill(store: Any, *, dry_run: bool = False) -> dict[str, int]:
             counts[kind] += 1
 
     return counts
+
+
+# ── Step 6: ledger-derived flip reconciliation ──────────────────────────────
+# Seeds the typed-DML-owned counters for a workspace at the moment it is flipped
+# to typed enforcement. This is the FULL-ROW seed that backfill()/mirror_write no
+# longer do after the 2026-06-25 ownership split — and the ONLY sanctioned writer
+# of typed reserved/total_usage outside the typed authorize/finalize DML.
+#
+# Safe ONLY for a NEVER-TYPED, DRAINED workspace (fail-closed). A workspace with
+# prior typed-origin history (the cohort, or a rolled-back ws like the incident's
+# ea7dd3d8) already has typed gross counters that JSON does not reflect; blindly
+# seeding from JSON would lose typed-era usage, so this tool REFUSES it (needs a
+# ledger reconcile instead). The caller MUST first QUIESCE the workspace (disable
+# its keys) and DRAIN in-flight requests — incl. no-hold (uncapped / BYOK-excluded)
+# paths that settle usage without a reserved hold — before apply=True
+# (codex Step-6 design: enforced quiesce, not observed idle, is the safety).
+
+# Full typed-row column sets — the seed writes reserved/usage too (unlike the
+# narrowed mirror constants, which deliberately omit the typed-owned columns).
+_CREDIT_SEED_COLUMNS = (
+    "workspace_id", "shard", "total_credits", "total_usage", "reserved",
+    "source_updated_at", "updated_at",
+)
+_KEY_SEED_COLUMNS = (
+    "key_hash", "shard", "limit_micro", "usage", "byok_usage", "reserved",
+    "include_byok", "source_updated_at", "updated_at",
+)
+
+
+@dataclass
+class FlipReadiness:
+    workspace_id: str
+    ready: bool
+    reasons: list[str] = field(default_factory=list)  # why NOT ready (empty == ready)
+    applied: bool = False
+    credit_seeded: dict | None = None
+    keys_seeded: int = 0
+
+
+def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) -> FlipReadiness:
+    """Assess (and optionally apply) the typed-counter SEED for flipping ONE
+    never-typed, drained workspace to typed enforcement.
+
+    Fail-closed: refuses unless the workspace has a credit account, has NO
+    tr_reservation history (never typed), and is fully drained (json credit
+    reserved == 0 and every json api_key reserved == 0). With apply=True it
+    re-reads the JSON rows INSIDE one Spanner transaction, re-checks the
+    reserved==0 predicates (a legacy hold racing the seed aborts it), and upserts
+    the full typed rows: total_credits/total_usage (credit) and
+    limit/usage/byok_usage/include_byok (key) from JSON, with reserved = 0 (the
+    workspace is drained and never-typed, so there are no open holds to carry).
+    Read-only when apply=False.
+
+    CAUTION — reserved==0 does NOT by itself prove drained: a no-hold (uncapped /
+    BYOK-excluded) request can be mid-flight with reserved==0 and settle usage
+    AFTER the seed, leaving typed usage stale-low. The caller MUST enforce quiesce
+    (disable the workspace's keys) and drain in-flight requests first; this
+    function only checks DB predicates. The key set is captured at assess time, so
+    quiesce must also prevent a new key appearing mid-flip. Run before the cohort
+    gate flip, never after.
+    """
+    pt = store._param_types
+    res = FlipReadiness(workspace_id=workspace_id, ready=False)
+
+    credit = next(
+        (b for b in store._list_entities("credit", cls=dict) if b.get("workspace_id") == workspace_id),
+        None,
+    )
+    if credit is None:
+        res.reasons.append("no credit account")
+        return res
+    keys = [b for b in store._list_entities("api_key", cls=dict) if b.get("workspace_id") == workspace_id]
+
+    with store._database.snapshot() as snap:
+        typed_history = list(snap.execute_sql(
+            "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws",
+            params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+    if int(typed_history) != 0:
+        res.reasons.append(
+            f"{typed_history} tr_reservation rows (typed history) — needs a ledger reconcile, not a JSON seed"
+        )
+    if int(credit.get("reserved_microdollars", 0)) != 0:
+        res.reasons.append(
+            f"credit.reserved={credit['reserved_microdollars']} (open legacy holds — quiesce + drain first)"
+        )
+    for k in keys:
+        if int(k.get("reserved_microdollars", 0)) != 0:
+            res.reasons.append(f"key {k['hash'][:12]} reserved={k['reserved_microdollars']} (drain first)")
+
+    res.ready = not res.reasons
+    if not res.ready or not apply:
+        return res
+
+    cts = store._spanner.COMMIT_TIMESTAMP
+
+    def _txn(transaction: Any) -> dict | None:
+        # Returning None from a run_in_transaction callback COMMITS the buffered
+        # mutations (only a RAISE aborts), so we must issue ZERO mutations until
+        # EVERY predicate has passed — read + re-check all rows first, then write
+        # all of them. Otherwise a hold on a later key would partial-seed the
+        # earlier ones.
+        # Defense-in-depth: re-check no typed history INSIDE the txn — a ws that
+        # got a typed reservation concurrently is already typed; never JSON-seed it.
+        hist = list(transaction.execute_sql(
+            "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws",
+            params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))
+        if hist and int(hist[0][0]) != 0:
+            return None
+        c = store._read_entity_tx(transaction, "credit", workspace_id, dict)
+        if c is None or int(c.get("reserved_microdollars", 0)) != 0:
+            return None  # account vanished or a legacy hold appeared mid-seed — no writes issued
+        fresh_keys = []
+        for k in keys:
+            kb = store._read_entity_tx(transaction, "api_key", k["hash"], dict)
+            if kb is None:
+                continue
+            if int(kb.get("reserved_microdollars", 0)) != 0:
+                return None  # a key hold appeared mid-seed — no writes issued yet
+            fresh_keys.append(kb)
+        # All predicates hold — now issue every upsert (no partial seed possible).
+        for kb in fresh_keys:
+            limit = kb.get("limit_microdollars")
+            transaction.insert_or_update(
+                table="tr_key_limit",
+                columns=_KEY_SEED_COLUMNS,
+                values=[(
+                    kb["hash"], 0,
+                    None if limit is None else int(limit),
+                    int(kb.get("usage_microdollars", 0)),
+                    int(kb.get("byok_usage_microdollars", 0)),
+                    0,
+                    bool(kb.get("include_byok_in_limit", True)),
+                    cts, cts,
+                )],
+            )
+        transaction.insert_or_update(
+            table="tr_credit_balance",
+            columns=_CREDIT_SEED_COLUMNS,
+            values=[(
+                workspace_id, 0,
+                int(c.get("total_credits_microdollars", 0)),
+                int(c.get("total_usage_microdollars", 0)),
+                0,
+                cts, cts,
+            )],
+        )
+        return {
+            "total_credits": int(c.get("total_credits_microdollars", 0)),
+            "total_usage": int(c.get("total_usage_microdollars", 0)),
+            "reserved": 0,
+            "keys": len(fresh_keys),
+        }
+
+    seeded = store._run_in_transaction(_txn)
+    if seeded is None:
+        res.ready = False
+        res.reasons.append("aborted: a hold appeared during seed (re-drain and retry)")
+        return res
+    res.applied = True
+    res.keys_seeded = seeded.pop("keys")
+    res.credit_seeded = seeded
+    return res

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -490,6 +490,10 @@ def _execute_sql(
                 if len(out) >= limit:
                     break
         return out
+    # Flip-reconcile: does this workspace have ANY typed reservation history?
+    if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
+        ws = params["ws"]
+        return [[sum(1 for rec in db.reservations.values() if rec.get("workspace_id") == ws)]]
     # tr_reservation reads (idempotency replay + by-id for settle/reaper).
     if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
         scope = params["scope"]

--- a/tests/test_billing_flip_reconcile.py
+++ b/tests/test_billing_flip_reconcile.py
@@ -1,0 +1,145 @@
+"""Step 6 of the billing typed-column migration: the ledger-derived FLIP SEED.
+
+reconcile_for_flip() is the sanctioned full-row seed that the ownership-split
+mirror/backfill no longer do. It must be FAIL-CLOSED: only a never-typed, fully
+drained workspace may be seeded from JSON gross counters (with reserved=0), and a
+legacy hold racing the seed must abort it.
+
+See docs/design/billing-typed-counters.md.
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount
+from trusted_router.storage_gcp_counter_reconcile import reconcile_for_flip
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _typed_credit(db, ws: str) -> dict:
+    return db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]
+
+
+def _typed_key(db, key_hash: str) -> dict:
+    return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
+
+
+def _seed_drained_workspace(store, ws: str, *, total_credits: int, total_usage: int):
+    """A never-typed workspace with lifetime usage but no open holds (drained).
+    After the ownership split the mirror carries only total_credits, so the typed
+    row's total_usage is intentionally stale (0) until reconcile_for_flip seeds it."""
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(
+            workspace_id=ws,
+            total_credits_microdollars=total_credits,
+            total_usage_microdollars=total_usage,
+        ),
+    )
+
+
+def test_reconcile_ready_seeds_gross_counters_with_zero_reserved() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_flip"
+    _seed_drained_workspace(store, ws, total_credits=5_000_000, total_usage=1_200_000)
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=2_000_000
+    )
+    store.api_keys.add_usage(key.hash, 300_000, is_byok=False)  # JSON usage only (mirror skips it)
+
+    # Pre-state: the mirror carried total_credits + key config, NOT usage.
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert _typed_key(db, key.hash)["usage"] == 0
+
+    assessment = reconcile_for_flip(store, ws, apply=False)
+    assert assessment.ready, assessment.reasons
+    assert not assessment.applied  # read-only
+    assert _typed_credit(db, ws)["total_usage"] == 0  # unchanged by assessment
+
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert result.ready and result.applied, result.reasons
+    assert result.keys_seeded == 1
+    # Gross counters now seeded from JSON; reserved is 0 (drained, never typed).
+    assert _typed_credit(db, ws)["total_credits"] == 5_000_000
+    assert _typed_credit(db, ws)["total_usage"] == 1_200_000
+    assert _typed_credit(db, ws)["reserved"] == 0
+    assert _typed_key(db, key.hash)["usage"] == 300_000
+    assert _typed_key(db, key.hash)["reserved"] == 0
+    assert _typed_key(db, key.hash)["limit_micro"] == 2_000_000
+
+
+def test_reconcile_refuses_open_credit_hold() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_hold"
+    _seed_drained_workspace(store, ws, total_credits=1_000_000, total_usage=0)
+    store.reserve(ws, "key_1", 250_000)  # open legacy credit hold
+
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert not result.ready
+    assert any("reserved" in r for r in result.reasons), result.reasons
+    assert not result.applied
+    # No seed written: typed total_usage untouched (still 0 default).
+    assert _typed_credit(db, ws)["reserved"] == 0  # never seeded a nonzero reserved
+
+
+def test_reconcile_refuses_open_key_hold() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_keyhold"
+    _seed_drained_workspace(store, ws, total_credits=2_000_000, total_usage=0)
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    store.reserve_key_limit(key.hash, 400_000, usage_type="Credits")  # open legacy key hold
+
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert not result.ready
+    assert any("reserved" in r for r in result.reasons), result.reasons
+    assert not result.applied
+
+
+def test_reconcile_refuses_typed_history() -> None:
+    """A workspace with ANY tr_reservation history already has typed gross
+    counters JSON doesn't reflect; a JSON seed would lose typed-era usage."""
+    store, db, _ = make_fake_store()
+    ws = "ws_typed_hist"
+    _seed_drained_workspace(store, ws, total_credits=1_000_000, total_usage=0)
+    db.reservations["r_hist"] = {
+        "reservation_id": "r_hist", "workspace_id": ws, "settled": True,
+    }
+
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert not result.ready
+    assert any("typed history" in r for r in result.reasons), result.reasons
+    assert not result.applied
+
+
+def test_reconcile_no_partial_seed_when_any_key_has_a_hold() -> None:
+    """Multi-key: a hold on ANY key must abort the whole seed with NO partial
+    write to the others (returning None commits buffered mutations, so the seed
+    must issue none until every predicate passes)."""
+    store, db, _ = make_fake_store()
+    ws = "ws_partial"
+    _seed_drained_workspace(store, ws, total_credits=3_000_000, total_usage=0)
+    _raw, k1 = store.api_keys.create(
+        workspace_id=ws, name="k1", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    _raw, k2 = store.api_keys.create(
+        workspace_id=ws, name="k2", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    store.api_keys.add_usage(k1.hash, 100_000, is_byok=False)  # k1 has seedable usage
+    store.reserve_key_limit(k2.hash, 200_000, usage_type="Credits")  # k2 has an open hold
+
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert not result.ready and not result.applied
+    # NOTHING seeded — neither key's usage nor the credit usage moved off 0.
+    assert _typed_key(db, k1.hash)["usage"] == 0
+    assert _typed_key(db, k2.hash)["usage"] == 0
+    assert _typed_credit(db, ws)["total_usage"] == 0
+
+
+def test_reconcile_refuses_no_account() -> None:
+    store, _db, _ = make_fake_store()
+    result = reconcile_for_flip(store, "ws_missing", apply=True)
+    assert not result.ready
+    assert any("no credit account" in r for r in result.reasons), result.reasons
+    assert not result.applied


### PR DESCRIPTION
## Why
After the ownership split (#79), `backfill() == mirror_write()` no longer seeds the typed-DML-owned `reserved`/`total_usage`. So the previous "backfill + flip the env gate" flow is **no longer a safe flip** — it would leave `typed.reserved` blind to open holds (silent overspend) and `total_usage` stale-low (permanently overstated available). This adds the sanctioned full-row **seed** that makes a workspace safe to flip.

## `reconcile_for_flip(store, workspace_id, *, apply=False)`
Fail-closed. Refuses unless the workspace: has a credit account; has **zero** `tr_reservation` history (never typed — a ws with typed history has gross counters JSON can't reflect, needs a ledger reconcile); and is **fully drained** (`json credit reserved==0` and every key `reserved==0`). With `apply=True` it re-reads JSON inside one Spanner txn, re-checks no-typed-history + `reserved==0` (a racing legacy hold aborts), then upserts the full typed rows from JSON gross counters with `reserved=0`.

## codex review (real money) — PASS after fixes
- **Critical (fixed):** returning `None` from a `run_in_transaction` callback **commits** the buffered mutations (only a raise aborts) — a hold on a *later* key would have partial-seeded the earlier ones. Restructured to **check-all-then-write-all** (zero mutations until every predicate passes) + added a multi-key regression test.
- Added the **in-txn typed-history re-check** (defense-in-depth).
- Documented that **enforced quiesce/drain is the real safety**, not `reserved==0` (a no-hold uncapped/BYOK request can be mid-flight with `reserved==0` and settle usage after the seed).

6 reconcile tests + 64 existing typed tests pass; lint clean.

## Scope
This is the **seed half** of Step 6. Follow-ups (separate PRs): the quiesce→drain→seed→verify→deploy→canary→unquiesce runbook + CLI wrapper; typed-aware balance reads (auto-refill/console/invoicing); the typed-side invariant auditor; key-deletion drain. The **actual production re-flip to `*` is gated** on those + an explicit go (it's what caused the 2026-06-25 outage).