### PR TITLE
billing(step6): workspace billing-pause (enforced quiesce primitive)

### DIFF
--- a/src/trusted_router/errors.py
+++ b/src/trusted_router/errors.py
@@ -41,11 +41,32 @@ def api_error(
     type_: str,
     *,
     source: str | None = None,
+    headers: dict[str, str] | None = None,
 ) -> HTTPException:
     return HTTPException(
         status_code=code,
         detail=error_body(code, message, type_, source=source),
+        headers=headers,
     )
+
+
+def assert_workspace_billing_active(workspace: Any) -> None:
+    """Quiesce guard for the typed-billing migration (and a general billing kill
+    switch): raise 503 + Retry-After if the workspace is billing-paused. Call at
+    EVERY entry point that starts new billable work or mints an API key — gateway
+    authorize/validate, and every key-creation path (/v1/keys, console keys, OAuth
+    code exchange, chat-browser key issuance) — so a paused workspace truly drains
+    to zero holds before a flip. Settle is intentionally NOT guarded (it routes by
+    reservation origin and must still finalize in-flight work)."""
+    if workspace is not None and getattr(workspace, "billing_paused", False):
+        from trusted_router.types import ErrorType
+
+        raise api_error(
+            503,
+            "Workspace billing is paused",
+            ErrorType.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": "30"},
+        )
 
 
 def error_response(

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Form, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from trusted_router.auth import SettingsDep
+from trusted_router.errors import assert_workspace_billing_active
 from trusted_router.money import dollars_to_microdollars, microdollars_to_decimal
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.storage import STORE, ApiKey
@@ -46,6 +47,7 @@ def register(app: FastAPI) -> None:
                 return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
             if limit_microdollars < 0:
                 return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
+        assert_workspace_billing_active(ctx.workspace)  # quiesce: no new keys while paused
         raw, _ = STORE.create_api_key(
             workspace_id=ctx.workspace.id,
             name=name,

--- a/src/trusted_router/routes/internal/chat_browser_key.py
+++ b/src/trusted_router/routes/internal/chat_browser_key.py
@@ -41,6 +41,7 @@ from typing import Any
 from fastapi import APIRouter, Response
 
 from trusted_router.auth import SettingsDep
+from trusted_router.errors import assert_workspace_billing_active
 from trusted_router.routes.console._shared import ConsoleDep
 from trusted_router.storage import STORE
 
@@ -87,6 +88,7 @@ def register(router: APIRouter) -> None:
             timespec="seconds"
         ).replace("+00:00", "Z")
 
+        assert_workspace_billing_active(ctx.workspace)  # quiesce: no new keys while paused
         raw_key, api_key = STORE.create_api_key(
             workspace_id=ctx.workspace.id,
             name=name,

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -30,7 +30,7 @@ from trusted_router.catalog import (
     endpoint_for_id,
 )
 from trusted_router.config import Settings
-from trusted_router.errors import api_error
+from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import money_pair, token_cost_microdollars
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.routes.internal._shared import require_internal_gateway
@@ -71,13 +71,7 @@ def register(router: APIRouter) -> None:
         workspace = STORE.get_workspace(api_key.workspace_id)
         if workspace is None:
             raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
-        if getattr(workspace, "billing_paused", False):
-            # Operational quiesce (billing migration / kill switch): reject NEW work
-            # so in-flight holds drain. Settle of already-authorized requests is
-            # unaffected (it routes by reservation origin, not through here).
-            raise api_error(
-                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
-            )
+        assert_workspace_billing_active(workspace)
         return {
             "data": {
                 "workspace_id": workspace.id,
@@ -99,13 +93,7 @@ def register(router: APIRouter) -> None:
         workspace = STORE.get_workspace(api_key.workspace_id)
         if workspace is None:
             raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
-        if getattr(workspace, "billing_paused", False):
-            # Operational quiesce (billing migration / kill switch): reject NEW work
-            # so in-flight holds drain. Settle of already-authorized requests is
-            # unaffected (it routes by reservation origin, not through here).
-            raise api_error(
-                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
-            )
+        assert_workspace_billing_active(workspace)
         body_dict = body.model_dump(exclude_none=True)
         _require_monitor_model_key(body_dict, api_key.lookup_hash, settings)
         requested_model_id = body.model

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -71,6 +71,13 @@ def register(router: APIRouter) -> None:
         workspace = STORE.get_workspace(api_key.workspace_id)
         if workspace is None:
             raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
+        if getattr(workspace, "billing_paused", False):
+            # Operational quiesce (billing migration / kill switch): reject NEW work
+            # so in-flight holds drain. Settle of already-authorized requests is
+            # unaffected (it routes by reservation origin, not through here).
+            raise api_error(
+                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
+            )
         return {
             "data": {
                 "workspace_id": workspace.id,
@@ -92,6 +99,13 @@ def register(router: APIRouter) -> None:
         workspace = STORE.get_workspace(api_key.workspace_id)
         if workspace is None:
             raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
+        if getattr(workspace, "billing_paused", False):
+            # Operational quiesce (billing migration / kill switch): reject NEW work
+            # so in-flight holds drain. Settle of already-authorized requests is
+            # unaffected (it routes by reservation origin, not through here).
+            raise api_error(
+                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
+            )
         body_dict = body.model_dump(exclude_none=True)
         _require_monitor_model_key(body_dict, api_key.lookup_hash, settings)
         requested_model_id = body.model

--- a/src/trusted_router/routes/keys.py
+++ b/src/trusted_router/routes/keys.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from trusted_router.auth import InferencePrincipal, ManagementPrincipal, Principal
-from trusted_router.errors import api_error
+from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import dollars_to_microdollars
 from trusted_router.schemas import CreateKeyRequest, PatchKeyRequest, model_to_dict
 from trusted_router.serialization import key_shape
@@ -34,12 +34,8 @@ def register_key_routes(router: APIRouter) -> None:
         workspace_id = body.workspace_id or principal.workspace.id
         if workspace_id != principal.workspace.id:
             raise api_error(403, "Forbidden", ErrorType.FORBIDDEN)
-        if getattr(principal.workspace, "billing_paused", False):
-            # Quiesce: no new keys while paused, so the workspace's key set is
-            # stable through a flip (the reconcile captures keys at assess time).
-            raise api_error(
-                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
-            )
+        # Quiesce: no new keys while paused, so the key set is stable through a flip.
+        assert_workspace_billing_active(principal.workspace)
         raw, k = STORE.create_api_key(
             workspace_id=workspace_id,
             name=body.name,

--- a/src/trusted_router/routes/keys.py
+++ b/src/trusted_router/routes/keys.py
@@ -34,6 +34,12 @@ def register_key_routes(router: APIRouter) -> None:
         workspace_id = body.workspace_id or principal.workspace.id
         if workspace_id != principal.workspace.id:
             raise api_error(403, "Forbidden", ErrorType.FORBIDDEN)
+        if getattr(principal.workspace, "billing_paused", False):
+            # Quiesce: no new keys while paused, so the workspace's key set is
+            # stable through a flip (the reconcile captures keys at assess time).
+            raise api_error(
+                503, "Workspace billing is paused", ErrorType.SERVICE_UNAVAILABLE
+            )
         raw, k = STORE.create_api_key(
             workspace_id=workspace_id,
             name=body.name,

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -11,7 +11,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Resp
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
 from trusted_router.config import Settings
-from trusted_router.errors import api_error
+from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import dollars_to_microdollars
 from trusted_router.routes.helpers import json_body
 from trusted_router.serialization import key_shape
@@ -75,6 +75,8 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         if code is None:
             raise api_error(403, "Invalid or expired authorization code", ErrorType.FORBIDDEN)
         _verify_pkce(code, body)
+        # Quiesce: a pre-pause OAuth code must not mint a key during pause.
+        assert_workspace_billing_active(STORE.get_workspace(code.workspace_id))
         raw_key, key = STORE.create_api_key(
             workspace_id=code.workspace_id,
             name=code.key_label,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -224,6 +224,8 @@ class InMemoryStore:
         *,
         name: str | None = None,
         deleted: bool | None = None,
+        billing_paused: bool | None = None,
+        billing_pause_reason: str | None = None,
     ) -> Workspace | None:
         with self._lock:
             workspace = self.workspaces.get(workspace_id)
@@ -233,6 +235,10 @@ class InMemoryStore:
                 workspace.name = name
             if deleted is not None:
                 workspace.deleted = deleted
+            if billing_paused is not None:
+                workspace.billing_paused = billing_paused
+            if billing_pause_reason is not None:
+                workspace.billing_pause_reason = billing_pause_reason
             return workspace
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -364,6 +364,8 @@ class SpannerBigtableStore:
         *,
         name: str | None = None,
         deleted: bool | None = None,
+        billing_paused: bool | None = None,
+        billing_pause_reason: str | None = None,
     ) -> Workspace | None:
         def txn(transaction: Any) -> Workspace | None:
             workspace = self._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
@@ -373,6 +375,10 @@ class SpannerBigtableStore:
                 workspace.name = name
             if deleted is not None:
                 workspace.deleted = deleted
+            if billing_paused is not None:
+                workspace.billing_paused = billing_paused
+            if billing_pause_reason is not None:
+                workspace.billing_pause_reason = billing_pause_reason
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
             return None if workspace.deleted else workspace
 

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -65,6 +65,13 @@ class Workspace:
     created_at: str = field(default_factory=iso_now)
     deleted: bool = False
     content_storage_enabled: bool = False
+    # Operational QUIESCE for the typed-billing migration (and a general billing
+    # kill switch): when paused, the gateway rejects new authorizes/validates and
+    # key creation is blocked, so in-flight requests can drain to zero holds before
+    # a workspace is flipped to typed enforcement (codex Step-6 design). Settle of
+    # already-authorized requests is NOT blocked — only new work is.
+    billing_paused: bool = False
+    billing_pause_reason: str = ""
 
 
 @dataclass

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -75,6 +75,8 @@ class Store(Protocol):
         *,
         name: str | None = ...,
         deleted: bool | None = ...,
+        billing_paused: bool | None = ...,
+        billing_pause_reason: str | None = ...,
     ) -> Workspace | None: ...
     def add_members(
         self, workspace_id: str, emails: list[str], role: str = ...

--- a/tests/test_billing_workspace_pause.py
+++ b/tests/test_billing_workspace_pause.py
@@ -42,7 +42,9 @@ def test_paused_workspace_rejects_authorize_and_validate() -> None:
     assert _authorize(client, key["hash"]).status_code == 200  # baseline: not paused
 
     STORE.update_workspace(ws_id, billing_paused=True, billing_pause_reason="flip")
-    assert _authorize(client, key["hash"]).status_code == 503
+    paused = _authorize(client, key["hash"])
+    assert paused.status_code == 503
+    assert paused.headers.get("retry-after") == "30"  # tell SDKs to back off, not hammer
 
     validate = client.post(
         "/v1/internal/gateway/validate",
@@ -52,6 +54,46 @@ def test_paused_workspace_rejects_authorize_and_validate() -> None:
 
     STORE.update_workspace(ws_id, billing_paused=False)
     assert _authorize(client, key["hash"]).status_code == 200  # unpause restores
+
+
+def test_settle_is_not_blocked_while_paused() -> None:
+    """In-flight requests must still settle while paused (settle routes by
+    reservation origin, not through the paused endpoints) — else holds strand."""
+    client, key = _client_and_key("pause-settle@example.com")
+    ws_id = STORE.get_key_by_hash(key["hash"]).workspace_id
+    auth = _authorize(client, key["hash"])
+    assert auth.status_code == 200
+    authorization_id = auth.json()["data"]["authorization_id"]
+
+    STORE.update_workspace(ws_id, billing_paused=True)
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": authorization_id,
+            "actual_input_tokens": 10,
+            "actual_output_tokens": 5,
+            "request_id": "pause-settle-req",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text  # NOT 503
+
+
+def test_assert_workspace_billing_active_helper() -> None:
+    from fastapi import HTTPException
+
+    from trusted_router.errors import assert_workspace_billing_active
+
+    assert assert_workspace_billing_active(None) is None  # no workspace → no-op
+    active = Workspace(id="w", name="n", owner_user_id="u")
+    assert assert_workspace_billing_active(active) is None  # not paused → no-op
+    paused = Workspace(id="w", name="n", owner_user_id="u", billing_paused=True)
+    try:
+        assert_workspace_billing_active(paused)
+        raise AssertionError("expected a 503")
+    except HTTPException as exc:
+        assert exc.status_code == 503
+        assert exc.headers["Retry-After"] == "30"
 
 
 def test_paused_workspace_blocks_key_creation() -> None:

--- a/tests/test_billing_workspace_pause.py
+++ b/tests/test_billing_workspace_pause.py
@@ -1,0 +1,75 @@
+"""Workspace billing-pause = the enforced QUIESCE primitive for the typed-billing
+migration. When paused, the gateway rejects NEW authorize/validate and key
+creation (so in-flight holds can drain to zero before a flip); settle of
+already-authorized requests is unaffected (it routes by reservation origin).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, Workspace
+
+
+def _client_and_key(email: str) -> tuple[TestClient, dict]:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    client = TestClient(app)
+    created = client.post(
+        "/v1/keys", headers={"x-trustedrouter-user": email}, json={"name": "k"}
+    )
+    assert created.status_code == 201, created.text
+    return client, created.json()["data"]
+
+
+def _authorize(client: TestClient, key_hash: str):
+    return client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key_hash,
+            "model": "anthropic/claude-haiku-4.5",
+            "estimated_input_tokens": 8_000,
+            "max_output_tokens": 1_000,
+        },
+    )
+
+
+def test_paused_workspace_rejects_authorize_and_validate() -> None:
+    client, key = _client_and_key("pause-authz@example.com")
+    ws_id = STORE.get_key_by_hash(key["hash"]).workspace_id
+
+    assert _authorize(client, key["hash"]).status_code == 200  # baseline: not paused
+
+    STORE.update_workspace(ws_id, billing_paused=True, billing_pause_reason="flip")
+    assert _authorize(client, key["hash"]).status_code == 503
+
+    validate = client.post(
+        "/v1/internal/gateway/validate",
+        json={"api_key_hash": key["hash"], "route_type": "chat"},
+    )
+    assert validate.status_code == 503, validate.text
+
+    STORE.update_workspace(ws_id, billing_paused=False)
+    assert _authorize(client, key["hash"]).status_code == 200  # unpause restores
+
+
+def test_paused_workspace_blocks_key_creation() -> None:
+    email = "pause-keys@example.com"
+    client, key = _client_and_key(email)
+    ws_id = STORE.get_key_by_hash(key["hash"]).workspace_id
+
+    STORE.update_workspace(ws_id, billing_paused=True)
+    blocked = client.post("/v1/keys", headers={"x-trustedrouter-user": email}, json={"name": "k2"})
+    assert blocked.status_code == 503, blocked.text
+
+    STORE.update_workspace(ws_id, billing_paused=False)
+    ok = client.post("/v1/keys", headers={"x-trustedrouter-user": email}, json={"name": "k3"})
+    assert ok.status_code == 201, ok.text
+
+
+def test_billing_paused_defaults_false_back_compat() -> None:
+    # Old workspace rows / objects without the field default to not-paused.
+    ws = Workspace(id="w", name="n", owner_user_id="u")
+    assert ws.billing_paused is False
+    assert ws.billing_pause_reason == ""


### PR DESCRIPTION
## Why
The safe re-flip needs an **enforced quiesce**: before flipping a workspace to typed enforcement, new work must stop so in-flight holds drain to zero (then `reconcile_for_flip` can seed a clean typed row). codex's review established that per-key `disabled` is insufficient (uncapped/BYOK-excluded keys still run) and the denylist routes to legacy rather than pausing — so this adds a real workspace-level pause.

## What
- `Workspace.billing_paused` (+ `billing_pause_reason`), settable via `update_workspace` on all three store impls (InMemory, GCP, Protocol). Back-compat: defaults `False` (precedent: `content_storage_enabled`).
- Enforced in `/internal/gateway/validate` + `/internal/gateway/authorize` → **503** 'Workspace billing is paused'.
- `POST /keys` blocked while paused, so the key set is stable through a flip (`reconcile_for_flip` captures keys at assess time).
- **Settle is unaffected** — already-authorized requests settle by reservation origin, not through these endpoints, so quiescing drains cleanly without stranding holds.

It doubles as a general billing kill switch.

## Tests
Route-level (TestClient): paused → authorize/validate/key-creation all 503; unpause restores; back-compat default. 257 gateway/keys/store tests green; lint clean.

Step 6 'safe re-flip' series (after #79 ownership split, #80 reconciliation, #81 typed-aware reads).