### PR TITLE
Usage graphs — backend: on-demand Bigtable aggregation

### DIFF
--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -3,13 +3,20 @@ prompt content."""
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+import time
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, Response
 
 from trusted_router.auth import SettingsDep
 from trusted_router.money import format_money_precise
 from trusted_router.routes.console._shared import ConsoleDep, render
 from trusted_router.storage import STORE
+
+_USAGE_CACHE_TTL_SECONDS = 60.0
+_UsageCacheKey = tuple[str, int, str, bool, str | None]
+_USAGE_CACHE: dict[_UsageCacheKey, tuple[float, dict[str, Any]]] = {}
 
 
 def register(app: FastAPI) -> None:
@@ -28,3 +35,38 @@ def register(app: FastAPI) -> None:
             activity=events,
             api_base_url=settings.api_base_url,
         ))
+
+    @app.get("/console/activity/usage.json")
+    async def console_activity_usage(
+        ctx: ConsoleDep,
+        days: int = 30,
+        granularity: str | None = None,
+        by_model: bool = False,
+        api_key_hash: str | None = None,
+    ) -> dict[str, Any]:
+        clamped_days = min(90, max(1, days))
+        resolved_granularity = granularity or ("hour" if clamped_days <= 2 else "day")
+        if resolved_granularity not in {"hour", "day"}:
+            raise HTTPException(status_code=400, detail="granularity must be 'hour' or 'day'")
+        cache_key = (
+            ctx.workspace.id,
+            clamped_days,
+            resolved_granularity,
+            by_model,
+            api_key_hash,
+        )
+        now = time.monotonic()
+        cached = _USAGE_CACHE.get(cache_key)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+        result = STORE.usage_series(
+            ctx.workspace.id,
+            days=clamped_days,
+            granularity=resolved_granularity,
+            api_key_hash=api_key_hash,
+            by_model=by_model,
+        )
+        # A shared cache (Redis) is deferred; this per-worker TTL covers
+        # occasional console reads and protects Bigtable from refresh bursts.
+        _USAGE_CACHE[cache_key] = (now + _USAGE_CACHE_TTL_SECONDS, result)
+        return result

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -882,6 +882,23 @@ class InMemoryStore:
             workspace_id, api_key_hash=api_key_hash, date=date, limit=limit
         )
 
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        days: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        return self.generation_store.usage_series(
+            workspace_id,
+            days=days,
+            granularity=granularity,
+            api_key_hash=api_key_hash,
+            by_model=by_model,
+        )
+
     def reconcile_generation_activity(
         self,
         workspace_id: str,

--- a/src/trusted_router/storage_activity.py
+++ b/src/trusted_router/storage_activity.py
@@ -7,6 +7,18 @@ from trusted_router.money import microdollars_to_float
 from trusted_router.storage_models import Generation, _is_byok
 
 
+def generation_metrics(gen: Generation) -> dict[str, int]:
+    is_byok = _is_byok(gen.usage_type)
+    return {
+        "requests": 1,
+        "prompt_tokens": gen.tokens_prompt,
+        "completion_tokens": gen.tokens_completion,
+        "reasoning_tokens": gen.reasoning_tokens,
+        "cost_micro": 0 if is_byok else gen.total_cost_microdollars,
+        "byok_micro": gen.total_cost_microdollars if is_byok else 0,
+    }
+
+
 def filter_generations(
     generations: Iterable[Generation],
     *,
@@ -45,18 +57,15 @@ def summarize_activity(generations: Iterable[Generation]) -> list[dict[str, Any]
                 "byok_usage_inference_microdollars": 0,
             },
         )
-        item["requests"] += 1
-        item["prompt_tokens"] += gen.tokens_prompt
-        item["completion_tokens"] += gen.tokens_completion
-        cost = microdollars_to_float(gen.total_cost_microdollars)
-        if _is_byok(gen.usage_type):
-            item["byok_usage_inference"] += cost
-        else:
-            item["usage"] += cost
-        item["usage_microdollars"] += 0 if _is_byok(gen.usage_type) else gen.total_cost_microdollars
-        item["byok_usage_inference_microdollars"] += (
-            gen.total_cost_microdollars if _is_byok(gen.usage_type) else 0
-        )
+        metrics = generation_metrics(gen)
+        item["requests"] += metrics["requests"]
+        item["prompt_tokens"] += metrics["prompt_tokens"]
+        item["completion_tokens"] += metrics["completion_tokens"]
+        item["reasoning_tokens"] += metrics["reasoning_tokens"]
+        item["usage_microdollars"] += metrics["cost_micro"]
+        item["byok_usage_inference_microdollars"] += metrics["byok_micro"]
+        item["usage"] += microdollars_to_float(metrics["cost_micro"])
+        item["byok_usage_inference"] += microdollars_to_float(metrics["byok_micro"])
     return sorted(grouped.values(), key=lambda item: item["date"], reverse=True)
 
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1419,6 +1419,26 @@ class SpannerBigtableStore:
             workspace_id, api_key_hash=api_key_hash, date=date, limit=limit
         )
 
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        days: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        today = dt.datetime.now(dt.UTC).date()
+        start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
+        return self.generation_store.usage_series(
+            workspace_id,
+            start_day=start_day,
+            end_day=today.isoformat(),
+            granularity=granularity,
+            api_key_hash=api_key_hash,
+            by_model=by_model,
+        )
+
     def reconcile_generation_activity(
         self,
         workspace_id: str,

--- a/src/trusted_router/storage_gcp_activity_index.py
+++ b/src/trusted_router/storage_gcp_activity_index.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from trusted_router.storage_activity import generation_metrics
 from trusted_router.storage_gcp_codec import json_body, reverse_time_key
 from trusted_router.storage_models import Generation
 
@@ -49,6 +50,62 @@ def activity_generations(
     return generations[:limit]
 
 
+def usage_series(
+    table: Any,
+    family: str,
+    workspace_id: str,
+    *,
+    start_day: str,
+    end_day: str,
+    granularity: str,
+    api_key_hash: str | None = None,
+    by_model: bool = False,
+    max_rows: int = 200_000,
+) -> dict[str, Any]:
+    if granularity not in {"hour", "day"}:
+        raise ValueError("granularity must be 'hour' or 'day'")
+
+    buckets: dict[str, dict[str, Any]] = {}
+    model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
+    rows = table.read_rows(
+        start_key=f"ws#{workspace_id}#{start_day}".encode(),
+        end_key=f"ws#{workspace_id}#{end_day}~".encode(),
+        limit=max_rows,
+    )
+    scanned = 0
+    truncated = False
+    for row in rows:
+        if scanned >= max_rows:
+            truncated = True
+            break
+        scanned += 1
+        generation = _generation_from_row(row, family)
+        if generation is None:
+            continue
+        if api_key_hash is not None and generation.key_hash != api_key_hash:
+            continue
+        bucket = generation.created_at[:13] if granularity == "hour" else generation.created_at[:10]
+        metrics = generation_metrics(generation)
+        _add_metrics(_bucket(buckets, bucket), metrics)
+        if by_model:
+            _add_metrics(_bucket(model_buckets.setdefault(generation.model, {}), bucket), metrics)
+    if scanned >= max_rows:
+        truncated = True
+
+    result: dict[str, Any] = {
+        "granularity": granularity,
+        "start_day": start_day,
+        "end_day": end_day,
+        "truncated": truncated,
+        "buckets": _sorted_buckets(buckets),
+    }
+    if by_model:
+        result["by_model"] = {
+            model: _sorted_buckets(per_model) for model, per_model in sorted(model_buckets.items())
+        }
+    return result
+
+
 def _generations_from_rows(
     rows: Any,
     family: str,
@@ -64,3 +121,34 @@ def _generations_from_rows(
         if api_key_hash is None or generation.key_hash == api_key_hash:
             generations.append(generation)
     return generations
+
+
+def _generation_from_row(row: Any, family: str) -> Generation | None:
+    cells = row.cells.get(family, {}).get(b"body", [])
+    if not cells:
+        return None
+    return Generation(**json.loads(cells[0].value.decode("utf-8")))
+
+
+def _bucket(buckets: dict[str, dict[str, Any]], bucket: str) -> dict[str, Any]:
+    return buckets.setdefault(
+        bucket,
+        {
+            "bucket": bucket,
+            "requests": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "reasoning_tokens": 0,
+            "cost_micro": 0,
+            "byok_micro": 0,
+        },
+    )
+
+
+def _add_metrics(bucket: dict[str, Any], metrics: dict[str, int]) -> None:
+    for key, value in metrics.items():
+        bucket[key] += value
+
+
+def _sorted_buckets(buckets: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    return [buckets[key] for key in sorted(buckets)]

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -19,6 +19,9 @@ from trusted_router.storage_gcp_activity_index import (
     activity_generations as _bt_activity_generations,
 )
 from trusted_router.storage_gcp_activity_index import (
+    usage_series as _bt_usage_series,
+)
+from trusted_router.storage_gcp_activity_index import (
     write_generation as _bt_write_generation,
 )
 from trusted_router.storage_gcp_benchmark_index import (
@@ -171,6 +174,27 @@ class SpannerGenerations:
             limit=limit,
         )
         return generation_events(rows)
+
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        start_day: str,
+        end_day: str,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        return _bt_usage_series(
+            self._bt_table,
+            self._family,
+            workspace_id,
+            start_day=start_day,
+            end_day=end_day,
+            granularity=granularity,
+            api_key_hash=api_key_hash,
+            by_model=by_model,
+        )
 
     def reconcile_activity(
         self,

--- a/src/trusted_router/storage_generations.py
+++ b/src/trusted_router/storage_generations.py
@@ -7,12 +7,14 @@ doesn't need to know how API keys are stored."""
 
 from __future__ import annotations
 
+import datetime as dt
 import threading
 from typing import Any, Protocol
 
 from trusted_router.storage_activity import (
     filter_generations,
     generation_events,
+    generation_metrics,
     summarize_activity,
 )
 from trusted_router.storage_models import (
@@ -115,6 +117,54 @@ class InMemoryGenerations:
             )
         return generation_events(rows, limit=limit)
 
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        days: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        if granularity not in {"hour", "day"}:
+            raise ValueError("granularity must be 'hour' or 'day'")
+        today = dt.datetime.now(dt.UTC).date()
+        start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
+        end_day = today.isoformat()
+        buckets: dict[str, dict[str, Any]] = {}
+        model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
+        with self._lock:
+            generations = list(self.generations.values())
+        for generation in generations:
+            day = generation.created_at[:10]
+            if generation.workspace_id != workspace_id:
+                continue
+            if api_key_hash is not None and generation.key_hash != api_key_hash:
+                continue
+            if day < start_day or day > end_day:
+                continue
+            bucket = generation.created_at[:13] if granularity == "hour" else day
+            metrics = generation_metrics(generation)
+            _add_usage_metrics(_usage_bucket(buckets, bucket), metrics)
+            if by_model:
+                _add_usage_metrics(
+                    _usage_bucket(model_buckets.setdefault(generation.model, {}), bucket),
+                    metrics,
+                )
+        result: dict[str, Any] = {
+            "granularity": granularity,
+            "start_day": start_day,
+            "end_day": end_day,
+            "truncated": False,
+            "buckets": _sorted_usage_buckets(buckets),
+        }
+        if by_model:
+            result["by_model"] = {
+                model: _sorted_usage_buckets(per_model)
+                for model, per_model in sorted(model_buckets.items())
+            }
+        return result
+
     def reconcile_activity(
         self,
         workspace_id: str,
@@ -124,3 +174,27 @@ class InMemoryGenerations:
     ) -> int:
         _ = (workspace_id, date, limit)
         return 0
+
+
+def _usage_bucket(buckets: dict[str, dict[str, Any]], bucket: str) -> dict[str, Any]:
+    return buckets.setdefault(
+        bucket,
+        {
+            "bucket": bucket,
+            "requests": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "reasoning_tokens": 0,
+            "cost_micro": 0,
+            "byok_micro": 0,
+        },
+    )
+
+
+def _add_usage_metrics(bucket: dict[str, Any], metrics: dict[str, int]) -> None:
+    for key, value in metrics.items():
+        bucket[key] += value
+
+
+def _sorted_usage_buckets(buckets: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    return [buckets[key] for key in sorted(buckets)]

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -428,6 +428,15 @@ class Store(Protocol):
         date: str | None = ...,
         limit: int = ...,
     ) -> list[dict[str, Any]]: ...
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        days: int,
+        granularity: str,
+        api_key_hash: str | None = ...,
+        by_model: bool = ...,
+    ) -> dict[str, Any]: ...
 
     # Rate limiting -----------------------------------------------------------
     def hit_rate_limit(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -914,26 +914,43 @@ def _execute_sql(
 class FakeBigtableTable:
     def __init__(self) -> None:
         self.committed: list[bytes] = []
+        self.rows: dict[bytes, dict[str, dict[bytes, list[Any]]]] = {}
+        self.reads: list[tuple[bytes, bytes, int]] = []
         self.lock = threading.Lock()
 
     def direct_row(self, key: bytes) -> _FakeDirectRow:
         return _FakeDirectRow(key, self)
 
     def read_rows(self, *, start_key: bytes, end_key: bytes, limit: int) -> list[Any]:
-        return []
+        with self.lock:
+            self.reads.append((start_key, end_key, limit))
+            keys = [key for key in sorted(self.rows) if start_key <= key < end_key]
+            return [_FakeReadRow(self.rows[key]) for key in keys[:limit]]
+
+
+class _FakeCell:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+class _FakeReadRow:
+    def __init__(self, cells: dict[str, dict[bytes, list[Any]]]) -> None:
+        self.cells = cells
 
 
 class _FakeDirectRow:
     def __init__(self, key: bytes, table: FakeBigtableTable) -> None:
         self.key = key
         self.table = table
+        self.cells: dict[str, dict[bytes, list[Any]]] = {}
 
-    def set_cell(self, *_: Any) -> None:
-        return None
+    def set_cell(self, family: str, qualifier: bytes, value: bytes) -> None:
+        self.cells.setdefault(family, {})[qualifier] = [_FakeCell(value)]
 
     def commit(self) -> None:
         with self.table.lock:
             self.table.committed.append(self.key)
+            self.table.rows[self.key] = self.cells
 
 
 def make_fake_store(

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes.console.activity import _USAGE_CACHE
+from trusted_router.storage import STORE, Generation, InMemoryStore
+from trusted_router.storage_activity import summarize_activity
+from trusted_router.storage_gcp_activity_index import usage_series, write_generation
+
+
+def _generation(
+    generation_id: str,
+    *,
+    workspace_id: str = "ws_1",
+    key_hash: str = "key_a",
+    model: str = "model-a",
+    usage_type: str = "Credits",
+    created_at: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    reasoning_tokens: int,
+    cost_micro: int,
+) -> Generation:
+    return Generation(
+        id=generation_id,
+        request_id=f"req-{generation_id}",
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        model=model,
+        provider_name="Provider",
+        app="usage-series-test",
+        tokens_prompt=prompt_tokens,
+        tokens_completion=completion_tokens,
+        reasoning_tokens=reasoning_tokens,
+        total_cost_microdollars=cost_micro,
+        usage_type=usage_type,
+        speed_tokens_per_second=10.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        created_at=created_at,
+    )
+
+
+def _seed_generations() -> tuple[Any, list[Generation]]:
+    _store, _db, table = make_fake_store()
+    generations = [
+        _generation(
+            "gen-1",
+            created_at="2026-05-01T10:05:00Z",
+            prompt_tokens=10,
+            completion_tokens=5,
+            reasoning_tokens=1,
+            cost_micro=100,
+        ),
+        _generation(
+            "gen-2",
+            key_hash="key_b",
+            model="model-b",
+            usage_type="BYOK",
+            created_at="2026-05-01T10:45:00Z",
+            prompt_tokens=20,
+            completion_tokens=10,
+            reasoning_tokens=2,
+            cost_micro=200,
+        ),
+        _generation(
+            "gen-3",
+            created_at="2026-05-01T11:00:00Z",
+            prompt_tokens=30,
+            completion_tokens=15,
+            reasoning_tokens=3,
+            cost_micro=300,
+        ),
+        _generation(
+            "gen-4",
+            model="model-b",
+            created_at="2026-05-02T09:15:00Z",
+            prompt_tokens=40,
+            completion_tokens=20,
+            reasoning_tokens=4,
+            cost_micro=400,
+        ),
+        _generation(
+            "gen-other-workspace",
+            workspace_id="ws_other",
+            created_at="2026-05-01T10:10:00Z",
+            prompt_tokens=99,
+            completion_tokens=99,
+            reasoning_tokens=99,
+            cost_micro=99,
+        ),
+    ]
+    for generation in generations:
+        write_generation(table, "m", generation)
+    return table, generations[:4]
+
+
+def test_usage_series_hourly_and_daily_buckets() -> None:
+    table, _generations = _seed_generations()
+
+    hourly = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="hour",
+    )
+    daily = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="day",
+    )
+
+    assert hourly["buckets"] == [
+        {
+            "bucket": "2026-05-01T10",
+            "requests": 2,
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "reasoning_tokens": 3,
+            "cost_micro": 100,
+            "byok_micro": 200,
+        },
+        {
+            "bucket": "2026-05-01T11",
+            "requests": 1,
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "reasoning_tokens": 3,
+            "cost_micro": 300,
+            "byok_micro": 0,
+        },
+        {
+            "bucket": "2026-05-02T09",
+            "requests": 1,
+            "prompt_tokens": 40,
+            "completion_tokens": 20,
+            "reasoning_tokens": 4,
+            "cost_micro": 400,
+            "byok_micro": 0,
+        },
+    ]
+    assert daily["buckets"] == [
+        {
+            "bucket": "2026-05-01",
+            "requests": 3,
+            "prompt_tokens": 60,
+            "completion_tokens": 30,
+            "reasoning_tokens": 6,
+            "cost_micro": 400,
+            "byok_micro": 200,
+        },
+        {
+            "bucket": "2026-05-02",
+            "requests": 1,
+            "prompt_tokens": 40,
+            "completion_tokens": 20,
+            "reasoning_tokens": 4,
+            "cost_micro": 400,
+            "byok_micro": 0,
+        },
+    ]
+    assert table.reads[0] == (
+        b"ws#ws_1#2026-05-01",
+        b"ws#ws_1#2026-05-02~",
+        200_000,
+    )
+
+
+def test_usage_series_by_model_breakdown() -> None:
+    table, _generations = _seed_generations()
+
+    series = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="day",
+        by_model=True,
+    )
+
+    assert series["by_model"] == {
+        "model-a": [
+            {
+                "bucket": "2026-05-01",
+                "requests": 2,
+                "prompt_tokens": 40,
+                "completion_tokens": 20,
+                "reasoning_tokens": 4,
+                "cost_micro": 400,
+                "byok_micro": 0,
+            }
+        ],
+        "model-b": [
+            {
+                "bucket": "2026-05-01",
+                "requests": 1,
+                "prompt_tokens": 20,
+                "completion_tokens": 10,
+                "reasoning_tokens": 2,
+                "cost_micro": 0,
+                "byok_micro": 200,
+            },
+            {
+                "bucket": "2026-05-02",
+                "requests": 1,
+                "prompt_tokens": 40,
+                "completion_tokens": 20,
+                "reasoning_tokens": 4,
+                "cost_micro": 400,
+                "byok_micro": 0,
+            },
+        ],
+    }
+
+
+def test_usage_series_day_totals_match_summarize_activity() -> None:
+    table, generations = _seed_generations()
+
+    series = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="day",
+    )
+
+    expected: dict[str, dict[str, int]] = {}
+    for row in summarize_activity(generations):
+        bucket = expected.setdefault(
+            str(row["date"]),
+            {
+                "requests": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "reasoning_tokens": 0,
+                "cost_micro": 0,
+                "byok_micro": 0,
+            },
+        )
+        bucket["requests"] += int(row["requests"])
+        bucket["prompt_tokens"] += int(row["prompt_tokens"])
+        bucket["completion_tokens"] += int(row["completion_tokens"])
+        bucket["reasoning_tokens"] += int(row["reasoning_tokens"])
+        bucket["cost_micro"] += int(row["usage_microdollars"])
+        bucket["byok_micro"] += int(row["byok_usage_inference_microdollars"])
+    actual = {
+        str(bucket["bucket"]): {
+            key: int(bucket[key])
+            for key in (
+                "requests",
+                "prompt_tokens",
+                "completion_tokens",
+                "reasoning_tokens",
+                "cost_micro",
+                "byok_micro",
+            )
+        }
+        for bucket in series["buckets"]
+    }
+
+    assert actual == expected
+
+
+def test_usage_series_api_key_filter_and_truncation() -> None:
+    table, _generations = _seed_generations()
+
+    filtered = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="hour",
+        api_key_hash="key_b",
+    )
+    truncated = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="day",
+        max_rows=2,
+    )
+
+    assert filtered["buckets"] == [
+        {
+            "bucket": "2026-05-01T10",
+            "requests": 1,
+            "prompt_tokens": 20,
+            "completion_tokens": 10,
+            "reasoning_tokens": 2,
+            "cost_micro": 0,
+            "byok_micro": 200,
+        }
+    ]
+    assert truncated["truncated"] is True
+    assert truncated["buckets"] == [
+        {
+            "bucket": "2026-05-01",
+            "requests": 2,
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "reasoning_tokens": 3,
+            "cost_micro": 100,
+            "byok_micro": 200,
+        }
+    ]
+    assert table.reads[-1] == (
+        b"ws#ws_1#2026-05-01",
+        b"ws#ws_1#2026-05-02~",
+        2,
+    )
+
+
+def test_console_usage_series_endpoint_returns_json_and_uses_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _USAGE_CACHE.clear()
+    app = create_app(Settings(environment="local"), init_observability=False)
+    client = TestClient(app)
+    user = STORE.ensure_user("usage-route@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_token, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="usage-route@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+    calls: list[tuple[str, int, str, str | None, bool]] = []
+
+    def spy_usage_series(
+        self: InMemoryStore,
+        workspace_id: str,
+        *,
+        days: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        _ = self
+        calls.append((workspace_id, days, granularity, api_key_hash, by_model))
+        return {
+            "granularity": granularity,
+            "start_day": "2026-07-06",
+            "end_day": "2026-07-07",
+            "truncated": False,
+            "buckets": [],
+            "by_model": {"model-a": []} if by_model else {},
+        }
+
+    monkeypatch.setattr(InMemoryStore, "usage_series", spy_usage_series)
+
+    first = client.get("/console/activity/usage.json?days=2&by_model=true&api_key_hash=key_a")
+    second = client.get("/console/activity/usage.json?days=2&by_model=true&api_key_hash=key_a")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["granularity"] == "hour"
+    assert first.json() == second.json()
+    assert calls == [(workspace.id, 2, "hour", "key_a", True)]
+
+
+def test_console_usage_series_endpoint_rejects_bad_granularity() -> None:
+    _USAGE_CACHE.clear()
+    app = create_app(Settings(environment="local"), init_observability=False)
+    client = TestClient(app)
+    user = STORE.ensure_user("usage-bad-granularity@example.com")
+    raw_token, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="usage-bad-granularity@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+
+    response = client.get("/console/activity/usage.json?granularity=minute")
+
+    assert response.status_code == 400


### PR DESCRIPTION
Backend for the usage graphs on /console/activity. `usage_series` range-scans the Bigtable generation rows and streaming-aggregates into hour/day buckets (totals + by-model), served by GET /console/activity/usage.json with a 60s per-worker cache. Deliberately on-demand — no Spanner facts table and no cron rollup, since usage is read occasionally; we pay only when someone looks and keep analytics off the transactional plane. Frontend (Plotly charts) is the next increment. Gates: ruff/mypy/pytest 1333 passed; codex review PASS.