### PR TITLE
Emit a per-settle timing-breakdown INFO line (latency investigation)

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import uuid
+from time import perf_counter
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Request
@@ -727,10 +728,13 @@ def _settle_gateway_authorization(
     settings: Settings,
     background_tasks: BackgroundTasks | None = None,
 ) -> dict[str, Any]:
+    timing_start = perf_counter()
     authorization = STORE.get_gateway_authorization(body.authorization_id)
     if authorization is None:
         raise api_error(404, "Gateway authorization not found", ErrorType.NOT_FOUND)
     if authorization.settled:
+        # No timing line for replays: they are ~one point-read and would dominate
+        # the latency dataset with noise.
         return {
             "data": {
                 "authorization_id": authorization.id,
@@ -749,6 +753,7 @@ def _settle_gateway_authorization(
     model = MODELS.get(selected_endpoint.model_id)
     if model is None:
         raise api_error(500, "Authorized model is no longer configured", ErrorType.INTERNAL_ERROR)
+    auth_ms = (perf_counter() - timing_start) * 1000
 
     output_tokens = body.output_count
     uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
@@ -792,7 +797,9 @@ def _settle_gateway_authorization(
         )
     )
     intent_kind = "settle" if success else "refund"
+    enqueue_ms = 0.0
     if settings.settle_outbox_enabled:
+        enqueue_start = perf_counter()
         try:
             # §5.4 honest scope: durability starts only when this INSERT commits;
             # crashes before it still rely on enclave redelivery. MF4/MF5 freeze
@@ -819,9 +826,13 @@ def _settle_gateway_authorization(
                 authorization.id,
                 exc_info=True,
             )
+        enqueue_ms = (perf_counter() - enqueue_start) * 1000
 
+    finalize_start = perf_counter()
     if is_typed:
         assert _typed_store is not None
+        # Typed finalize includes the Bigtable activity-index and benchmark
+        # write inside the wrapper's index_after_commit.
         finalized = _typed_store.typed_finalize_gateway_authorization(
             authorization.id,
             success=success,
@@ -837,11 +848,14 @@ def _settle_gateway_authorization(
             selected_usage_type=selected_usage_type,
             generation=generation,
         )
+    finalize_ms = (perf_counter() - finalize_start) * 1000
     if not finalized:
         # §3/§6/§7: leave the row pending on purpose. Inline's False only says
         # "claim lost"; it cannot distinguish a charged replay from reaper-free
         # lost charge. The drain's apply_frozen_settle outcome disambiguates, and
         # marking done here would silently swallow a lost charge.
+        # No timing line for replays: they would dominate the latency dataset
+        # with noise instead of measuring full settle/refund work.
         return {
             "data": {
                 "authorization_id": authorization.id,
@@ -849,7 +863,9 @@ def _settle_gateway_authorization(
                 "already_settled": True,
             }
         }
+    mark_ms = 0.0
     if settings.settle_outbox_enabled:
+        mark_start = perf_counter()
         try:
             marked = spanner_settle_outbox().mark(authorization.id, intent_kind, done=True)
             if marked is None:
@@ -868,6 +884,7 @@ def _settle_gateway_authorization(
                 authorization.id,
                 exc_info=True,
             )
+        mark_ms = (perf_counter() - mark_start) * 1000
 
     if success and selected_usage_type == UsageType.CREDITS:
         _schedule_auto_refill(authorization.workspace_id, settings, background_tasks)
@@ -916,6 +933,21 @@ def _settle_gateway_authorization(
             )
         )
 
+    total_ms = (perf_counter() - timing_start) * 1000
+    # Request-log latency minus total_ms ~= Cloud Run queue + transport time;
+    # that subtraction is the point of this line (2026-07-05 latency investigation).
+    logger.info(
+        "settle timing authorization_id=%s success=%s origin=%s total_ms=%.1f "
+        "auth_ms=%.1f enqueue_ms=%.1f finalize_ms=%.1f mark_ms=%.1f",
+        authorization.id,
+        success,
+        "typed" if is_typed else "legacy",
+        total_ms,
+        auth_ms,
+        enqueue_ms,
+        finalize_ms,
+        mark_ms,
+    )
     return {
         "data": {
             "authorization_id": authorization.id,

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import re
 from collections.abc import Iterator
 from typing import Any
 
@@ -32,6 +34,8 @@ ESTIMATE = 1_000_000
 TOTAL_CREDIT = 5_000_000
 NOW = "2026-07-04T12:00:00Z"
 EXPIRED_AT = "2000-01-01T00:00:00Z"
+GATEWAY_LOGGER = "trusted_router.routes.internal.gateway"
+TIMING_FIELDS = ("total_ms", "auth_ms", "enqueue_ms", "finalize_ms", "mark_ms")
 
 
 @pytest.fixture
@@ -202,6 +206,14 @@ def _row(
     )
 
 
+def _settle_timing_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == GATEWAY_LOGGER and record.getMessage().startswith("settle timing ")
+    ]
+
+
 # Unit (storage)
 
 
@@ -352,6 +364,55 @@ def test_flag_on_successful_typed_settle_enqueues_frozen_done_row(
     assert json.loads(row.settle_body or "{}") == GatewaySettleRequest(
         **body
     ).model_dump(exclude_none=True)
+
+
+def test_settle_emits_timing_line(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-route-timing"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    with caplog.at_level(logging.INFO, logger=GATEWAY_LOGGER):
+        resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    [record] = _settle_timing_records(caplog)
+    message = record.getMessage()
+    for field in TIMING_FIELDS:
+        assert re.search(rf"\b{field}=\d+\.\d\b", message)
+    assert isinstance(record.args, tuple)
+    assert record.args[0] == auth.id
+    assert record.args[2] == "typed"
+    total_ms_arg = record.args[3]
+    assert isinstance(total_ms_arg, float)
+    assert total_ms_arg > 0
+
+
+def test_settle_replay_emits_no_timing_line(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-route-timing-replay"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+    first = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+    assert first.status_code == 200, first.text
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO, logger=GATEWAY_LOGGER):
+        replay = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert _settle_timing_records(caplog) == []
 
 
 def test_flag_on_refund_enqueues_refund_done_row(fake_store: tuple[Any, Any, Any]) -> None:


### PR DESCRIPTION
Production settles record 1-9s request latencies (predating the outbox work; the inline broadcast drain is OFF in prod, so the original suspect is exonerated). This adds one INFO line per full settle/refund with auth/enqueue/finalize/mark/total milliseconds — request-log latency minus total_ms isolates Cloud Run queue + transport time, deciding between an env fix (concurrency) and a code fix (a slow section). Replays emit nothing. Ships via #124's scoped INFO unlock; the scrub filter collapses args before anything leaves the process. Zero behavior change; two caplog tests. Gates: ruff, mypy, pytest 1290 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)