### PR TITLE
Extract catalog_privacy.py + routing_candidates.py — complete #38 catalog split

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -108,6 +108,18 @@ from trusted_router.catalog_ingest import (  # noqa: F401 - used by import-time 
     _is_provider_deprecated_model,
     _supplemental_provider_models_and_endpoints,
 )
+
+# Privacy tiers + routing candidate selection were split into dedicated
+# modules (#38); re-exported here so `from trusted_router.catalog import ...`
+# keeps working for every existing caller.
+from trusted_router.catalog_privacy import (  # noqa: F401 - re-exported for back-compat
+    endpoint_privacy_tier,
+    model_provider_policy,
+    model_provider_policy_url,
+    model_provider_privacy_tier,
+    model_provider_zero_data_retention,
+    provider_privacy_tier,
+)
 from trusted_router.catalog_registry import (  # noqa: F401 - built there, re-exported
     MODEL_ENDPOINTS,
     MODELS,
@@ -136,75 +148,25 @@ from trusted_router.pricing import (  # noqa: F401 - re-exported for back-compat
     cache_token_prices_microdollars,
     select_price_tier,
 )
-
-# Privacy-posture tier logic (the PRIVACY_TIER_* ranks + aliases these read now
-# live in catalog_data; these functions apply them).
-
-
-
-
-
-def provider_privacy_tier(provider: Provider) -> int:
-    """The highest privacy bar a provider clears. Used to enforce a
-    request's minimum-privacy routing preference. Note the TR gateway hop
-    is always attested regardless of tier — this rank is about the
-    UPSTREAM provider's posture, which is what varies."""
-    if provider.provider_confidential_compute and provider.provider_e2ee:
-        return PRIVACY_TIER_CONFIDENTIAL
-    if provider.provider_zero_data_retention:
-        return PRIVACY_TIER_ZERO_RETENTION
-    if provider.stores_content is False:
-        return PRIVACY_TIER_NO_STORE
-    return PRIVACY_TIER_STANDARD
-
-
-
-
-
-
-def model_provider_privacy_tier(model_id: str, provider_slug: str) -> int:
-    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
-    if override is not None:
-        return override.privacy_tier
-    return provider_privacy_tier(PROVIDERS[provider_slug])
-
-
-def endpoint_privacy_tier(endpoint: ModelEndpoint) -> int:
-    return model_provider_privacy_tier(endpoint.model_id, endpoint.provider)
-
-
-def model_provider_zero_data_retention(model_id: str, provider_slug: str) -> bool | None:
-    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
-    if override is not None and override.provider_zero_data_retention is not None:
-        return override.provider_zero_data_retention
-    return PROVIDERS[provider_slug].provider_zero_data_retention
-
-
-def model_provider_policy(model_id: str, provider_slug: str) -> str:
-    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
-    if override is not None and override.provider_policy is not None:
-        return override.provider_policy
-    return PROVIDERS[provider_slug].provider_policy
-
-
-def model_provider_policy_url(model_id: str, provider_slug: str) -> str | None:
-    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
-    if override is not None and override.provider_policy_url is not None:
-        return override.provider_policy_url
-    return PROVIDERS[provider_slug].provider_policy_url
-
-
-
-
-
-
-
-
-
-
-
-
-
+from trusted_router.routing_candidates import (  # noqa: F401 - re-exported for back-compat
+    InvalidAutoModelOrder,
+    _is_regular_chat_model,
+    _meta_route_kind,
+    _models_for_ids,
+    _price_sort_key,
+    _privacy_candidate_models,
+    auto_candidate_models,
+    cheap_candidate_models,
+    e2e_candidate_models,
+    eu_candidate_models,
+    fast_candidate_models,
+    free_candidate_models,
+    meta_candidate_models,
+    monitor_candidate_models,
+    socrates_candidate_models,
+    validate_auto_model_order,
+    zdr_candidate_models,
+)
 
 # Uniform pricing: customer pays cost + 10%, floor $0.01/M tokens. Same
 # value goes into both `prompt_price_*` and `published_*` — TR no longer
@@ -320,353 +282,6 @@ def default_endpoint_for_model(model: Model) -> ModelEndpoint | None:
     return endpoints[0]
 
 
-class InvalidAutoModelOrder(ValueError):
-    """Raised when TR_AUTO_MODEL_ORDER includes a router/orchestration model."""
-
-
-def validate_auto_model_order(order: str | None = None) -> None:
-    raw_ids = [
-        item.strip()
-        for item in (order.split(",") if order else DEFAULT_AUTO_MODEL_ORDER)
-        if item.strip()
-    ]
-    meta_ids = [model_id for model_id in raw_ids if model_id in META_MODEL_IDS]
-    if meta_ids:
-        joined = ", ".join(meta_ids)
-        raise InvalidAutoModelOrder(
-            "TR_AUTO_MODEL_ORDER cannot include TrustedRouter meta or orchestration "
-            f"models: {joined}. Use regular provider/model IDs only."
-        )
-
-
-def auto_candidate_models(order: str | None = None) -> list[Model]:
-    raw_ids = [
-        item.strip()
-        for item in (order.split(",") if order else DEFAULT_AUTO_MODEL_ORDER)
-        if item.strip()
-    ]
-    validate_auto_model_order(order)
-    candidates: list[Model] = []
-    seen: set[str] = set()
-    for model_id in raw_ids:
-        if model_id in seen:
-            continue
-        model = MODELS.get(model_id)
-        if model is not None and _is_regular_chat_model(model):
-            candidates.append(model)
-            seen.add(model_id)
-    return candidates
-
-
-def free_candidate_models(limit: int = 16) -> list[Model]:
-    candidates = [
-        model
-        for model in MODELS.values()
-        if _is_regular_chat_model(model) and model.id.endswith(":free")
-    ]
-    candidates.sort(key=_price_sort_key)
-    return candidates[:limit]
-
-
-def cheap_candidate_models(limit: int = 8) -> list[Model]:
-    by_provider: dict[str, Model] = {}
-    for model in MODELS.values():
-        if not _is_regular_chat_model(model) or model.id.endswith(":free"):
-            continue
-        current = by_provider.get(model.provider)
-        if current is None or _price_sort_key(model) < _price_sort_key(current):
-            by_provider[model.provider] = model
-    return sorted(by_provider.values(), key=_price_sort_key)[:limit]
-
-
-def fast_candidate_models(limit: int = 8) -> list[Model]:
-    # Low-latency pool: Cerebras first, then Xiaomi MiMo's UltraSpeed tier.
-    # Keep this as a small explicit pool so callers who choose
-    # `trustedrouter/fast` do not accidentally get a cheap-but-slower model
-    # just because it has a lower token price.
-    preferred_ids = [
-        "cerebras/gpt-oss-120b",
-        "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "xiaomi/mimo-v2-flash",
-        "cerebras/zai-glm-4.7",
-    ]
-    candidates: list[Model] = []
-    seen: set[str] = set()
-    for model_id in preferred_ids:
-        model = MODELS.get(model_id)
-        if model is not None and _is_regular_chat_model(model):
-            candidates.append(model)
-            seen.add(model.id)
-        if len(candidates) >= limit:
-            return candidates
-    return candidates
-
-
-def monitor_candidate_models(limit: int = 12) -> list[Model]:
-    # Order favors models that reliably emit a visible one-token PONG.
-    # DeepSeek V4 Flash is cheaper, but in thinking-default mode it can spend
-    # the entire tiny output budget on hidden reasoning and return an empty
-    # visible message. That is a false status-page outage. Keep cheap reasoning
-    # models in the tail; use visible-output models for the steady-state probe.
-    #
-    # Costs at 2026-06 prices ($/M tokens, in / out):
-    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← lead (4 providers)
-    #   deepseek/deepseek-v3.2        0.308 / 0.495   ← same-family backup
-    #   deepseek/deepseek-v4-pro      0.478 / 0.957   ← +tinfoil +gmi
-    #   mistralai/mistral-small-2603  0.165 / 0.660   ← cross-provider
-    #   openai/gpt-4.1-mini           0.440 / 1.760
-    #   z-ai/glm-4.5-air              0.220 / 1.210
-    #   google/gemini-2.5-flash       0.330 / 2.750
-    #   z-ai/glm-4.6                  0.660 / 2.420   ← reasoning, tail
-    #   moonshotai/kimi-k2.6          0.880 / 3.850   ← reasoning, tail
-    #   anthropic/claude-haiku-4.5    1.100 / 5.500   ← most expensive
-    preferred_ids = [
-        "openai/gpt-4.1-mini",
-        "mistralai/mistral-small-2603",
-        "google/gemini-2.5-flash",
-        "anthropic/claude-haiku-4.5",
-        "deepseek/deepseek-v4-flash",
-        "deepseek/deepseek-v3.2",
-        "deepseek/deepseek-v4-pro",
-        "z-ai/glm-4.5-air",
-        "z-ai/glm-4.6",
-        "moonshotai/kimi-k2.6",
-    ]
-    candidates: list[Model] = []
-    seen: set[str] = set()
-    for model_id in preferred_ids:
-        model = MODELS.get(model_id)
-        if model is not None and _is_regular_chat_model(model) and not model.id.endswith(":free"):
-            candidates.append(model)
-            seen.add(model.id)
-    for model in cheap_candidate_models(limit=limit * 2):
-        if model.id not in seen:
-            candidates.append(model)
-            seen.add(model.id)
-        if len(candidates) >= limit:
-            break
-    return candidates[:limit]
-
-
-def _privacy_candidate_models(
-    *,
-    min_tier: int,
-    preferred_providers: tuple[str, ...] = (),
-    allowed_providers: frozenset[str] | None = None,
-    limit: int = 12,
-) -> list[Model]:
-    """Unique chat models with at least one endpoint clearing min_tier.
-
-    This builds the model-level rollover ladder. The routing layer forces the
-    same privacy floor, so the gateway still picks only qualifying endpoints.
-    """
-    provider_rank = {provider: index for index, provider in enumerate(preferred_providers)}
-    eligible: list[tuple[int, int, int, str, Model]] = []
-    per_provider: dict[str, list[tuple[int, int, Model]]] = {}
-    for endpoint in MODEL_ENDPOINTS.values():
-        provider = PROVIDERS.get(endpoint.provider)
-        model = MODELS.get(endpoint.model_id)
-        if (
-            provider is None
-            or model is None
-            or not _is_regular_chat_model(model)
-            or model.id.endswith(":free")
-            or endpoint_privacy_tier(endpoint) < min_tier
-        ):
-            continue
-        if allowed_providers is not None and endpoint.provider not in allowed_providers:
-            continue
-        price = (
-            endpoint.prompt_price_microdollars_per_million_tokens
-            + endpoint.completion_price_microdollars_per_million_tokens
-        )
-        usage_rank = 0 if endpoint.usage_type == "Credits" else 1
-        rank = provider_rank.get(endpoint.provider, len(provider_rank))
-        eligible.append((rank, usage_rank, price, endpoint.provider, model))
-        per_provider.setdefault(endpoint.provider, []).append((usage_rank, price, model))
-
-    result: list[Model] = []
-    seen: set[str] = set()
-    for provider_slug in preferred_providers:
-        options = sorted(
-            per_provider.get(provider_slug, []),
-            key=lambda item: (item[0], item[1], item[2].provider, item[2].id),
-        )
-        for _usage_rank, _price, model in options:
-            if model.id not in seen:
-                result.append(model)
-                seen.add(model.id)
-                break
-        if len(result) >= limit:
-            return result
-
-    for _rank, _usage_rank, _price, _provider, model in sorted(
-        eligible,
-        key=lambda item: (item[0], item[1], item[2], item[3], item[4].provider, item[4].id),
-    ):
-        if model.id in seen:
-            continue
-        result.append(model)
-        seen.add(model.id)
-        if len(result) >= limit:
-            break
-    return result
-
-
-def eu_candidate_models(limit: int = 12) -> list[Model]:
-    return _privacy_candidate_models(
-        min_tier=PRIVACY_TIER_STANDARD,
-        preferred_providers=EU_FOCUSED_PROVIDER_ORDER,
-        allowed_providers=frozenset(EU_FOCUSED_PROVIDER_ORDER),
-        limit=limit,
-    )
-
-
-def zdr_candidate_models(limit: int = 12) -> list[Model]:
-    return _privacy_candidate_models(
-        min_tier=PRIVACY_TIER_ZERO_RETENTION,
-        preferred_providers=("anthropic", "openai", "gemini", "tinfoil", "venice", "phala"),
-        limit=limit,
-    )
-
-
-def e2e_candidate_models(limit: int = 12) -> list[Model]:
-    return _privacy_candidate_models(
-        min_tier=PRIVACY_TIER_CONFIDENTIAL,
-        preferred_providers=("tinfoil", "venice", "phala", "gmi"),
-        limit=limit,
-    )
-
-
-def _models_for_ids(model_ids: tuple[str, ...]) -> list[Model]:
-    models: list[Model] = []
-    seen: set[str] = set()
-    for model_id in model_ids:
-        if model_id in seen or model_id not in MODELS:
-            continue
-        seen.add(model_id)
-        models.append(MODELS[model_id])
-    return models
-
-
-def socrates_candidate_models() -> list[Model]:
-    return _models_for_ids(SOCRATES_CATALOG_MODEL_ORDER)
-
-
-def meta_candidate_models(model_id: str) -> list[Model]:
-    if model_id == AUTO_MODEL_ID:
-        return auto_candidate_models()
-    if model_id == FREE_MODEL_ID:
-        return free_candidate_models()
-    if model_id == CHEAP_MODEL_ID:
-        return cheap_candidate_models()
-    if model_id == FAST_MODEL_ID:
-        return fast_candidate_models()
-    if model_id == EU_MODEL_ID:
-        return eu_candidate_models()
-    if model_id == ZDR_MODEL_ID:
-        return zdr_candidate_models()
-    if model_id == E2E_MODEL_ID:
-        return e2e_candidate_models()
-    if model_id == MONITOR_MODEL_ID:
-        return monitor_candidate_models()
-    advisor_order = ADVISOR_CATALOG_MODEL_ORDERS.get(model_id)
-    if advisor_order is not None:
-        return _models_for_ids(advisor_order)
-    if model_id == PROMETHEUS_1_0_1M_MODEL_ID:
-        return _models_for_ids(SYNTH_QUALITY_1M_MODEL_ORDER)
-    if model_id in (PROMETHEUS_MODEL_ID, PROMETHEUS_1_0_MODEL_ID):
-        return _models_for_ids(SYNTH_QUALITY_MODEL_ORDER)
-    if model_id in (IRIS_MODEL_ID, IRIS_1_0_MODEL_ID):
-        return _models_for_ids(SYNTH_BUDGET_MODEL_ORDER)
-    if model_id in (ZEUS_MODEL_ID, ZEUS_1_0_MODEL_ID):
-        return _models_for_ids(SYNTH_FRONTIER_MODEL_ORDER)
-    if model_id == ZEUS_1_0_MINI_MODEL_ID:
-        return _models_for_ids(SYNTH_FRONTIER_MINI_MODEL_ORDER)
-    if model_id == OPEN_PATCHER_S1_MODEL_ID:
-        return _models_for_ids(
-            (
-                "moonshotai/kimi-k2.7-code",
-                "z-ai/glm-5.2",
-            )
-        )
-    if model_id in (
-        PROMETHEUS_CODE_MODEL_ID,
-        PROMETHEUS_CODE_1_0_MODEL_ID,
-    ):
-        return _models_for_ids(SYNTH_CODE_QUALITY_MODEL_ORDER)
-    if model_id in (IRIS_CODE_MODEL_ID, IRIS_CODE_1_0_MODEL_ID):
-        return _models_for_ids(SYNTH_CODE_BUDGET_MODEL_ORDER)
-    if model_id in (ZEUS_CODE_MODEL_ID, ZEUS_CODE_1_0_MODEL_ID):
-        return _models_for_ids(SYNTH_CODE_FRONTIER_MODEL_ORDER)
-    if model_id == SELECTOR_MODEL_ID:
-        return _models_for_ids(SELECTOR_CATALOG_MODEL_ORDER)
-    if model_id == MAPREDUCE_MODEL_ID:
-        return _models_for_ids(MAPREDUCE_CATALOG_MODEL_ORDER)
-    return []
-
-
-def _meta_route_kind(model_id: str) -> str:
-    if model_id == FREE_MODEL_ID:
-        return "free_pool"
-    if model_id == CHEAP_MODEL_ID:
-        return "cheap_pool"
-    if model_id == FAST_MODEL_ID:
-        return "fast_pool"
-    if model_id == EU_MODEL_ID:
-        return "eu_pool"
-    if model_id == ZDR_MODEL_ID:
-        return "zdr_pool"
-    if model_id == E2E_MODEL_ID:
-        return "e2e_pool"
-    if model_id == MONITOR_MODEL_ID:
-        return "synthetic_monitor_pool"
-    if model_id == SUBAGENT_MODEL_ID:
-        return "subagent_orchestration"
-    if model_id in ADVISOR_CATALOG_MODEL_ORDERS:
-        return "advisor_orchestration"
-    if model_id in (
-        SYNTH_MODEL_ID,
-        IRIS_MODEL_ID,
-        PROMETHEUS_MODEL_ID,
-        ZEUS_MODEL_ID,
-        IRIS_1_0_MODEL_ID,
-        PROMETHEUS_1_0_MODEL_ID,
-        PROMETHEUS_1_0_1M_MODEL_ID,
-        ZEUS_1_0_MODEL_ID,
-        ZEUS_1_0_MINI_MODEL_ID,
-        SYNTH_CODE_MODEL_ID,
-        IRIS_CODE_MODEL_ID,
-        PROMETHEUS_CODE_MODEL_ID,
-        ZEUS_CODE_MODEL_ID,
-        IRIS_CODE_1_0_MODEL_ID,
-        PROMETHEUS_CODE_1_0_MODEL_ID,
-        ZEUS_CODE_1_0_MODEL_ID,
-        OPEN_PATCHER_S1_MODEL_ID,
-        FUSION_MODEL_ID,
-        FUSION_CODE_MODEL_ID,
-    ):
-        return "fusion_panel"
-    if model_id == SELECTOR_MODEL_ID:
-        return "selector_orchestration"
-    if model_id == MAPREDUCE_MODEL_ID:
-        return "mapreduce_orchestration"
-    if model_id == AUTO_MODEL_ID:
-        return "auto_pool"
-    return "model"
-
-
-def _is_regular_chat_model(model: Model) -> bool:
-    return model.id not in META_MODEL_IDS and model.supports_chat
-
-
-def _price_sort_key(model: Model) -> tuple[int, str, str]:
-    return (
-        model.prompt_price_microdollars_per_million_tokens
-        + model.completion_price_microdollars_per_million_tokens,
-        model.provider,
-        model.id,
-    )
 
 
 def _meta_price_range(

--- a/src/trusted_router/catalog_privacy.py
+++ b/src/trusted_router/catalog_privacy.py
@@ -1,0 +1,73 @@
+"""Privacy-posture tier logic for catalog providers and endpoints.
+
+The PRIVACY_TIER_* ranks + aliases these read live in catalog_data; these
+functions apply them to decide the highest privacy bar a provider or endpoint
+clears, which is what enforces a request's minimum-privacy routing preference
+(the TR gateway hop is always attested regardless — this rank is about the
+UPSTREAM provider's posture). Split out of the catalog.py god-module (#38);
+catalog.py re-exports these and routing_candidates.py imports
+endpoint_privacy_tier. Depends only on the catalog_data leaf, so importing it
+never pulls in catalog.py (no cycle)."""
+
+from __future__ import annotations
+
+from trusted_router.catalog_data import (
+    _MODEL_PROVIDER_PRIVACY_OVERRIDES,
+    PRIVACY_TIER_CONFIDENTIAL,
+    PRIVACY_TIER_NO_STORE,
+    PRIVACY_TIER_STANDARD,
+    PRIVACY_TIER_ZERO_RETENTION,
+    PROVIDERS,
+    ModelEndpoint,
+    Provider,
+)
+
+
+def provider_privacy_tier(provider: Provider) -> int:
+    """The highest privacy bar a provider clears. Used to enforce a
+    request's minimum-privacy routing preference. Note the TR gateway hop
+    is always attested regardless of tier — this rank is about the
+    UPSTREAM provider's posture, which is what varies."""
+    if provider.provider_confidential_compute and provider.provider_e2ee:
+        return PRIVACY_TIER_CONFIDENTIAL
+    if provider.provider_zero_data_retention:
+        return PRIVACY_TIER_ZERO_RETENTION
+    if provider.stores_content is False:
+        return PRIVACY_TIER_NO_STORE
+    return PRIVACY_TIER_STANDARD
+
+
+
+
+
+
+def model_provider_privacy_tier(model_id: str, provider_slug: str) -> int:
+    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
+    if override is not None:
+        return override.privacy_tier
+    return provider_privacy_tier(PROVIDERS[provider_slug])
+
+
+def endpoint_privacy_tier(endpoint: ModelEndpoint) -> int:
+    return model_provider_privacy_tier(endpoint.model_id, endpoint.provider)
+
+
+def model_provider_zero_data_retention(model_id: str, provider_slug: str) -> bool | None:
+    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
+    if override is not None and override.provider_zero_data_retention is not None:
+        return override.provider_zero_data_retention
+    return PROVIDERS[provider_slug].provider_zero_data_retention
+
+
+def model_provider_policy(model_id: str, provider_slug: str) -> str:
+    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
+    if override is not None and override.provider_policy is not None:
+        return override.provider_policy
+    return PROVIDERS[provider_slug].provider_policy
+
+
+def model_provider_policy_url(model_id: str, provider_slug: str) -> str | None:
+    override = _MODEL_PROVIDER_PRIVACY_OVERRIDES.get((model_id, provider_slug))
+    if override is not None and override.provider_policy_url is not None:
+        return override.provider_policy_url
+    return PROVIDERS[provider_slug].provider_policy_url

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -1,0 +1,416 @@
+"""Candidate-model selection for TrustedRouter's meta-models and routing pools.
+
+Given a meta-model target (auto / free / cheap / fast / monitor / eu / zdr /
+e2e / socrates / synth / the meta router), these functions produce the ordered
+list of concrete provider Models the attested gateway will try. This is the
+money-path routing surface, split out of the catalog.py god-module (#38).
+
+Depends on the catalog_registry (the built MODELS / MODEL_ENDPOINTS), the
+catalog_data constants, and catalog_privacy.endpoint_privacy_tier — all leaves
+with respect to catalog.py, so there is no import cycle."""
+
+from __future__ import annotations
+
+from trusted_router.catalog_data import (
+    ADVISOR_CATALOG_MODEL_ORDERS,
+    AUTO_MODEL_ID,
+    CHEAP_MODEL_ID,
+    DEFAULT_AUTO_MODEL_ORDER,
+    E2E_MODEL_ID,
+    EU_FOCUSED_PROVIDER_ORDER,
+    EU_MODEL_ID,
+    FAST_MODEL_ID,
+    FREE_MODEL_ID,
+    FUSION_CODE_MODEL_ID,
+    FUSION_MODEL_ID,
+    IRIS_1_0_MODEL_ID,
+    IRIS_CODE_1_0_MODEL_ID,
+    IRIS_CODE_MODEL_ID,
+    IRIS_MODEL_ID,
+    MAPREDUCE_CATALOG_MODEL_ORDER,
+    MAPREDUCE_MODEL_ID,
+    META_MODEL_IDS,
+    MONITOR_MODEL_ID,
+    OPEN_PATCHER_S1_MODEL_ID,
+    PRIVACY_TIER_CONFIDENTIAL,
+    PRIVACY_TIER_STANDARD,
+    PRIVACY_TIER_ZERO_RETENTION,
+    PROMETHEUS_1_0_1M_MODEL_ID,
+    PROMETHEUS_1_0_MODEL_ID,
+    PROMETHEUS_CODE_1_0_MODEL_ID,
+    PROMETHEUS_CODE_MODEL_ID,
+    PROMETHEUS_MODEL_ID,
+    PROVIDERS,
+    SELECTOR_CATALOG_MODEL_ORDER,
+    SELECTOR_MODEL_ID,
+    SOCRATES_CATALOG_MODEL_ORDER,
+    SUBAGENT_MODEL_ID,
+    SYNTH_BUDGET_MODEL_ORDER,
+    SYNTH_CODE_BUDGET_MODEL_ORDER,
+    SYNTH_CODE_FRONTIER_MODEL_ORDER,
+    SYNTH_CODE_MODEL_ID,
+    SYNTH_CODE_QUALITY_MODEL_ORDER,
+    SYNTH_FRONTIER_MINI_MODEL_ORDER,
+    SYNTH_FRONTIER_MODEL_ORDER,
+    SYNTH_MODEL_ID,
+    SYNTH_QUALITY_1M_MODEL_ORDER,
+    SYNTH_QUALITY_MODEL_ORDER,
+    ZDR_MODEL_ID,
+    ZEUS_1_0_MINI_MODEL_ID,
+    ZEUS_1_0_MODEL_ID,
+    ZEUS_CODE_1_0_MODEL_ID,
+    ZEUS_CODE_MODEL_ID,
+    ZEUS_MODEL_ID,
+    Model,
+)
+from trusted_router.catalog_privacy import endpoint_privacy_tier
+from trusted_router.catalog_registry import MODEL_ENDPOINTS, MODELS
+
+
+class InvalidAutoModelOrder(ValueError):
+    """Raised when TR_AUTO_MODEL_ORDER includes a router/orchestration model."""
+
+
+def validate_auto_model_order(order: str | None = None) -> None:
+    raw_ids = [
+        item.strip()
+        for item in (order.split(",") if order else DEFAULT_AUTO_MODEL_ORDER)
+        if item.strip()
+    ]
+    meta_ids = [model_id for model_id in raw_ids if model_id in META_MODEL_IDS]
+    if meta_ids:
+        joined = ", ".join(meta_ids)
+        raise InvalidAutoModelOrder(
+            "TR_AUTO_MODEL_ORDER cannot include TrustedRouter meta or orchestration "
+            f"models: {joined}. Use regular provider/model IDs only."
+        )
+
+
+def auto_candidate_models(order: str | None = None) -> list[Model]:
+    raw_ids = [
+        item.strip()
+        for item in (order.split(",") if order else DEFAULT_AUTO_MODEL_ORDER)
+        if item.strip()
+    ]
+    validate_auto_model_order(order)
+    candidates: list[Model] = []
+    seen: set[str] = set()
+    for model_id in raw_ids:
+        if model_id in seen:
+            continue
+        model = MODELS.get(model_id)
+        if model is not None and _is_regular_chat_model(model):
+            candidates.append(model)
+            seen.add(model_id)
+    return candidates
+
+
+def free_candidate_models(limit: int = 16) -> list[Model]:
+    candidates = [
+        model
+        for model in MODELS.values()
+        if _is_regular_chat_model(model) and model.id.endswith(":free")
+    ]
+    candidates.sort(key=_price_sort_key)
+    return candidates[:limit]
+
+
+def cheap_candidate_models(limit: int = 8) -> list[Model]:
+    by_provider: dict[str, Model] = {}
+    for model in MODELS.values():
+        if not _is_regular_chat_model(model) or model.id.endswith(":free"):
+            continue
+        current = by_provider.get(model.provider)
+        if current is None or _price_sort_key(model) < _price_sort_key(current):
+            by_provider[model.provider] = model
+    return sorted(by_provider.values(), key=_price_sort_key)[:limit]
+
+
+def fast_candidate_models(limit: int = 8) -> list[Model]:
+    # Low-latency pool: Cerebras first, then Xiaomi MiMo's UltraSpeed tier.
+    # Keep this as a small explicit pool so callers who choose
+    # `trustedrouter/fast` do not accidentally get a cheap-but-slower model
+    # just because it has a lower token price.
+    preferred_ids = [
+        "cerebras/gpt-oss-120b",
+        "xiaomi/mimo-v2.5-pro-ultraspeed",
+        "xiaomi/mimo-v2-flash",
+        "cerebras/zai-glm-4.7",
+    ]
+    candidates: list[Model] = []
+    seen: set[str] = set()
+    for model_id in preferred_ids:
+        model = MODELS.get(model_id)
+        if model is not None and _is_regular_chat_model(model):
+            candidates.append(model)
+            seen.add(model.id)
+        if len(candidates) >= limit:
+            return candidates
+    return candidates
+
+
+def monitor_candidate_models(limit: int = 12) -> list[Model]:
+    # Order favors models that reliably emit a visible one-token PONG.
+    # DeepSeek V4 Flash is cheaper, but in thinking-default mode it can spend
+    # the entire tiny output budget on hidden reasoning and return an empty
+    # visible message. That is a false status-page outage. Keep cheap reasoning
+    # models in the tail; use visible-output models for the steady-state probe.
+    #
+    # Costs at 2026-06 prices ($/M tokens, in / out):
+    #   deepseek/deepseek-v4-flash    0.154 / 0.308   ← lead (4 providers)
+    #   deepseek/deepseek-v3.2        0.308 / 0.495   ← same-family backup
+    #   deepseek/deepseek-v4-pro      0.478 / 0.957   ← +tinfoil +gmi
+    #   mistralai/mistral-small-2603  0.165 / 0.660   ← cross-provider
+    #   openai/gpt-4.1-mini           0.440 / 1.760
+    #   z-ai/glm-4.5-air              0.220 / 1.210
+    #   google/gemini-2.5-flash       0.330 / 2.750
+    #   z-ai/glm-4.6                  0.660 / 2.420   ← reasoning, tail
+    #   moonshotai/kimi-k2.6          0.880 / 3.850   ← reasoning, tail
+    #   anthropic/claude-haiku-4.5    1.100 / 5.500   ← most expensive
+    preferred_ids = [
+        "openai/gpt-4.1-mini",
+        "mistralai/mistral-small-2603",
+        "google/gemini-2.5-flash",
+        "anthropic/claude-haiku-4.5",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v3.2",
+        "deepseek/deepseek-v4-pro",
+        "z-ai/glm-4.5-air",
+        "z-ai/glm-4.6",
+        "moonshotai/kimi-k2.6",
+    ]
+    candidates: list[Model] = []
+    seen: set[str] = set()
+    for model_id in preferred_ids:
+        model = MODELS.get(model_id)
+        if model is not None and _is_regular_chat_model(model) and not model.id.endswith(":free"):
+            candidates.append(model)
+            seen.add(model.id)
+    for model in cheap_candidate_models(limit=limit * 2):
+        if model.id not in seen:
+            candidates.append(model)
+            seen.add(model.id)
+        if len(candidates) >= limit:
+            break
+    return candidates[:limit]
+
+
+def _privacy_candidate_models(
+    *,
+    min_tier: int,
+    preferred_providers: tuple[str, ...] = (),
+    allowed_providers: frozenset[str] | None = None,
+    limit: int = 12,
+) -> list[Model]:
+    """Unique chat models with at least one endpoint clearing min_tier.
+
+    This builds the model-level rollover ladder. The routing layer forces the
+    same privacy floor, so the gateway still picks only qualifying endpoints.
+    """
+    provider_rank = {provider: index for index, provider in enumerate(preferred_providers)}
+    eligible: list[tuple[int, int, int, str, Model]] = []
+    per_provider: dict[str, list[tuple[int, int, Model]]] = {}
+    for endpoint in MODEL_ENDPOINTS.values():
+        provider = PROVIDERS.get(endpoint.provider)
+        model = MODELS.get(endpoint.model_id)
+        if (
+            provider is None
+            or model is None
+            or not _is_regular_chat_model(model)
+            or model.id.endswith(":free")
+            or endpoint_privacy_tier(endpoint) < min_tier
+        ):
+            continue
+        if allowed_providers is not None and endpoint.provider not in allowed_providers:
+            continue
+        price = (
+            endpoint.prompt_price_microdollars_per_million_tokens
+            + endpoint.completion_price_microdollars_per_million_tokens
+        )
+        usage_rank = 0 if endpoint.usage_type == "Credits" else 1
+        rank = provider_rank.get(endpoint.provider, len(provider_rank))
+        eligible.append((rank, usage_rank, price, endpoint.provider, model))
+        per_provider.setdefault(endpoint.provider, []).append((usage_rank, price, model))
+
+    result: list[Model] = []
+    seen: set[str] = set()
+    for provider_slug in preferred_providers:
+        options = sorted(
+            per_provider.get(provider_slug, []),
+            key=lambda item: (item[0], item[1], item[2].provider, item[2].id),
+        )
+        for _usage_rank, _price, model in options:
+            if model.id not in seen:
+                result.append(model)
+                seen.add(model.id)
+                break
+        if len(result) >= limit:
+            return result
+
+    for _rank, _usage_rank, _price, _provider, model in sorted(
+        eligible,
+        key=lambda item: (item[0], item[1], item[2], item[3], item[4].provider, item[4].id),
+    ):
+        if model.id in seen:
+            continue
+        result.append(model)
+        seen.add(model.id)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def eu_candidate_models(limit: int = 12) -> list[Model]:
+    return _privacy_candidate_models(
+        min_tier=PRIVACY_TIER_STANDARD,
+        preferred_providers=EU_FOCUSED_PROVIDER_ORDER,
+        allowed_providers=frozenset(EU_FOCUSED_PROVIDER_ORDER),
+        limit=limit,
+    )
+
+
+def zdr_candidate_models(limit: int = 12) -> list[Model]:
+    return _privacy_candidate_models(
+        min_tier=PRIVACY_TIER_ZERO_RETENTION,
+        preferred_providers=("anthropic", "openai", "gemini", "tinfoil", "venice", "phala"),
+        limit=limit,
+    )
+
+
+def e2e_candidate_models(limit: int = 12) -> list[Model]:
+    return _privacy_candidate_models(
+        min_tier=PRIVACY_TIER_CONFIDENTIAL,
+        preferred_providers=("tinfoil", "venice", "phala", "gmi"),
+        limit=limit,
+    )
+
+
+def _models_for_ids(model_ids: tuple[str, ...]) -> list[Model]:
+    models: list[Model] = []
+    seen: set[str] = set()
+    for model_id in model_ids:
+        if model_id in seen or model_id not in MODELS:
+            continue
+        seen.add(model_id)
+        models.append(MODELS[model_id])
+    return models
+
+
+def socrates_candidate_models() -> list[Model]:
+    return _models_for_ids(SOCRATES_CATALOG_MODEL_ORDER)
+
+
+def meta_candidate_models(model_id: str) -> list[Model]:
+    if model_id == AUTO_MODEL_ID:
+        return auto_candidate_models()
+    if model_id == FREE_MODEL_ID:
+        return free_candidate_models()
+    if model_id == CHEAP_MODEL_ID:
+        return cheap_candidate_models()
+    if model_id == FAST_MODEL_ID:
+        return fast_candidate_models()
+    if model_id == EU_MODEL_ID:
+        return eu_candidate_models()
+    if model_id == ZDR_MODEL_ID:
+        return zdr_candidate_models()
+    if model_id == E2E_MODEL_ID:
+        return e2e_candidate_models()
+    if model_id == MONITOR_MODEL_ID:
+        return monitor_candidate_models()
+    advisor_order = ADVISOR_CATALOG_MODEL_ORDERS.get(model_id)
+    if advisor_order is not None:
+        return _models_for_ids(advisor_order)
+    if model_id == PROMETHEUS_1_0_1M_MODEL_ID:
+        return _models_for_ids(SYNTH_QUALITY_1M_MODEL_ORDER)
+    if model_id in (PROMETHEUS_MODEL_ID, PROMETHEUS_1_0_MODEL_ID):
+        return _models_for_ids(SYNTH_QUALITY_MODEL_ORDER)
+    if model_id in (IRIS_MODEL_ID, IRIS_1_0_MODEL_ID):
+        return _models_for_ids(SYNTH_BUDGET_MODEL_ORDER)
+    if model_id in (ZEUS_MODEL_ID, ZEUS_1_0_MODEL_ID):
+        return _models_for_ids(SYNTH_FRONTIER_MODEL_ORDER)
+    if model_id == ZEUS_1_0_MINI_MODEL_ID:
+        return _models_for_ids(SYNTH_FRONTIER_MINI_MODEL_ORDER)
+    if model_id == OPEN_PATCHER_S1_MODEL_ID:
+        return _models_for_ids(
+            (
+                "moonshotai/kimi-k2.7-code",
+                "z-ai/glm-5.2",
+            )
+        )
+    if model_id in (
+        PROMETHEUS_CODE_MODEL_ID,
+        PROMETHEUS_CODE_1_0_MODEL_ID,
+    ):
+        return _models_for_ids(SYNTH_CODE_QUALITY_MODEL_ORDER)
+    if model_id in (IRIS_CODE_MODEL_ID, IRIS_CODE_1_0_MODEL_ID):
+        return _models_for_ids(SYNTH_CODE_BUDGET_MODEL_ORDER)
+    if model_id in (ZEUS_CODE_MODEL_ID, ZEUS_CODE_1_0_MODEL_ID):
+        return _models_for_ids(SYNTH_CODE_FRONTIER_MODEL_ORDER)
+    if model_id == SELECTOR_MODEL_ID:
+        return _models_for_ids(SELECTOR_CATALOG_MODEL_ORDER)
+    if model_id == MAPREDUCE_MODEL_ID:
+        return _models_for_ids(MAPREDUCE_CATALOG_MODEL_ORDER)
+    return []
+
+
+def _meta_route_kind(model_id: str) -> str:
+    if model_id == FREE_MODEL_ID:
+        return "free_pool"
+    if model_id == CHEAP_MODEL_ID:
+        return "cheap_pool"
+    if model_id == FAST_MODEL_ID:
+        return "fast_pool"
+    if model_id == EU_MODEL_ID:
+        return "eu_pool"
+    if model_id == ZDR_MODEL_ID:
+        return "zdr_pool"
+    if model_id == E2E_MODEL_ID:
+        return "e2e_pool"
+    if model_id == MONITOR_MODEL_ID:
+        return "synthetic_monitor_pool"
+    if model_id == SUBAGENT_MODEL_ID:
+        return "subagent_orchestration"
+    if model_id in ADVISOR_CATALOG_MODEL_ORDERS:
+        return "advisor_orchestration"
+    if model_id in (
+        SYNTH_MODEL_ID,
+        IRIS_MODEL_ID,
+        PROMETHEUS_MODEL_ID,
+        ZEUS_MODEL_ID,
+        IRIS_1_0_MODEL_ID,
+        PROMETHEUS_1_0_MODEL_ID,
+        PROMETHEUS_1_0_1M_MODEL_ID,
+        ZEUS_1_0_MODEL_ID,
+        ZEUS_1_0_MINI_MODEL_ID,
+        SYNTH_CODE_MODEL_ID,
+        IRIS_CODE_MODEL_ID,
+        PROMETHEUS_CODE_MODEL_ID,
+        ZEUS_CODE_MODEL_ID,
+        IRIS_CODE_1_0_MODEL_ID,
+        PROMETHEUS_CODE_1_0_MODEL_ID,
+        ZEUS_CODE_1_0_MODEL_ID,
+        OPEN_PATCHER_S1_MODEL_ID,
+        FUSION_MODEL_ID,
+        FUSION_CODE_MODEL_ID,
+    ):
+        return "fusion_panel"
+    if model_id == SELECTOR_MODEL_ID:
+        return "selector_orchestration"
+    if model_id == MAPREDUCE_MODEL_ID:
+        return "mapreduce_orchestration"
+    if model_id == AUTO_MODEL_ID:
+        return "auto_pool"
+    return "model"
+
+
+def _is_regular_chat_model(model: Model) -> bool:
+    return model.id not in META_MODEL_IDS and model.supports_chat
+
+
+def _price_sort_key(model: Model) -> tuple[int, str, str]:
+    return (
+        model.prompt_price_microdollars_per_million_tokens
+        + model.completion_price_microdollars_per_million_tokens,
+        model.provider,
+        model.id,
+    )

--- a/tests/test_catalog_routing_split.py
+++ b/tests/test_catalog_routing_split.py
@@ -12,23 +12,44 @@ only on the registry/data leaves).
 from __future__ import annotations
 
 import importlib
+import os
+import subprocess
 import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _fresh_import(name: str) -> object:
-    for mod in list(sys.modules):
-        if mod.startswith("trusted_router"):
-            del sys.modules[mod]
-    return importlib.import_module(name)
+def _catalog_loaded_when_importing(module: str) -> bool:
+    """Import `module` in a BRAND-NEW interpreter and report whether
+    trusted_router.catalog got pulled in as a side effect.
+
+    Deliberately a subprocess: the obvious in-process version would clear
+    trusted_router.* out of sys.modules to force a fresh import, but doing that
+    mid-suite poisons the singleton STORE and every active monkeypatch for the
+    tests that run after this one (a real cascade — do not reintroduce it).
+    """
+    code = (
+        f"import sys; import {module}; "
+        "print('LOADED' if 'trusted_router.catalog' in sys.modules else 'CLEAN')"
+    )
+    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT / "src")}
+    out = subprocess.run(  # noqa: S603 - `module` is a hardcoded literal, not user input
+        [sys.executable, "-c", code],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip() == "LOADED"
 
 
 def test_privacy_and_routing_import_without_loading_catalog() -> None:
     # Importing either split module standalone must NOT drag in catalog.py —
     # that is the invariant that keeps the dependency graph acyclic.
-    _fresh_import("trusted_router.catalog_privacy")
-    assert "trusted_router.catalog" not in sys.modules
-    _fresh_import("trusted_router.routing_candidates")
-    assert "trusted_router.catalog" not in sys.modules
+    assert not _catalog_loaded_when_importing("trusted_router.catalog_privacy")
+    assert not _catalog_loaded_when_importing("trusted_router.routing_candidates")
 
 
 def test_catalog_reexports_the_same_function_objects() -> None:

--- a/tests/test_catalog_routing_split.py
+++ b/tests/test_catalog_routing_split.py
@@ -1,0 +1,55 @@
+"""Contract for the catalog.py -> catalog_privacy.py / routing_candidates.py
+split (#38).
+
+Privacy-posture tiers and meta-model candidate selection were lifted out of the
+catalog.py god-module into two dedicated modules. catalog.py re-exports both so
+every existing `from trusted_router.catalog import ...` caller keeps working.
+These tests pin (a) no import cycle, (b) re-export identity, and (c) the
+money-path routing/privacy layering (routing depends on privacy, both depend
+only on the registry/data leaves).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _fresh_import(name: str) -> object:
+    for mod in list(sys.modules):
+        if mod.startswith("trusted_router"):
+            del sys.modules[mod]
+    return importlib.import_module(name)
+
+
+def test_privacy_and_routing_import_without_loading_catalog() -> None:
+    # Importing either split module standalone must NOT drag in catalog.py —
+    # that is the invariant that keeps the dependency graph acyclic.
+    _fresh_import("trusted_router.catalog_privacy")
+    assert "trusted_router.catalog" not in sys.modules
+    _fresh_import("trusted_router.routing_candidates")
+    assert "trusted_router.catalog" not in sys.modules
+
+
+def test_catalog_reexports_the_same_function_objects() -> None:
+    from trusted_router import catalog, catalog_privacy, routing_candidates
+
+    # Re-export identity (not copies): callers importing from catalog get the
+    # exact functions that live in the split modules.
+    assert catalog.endpoint_privacy_tier is catalog_privacy.endpoint_privacy_tier
+    assert catalog.provider_privacy_tier is catalog_privacy.provider_privacy_tier
+    assert catalog.auto_candidate_models is routing_candidates.auto_candidate_models
+    assert catalog.meta_candidate_models is routing_candidates.meta_candidate_models
+    assert catalog.InvalidAutoModelOrder is routing_candidates.InvalidAutoModelOrder
+
+
+def test_routing_uses_privacy_not_the_other_way() -> None:
+    # Routing selection reads privacy tiers; privacy must stay a pure leaf that
+    # never reaches back into routing (or catalog). This encodes the layering.
+    privacy = importlib.import_module("trusted_router.catalog_privacy")
+    routing = importlib.import_module("trusted_router.routing_candidates")
+    assert routing.endpoint_privacy_tier is privacy.endpoint_privacy_tier
+    for leaked in ("auto_candidate_models", "meta_candidate_models", "MODELS"):
+        assert not hasattr(privacy, leaked), (
+            f"{leaked} leaked into catalog_privacy; it must remain a pure leaf"
+        )


### PR DESCRIPTION
## What

Final step of decomposing the `catalog.py` god-module (originally 1592 lines). Lifts out the two remaining cohesive concerns:

- **`catalog_privacy.py`** (~70 lines) — the 6 privacy-posture tier functions (`provider_privacy_tier`, `model_provider_privacy_tier`, `endpoint_privacy_tier`, `model_provider_zero_data_retention`, `model_provider_policy`, `model_provider_policy_url`). Pure leaf — imports only `catalog_data`.
- **`routing_candidates.py`** (~415 lines) — the meta-model candidate-selection surface (`auto`/`free`/`cheap`/`fast`/`monitor`/`eu`/`zdr`/`e2e`/`socrates`/`meta` `candidate_models`, the meta router `_meta_route_kind`, `InvalidAutoModelOrder`, and private helpers). Imports the registry (`MODELS`/`MODEL_ENDPOINTS`), `catalog_data` constants, and `catalog_privacy.endpoint_privacy_tier`.

`catalog.py` drops from ~1000 → **620 lines** and re-exports both modules' full public surface, so every `from trusted_router.catalog import ...` caller keeps working unchanged.

Together with the earlier pricing / data / ingest / registry extractions, this completes the `pricing/data/ingest/routing` split named in #38.

## Why it's safe (money-path routing)

- **Byte-identical** function-body moves — both blocks were already contiguous and self-contained.
- **No import cycle**: the routing region references **zero** catalog-STAY functions (verified). `catalog_privacy` and `routing_candidates` both import without loading `catalog` (pinned by a test).
- **Public surface unchanged**: `dir(catalog)` non-underscore names = **124, same as before**.
- **Behavioral equivalence**: a snapshot over every candidate function, every meta model, every provider/endpoint privacy tier, `model_open_weights`, `_meta_route_kind`, and `validate_auto_model_order` is **byte-for-byte identical** pre/post split (52,739-byte snapshots, empty diff).

## Verification

- Full suite: **1193 passed, 33 skipped**.
- ruff + mypy clean.
- New `tests/test_catalog_routing_split.py`: no-cycle, re-export identity, privacy-stays-a-leaf layering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)