### PR TITLE
Split finalize timing into Spanner-txn vs Bigtable-index (latency investigation)

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -4,6 +4,7 @@ import datetime as dt
 import json
 import logging
 import os
+import time
 import uuid
 from typing import Any, TypeVar
 
@@ -983,9 +984,23 @@ class SpannerBigtableStore:
             )
             return True
 
+        spanner_start = time.perf_counter()
         finalized = self._run_in_transaction(txn)
+        spanner_ms = (time.perf_counter() - spanner_start) * 1000
+        index_ms = 0.0
         if finalized and success and generation is not None:
+            index_start = time.perf_counter()
             self.generation_store.index_after_commit(generation)
+            index_ms = (time.perf_counter() - index_start) * 1000
+        if finalized:
+            # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
+            # into Spanner-txn vs Bigtable-index time.
+            log.info(
+                "legacy finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f",
+                authorization_id,
+                spanner_ms,
+                index_ms,
+            )
         return bool(finalized)
 
     # ── Typed-column billing (Step 3): thin wrappers over storage_gcp_authorize.
@@ -1033,6 +1048,7 @@ class SpannerBigtableStore:
                 ),
             ]
         authorization.settled = True
+        spanner_start = time.perf_counter()
         result = typed_finalize_atomic(
             self._database,
             self._param_types,
@@ -1045,11 +1061,23 @@ class SpannerBigtableStore:
             auth_body_settled=_json_body(authorization),
             generation_writes=generation_writes,
         )
+        spanner_ms = (time.perf_counter() - spanner_start) * 1000
         if result["outcome"] == SettleOutcome.ERROR:
             raise RuntimeError("typed finalize failed: release row-count != 1")
         if result["outcome"] == SettleOutcome.SETTLED:
+            index_ms = 0.0
             if success and generation is not None:
+                index_start = time.perf_counter()
                 self.generation_store.index_after_commit(generation)
+                index_ms = (time.perf_counter() - index_start) * 1000
+            # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
+            # into Spanner-txn vs Bigtable-index time.
+            log.info(
+                "typed finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f",
+                authorization_id,
+                spanner_ms,
+                index_ms,
+            )
             return True
         return False  # already_settled / not_found
 

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -12,6 +12,7 @@ See docs/design/billing-typed-counters.md.
 
 from __future__ import annotations
 
+import logging
 import threading
 
 import pytest
@@ -21,6 +22,7 @@ from trusted_router.spend_windows import utcnow, window_floors
 from trusted_router.storage import CreditAccount
 from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_models import Generation
 
 
 def _floors() -> dict:
@@ -976,6 +978,78 @@ def test_store_typed_finalize_wrapper_and_reaper_wrapper() -> None:
     assert _typed(db, ws)["total_usage"] == 900_000
     # reaper wrapper: nothing expired+unsettled now
     assert store.reap_expired_reservations(now=_NOW) == 0
+
+
+def test_typed_finalize_gateway_authorization_logs_split_timing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, _db, _ = make_fake_store()
+    ws = "ws_wrap_timing"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    outcome, auth = store.authorize_gateway_typed(
+        workspace_id=ws,
+        key_hash=key.hash,
+        estimate=1_000_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="m",
+        provider="openai",
+        requested_model_id=None,
+        candidate_model_ids=["m"],
+        region="us",
+        endpoint_id="e",
+        candidate_endpoint_ids=["e"],
+        idempotency_key=None,
+        idempotency_fingerprint=None,
+        expires_at="2026-01-01T00:00:00Z",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert auth is not None
+    generation = Generation(
+        id="gen-wrap-timing",
+        request_id="req-wrap-timing",
+        workspace_id=ws,
+        key_hash=key.hash,
+        model="m",
+        provider_name="OpenAI",
+        app="typed-finalize-test",
+        tokens_prompt=10,
+        tokens_completion=5,
+        total_cost_microdollars=900_000,
+        usage_type="Credits",
+        speed_tokens_per_second=10.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+    )
+
+    with caplog.at_level(logging.INFO, logger="trusted_router.storage_gcp"):
+        finalized = store.typed_finalize_gateway_authorization(
+            auth.id,
+            success=True,
+            actual_microdollars=900_000,
+            selected_usage_type="Credits",
+            generation=generation,
+        )
+
+    assert finalized is True
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "trusted_router.storage_gcp"
+        and record.getMessage().startswith("typed finalize timing ")
+    ]
+    [record] = records
+    message = record.getMessage()
+    assert f"authorization_id={auth.id}" in message
+    assert " spanner_ms=" in message
+    assert " index_ms=" in message
+    assert isinstance(record.args, tuple)
+    assert len(record.args) == 3
+    assert record.args[0] == auth.id
+    assert isinstance(record.args[1], float)
+    assert isinstance(record.args[2], float)
 
 
 def test_typed_idempotency_lookup_survives_cohort_rollback() -> None:


### PR DESCRIPTION
Prod data from #125's settle timing line convicts finalize (p50 1.7s, p90 5.7s of a 2.2s/6.1s total; auth/enqueue/mark are all tens of ms). This splits finalize into its two components — the typed/legacy finalize transaction vs the synchronous Bigtable index_after_commit — with one scrub-safe INFO line per settled finalize. The split decides the fix: contention-shaped (Spanner) or I/O-shaped (move the index off the request path; it is already documented as repairable via reconcile_activity). Zero behavior change; caplog test. Gates: ruff, mypy, pytest 1291 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)