### PR TITLE
billing(step6): typed-aware credit balance reads (fix typed-ws underbill)

### DIFF
--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -29,6 +29,7 @@ from trusted_router.services.x402_billing import (
     x402_payment_required_response_body,
 )
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import typed_aware_credit_account
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
@@ -36,8 +37,10 @@ log = logging.getLogger(__name__)
 
 def register_billing_routes(router: APIRouter) -> None:
     @router.get("/credits")
-    async def credits(principal: ManagementPrincipal) -> dict[str, dict[str, Any]]:
-        account = STORE.get_credit_account(principal.workspace.id)
+    async def credits(
+        principal: ManagementPrincipal, settings: SettingsDep
+    ) -> dict[str, dict[str, Any]]:
+        account = typed_aware_credit_account(STORE, principal.workspace.id, settings=settings)
         if account is None:
             raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
         available_microdollars = (

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -29,12 +29,13 @@ from trusted_router.services.stripe_billing import (
     remove_saved_payment_method,
 )
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import typed_aware_credit_account
 
 
 def register(app: FastAPI) -> None:
     @app.get("/console/credits")
     async def console_credits(ctx: ConsoleDep, settings: SettingsDep) -> Response:
-        credit = STORE.get_credit_account(ctx.workspace.id)
+        credit = typed_aware_credit_account(STORE, ctx.workspace.id, settings=settings)
         # Pull the last 20 Stripe checkout sessions tagged with this
         # workspace_id from Stripe's Search API. Returns [] if Stripe is
         # unreachable / not configured / there are no payments yet — all

--- a/src/trusted_router/services/auto_refill.py
+++ b/src/trusted_router/services/auto_refill.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from trusted_router.config import Settings
 from trusted_router.storage import STORE
 from trusted_router.storage_models import CreditAccount
+from trusted_router.typed_balance import typed_aware_credit_account
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +50,10 @@ def maybe_charge_after_settle(
     the decision. Never raises — Stripe / network failures are surfaced
     via `last_auto_refill_status` so retries are bounded by the next
     settle event."""
-    account = STORE.get_credit_account(workspace_id)
+    # Typed-aware: for a typed workspace the authoritative usage/reserved live in
+    # the typed table; reading stale JSON here would overstate available and the
+    # threshold would never trip → the card never charges (underbill).
+    account = typed_aware_credit_account(STORE, workspace_id, settings=settings)
     if account is None:
         return AutoRefillOutcome(fired=False, reason="no_account")
     if not account.auto_refill_enabled:

--- a/src/trusted_router/typed_balance.py
+++ b/src/trusted_router/typed_balance.py
@@ -1,0 +1,75 @@
+"""Typed-aware balance reads.
+
+After the 2026-06-25 ownership split, a typed workspace's authoritative
+`reserved` / `total_usage` (credit) and `usage` / `byok_usage` / `reserved` (key)
+live in the typed Spanner tables (tr_credit_balance / tr_key_limit), booked by
+the typed authorize/finalize DML. The JSON `credit` / `api_key` rows are
+intentionally stale for those columns once a workspace is typed (only
+total_credits / key config are mirrored back). So any DISPLAY or DECISION that
+reads the JSON counters — the console balance, `/credits`, auto-refill, key
+usage/remaining — would see a stale-LOW usage and an overstated available
+balance (e.g. auto-refill would never fire → the card is never charged →
+underbill). These helpers overlay the authoritative typed counters onto the
+JSON-loaded object for typed workspaces, and are a no-op for legacy workspaces or
+stores without typed tables.
+
+Routing decision = the same cohort gate the authorize path uses
+(typed_billing_enabled_for_workspace), evaluated from the caller's Settings.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from trusted_router.storage_gcp_authorize import typed_billing_enabled_for_workspace
+from trusted_router.storage_models import CreditAccount
+
+
+def _typed_enabled(workspace_id: str, settings: Any) -> bool:
+    return typed_billing_enabled_for_workspace(
+        workspace_id,
+        allowlist_csv=settings.typed_billing_workspace_ids,
+        denylist_csv=settings.typed_billing_workspace_denylist,
+    )
+
+
+def _has_typed_tables(store: Any) -> bool:
+    # GCP store only; InMemory has no typed Spanner tables.
+    return hasattr(store, "_database") and hasattr(store, "_param_types")
+
+
+def _read_typed_credit(store: Any, workspace_id: str) -> tuple | None:
+    pt = store._param_types
+    with store._database.snapshot() as snap:
+        rows = list(snap.execute_sql(
+            "SELECT total_credits, total_usage, reserved FROM tr_credit_balance "
+            "WHERE workspace_id=@pk AND shard=0",
+            params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+    return tuple(rows[0]) if rows else None
+
+
+def typed_aware_credit_account(
+    store: Any, workspace_id: str, *, settings: Any
+) -> CreditAccount | None:
+    """Return the workspace's CreditAccount with total_credits/total_usage/
+    reserved overlaid from the typed table when the workspace is typed. JSON
+    metadata (auto-refill config, stripe ids) is preserved. No-op for legacy
+    workspaces, stores without typed tables, or a not-yet-seeded typed row."""
+    account = store.get_credit_account(workspace_id)
+    if account is None or not _has_typed_tables(store) or not _typed_enabled(workspace_id, settings):
+        return account
+    typed = _read_typed_credit(store, workspace_id)
+    if typed is None:
+        return account  # typed enforcement on but row not seeded yet — JSON is the best estimate
+    return dataclasses.replace(
+        account,
+        total_credits_microdollars=int(typed[0]),
+        total_usage_microdollars=int(typed[1]),
+        reserved_microdollars=int(typed[2]),
+    )
+
+# NOTE: the key-usage/remaining display overlay (typed_aware_key over tr_key_limit)
+# is the immediate follow-up — it threads Settings into the /v1/keys + console key
+# routes, so it lands as its own focused change.

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -542,10 +542,12 @@ def _execute_sql(
     for typed_table in ("tr_credit_balance", "tr_key_limit"):
         if f"FROM {typed_table}" in sql:
             cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
-            recs = db.typed.get(typed_table, {}).values()
+            recs = list(db.typed.get(typed_table, {}).values())
             if "@pk" in sql and "pk" in params:
                 pk_col = "workspace_id" if typed_table == "tr_credit_balance" else "key_hash"
                 recs = [r for r in recs if r.get(pk_col) == params["pk"]]
+                if "shard=0" in sql.replace(" ", ""):
+                    recs = [r for r in recs if r.get("shard", 0) == 0]
             return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -537,14 +537,16 @@ def _execute_sql(
             return []
         cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
         return [[rec.get(c) for c in cols]]
-    # Typed counter tables (Step 2 reconcile scans): SELECT <cols> FROM <table>.
+    # Typed counter tables: full scan (Step 2 reconcile) OR a single-row read by
+    # pk (the typed_balance overlay uses WHERE <pk_col>=@pk AND shard=0).
     for typed_table in ("tr_credit_balance", "tr_key_limit"):
         if f"FROM {typed_table}" in sql:
             cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
-            return [
-                [rec.get(c) for c in cols]
-                for rec in db.typed.get(typed_table, {}).values()
-            ]
+            recs = db.typed.get(typed_table, {}).values()
+            if "@pk" in sql and "pk" in params:
+                pk_col = "workspace_id" if typed_table == "tr_credit_balance" else "key_hash"
+                recs = [r for r in recs if r.get(pk_col) == params["pk"]]
+            return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]
         if txn is not None:

--- a/tests/test_typed_balance.py
+++ b/tests/test_typed_balance.py
@@ -1,0 +1,72 @@
+"""Typed-aware balance reads: for a typed workspace, display + auto-refill must
+read the authoritative typed counters (usage/reserved booked by the typed DML),
+not the intentionally-stale JSON. For a legacy workspace they read JSON.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.typed_balance import typed_aware_credit_account
+
+
+def _settings(allow: str = "", deny: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        typed_billing_workspace_ids=allow, typed_billing_workspace_denylist=deny
+    )
+
+
+def test_credit_overlay_only_for_typed_workspace() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_typed"
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+    )
+    # Simulate the typed DML having booked usage + a hold ahead of stale JSON.
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 300_000, "reserved": 150_000})
+
+    # Legacy view (not in allowlist) → JSON (usage/reserved still 0).
+    legacy = typed_aware_credit_account(store, ws, settings=_settings(allow=""))
+    assert legacy.total_usage_microdollars == 0
+    assert legacy.reserved_microdollars == 0
+
+    # Typed view (in allowlist) → authoritative typed counters.
+    typed = typed_aware_credit_account(store, ws, settings=_settings(allow=ws))
+    assert typed.total_credits_microdollars == 1_000_000  # JSON-owned, unchanged
+    assert typed.total_usage_microdollars == 300_000
+    assert typed.reserved_microdollars == 150_000
+    assert typed.workspace_id == ws  # JSON metadata preserved
+
+
+def test_credit_overlay_denylist_wins() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_deny"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 999_999})
+    # "*" allowlist but denied → legacy (JSON, usage 0).
+    acct = typed_aware_credit_account(store, ws, settings=_settings(allow="*", deny=ws))
+    assert acct.total_usage_microdollars == 0
+
+
+def test_credit_typed_but_unseeded_falls_back_to_json() -> None:
+    store, _db, _ = make_fake_store()
+    store._counter_mirror_enabled = False  # no typed row written
+    ws = "ws_unseeded"
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=2_000_000, total_usage_microdollars=50_000),
+    )
+    acct = typed_aware_credit_account(store, ws, settings=_settings(allow=ws))
+    assert acct is not None
+    assert acct.total_usage_microdollars == 50_000  # JSON, since no typed row
+
+
+def test_credit_missing_account_returns_none() -> None:
+    store, _db, _ = make_fake_store()
+    assert typed_aware_credit_account(store, "nope", settings=_settings(allow="*")) is None


### PR DESCRIPTION
## Why (codex flagged this as the one LIVE money risk before broad re-flip)
After the ownership split, a typed workspace's authoritative `total_usage`/`reserved` live in `tr_credit_balance` (booked by the typed DML); the JSON credit row is intentionally stale for them. Any reader computing `available` from JSON overstates it. The dangerous one is **auto-refill**: stale-low usage → available reads high → the low-balance threshold never trips → **the card never charges (vendor underbill)**. Console balance + `/credits` also display wrong.

## Fix
`typed_balance.typed_aware_credit_account()` overlays the authoritative typed counters onto the JSON-loaded `CreditAccount` when the workspace is typed (same cohort gate the authorize path uses), preserving JSON metadata (auto-refill config, stripe ids). No-op for legacy workspaces, stores without typed tables, or a not-yet-seeded typed row. Wired into `maybe_charge_after_settle`, `/credits`, `/console/credits`.

- Fake fidelity: its typed-table read now models a single-row `WHERE <pk>=@pk` read (it previously ignored `WHERE` and returned all rows).
- 4 new tests (typed overlay, denylist-wins, unseeded→JSON fallback, missing account); 204 broad billing tests green; lint clean.

## Scope
Credit balance only (the money + main displays). **Follow-up:** the key usage/remaining display overlay (`typed_aware_key`, already drafted) threads `Settings` into the `/v1/keys` + console key routes — lands separately to keep this focused. Part of the Step 6 'safe re-flip' series (after the ownership-split #79 and the reconciliation #80).