### PR TITLE
Add retry-attempt count to typed finalize timing (contention attribution)

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1072,11 +1072,15 @@ class SpannerBigtableStore:
                 index_ms = (time.perf_counter() - index_start) * 1000
             # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
             # into Spanner-txn vs Bigtable-index time.
+            # attempts counts only OUTER wrapper retries; Spanner's own internal
+            # Aborted retries are invisible, so attempts>1 is definitive severe
+            # contention while attempts==1 does not rule out absorbed contention.
             log.info(
-                "typed finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f",
+                "typed finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f attempts=%d",
                 authorization_id,
                 spanner_ms,
                 index_ms,
+                result.get("attempts", 1),
             )
             return True
         return False  # already_settled / not_found

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -498,7 +498,10 @@ def typed_finalize_atomic(
         return {"outcome": SettleOutcome.SETTLED}
 
     try:
-        return run_in_transaction_with_retry(database, txn)
+        attempts_box: list[int] = []
+        result = run_in_transaction_with_retry(database, txn, attempts_out=attempts_box)
+        result["attempts"] = attempts_box[0] if attempts_box else 1
+        return result
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
 

--- a/src/trusted_router/storage_gcp_io.py
+++ b/src/trusted_router/storage_gcp_io.py
@@ -22,7 +22,13 @@ from typing import Any, TypeVar
 T = TypeVar("T")
 
 
-def run_in_transaction_with_retry(database: Any, func: Callable[..., T], *, attempts: int = 8) -> T:
+def run_in_transaction_with_retry(
+    database: Any,
+    func: Callable[..., T],
+    *,
+    attempts: int = 8,
+    attempts_out: list[int] | None = None,
+) -> T:
     """Run a Spanner transaction, retrying on ABORTED with backoff + jitter.
 
     Spanner already retries ABORTED to an internal deadline, but sustained
@@ -45,19 +51,26 @@ def run_in_transaction_with_retry(database: Any, func: Callable[..., T], *, atte
     Unlike the rate limiter (middleware._enforce_rate_limit), which fails OPEN
     on this same contention, billing transactions must not be dropped — so we
     retry rather than swallow the abort.
+
+    ``attempts_out``, if given, receives the winning attempt number (1 = no
+    retry) — used to attribute finalize latency to contention.
     """
     from google.api_core.exceptions import Aborted
 
     delay = 0.05
     for attempt in range(1, attempts + 1):
         try:
-            return database.run_in_transaction(func)
+            result = database.run_in_transaction(func)
         except Aborted:
             if attempt >= attempts:
                 raise
             jitter = secrets.randbelow(1_000_000) / 1_000_000 * delay
             time.sleep(delay + jitter)
             delay = min(delay * 2.0, 2.0)
+            continue
+        if attempts_out is not None:
+            attempts_out.append(attempt)
+        return result
     raise AssertionError("unreachable")  # pragma: no cover
 
 

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -1045,11 +1045,13 @@ def test_typed_finalize_gateway_authorization_logs_split_timing(
     assert f"authorization_id={auth.id}" in message
     assert " spanner_ms=" in message
     assert " index_ms=" in message
+    assert " attempts=1" in message
     assert isinstance(record.args, tuple)
-    assert len(record.args) == 3
+    assert len(record.args) == 4
     assert record.args[0] == auth.id
     assert isinstance(record.args[1], float)
     assert isinstance(record.args[2], float)
+    assert record.args[3] == 1
 
 
 def test_typed_idempotency_lookup_survives_cohort_rollback() -> None:

--- a/tests/test_storage_gcp_io.py
+++ b/tests/test_storage_gcp_io.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from google.api_core.exceptions import Aborted
+
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+
+
+class _RetryingDatabase:
+    def __init__(self, aborts_before_success: int) -> None:
+        self.aborts_before_success = aborts_before_success
+        self.calls = 0
+
+    def run_in_transaction(self, func: Callable[..., str]) -> str:
+        self.calls += 1
+        if self.calls <= self.aborts_before_success:
+            raise Aborted("spanner aborted")
+        return func("txn")
+
+
+def _txn(_transaction: object) -> str:
+    return "ok"
+
+
+def test_run_in_transaction_with_retry_records_winning_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("trusted_router.storage_gcp_io.time.sleep", lambda _seconds: None)
+
+    first_try = _RetryingDatabase(aborts_before_success=0)
+    attempts_box: list[int] = []
+    assert run_in_transaction_with_retry(first_try, _txn, attempts_out=attempts_box) == "ok"
+    assert attempts_box == [1]
+    assert first_try.calls == 1
+
+    retried = _RetryingDatabase(aborts_before_success=2)
+    attempts_box = []
+    assert run_in_transaction_with_retry(retried, _txn, attempts=4, attempts_out=attempts_box) == "ok"
+    assert attempts_box == [3]
+    assert retried.calls == 3
+
+    omitted = _RetryingDatabase(aborts_before_success=1)
+    assert run_in_transaction_with_retry(omitted, _txn, attempts=3) == "ok"
+    assert omitted.calls == 2
+
+
+def test_run_in_transaction_with_retry_does_not_record_exhausted_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("trusted_router.storage_gcp_io.time.sleep", lambda _seconds: None)
+
+    database = _RetryingDatabase(aborts_before_success=5)
+    attempts_out: list[int] = []
+    with pytest.raises(Aborted):
+        run_in_transaction_with_retry(database, _txn, attempts=3, attempts_out=attempts_out)
+
+    assert attempts_out == []


### PR DESCRIPTION
Prod `typed finalize timing` shows `spanner_ms` p50 977ms / p90 5.76s — but that number bundles wound-retry contention and baseline multi-region commit latency. This surfaces the retry helper's winning attempt count onto the timing line (`attempts=N`) so we can bucket spanner_ms by attempts and separate the two.

Caveat documented: counts only the outer `run_in_transaction_with_retry` retries — Spanner's own internal Aborted retries are invisible — so `attempts>1` is a definitive severe-contention signal, while `attempts==1` doesn't rule out contention Spanner absorbed internally. Optional `attempts_out`, default None = zero behavior change. Tests cover the retry counter and the extended timing line. Gates: ruff, mypy, pytest 1292 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)