### PR TITLE
gateway(internal): key self-introspection for the enclave /v1/key relay

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -84,6 +84,30 @@ def register(router: APIRouter) -> None:
             }
         }
 
+    @router.post("/internal/gateway/key")
+    async def gateway_key_info(
+        request: Request,
+        body: GatewayValidateRequest,
+        settings: SettingsDep,
+    ) -> dict[str, Any]:
+        """Key self-introspection for the enclave: the /v1/key passthrough.
+
+        The enclave NEVER forwards the raw bearer to the control plane (the
+        attested contract; authorize sends a lookup hash) — so agent budget
+        reads come through here keyed by the same lookup hash + internal
+        token. Deliberately no billing-pause gate: reading your own limits
+        while paused is a harmless, useful read."""
+        require_internal_gateway(request, settings)
+        api_key = _api_key_for_gateway_lookup(
+            api_key_hash=body.api_key_hash,
+            api_key_lookup_hash=body.api_key_lookup_hash,
+        )
+        if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
+            raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+        from trusted_router.routes.keys import _enriched_key_shape
+
+        return {"data": _enriched_key_shape(api_key)}
+
     @router.post("/internal/gateway/resolve-custom-model")
     async def gateway_resolve_custom_model(
         request: Request,

--- a/tests/test_gateway_key_info.py
+++ b/tests/test_gateway_key_info.py
@@ -63,3 +63,35 @@ def test_key_info_allowed_while_workspace_paused(client: TestClient) -> None:
         assert resp.status_code == 200, resp.text
     finally:
         STORE.update_workspace(key.workspace_id, billing_paused=False)
+
+
+def test_key_info_requires_internal_token_when_configured() -> None:
+    """codex #95: prove the internal gateway token is enforced (the default
+    test fixture leaves it None, so the other tests don't exercise it)."""
+    from fastapi.testclient import TestClient
+
+    from trusted_router.config import Settings
+    from trusted_router.main import create_app
+
+    internal_token = "internal" + "-keyinfo-token"
+    app = create_app(Settings(environment="test", internal_gateway_token=internal_token))
+    tc = TestClient(app)
+    user = STORE.ensure_user("keyinfo-tok@example.com")
+    ws = STORE.list_workspaces_for_user(user.id)[0]
+    _raw, key = STORE.create_api_key(workspace_id=ws.id, name="k", creator_user_id=user.id)
+    body = {"api_key_lookup_hash": key.lookup_hash}
+
+    missing = tc.post("/v1/internal/gateway/key", json=body)
+    wrong = tc.post(
+        "/v1/internal/gateway/key",
+        headers={"x-trustedrouter-internal-token": "wrong"},
+        json=body,
+    )
+    correct = tc.post(
+        "/v1/internal/gateway/key",
+        headers={"x-trustedrouter-internal-token": internal_token},
+        json=body,
+    )
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert correct.status_code == 200, correct.text

--- a/tests/test_gateway_key_info.py
+++ b/tests/test_gateway_key_info.py
@@ -1,0 +1,65 @@
+"""POST /internal/gateway/key — the enclave's /v1/key passthrough backend.
+
+Keyed by api_key_lookup_hash + the internal gateway token so the raw bearer
+NEVER leaves the enclave (the attested contract; authorize does the same).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.storage import STORE
+
+
+def _make_key(**kwargs):
+    user = STORE.ensure_user("keyinfo@example.com")
+    ws = STORE.list_workspaces_for_user(user.id)[0]
+    raw, key = STORE.create_api_key(
+        workspace_id=ws.id, name="k", creator_user_id=user.id, **kwargs
+    )
+    return raw, key
+
+
+def test_key_info_by_lookup_hash_returns_budget_fields(client: TestClient) -> None:
+    _raw, key = _make_key(limit_daily_microdollars=2_000_000)
+    resp = client.post(
+        "/v1/internal/gateway/key",
+        json={"api_key_lookup_hash": key.lookup_hash},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["hash"] == key.hash
+    assert data["limit_daily"] == 2.0
+    assert data["limit_daily_resets_at"].endswith("Z")
+    assert "usage_daily_microdollars" in data
+
+
+def test_key_info_rejects_disabled_and_unknown(client: TestClient) -> None:
+    _raw, key = _make_key()
+    STORE.update_key(key.hash, {"disabled": True})
+    resp = client.post(
+        "/v1/internal/gateway/key",
+        json={"api_key_lookup_hash": key.lookup_hash},
+    )
+    assert resp.status_code == 401
+
+    resp = client.post(
+        "/v1/internal/gateway/key",
+        json={"api_key_lookup_hash": "sha256-of-nothing"},
+    )
+    assert resp.status_code == 401
+
+
+def test_key_info_allowed_while_workspace_paused(client: TestClient) -> None:
+    """Reading your own budget while billing-paused is a harmless read — the
+    pause gate deliberately does not apply here."""
+    _raw, key = _make_key()
+    STORE.update_workspace(key.workspace_id, billing_paused=True)
+    try:
+        resp = client.post(
+            "/v1/internal/gateway/key",
+            json={"api_key_lookup_hash": key.lookup_hash},
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        STORE.update_workspace(key.workspace_id, billing_paused=False)


### PR DESCRIPTION
Backend for forwarding `GET api.trustedrouter.com/v1/key` through the enclave WITHOUT the raw bearer crossing the attested boundary (codex enclave-review finding): `POST /internal/gateway/key` keyed by `api_key_lookup_hash` + internal gateway token, returning the enriched key shape (live typed usage + window budgets). Enclave-side relay ships after this deploys. 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)