### PR TITLE
Control-plane parity: honor max_completion_tokens / max_output_tokens

### DIFF
--- a/src/trusted_router/adapter.py
+++ b/src/trusted_router/adapter.py
@@ -18,16 +18,29 @@ from typing import Any
 
 from trusted_router.errors import api_error
 
+_OUTPUT_TOKEN_FIELDS = ("max_tokens", "max_completion_tokens", "max_output_tokens")
+
 
 def resolve_max_output_tokens(body: Mapping[str, Any]) -> int | None:
     # Honor all three documented output-limit spellings; precedence:
     # max_tokens (legacy/explicit) > max_completion_tokens (modern OpenAI
     # chat; gpt-5.x requires it) > max_output_tokens (Responses/Gemini).
-    for key in ("max_tokens", "max_completion_tokens", "max_output_tokens"):
+    for key in _OUTPUT_TOKEN_FIELDS:
         value = body.get(key)
         if value is not None:
             return int(value)
     return None
+
+
+def _resolve_route_max_output_tokens(body: Mapping[str, Any]) -> int | None:
+    output_token_field = next(
+        (field for field in _OUTPUT_TOKEN_FIELDS if body.get(field) is not None),
+        "max_tokens",
+    )
+    try:
+        return resolve_max_output_tokens(body)
+    except (TypeError, ValueError) as exc:
+        raise api_error(400, f"{output_token_field} must be an integer", "bad_request") from exc
 
 
 def responses_to_chat_body(body: dict[str, Any]) -> dict[str, Any]:
@@ -53,7 +66,7 @@ def responses_to_chat_body(body: dict[str, Any]) -> dict[str, Any]:
         "messages": messages,
         "temperature": body.get("temperature"),
         "top_p": body.get("top_p"),
-        "max_tokens": resolve_max_output_tokens(body),
+        "max_tokens": _resolve_route_max_output_tokens(body),
         "stream": False,
     }
 
@@ -66,7 +79,7 @@ def messages_to_chat_body(body: dict[str, Any], *, model_id: str) -> dict[str, A
     chat_body: dict[str, Any] = {
         "model": model_id,
         "messages": list(body.get("messages") or []),
-        "max_tokens": resolve_max_output_tokens(body),
+        "max_tokens": _resolve_route_max_output_tokens(body),
         "temperature": body.get("temperature"),
     }
     if system := body.get("system"):

--- a/src/trusted_router/adapter.py
+++ b/src/trusted_router/adapter.py
@@ -13,9 +13,21 @@ mappings in one place and makes it easy to add a new shape.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from trusted_router.errors import api_error
+
+
+def resolve_max_output_tokens(body: Mapping[str, Any]) -> int | None:
+    # Honor all three documented output-limit spellings; precedence:
+    # max_tokens (legacy/explicit) > max_completion_tokens (modern OpenAI
+    # chat; gpt-5.x requires it) > max_output_tokens (Responses/Gemini).
+    for key in ("max_tokens", "max_completion_tokens", "max_output_tokens"):
+        value = body.get(key)
+        if value is not None:
+            return int(value)
+    return None
 
 
 def responses_to_chat_body(body: dict[str, Any]) -> dict[str, Any]:
@@ -41,7 +53,7 @@ def responses_to_chat_body(body: dict[str, Any]) -> dict[str, Any]:
         "messages": messages,
         "temperature": body.get("temperature"),
         "top_p": body.get("top_p"),
-        "max_tokens": body.get("max_output_tokens") or body.get("max_tokens"),
+        "max_tokens": resolve_max_output_tokens(body),
         "stream": False,
     }
 
@@ -54,7 +66,7 @@ def messages_to_chat_body(body: dict[str, Any], *, model_id: str) -> dict[str, A
     chat_body: dict[str, Any] = {
         "model": model_id,
         "messages": list(body.get("messages") or []),
-        "max_tokens": body.get("max_tokens"),
+        "max_tokens": resolve_max_output_tokens(body),
         "temperature": body.get("temperature"),
     }
     if system := body.get("system"):

--- a/src/trusted_router/provider_adapters.py
+++ b/src/trusted_router/provider_adapters.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from trusted_router.adapter import resolve_max_output_tokens
 from trusted_router.catalog import PROVIDERS, Model
 from trusted_router.provider_payloads import (
     anthropic_messages_payload,
@@ -62,7 +63,7 @@ async def openai_compatible_chat(
         "messages": messages(request),
         "stream": False,
         "temperature": request.get("temperature"),
-        "max_tokens": request.get("max_tokens"),
+        "max_tokens": resolve_max_output_tokens(request),
     }
     payload.update(_openai_compatible_passthrough(request))
     payload = {k: v for k, v in payload.items() if v is not None}
@@ -110,7 +111,7 @@ async def openai_compatible_chat_stream(
         "stream": True,
         "stream_options": {"include_usage": True},
         "temperature": request.get("temperature"),
-        "max_tokens": request.get("max_tokens"),
+        "max_tokens": resolve_max_output_tokens(request),
     }
     payload.update(_openai_compatible_passthrough(request))
     payload = {k: v for k, v in payload.items() if v is not None}

--- a/src/trusted_router/provider_payloads.py
+++ b/src/trusted_router/provider_payloads.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from trusted_router.adapter import chat_to_anthropic, chat_to_gemini
+from trusted_router.adapter import chat_to_anthropic, chat_to_gemini, resolve_max_output_tokens
 from trusted_router.catalog import Model
 
 
 def anthropic_messages_payload(model: Model, request: dict[str, Any], *, stream: bool) -> dict[str, Any]:
-    base = chat_to_anthropic(messages(request), max_tokens=request.get("max_tokens") or 1024)
+    base = chat_to_anthropic(messages(request), max_tokens=resolve_max_output_tokens(request) or 1024)
     payload: dict[str, Any] = {
         "model": upstream_model_id(model),
         "stream": stream,
@@ -21,8 +21,9 @@ def anthropic_messages_payload(model: Model, request: dict[str, Any], *, stream:
 def gemini_payload(request: dict[str, Any]) -> dict[str, Any]:
     payload: dict[str, Any] = {"contents": chat_to_gemini(messages(request))}
     generation_config: dict[str, Any] = {}
-    if request.get("max_tokens") is not None:
-        generation_config["maxOutputTokens"] = request["max_tokens"]
+    max_output_tokens = resolve_max_output_tokens(request)
+    if max_output_tokens is not None:
+        generation_config["maxOutputTokens"] = max_output_tokens
     if request.get("temperature") is not None:
         generation_config["temperature"] = request["temperature"]
     if request.get("top_p") is not None:

--- a/src/trusted_router/routes/inference.py
+++ b/src/trusted_router/routes/inference.py
@@ -24,7 +24,11 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from trusted_router.adapter import messages_to_chat_body, responses_to_chat_body
+from trusted_router.adapter import (
+    messages_to_chat_body,
+    resolve_max_output_tokens,
+    responses_to_chat_body,
+)
 from trusted_router.auth import (
     InferencePrincipal,
     Principal,
@@ -52,6 +56,7 @@ from trusted_router.services.inference import (
 from trusted_router.types import ErrorType, UsageType
 
 _VALID_ROLES = frozenset({"system", "user", "assistant", "tool", "developer"})
+_OUTPUT_TOKEN_FIELDS = ("max_tokens", "max_completion_tokens", "max_output_tokens")
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +78,7 @@ def register_inference_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> Any:
         body = await json_body(request)
+        _validate_output_token_limit(body)
         _validate_chat_messages(body)
         _require_monitor_model_key(body, principal, settings)
         provider_prefs = provider_route_preferences(body)
@@ -180,6 +186,7 @@ def register_inference_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> Any:
         body = await json_body(request)
+        _validate_output_token_limit(body)
         model = _require_messages_model(body)
         chat_body = messages_to_chat_body(body, model_id=model.id)
         app_name = _app_name(request)
@@ -244,6 +251,7 @@ def register_inference_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> JSONResponse:
         body = await json_body(request)
+        _validate_output_token_limit(body)
         chat_body = responses_to_chat_body(body)
         _require_monitor_model_key(chat_body, principal, settings)
         model = _require_chat_model(chat_body)
@@ -439,6 +447,25 @@ def _validate_chat_messages(body: dict[str, Any]) -> None:
     as `_require_chat_model` does internally; this is the standalone
     pre-route-resolution gate."""
     _validate_messages_field(body)
+
+
+def _validate_output_token_limit(body: dict[str, Any]) -> None:
+    field = next(
+        (key for key in _OUTPUT_TOKEN_FIELDS if body.get(key) is not None),
+        "max_tokens",
+    )
+    try:
+        max_tokens = resolve_max_output_tokens(body)
+    except (TypeError, ValueError) as exc:
+        raise api_error(
+            400,
+            f"{field} must be an integer",
+            ErrorType.BAD_REQUEST,
+        ) from exc
+    if max_tokens is not None and max_tokens < 1:
+        raise api_error(400, f"{field} must be at least 1", ErrorType.BAD_REQUEST)
+    if max_tokens is not None:
+        body[field] = max_tokens
 
 
 def _validate_messages_field(body: dict[str, Any]) -> None:

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -202,12 +202,12 @@ class GatewayAuthorizeRequest(_Lenient):
 
     @property
     def output_estimate(self) -> int:
-        if self.max_output_tokens is not None:
-            return self.max_output_tokens
-        if self.max_completion_tokens is not None:
-            return self.max_completion_tokens
         if self.max_tokens is not None:
             return self.max_tokens
+        if self.max_completion_tokens is not None:
+            return self.max_completion_tokens
+        if self.max_output_tokens is not None:
+            return self.max_output_tokens
         return 512
 
 

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -185,6 +185,7 @@ class GatewayAuthorizeRequest(_Lenient):
     provider: dict[str, Any] | None = None
     estimated_input_tokens: int = Field(default=1, ge=0)
     max_output_tokens: int | None = Field(default=None, ge=1)
+    max_completion_tokens: int | None = Field(default=None, ge=1)
     max_tokens: int | None = Field(default=None, ge=1)
     region: str | None = None
     user: str | None = Field(default=None, max_length=256)
@@ -203,6 +204,8 @@ class GatewayAuthorizeRequest(_Lenient):
     def output_estimate(self) -> int:
         if self.max_output_tokens is not None:
             return self.max_output_tokens
+        if self.max_completion_tokens is not None:
+            return self.max_completion_tokens
         if self.max_tokens is not None:
             return self.max_tokens
         return 512

--- a/src/trusted_router/services/inference.py
+++ b/src/trusted_router/services/inference.py
@@ -15,16 +15,18 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from trusted_router.adapter import resolve_max_output_tokens
 from trusted_router.auth import Principal
 from trusted_router.catalog import MODELS, PROVIDERS, Model, auto_candidate_models
 from trusted_router.config import Settings
+from trusted_router.errors import api_error
 from trusted_router.providers import (
     ProviderClient,
     ProviderError,
     estimate_tokens_from_messages,
     estimate_tokens_from_text,
 )
-from trusted_router.routes.helpers import cost_microdollars, integer_body_field
+from trusted_router.routes.helpers import cost_microdollars
 from trusted_router.secrets import LocalKeyFile
 from trusted_router.services.inference_errors import (
     all_candidates_failed,
@@ -358,7 +360,22 @@ async def run_chat_candidates(
 
 def _estimate_reserve(body: dict[str, Any], model: Model, *, input_estimate: int | None = None) -> int:
     input_estimate = input_estimate or estimate_tokens_from_messages(body.get("messages", []))
-    max_tokens = integer_body_field(body, "max_tokens", default=512, minimum=1)
+    output_token_field = next(
+        (
+            field
+            for field in ("max_tokens", "max_completion_tokens", "max_output_tokens")
+            if body.get(field) is not None
+        ),
+        "max_tokens",
+    )
+    try:
+        max_tokens = resolve_max_output_tokens(body)
+    except (TypeError, ValueError) as exc:
+        raise api_error(400, f"{output_token_field} must be an integer", "bad_request") from exc
+    if max_tokens is None:
+        max_tokens = 512
+    if max_tokens < 1:
+        raise api_error(400, f"{output_token_field} must be at least 1", "bad_request")
     return cost_microdollars(model, input_estimate, max_tokens)
 
 

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
+import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.catalog import PROVIDER_JURISDICTION_US, PROVIDERS
@@ -233,6 +234,47 @@ def test_malformed_json_and_bad_messages_are_stable_errors(
     )
     assert bad_max_tokens.status_code == 400
     assert bad_max_tokens.json()["error"]["type"] == "bad_request"
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "openai/gpt-5.4-nano",
+                "max_tokens": "a lot",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        (
+            "/v1/messages",
+            {
+                "model": "anthropic/claude-sonnet-4.6",
+                "max_tokens": "a lot",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        (
+            "/v1/responses",
+            {
+                "model": "openai/gpt-5.4-nano",
+                "max_output_tokens": "a lot",
+                "input": "hello",
+            },
+        ),
+    ],
+)
+def test_non_integer_output_token_limits_return_bad_request(
+    client: TestClient,
+    inference_headers: dict[str, str],
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    resp = client.post(path, headers=inference_headers, json=payload)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["type"] == "bad_request"
 
 
 def test_key_limit_validation_uses_stable_errors(

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -277,6 +277,55 @@ def test_non_integer_output_token_limits_return_bad_request(
     assert resp.json()["error"]["type"] == "bad_request"
 
 
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "openai/gpt-5.4-nano",
+                "max_completion_tokens": "a lot",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        (
+            "/v1/messages",
+            {
+                "model": "anthropic/claude-sonnet-4.6",
+                "max_completion_tokens": "a lot",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        (
+            "/v1/responses",
+            {
+                "model": "openai/gpt-5.4-nano",
+                "max_completion_tokens": "a lot",
+                "input": "hello",
+            },
+        ),
+    ],
+)
+def test_non_integer_max_completion_tokens_returns_bad_request_before_dispatch(
+    client: TestClient,
+    inference_headers: dict[str, str],
+    path: str,
+    payload: dict[str, object],
+    stream: bool,
+) -> None:
+    resp = client.post(
+        path,
+        headers=inference_headers,
+        json={**payload, "stream": stream},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["type"] == "bad_request"
+    assert resp.json()["error"]["source"] == "router"
+    assert resp.json()["error"]["message"] == "max_completion_tokens must be an integer"
+
+
 def test_key_limit_validation_uses_stable_errors(
     client: TestClient,
     user_headers: dict[str, str],

--- a/tests/test_max_output_tokens_aliases.py
+++ b/tests/test_max_output_tokens_aliases.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from trusted_router.adapter import (
+    messages_to_chat_body,
+    resolve_max_output_tokens,
+    responses_to_chat_body,
+)
+from trusted_router.catalog import MODELS
+from trusted_router.provider_adapters import openai_compatible_chat
+from trusted_router.provider_payloads import anthropic_messages_payload, gemini_payload
+from trusted_router.schemas import GatewayAuthorizeRequest
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ({"max_tokens": 100}, 100),
+        ({"max_completion_tokens": 200}, 200),
+        ({"max_output_tokens": 300}, 300),
+        ({}, None),
+    ],
+)
+def test_resolve_max_output_tokens_accepts_all_spellings(
+    body: dict[str, int], expected: int | None
+) -> None:
+    assert resolve_max_output_tokens(body) == expected
+
+
+def test_resolve_max_output_tokens_precedence() -> None:
+    assert (
+        resolve_max_output_tokens({
+            "max_tokens": 100,
+            "max_completion_tokens": 200,
+            "max_output_tokens": 300,
+        })
+        == 100
+    )
+    assert (
+        resolve_max_output_tokens({
+            "max_completion_tokens": 200,
+            "max_output_tokens": 300,
+        })
+        == 200
+    )
+
+
+def test_gateway_authorize_request_uses_max_completion_tokens_for_output_estimate() -> None:
+    body = GatewayAuthorizeRequest(
+        api_key_hash="hash",
+        model="openai/gpt-5.4-nano",
+        max_completion_tokens=8000,
+    )
+
+    assert body.output_estimate == 8000
+
+
+def test_adapter_conversions_use_max_completion_tokens() -> None:
+    chat_body = responses_to_chat_body({
+        "model": "openai/gpt-5.4-nano",
+        "input": "hello",
+        "max_completion_tokens": 1234,
+    })
+    messages_body = messages_to_chat_body(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_completion_tokens": 2345,
+        },
+        model_id="anthropic/claude-sonnet-4.6",
+    )
+
+    assert chat_body["max_tokens"] == 1234
+    assert messages_body["max_tokens"] == 2345
+
+
+def test_provider_payloads_use_max_completion_tokens() -> None:
+    request = {
+        "model": "google/gemini-2.5-flash",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_completion_tokens": 3456,
+    }
+
+    anthropic = anthropic_messages_payload(
+        MODELS["anthropic/claude-sonnet-4.6"], request, stream=False
+    )
+    gemini = gemini_payload(request)
+
+    assert anthropic["max_tokens"] == 3456
+    assert gemini["generationConfig"]["maxOutputTokens"] == 3456
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_payload_uses_max_completion_tokens(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout: int) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: dict[str, Any],
+            **_: Any,
+        ) -> httpx.Response:
+            calls.append({"url": url, "headers": headers, "json": json})
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_alias",
+                    "choices": [{"message": {"content": "hello"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            )
+
+    monkeypatch.setattr("trusted_router.provider_adapters.httpx.AsyncClient", FakeAsyncClient)
+
+    await openai_compatible_chat(
+        MODELS["openai/gpt-5.4-nano"],
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_completion_tokens": 4567,
+        },
+        api_key="openai-value",
+        base_url="https://example.test/v1",
+    )
+
+    assert calls[0]["json"]["max_tokens"] == 4567

--- a/tests/test_max_output_tokens_aliases.py
+++ b/tests/test_max_output_tokens_aliases.py
@@ -13,7 +13,9 @@ from trusted_router.adapter import (
 from trusted_router.catalog import MODELS
 from trusted_router.provider_adapters import openai_compatible_chat
 from trusted_router.provider_payloads import anthropic_messages_payload, gemini_payload
+from trusted_router.routes.helpers import cost_microdollars
 from trusted_router.schemas import GatewayAuthorizeRequest
+from trusted_router.services.inference import _estimate_reserve
 
 
 @pytest.mark.parametrize(
@@ -57,6 +59,38 @@ def test_gateway_authorize_request_uses_max_completion_tokens_for_output_estimat
     )
 
     assert body.output_estimate == 8000
+
+
+def test_gateway_authorize_request_prefers_max_tokens_for_output_estimate() -> None:
+    body = GatewayAuthorizeRequest(
+        api_key_hash="hash",
+        model="openai/gpt-5.4-nano",
+        max_tokens=100,
+        max_completion_tokens=8000,
+    )
+
+    assert body.output_estimate == 100
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_completion_tokens", 12_000),
+        ("max_output_tokens", 13_000),
+    ],
+)
+def test_estimate_reserve_uses_output_token_aliases(field: str, value: int) -> None:
+    model = MODELS["anthropic/claude-sonnet-4.6"]
+    input_estimate = 37
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        field: value,
+    }
+
+    reserve = _estimate_reserve(body, model, input_estimate=input_estimate)
+
+    assert reserve == cost_microdollars(model, input_estimate, value)
+    assert reserve != cost_microdollars(model, input_estimate, 512)
 
 
 def test_adapter_conversions_use_max_completion_tokens() -> None:


### PR DESCRIPTION
Companion to the enclave fix for the publicly-reported truncation bug. quill-router read only `max_tokens` for the output cap, so clients using the modern `max_completion_tokens` spelling got an under-sized billing reservation and an under-capped provider request on the local/test + meta-routing paths. Adds one shared `resolve_max_output_tokens` accessor (precedence max_tokens > max_completion_tokens > max_output_tokens) used by the adapter, provider payloads, and the authorize estimate. Focused alias tests; gates ruff/mypy/pytest 1302 passed. Behavior identical for existing max_tokens clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)