### PR TITLE
Fast global kill-switch for typed billing enforcement (#43)

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -45,7 +45,10 @@ class Settings(BaseSettings):
     # Per-workspace allowlist (CSV) that authorize uses the typed conditional-DML
     # path for; settle/refund route by reservation ORIGIN, not this flag. Default
     # empty = legacy path everywhere (zero behavior change). "*" = all workspaces.
-    # The denylist is an emergency kill switch that always wins.
+    # The denylist is an emergency kill switch that always wins; "*" in the
+    # DENYLIST is the FAST GLOBAL kill-switch — it disables typed enforcement for
+    # every workspace on the next request (no deploy), falling back to the
+    # fail-safe legacy path. Flip via TR_TYPED_BILLING_WORKSPACE_DENYLIST=*.
     typed_billing_workspace_ids: str = ""
     typed_billing_workspace_denylist: str = ""
 

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -438,9 +438,19 @@ def typed_billing_enabled_for_workspace(
 ) -> bool:
     """Cohort gate for the typed AUTHORIZE path. Default-off; the denylist is an
     emergency kill switch that always wins; "*" in the allowlist = all. Settle/
-    refund route by reservation ORIGIN, not this gate (codex 3e)."""
+    refund route by reservation ORIGIN, not this gate (codex 3e).
+
+    Fast global kill-switch: "*" in the DENYLIST disables typed enforcement for
+    every workspace at once (deny always wins, so it beats an "*" allowlist).
+    Flip it with `gcloud run services update --update-env-vars
+    TR_TYPED_BILLING_WORKSPACE_DENYLIST=*` — takes effect on the next request
+    across the region without a code deploy, and reverting is just clearing the
+    var. Every typed path (authorize + the typed-aware balance reads) funnels
+    through this one predicate, so the kill is comprehensive. When killed,
+    authorize/settle fall back to the legacy JSON path, which is fail-safe (the
+    app keeps working; billing is approximate until re-enabled)."""
     deny = {w.strip() for w in denylist_csv.split(",") if w.strip()}
-    if workspace_id in deny:
+    if "*" in deny or workspace_id in deny:
         return False
     allow = {w.strip() for w in allowlist_csv.split(",") if w.strip()}
     return "*" in allow or workspace_id in allow

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -916,6 +916,20 @@ def test_cohort_gate_allowlist_denylist_wildcard() -> None:
     assert f("ws1", allowlist_csv="", denylist_csv="") is False  # default off
 
 
+def test_cohort_gate_denylist_wildcard_is_global_kill_switch() -> None:
+    """"*" in the denylist = fast global kill: typed enforcement off for EVERY
+    workspace, beating even an "*" allowlist (deny always wins)."""
+    f = typed_billing_enabled_for_workspace
+    # Kills a workspace that would otherwise be allowed by an explicit allowlist…
+    assert f("ws1", allowlist_csv="ws1,ws2", denylist_csv="*") is False
+    # …and one allowed by the "*" allowlist (the "everyone on" cutover state).
+    assert f("ws9", allowlist_csv="*", denylist_csv="*") is False
+    # Works alongside specific denies, and any workspace is killed.
+    assert f("anything", allowlist_csv="*", denylist_csv="ws1, *") is False
+    # Sanity: without the wildcard, a specific deny only kills that workspace.
+    assert f("ws2", allowlist_csv="*", denylist_csv="ws1") is True
+
+
 def test_store_authorize_wrapper_and_origin_detection() -> None:
     store, _db, _ = make_fake_store()
     ws = "ws_wrap"


### PR DESCRIPTION
## What

Adds a fast, global kill-switch for the typed-billing dynamic gate — the "kill switch before whales" half of #43/#33.

Before this, the cohort gate (`typed_billing_enabled_for_workspace`) had a per-workspace allowlist + per-workspace denylist, but **no way to turn the whole typed enforcement path off at once** if it misbehaves under load. Now `"*"` in `TR_TYPED_BILLING_WORKSPACE_DENYLIST` disables typed enforcement for every workspace.

## Why it's safe & correct

- **Central + comprehensive**: every typed path (authorize *and* the typed-aware balance reads via `typed_balance._typed_enabled`) funnels through this one predicate — a single change kills all of them.
- **Absolute**: deny always wins, so `"*"`-deny beats an `"*"`-allow (the "everyone on" cutover state).
- **Fail-safe**: when killed, authorize/settle fall back to the legacy JSON path — the app keeps working; billing goes approximate until re-enabled.
- **Fast**: env-var flip (`gcloud run services update --update-env-vars TR_TYPED_BILLING_WORKSPACE_DENYLIST=*`) takes effect on the next request region-wide, no code deploy; reverting = clear the var. Mirrors the existing `TR_READ_ONLY` operational-flag pattern.
- **Default-off**: empty denylist is unchanged; consistent with the existing allowlist `"*"` convention. Zero behavior change until deliberately flipped.

## Verification

- New `test_cohort_gate_denylist_wildcard_is_global_kill_switch`: `"*"`-deny beats explicit + `"*"` allowlists; specific deny still scoped.
- Full suite: **1196 passed, 33 skipped**. ruff + mypy clean.

## Follow-up (same ticket)

The **durable settle outbox** half of #43 (recover the rare completed-but-settle-lost charge instead of the reaper releasing it free) is a separate PR — it mirrors the existing broadcast durable-job + `/v1/internal/*/drain` worker pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)