### PR TITLE
Settle outbox Increment 2: reaper in-txn guard (MF1/MF2/MF3)

### DIFF
--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -326,32 +326,39 @@ def settle_atomic(
 
 def _is_table_missing(exc: Exception) -> bool:
     # Rollout guard: code can deploy before the operator-applied outbox DDL.
-    # FAIL CLOSED on anything else (e.g. a transient "Session not found" is
-    # also typed NotFound): only a message naming the table counts — real
-    # Spanner raises NotFound("Table not found: tr_settle_outbox"). Any other
-    # probe error re-raises, so a transient can only delay reaping, never
-    # silently disable the interlock.
-    text = str(exc)
-    lowered = text.lower()
-    if "tr_settle_outbox" not in text:
-        return False
+    # FAIL CLOSED on everything except the ONE real "table itself is missing"
+    # shape: Cloud Spanner (and its emulator) raise NotFound("Table not found:
+    # tr_settle_outbox") — table name AFTER the phrase. Anchoring on position
+    # keeps wrapped transients ("Session not found while querying
+    # tr_settle_outbox") and schema errors ('column "status" of relation
+    # "tr_settle_outbox" does not exist') from silently unguarding a cycle;
+    # any other probe error re-raises, so a mismatch can only delay reaping,
+    # never free-release a guarded hold.
+    lowered = str(exc).lower()
     return (
-        type(exc).__name__ == "NotFound"
-        or "not found" in lowered
-        or "does not exist" in lowered
+        "table not found" in lowered
+        and "tr_settle_outbox" in lowered.split("table not found", 1)[1]
     )
 
 
-def _outbox_has_intent(database: Any, param_types: Any, authorization_id: str) -> bool:
-    """Advisory snapshot check for reaper latency only; settle_atomic re-checks
-    inside the claim transaction for the MF2 interlock."""
-    with database.snapshot() as snapshot:
-        rows = list(snapshot.execute_sql(
-            GUARD_COUNT_SQL,
-            params={"aid": authorization_id},
-            param_types={"aid": param_types.STRING},
-        ))
-    return bool(rows) and int(rows[0][0]) > 0
+# Reaper scan, two forms. The guarded form excludes holds with a pending/dead
+# outbox row IN THE SCAN so frozen holds never consume @limit and cannot
+# starve unguarded expired holds behind them (PR #116 review P2). The NOT
+# EXISTS runs on a snapshot, so it is ADVISORY ONLY — the strong re-read
+# inside settle_atomic(guard_outbox=True) remains the MF2 interlock. Keep the
+# subquery predicates literally in sync with GUARD_COUNT_SQL / GUARD_STATUSES.
+_REAP_SCAN_SQL = (
+    "SELECT reservation_id, authorization_id FROM tr_reservation "
+    "WHERE settled=false AND expires_at < @now LIMIT @limit"
+)
+_REAP_SCAN_GUARDED_SQL = (
+    "SELECT reservation_id, authorization_id FROM tr_reservation "
+    "WHERE settled=false AND expires_at < @now "
+    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    "AND o.status IN ('pending', 'dead')) "
+    "LIMIT @limit"
+)
 
 
 def reap_expired_reservations(
@@ -363,8 +370,11 @@ def reap_expired_reservations(
     path (success=False = refund, books nothing), so a late settle racing the
     reaper is safe — whoever claims the row first wins, the other no-ops.
 
-    The outbox guard is live: a hold whose authorization has a pending/dead
-    `tr_settle_outbox` row is FROZEN and never free-released. `release_approved`
+    The outbox guard is live: advisory filtering happens in the scan SQL, so a
+    hold whose authorization has a pending/dead `tr_settle_outbox` row is
+    invisible to the scan and cannot starve later unguarded holds behind @limit
+    (PR #116 review P2). `settle_atomic(..., guard_outbox=True)` still does the
+    in-txn re-check; that strong read remains the MF2 interlock. `release_approved`
     is the only human-set status that re-permits this free release. Returns the
     count reaped.
     """
@@ -385,21 +395,17 @@ def reap_expired_reservations(
         # arms itself the moment the DDL is applied.
         guard_active = False
 
+    scan_sql = _REAP_SCAN_GUARDED_SQL if guard_active else _REAP_SCAN_SQL
     with database.snapshot() as snapshot:
         rows = list(
             snapshot.execute_sql(
-                "SELECT reservation_id, authorization_id FROM tr_reservation "
-                "WHERE settled=false AND expires_at < @now LIMIT @limit",
+                scan_sql,
                 params={"now": now, "limit": int(limit)},
                 param_types={"now": pt.TIMESTAMP, "limit": pt.INT64},
             )
         )
     reaped = 0
-    for reservation_id, authorization_id in rows:
-        if guard_active and authorization_id and _outbox_has_intent(
-            database, pt, authorization_id
-        ):
-            continue  # advisory skip — latency only; the in-txn re-check is the interlock
+    for reservation_id, _authorization_id in rows:
         result = settle_atomic(
             database, pt, reservation_id=reservation_id, actual_micro=0,
             settled_usage_type="Credits", success=False, guard_outbox=guard_active,

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -38,6 +38,7 @@ from trusted_router.storage_gcp_counter_dml import (
     reserve_key,
 )
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_settle_outbox import GUARD_COUNT_SQL
 
 
 class AuthorizeOutcome:
@@ -234,6 +235,7 @@ class SettleOutcome:
     ALREADY_SETTLED = "already_settled"  # replay: another caller already settled
     NOT_FOUND = "not_found"  # no such reservation
     ERROR = "error"  # a release row-count != 1 -> rolled back, re-drive/alarm
+    OUTBOX_GUARDED = "outbox_guarded"  # reaper aborted: a pending/dead outbox row intends a charge
 
 
 class _SettleError(Exception):
@@ -249,6 +251,7 @@ def settle_atomic(
     actual_micro: int,
     settled_usage_type: str,
     success: bool,
+    guard_outbox: bool = False,
 ) -> dict:
     """Claim-gated settle/refund in ONE transaction (key then credit lock order).
 
@@ -273,6 +276,20 @@ def settle_atomic(
         res = read_reservation(transaction, pt, reservation_id)
         if res is None:
             return {"outcome": SettleOutcome.NOT_FOUND}
+        if guard_outbox:
+            aid = res.get("authorization_id")
+            if aid:
+                # MF2: this strong read inside the read-write claim txn is the
+                # real interlock; Spanner serializes it against a concurrent
+                # enqueue commit. Snapshot scans are advisory latency filters
+                # only and can miss that commit.
+                rows = list(transaction.execute_sql(
+                    GUARD_COUNT_SQL,
+                    params={"aid": aid},
+                    param_types={"aid": pt.STRING},
+                ))
+                if rows and int(rows[0][0]) > 0:
+                    return {"outcome": SettleOutcome.OUTBOX_GUARDED}
         won = claim_reservation(
             transaction, pt, reservation_id,
             actual_micro=book_actual, settled_usage_type=settled_usage_type,
@@ -307,6 +324,36 @@ def settle_atomic(
         return {"outcome": SettleOutcome.ERROR}
 
 
+def _is_table_missing(exc: Exception) -> bool:
+    # Rollout guard: code can deploy before the operator-applied outbox DDL.
+    # FAIL CLOSED on anything else (e.g. a transient "Session not found" is
+    # also typed NotFound): only a message naming the table counts — real
+    # Spanner raises NotFound("Table not found: tr_settle_outbox"). Any other
+    # probe error re-raises, so a transient can only delay reaping, never
+    # silently disable the interlock.
+    text = str(exc)
+    lowered = text.lower()
+    if "tr_settle_outbox" not in text:
+        return False
+    return (
+        type(exc).__name__ == "NotFound"
+        or "not found" in lowered
+        or "does not exist" in lowered
+    )
+
+
+def _outbox_has_intent(database: Any, param_types: Any, authorization_id: str) -> bool:
+    """Advisory snapshot check for reaper latency only; settle_atomic re-checks
+    inside the claim transaction for the MF2 interlock."""
+    with database.snapshot() as snapshot:
+        rows = list(snapshot.execute_sql(
+            GUARD_COUNT_SQL,
+            params={"aid": authorization_id},
+            param_types={"aid": param_types.STRING},
+        ))
+    return bool(rows) and int(rows[0][0]) > 0
+
+
 def reap_expired_reservations(
     database: Any, param_types: Any, *, now: Any, limit: int = 100
 ) -> int:
@@ -316,29 +363,46 @@ def reap_expired_reservations(
     path (success=False = refund, books nothing), so a late settle racing the
     reaper is safe — whoever claims the row first wins, the other no-ops.
 
-    `expires_at` is set at authorize to the EXECUTION DEADLINE (max stream
-    duration + settle-retry window + margin), so a reaped reservation is genuinely
-    abandoned; releasing without a charge is the bounded-loss accept (red-team P1).
-    A durable settle outbox (gateway persists actuals on response) is the planned
-    enhancement to recover the rare completed-but-settle-lost charge instead of
-    releasing it free; until then, keep `expires_at` generous. Returns the count
-    reaped.
+    The outbox guard is live: a hold whose authorization has a pending/dead
+    `tr_settle_outbox` row is FROZEN and never free-released. `release_approved`
+    is the only human-set status that re-permits this free release. Returns the
+    count reaped.
     """
     pt = param_types
+    guard_active = True
+    try:
+        with database.snapshot() as snapshot:
+            list(snapshot.execute_sql(
+                GUARD_COUNT_SQL,
+                params={"aid": ""},
+                param_types={"aid": pt.STRING},
+            ))
+    except Exception as exc:
+        if not _is_table_missing(exc):
+            raise
+        # Pre-migration: the table does not exist, so no intent rows can exist
+        # either. Unguarded free-release is exactly today's behavior; the guard
+        # arms itself the moment the DDL is applied.
+        guard_active = False
+
     with database.snapshot() as snapshot:
         rows = list(
             snapshot.execute_sql(
-                "SELECT reservation_id FROM tr_reservation "
+                "SELECT reservation_id, authorization_id FROM tr_reservation "
                 "WHERE settled=false AND expires_at < @now LIMIT @limit",
                 params={"now": now, "limit": int(limit)},
                 param_types={"now": pt.TIMESTAMP, "limit": pt.INT64},
             )
         )
     reaped = 0
-    for (reservation_id,) in rows:
+    for reservation_id, authorization_id in rows:
+        if guard_active and authorization_id and _outbox_has_intent(
+            database, pt, authorization_id
+        ):
+            continue  # advisory skip — latency only; the in-txn re-check is the interlock
         result = settle_atomic(
             database, pt, reservation_id=reservation_id, actual_micro=0,
-            settled_usage_type="Credits", success=False,
+            settled_usage_type="Credits", success=False, guard_outbox=guard_active,
         )
         if result["outcome"] == SettleOutcome.SETTLED:
             reaped += 1

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -50,6 +50,17 @@ OUTBOX_COLUMNS = [
 # let the reaper free the hold. `done` means the charge already applied.
 GUARD_STATUSES = ("pending", "dead")
 
+# The reaper-guard predicate. SINGLE SOURCE OF TRUTH for this SQL: it is
+# executed on a snapshot by has_intent (advisory pre-scan), on a snapshot by
+# the reaper's advisory skip, and INSIDE settle_atomic's read-write
+# transaction (the real interlock, MF2). The fake asserts both predicates
+# (`authorization_id=@aid`, `status IN ('pending', 'dead')`) — keep the
+# literal exactly in sync with GUARD_STATUSES.
+GUARD_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "
+    "AND status IN ('pending', 'dead')"
+)
+
 # Enqueue outcomes.
 ENQ_INSERTED = "inserted"          # new pending row
 ENQ_REFRESHED = "refreshed"        # existing pending row's frozen inputs updated
@@ -333,10 +344,7 @@ class SpannerSettleOutbox:
         also re-checks in-transaction (Increment 2) for the real interlock."""
         with self._database.snapshot() as snapshot:
             rows = list(snapshot.execute_sql(
-                # GUARD_STATUSES inlined as a fixed literal (not user input) so the
-                # predicate needs no Array param type — keeps the fake faithful.
-                "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "
-                "AND status IN ('pending', 'dead')",
+                GUARD_COUNT_SQL,
                 params={"aid": authorization_id},
                 param_types={"aid": self._pt.STRING},
             ))

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -658,28 +658,52 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
-    # tr_settle_outbox (durable settle outbox) — modeled explicitly so a guard/
-    # column/status typo makes a test FAIL rather than silently matching a
-    # generic branch (the substring-collision hazard the design flags).
-    if "tr_settle_outbox" in sql:
-        return _execute_settle_outbox_sql(db, txn, sql, params)
-    # Reaper scan: expired unsettled reservations.
+    # Reaper scan: expired unsettled reservations. This must precede the generic
+    # tr_settle_outbox dispatcher because the guarded scan names both tables; match
+    # the more specific query first.
     if "FROM tr_reservation WHERE settled=false AND expires_at" in sql:
         _require_pred(
             sql,
             "SELECT reservation_id, authorization_id FROM tr_reservation",
             "reaper-scan",
         )
+        _require_pred(sql, "expires_at < @now", "reaper-scan")
+        _require_pred(sql, "LIMIT @limit", "reaper-scan")
+        guarded = "NOT EXISTS" in sql
+        if guarded:
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_reservation.authorization_id",
+                "reaper-scan-guard",
+            )
+            _require_pred(sql, "o.status IN ('pending', 'dead')", "reaper-scan-guard")
         now = params["now"]
         limit = int(params.get("limit", 100))
         out: list[list] = []
         for rid, rec in db.reservations.items():
             exp = rec.get("expires_at")
-            if not rec.get("settled") and exp is not None and exp < now:
-                out.append([rid, rec.get("authorization_id")])
-                if len(out) >= limit:
-                    break
+            if rec.get("settled") or exp is None or exp >= now:
+                continue
+            if guarded:
+                # Model NOT EXISTS semantics before LIMIT (MF6): a dropped guard
+                # predicate must fail tests instead of letting frozen rows consume
+                # the reaper's scan window.
+                aid = rec.get("authorization_id")
+                if any(
+                    row.get("authorization_id") == aid
+                    and row.get("status") in ("pending", "dead")
+                    for row in db.settle_outbox.values()
+                ):
+                    continue
+            out.append([rid, rec.get("authorization_id")])
+            if len(out) >= limit:
+                break
         return out
+    # tr_settle_outbox (durable settle outbox) — modeled explicitly so a guard/
+    # column/status typo makes a test FAIL rather than silently matching a
+    # generic branch (the substring-collision hazard the design flags).
+    if "tr_settle_outbox" in sql:
+        return _execute_settle_outbox_sql(db, txn, sql, params)
     # Repair: any OPEN holds on a nonzero shard? (checked first — its query string
     # contains the generic count substrings below.)
     if "key_shard!=0" in sql:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -638,6 +638,8 @@ def _execute_settle_outbox_sql(
         _require_pred(sql, "authorization_id=@aid", "has_intent")
         _require_pred(sql, "status IN ('pending', 'dead')", "has_intent")
         aid = p["aid"]
+        # Committed-state read is correct for the in-txn guard too: enqueue
+        # commits in its own txn, and the reaper txn never writes outbox rows.
         n = sum(
             1 for rec in db.settle_outbox.values()
             if rec.get("authorization_id") == aid and rec.get("status") in ("pending", "dead")
@@ -663,13 +665,18 @@ def _execute_sql(
         return _execute_settle_outbox_sql(db, txn, sql, params)
     # Reaper scan: expired unsettled reservations.
     if "FROM tr_reservation WHERE settled=false AND expires_at" in sql:
+        _require_pred(
+            sql,
+            "SELECT reservation_id, authorization_id FROM tr_reservation",
+            "reaper-scan",
+        )
         now = params["now"]
         limit = int(params.get("limit", 100))
         out: list[list] = []
         for rid, rec in db.reservations.items():
             exp = rec.get("expires_at")
             if not rec.get("settled") and exp is not None and exp < now:
-                out.append([rid])
+                out.append([rid, rec.get("authorization_id")])
                 if len(out) >= limit:
                     break
         return out

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -1,0 +1,267 @@
+"""Durable settle outbox — Increment 2: reaper guard wiring.
+
+Mirrors the typed-billing reaper helpers from test_billing_typed_enforcement and
+the outbox row builder style from test_settle_outbox_storage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from tests.test_billing_typed_enforcement import (
+    _NOW,
+    _authorize,
+    _make_key,
+    _seed_credit,
+    _typed,
+)
+from trusted_router import storage_gcp_authorize as authorize_mod
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    reap_expired_reservations,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_settle_outbox import GUARD_COUNT_SQL, SpannerSettleOutbox
+from trusted_router.storage_models import SettleOutboxRow
+
+
+def _outbox(store: Any) -> SpannerSettleOutbox:
+    return SpannerSettleOutbox(store._database, store._param_types)
+
+
+def _row(aid: str, rid: str, *, cost: int = 900_000) -> SettleOutboxRow:
+    return SettleOutboxRow(
+        authorization_id=aid,
+        intent_kind="settle",
+        settle_origin="typed",
+        actual_cost_micro=cost,
+        reservation_id=rid,
+        selected_endpoint_id="openai/gpt-4o@openai",
+        model_id="openai/gpt-4o",
+        selected_usage_type="Credits",
+        settle_body=f'{{"authorization_id":"{aid}","reservation_id":"{rid}"}}',
+    )
+
+
+def _expired_authorization(store: Any, *, ws: str, estimate: int = 1_000_000) -> dict[str, Any]:
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=estimate)
+    assert auth["outcome"] == AuthorizeOutcome.ACCEPTED
+    return auth
+
+
+def _assert_frozen(db: Any, ws: str, rid: str) -> None:
+    assert _typed(db, ws)["reserved"] == 1_000_000
+    assert db.reservations[rid]["settled"] is False
+
+
+def _assert_free_released(db: Any, ws: str, rid: str) -> None:
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 0
+    assert db.reservations[rid]["settled"] is True
+    assert db.reservations[rid]["actual_micro"] == 0
+
+
+def test_pending_row_freezes_hold() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_pending"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    _outbox(store).enqueue(_row(aid, rid))
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+    _assert_frozen(db, ws, rid)
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+    _assert_frozen(db, ws, rid)
+
+
+def test_dead_row_freezes_hold() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_dead"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    ob = _outbox(store)
+    ob.enqueue(_row(aid, rid))
+    [job] = ob.claim()
+    assert ob.mark(aid, "settle", done=False, lease_owner=job.lease_owner, max_attempts=1) == "dead"
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+    _assert_frozen(db, ws, rid)
+
+
+def test_release_approved_row_is_reaped() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_release_approved"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    _outbox(store).enqueue(_row(aid, rid))
+    db.settle_outbox[(aid, "settle")]["status"] = "release_approved"
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 1
+    _assert_free_released(db, ws, rid)
+
+
+def test_done_row_is_reaped() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_done"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    ob = _outbox(store)
+    ob.enqueue(_row(aid, rid))
+    assert ob.mark(aid, "settle", done=True) == "done"
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 1
+    _assert_free_released(db, ws, rid)
+
+
+def test_empty_table_reaper_unchanged() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_empty"
+    auth = _expired_authorization(store, ws=ws)
+    rid = auth["reservation_id"]
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 1
+    _assert_free_released(db, ws, rid)
+
+
+def test_in_txn_guard_beats_stale_advisory(monkeypatch: pytest.MonkeyPatch) -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_mf2"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    _outbox(store).enqueue(_row(aid, rid))
+    monkeypatch.setattr(authorize_mod, "_outbox_has_intent", lambda *_args, **_kwargs: False)
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+    _assert_frozen(db, ws, rid)
+
+
+def test_settle_atomic_guard_outbox_semantics() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_settle_atomic"
+    auth = _expired_authorization(store, ws=ws)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    _outbox(store).enqueue(_row(aid, rid))
+
+    guarded = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=rid,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+        guard_outbox=True,
+    )
+    assert guarded["outcome"] == SettleOutcome.OUTBOX_GUARDED
+    _assert_frozen(db, ws, rid)
+
+    inline = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=rid,
+        actual_micro=900_000,
+        settled_usage_type="Credits",
+        success=True,
+        guard_outbox=False,
+    )
+    assert inline["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 900_000
+
+
+def test_probe_falls_back_when_table_missing() -> None:
+    class NotFound(Exception):
+        pass
+
+    class MissingOutboxSnapshot:
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+            self._snapshot: Any = None
+
+        def __enter__(self) -> MissingOutboxSnapshot:
+            self._snapshot = self._inner.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return self._inner.__exit__(*args)
+
+        def execute_sql(
+            self,
+            sql: str,
+            *,
+            params: dict[str, Any] | None = None,
+            param_types: Any = None,
+        ) -> list[list[Any]]:
+            if sql == GUARD_COUNT_SQL:
+                raise NotFound("tr_settle_outbox table not found")
+            return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
+
+    class MissingOutboxDatabase:
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+
+        def snapshot(self, **kwargs: Any) -> MissingOutboxSnapshot:
+            return MissingOutboxSnapshot(self._inner.snapshot(**kwargs))
+
+        def run_in_transaction(self, fn: Any) -> Any:
+            return self._inner.run_in_transaction(fn)
+
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_missing_table"
+    auth = _expired_authorization(store, ws=ws)
+    rid = auth["reservation_id"]
+
+    assert reap_expired_reservations(MissingOutboxDatabase(store._database), store._param_types, now=_NOW) == 1
+    _assert_free_released(db, ws, rid)
+
+
+def test_probe_transient_notfound_fails_closed() -> None:
+    class NotFound(Exception):
+        pass
+
+    class MissingOutboxSnapshot:
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+            self._snapshot: Any = None
+
+        def __enter__(self) -> MissingOutboxSnapshot:
+            self._snapshot = self._inner.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return self._inner.__exit__(*args)
+
+        def execute_sql(
+            self,
+            sql: str,
+            *,
+            params: dict[str, Any] | None = None,
+            param_types: Any = None,
+        ) -> list[list[Any]]:
+            if sql == GUARD_COUNT_SQL:
+                raise NotFound("Session not found")
+            return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
+
+    class MissingOutboxDatabase:
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+
+        def snapshot(self, **kwargs: Any) -> MissingOutboxSnapshot:
+            return MissingOutboxSnapshot(self._inner.snapshot(**kwargs))
+
+        def run_in_transaction(self, fn: Any) -> Any:
+            return self._inner.run_in_transaction(fn)
+
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_transient_notfound"
+    auth = _expired_authorization(store, ws=ws)
+    rid = auth["reservation_id"]
+
+    with pytest.raises(NotFound):
+        reap_expired_reservations(MissingOutboxDatabase(store._database), store._param_types, now=_NOW)
+    _assert_frozen(db, ws, rid)

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -18,8 +18,9 @@ from tests.test_billing_typed_enforcement import (
     _seed_credit,
     _typed,
 )
-from trusted_router import storage_gcp_authorize as authorize_mod
 from trusted_router.storage_gcp_authorize import (
+    _REAP_SCAN_GUARDED_SQL,
+    _REAP_SCAN_SQL,
     AuthorizeOutcome,
     SettleOutcome,
     reap_expired_reservations,
@@ -31,6 +32,44 @@ from trusted_router.storage_models import SettleOutboxRow
 
 def _outbox(store: Any) -> SpannerSettleOutbox:
     return SpannerSettleOutbox(store._database, store._param_types)
+
+
+class _ProxySnapshot:
+    def __init__(self, inner: Any, on_execute: Any) -> None:
+        self._inner = inner
+        self._on_execute = on_execute
+        self._snapshot: Any = None
+
+    def __enter__(self) -> _ProxySnapshot:
+        self._snapshot = self._inner.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> Any:
+        return self._inner.__exit__(*args)
+
+    def execute_sql(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any] | None = None,
+        param_types: Any = None,
+    ) -> list[list[Any]]:
+        replacement = self._on_execute(sql)
+        if isinstance(replacement, str):
+            sql = replacement
+        return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
+
+
+class _ProxyDatabase:
+    def __init__(self, inner: Any, on_execute: Any) -> None:
+        self._inner = inner
+        self._on_execute = on_execute
+
+    def snapshot(self, **kwargs: Any) -> _ProxySnapshot:
+        return _ProxySnapshot(self._inner.snapshot(**kwargs), self._on_execute)
+
+    def run_in_transaction(self, fn: Any) -> Any:
+        return self._inner.run_in_transaction(fn)
 
 
 def _row(aid: str, rid: str, *, cost: int = 900_000) -> SettleOutboxRow:
@@ -129,15 +168,25 @@ def test_empty_table_reaper_unchanged() -> None:
     _assert_free_released(db, ws, rid)
 
 
-def test_in_txn_guard_beats_stale_advisory(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_in_txn_guard_beats_stale_advisory() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_guard_mf2"
     auth = _expired_authorization(store, ws=ws)
     rid, aid = auth["reservation_id"], auth["authorization_id"]
     _outbox(store).enqueue(_row(aid, rid))
-    monkeypatch.setattr(authorize_mod, "_outbox_has_intent", lambda *_args, **_kwargs: False)
 
-    assert reap_expired_reservations(store._database, store._param_types, now=_NOW) == 0
+    fired = []
+
+    def stale_scan(sql: str) -> str | None:
+        if sql == _REAP_SCAN_GUARDED_SQL:
+            fired.append(True)
+            return _REAP_SCAN_SQL
+        return None
+
+    proxied = _ProxyDatabase(store._database, stale_scan)
+
+    assert reap_expired_reservations(proxied, store._param_types, now=_NOW) == 0
+    assert fired
     _assert_frozen(db, ws, rid)
 
 
@@ -178,45 +227,19 @@ def test_probe_falls_back_when_table_missing() -> None:
     class NotFound(Exception):
         pass
 
-    class MissingOutboxSnapshot:
-        def __init__(self, inner: Any) -> None:
-            self._inner = inner
-            self._snapshot: Any = None
-
-        def __enter__(self) -> MissingOutboxSnapshot:
-            self._snapshot = self._inner.__enter__()
-            return self
-
-        def __exit__(self, *args: Any) -> None:
-            return self._inner.__exit__(*args)
-
-        def execute_sql(
-            self,
-            sql: str,
-            *,
-            params: dict[str, Any] | None = None,
-            param_types: Any = None,
-        ) -> list[list[Any]]:
-            if sql == GUARD_COUNT_SQL:
-                raise NotFound("tr_settle_outbox table not found")
-            return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
-
-    class MissingOutboxDatabase:
-        def __init__(self, inner: Any) -> None:
-            self._inner = inner
-
-        def snapshot(self, **kwargs: Any) -> MissingOutboxSnapshot:
-            return MissingOutboxSnapshot(self._inner.snapshot(**kwargs))
-
-        def run_in_transaction(self, fn: Any) -> Any:
-            return self._inner.run_in_transaction(fn)
+    def missing_table(sql: str) -> None:
+        if "tr_settle_outbox" in sql:
+            raise NotFound("Table not found: tr_settle_outbox")
+        return None
 
     store, db, _ = make_fake_store()
     ws = "ws_guard_missing_table"
     auth = _expired_authorization(store, ws=ws)
     rid = auth["reservation_id"]
 
-    assert reap_expired_reservations(MissingOutboxDatabase(store._database), store._param_types, now=_NOW) == 1
+    proxied = _ProxyDatabase(store._database, missing_table)
+
+    assert reap_expired_reservations(proxied, store._param_types, now=_NOW) == 1
     _assert_free_released(db, ws, rid)
 
 
@@ -224,44 +247,94 @@ def test_probe_transient_notfound_fails_closed() -> None:
     class NotFound(Exception):
         pass
 
-    class MissingOutboxSnapshot:
-        def __init__(self, inner: Any) -> None:
-            self._inner = inner
-            self._snapshot: Any = None
-
-        def __enter__(self) -> MissingOutboxSnapshot:
-            self._snapshot = self._inner.__enter__()
-            return self
-
-        def __exit__(self, *args: Any) -> None:
-            return self._inner.__exit__(*args)
-
-        def execute_sql(
-            self,
-            sql: str,
-            *,
-            params: dict[str, Any] | None = None,
-            param_types: Any = None,
-        ) -> list[list[Any]]:
-            if sql == GUARD_COUNT_SQL:
-                raise NotFound("Session not found")
-            return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
-
-    class MissingOutboxDatabase:
-        def __init__(self, inner: Any) -> None:
-            self._inner = inner
-
-        def snapshot(self, **kwargs: Any) -> MissingOutboxSnapshot:
-            return MissingOutboxSnapshot(self._inner.snapshot(**kwargs))
-
-        def run_in_transaction(self, fn: Any) -> Any:
-            return self._inner.run_in_transaction(fn)
+    def transient(sql: str) -> None:
+        if sql == GUARD_COUNT_SQL:
+            raise NotFound("Session not found")
+        return None
 
     store, db, _ = make_fake_store()
     ws = "ws_guard_transient_notfound"
     auth = _expired_authorization(store, ws=ws)
     rid = auth["reservation_id"]
 
+    proxied = _ProxyDatabase(store._database, transient)
+
     with pytest.raises(NotFound):
-        reap_expired_reservations(MissingOutboxDatabase(store._database), store._param_types, now=_NOW)
+        reap_expired_reservations(proxied, store._param_types, now=_NOW)
     _assert_frozen(db, ws, rid)
+
+
+def test_probe_wrapped_transient_naming_table_fails_closed() -> None:
+    class NotFound(Exception):
+        pass
+
+    def wrapped_transient(sql: str) -> None:
+        if sql == GUARD_COUNT_SQL:
+            raise NotFound("Session not found while querying tr_settle_outbox")
+        return None
+
+    store, db, _ = make_fake_store()
+    ws = "ws_guard_wrapped_transient"
+    auth = _expired_authorization(store, ws=ws)
+    rid = auth["reservation_id"]
+
+    proxied = _ProxyDatabase(store._database, wrapped_transient)
+
+    with pytest.raises(NotFound):
+        reap_expired_reservations(proxied, store._param_types, now=_NOW)
+    _assert_frozen(db, ws, rid)
+
+
+def test_probe_does_not_exist_shapes_fail_closed() -> None:
+    class NotFound(Exception):
+        pass
+
+    for i, message in enumerate((
+        "Table tr_settle_outbox does not exist",
+        'column "status" of relation "tr_settle_outbox" does not exist',
+    )):
+
+        def missing_table(sql: str, message: str = message) -> None:
+            if sql == GUARD_COUNT_SQL:
+                raise NotFound(message)
+            return None
+
+        store, db, _ = make_fake_store()
+        ws = f"ws_guard_does_not_exist_{i}"
+        auth = _expired_authorization(store, ws=ws)
+        rid = auth["reservation_id"]
+
+        proxied = _ProxyDatabase(store._database, missing_table)
+
+        with pytest.raises(NotFound):
+            reap_expired_reservations(proxied, store._param_types, now=_NOW)
+        _assert_frozen(db, ws, rid)
+
+
+def test_guarded_rows_do_not_starve_unguarded() -> None:
+    store, db, _ = make_fake_store()
+    ws_a = "ws_guard_starve_a"
+    auth_a = _expired_authorization(store, ws=ws_a)
+    rid_a, aid_a = auth_a["reservation_id"], auth_a["authorization_id"]
+    _outbox(store).enqueue(_row(aid_a, rid_a))
+
+    ws_b = "ws_guard_starve_b"
+    auth_b = _expired_authorization(store, ws=ws_b)
+    rid_b = auth_b["reservation_id"]
+
+    # The sandwich guarantees a guarded row precedes the unguarded one in scan
+    # order regardless of which side a future edit moves the setup blocks to
+    # (round-1 starvation repro requires a guarded row ahead of the unguarded victim).
+    ws_c = "ws_guard_starve_c"
+    auth_c = _expired_authorization(store, ws=ws_c)
+    rid_c, aid_c = auth_c["reservation_id"], auth_c["authorization_id"]
+    _outbox(store).enqueue(_row(aid_c, rid_c))
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW, limit=1) == 1
+    _assert_free_released(db, ws_b, rid_b)
+    _assert_frozen(db, ws_a, rid_a)
+    _assert_frozen(db, ws_c, rid_c)
+
+    assert reap_expired_reservations(store._database, store._param_types, now=_NOW, limit=1) == 0
+    _assert_frozen(db, ws_a, rid_a)
+    _assert_frozen(db, ws_c, rid_c)


### PR DESCRIPTION
Increment 2 of `docs/design/durable-settle-outbox.md` (§4 — read §3 for why this guard is the SOLE lost-charge correctness mechanism). Increment 1 (native-table storage, #113) is merged; this wires the reaper interlock. Authored by codex-cli against a decision-final spec; adversarially reviewed by Claude (one fail-closed fix applied, see below).

## What
- `settle_atomic(guard_outbox=False)` — when True (reaper only), a strong read of `GUARD_COUNT_SQL` **inside the read-write claim transaction** aborts the free-release with `SettleOutcome.OUTBOX_GUARDED` if the authorization has a `pending`/`dead` outbox row. In-txn is the MF2 interlock: Spanner serializes it against a concurrent enqueue commit that a snapshot pre-filter would miss. Every live settle/refund caller keeps `guard_outbox=False` — the **inline** settle must proceed (it's what resolves the intent); only the reaper's zero-charge release is guarded.
- `reap_expired_reservations` now projects `authorization_id` (the design calls out it only projected `reservation_id`), advisory-skips candidates with live intents (latency only), and reaps with `guard_outbox=True`.
- **Rollout-safe probe**: the DDL is operator-applied and may lag the deploy. A per-reap probe arms the guard only when the table exists; table-missing (message must *name* `tr_settle_outbox`) falls back to today's exact behavior — correct, since no intent rows can exist without the table.
- **Review finding fixed (fail-closed)**: transient Spanner errors are also typed `NotFound` (e.g. "Session not found"); classifying those as table-missing would have silently disabled the interlock for the cycle. Now any probe error not naming the table **re-raises** — a transient can delay reaping, never unguard it.
- `GUARD_COUNT_SQL` is single-source (has_intent + advisory + in-txn all execute the same literal); the fake `_require_pred`s both predicates and the new scan projection (MF6: a dropped predicate fails a test, it is never silently absorbed).

## Inertness
Byte-identical when: `guard_outbox=False` (all live callers), the table is empty (`NOT EXISTS` vacuous), or the table doesn't exist yet. Enqueue ships default-off in Increment 4; nothing populates the table today.

## Tests
9 new (`tests/test_settle_outbox_guard.py`): pending/dead freeze (twice — frozen, not deferred), `release_approved`/`done` reap, empty-table baseline, **MF2 stale-advisory race** (advisory stubbed False → in-txn check still blocks), `guard_outbox` semantics both ways, table-missing fallback, transient-NotFound fail-closed. Full suite **1228 passed**, ruff + mypy clean repo-wide.

Per the handoff hard constraints: codex review will be posted on this PR before merge; no auto-merge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)