### PR TITLE
billing(step6): rollback backsync (typed->JSON) + batch ramp CLI

### DIFF
--- a/scripts/deploy/ramp_typed_billing.py
+++ b/scripts/deploy/ramp_typed_billing.py
@@ -1,0 +1,122 @@
+"""Operator CLI for the safe typed-billing ramp (Step 6).
+
+Sequences the tested primitives — workspace pause (quiesce), drain check, the
+fail-closed flip reconciliation, the invariant auditor, and the rollback
+backsync — into an explicit, step-by-step flip. Every mutating step is
+fail-closed and requires --apply. The env-allowlist deploy is a SEPARATE manual
+step done WHILE the batch is paused (this CLI never edits the gate).
+
+SAFE BATCH FLIP (codex Step-6 design):
+
+  # 1. quiesce the batch (no new work / no new keys; settle still drains)
+  python scripts/deploy/ramp_typed_billing.py pause WS1 WS2 --apply
+
+  # 2. wait until drained, then confirm every workspace is flip-ready
+  python scripts/deploy/ramp_typed_billing.py status WS1 WS2
+
+  # 3. seed the typed counters (fail-closed: refuses unless never-typed + drained)
+  python scripts/deploy/ramp_typed_billing.py reconcile WS1 WS2 --apply
+
+  # 4. [MANUAL] add WS1,WS2 to TR_TYPED_BILLING_WORKSPACE_IDS and deploy all
+  #    regions WHILE STILL PAUSED; confirm every region serves the new allowlist.
+
+  # 5. canary one, then unpause the batch
+  python scripts/deploy/ramp_typed_billing.py unpause WS1 WS2 --apply
+
+  # standing tripwire (run on a schedule + before each batch)
+  python scripts/deploy/ramp_typed_billing.py audit
+
+ROLLBACK (denylist is NOT correct alone once typed usage exists):
+
+  python scripts/deploy/ramp_typed_billing.py pause WS --apply        # quiesce + drain
+  python scripts/deploy/ramp_typed_billing.py rollback WS --apply     # typed -> JSON backsync
+  # [MANUAL] denylist / remove WS from the allowlist + deploy, then unpause.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_gcp_counter_reconcile import (
+    audit_typed_invariants,
+    backsync_typed_to_json,
+    reconcile_for_flip,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    for name in ("pause", "unpause", "status", "reconcile", "rollback"):
+        p = sub.add_parser(name)
+        p.add_argument("workspaces", nargs="+")
+        if name in ("pause", "unpause", "reconcile", "rollback"):
+            p.add_argument("--apply", action="store_true", help="actually mutate (else dry-run)")
+        if name == "pause":
+            p.add_argument("--reason", default="typed-billing ramp")
+    sub.add_parser("audit")
+
+    args = parser.parse_args()
+    store = create_store(Settings())
+
+    if args.cmd == "audit":
+        report = audit_typed_invariants(store)
+        print(report.summary())
+        for scope, detail in report.samples.items():
+            print(f"  VIOLATION {scope}: {detail}")
+        return 0 if report.clean else 1
+
+    rc = 0
+    for ws in args.workspaces:
+        if args.cmd in ("pause", "unpause"):
+            paused = args.cmd == "pause"
+            if args.apply:
+                ok = store.update_workspace(
+                    ws, billing_paused=paused,
+                    billing_pause_reason=(args.reason if paused else ""),
+                )
+                print(f"{ws}: {'PAUSED' if paused else 'UNPAUSED'}{'' if ok else ' (NOT FOUND)'}")
+            else:
+                print(f"{ws}: would {'pause' if paused else 'unpause'} (dry-run; pass --apply)")
+
+        elif args.cmd == "status":
+            flip = reconcile_for_flip(store, ws, apply=False)
+            print(f"{ws}: flip-ready={flip.ready}" + ("" if flip.ready else f" — {flip.reasons}"))
+
+        elif args.cmd == "reconcile":
+            flip = reconcile_for_flip(store, ws, apply=args.apply)
+            if not flip.ready:
+                print(f"{ws}: NOT flip-ready — {flip.reasons}")
+                rc = 1
+            elif flip.applied:
+                print(f"{ws}: SEEDED credit={flip.credit_seeded} keys={flip.keys_seeded}")
+            else:
+                print(f"{ws}: ready (dry-run; pass --apply to seed)")
+
+        elif args.cmd == "rollback":
+            bs = backsync_typed_to_json(store, ws, apply=args.apply)
+            if not bs.ready:
+                print(f"{ws}: NOT backsync-ready — {bs.reasons}")
+                rc = 1
+            elif bs.applied:
+                print(f"{ws}: BACKSYNCED credit={bs.credit} keys={bs.keys}")
+            else:
+                print(f"{ws}: ready (dry-run; pass --apply to backsync)")
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -29,6 +29,7 @@ from trusted_router.storage_gcp_counters import (
     key_drift,
     mirror_write,
 )
+from trusted_router.storage_models import ApiKey, CreditAccount
 
 _CREDIT_TYPED_SCAN = (
     "SELECT workspace_id, total_credits, total_usage, reserved FROM tr_credit_balance"
@@ -431,3 +432,101 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
     report.credit_rows, report.credit_violations = _check(typed_credit, credit_holds, "credit")
     report.key_rows, report.key_violations = _check(typed_key, key_holds, "api_key")
     return report
+
+
+# ── Rollback: typed → JSON backsync ─────────────────────────────────────────
+# The INVERSE of reconcile_for_flip. Denylisting a workspace back to legacy is NOT
+# rollback-correct on its own: once typed usage exists, the JSON counters are
+# stale-low, so the legacy path would over-admit. Before rolling back, copy the
+# typed-DML-owned gross counters back into JSON so the legacy path is authoritative
+# and correct. Fail-closed: the workspace must have NO open typed holds (pause +
+# drain first); writing JSON re-fires the ownership-split mirror, which only writes
+# total_credits/config, so it does NOT re-clobber the typed counters mid-backsync.
+
+
+@dataclass
+class BacksyncResult:
+    workspace_id: str
+    ready: bool
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+    credit: dict | None = None
+    keys: int = 0
+
+
+def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False) -> BacksyncResult:
+    """Copy the typed gross counters back into JSON for a drained workspace so a
+    rollback to legacy is correct. Fail-closed: refuses unless there are NO open
+    typed holds (settled=false). With apply=True it re-checks no-open-holds inside
+    one transaction and writes JSON credit total_usage/reserved + key
+    usage/byok_usage/reserved from the typed values. Read-only when apply=False."""
+    pt = store._param_types
+    res = BacksyncResult(workspace_id=workspace_id, ready=False)
+    open_holds_sql = (
+        "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false"
+    )
+
+    keys = [b for b in store._list_entities("api_key", cls=dict) if b.get("workspace_id") == workspace_id]
+    with store._database.snapshot() as snap:
+        open_holds = list(snap.execute_sql(
+            open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        credit_rows = list(snap.execute_sql(
+            "SELECT total_usage, reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0",
+            params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+        typed_keys: dict[str, tuple] = {}
+        for k in keys:
+            kr = list(snap.execute_sql(
+                "SELECT usage, byok_usage, reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0",
+                params={"pk": k["hash"]}, param_types={"pk": pt.STRING},
+            ))
+            if kr:
+                typed_keys[k["hash"]] = (int(kr[0][0]), int(kr[0][1]), int(kr[0][2]))
+
+    if int(open_holds) != 0:
+        res.reasons.append(f"{open_holds} open typed holds — pause + drain before rollback backsync")
+    if not credit_rows:
+        res.reasons.append("no typed credit row to backsync")
+    res.ready = not res.reasons
+    if credit_rows:
+        res.credit = {"total_usage": int(credit_rows[0][0]), "reserved": int(credit_rows[0][1])}
+    if not res.ready or not apply:
+        return res
+
+    typed_total_usage = int(credit_rows[0][0])
+    typed_reserved = int(credit_rows[0][1])
+
+    def _txn(transaction: Any) -> dict | None:
+        oh = list(transaction.execute_sql(
+            open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        if int(oh) != 0:
+            return None  # a hold appeared mid-backsync — abort, no writes issued
+        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if credit is None:
+            return None
+        credit.total_usage_microdollars = typed_total_usage
+        credit.reserved_microdollars = typed_reserved
+        store._write_entity_tx(transaction, "credit", workspace_id, credit)
+        n = 0
+        for k in keys:
+            typed = typed_keys.get(k["hash"])
+            if typed is None:
+                continue
+            key_obj = store._read_entity_tx(transaction, "api_key", k["hash"], ApiKey)
+            if key_obj is None:
+                continue
+            key_obj.usage_microdollars, key_obj.byok_usage_microdollars, key_obj.reserved_microdollars = typed
+            store._write_entity_tx(transaction, "api_key", k["hash"], key_obj)
+            n += 1
+        return {"keys": n}
+
+    result = store._run_in_transaction(_txn)
+    if result is None:
+        res.ready = False
+        res.reasons.append("aborted: a hold appeared during backsync (re-drain and retry)")
+        return res
+    res.applied = True
+    res.keys = result["keys"]
+    return res

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -29,7 +29,7 @@ from trusted_router.storage_gcp_counters import (
     key_drift,
     mirror_write,
 )
-from trusted_router.storage_models import ApiKey, CreditAccount
+from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
 
 _CREDIT_TYPED_SCAN = (
     "SELECT workspace_id, total_credits, total_usage, reserved FROM tr_credit_balance"
@@ -248,6 +248,10 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
         return res
     keys = [b for b in store._list_entities("api_key", cls=dict) if b.get("workspace_id") == workspace_id]
 
+    workspace = store.get_workspace(workspace_id)
+    if workspace is None or not getattr(workspace, "billing_paused", False):
+        res.reasons.append("workspace not billing-paused — pause (quiesce) it before flipping")
+
     with store._database.snapshot() as snap:
         typed_history = list(snap.execute_sql(
             "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws",
@@ -277,6 +281,11 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
         # EVERY predicate has passed — read + re-check all rows first, then write
         # all of them. Otherwise a hold on a later key would partial-seed the
         # earlier ones.
+        # Hard precondition: the workspace MUST be billing-paused (quiesced) so no
+        # new work races the seed. Re-checked in-txn, not just trusted from assess.
+        ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if ws is None or not ws.billing_paused:
+            return None
         # Defense-in-depth: re-check no typed history INSIDE the txn — a ws that
         # got a typed reservation concurrently is already typed; never JSON-seed it.
         hist = list(transaction.execute_sql(
@@ -456,36 +465,39 @@ class BacksyncResult:
 
 def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False) -> BacksyncResult:
     """Copy the typed gross counters back into JSON for a drained workspace so a
-    rollback to legacy is correct. Fail-closed: refuses unless there are NO open
-    typed holds (settled=false). With apply=True it re-checks no-open-holds inside
-    one transaction and writes JSON credit total_usage/reserved + key
-    usage/byok_usage/reserved from the typed values. Read-only when apply=False."""
+    rollback to legacy is correct. Fail-closed: refuses unless the workspace is
+    billing-PAUSED and has NO open typed holds (settled=false). With apply=True
+    it re-reads everything INSIDE one transaction (the paused gate, the open-hold
+    count, the FRESH typed credit + key counters) — because typed usage can still
+    advance via an in-flight settle between an outer snapshot and the txn — builds
+    a COMPLETE plan (failing if any active JSON key has no typed row, rather than
+    silently skipping it), and only then writes JSON credit total_usage/reserved +
+    key usage/byok_usage/reserved. Read-only when apply=False."""
     pt = store._param_types
     res = BacksyncResult(workspace_id=workspace_id, ready=False)
     open_holds_sql = (
         "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false"
     )
+    credit_sql = "SELECT total_usage, reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
+    key_sql = "SELECT usage, byok_usage, reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0"
 
-    keys = [b for b in store._list_entities("api_key", cls=dict) if b.get("workspace_id") == workspace_id]
+    key_hashes = [
+        b["hash"] for b in store._list_entities("api_key", cls=dict)
+        if b.get("workspace_id") == workspace_id
+    ]
+    workspace = store.get_workspace(workspace_id)
     with store._database.snapshot() as snap:
         open_holds = list(snap.execute_sql(
             open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]
         credit_rows = list(snap.execute_sql(
-            "SELECT total_usage, reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0",
-            params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+            credit_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))
-        typed_keys: dict[str, tuple] = {}
-        for k in keys:
-            kr = list(snap.execute_sql(
-                "SELECT usage, byok_usage, reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0",
-                params={"pk": k["hash"]}, param_types={"pk": pt.STRING},
-            ))
-            if kr:
-                typed_keys[k["hash"]] = (int(kr[0][0]), int(kr[0][1]), int(kr[0][2]))
 
+    if workspace is None or not getattr(workspace, "billing_paused", False):
+        res.reasons.append("workspace not billing-paused — pause (quiesce) it before rollback")
     if int(open_holds) != 0:
-        res.reasons.append(f"{open_holds} open typed holds — pause + drain before rollback backsync")
+        res.reasons.append(f"{open_holds} open typed holds — drain before rollback backsync")
     if not credit_rows:
         res.reasons.append("no typed credit row to backsync")
     res.ready = not res.reasons
@@ -494,39 +506,54 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
     if not res.ready or not apply:
         return res
 
-    typed_total_usage = int(credit_rows[0][0])
-    typed_reserved = int(credit_rows[0][1])
-
     def _txn(transaction: Any) -> dict | None:
+        # Re-read ALL preconditions + values INSIDE the txn (no stale outer reads).
+        # Issue ZERO mutations until the complete plan is validated.
+        ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if ws is None or not ws.billing_paused:
+            return None
         oh = list(transaction.execute_sql(
             open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]
         if int(oh) != 0:
-            return None  # a hold appeared mid-backsync — abort, no writes issued
-        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if credit is None:
             return None
+        tc = list(transaction.execute_sql(
+            credit_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if not tc or credit is None:
+            return None
+        plan: list[tuple] = []
+        for kh in key_hashes:
+            key_obj = store._read_entity_tx(transaction, "api_key", kh, ApiKey)
+            if key_obj is None:
+                continue  # key deleted since assess (pause blocks creation, not deletion)
+            kt = list(transaction.execute_sql(
+                key_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
+            ))
+            if not kt:
+                return None  # active JSON key with NO typed row — unsafe to backsync, abort
+            plan.append((key_obj, int(kt[0][0]), int(kt[0][1]), int(kt[0][2])))
+        # All checks passed — write credit + every key (no mutation was issued above).
+        typed_total_usage, typed_reserved = int(tc[0][0]), int(tc[0][1])
         credit.total_usage_microdollars = typed_total_usage
         credit.reserved_microdollars = typed_reserved
         store._write_entity_tx(transaction, "credit", workspace_id, credit)
-        n = 0
-        for k in keys:
-            typed = typed_keys.get(k["hash"])
-            if typed is None:
-                continue
-            key_obj = store._read_entity_tx(transaction, "api_key", k["hash"], ApiKey)
-            if key_obj is None:
-                continue
-            key_obj.usage_microdollars, key_obj.byok_usage_microdollars, key_obj.reserved_microdollars = typed
-            store._write_entity_tx(transaction, "api_key", k["hash"], key_obj)
-            n += 1
-        return {"keys": n}
+        for key_obj, usage, byok, reserved in plan:
+            key_obj.usage_microdollars = usage
+            key_obj.byok_usage_microdollars = byok
+            key_obj.reserved_microdollars = reserved
+            store._write_entity_tx(transaction, "api_key", key_obj.hash, key_obj)
+        return {"total_usage": typed_total_usage, "reserved": typed_reserved, "keys": len(plan)}
 
     result = store._run_in_transaction(_txn)
     if result is None:
         res.ready = False
-        res.reasons.append("aborted: a hold appeared during backsync (re-drain and retry)")
+        res.reasons.append(
+            "aborted: not paused / a hold appeared / an active key lacked a typed row (re-drain and retry)"
+        )
         return res
     res.applied = True
     res.keys = result["keys"]
+    res.credit = {"total_usage": result["total_usage"], "reserved": result["reserved"]}
     return res

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -490,6 +490,14 @@ def _execute_sql(
                 if len(out) >= limit:
                     break
         return out
+    # Rollback backsync: how many OPEN typed holds remain for this workspace?
+    # (checked BEFORE the generic count below, which this query string contains.)
+    if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false" in sql:
+        ws = params["ws"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("workspace_id") == ws and not rec.get("settled")
+        )]]
     # Flip-reconcile: does this workspace have ANY typed reservation history?
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]

--- a/tests/test_billing_flip_reconcile.py
+++ b/tests/test_billing_flip_reconcile.py
@@ -11,7 +11,7 @@ See docs/design/billing-typed-counters.md.
 from __future__ import annotations
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount
+from trusted_router.storage import CreditAccount, Workspace
 from trusted_router.storage_gcp_counter_reconcile import reconcile_for_flip
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 
@@ -24,10 +24,15 @@ def _typed_key(db, key_hash: str) -> dict:
     return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
 
 
-def _seed_drained_workspace(store, ws: str, *, total_credits: int, total_usage: int):
-    """A never-typed workspace with lifetime usage but no open holds (drained).
-    After the ownership split the mirror carries only total_credits, so the typed
-    row's total_usage is intentionally stale (0) until reconcile_for_flip seeds it."""
+def _seed_drained_workspace(store, ws: str, *, total_credits: int, total_usage: int, paused: bool = True):
+    """A never-typed workspace with lifetime usage but no open holds (drained), and
+    billing-PAUSED (reconcile/flip require the quiesce). After the ownership split
+    the mirror carries only total_credits, so the typed row's total_usage is
+    intentionally stale (0) until reconcile_for_flip seeds it."""
+    store._write_entity(
+        "workspace", ws,
+        Workspace(id=ws, name="t", owner_user_id="u", billing_paused=paused),
+    )
     store._write_entity(
         "credit", ws,
         CreditAccount(
@@ -142,4 +147,14 @@ def test_reconcile_refuses_no_account() -> None:
     result = reconcile_for_flip(store, "ws_missing", apply=True)
     assert not result.ready
     assert any("no credit account" in r for r in result.reasons), result.reasons
+    assert not result.applied
+
+
+def test_reconcile_refuses_unpaused_workspace() -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_live"
+    _seed_drained_workspace(store, ws, total_credits=1_000_000, total_usage=0, paused=False)
+    result = reconcile_for_flip(store, ws, apply=True)
+    assert not result.ready
+    assert any("not billing-paused" in r for r in result.reasons), result.reasons
     assert not result.applied

--- a/tests/test_billing_rollback_backsync.py
+++ b/tests/test_billing_rollback_backsync.py
@@ -1,0 +1,95 @@
+"""Rollback backsync: the inverse of reconcile_for_flip. Before denylisting a
+workspace back to legacy, copy the typed gross counters back into JSON so the
+legacy path is authoritative + correct (denylist alone is NOT rollback-correct
+once typed usage exists). Fail-closed unless the workspace is drained.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount
+from trusted_router.storage_gcp_counter_reconcile import backsync_typed_to_json
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _json_credit(db, ws: str) -> dict:
+    return json.loads(db.rows[("credit", ws)].body)
+
+
+def _json_key(db, key_hash: str) -> dict:
+    return json.loads(db.rows[("api_key", key_hash)].body)
+
+
+def test_backsync_copies_typed_gross_into_json_when_drained() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_rollback"
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 400_000, "reserved": 0})
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)].update(
+        {"usage": 150_000, "byok_usage": 20_000, "reserved": 0}
+    )
+
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 0  # stale before
+
+    result = backsync_typed_to_json(store, ws, apply=True)
+    assert result.ready and result.applied, result.reasons
+    assert result.keys == 1
+    # JSON now mirrors the typed gross counters → legacy path is correct on rollback.
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 400_000
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_000_000  # untouched
+    assert _json_key(db, key.hash)["usage_microdollars"] == 150_000
+    assert _json_key(db, key.hash)["byok_usage_microdollars"] == 20_000
+
+
+def test_backsync_refuses_open_typed_holds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_holds"
+    store._write_entity("credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000))
+    db.reservations["r1"] = {
+        "reservation_id": "r1", "workspace_id": ws, "credit_reserved_micro": 100_000, "settled": False,
+    }
+
+    result = backsync_typed_to_json(store, ws, apply=True)
+    assert not result.ready
+    assert any("open typed holds" in r for r in result.reasons), result.reasons
+    assert not result.applied
+
+
+def test_backsync_settled_holds_do_not_block() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_settled"
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 200_000, "reserved": 0})
+    db.reservations["r1"] = {
+        "reservation_id": "r1", "workspace_id": ws, "credit_reserved_micro": 50_000, "settled": True,
+    }  # settled → drained
+
+    result = backsync_typed_to_json(store, ws, apply=True)
+    assert result.ready and result.applied
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 200_000
+
+
+def test_backsync_assess_only_is_read_only() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_assess"
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 99_000, "reserved": 0})
+
+    result = backsync_typed_to_json(store, ws, apply=False)
+    assert result.ready and not result.applied
+    assert result.credit == {"total_usage": 99_000, "reserved": 0}
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 0  # unchanged by assess

--- a/tests/test_billing_rollback_backsync.py
+++ b/tests/test_billing_rollback_backsync.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 import json
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount
+from trusted_router.storage import CreditAccount, Workspace
 from trusted_router.storage_gcp_counter_reconcile import backsync_typed_to_json
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _pause(store, ws: str, *, paused: bool = True) -> None:
+    store._write_entity("workspace", ws, Workspace(id=ws, name="t", owner_user_id="u", billing_paused=paused))
 
 
 def _json_credit(db, ws: str) -> dict:
@@ -25,6 +29,7 @@ def _json_key(db, key_hash: str) -> dict:
 def test_backsync_copies_typed_gross_into_json_when_drained() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_rollback"
+    _pause(store, ws)
     store._write_entity(
         "credit", ws,
         CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
@@ -52,6 +57,7 @@ def test_backsync_copies_typed_gross_into_json_when_drained() -> None:
 def test_backsync_refuses_open_typed_holds() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_holds"
+    _pause(store, ws)
     store._write_entity("credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000))
     db.reservations["r1"] = {
         "reservation_id": "r1", "workspace_id": ws, "credit_reserved_micro": 100_000, "settled": False,
@@ -66,6 +72,7 @@ def test_backsync_refuses_open_typed_holds() -> None:
 def test_backsync_settled_holds_do_not_block() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_settled"
+    _pause(store, ws)
     store._write_entity(
         "credit", ws,
         CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
@@ -83,6 +90,7 @@ def test_backsync_settled_holds_do_not_block() -> None:
 def test_backsync_assess_only_is_read_only() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_assess"
+    _pause(store, ws)
     store._write_entity(
         "credit", ws,
         CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
@@ -93,3 +101,20 @@ def test_backsync_assess_only_is_read_only() -> None:
     assert result.ready and not result.applied
     assert result.credit == {"total_usage": 99_000, "reserved": 0}
     assert _json_credit(db, ws)["total_usage_microdollars"] == 0  # unchanged by assess
+
+
+def test_backsync_refuses_unpaused_workspace() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_live"
+    _pause(store, ws, paused=False)
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 300_000, "reserved": 0})
+
+    result = backsync_typed_to_json(store, ws, apply=True)
+    assert not result.ready
+    assert any("not billing-paused" in r for r in result.reasons), result.reasons
+    assert not result.applied
+    assert _json_credit(db, ws)["total_usage_microdollars"] == 0  # untouched


### PR DESCRIPTION
## Why
**Rollback correctness:** denylisting a workspace back to legacy is **not** correct on its own once typed usage exists — the JSON counters are stale-low, so the legacy path would over-admit. And the **ramp** needs an operator tool that sequences the (now all-tested) primitives safely.

## What
- **`backsync_typed_to_json()`** — the inverse of `reconcile_for_flip`: for a DRAINED workspace, copy the typed gross counters back into JSON (credit `total_usage`/`reserved`, key `usage`/`byok_usage`/`reserved`) so the legacy path is authoritative + correct. **Fail-closed:** refuses unless there are **no open typed holds** (`settled=false`), re-checked inside the txn. Writing JSON re-fires the ownership-split mirror (which only writes `total_credits`/config) so it can't re-clobber typed mid-backsync.
- **`ramp_typed_billing.py`** — operator CLI for the safe batch flip: `pause`/`unpause` (quiesce), `status` (flip-ready?), `reconcile` (seed), `audit` (tripwire), `rollback` (backsync). Every mutating step is fail-closed and needs `--apply`; the env-allowlist deploy stays a **separate manual step done while paused**.

## Tests
4 backsync tests (drained copy; refuse open holds; settled-don't-block; assess read-only). 44 billing tests green; lint clean.

This is the **last engineering gate** before the metered ramp itself — it makes the flip executable and rollback-safe.