### PR TITLE
Kill-switch honesty: break-glass availability brake, not clean rollback (#43 follow-up)

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -47,8 +47,12 @@ class Settings(BaseSettings):
     # empty = legacy path everywhere (zero behavior change). "*" = all workspaces.
     # The denylist is an emergency kill switch that always wins; "*" in the
     # DENYLIST is the FAST GLOBAL kill-switch — it disables typed enforcement for
-    # every workspace on the next request (no deploy), falling back to the
-    # fail-safe legacy path. Flip via TR_TYPED_BILLING_WORKSPACE_DENYLIST=*.
+    # every workspace on the next request (no deploy). It is a break-glass
+    # AVAILABILITY brake (keeps the app serving via the legacy path), NOT a
+    # billing-clean rollback: already-typed workspaces have stale-low JSON usage
+    # (#79) so the fallback under-bills until re-enabled or reconciled via the
+    # pause->drain->backsync runbook (#32). Flip via
+    # TR_TYPED_BILLING_WORKSPACE_DENYLIST=*, then run the backsync.
     typed_billing_workspace_ids: str = ""
     typed_billing_workspace_denylist: str = ""
 

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -446,9 +446,20 @@ def typed_billing_enabled_for_workspace(
     TR_TYPED_BILLING_WORKSPACE_DENYLIST=*` — takes effect on the next request
     across the region without a code deploy, and reverting is just clearing the
     var. Every typed path (authorize + the typed-aware balance reads) funnels
-    through this one predicate, so the kill is comprehensive. When killed,
-    authorize/settle fall back to the legacy JSON path, which is fail-safe (the
-    app keeps working; billing is approximate until re-enabled)."""
+    through this one predicate, so the kill is comprehensive.
+
+    This is a BREAK-GLASS AVAILABILITY brake, NOT a billing-clean rollback.
+    Reach for it when the typed gate itself misbehaves (deadlocks, elevated
+    errors/latency) and you need requests flowing again NOW; killed workspaces
+    fall back to the legacy JSON authorize path, so the app keeps serving. But
+    it is deliberately NOT revenue-neutral for a workspace that was already
+    running typed: its JSON usage columns are stale-LOW because the typed-owned
+    counters are never mirrored back to JSON (the #79 ownership split), so the
+    JSON fallback under-counts spend and can OVER-admit / UNDER-bill until typed
+    is re-enabled. A *correct* rollback is the pause -> drain -> backsync runbook
+    (storage_gcp_counter_reconcile / #32), which reconciles JSON before cutting
+    over; denylisting alone is knowingly lossy. Use the kill-switch to stop the
+    bleeding, then run the backsync — don't treat it as a clean off-switch."""
     deny = {w.strip() for w in denylist_csv.split(",") if w.strip()}
     if "*" in deny or workspace_id in deny:
         return False

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -918,7 +918,10 @@ def test_cohort_gate_allowlist_denylist_wildcard() -> None:
 
 def test_cohort_gate_denylist_wildcard_is_global_kill_switch() -> None:
     """"*" in the denylist = fast global kill: typed enforcement off for EVERY
-    workspace, beating even an "*" allowlist (deny always wins)."""
+    workspace, beating even an "*" allowlist (deny always wins). This is a
+    break-glass availability brake — for already-typed workspaces the JSON
+    fallback is stale-low (#79), so it under-bills until the backsync runbook
+    (#32) runs; see typed_billing_enabled_for_workspace + test_typed_balance."""
     f = typed_billing_enabled_for_workspace
     # Kills a workspace that would otherwise be allowed by an explicit allowlist…
     assert f("ws1", allowlist_csv="ws1,ws2", denylist_csv="*") is False

--- a/tests/test_typed_balance.py
+++ b/tests/test_typed_balance.py
@@ -54,6 +54,24 @@ def test_credit_overlay_denylist_wins() -> None:
     assert acct.total_usage_microdollars == 0
 
 
+def test_credit_overlay_denylist_wildcard_global_kill_reads_stale_json() -> None:
+    """The "*" global kill-switch routes the balance read to JSON for EVERY
+    workspace — and this test pins the documented hazard: a workspace that was
+    running typed has stale-LOW JSON usage, so under the kill it under-reports
+    spend (999_999 booked in typed, but JSON reads 0). That is exactly why the
+    kill-switch is a break-glass availability brake, not a billing-clean
+    rollback (the pause->drain->backsync runbook reconciles JSON first)."""
+    store, db, _ = make_fake_store()
+    ws = "ws_globalkill"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 999_999})
+    # "*" allowlist (everyone-on cutover) + "*" denylist (global kill) → JSON.
+    acct = typed_aware_credit_account(store, ws, settings=_settings(allow="*", deny="*"))
+    assert acct.total_usage_microdollars == 0  # stale-low JSON, NOT the typed 999_999
+
+
 def test_credit_typed_but_unseeded_falls_back_to_json() -> None:
     store, _db, _ = make_fake_store()
     store._counter_mirror_enabled = False  # no typed row written


### PR DESCRIPTION
## Why

Follow-up to #109, addressing a **codex review finding**. The `"*"` denylist global kill-switch predicate is correct, but its docs **oversold the JSON fallback as "fail-safe / billing approximate."** codex correctly flagged that for an already-*typed* workspace this is wrong:

> typed-owned `reserved`/`total_usage` are never mirrored back to JSON (#79), so the legacy fallback reads **stale-LOW** spend → can over-admit / **under-bill** until typed is re-enabled. Denylisting alone is *not* rollback-correct (see `storage_gcp_counter_reconcile` / #32).

The merged #109 code is **dormant by default** (empty denylist = zero behavior change), so there's no live risk — but the misleading framing needed correcting before anyone reaches for the switch.

## What changed

- **No code/logic change.** The predicate and default-off behavior are identical.
- Corrects the framing in the config comment, the `typed_billing_enabled_for_workspace` docstring, and the test docstrings: the kill-switch is a **break-glass AVAILABILITY brake** — use it to stop a misbehaving typed gate and keep the app serving, then run the **pause → drain → backsync runbook (#32)** to reconcile billing. It is knowingly lossy, not a clean off-switch.
- Adds the test coverage codex flagged as missing:
  - `test_typed_balance`: the `"*"` global kill routes the balance read to JSON for a typed workspace, **pinning the stale-low under-report** (999_999 booked in typed, JSON reads 0) — the documented hazard made explicit.

## Verification

- Full suite: **1197 passed, 33 skipped**. ruff + mypy clean.

Note: this PR will **not** be merged until codex reviews it (the previous one raced CI ahead of codex — fixed process here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)