### PR TITLE
Fix red main: sync price-coverage test mock for makora provider

### DIFF
--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -31,6 +31,11 @@ def _known_provider_model_payload(url: str, _env_names: tuple[str, ...]) -> dict
         return {"data": [{"id": "zai/GLM-5.2"}]}
     if "maas.aliyuncs.com" in url:
         return {"data": [{"id": "glm-5.2"}]}
+    if "inference.makora.com" in url:
+        # Makora serves the GLM flagship as a quantized native id (see
+        # _MAKORA_MODEL_IDS); mirror the other GLM providers' mock so discovery
+        # matches instead of warning "returned no model ids".
+        return {"data": [{"id": "zai-org/GLM-5.2-FP8"}]}
     return {"data": []}
 
 


### PR DESCRIPTION
**Restores main to green.** Test-only fix.

The `Add Makora hourly pricing refresh` commit (d785bcc) added `makora` to `check_price_coverage`'s model-discovery audit (`inference.makora.com` + `_makora_model_id`) but didn't add a branch for it to the test's `_known_provider_model_payload` mock. So `_model_discovery_audit` returned no model ids for makora and emitted a spurious `makora: model discovery returned no model ids` warning, failing `test_model_discovery_warns_when_docs_mention_unpublished_model` and `test_model_discovery_reports_match_when_docs_models_are_published` on main — which was blocking **every** PR's CI.

Fix: add the makora mock branch mirroring the other GLM providers (returns `zai-org/GLM-5.2-FP8`, which `_MAKORA_MODEL_IDS` maps to `z-ai/glm-5.2`), so discovery matches instead of warning.

Full suite: **1204 passed, 33 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)