### PR TITLE
console(keys): disable/enable + disable-first delete + window-limit budgets

### DIFF
--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -121,19 +121,19 @@ def register(app: FastAPI) -> None:
 
     @app.post("/console/api-keys/{key_hash}/disable")
     async def console_disable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
-        _require_key(ctx, key_hash)
+        _require_key(ctx, key_hash, manage=True)
         STORE.update_key(key_hash, {"disabled": True})
         return RedirectResponse(url="/console/api-keys?saved=disabled", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/enable")
     async def console_enable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
-        _require_key(ctx, key_hash)
+        _require_key(ctx, key_hash, manage=True)
         STORE.update_key(key_hash, {"disabled": False})
         return RedirectResponse(url="/console/api-keys?saved=enabled", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/delete")
     async def console_delete_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
-        key = _require_key(ctx, key_hash)
+        key = _require_key(ctx, key_hash, manage=True)
         # Disable-first, then delete: an ACTIVE key may have in-flight typed
         # holds; deleting it mid-flight strands them (issue #29). Disabling
         # stops new authorizes and the holds settle/drain, making the delete
@@ -144,10 +144,16 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url="/console/api-keys?saved=deleted", status_code=303)
 
 
-def _require_key(ctx: Any, key_hash: str) -> ApiKey:
+def _require_key(ctx: Any, key_hash: str, *, manage: bool = False) -> ApiKey:
+    """Ownership check for every mutating route; `manage=True` additionally
+    requires owner/manager role (codex #94: disable/enable/delete are
+    destructive — a plain workspace member must not kill another member's
+    keys; budget edits keep the console's pre-existing member-level access)."""
     key = STORE.get_key_by_hash(key_hash)
     if key is None or key.workspace_id != ctx.workspace.id:
         raise HTTPException(status_code=404, detail="API key not found")
+    if manage and not STORE.user_can_manage(ctx.user.id, ctx.workspace.id):
+        raise HTTPException(status_code=403, detail="Requires workspace manager role")
     return key
 
 

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -1,6 +1,9 @@
-"""/console/api-keys — list, create, and reveal API keys for the current
-workspace. POST creates a new key and renders the same page with the
-raw key one-shot revealed in the response."""
+"""/console/api-keys — list, create, and manage API keys for the current
+workspace: one-shot reveal on create, budgets (lifetime + daily/weekly/monthly
+windows), disable/enable, and delete (disabled keys only — disabling first
+stops new authorizes so in-flight typed holds drain before the row goes away).
+All mutations are form POSTs -> 303 redirects with ?saved=/?error= flash params
+(the console's no-JS pattern)."""
 
 from __future__ import annotations
 
@@ -13,13 +16,34 @@ from trusted_router.auth import SettingsDep
 from trusted_router.errors import assert_workspace_billing_active
 from trusted_router.money import dollars_to_microdollars, microdollars_to_decimal
 from trusted_router.routes.console._shared import ConsoleDep, money, render
+from trusted_router.spend_windows import WINDOWS
 from trusted_router.storage import STORE, ApiKey
+
+_FLASH = {
+    "saved:limit": ("success", "Budgets saved."),
+    "saved:disabled": ("success", "Key disabled — it can no longer authorize requests."),
+    "saved:enabled": ("success", "Key enabled."),
+    "saved:deleted": ("success", "Key deleted."),
+    "error:limit": ("error", "Budgets must be non-negative dollar amounts."),
+    "error:delete-active": ("error", "Disable the key first, then delete it."),
+}
 
 
 def register(app: FastAPI) -> None:
-    @app.get("/console/api-keys")
-    async def console_api_keys(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def _render_page(
+        ctx: Any,
+        settings: Any,
+        *,
+        created_key: str | None = None,
+        saved: str | None = None,
+        error: str | None = None,
+    ) -> Response:
         keys = [_key_view(k) for k in STORE.list_keys(ctx.workspace.id)]
+        flash = None
+        if saved:
+            flash = _FLASH.get(f"saved:{saved}")
+        elif error:
+            flash = _FLASH.get(f"error:{error}")
         return HTMLResponse(render(
             "console/api_keys.html",
             settings=settings,
@@ -28,9 +52,19 @@ def register(app: FastAPI) -> None:
             page_title="API Keys",
             page_subtitle="Long-lived keys for your applications.",
             keys=keys,
-            created_key=None,
+            created_key=created_key,
+            flash=flash,
             api_base_url=settings.api_base_url,
         ))
+
+    @app.get("/console/api-keys")
+    async def console_api_keys(
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+        saved: str | None = None,
+        error: str | None = None,
+    ) -> Response:
+        return _render_page(ctx, settings, saved=saved, error=error)
 
     @app.post("/console/api-keys")
     async def console_create_api_key(
@@ -38,15 +72,20 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         name: str = Form("API key", min_length=1, max_length=120),
         limit: str = Form(""),
+        limit_daily: str = Form(""),
+        limit_weekly: str = Form(""),
+        limit_monthly: str = Form(""),
     ) -> Response:
-        limit_microdollars = None
-        if limit:
-            try:
-                limit_microdollars = dollars_to_microdollars(limit)
-            except ValueError:
-                return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
-            if limit_microdollars < 0:
-                return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
+        try:
+            limit_microdollars = _parse_limit(limit)
+            window_micro = {
+                f"limit_{window}_microdollars": _parse_limit(value)
+                for window, value in (
+                    ("daily", limit_daily), ("weekly", limit_weekly), ("monthly", limit_monthly),
+                )
+            }
+        except ValueError:
+            return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
         assert_workspace_billing_active(ctx.workspace)  # quiesce: no new keys while paused
         raw, _ = STORE.create_api_key(
             workspace_id=ctx.workspace.id,
@@ -54,46 +93,92 @@ def register(app: FastAPI) -> None:
             creator_user_id=ctx.user.id,
             management=False,
             limit_microdollars=limit_microdollars,
+            **window_micro,
         )
-        keys = [_key_view(k) for k in STORE.list_keys(ctx.workspace.id)]
-        return HTMLResponse(render(
-            "console/api_keys.html",
-            settings=settings,
-            user=ctx.user,
-            active="api-keys",
-            page_title="API Keys",
-            page_subtitle="Long-lived keys for your applications.",
-            keys=keys,
-            created_key=raw,
-            api_base_url=settings.api_base_url,
-        ))
+        return _render_page(ctx, settings, created_key=raw)
 
     @app.post("/console/api-keys/{key_hash}/limit")
     async def console_update_api_key_limit(
         ctx: ConsoleDep,
         key_hash: str,
         limit: str = Form(""),
+        limit_daily: str = Form(""),
+        limit_weekly: str = Form(""),
+        limit_monthly: str = Form(""),
     ) -> Response:
-        key = STORE.get_key_by_hash(key_hash)
-        if key is None or key.workspace_id != ctx.workspace.id:
-            raise HTTPException(status_code=404, detail="API key not found")
-
-        limit_microdollars = None
-        normalized_limit = limit.strip()
-        if normalized_limit:
-            try:
-                limit_microdollars = dollars_to_microdollars(normalized_limit)
-            except ValueError:
-                return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
-            if limit_microdollars < 0:
-                return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
-
-        STORE.update_key(key_hash, {"limit_microdollars": limit_microdollars})
+        _require_key(ctx, key_hash)
+        try:
+            patch: dict[str, Any] = {"limit_microdollars": _parse_limit(limit)}
+            for window, value in (
+                ("daily", limit_daily), ("weekly", limit_weekly), ("monthly", limit_monthly),
+            ):
+                # Empty input = clear the window limit (explicit None).
+                patch[f"limit_{window}_microdollars"] = _parse_limit(value)
+        except ValueError:
+            return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
+        STORE.update_key(key_hash, patch)
         return RedirectResponse(url="/console/api-keys?saved=limit", status_code=303)
+
+    @app.post("/console/api-keys/{key_hash}/disable")
+    async def console_disable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+        _require_key(ctx, key_hash)
+        STORE.update_key(key_hash, {"disabled": True})
+        return RedirectResponse(url="/console/api-keys?saved=disabled", status_code=303)
+
+    @app.post("/console/api-keys/{key_hash}/enable")
+    async def console_enable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+        _require_key(ctx, key_hash)
+        STORE.update_key(key_hash, {"disabled": False})
+        return RedirectResponse(url="/console/api-keys?saved=enabled", status_code=303)
+
+    @app.post("/console/api-keys/{key_hash}/delete")
+    async def console_delete_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+        key = _require_key(ctx, key_hash)
+        # Disable-first, then delete: an ACTIVE key may have in-flight typed
+        # holds; deleting it mid-flight strands them (issue #29). Disabling
+        # stops new authorizes and the holds settle/drain, making the delete
+        # safe in practice.
+        if not key.disabled:
+            return RedirectResponse(url="/console/api-keys?error=delete-active", status_code=303)
+        STORE.delete_key(key_hash)
+        return RedirectResponse(url="/console/api-keys?saved=deleted", status_code=303)
+
+
+def _require_key(ctx: Any, key_hash: str) -> ApiKey:
+    key = STORE.get_key_by_hash(key_hash)
+    if key is None or key.workspace_id != ctx.workspace.id:
+        raise HTTPException(status_code=404, detail="API key not found")
+    return key
+
+
+def _parse_limit(value: str) -> int | None:
+    """'' -> None (no limit); a dollar string -> microdollars; negative raises."""
+    normalized = value.strip()
+    if not normalized:
+        return None
+    micro = dollars_to_microdollars(normalized)
+    if micro < 0:
+        raise ValueError("limit must be non-negative")
+    return micro
 
 
 def _key_view(key: ApiKey) -> dict[str, Any]:
     limit_display = "none" if key.limit_microdollars is None else money(key.limit_microdollars)
+    # One typed point-read for live usage + current window spend (falls back to
+    # the JSON values when typed is off / row missing).
+    typed = getattr(STORE, "typed_key_usage", None)
+    usage = typed(key.hash) if typed is not None else None
+    windows_used = (usage or {}).get("windows", {})
+    lifetime_used = usage["usage"] if usage is not None else key.usage_microdollars
+    window_views = []
+    for window in WINDOWS:
+        limit_value = getattr(key, f"limit_{window}_microdollars", None)
+        window_views.append({
+            "name": window,
+            "input": "" if limit_value is None else microdollars_to_decimal(limit_value),
+            "limit_display": None if limit_value is None else money(limit_value),
+            "used_display": money(windows_used.get(window, 0)) if limit_value is not None else None,
+        })
     return {
         "hash": key.hash,
         "name": key.name,
@@ -102,5 +187,7 @@ def _key_view(key: ApiKey) -> dict[str, Any]:
         "limit_input": (
             "" if key.limit_microdollars is None else microdollars_to_decimal(key.limit_microdollars)
         ),
+        "usage_display": money(lifetime_used),
+        "windows": window_views,
         "disabled": key.disabled,
     }

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -78,12 +78,9 @@ def register(app: FastAPI) -> None:
     ) -> Response:
         try:
             limit_microdollars = _parse_limit(limit)
-            window_micro = {
-                f"limit_{window}_microdollars": _parse_limit(value)
-                for window, value in (
-                    ("daily", limit_daily), ("weekly", limit_weekly), ("monthly", limit_monthly),
-                )
-            }
+            daily_micro = _parse_limit(limit_daily)
+            weekly_micro = _parse_limit(limit_weekly)
+            monthly_micro = _parse_limit(limit_monthly)
         except ValueError:
             return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
         assert_workspace_billing_active(ctx.workspace)  # quiesce: no new keys while paused
@@ -93,7 +90,9 @@ def register(app: FastAPI) -> None:
             creator_user_id=ctx.user.id,
             management=False,
             limit_microdollars=limit_microdollars,
-            **window_micro,
+            limit_daily_microdollars=daily_micro,
+            limit_weekly_microdollars=weekly_micro,
+            limit_monthly_microdollars=monthly_micro,
         )
         return _render_page(ctx, settings, created_key=raw)
 

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -12,8 +12,12 @@ body.console {
   background: var(--top);
   border-bottom: 1px solid var(--line);
   display: flex;
+  /* Wrap at any width: at full desktop nothing wraps; at intermediate widths
+     the workspace selector / user cluster drop to a second row instead of
+     painting over each other (rigid label/select content can't shrink). */
+  flex-wrap: wrap;
   align-items: center;
-  gap: 24px;
+  gap: 12px 24px;
   padding: 12px 24px;
   backdrop-filter: blur(12px);
 }
@@ -39,10 +43,15 @@ body.console {
   align-items: center;
   gap: 12px;
   font-size: 13px;
+  min-width: 0;
 }
 
 .console-user-email {
   color: var(--muted);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .console-user .inline-form {
@@ -53,12 +62,19 @@ body.console {
   display: flex;
   align-items: end;
   gap: 8px;
-  min-width: 210px;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.workspace-selector select {
+  min-width: 0;
+  max-width: 240px;
 }
 
 .workspace-selector label {
   gap: 4px;
-  min-width: 170px;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .workspace-selector label span {
@@ -212,6 +228,14 @@ body.console {
 
 .copy-status.error {
   color: var(--red);
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.keys-table {
+  min-width: 860px;
 }
 
 .key-budget-form {
@@ -447,9 +471,19 @@ body.console {
   .secret-row {
     grid-template-columns: 1fr;
   }
+  /* Topbar: children (brand / workspace selector / user cluster) overflow a
+     phone width when forced onto one line — wrap into rows instead of
+     clipping the workspace Switch control off-screen. */
+  .console-topbar {
+    flex-wrap: wrap;
+    gap: 10px 16px;
+  }
   /* Keys table -> stacked cards: each row becomes a bordered block, each cell
      a labeled line (data-col drives the label), so budgets/actions stay usable
      on a phone instead of overflowing horizontally. */
+  .keys-table {
+    min-width: 0;
+  }
   .keys-table thead {
     display: none;
   }

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -216,10 +216,29 @@ body.console {
 
 .key-budget-form {
   display: grid;
-  grid-template-columns: minmax(110px, 1fr) auto;
+  grid-template-columns: 1fr auto;
   gap: 8px;
-  align-items: center;
-  max-width: 260px;
+  align-items: end;
+  max-width: 520px;
+}
+
+.key-budget-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(84px, 1fr));
+  gap: 8px;
+}
+
+.key-budget-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.key-budget-grid input {
+  width: 100%;
+  min-width: 0;
 }
 
 .key-budget-form .btn {
@@ -231,6 +250,22 @@ body.console {
   margin-top: 5px;
   color: var(--muted);
   font-size: 12px;
+}
+
+.key-window-note {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 2px 0 12px;
+}
+
+.key-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.key-row-disabled td {
+  opacity: 0.75;
 }
 
 .warning-note {
@@ -411,5 +446,49 @@ body.console {
   }
   .secret-row {
     grid-template-columns: 1fr;
+  }
+  /* Keys table -> stacked cards: each row becomes a bordered block, each cell
+     a labeled line (data-col drives the label), so budgets/actions stay usable
+     on a phone instead of overflowing horizontally. */
+  .keys-table thead {
+    display: none;
+  }
+  .keys-table,
+  .keys-table tbody,
+  .keys-table tr,
+  .keys-table td {
+    display: block;
+    width: 100%;
+  }
+  .keys-table tr {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+    margin-bottom: 12px;
+  }
+  .keys-table td {
+    border-bottom: 0;
+    padding: 6px 0;
+  }
+  .keys-table td[data-col]::before {
+    content: attr(data-col);
+    display: block;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .key-budget-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .key-budget-form {
+    grid-template-columns: 1fr;
+    max-width: none;
+  }
+  .key-actions .btn {
+    flex: 1 1 auto;
+    justify-content: center;
   }
 }

--- a/src/trusted_router/templates/console/api_keys.html
+++ b/src/trusted_router/templates/console/api_keys.html
@@ -1,5 +1,8 @@
 {% extends "console/_layout.html" %}
 {% block body %}
+{% if flash %}
+<div class="console-flash {{ flash[0] }}" role="status">{{ flash[1] }}</div>
+{% endif %}
 {% if created_key %}
 <section class="panel">
   <div class="panel-head"><h2>Save this key. It will not be shown again</h2><span class="pill warn">one time reveal</span></div>
@@ -20,34 +23,64 @@
     <form class="form" method="post" action="/console/api-keys">
       <div class="row">
         <label>Name<input name="name" required placeholder="Production key" maxlength="120"></label>
-        <label>Budget (USD, optional)<input name="limit" type="number" min="0" step="0.000001" placeholder="e.g. 100"></label>
+        <label>Total budget (USD, optional)<input name="limit" type="number" min="0" step="0.000001" placeholder="e.g. 100"></label>
       </div>
+      <div class="row key-window-row">
+        <label>Daily limit (USD, optional)<input name="limit_daily" type="number" min="0" step="0.000001" placeholder="e.g. 5"></label>
+        <label>Weekly limit (USD, optional)<input name="limit_weekly" type="number" min="0" step="0.000001" placeholder="e.g. 25"></label>
+        <label>Monthly limit (USD, optional)<input name="limit_monthly" type="number" min="0" step="0.000001" placeholder="e.g. 80"></label>
+      </div>
+      <p class="key-window-note">Window limits reset at UTC midnight / Monday / the 1st. Enforcement is approximate: a burst of in-flight requests can slightly overshoot. Agents can read their remaining budget from <code>GET /v1/key</code>.</p>
       <button class="btn primary" type="submit">Create key</button>
     </form>
   </div>
 </section>
 <section class="panel">
-  <div class="panel-head"><h2>Existing keys</h2><span class="pill">{{ keys|length }} active</span></div>
+  <div class="panel-head"><h2>Existing keys</h2><span class="pill">{{ keys|length }} total</span></div>
   <div class="panel-body">
-    <table>
-      <thead><tr><th>Name</th><th>Label</th><th>Budget</th><th>Status</th></tr></thead>
+    <table class="keys-table">
+      <thead><tr><th>Name</th><th>Label</th><th>Budgets</th><th>Status</th><th>Actions</th></tr></thead>
       <tbody>
         {% for k in keys %}
-        <tr>
-          <td>{{ k.name }}</td>
-          <td><code>{{ k.label }}</code></td>
-          <td>
+        <tr class="key-row{% if k.disabled %} key-row-disabled{% endif %}">
+          <td data-col="Name">{{ k.name }}</td>
+          <td data-col="Label"><code>{{ k.label }}</code></td>
+          <td data-col="Budgets">
             <form class="key-budget-form" method="post" action="/console/api-keys/{{ k.hash }}/limit">
-              <input name="limit" type="number" min="0" step="0.000001" placeholder="unlimited" value="{{ k.limit_input }}" aria-label="Budget for {{ k.name }}">
+              <div class="key-budget-grid">
+                <label>Total<input name="limit" type="number" min="0" step="0.000001" placeholder="unlimited" value="{{ k.limit_input }}" aria-label="Total budget for {{ k.name }}"></label>
+                {% for w in k.windows %}
+                <label>{{ w.name|capitalize }}<input name="limit_{{ w.name }}" type="number" min="0" step="0.000001" placeholder="off" value="{{ w.input }}" aria-label="{{ w.name|capitalize }} limit for {{ k.name }}"></label>
+                {% endfor %}
+              </div>
               <button class="btn" type="submit">Save</button>
             </form>
-            <div class="key-budget-current">Current: {{ k.limit_display }}</div>
+            <div class="key-budget-current">
+              Used {{ k.usage_display }}{% if k.limit_display != 'none' %} of {{ k.limit_display }}{% endif %}
+              {%- for w in k.windows if w.limit_display %} · {{ w.name }} {{ w.used_display }} / {{ w.limit_display }}{% endfor %}
+            </div>
           </td>
-          <td>{% if k.disabled %}<span class="pill warn">disabled</span>{% else %}<span class="pill good">active</span>{% endif %}</td>
+          <td data-col="Status">{% if k.disabled %}<span class="pill warn">disabled</span>{% else %}<span class="pill good">active</span>{% endif %}</td>
+          <td data-col="Actions">
+            <div class="key-actions">
+              {% if k.disabled %}
+              <form class="inline-form" method="post" action="/console/api-keys/{{ k.hash }}/enable">
+                <button class="btn" type="submit">Enable</button>
+              </form>
+              <form class="inline-form" method="post" action="/console/api-keys/{{ k.hash }}/delete">
+                <button class="btn danger" type="submit" title="Permanently delete this key">Delete</button>
+              </form>
+              {% else %}
+              <form class="inline-form" method="post" action="/console/api-keys/{{ k.hash }}/disable">
+                <button class="btn" type="submit" title="Stop this key from authorizing requests. Disable first to delete.">Disable</button>
+              </form>
+              {% endif %}
+            </div>
+          </td>
         </tr>
         {% endfor %}
         {% if not keys %}
-        <tr><td class="empty" colspan="4">No keys yet. Create one above.</td></tr>
+        <tr><td class="empty" colspan="5">No keys yet. Create one above.</td></tr>
         {% endif %}
       </tbody>
     </table>

--- a/src/trusted_router/templates/console/api_keys.html
+++ b/src/trusted_router/templates/console/api_keys.html
@@ -38,6 +38,7 @@
 <section class="panel">
   <div class="panel-head"><h2>Existing keys</h2><span class="pill">{{ keys|length }} total</span></div>
   <div class="panel-body">
+    <div class="table-scroll">
     <table class="keys-table">
       <thead><tr><th>Name</th><th>Label</th><th>Budgets</th><th>Status</th><th>Actions</th></tr></thead>
       <tbody>
@@ -84,6 +85,7 @@
         {% endif %}
       </tbody>
     </table>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/tests/test_console_keys_manage.py
+++ b/tests/test_console_keys_manage.py
@@ -109,3 +109,20 @@ def test_cross_workspace_key_is_404(console: dict, client: TestClient) -> None:
             f"/console/api-keys/{other_key.hash}/{action}", follow_redirects=False
         )
         assert resp.status_code == 404
+
+
+def test_member_cannot_disable_enable_or_delete(console: dict, client: TestClient) -> None:
+    """codex #94: disable/enable/delete are manager-only; a plain workspace
+    member gets 403 (budget edits keep pre-existing member-level access)."""
+    workspace, key = console["workspace"], console["key"]
+    member = STORE.add_members(workspace.id, ["member@example.com"], role="member")[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=member.user_id, provider="test", label="m", ttl_seconds=3600,
+        workspace_id=workspace.id, state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    for action in ("disable", "enable", "delete"):
+        resp = client.post(f"/console/api-keys/{key.hash}/{action}", follow_redirects=False)
+        assert resp.status_code == 403, (action, resp.status_code)
+    assert STORE.get_key_by_hash(key.hash) is not None
+    assert STORE.get_key_by_hash(key.hash).disabled is False

--- a/tests/test_console_keys_manage.py
+++ b/tests/test_console_keys_manage.py
@@ -1,0 +1,111 @@
+"""Console key management: disable/enable toggle, disable-first delete, and
+window-limit budget edits — the form-POST -> 303 flash pattern."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.storage import STORE
+
+
+@pytest.fixture
+def console(client: TestClient) -> dict:
+    """A signed-in console session + one API key in the workspace."""
+    user = STORE.ensure_user("console-keys@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id, provider="test", label="t", ttl_seconds=3600,
+        workspace_id=workspace.id, state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    _raw, key = STORE.create_api_key(
+        workspace_id=workspace.id, name="prod key", creator_user_id=user.id
+    )
+    return {"client": client, "workspace": workspace, "key": key}
+
+
+def test_disable_enable_toggle(console: dict) -> None:
+    client, key = console["client"], console["key"]
+    resp = client.post(f"/console/api-keys/{key.hash}/disable", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/console/api-keys?saved=disabled"
+    assert STORE.get_key_by_hash(key.hash).disabled is True
+
+    page = client.get("/console/api-keys?saved=disabled")
+    assert "Key disabled" in page.text  # flash banner
+    assert "Enable" in page.text and "Delete" in page.text
+
+    resp = client.post(f"/console/api-keys/{key.hash}/enable", follow_redirects=False)
+    assert resp.status_code == 303
+    assert STORE.get_key_by_hash(key.hash).disabled is False
+
+
+def test_delete_requires_disabled_first(console: dict) -> None:
+    client, key = console["client"], console["key"]
+    # Active key: delete refused, key survives.
+    resp = client.post(f"/console/api-keys/{key.hash}/delete", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/console/api-keys?error=delete-active"
+    assert STORE.get_key_by_hash(key.hash) is not None
+
+    # Disable, then delete succeeds.
+    client.post(f"/console/api-keys/{key.hash}/disable", follow_redirects=False)
+    resp = client.post(f"/console/api-keys/{key.hash}/delete", follow_redirects=False)
+    assert resp.headers["location"] == "/console/api-keys?saved=deleted"
+    assert STORE.get_key_by_hash(key.hash) is None
+
+
+def test_budget_form_saves_window_limits(console: dict) -> None:
+    client, key = console["client"], console["key"]
+    resp = client.post(
+        f"/console/api-keys/{key.hash}/limit",
+        data={"limit": "100", "limit_daily": "5", "limit_weekly": "", "limit_monthly": "80"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/console/api-keys?saved=limit"
+    updated = STORE.get_key_by_hash(key.hash)
+    assert updated.limit_microdollars == 100_000_000
+    assert updated.limit_daily_microdollars == 5_000_000
+    assert updated.limit_weekly_microdollars is None  # empty input clears
+    assert updated.limit_monthly_microdollars == 80_000_000
+
+    # Negative rejected with the flash error, nothing changed.
+    resp = client.post(
+        f"/console/api-keys/{key.hash}/limit",
+        data={"limit": "-1"},
+        follow_redirects=False,
+    )
+    assert resp.headers["location"] == "/console/api-keys?error=limit"
+    assert STORE.get_key_by_hash(key.hash).limit_microdollars == 100_000_000
+
+    # The page shows the window usage line for keys with window limits.
+    page = client.get("/console/api-keys")
+    assert "daily" in page.text and "monthly" in page.text
+
+
+def test_create_form_accepts_window_limits(console: dict) -> None:
+    client, workspace = console["client"], console["workspace"]
+    resp = client.post(
+        "/console/api-keys",
+        data={"name": "windowed", "limit": "", "limit_daily": "2.50"},
+    )
+    assert resp.status_code == 200
+    created = [k for k in STORE.list_keys(workspace.id) if k.name == "windowed"]
+    assert len(created) == 1
+    assert created[0].limit_microdollars is None
+    assert created[0].limit_daily_microdollars == 2_500_000
+
+
+def test_cross_workspace_key_is_404(console: dict, client: TestClient) -> None:
+    other = STORE.ensure_user("other-ws@example.com")
+    other_ws = STORE.list_workspaces_for_user(other.id)[0]
+    _raw, other_key = STORE.create_api_key(
+        workspace_id=other_ws.id, name="other", creator_user_id=other.id
+    )
+    for action in ("disable", "enable", "delete"):
+        resp = console["client"].post(
+            f"/console/api-keys/{other_key.hash}/{action}", follow_redirects=False
+        )
+        assert resp.status_code == 404

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -780,7 +780,7 @@ def test_console_api_key_budget_can_be_edited_and_cleared(
 
     updated_page = client.get("/console/api-keys")
     assert 'value="25.123456"' in updated_page.text
-    assert "Current: $25.12" in updated_page.text
+    assert "of $25.12" in updated_page.text  # "Used $X of $25.12" budget line
 
     cleared = client.post(
         f"/console/api-keys/{key.hash}/limit",


### PR DESCRIPTION
Console UI for key management, stacked on #93 (retarget to main after it merges): disable/enable toggle actions, delete gated on disabled-first (drains in-flight holds — sidesteps #29), optional Daily/Weekly/Monthly budget inputs with live 'used X of Y' from one typed point-read, flash banners, and a stacked-card mobile layout for the keys table. Visual pass (desktop+mobile, dark+light) follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)