### PR TITLE
Durable settle outbox — Increment 4: enqueue-at-settle + drain endpoint

### DIFF
--- a/docs/design/durable-settle-outbox.md
+++ b/docs/design/durable-settle-outbox.md
@@ -164,6 +164,10 @@ the enqueue INSERT commits** — a crash between receiving the POST and the enqu
 still relies on the enclave re-delivering; quantify recovery as "finalize-after-
 enqueue failures", not "all losses".
 
+Flag-on hot-path cost: two additional sequential Spanner commits on settle
+(enqueue before finalize, done-mark after finalize), accepted for the gated
+cohort.
+
 ## 6. Drain — apply the FROZEN amount via a narrow primitive (fixes MF4/MF5/SF7)
 
 `POST /internal/gateway/settle-outbox/drain?limit=N` (internal-token auth),
@@ -183,6 +187,9 @@ lease-claims due `pending` rows and for each:
   row that intended a charge → **`dead` + alert** (the reaper beat us — invariant
   violation, do not report "recovered"); deterministic non-retryable errors →
   `dead` (no page); transient → backoff. After `max_attempts` → `dead` + alert.
+- Accepted SF7 loss: drained generations never reach metadata-broadcast
+  destinations.
+- Accepted SF7 loss: drained refunds record no provider-error benchmark sample.
 - Final `ApplyOutcome` contract for the drain:
   `settled_now` → done. `already_settled_with_charge` means done for settle
   intent; for refund intent with a charged reservation, done plus the same
@@ -229,6 +236,8 @@ lease-claims due `pending` rows and for each:
    split (§3).
 4. Flip `settle_outbox_enabled=True` fully once shadow is clean. **Billing
    prod-behavior flip → Joseph's explicit go** (typed-cutover bar).
+5. Retention is handled by the drain's done-row purge (default 30 days);
+   `pending`/`dead`/`release_approved` are never auto-deleted.
 
 ## 9. Open question for the owner (unchanged — §6 of v1)
 
@@ -300,41 +309,20 @@ Read this first if you are continuing the outbox build.
     (`_require_pred`) so a dropped predicate FAILS a test (the MF6 guarantee).
   - Tests: `tests/test_settle_outbox_storage.py` (11).
 
-### What REMAINS — Increments 2–4 (each its own codex-gated PR, default-off)
-2. **Reaper in-txn guard (MF1/MF2/MF3) — the correctness spine, the one live
-   change.** In `storage_gcp_authorize.py`:
-   - `settle_atomic` gains `guard_outbox: bool = False`. When True, INSIDE its
-     read-write txn after `read_reservation` (which returns `authorization_id` —
-     confirmed), do an in-txn `SELECT COUNT(*) FROM tr_settle_outbox WHERE
-     authorization_id=@aid AND status IN ('pending','dead')`; if > 0, ABORT the
-     free-release (return a new `SettleOutcome.OUTBOX_GUARDED`, do NOT claim). The
-     in-txn re-check is the interlock (a snapshot pre-filter alone has the MF2
-     TOCTOU).
-   - `reap_expired_reservations` must project `authorization_id` (today it
-     projects only `reservation_id`), advisory-skip candidates where
-     `settle_outbox.has_intent(aid)`, and call `settle_atomic(..., guard_outbox=True)`.
-   - INERT WHEN THE TABLE IS EMPTY → reaper is byte-identical to today when
-     disabled. Fake: the reaper query gains the guard subquery, so update the fake
-     reaper handler (`tests/fakes/spanner.py`, `"FROM tr_reservation WHERE
-     settled=false AND expires_at"` branch) to filter by the fake `settle_outbox`,
-     and add a `_require_pred` for the guard predicate (MF6 — a guard typo must
-     fail a test). Test both directions (row present → skipped; absent → reaped).
-3. **Frozen-cost finalize primitive + richer outcome (MF5/SF3/SF7).** A narrow
-   apply function (counter claim + gateway_authorization finalize + generation
-   write) that applies the STORED `actual_cost_micro` and returns the final
-   8-value §6 `ApplyOutcome` contract — NOT the full
-   `_settle_gateway_authorization` handler (which re-runs pricing + re-fires
-   alerts/refill/broadcast). The drain marks `done` on charged, `dead`+ALERT on
-   `already_released_free` (reaper beat us — never silently "recovered").
-4. **Enqueue-at-settle + drain endpoint.** In `_settle_gateway_authorization`
-   (`routes/internal/gateway.py`), gated on `settings.settle_outbox_enabled`:
-   enqueue BEFORE the inline finalize (capturing the resolved origin +
-   frozen cost the inline attempt computed), mark `done` after. Add
-   `POST /internal/gateway/settle-outbox/drain` (internal-token auth, mirror
-   `routes/internal/broadcast_queue.py`) that claims due rows and applies via the
-   Increment-3 primitive, routing on the STORED origin (MF4 — immune to a
-   `TR_TYPED_COUNTER_MIRROR` flip; PARK, don't dead-letter, if the typed store is
-   unavailable).
+- **Increment 2 — reaper in-txn guard (MF1/MF2/MF3)** = PR #116. `settle_atomic`
+  and `reap_expired_reservations` now freeze pending/dead outbox rows and fake
+  SQL asserts the guard predicates.
+- **Increment 3 — frozen-cost apply primitive (MF5/SF3/SF7)** = PR #118.
+  `apply_frozen_settle` applies stored origin/cost via the narrow 8-outcome
+  contract without the full HTTP settle side effects.
+- **Increment 4 — enqueue-at-settle + drain endpoint** = this PR. Live settle
+  enqueues frozen rows before inline finalize, marks done only on inline success,
+  and `/internal/gateway/settle-outbox/drain` claims and resolves rows.
+
+### What REMAINS — operator rollout
+
+The remaining operator steps are the §8 rollout sequence: apply the guarded DDL,
+then Joseph decides when to flip `settle_outbox_enabled=True`.
 
 ### HARD constraints (do not violate)
 - **codex-review BEFORE merge on every billing PR. Do NOT arm auto-merge-on-green

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import uuid
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Request
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep, is_api_key_expired
 from trusted_router.byok_crypto import byok_cache_key, encrypted_secret_payload
@@ -54,6 +56,10 @@ from trusted_router.services.broadcast import (
     should_drain_inline,
 )
 from trusted_router.services.settle_outbox_apply import normalized_prompt_accounting
+from trusted_router.services.settle_outbox_drain import (
+    drain_settle_outbox,
+    spanner_settle_outbox,
+)
 from trusted_router.storage import (
     STORE,
     Generation,
@@ -61,7 +67,10 @@ from trusted_router.storage import (
     typed_billing_store,
 )
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
+from trusted_router.storage_models import SettleOutboxRow
 from trusted_router.types import ErrorType, UsageType
+
+logger = logging.getLogger(__name__)
 
 
 async def authorize_gateway(
@@ -523,6 +532,15 @@ def register(router: APIRouter) -> None:
             background_tasks=background_tasks,
         )
 
+    @router.post("/internal/gateway/settle-outbox/drain")
+    async def gateway_settle_outbox_drain(
+        request: Request,
+        settings: SettingsDep,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        require_internal_gateway(request, settings)
+        return await run_in_threadpool(drain_settle_outbox, limit)
+
 
 def _api_key_for_gateway_authorization(body: GatewayAuthorizeRequest) -> Any | None:
     return _api_key_for_gateway_lookup(
@@ -767,9 +785,43 @@ def _settle_gateway_authorization(
     # JSON (codex 3e). Default: no typed reservation (or InMemory store) -> legacy
     # path unchanged.
     _typed_store = typed_billing_store()
-    if _typed_store is not None and _typed_store.is_typed_reservation(
-        authorization.credit_reservation_id, authorization.id
-    ):
+    is_typed = (
+        _typed_store is not None
+        and _typed_store.is_typed_reservation(
+            authorization.credit_reservation_id, authorization.id
+        )
+    )
+    intent_kind = "settle" if success else "refund"
+    if settings.settle_outbox_enabled:
+        try:
+            # §5.4 honest scope: durability starts only when this INSERT commits;
+            # crashes before it still rely on enclave redelivery. MF4/MF5 freeze
+            # the origin and exact resolved cost used by the inline finalize.
+            spanner_settle_outbox().enqueue(
+                SettleOutboxRow(
+                    authorization_id=authorization.id,
+                    intent_kind=intent_kind,
+                    settle_origin="typed" if is_typed else "legacy",
+                    actual_cost_micro=actual_cost,
+                    reservation_id=authorization.credit_reservation_id,
+                    selected_endpoint_id=selected_endpoint.id,
+                    model_id=model.id,
+                    selected_usage_type=str(selected_usage_type),
+                    settle_body=body.model_dump_json(exclude_none=True),
+                ),
+                # Grace so inline finalize wins the benign race; the drain only
+                # sees rows whose inline attempt is dead >=60s, avoiding replays.
+                initial_delay_seconds=60,
+            )
+        except Exception:
+            logger.error(
+                "settle outbox enqueue failed authorization_id=%s",
+                authorization.id,
+                exc_info=True,
+            )
+
+    if is_typed:
+        assert _typed_store is not None
         finalized = _typed_store.typed_finalize_gateway_authorization(
             authorization.id,
             success=success,
@@ -786,6 +838,10 @@ def _settle_gateway_authorization(
             generation=generation,
         )
     if not finalized:
+        # §3/§6/§7: leave the row pending on purpose. Inline's False only says
+        # "claim lost"; it cannot distinguish a charged replay from reaper-free
+        # lost charge. The drain's apply_frozen_settle outcome disambiguates, and
+        # marking done here would silently swallow a lost charge.
         return {
             "data": {
                 "authorization_id": authorization.id,
@@ -793,6 +849,25 @@ def _settle_gateway_authorization(
                 "already_settled": True,
             }
         }
+    if settings.settle_outbox_enabled:
+        try:
+            marked = spanner_settle_outbox().mark(authorization.id, intent_kind, done=True)
+            if marked is None:
+                logger.info(
+                    "settle outbox done mark skipped authorization_id=%s intent_kind=%s; "
+                    "row leased or already resolved; drain will re-derive done",
+                    authorization.id,
+                    intent_kind,
+                )
+        except Exception:
+            # Safe to swallow: §7 says a crash/failure after inline finalize
+            # leaves a pending replay, and the drain will re-derive done via
+            # ALREADY_SETTLED_WITH_CHARGE / ALREADY_SETTLED_LEGACY.
+            logger.error(
+                "settle outbox done mark failed authorization_id=%s",
+                authorization.id,
+                exc_info=True,
+            )
 
     if success and selected_usage_type == UsageType.CREDITS:
         _schedule_auto_refill(authorization.workspace_id, settings, background_tasks)

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Any
+
+from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
+from trusted_router.storage import STORE
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
+from trusted_router.storage_models import SettleOutboxRow
+
+logger = logging.getLogger(__name__)
+
+# SF7 / §6: the drain fires NONE of the inline post-settle side effects:
+# auto-refill, budget-alert emails, metadata broadcast, or provider-error
+# benchmark recording. Accepted losses from the §6 addendum: drained
+# generations never reach metadata-broadcast destinations, and drained refunds
+# record no provider-error benchmark sample.
+
+
+def spanner_settle_outbox() -> SpannerSettleOutbox:
+    """Build the native-table settle outbox from the active Spanner store."""
+    database = getattr(STORE, "_database", None)
+    param_types = getattr(STORE, "_param_types", None)
+    if database is None or param_types is None:
+        raise RuntimeError("settle outbox drain requires the Spanner store")
+    return SpannerSettleOutbox(database, param_types)
+
+
+def drain_settle_outbox(limit: int) -> dict[str, Any]:
+    limit = max(1, min(int(limit), 500))
+    outbox = spanner_settle_outbox()
+    rows = outbox.claim(limit=limit)
+    outcomes: Counter[str] = Counter()
+    recovered_micro = 0
+
+    for row in rows:
+        error_note: str | None = None
+        try:
+            outcome = apply_frozen_settle(row)
+        except Exception as exc:  # noqa: BLE001 - generic drain handler; apply classifies known errors.
+            outcome = ApplyOutcome.ERROR
+            error_note = f"{type(exc).__name__}: {exc}"
+            logger.exception(
+                "settle outbox apply failed authorization_id=%s intent_kind=%s",
+                row.authorization_id,
+                row.intent_kind,
+            )
+        outcomes[outcome] += 1
+        try:
+            _resolve_row(outbox, row, outcome, error_note=error_note)
+        except Exception:  # noqa: BLE001 - keep one bad row from aborting the batch.
+            # A Spanner blip during resolve must not abort the batch; unresolved
+            # rows stay leased and are reclaimed after lease expiry.
+            logger.exception(
+                "settle outbox resolve failed authorization_id=%s intent_kind=%s",
+                row.authorization_id,
+                row.intent_kind,
+            )
+            outcomes["resolve_error"] += 1
+            continue
+        if outcome == ApplyOutcome.SETTLED_NOW and row.intent_kind == "settle":
+            recovered_micro += int(row.actual_cost_micro)
+    purged = outbox.purge_done()
+
+    return {
+        "claimed": len(rows),
+        "outcomes": dict(outcomes),
+        "recovered_micro": recovered_micro,
+        "purged": purged,
+    }
+
+
+def _resolve_row(
+    outbox: SpannerSettleOutbox,
+    row: SettleOutboxRow,
+    outcome: str,
+    *,
+    error_note: str | None,
+) -> None:
+    lease_owner = row.lease_owner
+    if outcome == ApplyOutcome.SETTLED_NOW:
+        outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
+        logger.info(
+            "recovered settle charge authorization_id=%s actual_cost_micro=%s",
+            row.authorization_id,
+            row.actual_cost_micro,
+        )
+        return
+
+    if outcome == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE:
+        outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
+        if row.intent_kind == "refund" and row.actual_cost_micro > 0:
+            logger.warning(
+                "settle outbox review: kept charge beat refund intent authorization_id=%s",
+                row.authorization_id,
+            )
+        return
+
+    if outcome == ApplyOutcome.ALREADY_SETTLED_LEGACY:
+        outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
+        if row.intent_kind == "settle" and outbox.get(row.authorization_id, "refund") is not None:
+            logger.warning(
+                "settle outbox review: legacy settled with sibling refund intent authorization_id=%s",
+                row.authorization_id,
+            )
+        return
+
+    if outcome == ApplyOutcome.ALREADY_RELEASED_FREE:
+        if row.intent_kind == "settle":
+            error = "already_released_free: settle charge was lost"
+            outbox.mark(
+                row.authorization_id,
+                row.intent_kind,
+                done=False,
+                error=error,
+                lease_owner=lease_owner,
+                force_dead=True,
+            )
+            logger.error(
+                "ALERT settle outbox lost charge authorization_id=%s actual_cost_micro=%s",
+                row.authorization_id,
+                row.actual_cost_micro,
+            )
+        else:
+            outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
+        return
+
+    if outcome == ApplyOutcome.RESERVATION_MISSING:
+        outbox.mark(
+            row.authorization_id,
+            row.intent_kind,
+            done=False,
+            error="reservation_missing",
+            lease_owner=lease_owner,
+            force_dead=True,
+        )
+        logger.error(
+            "ALERT settle outbox reservation missing authorization_id=%s reservation_id=%s",
+            row.authorization_id,
+            row.reservation_id,
+        )
+        return
+
+    if outcome == ApplyOutcome.INVALID_ROW:
+        outbox.mark(
+            row.authorization_id,
+            row.intent_kind,
+            done=False,
+            error="invalid_row",
+            lease_owner=lease_owner,
+            force_dead=True,
+        )
+        logger.warning(
+            "settle outbox invalid frozen row authorization_id=%s intent_kind=%s",
+            row.authorization_id,
+            row.intent_kind,
+        )
+        return
+
+    if outcome == ApplyOutcome.PARK_TYPED_UNAVAILABLE:
+        outbox.park(
+            row.authorization_id,
+            row.intent_kind,
+            lease_owner=lease_owner,
+            note="typed store unavailable",
+        )
+        logger.warning(
+            "settle outbox parked typed row authorization_id=%s intent_kind=%s",
+            row.authorization_id,
+            row.intent_kind,
+        )
+        return
+
+    if outcome == ApplyOutcome.ERROR:
+        status = outbox.mark(
+            row.authorization_id,
+            row.intent_kind,
+            done=False,
+            error=error_note or "apply_frozen_settle error",
+            lease_owner=lease_owner,
+        )
+        if status == "dead":
+            logger.error(
+                "ALERT settle outbox exhausted retries authorization_id=%s intent_kind=%s",
+                row.authorization_id,
+                row.intent_kind,
+            )
+        return
+
+    status = outbox.mark(
+        row.authorization_id,
+        row.intent_kind,
+        done=False,
+        error=f"unknown outcome: {outcome}",
+        lease_owner=lease_owner,
+    )
+    if status == "dead":
+        logger.error(
+            "ALERT settle outbox exhausted retries authorization_id=%s intent_kind=%s",
+            row.authorization_id,
+            row.intent_kind,
+        )

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -124,7 +124,7 @@ class SpannerSettleOutbox:
         self._pt = param_types
 
     # ── enqueue (INSERT-as-claim, refresh-latest on a still-pending row) ──────
-    def enqueue(self, row: SettleOutboxRow) -> str:
+    def enqueue(self, row: SettleOutboxRow, *, initial_delay_seconds: int = 0) -> str:
         """Record a settle intent. Idempotent by (authorization_id, intent_kind):
 
         - no row yet -> INSERT a pending row (ENQ_INSERTED)
@@ -135,6 +135,11 @@ class SpannerSettleOutbox:
         """
         pt = self._pt
         now = _iso_now()
+        next_attempt_at = (
+            _iso_after_seconds(initial_delay_seconds)
+            if initial_delay_seconds > 0
+            else now
+        )
 
         def insert_txn(transaction: Any) -> None:
             cols = ", ".join(OUTBOX_COLUMNS)
@@ -152,7 +157,7 @@ class SpannerSettleOutbox:
                 "status": "pending",
                 "attempts": 0,
                 "last_error": None,
-                "next_attempt_at": now,
+                "next_attempt_at": next_attempt_at,
                 "lease_owner": None,
                 "leased_until": None,
                 "created_at": now,
@@ -284,12 +289,16 @@ class SpannerSettleOutbox:
         error: str | None = None,
         lease_owner: str | None = None,
         max_attempts: int = 8,
+        force_dead: bool = False,
     ) -> str | None:
         """Resolve a drained row in ONE lease-fenced conditional-DML transaction.
 
         `done=True` -> status='done' (terminal). `done=False` -> back off to
         'pending' with the next attempt time, or 'dead' at max_attempts (which
-        FREEZES the hold for a human — see GUARD_STATUSES). Returns the new
+        FREEZES the hold for a human — see GUARD_STATUSES). With
+        `done=False, force_dead=True`, the row goes straight to `dead` while
+        still incrementing attempts for the audit trail. Dead FREEZES the hold
+        (GUARD_STATUSES) until a human sets `release_approved`. Returns the new
         status, or None if the row was not claimable by this owner (lost lease /
         already resolved). Only 'pending' rows are marked."""
         now = _iso_now()
@@ -309,6 +318,8 @@ class SpannerSettleOutbox:
             next_attempts = attempts + 1
             if done:
                 new_status, next_at, err = "done", None, None
+            elif force_dead:
+                new_status, next_at, err = "dead", None, (error or "drain failed")[:1000]
             elif next_attempts >= max_attempts:
                 new_status, next_at, err = "dead", None, (error or "drain failed")[:1000]
             else:
@@ -319,22 +330,75 @@ class SpannerSettleOutbox:
                 "UPDATE tr_settle_outbox SET status=@status, attempts=@attempts, "
                 "last_error=@err, next_attempt_at=@next_at, lease_owner=NULL, "
                 "leased_until=NULL, updated_at=@now WHERE authorization_id=@aid "
-                "AND intent_kind=@kind AND status='pending'",
+                "AND intent_kind=@kind AND status='pending' "
+                "AND (lease_owner IS NULL OR lease_owner=@lease_owner)",
                 params={
                     "status": new_status, "attempts": next_attempts, "err": err,
                     "next_at": next_at, "now": now,
                     "aid": authorization_id, "kind": intent_kind,
+                    "lease_owner": lease_owner,
                 },
                 param_types={
                     "status": self._pt.STRING, "attempts": self._pt.INT64,
                     "err": self._pt.STRING, "next_at": self._pt.TIMESTAMP,
                     "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
-                    "kind": self._pt.STRING,
+                    "kind": self._pt.STRING, "lease_owner": self._pt.STRING,
                 },
             )
             return new_status if updated == 1 else None
 
         return self._database.run_in_transaction(txn)
+
+    def park(
+        self,
+        authorization_id: str,
+        intent_kind: str,
+        *,
+        lease_owner: str | None,
+        retry_after_seconds: int = 60,
+        note: str = "typed store unavailable",
+    ) -> bool:
+        """Reschedule a row without burning attempts when typed storage is down."""
+        now = _iso_now()
+        next_at = _iso_after_seconds(retry_after_seconds)
+
+        def txn(transaction: Any) -> bool:
+            rows = list(transaction.execute_sql(
+                "SELECT attempts, lease_owner FROM tr_settle_outbox "
+                "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
+                params={"aid": authorization_id, "kind": intent_kind},
+                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+            ))
+            if not rows:
+                return False
+            attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
+            if lease_owner is not None and cur_owner not in (None, lease_owner):
+                return False
+            # §6: park != failure. A whole typed-backend outage must not walk
+            # frozen rows toward dead; attempts stays unchanged and only the
+            # schedule/error/lease fields move.
+            updated = transaction.execute_update(
+                "UPDATE tr_settle_outbox SET status='pending', last_error=@err, "
+                "next_attempt_at=@next_at, lease_owner=NULL, leased_until=NULL, "
+                "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
+                "AND status='pending' AND attempts=@attempts "
+                "AND (lease_owner IS NULL OR lease_owner=@lease_owner)",
+                params={
+                    "attempts": attempts, "err": note[:1000],
+                    "next_at": next_at, "now": now,
+                    "aid": authorization_id, "kind": intent_kind,
+                    "lease_owner": lease_owner,
+                },
+                param_types={
+                    "attempts": self._pt.INT64, "err": self._pt.STRING,
+                    "next_at": self._pt.TIMESTAMP, "now": self._pt.TIMESTAMP,
+                    "aid": self._pt.STRING, "kind": self._pt.STRING,
+                    "lease_owner": self._pt.STRING,
+                },
+            )
+            return updated == 1
+
+        return bool(self._database.run_in_transaction(txn))
 
     # ── reaper guard predicate ───────────────────────────────────────────────
     def has_intent(self, authorization_id: str) -> bool:
@@ -359,6 +423,23 @@ class SpannerSettleOutbox:
                 param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
             ))
         return _row_from_tuple(rows[0]) if rows else None
+
+    def purge_done(self, *, older_than_days: int = 30) -> int:
+        cutoff = (
+            datetime.now(UTC).replace(microsecond=0) - timedelta(days=int(older_than_days))
+        ).isoformat().replace("+00:00", "Z")
+
+        def txn(transaction: Any) -> int:
+            # Done is the only safe-to-delete status: pending/dead/release_approved
+            # guard or document holds, and release_approved cleanup stays manual.
+            return transaction.execute_update(
+                "DELETE FROM tr_settle_outbox WHERE status='done' "
+                "AND updated_at < @cutoff",
+                params={"cutoff": cutoff},
+                param_types={"cutoff": self._pt.TIMESTAMP},
+            )
+
+        return int(self._database.run_in_transaction(txn))
 
 
 def _is_already_exists(exc: Exception) -> bool:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -205,6 +205,10 @@ class FakeSpannerDatabase:
                     _, pk, record = op
                     self.settle_outbox[pk] = record
                     self.settle_outbox_versions[pk] = new_version
+                elif op[0] == "delete_settle_outbox":
+                    _, pk = op
+                    self.settle_outbox.pop(pk, None)
+                    self.settle_outbox_versions.pop(pk, None)
                 elif op[0] == "update_reservation":
                     _, rid, record = op
                     self.reservations[rid] = record
@@ -313,6 +317,7 @@ class _FakeTransaction:
                 return 1
             return 0
         if "UPDATE tr_credit_balance SET reserved = reserved - @hold" in sql:
+            _require_pred(sql, "workspace_id=@ws AND shard=@shard AND reserved >= @hold", "credit-release")
             pk = (p["ws"], p["shard"])
             rec = self._typed_current("tr_credit_balance", pk)
             # mirrors the `AND reserved >= @hold` guard: underflow = 0-row no-op
@@ -340,6 +345,7 @@ class _FakeTransaction:
                 return 1
             return 0
         if "UPDATE tr_key_limit " in sql and "reserved = reserved - @hold" in sql:
+            _require_pred(sql, "key_hash=@kh AND shard=@shard AND reserved >= @hold", "key-release")
             pk = (p["kh"], p["shard"])
             rec = self._typed_current("tr_key_limit", pk)
             if rec is None or rec["reserved"] < p["hold"]:
@@ -388,6 +394,7 @@ class _FakeTransaction:
             self.pending_writes.append(("insert_reservation", record))
             return 1
         if "UPDATE tr_reservation SET settled=true" in sql:
+            _require_pred(sql, "reservation_id=@rid AND settled=false", "reservation-claim")
             rec = self._reservation_current(p["rid"])
             if rec is None or rec["settled"]:
                 return 0  # missing or already-claimed (replay)
@@ -468,12 +475,48 @@ class _FakeTransaction:
             new = dict(rec, lease_owner=p["owner"], leased_until=p["lease"], updated_at=p["now"])
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
-        if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
-            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark")
-            _require_pred(sql, "status='pending'", "mark")
+        if sql.startswith("UPDATE tr_settle_outbox SET status='pending'"):  # park
+            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "park")
+            _require_pred(sql, "AND status='pending' AND attempts=@attempts", "park")
+            _require_pred(sql, "lease_owner IS NULL OR lease_owner=@lease_owner", "park")
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
+                return 0
+            if int(rec.get("attempts", 0) or 0) != int(p["attempts"]):
+                return 0
+            owner = rec.get("lease_owner")
+            if owner is not None and owner != p.get("lease_owner"):
+                return 0
+            new = dict(
+                rec, status="pending", attempts=rec.get("attempts", 0), last_error=p["err"],
+                next_attempt_at=p["next_at"], lease_owner=None, leased_until=None,
+                updated_at=p["now"],
+            )
+            self.pending_writes.append(("update_settle_outbox", pk, new))
+            return 1
+        if sql.startswith("DELETE FROM tr_settle_outbox"):  # purge done
+            _require_pred(sql, "WHERE status='done'", "purge_done")
+            _require_pred(sql, "AND updated_at < @cutoff", "purge_done")
+            deleted = 0
+            for pk, rec in list(self.db.settle_outbox.items()):
+                vkey = ("outbox", pk)
+                if vkey not in self.read_versions:
+                    self.read_versions[vkey] = self.db.settle_outbox_versions.get(pk, 0)
+                if rec.get("status") == "done" and rec.get("updated_at") < p["cutoff"]:
+                    self.pending_writes.append(("delete_settle_outbox", pk))
+                    deleted += 1
+            return deleted
+        if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
+            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark")
+            _require_pred(sql, "status='pending'", "mark")
+            _require_pred(sql, "lease_owner IS NULL OR lease_owner=@lease_owner", "mark")
+            pk = (p["aid"], p["kind"])
+            rec = self._settle_outbox_current(pk)
+            if rec is None or rec["status"] != "pending":
+                return 0
+            owner = rec.get("lease_owner")
+            if owner is not None and owner != p.get("lease_owner"):
                 return 0
             new = dict(
                 rec, status=p["status"], attempts=p["attempts"], last_error=p["err"],
@@ -898,6 +941,7 @@ def make_fake_store(
     from trusted_router.storage_gcp_keys import SpannerApiKeys
     from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
     from trusted_router.storage_gcp_rate_limits import SpannerRateLimits
+    from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
     from trusted_router.storage_gcp_verification_tokens import SpannerVerificationTokens
     from trusted_router.storage_gcp_wallet_challenges import SpannerWalletChallenges
 
@@ -929,6 +973,7 @@ def make_fake_store(
     )
     store.byok_store = SpannerByok(io)
     store.broadcast_store = SpannerBroadcastDestinations(io)
+    store.settle_outbox = SpannerSettleOutbox(store._database, store._param_types)
     store.auth_session_store = SpannerAuthSessions(io)
     store.oauth_code_store = SpannerOAuthCodes(io)
     store.rate_limit_store = SpannerRateLimits(io)

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1,0 +1,720 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import _FakeTransaction, make_fake_store
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.schemas import GatewaySettleRequest
+from trusted_router.services import settle_outbox_apply as apply_mod
+from trusted_router.services import settle_outbox_drain as drain_mod
+from trusted_router.services.settle_outbox_apply import ApplyOutcome
+from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    reap_expired_reservations,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
+from trusted_router.storage_models import CreditAccount, GatewayAuthorization, SettleOutboxRow
+
+MODEL_ID = "anthropic/claude-haiku-4.5"
+PROVIDER = "anthropic"
+ENDPOINT_ID = "anthropic/claude-haiku-4.5@anthropic/prepaid"
+ESTIMATE = 1_000_000
+TOTAL_CREDIT = 5_000_000
+NOW = "2026-07-04T12:00:00Z"
+
+
+@pytest.fixture
+def fake_store() -> Iterator[tuple[Any, Any, Any]]:
+    store, db, bt = make_fake_store()
+    configure_store(store)
+    try:
+        yield store, db, bt
+    finally:
+        configure_store(InMemoryStore())
+
+
+def _client(settings: Settings, *, raise_server_exceptions: bool = True) -> TestClient:
+    return TestClient(
+        create_app(settings, configure_store_arg=False, init_observability=False),
+        raise_server_exceptions=raise_server_exceptions,
+    )
+
+
+def _outbox(store: Any) -> SpannerSettleOutbox:
+    return SpannerSettleOutbox(store._database, store._param_types)
+
+
+def _seed_credit(store: Any, workspace_id: str, total: int = TOTAL_CREDIT) -> None:
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id, total_credits_microdollars=total),
+    )
+
+
+def _make_key(store: Any, workspace_id: str, *, limit: int | None = TOTAL_CREDIT) -> Any:
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="primary",
+        creator_user_id=None,
+        limit_microdollars=limit,
+    )
+    return key
+
+
+def _typed_credit(db: Any, workspace_id: str) -> dict[str, Any]:
+    return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+
+
+def _typed_authorization(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int = ESTIMATE,
+    expires_at: str = "2026-01-01T00:00:00Z",
+) -> GatewayAuthorization:
+    outcome, auth = store.authorize_gateway_typed(
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=estimate,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        requested_model_id=MODEL_ID,
+        candidate_model_ids=[MODEL_ID],
+        region="us",
+        endpoint_id=ENDPOINT_ID,
+        candidate_endpoint_ids=[ENDPOINT_ID],
+        idempotency_key=None,
+        idempotency_fingerprint=None,
+        expires_at=expires_at,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert auth is not None
+    return auth
+
+
+def _legacy_authorization(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int = ESTIMATE,
+) -> GatewayAuthorization:
+    reservation = store.reserve(workspace_id, key_hash, estimate)
+    store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
+    return store.create_gateway_authorization(
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        usage_type="Credits",
+        estimated_microdollars=estimate,
+        credit_reservation_id=reservation.id,
+        requested_model_id=MODEL_ID,
+        candidate_model_ids=[MODEL_ID],
+        region="us",
+        endpoint_id=ENDPOINT_ID,
+        candidate_endpoint_ids=[ENDPOINT_ID],
+    )
+
+
+def _bare_authorization(auth_id: str) -> GatewayAuthorization:
+    return GatewayAuthorization(
+        id=auth_id,
+        workspace_id=f"ws-{auth_id}",
+        key_hash=f"key-{auth_id}",
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        usage_type="Credits",
+        estimated_microdollars=ESTIMATE,
+        credit_reservation_id=f"res-{auth_id}",
+    )
+
+
+def _settle_json(auth_id: str, *, request_id: str = "req-settle") -> dict[str, Any]:
+    return {
+        "authorization_id": auth_id,
+        "actual_input_tokens": 14,
+        "actual_output_tokens": 7,
+        "cache_read_input_tokens": 6_081,
+        "cache_creation_input_tokens": 2,
+        "request_id": request_id,
+        "finish_reason": "stop",
+        "status": "success",
+        "streamed": True,
+        "elapsed_seconds": 2.0,
+        "selected_model": MODEL_ID,
+        "selected_endpoint": ENDPOINT_ID,
+    }
+
+
+def _row(
+    auth: GatewayAuthorization,
+    *,
+    intent: str = "settle",
+    origin: str = "typed",
+    cost: int = 777_777,
+    selected_usage_type: str | None = "Credits",
+    settle_body: str | None = None,
+) -> SettleOutboxRow:
+    return SettleOutboxRow(
+        authorization_id=auth.id,
+        intent_kind=intent,
+        settle_origin=origin,
+        actual_cost_micro=cost,
+        reservation_id=auth.credit_reservation_id,
+        selected_endpoint_id=ENDPOINT_ID,
+        model_id=MODEL_ID,
+        selected_usage_type=selected_usage_type,
+        settle_body=settle_body
+        if settle_body is not None
+        else json.dumps(_settle_json(auth.id)),
+    )
+
+
+# Unit (storage)
+
+
+def test_park_leaves_attempts_unchanged_and_respects_lease(fake_store: tuple[Any, Any, Any]) -> None:
+    store, _db, _bt = fake_store
+    ob = _outbox(store)
+    row = _row(
+        GatewayAuthorization(
+            id="gwa-park",
+            workspace_id="ws-park",
+            key_hash="key-park",
+            model_id=MODEL_ID,
+            provider=PROVIDER,
+            usage_type="Credits",
+            estimated_microdollars=ESTIMATE,
+            credit_reservation_id="res-park",
+        )
+    )
+    ob.enqueue(row)
+    [job] = ob.claim(lease_seconds=300)
+    assert ob.park(row.authorization_id, "settle", lease_owner="soworker_intruder") is False
+    before = ob.get(row.authorization_id, "settle")
+    assert before is not None and before.attempts == 0 and before.lease_owner == job.lease_owner
+
+    assert ob.park(
+        row.authorization_id,
+        "settle",
+        lease_owner=job.lease_owner,
+        retry_after_seconds=120,
+        note="typed store unavailable",
+    )
+    after = ob.get(row.authorization_id, "settle")
+    assert after is not None
+    assert after.status == "pending"
+    assert after.attempts == 0
+    assert after.lease_owner is None and after.leased_until is None
+    assert after.last_error == "typed store unavailable"
+    assert after.next_attempt_at != before.next_attempt_at
+
+
+def test_mark_force_dead_goes_dead_immediately(fake_store: tuple[Any, Any, Any]) -> None:
+    store, _db, _bt = fake_store
+    ob = _outbox(store)
+    auth = GatewayAuthorization(
+        id="gwa-force-dead",
+        workspace_id="ws-force-dead",
+        key_hash="key-force-dead",
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        usage_type="Credits",
+        estimated_microdollars=ESTIMATE,
+        credit_reservation_id="res-force-dead",
+    )
+    ob.enqueue(_row(auth))
+
+    assert ob.mark(auth.id, "settle", done=False, force_dead=True, error="invalid") == "dead"
+    got = ob.get(auth.id, "settle")
+    assert got is not None
+    assert got.status == "dead"
+    assert got.attempts == 1
+    assert got.last_error == "invalid"
+
+
+def test_fake_requires_park_and_typed_dml_predicates(fake_store: tuple[Any, Any, Any]) -> None:
+    store, _db, _bt = fake_store
+    auth = GatewayAuthorization(
+        id="gwa-mf6",
+        workspace_id="ws-mf6",
+        key_hash="key-mf6",
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        usage_type="Credits",
+        estimated_microdollars=ESTIMATE,
+        credit_reservation_id="res-mf6",
+    )
+    _outbox(store).enqueue(_row(auth))
+    with pytest.raises(AssertionError, match="park"):
+        _FakeTransaction(store._database).execute_update(
+            "UPDATE tr_settle_outbox SET status='pending', last_error=@err, "
+            "next_attempt_at=@next_at, lease_owner=NULL, leased_until=NULL, "
+            "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
+            "AND status='pending'",
+            params={
+                "attempts": 0,
+                "err": "typed store unavailable",
+                "next_at": NOW,
+                "now": NOW,
+                "aid": auth.id,
+                "kind": "settle",
+            },
+        )
+    with pytest.raises(AssertionError, match="reservation-claim"):
+        _FakeTransaction(store._database).execute_update(
+            "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "
+            "settled_usage_type=@sut WHERE reservation_id=@rid",
+            params={"rid": "missing", "actual": 0, "sut": "Credits"},
+        )
+    with pytest.raises(AssertionError, match="credit-release"):
+        _FakeTransaction(store._database).execute_update(
+            "UPDATE tr_credit_balance SET reserved = reserved - @hold, "
+            "total_usage = total_usage + @actual WHERE workspace_id=@ws AND shard=@shard",
+            params={"hold": 1, "actual": 1, "ws": "ws", "shard": 0},
+        )
+    with pytest.raises(AssertionError, match="key-release"):
+        _FakeTransaction(store._database).execute_update(
+            "UPDATE tr_key_limit SET reserved = reserved - @hold, usage = usage + @actual "
+            "WHERE key_hash=@kh AND shard=@shard",
+            params={
+                "hold": 1,
+                "actual": 1,
+                "kh": "key",
+                "shard": 0,
+                "day_floor": NOW,
+                "week_floor": NOW,
+                "month_floor": NOW,
+            },
+        )
+
+
+# Functional (settle route)
+
+
+def test_flag_on_successful_typed_settle_enqueues_frozen_done_row(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-route-settle"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    settings = Settings(environment="test", settle_outbox_enabled=True)
+    client = _client(settings)
+    body = _settle_json(auth.id)
+
+    resp = client.post("/v1/internal/gateway/settle", json=body)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None
+    assert row.status == "done"
+    assert row.actual_cost_micro == data["cost_microdollars"]
+    assert row.settle_origin == "typed"
+    assert row.intent_kind == "settle"
+    assert row.selected_endpoint_id == ENDPOINT_ID
+    assert row.model_id == MODEL_ID
+    assert row.selected_usage_type == "Credits"
+    assert json.loads(row.settle_body or "{}") == GatewaySettleRequest(
+        **body
+    ).model_dump(exclude_none=True)
+
+
+def test_flag_on_refund_enqueues_refund_done_row(fake_store: tuple[Any, Any, Any]) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-route-refund"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    resp = client.post("/v1/internal/gateway/refund", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    row = _outbox(store).get(auth.id, "refund")
+    assert row is not None
+    assert row.status == "done"
+    assert row.intent_kind == "refund"
+    assert row.settle_origin == "typed"
+
+
+def test_flag_off_settle_creates_no_outbox_row(fake_store: tuple[Any, Any, Any]) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-route-off"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+
+    resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    assert _outbox(store).get(auth.id, "settle") is None
+
+
+def test_inline_finalize_false_leaves_outbox_pending(fake_store: tuple[Any, Any, Any]) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-route-free-first"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    freed = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=auth.credit_reservation_id,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+    )
+    assert freed["outcome"] == SettleOutcome.SETTLED
+    client = _client(
+        Settings(environment="test", settle_outbox_enabled=True),
+        raise_server_exceptions=False,
+    )
+
+    resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["already_settled"] is True
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None and row.status == "pending"
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == 0
+
+
+def test_enqueue_failure_does_not_fail_settle(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-route-enqueue-fails"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+
+    def fail_enqueue(
+        self: SpannerSettleOutbox,
+        row: SettleOutboxRow,
+        *,
+        initial_delay_seconds: int = 0,
+    ) -> str:
+        raise RuntimeError("insert unavailable")
+
+    monkeypatch.setattr(SpannerSettleOutbox, "enqueue", fail_enqueue)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    assert _typed_credit(db, ws)["total_usage"] == resp.json()["data"]["cost_microdollars"]
+    assert db.reservations[auth.credit_reservation_id]["settled"] is True
+
+
+# Integration (drain + reaper)
+
+
+def test_lost_charge_recovery_end_to_end(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-drain-recover"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    original = store.typed_finalize_gateway_authorization
+    state = {"crash": True}
+
+    def crash_once(*args: Any, **kwargs: Any) -> bool:
+        if state["crash"]:
+            state["crash"] = False
+            raise RuntimeError("crash after enqueue")
+        return original(*args, **kwargs)
+
+    store.typed_finalize_gateway_authorization = crash_once
+    client = _client(
+        Settings(environment="test", settle_outbox_enabled=True),
+        raise_server_exceptions=False,
+    )
+    first = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+    assert first.status_code == 500
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None and row.status == "pending"
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
+
+    assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+
+    drained = client.post("/v1/internal/gateway/settle-outbox/drain?limit=10")
+
+    assert drained.status_code == 200, drained.text
+    payload = drained.json()
+    assert payload["claimed"] == 1
+    assert payload["outcomes"] == {ApplyOutcome.SETTLED_NOW: 1}
+    assert payload["recovered_micro"] == row.actual_cost_micro
+    assert _outbox(store).get(auth.id, "settle").status == "done"
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == row.actual_cost_micro
+    assert _typed_credit(db, ws)["total_usage"] == row.actual_cost_micro
+    assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
+
+
+def test_drain_purges_only_old_done_rows_and_reports_count(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    ob = _outbox(store)
+    for aid in (
+        "gwa-old-done-a",
+        "gwa-old-done-b",
+        "gwa-fresh-done",
+        "gwa-pending",
+        "gwa-dead",
+        "gwa-release-approved",
+    ):
+        ob.enqueue(_row(_bare_authorization(aid)))
+
+    old = "2000-01-01T00:00:00Z"
+    ob.mark("gwa-old-done-a", "settle", done=True)
+    ob.mark("gwa-old-done-b", "settle", done=True)
+    ob.mark("gwa-fresh-done", "settle", done=True)
+    ob.mark("gwa-dead", "settle", done=False, force_dead=True, error="manual review")
+    db.settle_outbox[("gwa-release-approved", "settle")]["status"] = "release_approved"
+    for aid in (
+        "gwa-old-done-a",
+        "gwa-old-done-b",
+        "gwa-pending",
+        "gwa-dead",
+        "gwa-release-approved",
+    ):
+        db.settle_outbox[(aid, "settle")]["updated_at"] = old
+    db.settle_outbox[("gwa-pending", "settle")]["next_attempt_at"] = "2999-01-01T00:00:00Z"
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 2}
+    assert ob.get("gwa-old-done-a", "settle") is None
+    assert ob.get("gwa-old-done-b", "settle") is None
+    assert ob.get("gwa-fresh-done", "settle").status == "done"
+    assert ob.get("gwa-pending", "settle").status == "pending"
+    assert ob.get("gwa-dead", "settle").status == "dead"
+    assert ob.get("gwa-release-approved", "settle").status == "release_approved"
+
+
+def test_drain_switch_coverage(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, _db, _bt = fake_store
+    ob = _outbox(store)
+    ws = "ws-drain-switch"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    parked = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    error_auth = _legacy_authorization(store, workspace_id=ws, key_hash=key.hash)
+    lost_auth = _legacy_authorization(store, workspace_id=ws, key_hash=key.hash)
+    invalid_auth = _legacy_authorization(store, workspace_id=ws, key_hash=key.hash)
+    ob.enqueue(_row(parked))
+    ob.enqueue(_row(error_auth, origin="legacy"))
+    ob.enqueue(_row(lost_auth, origin="legacy"))
+    ob.enqueue(_row(invalid_auth, origin="legacy", selected_usage_type=None))
+    monkeypatch.setattr(apply_mod, "typed_billing_store", lambda: None)
+    sequence = iter(
+        [
+            ApplyOutcome.ERROR,
+            ApplyOutcome.ALREADY_RELEASED_FREE,
+            ApplyOutcome.INVALID_ROW,
+        ]
+    )
+    real_apply = drain_mod.apply_frozen_settle
+
+    def mixed_apply(row: SettleOutboxRow) -> str:
+        if row.authorization_id == parked.id:
+            return real_apply(row)
+        return next(sequence)
+
+    monkeypatch.setattr(drain_mod, "apply_frozen_settle", mixed_apply)
+    caplog.set_level("WARNING")
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 4
+    assert result["outcomes"] == {
+        ApplyOutcome.PARK_TYPED_UNAVAILABLE: 1,
+        ApplyOutcome.ERROR: 1,
+        ApplyOutcome.ALREADY_RELEASED_FREE: 1,
+        ApplyOutcome.INVALID_ROW: 1,
+    }
+    parked_row = ob.get(parked.id, "settle")
+    assert parked_row is not None and parked_row.status == "pending"
+    assert parked_row.attempts == 0
+    assert parked_row.lease_owner is None
+    error_row = ob.get(error_auth.id, "settle")
+    assert error_row is not None and error_row.status == "pending" and error_row.attempts == 1
+    lost_row = ob.get(lost_auth.id, "settle")
+    assert lost_row is not None and lost_row.status == "dead"
+    invalid_row = ob.get(invalid_auth.id, "settle")
+    assert invalid_row is not None and invalid_row.status == "dead"
+    assert any("ALERT settle outbox lost charge" in rec.message for rec in caplog.records)
+
+
+def test_drain_resolves_recovery_outcomes_and_warning_gates(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, _db, _bt = fake_store
+    ob = _outbox(store)
+    cases = {
+        "gwa-refund-kept-charge": ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE,
+        "gwa-refund-zero": ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE,
+        "gwa-legacy-settle": ApplyOutcome.ALREADY_SETTLED_LEGACY,
+        "gwa-legacy-refund-self": ApplyOutcome.ALREADY_SETTLED_LEGACY,
+        "gwa-refund-already-free": ApplyOutcome.ALREADY_RELEASED_FREE,
+        "gwa-missing": ApplyOutcome.RESERVATION_MISSING,
+        "gwa-unknown": "mystery_outcome",
+    }
+    ob.enqueue(_row(_bare_authorization("gwa-refund-kept-charge"), intent="refund", cost=50))
+    ob.enqueue(_row(_bare_authorization("gwa-refund-zero"), intent="refund", cost=0))
+    ob.enqueue(_row(_bare_authorization("gwa-legacy-settle"), origin="legacy"))
+    ob.enqueue(
+        _row(_bare_authorization("gwa-legacy-settle"), intent="refund", origin="legacy"),
+        initial_delay_seconds=60,
+    )
+    ob.enqueue(_row(_bare_authorization("gwa-legacy-refund-self"), intent="refund", origin="legacy"))
+    ob.enqueue(_row(_bare_authorization("gwa-refund-already-free"), intent="refund"))
+    ob.enqueue(_row(_bare_authorization("gwa-missing")))
+    ob.enqueue(_row(_bare_authorization("gwa-unknown")))
+
+    def fake_apply(row: SettleOutboxRow) -> str:
+        return cases[row.authorization_id]
+
+    monkeypatch.setattr(drain_mod, "apply_frozen_settle", fake_apply)
+    caplog.set_level("WARNING")
+
+    result = drain_mod.drain_settle_outbox(20)
+
+    assert result["claimed"] == 7
+    assert result["outcomes"] == {
+        ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE: 2,
+        ApplyOutcome.ALREADY_SETTLED_LEGACY: 2,
+        ApplyOutcome.ALREADY_RELEASED_FREE: 1,
+        ApplyOutcome.RESERVATION_MISSING: 1,
+        "mystery_outcome": 1,
+    }
+    assert result["purged"] == 0
+    assert ob.get("gwa-refund-kept-charge", "refund").status == "done"
+    assert ob.get("gwa-refund-zero", "refund").status == "done"
+    assert ob.get("gwa-legacy-settle", "settle").status == "done"
+    assert ob.get("gwa-legacy-settle", "refund").status == "pending"
+    assert ob.get("gwa-legacy-refund-self", "refund").status == "done"
+    assert ob.get("gwa-refund-already-free", "refund").status == "done"
+    assert ob.get("gwa-missing", "settle").status == "dead"
+    unknown = ob.get("gwa-unknown", "settle")
+    assert unknown is not None
+    assert unknown.status == "pending"
+    assert unknown.attempts == 1
+    assert unknown.last_error == "unknown outcome: mystery_outcome"
+    messages = [rec.message for rec in caplog.records]
+    assert any("kept charge beat refund intent authorization_id=gwa-refund-kept-charge" in msg for msg in messages)
+    assert not any("gwa-refund-zero" in msg for msg in messages)
+    assert any("legacy settled with sibling refund intent authorization_id=gwa-legacy-settle" in msg for msg in messages)
+    assert not any("gwa-legacy-refund-self" in msg for msg in messages)
+    assert any("ALERT settle outbox reservation missing authorization_id=gwa-missing" in msg for msg in messages)
+
+
+def test_drain_resolve_errors_do_not_abort_later_rows(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _db, _bt = fake_store
+    ob = _outbox(store)
+    first = _bare_authorization("gwa-resolve-error")
+    second = _bare_authorization("gwa-resolve-ok")
+    ob.enqueue(_row(first, cost=111))
+    ob.enqueue(_row(second, cost=222))
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.SETTLED_NOW,
+    )
+    original_mark = SpannerSettleOutbox.mark
+
+    def flaky_mark(
+        self: SpannerSettleOutbox,
+        authorization_id: str,
+        intent_kind: str,
+        **kwargs: Any,
+    ) -> str | None:
+        if authorization_id == first.id:
+            raise RuntimeError("mark unavailable")
+        return original_mark(self, authorization_id, intent_kind, **kwargs)
+
+    monkeypatch.setattr(SpannerSettleOutbox, "mark", flaky_mark)
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 2
+    assert result["outcomes"] == {ApplyOutcome.SETTLED_NOW: 2, "resolve_error": 1}
+    failed = ob.get(first.id, "settle")
+    assert failed is not None
+    assert failed.status == "pending"
+    assert failed.lease_owner is not None
+    assert ob.get(second.id, "settle").status == "done"
+
+
+def test_drain_clamps_limit_to_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SpyOutbox:
+        seen_limit: int | None = None
+
+        def claim(self, *, limit: int) -> list[SettleOutboxRow]:
+            self.seen_limit = limit
+            return []
+
+        def purge_done(self) -> int:
+            return 0
+
+    spy = SpyOutbox()
+    monkeypatch.setattr(drain_mod, "spanner_settle_outbox", lambda: spy)
+
+    result = drain_mod.drain_settle_outbox(99_999)
+
+    assert spy.seen_limit == 500
+    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0}
+
+
+def test_drain_endpoint_requires_internal_token(fake_store: tuple[Any, Any, Any]) -> None:
+    _store, _db, _bt = fake_store
+    token = "internal-test-token"  # noqa: S105 - test token.
+    client = _client(Settings(environment="test", internal_gateway_token=token))
+
+    missing = client.post("/v1/internal/gateway/settle-outbox/drain")
+    wrong = client.post(
+        "/v1/internal/gateway/settle-outbox/drain",
+        headers={"x-trustedrouter-internal-token": "wrong"},
+    )
+    ok = client.post(
+        "/v1/internal/gateway/settle-outbox/drain",
+        headers={"x-trustedrouter-internal-token": token},
+    )
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert ok.status_code == 200
+    assert ok.json() == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0}

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -128,6 +128,48 @@ def test_mark_rejects_a_lost_lease() -> None:
     assert ob.get("gwa-8", "settle").status == "pending"
 
 
+def test_mark_without_owner_respects_active_lease_then_owner_succeeds() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-lease-fence"))
+    [job] = ob.claim(lease_seconds=300)
+
+    assert ob.mark("gwa-lease-fence", "settle", done=True) is None
+    fenced = ob.get("gwa-lease-fence", "settle")
+    assert fenced is not None
+    assert fenced.status == "pending"
+    assert fenced.lease_owner == job.lease_owner
+
+    assert (
+        ob.mark(
+            "gwa-lease-fence",
+            "settle",
+            done=True,
+            lease_owner=job.lease_owner,
+        )
+        == "done"
+    )
+    done = ob.get("gwa-lease-fence", "settle")
+    assert done is not None
+    assert done.status == "done"
+    assert done.lease_owner is None and done.leased_until is None
+
+
+def test_enqueue_initial_delay_defers_claim_until_default_row_is_due() -> None:
+    store, _db, _ = make_fake_store()
+    ob = _outbox(store)
+    assert ob.enqueue(_row("gwa-delayed"), initial_delay_seconds=60) == ENQ_INSERTED
+    assert ob.claim() == []
+
+    assert ob.enqueue(_row("gwa-now")) == ENQ_INSERTED
+    claimed = ob.claim()
+    assert [row.authorization_id for row in claimed] == ["gwa-now"]
+    delayed = ob.get("gwa-delayed", "settle")
+    assert delayed is not None
+    assert delayed.status == "pending"
+    assert delayed.lease_owner is None
+
+
 def test_enqueue_refresh_does_not_overwrite_an_actively_leased_row() -> None:
     """codex #113 finding 2: a claimed row stays status='pending' while a drain
     applies it, so a retry-enqueue must NOT overwrite its frozen inputs mid-drain."""


### PR DESCRIPTION
Final increment of docs/design/durable-settle-outbox.md (§5.4, §6, §7, §8, §11). Increments 1-3 (#113, #116, #118) are merged. This wires the outbox live — still **default-off** (`settle_outbox_enabled=False`); the flag-off settle path is byte-identical (tested).

**What's in it**
- **Enqueue-at-settle** (§5.4): flag-gated durable INSERT of the frozen intent (origin/cost/validated body) before the inline finalize, 60s grace to remove the inline-vs-drain race, done-mark **only on truthy finalize** — on False the row stays pending on purpose so the drain can distinguish charged replay from reaper-free lost charge (§3). Enqueue/mark failures never fail the settle.
- **Drain endpoint** `POST /internal/gateway/settle-outbox/drain` (internal token, threadpool, limit≤500): claims due rows, applies via `apply_frozen_settle`, resolves per the §6 contract (done / force-dead+ALERT / park-no-attempt / backoff), per-row isolation, `claimed/outcomes/recovered_micro/purged` response.
- **Storage**: `park()` (attempts unchanged), `mark(force_dead=True)`, in-SQL lease fence on mark, and `purge_done()` retention — done rows >30d deleted by the drain; pending/dead/release_approved never auto-deleted (they freeze holds).
- **Fake**: strict `_require_pred` modeling for all new SQL + the MF6 follow-up anchors on the typed claim/release DML.
- **Tests**: 17 new across unit/functional/integration, including the end-to-end §1 scenario: enqueue → inline crash → reaper frozen by the Increment-2 guard → drain recovers the exact frozen cost.

**Verification**
- Gates green ×3 independently: ruff, mypy (162 files), pytest 1272 passed / 33 skipped.
- Two adversarial multi-agent verification passes (3 lenses each) drove two internal fix rounds before this PR: retention story, enqueue grace, drain robustness (clamp/threadpool/per-row isolation), warning precision (sibling self-match, zero-cost gate), vacuous fake predicate re-anchor, and lease-fence + resolver-branch coverage.

**After merge (operator steps, §8)**: apply the DDL, flip `TR_SETTLE_OUTBOX_ENABLED=true` (authorized), schedule the drain, monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)