### PR TITLE
billing(flip): reconcile_typed_credit_usage — post-flip usage catch-up

### DIFF
--- a/docs/design/billing-typed-cutover-handoff.md
+++ b/docs/design/billing-typed-cutover-handoff.md
@@ -1,0 +1,385 @@
+# Typed-billing cutover handoff — resolved synthetic cohort
+
+**Status as of 2026-06-21 10:55 Pacific.**  
+Owner handing back: Codex. Next reader: Claude.
+
+## TL;DR
+
+The typed-column conditional-DML billing path is now active in production for the
+synthetic monitor workspace:
+
+`45819281-0ce9-4811-a0cd-c660ab3a116d`
+
+The earlier "typed authorize path is deployed but not engaging" symptom is
+resolved. The real cause was not a bad cohort flag or stale image. The cohort
+runtime flags were correct, but the synthetic workspace's **typed credit mirror**
+was stale/exhausted. Typed authorize correctly read the typed counters, found no
+available balance, returned `402`, and therefore created no `tr_reservation`
+rows.
+
+Prod state was repaired through the app ledger path, not raw DML:
+
+1. Applied an idempotent synthetic top-up event.
+2. Ran a zero-dollar app-level mirror repair with `TR_TYPED_COUNTER_MIRROR=1`.
+3. Forced/observed synthetic monitor traffic.
+4. Verified typed reservations are now created and settled.
+
+## Current production verification
+
+Last verified by Codex on 2026-06-21:
+
+```text
+tr_reservation for workspace 45819281-0ce9-4811-a0cd-c660ab3a116d
+n=1932
+settled=1925
+open=7
+```
+
+Typed balance:
+
+```text
+total_credits=8687000000
+reserved=236803676
+total_usage=8333057599
+available=117138725
+```
+
+Recent `us-central1` gateway authorize logs showed only `200` responses in the
+sample window, including both:
+
+```text
+https://trustedrouter.com/internal/gateway/authorize
+https://trustedrouter.com/v1/internal/gateway/authorize
+```
+
+Control-plane `/health` also returned:
+
+```json
+{"status":"ok"}
+```
+
+Note: `https://api.trustedrouter.com/health` returned `401` without auth. That is
+not the signal used here; the gateway authorize logs and synthetic monitor
+reservations are the real typed-billing signal.
+
+## Root cause
+
+The synthetic monitor workspace had effectively no available balance in the typed
+counter table:
+
+```text
+total_credits=8567000000
+total_usage=8330197429
+reserved=236802847
+available=-276
+```
+
+An operator top-up was first run through `STORE.credit_workspace_once`, but that
+operator environment did **not** include `TR_TYPED_COUNTER_MIRROR=1`. That updated
+the canonical JSON credit state but not the typed mirror that the cohort-enforced
+authorize path reads.
+
+After a zero-dollar app-level credit event was run with `TR_TYPED_COUNTER_MIRROR=1`,
+the typed mirror matched the canonical state and authorizes immediately began
+creating `tr_reservation` rows.
+
+## Production actions taken
+
+### 1. Diagnostic PR
+
+PR: `https://github.com/Lore-Hex/quill-router/pull/68`  
+Commit deployed: `3c9242017e0c8d1fb7a8c95d6802be63069c6a23`
+
+Added scoped runtime diagnostics around the typed billing decision in:
+
+```text
+src/trusted_router/routes/internal/gateway.py
+```
+
+Important note: the diagnostic logger did not produce useful Cloud Logging lines
+in the expected query path, likely due app logger/root handler wiring. Runtime
+proof came from actual Spanner reservation rows and gateway HTTP status logs.
+
+Deploy run:
+
+```text
+GitHub Actions run 27910487991
+```
+
+Result: success.
+
+It passed:
+
+- us-central1 deploy, staged traffic, canary
+- europe-west4 deploy, staged traffic, canary
+- us-east4 deploy, staged traffic, canary
+- cold-region deploy
+- synthetic monitor job redeploy
+- prod smoke
+
+### 2. Production mirror repair
+
+Top-up event:
+
+```text
+manual_synthetic_billing_typed_cutover_2026-06-21_20_dollars
+```
+
+Then mirror-repair event:
+
+```text
+manual_synthetic_billing_typed_cutover_2026-06-21_mirror_repair_zero
+```
+
+The mirror repair was intentionally run through the normal store/app path with
+`TR_TYPED_COUNTER_MIRROR=1`, not raw SQL/DML.
+
+### 3. Operator guard PR
+
+PR: `https://github.com/Lore-Hex/quill-router/pull/69`  
+Merge commit: `37d023c55fbd2c8b3c528a786e920f64eca0a860`
+
+Files changed:
+
+```text
+scripts/credit_makeup.py
+scripts/credit_grant_joseph.py
+tests/test_operator_credit_scripts.py
+```
+
+The manual credit scripts now force:
+
+```python
+os.environ["TR_TYPED_COUNTER_MIRROR"] = "1"
+```
+
+before calling:
+
+```python
+create_store(Settings())
+```
+
+This prevents future manual operator credits from updating canonical credit JSON
+without also updating typed counters during the cutover.
+
+Main CI for `37d023c` passed fully:
+
+- ruff
+- mypy
+- TypeScript build
+- ESLint
+- Stylelint
+- pytest
+- coverage
+- Playwright/browser smoke
+
+No runtime deploy was triggered for PR #69 because the deploy workflow is path
+filtered and this PR only touched operator scripts/tests, not runtime service
+paths. That is expected and safe; the runtime deploy from PR #68 is already live.
+
+## Commands to re-check state
+
+Use:
+
+```bash
+--account=tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+```
+
+### Reservation growth
+
+```bash
+gcloud spanner databases execute-sql trusted-router \
+  --instance=trusted-router-nam6 \
+  --project=quill-cloud-proxy \
+  --account=tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com \
+  --sql="SELECT COUNT(*) n, COUNTIF(settled) settled, COUNTIF(NOT settled) open, MAX(created_at) latest FROM tr_reservation WHERE workspace_id='45819281-0ce9-4811-a0cd-c660ab3a116d'"
+```
+
+Success signal: `n > 0` and increasing; most rows settled; open count small and
+bounded.
+
+### Typed credit balance
+
+```bash
+gcloud spanner databases execute-sql trusted-router \
+  --instance=trusted-router-nam6 \
+  --project=quill-cloud-proxy \
+  --account=tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com \
+  --sql="SELECT total_credits, reserved, total_usage, total_credits-total_usage-reserved AS available FROM tr_credit_balance WHERE workspace_id='45819281-0ce9-4811-a0cd-c660ab3a116d'"
+```
+
+Success signal: `available > 0`.
+
+### Recent authorize statuses
+
+```bash
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="trusted-router" AND resource.labels.location="us-central1" AND timestamp>="2026-06-21T17:12:00Z" AND (httpRequest.requestUrl:"/internal/gateway/authorize" OR httpRequest.requestUrl:"/v1/internal/gateway/authorize")' \
+  --project quill-cloud-proxy \
+  --account=tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com \
+  --limit=30 \
+  --format=json \
+  | jq -r '.[] | [.timestamp, .httpRequest.status, .httpRequest.requestMethod, .httpRequest.requestUrl] | @tsv'
+```
+
+Success signal: recent synthetic authorizes are `200`, not `402`.
+
+### Force one synthetic pass
+
+```bash
+gcloud run jobs execute trusted-router-synthetic-us-central1 \
+  --region=us-central1 \
+  --project=quill-cloud-proxy \
+  --account=tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com \
+  --wait
+```
+
+Then re-check reservation growth.
+
+## What not to do
+
+- Do not raw-DML prod billing tables.
+- Do not use a one-off manual credit script unless it sets
+  `TR_TYPED_COUNTER_MIRROR=1` before store creation.
+- Do not broaden the typed billing cohort beyond the synthetic monitor workspace
+  without Joseph's explicit approval.
+- Do not treat missing diagnostic log lines as proof that typed billing is off.
+  Use `tr_reservation` rows plus authorize statuses as the source of truth.
+
+## Rollback
+
+If the synthetic cohort starts failing:
+
+1. Prefer removing the synthetic workspace from
+   `TR_TYPED_BILLING_WORKSPACE_IDS` in `scripts/deploy/rollout.sh` and redeploying.
+2. If a denylist env is wired into the deploy path, adding the workspace to
+   `TR_TYPED_BILLING_WORKSPACE_DENYLIST` is also safe because denylist wins.
+3. Existing typed reservations can still finalize because settle/refund routes by
+   reservation origin through `is_typed_reservation`.
+
+## Next cutover step
+
+Leave the synthetic cohort running and observe:
+
+- reservation growth
+- settle/open ratio
+- comparator drift
+- deadlock rate
+- 402 rate
+
+After a clean observation window, propose the next small allowlist cohort. Do not
+add more workspaces in this handoff without a fresh approval.
+
+## Local workspace note
+
+This file is untracked in `/Users/jperla/claude/qr-billing`.
+
+The `qr-billing` worktree is currently on:
+
+```text
+billing-typed-operator-mirror
+```
+
+That remote branch was deleted after PR #69 was squash-merged. The `main`
+worktree is already occupied by:
+
+```text
+/Users/jperla/claude/quill-router
+```
+
+So do not be surprised if `git switch main` fails from `qr-billing` with:
+
+```text
+fatal: 'main' is already used by worktree at '/Users/jperla/claude/quill-router'
+```
+
+---
+
+## Claude independent verification (2026-06-21, post-codex) — VERDICT: WORKING & HEALTHY
+
+Independently re-checked every dimension (not trusting pasted numbers). **The typed path is
+genuinely engaging and prod is healthy.** Evidence:
+
+- **`tr_reservation` growing live:** 0 (pre-fix) → 1932 (codex) → 3799 → 4046, settled tracking
+  (4031), open bounded (15). A forced synthetic probe incremented it in real time → typed
+  authorize is *actively* creating reservations now, not just historically.
+- **Typed balance positive:** `available = 116,988,687` (> 0). No re-exhaustion.
+- **Authorize statuses:** last 40 gateway authorizes all **200** (zero 402s).
+- **Deadlocks:** **0** `Deadlock`/`Aborted` errors in the trailing 2h (whole service).
+- **Infra:** all 3 regions still carry the cohort flag; `trustedrouter.com/health` = 200;
+  deploy run `27910487991` (PR #68) = success; PRs #68 + #69 merged; #69 operator-mirror guard
+  present in `scripts/credit_makeup.py`.
+
+### Correction to "comparator should be clean" — the drift is EXPECTED, not a bug
+The comparator now reports drift for the cohort workspace:
+`credit:45819281 total_usage JSON=8330197429 vs typed=8333200595` (typed ahead ~3.0M),
+`reserved` typed ahead ~4.6k, and its two API keys' `usage` typed ahead. **This is the correct
+post-flip signature, not a money bug:** the typed DML path books usage into the *typed*
+counters only, and the mirror is one-way (JSON→typed), so JSON usage **freezes** for a
+cohort workspace while typed advances. **`total_credits` IS consistent** between JSON and typed
+(codex's top-up mirrored correctly), so no credit was lost. Typed is the source of truth and
+it is correct. ⇒ Do NOT expect the comparator to be clean for active cohort workspaces; "typed
+ahead on usage/reserved, equal on total_credits" is the healthy state. **Implication for the
+ramp:** rolling a workspace back to legacy after a long typed period would leave JSON
+*under-counted* by the typed-era usage. Negligible for the synthetic monitor; decide a
+JSON-backfill-on-rollback policy before broadening the cohort to real whales.
+
+### Note on the root-cause narrative
+Codex's "exhausted typed balance → 402 → no reservation" explains the 402s codex saw, but does
+NOT explain the *earlier* state I observed (synthetic succeeding on the **legacy** path: HTTP
+200 + real settles `recorded:N` + `tr_reservation=0`). The thing that actually flipped
+engagement legacy→typed was the **PR #68 redeploy** (fresh build/restart), not the balance
+top-up. The balance exhaustion was a *second*, real issue that only surfaced once typed
+started engaging. The diagnostic logger codex added "did not produce useful lines," so the
+*original* reason the cohort branch wasn't taken pre-#68 was never definitively pinned down —
+it's working and stable now, but be aware a future redeploy is the only thing proven to have
+fixed it.
+
+### Two minor follow-ups (non-blocking)
+1. **Remove the dead diagnostic code** from `routes/internal/gateway.py`
+   (`_log_typed_billing_decision`, called at ~line 230, defined ~428, logger at ~57) — codex
+   confirmed it doesn't emit useful Cloud Logging lines. Small cleanup PR.
+2. Decide the **JSON-backfill-on-rollback** policy above before the whale ramp.
+
+---
+
+## Ramp-to-fleet strategy + decision (2026-06-21)
+
+**Goal / end state:** typed conditional-DML billing for **every** workspace, **new ones
+included**, with the allowlist gone. The `TR_TYPED_BILLING_WORKSPACE_IDS` allowlist is a
+*transitional safety valve*, not the architecture. The final form is the gate returning
+"typed unless denylisted" (universal default) + new workspaces starting on typed at creation.
+
+**Where we are:** synthetic monitor (45819281) + first real workspace (063e9fb9, deploy in
+flight) on typed. The dominant deadlock source (the synthetic, ~8000× the traffic of any real
+ws — the only ws in deadlock payloads) is already fixed → **0 deadlocks service-wide since its
+cutover.** So there is **no urgency** forcing a big-bang.
+
+**Why staged, not big-bang (the actual reasoning).** Two distinct failure modes:
+1. *Stale/wrong typed counters* → would 402 a customer. **Already de-risked fleet-wide:** the
+   drift comparator shows every workspace except the synthetic is CLEAN (typed == JSON); the
+   one-way mirror has kept all ~46 workspaces in sync. So data-wise the fleet is ready.
+2. *A billing code path the typed engine handles wrong* → **this is the gate.** The typed path
+   has run in prod for only two workspaces, one (synthetic) on the non-representative internal
+   monitor model. We have NOT yet watched the typed path handle, on real traffic: **BYOK
+   billing, refunds / failed-settles, mid-flight credit grants or monthly resets, or genuinely
+   high real-workspace concurrency.** A big-bang flip would expose every customer to any such
+   bug simultaneously (fleet-wide 402s until rollback, which is minutes→90min).
+
+The asymmetry decides it: going slow costs ~nothing now (no deadlocks happening); going
+fast-and-wrong rejects real paid traffic fleet-wide. For billing, stage it.
+
+**Accelerated plan (≈46 workspaces total → days, not a one-at-a-time grind):**
+1. **Validate 063e9fb9** (in flight) — first real workspace, real models.
+2. **Fleet pre-flight sweep** — run the comparator + the per-key `tr_key_limit` existence/funded
+   check (the one done for 063e9fb9) across ALL workspaces, programmatically; flag any not safe
+   to flip. (Build this; not built yet.)
+3. **One diverse batch** deliberately covering the untested traffic *types* — a BYOK workspace,
+   a refund-active one, the top few by volume — watch ~a day.
+4. **Flip the universal default** — gate → "typed unless denylisted" (= all existing + all new
+   in one move) + a small code change so new workspaces start on typed at creation (lowest risk,
+   no migration state). Only after step 3 is clean across traffic types.
+
+**DECISION (2026-06-21, Joseph):** **HOLD at 063e9fb9 until it reports.** Do NOT widen the
+cohort or build the sweep yet. Once 063e9fb9 is validated clean (reservations growing, no 402s,
+comparator behaving), resume at step 2 (build the fleet pre-flight sweep), then step 3, then the
+universal-default flip. Background monitor for the 063e9fb9 us-central1 engagement is running.

--- a/scripts/deploy/ramp_typed_billing.py
+++ b/scripts/deploy/ramp_typed_billing.py
@@ -52,6 +52,7 @@ from trusted_router.storage_gcp_counter_reconcile import (
     audit_typed_invariants,
     backsync_typed_to_json,
     reconcile_for_flip,
+    reconcile_typed_credit_usage,
     repair_typed_reserved,
 )
 
@@ -60,10 +61,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    for name in ("pause", "unpause", "status", "reconcile", "rollback", "repair"):
+    for name in ("pause", "unpause", "status", "reconcile", "rollback", "repair", "usage"):
         p = sub.add_parser(name)
         p.add_argument("workspaces", nargs="+")
-        if name in ("pause", "unpause", "reconcile", "rollback", "repair"):
+        if name in ("pause", "unpause", "reconcile", "rollback", "repair", "usage"):
             p.add_argument("--apply", action="store_true", help="actually mutate (else dry-run)")
         if name == "pause":
             p.add_argument("--reason", default="typed-billing ramp")
@@ -125,6 +126,17 @@ def main() -> int:
                 print(f"{ws}: REPAIRED credit reserved {rp.credit_reserved_before}->{rp.credit_reserved_after}, keys={rp.keys_repaired}")
             else:
                 print(f"{ws}: would set credit reserved {rp.credit_reserved_before}->{rp.credit_reserved_after} (dry-run; pass --apply)")
+
+        elif args.cmd == "usage":
+            ur = reconcile_typed_credit_usage(store, ws, apply=args.apply)
+            if not ur.ready:
+                print(f"{ws}: NOT usage-reconcile-ready — {ur.reasons}")
+                rc = 1
+            elif ur.applied:
+                print(f"{ws}: USAGE RECONCILED total_usage {ur.usage_before}->{ur.usage_after}")
+            else:
+                drift = (ur.usage_after or 0) - (ur.usage_before or 0)
+                print(f"{ws}: would set total_usage {ur.usage_before}->{ur.usage_after} (drift {drift:+d}; dry-run; pass --apply)")
 
     return rc
 

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -716,10 +716,20 @@ class UsageReconcileResult:
 
 def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool = False) -> UsageReconcileResult:
     """Set typed credit total_usage = JSON.total_usage + SUM(settled Credits
-    actual_micro) for a billing-PAUSED workspace (shard 0). Read-only when
-    apply=False. Fail-closed: refuses unless billing_paused; aborts if the typed
-    row is missing or any settled Credits actual is on a nonzero shard. Leaves
-    reserved + keys untouched."""
+    actual_micro) for a billing-PAUSED, DRAINED workspace (shard 0). Read-only
+    when apply=False. Fail-closed: refuses unless billing_paused AND there are NO
+    open typed holds (a hold settling after the write would book onto the new
+    baseline, which is fine, but draining first makes the ledger stable and the
+    op idempotent); aborts if the typed row is missing or any Credits actual is on
+    a nonzero shard. Leaves reserved + keys untouched.
+
+    Deliberately does NOT check JSON reserved_microdollars: under universal typed
+    enforcement the JSON reserved counter is legacy/irrelevant (often a stale,
+    leaked value) and gating on it would wrongly block correct reconciles. The
+    invariant we need is JSON total_usage stability — guaranteed because a typed-
+    enforced, paused workspace takes no new legacy bills. WARNING: must NOT be run
+    after backsync_typed_to_json (which copies typed usage back into JSON → JSON is
+    no longer the legacy baseline → JSON+ledger would double-count)."""
     pt = store._param_types
     res = UsageReconcileResult(workspace_id=workspace_id, ready=False)
     ledger_sql = (
@@ -731,6 +741,9 @@ def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool =
         "WHERE workspace_id=@ws AND settled=true AND settled_usage_type='Credits' AND ws_shard!=0"
     )
     credit_row_sql = "SELECT total_usage FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
+    # Drain guard: no open typed holds (any shard). This also subsumes the "open
+    # nonzero-shard reservation" gap — zero open holds means none on any shard.
+    open_holds_sql = "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false"
 
     workspace = store.get_workspace(workspace_id)
     cred = store.get_credit_account(workspace_id)
@@ -738,6 +751,7 @@ def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool =
         cb = list(snap.execute_sql(credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING}))
         ledger = list(snap.execute_sql(ledger_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING}))[0][0]
         nz = list(snap.execute_sql(nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING}))[0][0]
+        open_holds = list(snap.execute_sql(open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING}))[0][0]
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause it before reconcile")
@@ -745,6 +759,8 @@ def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool =
         res.reasons.append("no JSON credit account")
     if not cb:
         res.reasons.append("no typed credit row")
+    if int(open_holds) != 0:
+        res.reasons.append(f"{open_holds} open typed holds — drain (or reap) first")
     if int(nz) != 0:
         res.reasons.append(f"{nz} settled Credits actuals on a nonzero shard — sharded ws not handled")
     res.ready = not res.reasons
@@ -765,6 +781,10 @@ def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool =
         c = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
         if c is None:
             return None
+        if int(list(transaction.execute_sql(
+            open_holds_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]) != 0:
+            return None  # an open hold appeared — not drained, abort
         if int(list(transaction.execute_sql(
             nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]) != 0:

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -693,3 +693,102 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     res.applied = True
     res.keys_repaired = result["keys"]
     return res
+
+
+# ── Reconcile typed credit total_usage from the ledger ──────────────────────
+# Residual usage drift after the universal flip: an ever-typed leftover (typed
+# usage frozen-stale from the incident window) or a new workspace that straddled
+# legacy+typed during the cross-region rollout has typed total_usage that omits
+# part of its real usage. The correct all-time usage = JSON baseline (legacy-era)
+# + Σ typed-era settled-Credits actuals (the ledger). Set it for a billing-PAUSED
+# workspace. Does NOT touch reserved (repair_typed_reserved) or keys.
+
+
+@dataclass
+class UsageReconcileResult:
+    workspace_id: str
+    ready: bool
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+    usage_before: int | None = None
+    usage_after: int | None = None
+
+
+def reconcile_typed_credit_usage(store: Any, workspace_id: str, *, apply: bool = False) -> UsageReconcileResult:
+    """Set typed credit total_usage = JSON.total_usage + SUM(settled Credits
+    actual_micro) for a billing-PAUSED workspace (shard 0). Read-only when
+    apply=False. Fail-closed: refuses unless billing_paused; aborts if the typed
+    row is missing or any settled Credits actual is on a nonzero shard. Leaves
+    reserved + keys untouched."""
+    pt = store._param_types
+    res = UsageReconcileResult(workspace_id=workspace_id, ready=False)
+    ledger_sql = (
+        "SELECT COALESCE(SUM(actual_micro),0) FROM tr_reservation "
+        "WHERE workspace_id=@ws AND ws_shard=0 AND settled=true AND settled_usage_type='Credits'"
+    )
+    nonzero_shard_sql = (
+        "SELECT COUNT(*) FROM tr_reservation "
+        "WHERE workspace_id=@ws AND settled=true AND settled_usage_type='Credits' AND ws_shard!=0"
+    )
+    credit_row_sql = "SELECT total_usage FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
+
+    workspace = store.get_workspace(workspace_id)
+    cred = store.get_credit_account(workspace_id)
+    with store._database.snapshot(multi_use=True) as snap:
+        cb = list(snap.execute_sql(credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING}))
+        ledger = list(snap.execute_sql(ledger_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING}))[0][0]
+        nz = list(snap.execute_sql(nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING}))[0][0]
+
+    if workspace is None or not getattr(workspace, "billing_paused", False):
+        res.reasons.append("workspace not billing-paused — pause it before reconcile")
+    if cred is None:
+        res.reasons.append("no JSON credit account")
+    if not cb:
+        res.reasons.append("no typed credit row")
+    if int(nz) != 0:
+        res.reasons.append(f"{nz} settled Credits actuals on a nonzero shard — sharded ws not handled")
+    res.ready = not res.reasons
+    if cb and cred is not None:
+        res.usage_before = int(cb[0][0])
+        res.usage_after = int(cred.total_usage_microdollars) + int(ledger)
+    if not res.ready or not apply:
+        return res
+
+    cts = store._spanner.COMMIT_TIMESTAMP
+
+    def _txn(transaction: Any) -> dict | None:
+        # Re-read everything in-txn; abort (zero writes) if paused-state, the JSON
+        # account, or the typed row is gone, or a nonzero-shard actual appears.
+        ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if ws is None or not ws.billing_paused:
+            return None
+        c = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if c is None:
+            return None
+        if int(list(transaction.execute_sql(
+            nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]) != 0:
+            return None
+        if not list(transaction.execute_sql(
+            credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        )):
+            return None  # typed row missing — abort, never create
+        led = list(transaction.execute_sql(
+            ledger_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        target = int(c.total_usage_microdollars) + int(led)
+        transaction.insert_or_update(
+            table="tr_credit_balance",
+            columns=("workspace_id", "shard", "total_usage", "updated_at"),
+            values=[(workspace_id, 0, target, cts)],
+        )
+        return {"target": target}
+
+    result = store._run_in_transaction(_txn)
+    if result is None:
+        res.ready = False
+        res.reasons.append("aborted: not paused / no JSON account / typed row missing / nonzero shard")
+        return res
+    res.applied = True
+    res.usage_after = int(result["target"])
+    return res

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -490,6 +490,22 @@ def _execute_sql(
                 if len(out) >= limit:
                     break
         return out
+    # Usage reconcile: ledger = Σ settled-Credits actuals (shard 0); + nonzero-shard
+    # guard. Checked before the generic shard/count handlers (substring overlap).
+    if "SUM(actual_micro)" in sql and "settled_usage_type='Credits'" in sql and "ws_shard!=0" not in sql:
+        ws = params["ws"]
+        return [[sum(
+            (rec.get("actual_micro") or 0) for rec in db.reservations.values()
+            if rec.get("workspace_id") == ws and rec.get("settled")
+            and rec.get("settled_usage_type") == "Credits" and rec.get("ws_shard", 0) == 0
+        )]]
+    if "settled_usage_type='Credits' AND ws_shard!=0" in sql:
+        ws = params["ws"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("workspace_id") == ws and rec.get("settled")
+            and rec.get("settled_usage_type") == "Credits" and rec.get("ws_shard", 0) != 0
+        )]]
     # Repair: any OPEN holds on a nonzero shard? (checked first — its query string
     # contains the generic count substrings below.)
     if "key_shard!=0" in sql:

--- a/tests/test_billing_usage_reconcile.py
+++ b/tests/test_billing_usage_reconcile.py
@@ -37,7 +37,6 @@ def test_usage_reconcile_sets_typed_usage_to_json_plus_ledger() -> None:
     db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 3_000, "ws_shard": 0}
     db.reservations["r2"] = {"reservation_id": "r2", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 2_000, "ws_shard": 0}
     db.reservations["r3"] = {"reservation_id": "r3", "workspace_id": ws, "settled": True, "settled_usage_type": "BYOK", "actual_micro": 9_999, "ws_shard": 0}
-    db.reservations["r4"] = {"reservation_id": "r4", "workspace_id": ws, "settled": False, "credit_reserved_micro": 1_000, "ws_shard": 0}
 
     a = reconcile_typed_credit_usage(store, ws, apply=False)
     assert a.ready and not a.applied
@@ -60,6 +59,20 @@ def test_usage_reconcile_refuses_unpaused() -> None:
     r = reconcile_typed_credit_usage(store, ws, apply=True)
     assert not r.ready and not r.applied
     assert any("not billing-paused" in x for x in r.reasons), r.reasons
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000
+
+
+def test_usage_reconcile_aborts_on_open_holds() -> None:
+    """codex drain guard: an open typed hold means the ledger isn't stable — abort."""
+    store, db, _ = make_fake_store()
+    ws = "ws_undrained"
+    _paused_ws(store, ws, json_usage=10_000)
+    _typed(db, ws, total_usage=5_000)
+    db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 5_000, "ws_shard": 0}
+    db.reservations["open"] = {"reservation_id": "open", "workspace_id": ws, "settled": False, "credit_reserved_micro": 1_000, "ws_shard": 0}
+    r = reconcile_typed_credit_usage(store, ws, apply=True)
+    assert not r.ready and not r.applied
+    assert any("open typed holds" in x for x in r.reasons), r.reasons
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000
 
 

--- a/tests/test_billing_usage_reconcile.py
+++ b/tests/test_billing_usage_reconcile.py
@@ -1,0 +1,83 @@
+"""Post-flip usage reconcile: set typed credit total_usage = JSON.total_usage +
+Σ settled-Credits actual_micro (the ledger), for a billing-PAUSED workspace.
+
+Fixes residual usage drift after the universal typed flip — an ever-typed leftover
+whose typed usage froze stale, or a new workspace that straddled legacy+typed
+during the cross-region rollout. Leaves reserved + keys untouched.
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount, Workspace
+from trusted_router.storage_gcp_counter_reconcile import reconcile_typed_credit_usage
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+
+def _paused_ws(store, ws: str, *, json_usage: int, paused: bool = True, total_credits: int = 10_000_000) -> None:
+    store._write_entity("workspace", ws, Workspace(id=ws, name="t", owner_user_id="u", billing_paused=paused))
+    store._write_entity(
+        "credit", ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=total_credits, total_usage_microdollars=json_usage),
+    )
+
+
+def _typed(db, ws: str, *, total_usage: int) -> None:
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws, "shard": 0, "total_credits": 10_000_000, "total_usage": total_usage, "reserved": 0,
+    }
+
+
+def test_usage_reconcile_sets_typed_usage_to_json_plus_ledger() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_straddle"
+    _paused_ws(store, ws, json_usage=10_000)        # legacy-era baseline
+    _typed(db, ws, total_usage=5_000)               # straddle: only typed-era counted
+    # ledger = Σ settled-Credits actuals = 5000; BYOK + open holds excluded.
+    db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 3_000, "ws_shard": 0}
+    db.reservations["r2"] = {"reservation_id": "r2", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 2_000, "ws_shard": 0}
+    db.reservations["r3"] = {"reservation_id": "r3", "workspace_id": ws, "settled": True, "settled_usage_type": "BYOK", "actual_micro": 9_999, "ws_shard": 0}
+    db.reservations["r4"] = {"reservation_id": "r4", "workspace_id": ws, "settled": False, "credit_reserved_micro": 1_000, "ws_shard": 0}
+
+    a = reconcile_typed_credit_usage(store, ws, apply=False)
+    assert a.ready and not a.applied
+    assert a.usage_before == 5_000
+    assert a.usage_after == 15_000  # 10000 JSON + 5000 ledger (BYOK + open excluded)
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000  # unchanged by assess
+
+    r = reconcile_typed_credit_usage(store, ws, apply=True)
+    assert r.ready and r.applied
+    assert r.usage_after == 15_000
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 15_000
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 0  # untouched
+
+
+def test_usage_reconcile_refuses_unpaused() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_live"
+    _paused_ws(store, ws, json_usage=10_000, paused=False)
+    _typed(db, ws, total_usage=5_000)
+    r = reconcile_typed_credit_usage(store, ws, apply=True)
+    assert not r.ready and not r.applied
+    assert any("not billing-paused" in x for x in r.reasons), r.reasons
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000
+
+
+def test_usage_reconcile_aborts_on_nonzero_shard_credits_actual() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_sharded"
+    _paused_ws(store, ws, json_usage=10_000)
+    _typed(db, ws, total_usage=5_000)
+    db.reservations["r1"] = {"reservation_id": "r1", "workspace_id": ws, "settled": True, "settled_usage_type": "Credits", "actual_micro": 3_000, "ws_shard": 1}
+    r = reconcile_typed_credit_usage(store, ws, apply=True)
+    assert not r.ready
+    assert any("nonzero shard" in x for x in r.reasons), r.reasons
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000
+
+
+# NOTE: the "abort if the typed credit row is missing" path is correct for prod
+# (real Spanner returns [] for a missing row -> abort, never create), but the fake
+# returns a default-0 row for a missing tr_credit_balance point-read, so it can't be
+# exercised here. In prod every workspace has a mirror-created typed credit row, so
+# this path is defensive only. (Fake fidelity gap tracked with the single-use
+# snapshot one.)


### PR DESCRIPTION
The post-sweep fix for residual typed usage drift after the universal flip. Sets typed credit total_usage = JSON.total_usage + SUM(settled-Credits actual_micro) for a billing-PAUSED workspace (shard 0). Fixes the 2 ever-typed leftovers ($3.98) and any new-workspace straddle from the rollout window. Mirrors repair_typed_reserved's fail-closed shape (in-txn re-read, abort on missing typed row / nonzero-shard / not-paused); leaves reserved + keys untouched. CLI: `usage WS --apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)