### PR TITLE
billing(step6): repair clobbered typed reserved (= SUM open holds)

### DIFF
--- a/scripts/deploy/ramp_typed_billing.py
+++ b/scripts/deploy/ramp_typed_billing.py
@@ -52,6 +52,7 @@ from trusted_router.storage_gcp_counter_reconcile import (
     audit_typed_invariants,
     backsync_typed_to_json,
     reconcile_for_flip,
+    repair_typed_reserved,
 )
 
 
@@ -59,10 +60,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    for name in ("pause", "unpause", "status", "reconcile", "rollback"):
+    for name in ("pause", "unpause", "status", "reconcile", "rollback", "repair"):
         p = sub.add_parser(name)
         p.add_argument("workspaces", nargs="+")
-        if name in ("pause", "unpause", "reconcile", "rollback"):
+        if name in ("pause", "unpause", "reconcile", "rollback", "repair"):
             p.add_argument("--apply", action="store_true", help="actually mutate (else dry-run)")
         if name == "pause":
             p.add_argument("--reason", default="typed-billing ramp")
@@ -114,6 +115,16 @@ def main() -> int:
                 print(f"{ws}: BACKSYNCED credit={bs.credit} keys={bs.keys}")
             else:
                 print(f"{ws}: ready (dry-run; pass --apply to backsync)")
+
+        elif args.cmd == "repair":
+            rp = repair_typed_reserved(store, ws, apply=args.apply)
+            if not rp.ready:
+                print(f"{ws}: NOT repair-ready — {rp.reasons}")
+                rc = 1
+            elif rp.applied:
+                print(f"{ws}: REPAIRED credit reserved {rp.credit_reserved_before}->{rp.credit_reserved_after}, keys={rp.keys_repaired}")
+            else:
+                print(f"{ws}: would set credit reserved {rp.credit_reserved_before}->{rp.credit_reserved_after} (dry-run; pass --apply)")
 
     return rc
 

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -599,6 +599,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     )
     credit_row_sql = "SELECT reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
     key_row_sql = "SELECT reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0"
+    nonzero_key_shard_sql = (
+        "SELECT COUNT(*) FROM tr_reservation "
+        "WHERE key_hash=@kh AND settled=false AND key_shard!=0"
+    )
     nonzero_shard_sql = (
         "SELECT COUNT(*) FROM tr_reservation "
         "WHERE workspace_id=@ws AND settled=false AND ws_shard!=0"
@@ -659,6 +663,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
                 key_row_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
             )):
                 return None  # typed key row missing — abort, never create a partial row
+            if int(list(transaction.execute_sql(
+                nonzero_key_shard_sql, params={"kh": kh}, param_types={"kh": pt.STRING},
+            ))[0][0]) != 0:
+                return None  # key hold on a nonzero shard — would write reserved low; abort
             ok = list(transaction.execute_sql(
                 open_key_sql, params={"kh": kh}, param_types={"kh": pt.STRING},
             ))[0][0]

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -557,3 +557,102 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
     res.keys = result["keys"]
     res.credit = {"total_usage": result["total_usage"], "reserved": result["reserved"]}
     return res
+
+
+# ── Repair: clobbered typed `reserved` ──────────────────────────────────────
+# The 2026-06-25 incident's accumulated damage: before the ownership split the
+# mirror overwrote typed `reserved` with the stale JSON value, so already-typed
+# workspaces have `reserved` frozen far from the truth (auditor flags them). Fix:
+# set credit + each key `reserved` = SUM of that scope's OPEN typed holds. We do
+# NOT touch total_usage — it is monotonic and verified ledger-consistent
+# (JSON baseline + Σ settled actuals) for active workspaces; the lone usage-damaged
+# case (ea7dd3d8) is handled separately. Fail-closed: requires billing_paused so
+# the open-hold set is stable while we write.
+
+
+@dataclass
+class RepairResult:
+    workspace_id: str
+    ready: bool
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+    credit_reserved_before: int | None = None
+    credit_reserved_after: int | None = None
+    keys_repaired: int = 0
+
+
+def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False) -> RepairResult:
+    """Set typed `reserved` = SUM(open typed holds) for an already-typed PAUSED
+    workspace (credit + every key). Read-only when apply=False (reports the before/
+    after). Fail-closed: refuses unless billing_paused."""
+    pt = store._param_types
+    res = RepairResult(workspace_id=workspace_id, ready=False)
+    open_credit_sql = (
+        "SELECT COALESCE(SUM(credit_reserved_micro),0) FROM tr_reservation "
+        "WHERE workspace_id=@ws AND settled=false"
+    )
+    open_key_sql = (
+        "SELECT COALESCE(SUM(key_reserved_micro),0) FROM tr_reservation "
+        "WHERE key_hash=@kh AND settled=false"
+    )
+
+    workspace = store.get_workspace(workspace_id)
+    key_hashes = [
+        b["hash"] for b in store._list_entities("api_key", cls=dict)
+        if b.get("workspace_id") == workspace_id
+    ]
+    with store._database.snapshot() as snap:
+        cb = list(snap.execute_sql(
+            "SELECT reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0",
+            params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+        open_credit = list(snap.execute_sql(
+            open_credit_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+
+    if workspace is None or not getattr(workspace, "billing_paused", False):
+        res.reasons.append("workspace not billing-paused — pause it before repair")
+    if not cb:
+        res.reasons.append("no typed credit row")
+    res.ready = not res.reasons
+    if cb:
+        res.credit_reserved_before = int(cb[0][0])
+        res.credit_reserved_after = int(open_credit)
+    if not res.ready or not apply:
+        return res
+
+    cts = store._spanner.COMMIT_TIMESTAMP
+
+    def _txn(transaction: Any) -> dict | None:
+        ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if ws is None or not ws.billing_paused:
+            return None
+        oc = list(transaction.execute_sql(
+            open_credit_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        transaction.insert_or_update(
+            table="tr_credit_balance",
+            columns=("workspace_id", "shard", "reserved", "updated_at"),
+            values=[(workspace_id, 0, int(oc), cts)],
+        )
+        n = 0
+        for kh in key_hashes:
+            ok = list(transaction.execute_sql(
+                open_key_sql, params={"kh": kh}, param_types={"kh": pt.STRING},
+            ))[0][0]
+            transaction.insert_or_update(
+                table="tr_key_limit",
+                columns=("key_hash", "shard", "reserved", "updated_at"),
+                values=[(kh, 0, int(ok), cts)],
+            )
+            n += 1
+        return {"keys": n}
+
+    result = store._run_in_transaction(_txn)
+    if result is None:
+        res.ready = False
+        res.reasons.append("aborted: not paused")
+        return res
+    res.applied = True
+    res.keys_repaired = result["keys"]
+    return res

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -587,13 +587,21 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     after). Fail-closed: refuses unless billing_paused."""
     pt = store._param_types
     res = RepairResult(workspace_id=workspace_id, ready=False)
+    # SHARD-0 ONLY (prod has no other shards). Everything is filtered to shard 0;
+    # a sharded workspace is refused (no shard-0 typed row, or a key row missing).
     open_credit_sql = (
         "SELECT COALESCE(SUM(credit_reserved_micro),0) FROM tr_reservation "
-        "WHERE workspace_id=@ws AND settled=false"
+        "WHERE workspace_id=@ws AND ws_shard=0 AND settled=false"
     )
     open_key_sql = (
         "SELECT COALESCE(SUM(key_reserved_micro),0) FROM tr_reservation "
-        "WHERE key_hash=@kh AND settled=false"
+        "WHERE key_hash=@kh AND key_shard=0 AND settled=false"
+    )
+    credit_row_sql = "SELECT reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
+    key_row_sql = "SELECT reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0"
+    nonzero_shard_sql = (
+        "SELECT COUNT(*) FROM tr_reservation "
+        "WHERE workspace_id=@ws AND settled=false AND ws_shard!=0"
     )
 
     workspace = store.get_workspace(workspace_id)
@@ -603,17 +611,21 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     ]
     with store._database.snapshot() as snap:
         cb = list(snap.execute_sql(
-            "SELECT reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0",
-            params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+            credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))
         open_credit = list(snap.execute_sql(
             open_credit_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        nonzero_shard = list(snap.execute_sql(
+            nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause it before repair")
     if not cb:
         res.reasons.append("no typed credit row")
+    if int(nonzero_shard) != 0:
+        res.reasons.append(f"{nonzero_shard} open holds on a nonzero shard — sharded ws not handled")
     res.ready = not res.reasons
     if cb:
         res.credit_reserved_before = int(cb[0][0])
@@ -624,34 +636,51 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     cts = store._spanner.COMMIT_TIMESTAMP
 
     def _txn(transaction: Any) -> dict | None:
+        # Re-read everything INSIDE the txn and validate the COMPLETE plan before
+        # any write. A missing typed row (a key deleted mid-repair, or never
+        # created) must ABORT — never be re-created as a partial (uncapped) row.
         ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
         if ws is None or not ws.billing_paused:
             return None
+        if int(list(transaction.execute_sql(
+            nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]) != 0:
+            return None
+        if not list(transaction.execute_sql(
+            credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        )):
+            return None  # no shard-0 credit row — abort
         oc = list(transaction.execute_sql(
             open_credit_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]
+        plan: list[tuple[str, int]] = []
+        for kh in key_hashes:
+            if not list(transaction.execute_sql(
+                key_row_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
+            )):
+                return None  # typed key row missing — abort, never create a partial row
+            ok = list(transaction.execute_sql(
+                open_key_sql, params={"kh": kh}, param_types={"kh": pt.STRING},
+            ))[0][0]
+            plan.append((kh, int(ok)))
+        # all rows exist + validated — now write (insert_or_update UPDATES them).
         transaction.insert_or_update(
             table="tr_credit_balance",
             columns=("workspace_id", "shard", "reserved", "updated_at"),
             values=[(workspace_id, 0, int(oc), cts)],
         )
-        n = 0
-        for kh in key_hashes:
-            ok = list(transaction.execute_sql(
-                open_key_sql, params={"kh": kh}, param_types={"kh": pt.STRING},
-            ))[0][0]
+        for kh, ok in plan:
             transaction.insert_or_update(
                 table="tr_key_limit",
                 columns=("key_hash", "shard", "reserved", "updated_at"),
-                values=[(kh, 0, int(ok), cts)],
+                values=[(kh, 0, ok, cts)],
             )
-            n += 1
-        return {"keys": n}
+        return {"keys": len(plan)}
 
     result = store._run_in_transaction(_txn)
     if result is None:
         res.ready = False
-        res.reasons.append("aborted: not paused")
+        res.reasons.append("aborted: not paused / nonzero shard / a typed row was missing (key deleted?)")
         return res
     res.applied = True
     res.keys_repaired = result["keys"]

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -613,7 +613,7 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         b["hash"] for b in store._list_entities("api_key", cls=dict)
         if b.get("workspace_id") == workspace_id
     ]
-    with store._database.snapshot() as snap:
+    with store._database.snapshot(multi_use=True) as snap:  # 3 reads below — must be multi-use
         cb = list(snap.execute_sql(
             credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -491,7 +491,13 @@ def _execute_sql(
                     break
         return out
     # Repair: any OPEN holds on a nonzero shard? (checked first — its query string
-    # contains the generic workspace-count substring below.)
+    # contains the generic count substrings below.)
+    if "key_shard!=0" in sql:
+        kh = params["kh"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("key_hash") == kh and not rec.get("settled") and rec.get("key_shard", 0) != 0
+        )]]
     if "ws_shard!=0" in sql:
         ws = params["ws"]
         return [[sum(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -502,6 +502,20 @@ def _execute_sql(
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]
         return [[sum(1 for rec in db.reservations.values() if rec.get("workspace_id") == ws)]]
+    # Repair: open holds for ONE scope (checked before the grouped sums below,
+    # which match the same SUM(...) substring).
+    if "SUM(credit_reserved_micro)" in sql and "workspace_id=@ws" in sql:
+        ws = params["ws"]
+        return [[sum(
+            rec.get("credit_reserved_micro") or 0 for rec in db.reservations.values()
+            if rec.get("workspace_id") == ws and not rec.get("settled")
+        )]]
+    if "SUM(key_reserved_micro)" in sql and "key_hash=@kh" in sql:
+        kh = params["kh"]
+        return [[sum(
+            rec.get("key_reserved_micro") or 0 for rec in db.reservations.values()
+            if rec.get("key_hash") == kh and not rec.get("settled")
+        )]]
     # Invariant auditor: open typed-origin holds summed by (scope, shard).
     if "SUM(credit_reserved_micro)" in sql:
         sums: dict[tuple, int] = {}

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -490,6 +490,14 @@ def _execute_sql(
                 if len(out) >= limit:
                     break
         return out
+    # Repair: any OPEN holds on a nonzero shard? (checked first — its query string
+    # contains the generic workspace-count substring below.)
+    if "ws_shard!=0" in sql:
+        ws = params["ws"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("workspace_id") == ws and not rec.get("settled") and rec.get("ws_shard", 0) != 0
+        )]]
     # Rollback backsync: how many OPEN typed holds remain for this workspace?
     # (checked BEFORE the generic count below, which this query string contains.)
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false" in sql:
@@ -508,13 +516,13 @@ def _execute_sql(
         ws = params["ws"]
         return [[sum(
             rec.get("credit_reserved_micro") or 0 for rec in db.reservations.values()
-            if rec.get("workspace_id") == ws and not rec.get("settled")
+            if rec.get("workspace_id") == ws and not rec.get("settled") and rec.get("ws_shard", 0) == 0
         )]]
     if "SUM(key_reserved_micro)" in sql and "key_hash=@kh" in sql:
         kh = params["kh"]
         return [[sum(
             rec.get("key_reserved_micro") or 0 for rec in db.reservations.values()
-            if rec.get("key_hash") == kh and not rec.get("settled")
+            if rec.get("key_hash") == kh and not rec.get("settled") and rec.get("key_shard", 0) == 0
         )]]
     # Invariant auditor: open typed-origin holds summed by (scope, shard).
     if "SUM(credit_reserved_micro)" in sql:

--- a/tests/test_billing_repair_reserved.py
+++ b/tests/test_billing_repair_reserved.py
@@ -60,6 +60,42 @@ def test_repair_refuses_unpaused() -> None:
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 99_000  # untouched
 
 
+def test_repair_aborts_if_a_typed_key_row_is_missing() -> None:
+    """codex P1: a key whose typed row is missing (deleted mid-repair) must ABORT
+    with ZERO writes — never create a partial, uncapped tr_key_limit row."""
+    store, db, _ = make_fake_store()
+    ws = "ws_missing_key"
+    _paused_ws(store, ws)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000, "total_usage": 0, "reserved": 5_000,
+    }
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    del db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]  # typed key row gone
+
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert not result.ready and not result.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 5_000  # credit NOT touched (no partial write)
+    assert (key.hash, 0) not in db.typed[KEY_LIMIT_TABLE]  # no partial row created
+
+
+def test_repair_aborts_on_nonzero_shard_holds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_sharded"
+    _paused_ws(store, ws)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000, "total_usage": 0, "reserved": 1234,
+    }
+    db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "credit_reserved_micro": 500, "ws_shard": 1, "settled": False}
+
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert not result.ready
+    assert any("nonzero shard" in r for r in result.reasons), result.reasons
+    assert not result.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 1234  # untouched
+
+
 def test_repair_zero_holds_zeroes_reserved() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_zero"

--- a/tests/test_billing_repair_reserved.py
+++ b/tests/test_billing_repair_reserved.py
@@ -96,6 +96,31 @@ def test_repair_aborts_on_nonzero_shard_holds() -> None:
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 1234  # untouched
 
 
+def test_repair_aborts_on_nonzero_key_shard_holds() -> None:
+    """codex round-2 P3: a key hold on a nonzero key_shard (workspace shard 0) would
+    be silently omitted from the key reserved SUM and written low — must ABORT."""
+    store, db, _ = make_fake_store()
+    ws = "ws_key_sharded"
+    _paused_ws(store, ws)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000, "total_usage": 0, "reserved": 7_000,
+    }
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] = 700  # clobbered key reserved
+    # a key hold on a NONZERO key_shard (ws_shard=0) — the ws-level guard misses it.
+    db.reservations["rk1"] = {
+        "reservation_id": "rk1", "workspace_id": ws, "key_hash": key.hash,
+        "key_reserved_micro": 400, "ws_shard": 0, "key_shard": 1, "settled": False,
+    }
+
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert not result.applied  # aborted in-txn (no write)
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 7_000  # untouched
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 700  # untouched
+
+
 def test_repair_zero_holds_zeroes_reserved() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_zero"

--- a/tests/test_billing_repair_reserved.py
+++ b/tests/test_billing_repair_reserved.py
@@ -1,0 +1,73 @@
+"""Repair clobbered typed `reserved` (the 2026-06-25 incident's accumulated
+damage): set credit + each key reserved = SUM of that scope's OPEN typed holds,
+for a billing-PAUSED already-typed workspace. total_usage is left alone.
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import Workspace
+from trusted_router.storage_gcp_counter_reconcile import repair_typed_reserved
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def _paused_ws(store, ws: str, *, paused: bool = True) -> None:
+    store._write_entity("workspace", ws, Workspace(id=ws, name="t", owner_user_id="u", billing_paused=paused))
+
+
+def test_repair_sets_reserved_to_open_holds() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_repair"
+    _paused_ws(store, ws)
+    # clobbered: typed credit reserved=5M, but real open holds = 120k.
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 10_000_000,
+        "total_usage": 3_000_000, "reserved": 5_000_000,
+    }
+    db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "credit_reserved_micro": 120_000, "settled": False}
+    db.reservations["r2"] = {"reservation_id": "r2", "workspace_id": ws, "credit_reserved_micro": 9_000_000, "settled": True}  # settled → ignored
+    _raw, key = store.api_keys.create(
+        workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=1_000_000
+    )
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] = 800_000  # clobbered key reserved
+    db.reservations["rk"] = {"reservation_id": "rk", "key_hash": key.hash, "key_reserved_micro": 50_000, "settled": False}
+
+    assessment = repair_typed_reserved(store, ws, apply=False)
+    assert assessment.ready and not assessment.applied
+    assert assessment.credit_reserved_before == 5_000_000
+    assert assessment.credit_reserved_after == 120_000
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 5_000_000  # unchanged by assess
+
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert result.ready and result.applied
+    assert result.keys_repaired == 1
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 120_000  # = open holds
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 3_000_000  # untouched
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 50_000  # = open key holds
+
+
+def test_repair_refuses_unpaused() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_live"
+    _paused_ws(store, ws, paused=False)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000, "total_usage": 0, "reserved": 99_000,
+    }
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert not result.ready
+    assert any("not billing-paused" in r for r in result.reasons), result.reasons
+    assert not result.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 99_000  # untouched
+
+
+def test_repair_zero_holds_zeroes_reserved() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_zero"
+    _paused_ws(store, ws)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 1_000_000, "total_usage": 500_000, "reserved": 29_373,
+    }  # clobbered reserved, but NO open holds → should become 0
+
+    result = repair_typed_reserved(store, ws, apply=True)
+    assert result.ready and result.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 0


### PR DESCRIPTION
Fixes the 2026-06-25 incident's accumulated mirror-clobber damage: 10 already-typed scopes have typed `reserved` frozen at stale JSON values (synthetic: 237M vs 204K real open holds). `repair_typed_reserved()` sets credit + each key reserved = SUM(open shard-0 typed holds) for a billing-PAUSED workspace, re-reading every typed row in-txn and aborting (zero writes) if any is missing or any open hold is on a nonzero shard. `total_usage` is left untouched — verified ledger-consistent (JSON baseline + Σ settled actuals) for active workspaces.

codex-reviewed (3 rounds, PASS): no partial/uncapped row creation, key-delete race closed, shard-0 fail-closed, zero mutations until the full plan validates. Exposed as `ramp_typed_billing.py repair WS --apply`.

40 reconcile/repair/auditor tests green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)