### PR TITLE
Wire the reservation reaper into the settle-outbox drain

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -491,9 +491,10 @@ gcloud scheduler jobs resume trusted-router-settle-outbox-drain \
 
 Every 5 min it POSTs
 `/v1/internal/gateway/settle-outbox/drain?limit=100` with the internal-token
-header and returns `{claimed, outcomes, recovered_micro, purged}`. It also
+header and returns `{claimed, outcomes, recovered_micro, purged, reaped}`. It also
 purges `done` rows older than 30 days; it never purges `pending`, `dead`, or
-`release_approved`.
+`release_approved`. The drain also reclaims expired abandoned reservation holds
+(limit 200/tick); frozen `pending`/`dead`-guarded holds are never reaped.
 
 Outcome cheat-sheet:
 
@@ -506,6 +507,9 @@ Outcome cheat-sheet:
 | `reservation_missing` | Dead plus alert; investigate missing reservation state. |
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
+
+A persistently large `reaped` count means upstream abandonment (enclave crashes
+or client disconnects before settle); investigate the enclave, not the drain.
 
 Rollback normally by reverting the `TR_SETTLE_OUTBOX_ENABLED=true` line in
 `scripts/deploy/rollout.sh` and merging. The pipeline redeploys flag-off; the

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from collections import Counter
-from typing import Any
+from typing import Any, cast
 
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
 from trusted_router.storage import STORE
@@ -62,12 +63,25 @@ def drain_settle_outbox(limit: int) -> dict[str, Any]:
         if outcome == ApplyOutcome.SETTLED_NOW and row.intent_kind == "settle":
             recovered_micro += int(row.actual_cost_micro)
     purged = outbox.purge_done()
+    # §3/§4: free-release only expired settled=false holds whose authorization
+    # has no pending/dead outbox row. Running after row resolution means a just-
+    # recovered charge is already settled; the claim gate makes that ordering a
+    # latency nicety, while the Increment-2 guard is the lost-charge interlock.
+    # Limit 200 drains the ~2.6k wiring-time backlog in about an hour of 5-min
+    # ticks without a tr_credit_balance write burst; steady state is far lower.
+    reaped = cast(Any, STORE).reap_expired_reservations(
+        now=dt.datetime.now(dt.UTC),
+        limit=200,
+    )
+    if reaped > 0:
+        logger.info("reaped %s expired reservations", reaped)
 
     return {
         "claimed": len(rows),
         "outcomes": dict(outcomes),
         "recovered_micro": recovered_micro,
         "purged": purged,
+        "reaped": reaped,
     }
 
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import threading
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -646,6 +647,13 @@ def _require_pred(sql: str, needle: str, what: str) -> None:
         raise AssertionError(f"tr_settle_outbox {what} query missing predicate: {needle!r}")
 
 
+def _utc_datetime(value: Any) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)
+    parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=dt.UTC)
+
+
 def _execute_settle_outbox_sql(
     db: FakeSpannerDatabase,
     txn: _FakeTransaction | None,
@@ -725,7 +733,7 @@ def _execute_sql(
         out: list[list] = []
         for rid, rec in db.reservations.items():
             exp = rec.get("expires_at")
-            if rec.get("settled") or exp is None or exp >= now:
+            if rec.get("settled") or exp is None or _utc_datetime(exp) >= _utc_datetime(now):
                 continue
             if guarded:
                 # Model NOT EXISTS semantics before LIMIT (MF6): a dropped guard

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -31,6 +31,7 @@ ENDPOINT_ID = "anthropic/claude-haiku-4.5@anthropic/prepaid"
 ESTIMATE = 1_000_000
 TOTAL_CREDIT = 5_000_000
 NOW = "2026-07-04T12:00:00Z"
+EXPIRED_AT = "2000-01-01T00:00:00Z"
 
 
 @pytest.fixture
@@ -104,6 +105,22 @@ def _typed_authorization(
     assert outcome == AuthorizeOutcome.ACCEPTED
     assert auth is not None
     return auth
+
+
+def _expired_authorization(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int = ESTIMATE,
+) -> GatewayAuthorization:
+    return _typed_authorization(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=estimate,
+        expires_at=EXPIRED_AT,
+    )
 
 
 def _legacy_authorization(
@@ -429,6 +446,93 @@ def test_enqueue_failure_does_not_fail_settle(
 # Integration (drain + reaper)
 
 
+def test_drain_reaps_expired_unguarded_holds(fake_store: tuple[Any, Any, Any]) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-drain-reap-unguarded"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _expired_authorization(store, workspace_id=ws, key_hash=key.hash)
+    assert _typed_credit(db, ws)["reserved"] == ESTIMATE
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 0
+    assert result["reaped"] == 1
+    assert _typed_credit(db, ws)["reserved"] == 0
+    reservation = db.reservations[auth.credit_reservation_id]
+    assert reservation["settled"] is True
+    assert reservation["actual_micro"] == 0
+
+
+def test_drain_reap_respects_outbox_guard(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-drain-reap-guard"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _expired_authorization(store, workspace_id=ws, key_hash=key.hash)
+    row = _row(auth)
+    ob = _outbox(store)
+    ob.enqueue(row)
+    original_typed_store = apply_mod.typed_billing_store
+    monkeypatch.setattr(apply_mod, "typed_billing_store", lambda: None)
+
+    parked = drain_mod.drain_settle_outbox(10)
+
+    assert parked["claimed"] == 1
+    assert parked["outcomes"] == {ApplyOutcome.PARK_TYPED_UNAVAILABLE: 1}
+    assert parked["reaped"] == 0
+    parked_row = ob.get(auth.id, "settle")
+    assert parked_row is not None
+    assert parked_row.status == "pending"
+    assert parked_row.attempts == 0
+    assert _typed_credit(db, ws)["reserved"] == ESTIMATE
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+
+    monkeypatch.setattr(apply_mod, "typed_billing_store", original_typed_store)
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
+    recovered = drain_mod.drain_settle_outbox(10)
+
+    assert recovered["claimed"] == 1
+    assert recovered["outcomes"] == {ApplyOutcome.SETTLED_NOW: 1}
+    assert recovered["reaped"] == 0
+    assert ob.get(auth.id, "settle").status == "done"
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == row.actual_cost_micro
+    assert _typed_credit(db, ws)["reserved"] == 0
+    assert _typed_credit(db, ws)["total_usage"] == row.actual_cost_micro
+
+    again = drain_mod.drain_settle_outbox(10)
+    assert again["claimed"] == 0
+    assert again["reaped"] == 0
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == row.actual_cost_micro
+
+
+def test_drain_reap_limit_respected(fake_store: tuple[Any, Any, Any]) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-drain-reap-limit"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auths = [
+        _expired_authorization(store, workspace_id=ws, key_hash=key.hash)
+        for _ in range(3)
+    ]
+    assert _typed_credit(db, ws)["reserved"] == ESTIMATE * 3
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["reaped"] == 3
+    assert _typed_credit(db, ws)["reserved"] == 0
+    for auth in auths:
+        reservation = db.reservations[auth.credit_reservation_id]
+        assert reservation["settled"] is True
+        assert reservation["actual_micro"] == 0
+
+    again = drain_mod.drain_settle_outbox(10)
+    assert again["reaped"] == 0
+
+
 def test_lost_charge_recovery_end_to_end(
     fake_store: tuple[Any, Any, Any],
 ) -> None:
@@ -468,6 +572,7 @@ def test_lost_charge_recovery_end_to_end(
     assert payload["claimed"] == 1
     assert payload["outcomes"] == {ApplyOutcome.SETTLED_NOW: 1}
     assert payload["recovered_micro"] == row.actual_cost_micro
+    assert payload["reaped"] == 0
     assert _outbox(store).get(auth.id, "settle").status == "done"
     assert db.reservations[auth.credit_reservation_id]["actual_micro"] == row.actual_cost_micro
     assert _typed_credit(db, ws)["total_usage"] == row.actual_cost_micro
@@ -507,7 +612,7 @@ def test_drain_purges_only_old_done_rows_and_reports_count(
 
     result = drain_mod.drain_settle_outbox(10)
 
-    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 2}
+    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 2, "reaped": 0}
     assert ob.get("gwa-old-done-a", "settle") is None
     assert ob.get("gwa-old-done-b", "settle") is None
     assert ob.get("gwa-fresh-done", "settle").status == "done"
@@ -679,7 +784,12 @@ def test_drain_resolve_errors_do_not_abort_later_rows(
     assert ob.get(second.id, "settle").status == "done"
 
 
-def test_drain_clamps_limit_to_500(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_drain_clamps_limit_to_500(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert fake_store is not None
+
     class SpyOutbox:
         seen_limit: int | None = None
 
@@ -696,7 +806,7 @@ def test_drain_clamps_limit_to_500(monkeypatch: pytest.MonkeyPatch) -> None:
     result = drain_mod.drain_settle_outbox(99_999)
 
     assert spy.seen_limit == 500
-    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0}
+    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0, "reaped": 0}
 
 
 def test_drain_endpoint_requires_internal_token(fake_store: tuple[Any, Any, Any]) -> None:
@@ -717,4 +827,4 @@ def test_drain_endpoint_requires_internal_token(fake_store: tuple[Any, Any, Any]
     assert missing.status_code == 401
     assert wrong.status_code == 401
     assert ok.status_code == 200
-    assert ok.json() == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0}
+    assert ok.json() == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0, "reaped": 0}


### PR DESCRIPTION
The last piece of the settle-outbox system: `reap_expired_reservations` has never had a production caller — 2,636 expired holds currently leak reserved credit (one hot workspace alone holds 521). The drain (already scheduled */5) now reaps up to 200 unguarded expired holds per tick after row resolution, reports `reaped` in its response, and logs the count.

Safety: the Increment-2 guard is the interlock — pending/dead intent rows freeze their holds (in-txn re-check), and with the outbox live (#120) every fresh settle intent is enqueued before the inline finalize, so the §3 lost-charge race is structurally closed. Backlog drains in ~1 hour of ticks; steady state is far below the limit.

Tests include the full §3/§4 interplay through the drain endpoint: guarded hold frozen with zero attempts burned during a typed-store outage → recovery books the exact frozen cost → subsequent drains touch nothing. Gates: ruff, mypy, pytest 1282 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)