### PR TITLE
Durable settle outbox — Increment 1: native-table storage (dormant) (#44)

### DIFF
--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -175,4 +175,40 @@ ensure_column tr_key_limit week_start  "TIMESTAMP"
 ensure_column tr_key_limit month_usage "INT64 DEFAULT (0)"
 ensure_column tr_key_limit month_start "TIMESTAMP"
 
+# ── Durable settle outbox (docs/design/durable-settle-outbox.md) ────────────
+# Recovers completed-but-settle-lost charges. Additive + guarded; safe to apply
+# before the code reads it (the mechanism is gated off by settle_outbox_enabled).
+# PK is (authorization_id, intent_kind) so a settle and a refund on one
+# authorization never clobber each other. Frozen settle inputs (actual_cost_micro,
+# selected_endpoint_id, model_id, selected_usage_type, settle_origin,
+# reservation_id) are captured at enqueue so a drain replays a deterministic
+# amount+origin regardless of any later pricing/mirror-flag change.
+if table_exists tr_settle_outbox; then log "tr_settle_outbox exists, skip"; else
+  apply_ddl "CREATE TABLE tr_settle_outbox (
+    authorization_id STRING(64) NOT NULL,
+    intent_kind STRING(16) NOT NULL,
+    settle_origin STRING(16) NOT NULL,
+    reservation_id STRING(64),
+    actual_cost_micro INT64 NOT NULL,
+    selected_endpoint_id STRING(128),
+    model_id STRING(128),
+    selected_usage_type STRING(16),
+    settle_body STRING(MAX),
+    status STRING(24) NOT NULL DEFAULT ('pending'),
+    attempts INT64 NOT NULL DEFAULT (0),
+    last_error STRING(MAX),
+    next_attempt_at TIMESTAMP,
+    lease_owner STRING(64),
+    leased_until TIMESTAMP,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+  ) PRIMARY KEY (authorization_id, intent_kind)"
+fi
+
+# Due-scan index: the drain reads pending rows whose next_attempt_at has passed.
+# Without it the whale-burst backlog the feature exists for would full-scan.
+if index_exists tr_settle_outbox_due; then log "tr_settle_outbox_due exists, skip"; else
+  apply_ddl "CREATE INDEX tr_settle_outbox_due ON tr_settle_outbox (status, next_attempt_at)"
+fi
+
 log "done"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -152,6 +152,14 @@ class Settings(BaseSettings):
     # TR_READ_ONLY=1` per region during a planned cutover. See the
     # multi-region expansion plan for the cutover sequence.
     read_only: bool = False
+    # Durable settle outbox (docs/design/durable-settle-outbox.md). Default OFF:
+    # the settle path is byte-identical and nothing is enqueued. When True, the
+    # settle handler durably records each settle intent before applying it, and
+    # the /internal/gateway/settle-outbox/drain worker recovers any that were
+    # lost so the reaper never releases a completed request for free. Enabling is
+    # a billing prod-behavior change — flip deliberately, per the design's
+    # rollout section, after the shadow metrics are clean.
+    settle_outbox_enabled: bool = False
     # Bigtable application profile name. The default profile uses
     # single-cluster routing; `tr-multi` enables
     # multi-cluster-routing-use-any once we have ≥3 BT clusters

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -35,6 +35,7 @@ from trusted_router.storage import (
 )
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
 from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_gcp_byok import SpannerByok
 from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
@@ -208,6 +209,11 @@ class SpannerBigtableStore:
         self.byok_store = SpannerByok(io)
         self.custom_model_store = SpannerCustomModels(io)
         self.broadcast_store = SpannerBroadcastDestinations(io)
+        # Durable settle outbox (docs/design/durable-settle-outbox.md). Native
+        # table, so it takes the raw database + param_types like the counter DML
+        # rather than the entity IO. Dormant until settle_outbox_enabled + the
+        # later increments wire enqueue/drain/reaper-guard to it.
+        self.settle_outbox = SpannerSettleOutbox(self._database, self._param_types)
         self.auth_session_store = SpannerAuthSessions(io)
         self.oauth_code_store = SpannerOAuthCodes(io)
         self.rate_limit_store = SpannerRateLimits(io)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -35,7 +35,6 @@ from trusted_router.storage import (
 )
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
 from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
-from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_gcp_byok import SpannerByok
 from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
@@ -58,6 +57,7 @@ from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_ret
 from trusted_router.storage_gcp_keys import SpannerApiKeys
 from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
 from trusted_router.storage_gcp_rate_limits import SpannerRateLimits
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_gcp_synthetic_index import (
     synthetic_probe_samples as _bt_synthetic_probe_samples,
 )

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -1,0 +1,349 @@
+"""Durable settle outbox — native-Spanner storage (docs/design/durable-settle-outbox.md).
+
+A native `tr_settle_outbox` table, NOT the broadcast entity/upsert store: the
+exactly-once guarantee needs INSERT-as-claim (raises ALREADY_EXISTS on a
+duplicate PK) plus lease-fenced conditional-DML, the same primitives
+`storage_gcp_counter_dml` uses for `tr_reservation`. This module mirrors the
+broadcast durable-job STATE MACHINE (pending -> done/dead + lease + exponential
+backoff + max_attempts) but keeps its own persistence.
+
+Increment 1 (this module): the storage layer + a `has_intent` predicate for the
+reaper guard. The reaper wiring, the enqueue-at-settle call, the drain worker,
+and the frozen-cost finalize primitive land in later increments; nothing here is
+called on the live settle/reaper path yet.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from trusted_router.storage_models import SettleOutboxRow
+
+# Column order shared by INSERT and the row-tuple SELECTs (keep in sync with the
+# DDL in scripts/deploy/migrate_typed_counters.sh).
+OUTBOX_COLUMNS = [
+    "authorization_id",
+    "intent_kind",
+    "settle_origin",
+    "reservation_id",
+    "actual_cost_micro",
+    "selected_endpoint_id",
+    "model_id",
+    "selected_usage_type",
+    "settle_body",
+    "status",
+    "attempts",
+    "last_error",
+    "next_attempt_at",
+    "lease_owner",
+    "leased_until",
+    "created_at",
+    "updated_at",
+]
+
+# Statuses that must FREEZE the hold — the reaper may not free-release a
+# reservation whose authorization still has an outbox row in one of these
+# (pending = will be drained; dead = drain gave up, a human must resolve).
+# `release_approved` is deliberately excluded: it is the human's explicit ok to
+# let the reaper free the hold. `done` means the charge already applied.
+GUARD_STATUSES = ("pending", "dead")
+
+# Enqueue outcomes.
+ENQ_INSERTED = "inserted"          # new pending row
+ENQ_REFRESHED = "refreshed"        # existing pending row's frozen inputs updated
+ENQ_EXISTS_TERMINAL = "terminal"   # existing done/dead/release_approved row — left as is
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _iso_after_seconds(seconds: int) -> str:
+    return (
+        (datetime.now(UTC).replace(microsecond=0) + timedelta(seconds=seconds))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _backoff_seconds(attempts: int) -> int:
+    return min(60 * 60, 2 ** max(attempts - 1, 0))
+
+
+def _row_from_tuple(values: Any) -> SettleOutboxRow:
+    d = dict(zip(OUTBOX_COLUMNS, values, strict=True))
+    return SettleOutboxRow(
+        authorization_id=d["authorization_id"],
+        intent_kind=d["intent_kind"],
+        settle_origin=d["settle_origin"],
+        actual_cost_micro=int(d["actual_cost_micro"]),
+        reservation_id=d["reservation_id"],
+        selected_endpoint_id=d["selected_endpoint_id"],
+        model_id=d["model_id"],
+        selected_usage_type=d["selected_usage_type"],
+        settle_body=d["settle_body"],
+        status=d["status"],
+        attempts=int(d["attempts"] or 0),
+        last_error=d["last_error"],
+        next_attempt_at=_ts_str(d["next_attempt_at"]),
+        lease_owner=d["lease_owner"],
+        leased_until=_ts_str(d["leased_until"]),
+        created_at=_ts_str(d["created_at"]) or "",
+        updated_at=_ts_str(d["updated_at"]),
+    )
+
+
+def _ts_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    # spanner returns datetime; normalize to the Z-suffixed iso the model uses
+    return value.isoformat().replace("+00:00", "Z")
+
+
+class SpannerSettleOutbox:
+    """Durable settle-intent store on a native `tr_settle_outbox` table."""
+
+    def __init__(self, database: Any, param_types: Any) -> None:
+        self._database = database
+        self._pt = param_types
+
+    # ── enqueue (INSERT-as-claim, refresh-latest on a still-pending row) ──────
+    def enqueue(self, row: SettleOutboxRow) -> str:
+        """Record a settle intent. Idempotent by (authorization_id, intent_kind):
+
+        - no row yet -> INSERT a pending row (ENQ_INSERTED)
+        - a PENDING row exists -> refresh its frozen inputs to this (latest)
+          delivery (ENQ_REFRESHED) — the enclave may retry with corrected actuals
+        - a terminal row exists (done/dead/release_approved) -> leave it
+          (ENQ_EXISTS_TERMINAL); the charge is already resolved or frozen.
+        """
+        pt = self._pt
+        now = _iso_now()
+
+        def insert_txn(transaction: Any) -> None:
+            cols = ", ".join(OUTBOX_COLUMNS)
+            binds = ", ".join(f"@{c}" for c in OUTBOX_COLUMNS)
+            values = {
+                "authorization_id": row.authorization_id,
+                "intent_kind": row.intent_kind,
+                "settle_origin": row.settle_origin,
+                "reservation_id": row.reservation_id,
+                "actual_cost_micro": int(row.actual_cost_micro),
+                "selected_endpoint_id": row.selected_endpoint_id,
+                "model_id": row.model_id,
+                "selected_usage_type": row.selected_usage_type,
+                "settle_body": row.settle_body,
+                "status": "pending",
+                "attempts": 0,
+                "last_error": None,
+                "next_attempt_at": now,
+                "lease_owner": None,
+                "leased_until": None,
+                "created_at": now,
+                "updated_at": now,
+            }
+            types = {
+                "authorization_id": pt.STRING, "intent_kind": pt.STRING,
+                "settle_origin": pt.STRING, "reservation_id": pt.STRING,
+                "actual_cost_micro": pt.INT64, "selected_endpoint_id": pt.STRING,
+                "model_id": pt.STRING, "selected_usage_type": pt.STRING,
+                "settle_body": pt.STRING, "status": pt.STRING, "attempts": pt.INT64,
+                "last_error": pt.STRING, "next_attempt_at": pt.TIMESTAMP,
+                "lease_owner": pt.STRING, "leased_until": pt.TIMESTAMP,
+                "created_at": pt.TIMESTAMP, "updated_at": pt.TIMESTAMP,
+            }
+            transaction.execute_update(
+                f"INSERT INTO tr_settle_outbox ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
+                params=values, param_types=types,
+            )
+
+        try:
+            self._database.run_in_transaction(insert_txn)
+            return ENQ_INSERTED
+        except Exception as exc:  # ALREADY_EXISTS -> the intent is already recorded
+            if not _is_already_exists(exc):
+                raise
+
+        # Refresh the frozen inputs iff the existing row is still pending.
+        def refresh_txn(transaction: Any) -> int:
+            return transaction.execute_update(
+                "UPDATE tr_settle_outbox SET settle_origin=@settle_origin, "
+                "reservation_id=@reservation_id, actual_cost_micro=@actual_cost_micro, "
+                "selected_endpoint_id=@selected_endpoint_id, model_id=@model_id, "
+                "selected_usage_type=@selected_usage_type, settle_body=@settle_body, "
+                "updated_at=@now WHERE authorization_id=@authorization_id "
+                "AND intent_kind=@intent_kind AND status='pending'",
+                params={
+                    "settle_origin": row.settle_origin,
+                    "reservation_id": row.reservation_id,
+                    "actual_cost_micro": int(row.actual_cost_micro),
+                    "selected_endpoint_id": row.selected_endpoint_id,
+                    "model_id": row.model_id,
+                    "selected_usage_type": row.selected_usage_type,
+                    "settle_body": row.settle_body,
+                    "now": now,
+                    "authorization_id": row.authorization_id,
+                    "intent_kind": row.intent_kind,
+                },
+                param_types={
+                    "settle_origin": pt.STRING, "reservation_id": pt.STRING,
+                    "actual_cost_micro": pt.INT64, "selected_endpoint_id": pt.STRING,
+                    "model_id": pt.STRING, "selected_usage_type": pt.STRING,
+                    "settle_body": pt.STRING, "now": pt.TIMESTAMP,
+                    "authorization_id": pt.STRING, "intent_kind": pt.STRING,
+                },
+            )
+
+        refreshed = self._database.run_in_transaction(refresh_txn)
+        return ENQ_REFRESHED if refreshed == 1 else ENQ_EXISTS_TERMINAL
+
+    # ── due / claim / mark ───────────────────────────────────────────────────
+    def due(self, *, limit: int = 100) -> list[SettleOutboxRow]:
+        now = _iso_now()
+        with self._database.snapshot() as snapshot:
+            rows = list(snapshot.execute_sql(
+                f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608 - fixed column list
+                "WHERE status='pending' AND next_attempt_at <= @now "
+                "ORDER BY next_attempt_at LIMIT @limit",
+                params={"now": now, "limit": int(limit)},
+                param_types={"now": self._pt.TIMESTAMP, "limit": self._pt.INT64},
+            ))
+        return [_row_from_tuple(r) for r in rows]
+
+    def claim(self, *, limit: int = 100, lease_seconds: int = 60) -> list[SettleOutboxRow]:
+        owner = f"soworker_{uuid.uuid4().hex}"
+        lease_until = _iso_after_seconds(lease_seconds)
+        claimed: list[SettleOutboxRow] = []
+        for candidate in self.due(limit=limit * 2):
+            if len(claimed) >= limit:
+                break
+            if self._claim_one(candidate, owner=owner, lease_until=lease_until):
+                candidate.lease_owner = owner
+                candidate.leased_until = lease_until
+                claimed.append(candidate)
+        return claimed
+
+    def _claim_one(self, row: SettleOutboxRow, *, owner: str, lease_until: str) -> bool:
+        now = _iso_now()
+
+        def txn(transaction: Any) -> int:
+            return transaction.execute_update(
+                "UPDATE tr_settle_outbox SET lease_owner=@owner, leased_until=@lease, "
+                "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
+                "AND status='pending' AND (leased_until IS NULL OR leased_until < @now)",
+                params={
+                    "owner": owner, "lease": lease_until, "now": now,
+                    "aid": row.authorization_id, "kind": row.intent_kind,
+                },
+                param_types={
+                    "owner": self._pt.STRING, "lease": self._pt.TIMESTAMP,
+                    "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
+                    "kind": self._pt.STRING,
+                },
+            )
+
+        return self._database.run_in_transaction(txn) == 1
+
+    def mark(
+        self,
+        authorization_id: str,
+        intent_kind: str,
+        *,
+        done: bool,
+        error: str | None = None,
+        lease_owner: str | None = None,
+        max_attempts: int = 8,
+    ) -> str | None:
+        """Resolve a drained row in ONE lease-fenced conditional-DML transaction.
+
+        `done=True` -> status='done' (terminal). `done=False` -> back off to
+        'pending' with the next attempt time, or 'dead' at max_attempts (which
+        FREEZES the hold for a human — see GUARD_STATUSES). Returns the new
+        status, or None if the row was not claimable by this owner (lost lease /
+        already resolved). Only 'pending' rows are marked."""
+        now = _iso_now()
+
+        def txn(transaction: Any) -> str | None:
+            rows = list(transaction.execute_sql(
+                "SELECT attempts, lease_owner FROM tr_settle_outbox "
+                "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
+                params={"aid": authorization_id, "kind": intent_kind},
+                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+            ))
+            if not rows:
+                return None
+            attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
+            if lease_owner is not None and cur_owner not in (None, lease_owner):
+                return None  # lost the lease to another worker
+            next_attempts = attempts + 1
+            if done:
+                new_status, next_at, err = "done", None, None
+            elif next_attempts >= max_attempts:
+                new_status, next_at, err = "dead", None, (error or "drain failed")[:1000]
+            else:
+                new_status = "pending"
+                next_at = _iso_after_seconds(_backoff_seconds(next_attempts))
+                err = (error or "drain failed")[:1000]
+            updated = transaction.execute_update(
+                "UPDATE tr_settle_outbox SET status=@status, attempts=@attempts, "
+                "last_error=@err, next_attempt_at=@next_at, lease_owner=NULL, "
+                "leased_until=NULL, updated_at=@now WHERE authorization_id=@aid "
+                "AND intent_kind=@kind AND status='pending'",
+                params={
+                    "status": new_status, "attempts": next_attempts, "err": err,
+                    "next_at": next_at, "now": now,
+                    "aid": authorization_id, "kind": intent_kind,
+                },
+                param_types={
+                    "status": self._pt.STRING, "attempts": self._pt.INT64,
+                    "err": self._pt.STRING, "next_at": self._pt.TIMESTAMP,
+                    "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
+                    "kind": self._pt.STRING,
+                },
+            )
+            return new_status if updated == 1 else None
+
+        return self._database.run_in_transaction(txn)
+
+    # ── reaper guard predicate ───────────────────────────────────────────────
+    def has_intent(self, authorization_id: str) -> bool:
+        """True iff this authorization has an outbox row that FREEZES the hold
+        (status in GUARD_STATUSES). The reaper must not free-release such a
+        reservation. Read on a snapshot for the advisory pre-scan; the reaper
+        also re-checks in-transaction (Increment 2) for the real interlock."""
+        with self._database.snapshot() as snapshot:
+            rows = list(snapshot.execute_sql(
+                # GUARD_STATUSES inlined as a fixed literal (not user input) so the
+                # predicate needs no Array param type — keeps the fake faithful.
+                "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "
+                "AND status IN ('pending', 'dead')",
+                params={"aid": authorization_id},
+                param_types={"aid": self._pt.STRING},
+            ))
+        return bool(rows) and int(rows[0][0]) > 0
+
+    def get(self, authorization_id: str, intent_kind: str) -> SettleOutboxRow | None:
+        with self._database.snapshot() as snapshot:
+            rows = list(snapshot.execute_sql(
+                f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608 - fixed column list
+                "WHERE authorization_id=@aid AND intent_kind=@kind",
+                params={"aid": authorization_id, "kind": intent_kind},
+                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+            ))
+        return _row_from_tuple(rows[0]) if rows else None
+
+
+def _is_already_exists(exc: Exception) -> bool:
+    # Name-based check first (covers the test fake's FakeAlreadyExists too), then
+    # the real type when the google libs are importable.
+    if type(exc).__name__ in ("AlreadyExists", "FakeAlreadyExists"):
+        return True
+    try:
+        from google.api_core.exceptions import AlreadyExists
+    except Exception:  # pragma: no cover - google libs always present in prod/tests
+        return False
+    return isinstance(exc, AlreadyExists)

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -54,6 +54,7 @@ GUARD_STATUSES = ("pending", "dead")
 ENQ_INSERTED = "inserted"          # new pending row
 ENQ_REFRESHED = "refreshed"        # existing pending row's frozen inputs updated
 ENQ_EXISTS_TERMINAL = "terminal"   # existing done/dead/release_approved row — left as is
+ENQ_LEASED = "leased"              # existing pending row is actively leased by a drain — deferred
 
 
 def _iso_now() -> str:
@@ -206,7 +207,15 @@ class SpannerSettleOutbox:
             )
 
         refreshed = self._database.run_in_transaction(refresh_txn)
-        return ENQ_REFRESHED if refreshed == 1 else ENQ_EXISTS_TERMINAL
+        if refreshed == 1:
+            return ENQ_REFRESHED
+        # 0-row: classify for accurate observability (codex #113) — a still-pending
+        # row means the refresh was fenced out by an active lease (a drain holds
+        # it), distinct from a genuinely terminal (done/dead/release_approved) row.
+        existing = self.get(row.authorization_id, row.intent_kind)
+        if existing is not None and existing.status == "pending":
+            return ENQ_LEASED
+        return ENQ_EXISTS_TERMINAL
 
     # ── due / claim / mark ───────────────────────────────────────────────────
     def due(self, *, limit: int = 100) -> list[SettleOutboxRow]:

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -168,7 +168,13 @@ class SpannerSettleOutbox:
             if not _is_already_exists(exc):
                 raise
 
-        # Refresh the frozen inputs iff the existing row is still pending.
+        # Refresh the frozen inputs iff the existing row is still pending AND not
+        # actively leased. A claimed row stays status='pending' while a drain
+        # worker applies it, so refreshing on status alone could overwrite
+        # actual_cost_micro / body out from under an in-flight apply (codex #113
+        # finding 2). The lease fence makes a retry-enqueue a no-op while a drain
+        # holds the row; once the lease lapses (or the drain fails back to
+        # pending) a later enqueue can refresh again.
         def refresh_txn(transaction: Any) -> int:
             return transaction.execute_update(
                 "UPDATE tr_settle_outbox SET settle_origin=@settle_origin, "
@@ -176,7 +182,8 @@ class SpannerSettleOutbox:
                 "selected_endpoint_id=@selected_endpoint_id, model_id=@model_id, "
                 "selected_usage_type=@selected_usage_type, settle_body=@settle_body, "
                 "updated_at=@now WHERE authorization_id=@authorization_id "
-                "AND intent_kind=@intent_kind AND status='pending'",
+                "AND intent_kind=@intent_kind AND status='pending' "
+                "AND (leased_until IS NULL OR leased_until < @now)",
                 params={
                     "settle_origin": row.settle_origin,
                     "reservation_id": row.reservation_id,

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -199,6 +199,40 @@ class BroadcastDeliveryJob:
 
 
 @dataclass
+class SettleOutboxRow:
+    """A durable settle intent (docs/design/durable-settle-outbox.md).
+
+    Enqueued before the inline settle is attempted; recovered by the drain if the
+    inline attempt is lost. The FROZEN inputs (actual_cost_micro / selected_* /
+    model_id / settle_origin / reservation_id) are captured from the SAME decision
+    the inline attempt used, so a drain applies a deterministic amount and origin
+    no matter what pricing or the typed-mirror flag do afterward. The PK is
+    (authorization_id, intent_kind) so a settle and a refund never clobber.
+
+    status: pending -> done (charged, terminal) | dead (drain gave up, FREEZES the
+    hold — a human resolves) | release_approved (human ok'd freeing the hold).
+    """
+
+    authorization_id: str
+    intent_kind: str  # "settle" | "refund"
+    settle_origin: str  # "typed" | "legacy"
+    actual_cost_micro: int
+    reservation_id: str | None = None
+    selected_endpoint_id: str | None = None
+    model_id: str | None = None
+    selected_usage_type: str | None = None
+    settle_body: str | None = None  # raw GatewaySettleRequest JSON (audit/generation)
+    status: str = "pending"
+    attempts: int = 0
+    last_error: str | None = None
+    next_attempt_at: str | None = field(default_factory=iso_now)
+    lease_owner: str | None = None
+    leased_until: str | None = None
+    created_at: str = field(default_factory=iso_now)
+    updated_at: str | None = None
+
+
+@dataclass
 class CreditAccount:
     workspace_id: str
     total_credits_microdollars: int = 0

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -5,6 +5,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
+from trusted_router.storage_gcp_settle_outbox import OUTBOX_COLUMNS
+
 
 class _ParamTypes:
     STRING = "STRING"
@@ -123,6 +125,9 @@ class FakeSpannerDatabase:
         self.reservations: dict[str, dict] = {}
         self.reservation_versions: dict[str, int] = {}
         self.reservation_idemp: dict[str, str] = {}  # idempotency_scope -> reservation_id
+        # tr_settle_outbox: PK (authorization_id, intent_kind) -> {column: value}.
+        self.settle_outbox: dict[tuple, dict] = {}
+        self.settle_outbox_versions: dict[tuple, int] = {}
         self._global_version = 0
         self._commit_lock = threading.Lock()
         self._ready_barrier = ready_barrier
@@ -159,6 +164,8 @@ class FakeSpannerDatabase:
                     # presence-based: a same-scope insert committed since our read
                     # flips this, aborting the loser so its retry raises ALREADY_EXISTS
                     current_version = 1 if key[1] in self.reservation_idemp else 0
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "outbox":
+                    current_version = self.settle_outbox_versions.get(key[1], 0)
                 else:
                     current = self.rows.get(key)
                     current_version = current.version if current is not None else 0
@@ -194,6 +201,10 @@ class FakeSpannerDatabase:
                     scope = record.get("idempotency_scope")
                     if scope is not None:
                         self.reservation_idemp[scope] = rid
+                elif op[0] in ("insert_settle_outbox", "update_settle_outbox"):
+                    _, pk, record = op
+                    self.settle_outbox[pk] = record
+                    self.settle_outbox_versions[pk] = new_version
                 elif op[0] == "update_reservation":
                     _, rid, record = op
                     self.reservations[rid] = record
@@ -248,6 +259,17 @@ class _FakeTransaction:
         if version_key not in self.read_versions:
             self.read_versions[version_key] = self.db.reservation_versions.get(rid, 0)
         rec = self.db.reservations.get(rid)
+        return dict(rec) if rec is not None else None
+
+    def _settle_outbox_current(self, pk: tuple) -> dict | None:
+        """In-txn view of a settle-outbox row (read-your-writes) + read version."""
+        for op in reversed(self.pending_writes):
+            if op[0] in ("insert_settle_outbox", "update_settle_outbox") and op[1] == pk:
+                return dict(op[2])
+        version_key = ("outbox", pk)
+        if version_key not in self.read_versions:
+            self.read_versions[version_key] = self.db.settle_outbox_versions.get(pk, 0)
+        rec = self.db.settle_outbox.get(pk)
         return dict(rec) if rec is not None else None
 
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
@@ -399,6 +421,52 @@ class _FakeTransaction:
                     return 0  # no such row
             self.pending_writes.append(("update_entity_dml", p["kind"], p["id"], p["body"]))
             return 1
+        if sql.startswith("INSERT INTO tr_settle_outbox"):
+            pk = (p["authorization_id"], p["intent_kind"])
+            if pk in self.db.settle_outbox:
+                raise FakeAlreadyExists(str(pk))  # duplicate PK
+            vkey = ("outbox", pk)
+            if vkey not in self.read_versions:
+                self.read_versions[vkey] = self.db.settle_outbox_versions.get(pk, 0)
+            self.pending_writes.append(("insert_settle_outbox", pk, dict(p)))
+            return 1
+        if sql.startswith("UPDATE tr_settle_outbox SET settle_origin="):  # enqueue refresh
+            pk = (p["authorization_id"], p["intent_kind"])
+            rec = self._settle_outbox_current(pk)
+            if rec is None or rec["status"] != "pending":
+                return 0
+            new = dict(rec)
+            for col in (
+                "settle_origin", "reservation_id", "actual_cost_micro",
+                "selected_endpoint_id", "model_id", "selected_usage_type", "settle_body",
+            ):
+                new[col] = p[col]
+            new["updated_at"] = p["now"]
+            self.pending_writes.append(("update_settle_outbox", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_settle_outbox SET lease_owner=@owner"):  # claim
+            pk = (p["aid"], p["kind"])
+            rec = self._settle_outbox_current(pk)
+            if rec is None or rec["status"] != "pending":
+                return 0
+            leased = rec.get("leased_until")
+            if leased is not None and leased >= p["now"]:
+                return 0  # still held by a live lease
+            new = dict(rec, lease_owner=p["owner"], leased_until=p["lease"], updated_at=p["now"])
+            self.pending_writes.append(("update_settle_outbox", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
+            pk = (p["aid"], p["kind"])
+            rec = self._settle_outbox_current(pk)
+            if rec is None or rec["status"] != "pending":
+                return 0
+            new = dict(
+                rec, status=p["status"], attempts=p["attempts"], last_error=p["err"],
+                next_attempt_at=p["next_at"], lease_owner=None, leased_until=None,
+                updated_at=p["now"],
+            )
+            self.pending_writes.append(("update_settle_outbox", pk, new))
+            return 1
         raise NotImplementedError(sql)
 
     def insert_or_update(
@@ -512,6 +580,43 @@ class _FakeBatch:
                 self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
 
 
+def _execute_settle_outbox_sql(
+    db: FakeSpannerDatabase, sql: str, params: dict[str, Any]
+) -> list[list[Any]]:
+    """Model tr_settle_outbox reads. Ordered so the more-specific predicates are
+    matched before the generic (authorization_id) one — a status/column change in
+    the real query that isn't reflected here will fall through to
+    NotImplementedError, not silently pass (see the design's fake-fidelity note)."""
+    p = params
+    if sql.startswith("SELECT attempts, lease_owner FROM tr_settle_outbox"):
+        rec = db.settle_outbox.get((p["aid"], p["kind"]))
+        if rec is None or rec.get("status") != "pending":
+            return []
+        return [[rec.get("attempts", 0), rec.get("lease_owner")]]
+    if "WHERE status='pending' AND next_attempt_at <= @now" in sql:  # due scan
+        now = p["now"]
+        limit = int(p.get("limit", 100))
+        rows = [
+            rec for rec in db.settle_outbox.values()
+            if rec.get("status") == "pending"
+            and rec.get("next_attempt_at") is not None
+            and rec["next_attempt_at"] <= now
+        ]
+        rows.sort(key=lambda r: r.get("next_attempt_at") or "")
+        return [[rec.get(c) for c in OUTBOX_COLUMNS] for rec in rows[:limit]]
+    if "AND status IN ('pending', 'dead')" in sql:  # reaper-guard predicate (has_intent)
+        aid = p["aid"]
+        n = sum(
+            1 for rec in db.settle_outbox.values()
+            if rec.get("authorization_id") == aid and rec.get("status") in ("pending", "dead")
+        )
+        return [[n]]
+    if "WHERE authorization_id=@aid AND intent_kind=@kind" in sql:  # get by PK
+        rec = db.settle_outbox.get((p["aid"], p["kind"]))
+        return [[rec.get(c) for c in OUTBOX_COLUMNS]] if rec is not None else []
+    raise NotImplementedError(sql)
+
+
 def _execute_sql(
     db: FakeSpannerDatabase,
     txn: _FakeTransaction | None,
@@ -519,6 +624,11 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # tr_settle_outbox (durable settle outbox) — modeled explicitly so a guard/
+    # column/status typo makes a test FAIL rather than silently matching a
+    # generic branch (the substring-collision hazard the design flags).
+    if "tr_settle_outbox" in sql:
+        return _execute_settle_outbox_sql(db, sql, params)
     # Reaper scan: expired unsettled reservations.
     if "FROM tr_reservation WHERE settled=false AND expires_at" in sql:
         now = params["now"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -431,10 +431,17 @@ class _FakeTransaction:
             self.pending_writes.append(("insert_settle_outbox", pk, dict(p)))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET settle_origin="):  # enqueue refresh
+            # SQL-SENSITIVE (codex #113 finding 1): only enforce the fence the real
+            # query actually carries, so dropping a predicate FAILS a test.
+            _require_pred(sql, "status='pending'", "refresh")
+            _require_pred(sql, "leased_until IS NULL OR leased_until < @now", "refresh")
             pk = (p["authorization_id"], p["intent_kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
                 return 0
+            leased = rec.get("leased_until")
+            if leased is not None and leased >= p["now"]:
+                return 0  # actively leased -> refresh is a no-op (finding 2 fix)
             new = dict(rec)
             for col in (
                 "settle_origin", "reservation_id", "actual_cost_micro",
@@ -445,6 +452,8 @@ class _FakeTransaction:
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET lease_owner=@owner"):  # claim
+            _require_pred(sql, "status='pending'", "claim")
+            _require_pred(sql, "leased_until IS NULL OR leased_until < @now", "claim")
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
@@ -456,6 +465,7 @@ class _FakeTransaction:
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
+            _require_pred(sql, "status='pending'", "mark")
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
@@ -580,16 +590,31 @@ class _FakeBatch:
                 self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
 
 
+def _require_pred(sql: str, needle: str, what: str) -> None:
+    """Fail loudly if a load-bearing predicate is missing from the real SQL, so a
+    predicate typo/drop FAILS a test instead of the fake silently enforcing the
+    intended behavior in Python (codex #113 finding 1 / design MF6)."""
+    if needle not in sql:
+        raise AssertionError(f"tr_settle_outbox {what} query missing predicate: {needle!r}")
+
+
 def _execute_settle_outbox_sql(
-    db: FakeSpannerDatabase, sql: str, params: dict[str, Any]
+    db: FakeSpannerDatabase,
+    txn: _FakeTransaction | None,
+    sql: str,
+    params: dict[str, Any],
 ) -> list[list[Any]]:
-    """Model tr_settle_outbox reads. Ordered so the more-specific predicates are
-    matched before the generic (authorization_id) one — a status/column change in
-    the real query that isn't reflected here will fall through to
-    NotImplementedError, not silently pass (see the design's fake-fidelity note)."""
+    """Model tr_settle_outbox reads. SQL-SENSITIVE: each branch asserts the
+    predicates it relies on are present in the real query, so a dropped guard/
+    status/key predicate fails a test rather than silently matching."""
     p = params
     if sql.startswith("SELECT attempts, lease_owner FROM tr_settle_outbox"):
-        rec = db.settle_outbox.get((p["aid"], p["kind"]))
+        _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark-read")
+        _require_pred(sql, "status='pending'", "mark-read")
+        pk = (p["aid"], p["kind"])
+        # Txn-aware read (finding 3): read-your-writes + register the read version
+        # exactly like the reservation path, instead of peeking committed state.
+        rec = txn._settle_outbox_current(pk) if txn is not None else db.settle_outbox.get(pk)
         if rec is None or rec.get("status") != "pending":
             return []
         return [[rec.get("attempts", 0), rec.get("lease_owner")]]
@@ -604,7 +629,9 @@ def _execute_settle_outbox_sql(
         ]
         rows.sort(key=lambda r: r.get("next_attempt_at") or "")
         return [[rec.get(c) for c in OUTBOX_COLUMNS] for rec in rows[:limit]]
-    if "AND status IN ('pending', 'dead')" in sql:  # reaper-guard predicate (has_intent)
+    if "SELECT COUNT(*) FROM tr_settle_outbox" in sql:  # reaper-guard predicate (has_intent)
+        _require_pred(sql, "authorization_id=@aid", "has_intent")
+        _require_pred(sql, "status IN ('pending', 'dead')", "has_intent")
         aid = p["aid"]
         n = sum(
             1 for rec in db.settle_outbox.values()
@@ -628,7 +655,7 @@ def _execute_sql(
     # column/status typo makes a test FAIL rather than silently matching a
     # generic branch (the substring-collision hazard the design flags).
     if "tr_settle_outbox" in sql:
-        return _execute_settle_outbox_sql(db, sql, params)
+        return _execute_settle_outbox_sql(db, txn, sql, params)
     # Reaper scan: expired unsettled reservations.
     if "FROM tr_reservation WHERE settled=false AND expires_at" in sql:
         now = params["now"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -431,8 +431,11 @@ class _FakeTransaction:
             self.pending_writes.append(("insert_settle_outbox", pk, dict(p)))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET settle_origin="):  # enqueue refresh
-            # SQL-SENSITIVE (codex #113 finding 1): only enforce the fence the real
-            # query actually carries, so dropping a predicate FAILS a test.
+            # SQL-SENSITIVE (codex #113 finding 1): assert every load-bearing
+            # predicate — including the PK key — is present, so a dropped predicate
+            # FAILS a test (real Spanner would update every matching row, not the
+            # single pk the fake derives from params).
+            _require_pred(sql, "authorization_id=@authorization_id AND intent_kind=@intent_kind", "refresh")
             _require_pred(sql, "status='pending'", "refresh")
             _require_pred(sql, "leased_until IS NULL OR leased_until < @now", "refresh")
             pk = (p["authorization_id"], p["intent_kind"])
@@ -452,6 +455,7 @@ class _FakeTransaction:
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET lease_owner=@owner"):  # claim
+            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "claim")
             _require_pred(sql, "status='pending'", "claim")
             _require_pred(sql, "leased_until IS NULL OR leased_until < @now", "claim")
             pk = (p["aid"], p["kind"])
@@ -465,6 +469,7 @@ class _FakeTransaction:
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
+            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark")
             _require_pred(sql, "status='pending'", "mark")
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -8,7 +8,9 @@ drain worker, and frozen-cost finalize primitive land in later increments.
 
 from __future__ import annotations
 
-from tests.fakes.spanner import make_fake_store
+import pytest
+
+from tests.fakes.spanner import _execute_settle_outbox_sql, _FakeTransaction, make_fake_store
 from trusted_router.storage_gcp_settle_outbox import (
     ENQ_EXISTS_TERMINAL,
     ENQ_INSERTED,
@@ -123,6 +125,42 @@ def test_mark_rejects_a_lost_lease() -> None:
     # Worker B (wrong owner) cannot mark it.
     assert ob.mark("gwa-8", "settle", done=True, lease_owner="soworker_intruder") is None
     assert ob.get("gwa-8", "settle").status == "pending"
+
+
+def test_enqueue_refresh_does_not_overwrite_an_actively_leased_row() -> None:
+    """codex #113 finding 2: a claimed row stays status='pending' while a drain
+    applies it, so a retry-enqueue must NOT overwrite its frozen inputs mid-drain."""
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-11", cost=1000))
+    [job] = ob.claim(lease_seconds=300)  # a drain worker now owns it
+    # The enclave re-delivers with corrected actuals while the drain holds the lease.
+    assert ob.enqueue(_row("gwa-11", cost=8888)) == ENQ_EXISTS_TERMINAL  # no-op
+    got = ob.get("gwa-11", "settle")
+    assert got.actual_cost_micro == 1000  # unchanged under the active lease
+    assert got.lease_owner == job.lease_owner
+
+
+def test_fake_is_sql_sensitive_dropped_predicate_fails() -> None:
+    """MF6 / codex #113 finding 1: the fake must FAIL when a load-bearing SQL
+    predicate is dropped, not silently enforce the intended behavior in Python."""
+    store, db, _ = make_fake_store()
+    _outbox(store).enqueue(_row("gwa-12"))
+    # A has_intent query missing `authorization_id=@aid` must FAIL (not count).
+    with pytest.raises(AssertionError, match="has_intent"):
+        _execute_settle_outbox_sql(
+            db, None,
+            "SELECT COUNT(*) FROM tr_settle_outbox WHERE status IN ('pending', 'dead')",
+            {"aid": "gwa-12"},
+        )
+    # A claim query missing its `leased_until` lease fence must likewise FAIL.
+    with pytest.raises(AssertionError, match="claim"):
+        _FakeTransaction(db).execute_update(
+            "UPDATE tr_settle_outbox SET lease_owner=@owner, leased_until=@lease, "
+            "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
+            "AND status='pending'",  # dropped the leased_until fence
+            params={"owner": "x", "lease": "z", "now": "z", "aid": "gwa-12", "kind": "settle"},
+        )
 
 
 def test_has_intent_freezes_on_pending_and_dead_only() -> None:

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -14,6 +14,7 @@ from tests.fakes.spanner import _execute_settle_outbox_sql, _FakeTransaction, ma
 from trusted_router.storage_gcp_settle_outbox import (
     ENQ_EXISTS_TERMINAL,
     ENQ_INSERTED,
+    ENQ_LEASED,
     ENQ_REFRESHED,
     SpannerSettleOutbox,
 )
@@ -135,7 +136,7 @@ def test_enqueue_refresh_does_not_overwrite_an_actively_leased_row() -> None:
     ob.enqueue(_row("gwa-11", cost=1000))
     [job] = ob.claim(lease_seconds=300)  # a drain worker now owns it
     # The enclave re-delivers with corrected actuals while the drain holds the lease.
-    assert ob.enqueue(_row("gwa-11", cost=8888)) == ENQ_EXISTS_TERMINAL  # no-op
+    assert ob.enqueue(_row("gwa-11", cost=8888)) == ENQ_LEASED  # deferred, not terminal
     got = ob.get("gwa-11", "settle")
     assert got.actual_cost_micro == 1000  # unchanged under the active lease
     assert got.lease_owner == job.lease_owner
@@ -160,6 +161,16 @@ def test_fake_is_sql_sensitive_dropped_predicate_fails() -> None:
             "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
             "AND status='pending'",  # dropped the leased_until fence
             params={"owner": "x", "lease": "z", "now": "z", "aid": "gwa-12", "kind": "settle"},
+        )
+    # A mark query missing the PK key predicate must FAIL — real Spanner would
+    # update every matching pending row, not the single pk (codex #113 re-review).
+    with pytest.raises(AssertionError, match="mark"):
+        _FakeTransaction(db).execute_update(
+            "UPDATE tr_settle_outbox SET status=@status, attempts=@attempts, "
+            "last_error=@err, next_attempt_at=@next_at, lease_owner=NULL, "
+            "leased_until=NULL, updated_at=@now WHERE status='pending'",  # dropped the PK
+            params={"status": "done", "attempts": 1, "err": None, "next_at": None,
+                    "now": "z", "aid": "gwa-12", "kind": "settle"},
         )
 
 

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -172,6 +172,27 @@ def test_fake_is_sql_sensitive_dropped_predicate_fails() -> None:
             params={"status": "done", "attempts": 1, "err": None, "next_at": None,
                     "now": "z", "aid": "gwa-12", "kind": "settle"},
         )
+    # Symmetric coverage for the other two UPDATE handlers missing the PK filter.
+    with pytest.raises(AssertionError, match="refresh"):
+        _FakeTransaction(db).execute_update(
+            "UPDATE tr_settle_outbox SET settle_origin=@settle_origin, "
+            "reservation_id=@reservation_id, actual_cost_micro=@actual_cost_micro, "
+            "selected_endpoint_id=@selected_endpoint_id, model_id=@model_id, "
+            "selected_usage_type=@selected_usage_type, settle_body=@settle_body, "
+            "updated_at=@now WHERE status='pending' "
+            "AND (leased_until IS NULL OR leased_until < @now)",  # dropped the PK
+            params={"settle_origin": "typed", "reservation_id": None,
+                    "actual_cost_micro": 1, "selected_endpoint_id": None, "model_id": None,
+                    "selected_usage_type": None, "settle_body": None, "now": "z",
+                    "authorization_id": "gwa-12", "intent_kind": "settle"},
+        )
+    with pytest.raises(AssertionError, match="claim"):
+        _FakeTransaction(db).execute_update(
+            "UPDATE tr_settle_outbox SET lease_owner=@owner, leased_until=@lease, "
+            "updated_at=@now WHERE status='pending' "
+            "AND (leased_until IS NULL OR leased_until < @now)",  # dropped the PK
+            params={"owner": "x", "lease": "z", "now": "z", "aid": "gwa-12", "kind": "settle"},
+        )
 
 
 def test_has_intent_freezes_on_pending_and_dead_only() -> None:

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -1,0 +1,144 @@
+"""Durable settle outbox — Increment 1: native-table storage layer.
+
+Exercises the SpannerSettleOutbox primitives against the in-process Spanner fake
+(which models tr_settle_outbox explicitly, so a guard/status/column mistake fails
+here rather than silently passing). The reaper-guard wiring, enqueue-at-settle,
+drain worker, and frozen-cost finalize primitive land in later increments.
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_settle_outbox import (
+    ENQ_EXISTS_TERMINAL,
+    ENQ_INSERTED,
+    ENQ_REFRESHED,
+    SpannerSettleOutbox,
+)
+from trusted_router.storage_models import SettleOutboxRow
+
+
+def _outbox(store) -> SpannerSettleOutbox:
+    return SpannerSettleOutbox(store._database, store._param_types)
+
+
+def _row(aid: str, *, kind: str = "settle", cost: int = 1000, origin: str = "typed") -> SettleOutboxRow:
+    return SettleOutboxRow(
+        authorization_id=aid,
+        intent_kind=kind,
+        settle_origin=origin,
+        actual_cost_micro=cost,
+        reservation_id=f"res-{aid}",
+        selected_endpoint_id="openai/gpt-4o@openai",
+        model_id="openai/gpt-4o",
+        selected_usage_type="Credits",
+        settle_body=f'{{"authorization_id":"{aid}"}}',
+    )
+
+
+def test_enqueue_inserts_and_get_returns_frozen_inputs() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    assert ob.enqueue(_row("gwa-1", cost=4200)) == ENQ_INSERTED
+    got = ob.get("gwa-1", "settle")
+    assert got is not None
+    assert got.status == "pending"
+    assert got.actual_cost_micro == 4200  # frozen
+    assert got.settle_origin == "typed"
+    assert got.reservation_id == "res-gwa-1"
+    assert got.selected_usage_type == "Credits"
+
+
+def test_enqueue_is_idempotent_and_refreshes_a_pending_row() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    assert ob.enqueue(_row("gwa-2", cost=1000)) == ENQ_INSERTED
+    # A retry with corrected actuals updates the still-pending row (SF9), one row.
+    assert ob.enqueue(_row("gwa-2", cost=1750)) == ENQ_REFRESHED
+    got = ob.get("gwa-2", "settle")
+    assert got is not None and got.actual_cost_micro == 1750
+
+
+def test_enqueue_does_not_clobber_a_terminal_row() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-3", cost=1000))
+    assert ob.mark("gwa-3", "settle", done=True) == "done"
+    # Re-enqueue after the charge applied must NOT reopen or overwrite it.
+    assert ob.enqueue(_row("gwa-3", cost=9999)) == ENQ_EXISTS_TERMINAL
+    got = ob.get("gwa-3", "settle")
+    assert got is not None and got.status == "done" and got.actual_cost_micro == 1000
+
+
+def test_settle_and_refund_are_separate_rows_same_authorization() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-4", kind="settle", cost=500))
+    ob.enqueue(_row("gwa-4", kind="refund", cost=0))
+    assert ob.get("gwa-4", "settle").actual_cost_micro == 500
+    assert ob.get("gwa-4", "refund").actual_cost_micro == 0
+
+
+def test_due_then_claim_leases_and_second_claim_skips() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-5"))
+    assert [r.authorization_id for r in ob.due()] == ["gwa-5"]
+    claimed = ob.claim(lease_seconds=300)
+    assert [r.authorization_id for r in claimed] == ["gwa-5"]
+    # The lease is live -> a second claimer gets nothing (no double-drain).
+    assert ob.claim(lease_seconds=300) == []
+
+
+def test_mark_done_settles_and_drops_out_of_due() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-6"))
+    [job] = ob.claim(lease_seconds=300)
+    assert ob.mark("gwa-6", "settle", done=True, lease_owner=job.lease_owner) == "done"
+    assert ob.due() == []
+    assert ob.get("gwa-6", "settle").status == "done"
+
+
+def test_mark_failure_backs_off_then_dies_at_max_attempts() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-7"))
+    # First failure -> pending, attempts=1, next_attempt in the future (not due now).
+    assert ob.mark("gwa-7", "settle", done=False, error="boom", max_attempts=3) == "pending"
+    got = ob.get("gwa-7", "settle")
+    assert got.status == "pending" and got.attempts == 1 and got.last_error == "boom"
+    assert ob.due() == []  # backed off
+    # Drive to max_attempts -> dead (which FREEZES the hold for a human).
+    assert ob.mark("gwa-7", "settle", done=False, max_attempts=3) == "pending"
+    assert ob.mark("gwa-7", "settle", done=False, max_attempts=3) == "dead"
+    assert ob.get("gwa-7", "settle").status == "dead"
+
+
+def test_mark_rejects_a_lost_lease() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-8"))
+    ob.claim(lease_seconds=300)  # owned by worker A
+    # Worker B (wrong owner) cannot mark it.
+    assert ob.mark("gwa-8", "settle", done=True, lease_owner="soworker_intruder") is None
+    assert ob.get("gwa-8", "settle").status == "pending"
+
+
+def test_has_intent_freezes_on_pending_and_dead_only() -> None:
+    store, db, _ = make_fake_store()
+    ob = _outbox(store)
+    assert ob.has_intent("absent") is False
+    ob.enqueue(_row("gwa-9"))
+    assert ob.has_intent("gwa-9") is True  # pending freezes
+    ob.mark("gwa-9", "settle", done=True)
+    assert ob.has_intent("gwa-9") is False  # done does NOT freeze (charge applied)
+    # dead freezes (drain gave up, human must resolve).
+    ob.enqueue(_row("gwa-10"))
+    for _ in range(8):
+        ob.mark("gwa-10", "settle", done=False, max_attempts=8)
+    assert ob.get("gwa-10", "settle").status == "dead"
+    assert ob.has_intent("gwa-10") is True
+    # release_approved (human ok'd freeing) does NOT freeze.
+    db.settle_outbox[("gwa-10", "settle")]["status"] = "release_approved"
+    assert ob.has_intent("gwa-10") is False


### PR DESCRIPTION
First slice of the adversarially-hardened v2 design ([docs/design/durable-settle-outbox.md](docs/design/durable-settle-outbox.md)). **Purely additive and dormant** — nothing calls the outbox on the live settle/reaper path yet, so it's dead code in prod until later increments wire it (and even then only when `settle_outbox_enabled` flips). The prod-enable flip stays owner-gated.

## What's here
- **DDL** — native `tr_settle_outbox` table, PK `(authorization_id, intent_kind)` so a settle and a refund never clobber (MF7 + SF1), plus a `(status, next_attempt_at)` due-scan index (SF10). Additive/guarded in `migrate_typed_counters.sh`.
- **config** — `settle_outbox_enabled` (default `False`).
- **`SettleOutboxRow`** — carries the **frozen** settle inputs (`actual_cost_micro` / `settle_origin` / `reservation_id` / `selected_endpoint_id` / `model_id` / `selected_usage_type`) captured at enqueue (MF4/MF5).
- **`SpannerSettleOutbox`** — INSERT-as-claim enqueue that raises `ALREADY_EXISTS` and refreshes a still-pending row's frozen inputs (MF7, SF9); lease-fenced conditional-DML `claim`/`mark` with exponential backoff → `dead` at max_attempts; `has_intent()` = the reaper-guard predicate (freezes on `pending`|`dead`, **not** `done`|`release_approved`, MF3).
- **Fake Spanner models the table explicitly** (INSERT/UPDATE/SELECT + the guard predicate) so a status/column/guard typo **fails a test** rather than silently matching a generic branch (MF6). The column list is imported from the storage module to prevent schema drift.

## Verification
- 9 storage-layer tests: enqueue idempotency + refresh + terminal no-clobber, settle/refund polarity, due/claim lease, mark done/backoff/dead, lost-lease reject, `has_intent` freeze semantics.
- Full suite: **1210 passed, 33 skipped**. ruff + mypy clean.

## Next increments (separate PRs, each codex-gated)
1. Reaper in-txn guard (MF1/MF2/MF3) — the correctness spine.
2. Frozen-cost finalize primitive + richer outcome (MF5/SF3/SF7).
3. Enqueue-at-settle + drain endpoint (behind the flag).

Will not merge until codex reviews this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)