### PR TITLE
Drop third-party transport chatter from Axiom log shipping

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -85,6 +85,12 @@ def init_axiom(settings: Settings) -> None:
     # record. Reuses sentry_config's `_scrub` so the rules are defined
     # in one place.
     handler.addFilter(_AxiomScrubFilter())
+    # Drop third-party transport chatter before it ships. Measured
+    # 2026-07-04: urllib3.connectionpool (Sentry's envelope uploads)
+    # was 235 of 238 events in a 2h window — a feedback loop where
+    # observability traffic generates observability traffic. Name-based
+    # so it composes with any handler level.
+    handler.addFilter(_AxiomNoiseFilter())
 
     root = logging.getLogger()
     root.addHandler(handler)
@@ -163,6 +169,39 @@ class _AxiomScrubFilter(logging.Filter):
             scrubbed = _scrub(value)
             if scrubbed is not value:
                 record.__dict__[key] = scrubbed
+        return True
+
+
+class _AxiomNoiseFilter(logging.Filter):
+    """Drop third-party transport/client chatter before it ships to
+    Axiom. The dataset exists for the app's structured events
+    (request_id, provider, error_class joins) — not for the HTTP
+    plumbing underneath our own observability stack.
+
+    Measured 2026-07-04: `urllib3.connectionpool` alone (Sentry's
+    envelope uploads) was 235 of 238 events in a 2h window. Shipping
+    those burns ingest quota to record that we recorded something.
+
+    Prefix match on the logger name, so child loggers
+    (`urllib3.connectionpool`, `google.auth.transport`, ...) are
+    covered by their root entry. App loggers (`trusted_router.*`) and
+    uvicorn error logs are unaffected."""
+
+    _NOISY_PREFIXES = (
+        "urllib3",             # Sentry transport + assorted HTTP chatter
+        "sentry_sdk",          # the SDK's own internal logging
+        "google",              # spanner/bigtable/auth client libraries
+        "grpc",                # gRPC channel state churn
+        "httpx",               # per-request INFO lines for provider calls
+        "httpcore",            # httpx's transport layer
+        "hpack",               # HTTP/2 header codec debug noise
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        name = record.name
+        for prefix in self._NOISY_PREFIXES:
+            if name == prefix or name.startswith(prefix + "."):
+                return False
         return True
 
 

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -59,3 +59,48 @@ def test_axiom_client_kwargs_keep_standard_api_url_for_non_edge() -> None:
         "org_id": "org_1",
         "url": "https://api.axiom.co",
     }
+
+
+def _record(logger_name: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=logger_name, level=logging.INFO, pathname=__file__,
+        lineno=1, msg="hello", args=(), exc_info=None,
+    )
+
+
+def test_noise_filter_drops_third_party_transport_chatter() -> None:
+    """urllib3.connectionpool was 235/238 Axiom events in a 2h window
+    (Sentry envelope uploads). The noise filter must drop it and its
+    friends so the dataset stays app-events-only."""
+    from trusted_router.axiom_config import _AxiomNoiseFilter
+
+    f = _AxiomNoiseFilter()
+    for name in [
+        "urllib3",
+        "urllib3.connectionpool",
+        "sentry_sdk.errors",
+        "google.auth.transport.requests",
+        "grpc._channel",
+        "httpx",
+        "httpcore.http11",
+        "hpack.hpack",
+    ]:
+        assert f.filter(_record(name)) is False, name
+
+
+def test_noise_filter_keeps_app_and_server_logs() -> None:
+    """App loggers and uvicorn error logs must pass through — and a
+    prefix must not shadow lookalike names (e.g. `googleapis_custom`
+    is not `google.*`)."""
+    from trusted_router.axiom_config import _AxiomNoiseFilter
+
+    f = _AxiomNoiseFilter()
+    for name in [
+        "trusted_router.routes.inference",
+        "trusted_router.storage_gcp",
+        "uvicorn.error",
+        "root",
+        "googleapis_custom",
+        "urllib3x",
+    ]:
+        assert f.filter(_record(name)) is True, name


### PR DESCRIPTION
## Why

Now that Axiom shipping works (dataset `trusted-router-logs`, fixed 2026-07-04), 98.7% of shipped events are `urllib3.connectionpool` lines — Sentry's envelope uploads. An observability feedback loop: Sentry sends an error report, urllib3 logs the HTTP call, Axiom ships that log. Measured 235 of 238 events in a 2h window.

## What

`_AxiomNoiseFilter` on the Axiom handler, prefix-matching logger names: `urllib3`, `sentry_sdk`, `google`, `grpc`, `httpx`, `httpcore`, `hpack`. Exact-segment matching (`urllib3x` passes, `urllib3.foo` drops). App loggers (`trusted_router.*`), `uvicorn.error`, and root are untouched.

## Verification

- `uv run pytest tests/test_axiom_config.py` — 5 passed (2 new tests: drops chatter, keeps app logs, prefix can't shadow lookalikes)
- Takes effect on next rollout; expected result is the Axiom `summarize count() by name` breakdown flipping from ~99% urllib3 to ~100% trusted_router.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)