### PR TITLE
test: fix stale ZDR privacy-tier tests after 4faa10d (unblock red main)

### DIFF
--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -428,7 +428,10 @@ def test_public_legal_dpa_baa_and_subprocessors_are_honest(client: TestClient) -
     anthropic = next(
         row for row in payload["model_provider_subprocessors"] if row["id"] == "anthropic"
     )
-    assert anthropic["zdr"] is True
+    # anthropic was downgraded from ZDR to standard in 4faa10d ("excluded from
+    # trustedrouter/zdr until that posture is reverified") — the subprocessor
+    # page must reflect that honestly.
+    assert anthropic["zdr"] is False
 
 
 def test_public_soc2_and_hipaa_readiness_pages_are_explicitly_not_reports(

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -358,9 +358,11 @@ def test_min_privacy_too_high_for_model_raises() -> None:
 def test_model_shape_exposes_privacy_tier() -> None:
     from trusted_router.catalog import MODELS, model_to_openrouter_shape
 
-    # Anthropic is zero-retention → tier label present and >= ZDR.
-    anth = next(m for m in MODELS.values() if m.provider == "anthropic")
-    shape = model_to_openrouter_shape(anth)
+    # A model served by a zero-retention+ provider (deepseek via phala/tinfoil)
+    # exposes the tier label and >= ZDR. (anthropic/openai/google were downgraded
+    # from ZDR to standard in 4faa10d, so they no longer clear tier 2.)
+    zdr_model = MODELS["deepseek/deepseek-v3.2"]
+    shape = model_to_openrouter_shape(zdr_model)
     tr = shape["trustedrouter"]
     assert "privacy_tier" in tr
     assert "privacy_tier_label" in tr
@@ -368,13 +370,15 @@ def test_model_shape_exposes_privacy_tier() -> None:
 
 
 def test_data_collection_deny_keeps_zdr_drops_standard() -> None:
-    # deny == "no data collection" → require >= no-store tier. ZDR
-    # providers (anthropic) carry the conservative stores_content=True
-    # default but must NOT be dropped; standard providers must be.
+    # deny == "no data collection" → require >= no-store tier. A model on a
+    # no-store+ provider (deepseek via phala/tinfoil) must be KEPT; a model only
+    # on standard providers must be dropped. NOTE: anthropic/openai/google were
+    # downgraded from ZDR to standard in 4faa10d ("excluded from trustedrouter/zdr
+    # until reverified"), so they are no longer the ZDR example.
     from trusted_router.catalog import PRIVACY_TIER_NO_STORE, model_max_privacy_tier
 
     kept = chat_route_candidates(
-        {"model": "anthropic/claude-sonnet-4.6", "provider": {"data_collection": "deny"}},
+        {"model": "deepseek/deepseek-v3.2", "provider": {"data_collection": "deny"}},
         _settings(),
     )
     assert kept and all(model_max_privacy_tier(m) >= PRIVACY_TIER_NO_STORE for m in kept)


### PR DESCRIPTION
**Main is currently red** from `4faa10d "Fix ZDR provider flags"` — that commit intentionally downgraded anthropic/openai/google from ZDR to standard (documented: "excluded from trustedrouter/zdr until that posture is reverified") but left 3 tests asserting the old anthropic=ZDR assumption. This aligns those stale tests to the new (correct) posture: the two routing tests use `deepseek/deepseek-v3.2` (genuinely no-store via phala/tinfoil) for the ZDR-kept assertions, and the subprocessor-honesty test asserts `anthropic['zdr'] is False`. Test-only; full suite **1177 green**. Merges first to unblock #42/#102/etc.

@josephperla — flagging since it's your compliance flag change: confirm anthropic/openai/google being not-ZDR is the intended posture (I read the commit as deliberate). If claude models should still route no-store via TR's own gateway, that'd be a separate catalog fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)