### PR TITLE
billing(step6): typed-side invariant auditor (reserved-leak tripwire)

### DIFF
--- a/scripts/deploy/backfill_typed_counters.py
+++ b/scripts/deploy/backfill_typed_counters.py
@@ -28,17 +28,34 @@ os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations
 
 from trusted_router.config import Settings
 from trusted_router.storage import create_store
-from trusted_router.storage_gcp_counter_reconcile import backfill, compare
+from trusted_router.storage_gcp_counter_reconcile import (
+    audit_typed_invariants,
+    backfill,
+    compare,
+)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--backfill", action="store_true", help="write missing/stale typed rows")
     parser.add_argument("--dry-run", action="store_true", help="with --backfill, count only")
-    parser.add_argument("--compare", action="store_true", help="report drift (default)")
+    parser.add_argument("--compare", action="store_true", help="report JSON-vs-typed drift (default)")
+    parser.add_argument(
+        "--audit", action="store_true",
+        help="typed-side invariant check: reserved == SUM(open typed holds), reserved >= 0",
+    )
     args = parser.parse_args()
 
     store = create_store(Settings())
+
+    # Typed-side invariant audit (the leak tripwire compare() can't provide). Run
+    # on a schedule + before each ramp batch. Exits 1 on any violation.
+    if args.audit:
+        inv = audit_typed_invariants(store)
+        print(inv.summary())
+        for scope, detail in inv.samples.items():
+            print(f"  VIOLATION {scope}: {detail}")
+        return 0 if inv.clean else 1
 
     if args.backfill:
         counts = backfill(store, dry_run=args.dry_run)

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -350,13 +350,15 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
 # each ramp batch; wire an alert on the "release row-count != 1" log line as the
 # live signal between audits.
 
+# Shard-aware (the typed counter PK is (scope, shard); reservations carry the
+# per-scope shard), COALESCE so an empty SUM reads 0.
 _OPEN_CREDIT_HOLDS = (
-    "SELECT workspace_id, SUM(credit_reserved_micro) FROM tr_reservation "
-    "WHERE settled=false GROUP BY workspace_id"
+    "SELECT workspace_id, ws_shard, COALESCE(SUM(credit_reserved_micro), 0) "
+    "FROM tr_reservation WHERE settled = false GROUP BY workspace_id, ws_shard"
 )
 _OPEN_KEY_HOLDS = (
-    "SELECT key_hash, SUM(key_reserved_micro) FROM tr_reservation "
-    "WHERE settled=false GROUP BY key_hash"
+    "SELECT key_hash, key_shard, COALESCE(SUM(key_reserved_micro), 0) "
+    "FROM tr_reservation WHERE settled = false GROUP BY key_hash, key_shard"
 )
 
 
@@ -382,41 +384,50 @@ class InvariantReport:
 
 def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantReport:
     """Assert, in one consistent snapshot, that every typed `reserved` equals the
-    sum of that scope's OPEN typed-origin holds and is non-negative. Read-only."""
+    sum of that (scope, shard)'s OPEN typed-origin holds and is non-negative.
+    Checks BOTH directions: a typed row whose reserved != its open holds, AND an
+    open hold group with no typed row (that leak is invisible if you only iterate
+    typed rows). Read-only."""
     report = InvariantReport()
 
     with store._database.snapshot(multi_use=True) as snap:
         typed_credit = {
-            r[0]: int(r[1]) for r in snap.execute_sql(
-                "SELECT workspace_id, reserved FROM tr_credit_balance"
+            (r[0], r[1]): int(r[2]) for r in snap.execute_sql(
+                "SELECT workspace_id, shard, reserved FROM tr_credit_balance"
             )
         }
         typed_key = {
-            r[0]: int(r[1]) for r in snap.execute_sql(
-                "SELECT key_hash, reserved FROM tr_key_limit"
+            (r[0], r[1]): int(r[2]) for r in snap.execute_sql(
+                "SELECT key_hash, shard, reserved FROM tr_key_limit"
             )
         }
         credit_holds = {
-            r[0]: int(r[1] or 0) for r in snap.execute_sql(_OPEN_CREDIT_HOLDS)
+            (r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_CREDIT_HOLDS)
         }
-        key_holds = {r[0]: int(r[1] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
+        key_holds = {(r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
 
     def _sample(key: str, value: dict) -> None:
         if len(report.samples) < max_samples:
             report.samples[key] = value
 
-    report.credit_rows = len(typed_credit)
-    for ws_id, reserved in typed_credit.items():
-        expected = credit_holds.get(ws_id, 0)
-        if reserved != expected or reserved < 0:
-            report.credit_violations += 1
-            _sample(f"credit:{ws_id}", {"typed_reserved": reserved, "open_holds": expected})
+    def _check(typed: dict, holds: dict, kind: str) -> tuple[int, int]:
+        violations = 0
+        # forward: every typed row's reserved must equal its open holds, and >= 0.
+        for scope, reserved in typed.items():
+            expected = holds.get(scope, 0)
+            if reserved != expected or reserved < 0:
+                violations += 1
+                _sample(f"{kind}:{scope[0]}:{scope[1]}",
+                        {"typed_reserved": reserved, "open_holds": expected})
+        # reverse: an open hold group with NO typed row is a leak the forward pass
+        # cannot see (typed row deleted/never created while holds are outstanding).
+        for scope, held in holds.items():
+            if held > 0 and scope not in typed:
+                violations += 1
+                _sample(f"{kind}-orphan-hold:{scope[0]}:{scope[1]}",
+                        {"typed_reserved": None, "open_holds": held})
+        return len(typed), violations
 
-    report.key_rows = len(typed_key)
-    for key_hash, reserved in typed_key.items():
-        expected = key_holds.get(key_hash, 0)
-        if reserved != expected or reserved < 0:
-            report.key_violations += 1
-            _sample(f"api_key:{key_hash}", {"typed_reserved": reserved, "open_holds": expected})
-
+    report.credit_rows, report.credit_violations = _check(typed_credit, credit_holds, "credit")
+    report.key_rows, report.key_violations = _check(typed_key, key_holds, "api_key")
     return report

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -338,3 +338,85 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
     res.keys_seeded = seeded.pop("keys")
     res.credit_seeded = seeded
     return res
+
+
+# ── Standing typed-side invariant auditor ───────────────────────────────────
+# compare() audits JSON-vs-typed and was correctly NARROWED to JSON-owned columns
+# after the ownership split — so it can no longer see a typed `reserved` leak (the
+# exact incident class). This auditor is the typed-side tripwire that replaces it:
+# for every typed counter row, `reserved` MUST equal the sum of that scope's OPEN
+# typed-origin holds (tr_reservation, settled=false), and MUST be >= 0. A drift
+# means a hold leaked or a release double-applied. Run it on a schedule + before
+# each ramp batch; wire an alert on the "release row-count != 1" log line as the
+# live signal between audits.
+
+_OPEN_CREDIT_HOLDS = (
+    "SELECT workspace_id, SUM(credit_reserved_micro) FROM tr_reservation "
+    "WHERE settled=false GROUP BY workspace_id"
+)
+_OPEN_KEY_HOLDS = (
+    "SELECT key_hash, SUM(key_reserved_micro) FROM tr_reservation "
+    "WHERE settled=false GROUP BY key_hash"
+)
+
+
+@dataclass
+class InvariantReport:
+    credit_rows: int = 0
+    key_rows: int = 0
+    credit_violations: int = 0  # reserved != open-hold sum, or reserved < 0
+    key_violations: int = 0
+    samples: dict[str, dict] = field(default_factory=dict)
+
+    @property
+    def clean(self) -> bool:
+        return self.credit_violations == 0 and self.key_violations == 0
+
+    def summary(self) -> str:
+        return (
+            f"credit: {self.credit_violations}/{self.credit_rows} | "
+            f"key: {self.key_violations}/{self.key_rows} | "
+            f"{'CLEAN' if self.clean else 'VIOLATIONS'}"
+        )
+
+
+def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantReport:
+    """Assert, in one consistent snapshot, that every typed `reserved` equals the
+    sum of that scope's OPEN typed-origin holds and is non-negative. Read-only."""
+    report = InvariantReport()
+
+    with store._database.snapshot(multi_use=True) as snap:
+        typed_credit = {
+            r[0]: int(r[1]) for r in snap.execute_sql(
+                "SELECT workspace_id, reserved FROM tr_credit_balance"
+            )
+        }
+        typed_key = {
+            r[0]: int(r[1]) for r in snap.execute_sql(
+                "SELECT key_hash, reserved FROM tr_key_limit"
+            )
+        }
+        credit_holds = {
+            r[0]: int(r[1] or 0) for r in snap.execute_sql(_OPEN_CREDIT_HOLDS)
+        }
+        key_holds = {r[0]: int(r[1] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
+
+    def _sample(key: str, value: dict) -> None:
+        if len(report.samples) < max_samples:
+            report.samples[key] = value
+
+    report.credit_rows = len(typed_credit)
+    for ws_id, reserved in typed_credit.items():
+        expected = credit_holds.get(ws_id, 0)
+        if reserved != expected or reserved < 0:
+            report.credit_violations += 1
+            _sample(f"credit:{ws_id}", {"typed_reserved": reserved, "open_holds": expected})
+
+    report.key_rows = len(typed_key)
+    for key_hash, reserved in typed_key.items():
+        expected = key_holds.get(key_hash, 0)
+        if reserved != expected or reserved < 0:
+            report.key_violations += 1
+            _sample(f"api_key:{key_hash}", {"typed_reserved": reserved, "open_holds": expected})
+
+    return report

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -494,23 +494,21 @@ def _execute_sql(
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]
         return [[sum(1 for rec in db.reservations.values() if rec.get("workspace_id") == ws)]]
-    # Invariant auditor: open typed-origin holds summed by scope.
-    if "SUM(credit_reserved_micro) FROM tr_reservation WHERE settled=false" in sql:
-        sums: dict[Any, int] = {}
+    # Invariant auditor: open typed-origin holds summed by (scope, shard).
+    if "SUM(credit_reserved_micro)" in sql:
+        sums: dict[tuple, int] = {}
         for rec in db.reservations.values():
             if not rec.get("settled") and rec.get("workspace_id") is not None:
-                sums[rec["workspace_id"]] = sums.get(rec["workspace_id"], 0) + (
-                    rec.get("credit_reserved_micro") or 0
-                )
-        return [[scope, total] for scope, total in sums.items()]
-    if "SUM(key_reserved_micro) FROM tr_reservation WHERE settled=false" in sql:
-        ksums: dict[Any, int] = {}
+                grp = (rec["workspace_id"], rec.get("ws_shard", 0))
+                sums[grp] = sums.get(grp, 0) + (rec.get("credit_reserved_micro") or 0)
+        return [[ws, shard, total] for (ws, shard), total in sums.items()]
+    if "SUM(key_reserved_micro)" in sql:
+        ksums: dict[tuple, int] = {}
         for rec in db.reservations.values():
             if not rec.get("settled") and rec.get("key_hash") is not None:
-                ksums[rec["key_hash"]] = ksums.get(rec["key_hash"], 0) + (
-                    rec.get("key_reserved_micro") or 0
-                )
-        return [[scope, total] for scope, total in ksums.items()]
+                grp = (rec["key_hash"], rec.get("key_shard", 0))
+                ksums[grp] = ksums.get(grp, 0) + (rec.get("key_reserved_micro") or 0)
+        return [[kh, shard, total] for (kh, shard), total in ksums.items()]
     # tr_reservation reads (idempotency replay + by-id for settle/reaper).
     if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
         scope = params["scope"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -494,6 +494,23 @@ def _execute_sql(
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]
         return [[sum(1 for rec in db.reservations.values() if rec.get("workspace_id") == ws)]]
+    # Invariant auditor: open typed-origin holds summed by scope.
+    if "SUM(credit_reserved_micro) FROM tr_reservation WHERE settled=false" in sql:
+        sums: dict[Any, int] = {}
+        for rec in db.reservations.values():
+            if not rec.get("settled") and rec.get("workspace_id") is not None:
+                sums[rec["workspace_id"]] = sums.get(rec["workspace_id"], 0) + (
+                    rec.get("credit_reserved_micro") or 0
+                )
+        return [[scope, total] for scope, total in sums.items()]
+    if "SUM(key_reserved_micro) FROM tr_reservation WHERE settled=false" in sql:
+        ksums: dict[Any, int] = {}
+        for rec in db.reservations.values():
+            if not rec.get("settled") and rec.get("key_hash") is not None:
+                ksums[rec["key_hash"]] = ksums.get(rec["key_hash"], 0) + (
+                    rec.get("key_reserved_micro") or 0
+                )
+        return [[scope, total] for scope, total in ksums.items()]
     # tr_reservation reads (idempotency replay + by-id for settle/reaper).
     if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
         scope = params["scope"]

--- a/tests/test_billing_typed_auditor.py
+++ b/tests/test_billing_typed_auditor.py
@@ -1,0 +1,83 @@
+"""The typed-side invariant auditor: every typed `reserved` must equal the sum of
+that scope's OPEN typed-origin holds (tr_reservation, settled=false) and be >= 0.
+This is the leak detector the narrowed compare() (JSON-vs-typed) can no longer
+provide — it catches the exact incident class (a reserved that no longer matches
+its outstanding holds).
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _credit_row(db, ws: str, reserved: int) -> None:
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000,
+        "total_usage": 0, "reserved": reserved,
+    }
+
+
+def _key_row(db, key_hash: str, reserved: int) -> None:
+    db.typed.setdefault(KEY_LIMIT_TABLE, {})[(key_hash, 0)] = {
+        "key_hash": key_hash, "shard": 0, "limit_micro": 1_000_000, "usage": 0,
+        "byok_usage": 0, "reserved": reserved, "include_byok": True,
+    }
+
+
+def _resv(db, rid: str, *, ws=None, key=None, credit=0, key_micro=0, settled=False) -> None:
+    db.reservations[rid] = {
+        "reservation_id": rid, "workspace_id": ws, "key_hash": key,
+        "credit_reserved_micro": credit, "key_reserved_micro": key_micro, "settled": settled,
+    }
+
+
+def test_auditor_clean_when_reserved_equals_open_holds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_ok"
+    _credit_row(db, ws, reserved=300_000)
+    _resv(db, "r1", ws=ws, credit=200_000)
+    _resv(db, "r2", ws=ws, credit=100_000)
+    _resv(db, "r3", ws=ws, credit=999_999, settled=True)  # settled → ignored
+
+    report = audit_typed_invariants(store)
+    assert report.clean, (report.summary(), report.samples)
+    assert report.credit_rows == 1
+
+
+def test_auditor_flags_reserved_leak() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_leak"
+    _credit_row(db, ws, reserved=500_000)  # but only 100k is actually open
+    _resv(db, "r1", ws=ws, credit=100_000)
+
+    report = audit_typed_invariants(store)
+    assert not report.clean
+    assert report.credit_violations == 1
+    assert report.samples[f"credit:{ws}"] == {"typed_reserved": 500_000, "open_holds": 100_000}
+
+
+def test_auditor_flags_negative_reserved() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_neg"
+    _credit_row(db, ws, reserved=-50)  # underflow
+
+    report = audit_typed_invariants(store)
+    assert not report.clean
+    assert report.credit_violations == 1
+
+
+def test_auditor_key_invariant() -> None:
+    store, db, _ = make_fake_store()
+    kh = "key_abc"
+    _key_row(db, kh, reserved=250_000)
+    _resv(db, "rk", key=kh, key_micro=250_000)
+
+    assert audit_typed_invariants(store).clean
+
+    db.reservations["rk"]["key_reserved_micro"] = 100_000  # now reserved (250k) != open (100k)
+    report = audit_typed_invariants(store)
+    assert not report.clean
+    assert report.key_violations == 1
+    assert f"api_key:{kh}" in report.samples

--- a/tests/test_billing_typed_auditor.py
+++ b/tests/test_billing_typed_auditor.py
@@ -55,7 +55,23 @@ def test_auditor_flags_reserved_leak() -> None:
     report = audit_typed_invariants(store)
     assert not report.clean
     assert report.credit_violations == 1
-    assert report.samples[f"credit:{ws}"] == {"typed_reserved": 500_000, "open_holds": 100_000}
+    assert report.samples[f"credit:{ws}:0"] == {"typed_reserved": 500_000, "open_holds": 100_000}
+
+
+def test_auditor_flags_open_hold_with_no_typed_row() -> None:
+    """The dangerous false-negative codex caught: an open hold whose typed row was
+    deleted or never created. Iterating only typed rows would miss it; the reverse
+    direction catches it."""
+    store, db, _ = make_fake_store()
+    ws = "ws_orphan_hold"
+    _resv(db, "r1", ws=ws, credit=120_000)  # open hold, but NO tr_credit_balance row
+
+    report = audit_typed_invariants(store)
+    assert not report.clean
+    assert report.credit_violations == 1
+    assert report.samples[f"credit-orphan-hold:{ws}:0"] == {
+        "typed_reserved": None, "open_holds": 120_000
+    }
 
 
 def test_auditor_flags_negative_reserved() -> None:
@@ -80,4 +96,4 @@ def test_auditor_key_invariant() -> None:
     report = audit_typed_invariants(store)
     assert not report.clean
     assert report.key_violations == 1
-    assert f"api_key:{kh}" in report.samples
+    assert f"api_key:{kh}:0" in report.samples


### PR DESCRIPTION
## Why
`compare()` audits JSON-vs-typed and was correctly **narrowed** to JSON-owned columns after the ownership split — so it can no longer detect a typed `reserved` leak, which is the *exact* 2026-06-25 incident class. This adds the typed-side tripwire that replaces that coverage.

## What
`audit_typed_invariants(store)`: in one consistent snapshot, for every typed counter row assert **`reserved == SUM(open typed-origin holds)`** (`tr_reservation`, `settled=false`) and **`reserved >= 0`**. A mismatch = a leaked hold or a double-applied release. Read-only.

Exposed as `backfill_typed_counters.py --audit` (exits 1 on any violation) to run on a schedule and **before each ramp batch**. The live between-audits signal is an alert on the `typed finalize failed: release row-count != 1` log line (created separately via gcloud).

## Tests
4 auditor tests (clean; reserved leak; negative reserved; key invariant). The fake gains the open-holds SUM-by-scope queries. Lint clean.

Part of the Step 6 safety net (with the #82 quiesce) that must be live before any real-workspace flip.