### PR TITLE
Usage graphs — console UI (spend/tokens/requests chart + model breakdown)

### DIFF
--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -248,6 +248,280 @@ body.console {
   line-height: 1.35;
 }
 
+.usage-panel-head {
+  align-items: flex-start;
+}
+
+.usage-panel-head h2,
+.usage-breakdown-head h3 {
+  text-wrap: balance;
+}
+
+.usage-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  align-items: end;
+  margin-bottom: 14px;
+}
+
+.usage-segmented-control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+
+.usage-segmented-control legend {
+  flex: 0 0 100%;
+  padding: 0;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.usage-segmented-control label {
+  position: relative;
+  display: inline-flex;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.usage-segmented-control input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.usage-segmented-control span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 8px 11px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel2);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 650;
+  white-space: nowrap;
+  transition-property: background-color, border-color, color, transform;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.usage-segmented-control input:checked + span {
+  border-color: var(--blue);
+  background: var(--blue);
+  color: #fff;
+}
+
+.usage-segmented-control input:focus-visible + span {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.usage-segmented-control label:active span {
+  transform: scale(0.96);
+}
+
+.usage-message {
+  margin: 0 0 12px;
+  color: var(--amber);
+  font-size: 12px;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.usage-message.error {
+  color: var(--red);
+}
+
+.usage-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+  gap: 14px;
+  align-items: stretch;
+}
+
+.usage-chart-card,
+.usage-breakdown {
+  min-width: 0;
+  border: 1px solid var(--line2);
+  border-radius: 8px;
+  background: var(--panel2);
+}
+
+.usage-chart-card {
+  padding: 14px 14px 10px;
+}
+
+.usage-chart-summary {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 8px;
+}
+
+.usage-chart-summary div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.usage-chart-summary span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.usage-chart-summary strong {
+  color: var(--inkstrong);
+  font-size: 26px;
+  line-height: 1;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-chart-scroll {
+  width: 100%;
+  min-height: 292px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.usage-chart-svg {
+  display: block;
+  max-width: none;
+  height: 280px;
+}
+
+.usage-chart-grid {
+  stroke: var(--line);
+  stroke-width: 1;
+}
+
+.usage-chart-axis {
+  fill: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-chart-x-axis {
+  font-size: 10px;
+}
+
+.usage-chart-bar {
+  fill: var(--blue);
+  opacity: 0.84;
+  transition-property: opacity;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.usage-chart-bar-group:hover .usage-chart-bar,
+.usage-chart-bar-group:focus .usage-chart-bar {
+  opacity: 1;
+}
+
+.usage-chart-bar-group:focus {
+  outline: none;
+}
+
+.usage-breakdown {
+  padding: 14px;
+}
+
+.usage-breakdown-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+
+.usage-breakdown-head h3 {
+  margin: 0;
+  color: var(--inkstrong);
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+.usage-breakdown-head span,
+.usage-breakdown-empty {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.usage-breakdown-empty {
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.usage-model-list {
+  display: grid;
+  gap: 10px;
+}
+
+.usage-model-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 9px;
+  min-width: 0;
+}
+
+.usage-model-swatch {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px;
+  border-radius: 999px;
+  flex: 0 0 10px;
+}
+
+.usage-model-row strong {
+  display: block;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.usage-model-row div > span {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+  font-variant-numeric: tabular-nums;
+  text-wrap: pretty;
+}
+
+.usage-model-meter {
+  display: block;
+  height: 5px;
+  margin-top: 7px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--history-empty);
+}
+
+.usage-model-meter-fill {
+  display: block;
+  height: 100%;
+  min-width: 3px;
+  border-radius: inherit;
+}
+
 .keys-table {
   min-width: 860px;
 }
@@ -500,6 +774,15 @@ body.console {
   flex-wrap: wrap;
 }
 
+@media (max-width: 980px) {
+  .usage-layout {
+    grid-template-columns: 1fr;
+  }
+  .usage-breakdown-head {
+    flex-wrap: wrap;
+  }
+}
+
 @media (max-width: 800px) {
   .console-shell {
     grid-template-columns: 1fr;
@@ -580,6 +863,21 @@ body.console {
   .key-actions .btn {
     flex: 1 1 auto;
     justify-content: center;
+  }
+  .usage-controls {
+    align-items: stretch;
+  }
+  .usage-segmented-control {
+    width: 100%;
+  }
+  .usage-segmented-control label {
+    flex: 1 1 0;
+  }
+  .usage-segmented-control span {
+    width: 100%;
+  }
+  .usage-chart-summary {
+    flex-direction: column;
   }
 }
 

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -1,5 +1,426 @@
 {% extends "console/_layout.html" %}
+{% block scripts %}
+<script>
+(function () {
+  "use strict";
+
+  const ENDPOINT = "/console/activity/usage.json";
+  const SVG_NS = "http://www.w3.org/2000/svg";
+  const numberFormat = new Intl.NumberFormat("en-US");
+  const compactFormat = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1
+  });
+  const dollarsFormat = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+  const modelColors = ["var(--blue)", "var(--green)", "var(--amber)", "var(--rust)", "var(--red)"];
+
+  function tokenTotal(bucket) {
+    return Number(bucket.prompt_tokens || 0) + Number(bucket.completion_tokens || 0);
+  }
+
+  const metrics = {
+    spend: {
+      label: "Spend",
+      value: (bucket) => Number(bucket.cost_micro || 0) / 1000000,
+      format: (value) => dollarsFormat.format(value),
+      tooltip: (value) => dollarsFormat.format(value),
+      axis: (value) => dollarsFormat.format(value)
+    },
+    tokens: {
+      label: "Tokens",
+      value: tokenTotal,
+      format: (value) => numberFormat.format(Math.round(value)),
+      tooltip: (value) => numberFormat.format(Math.round(value)),
+      axis: (value) => compactFormat.format(value)
+    },
+    requests: {
+      label: "Requests",
+      value: (bucket) => Number(bucket.requests || 0),
+      format: (value) => numberFormat.format(Math.round(value)),
+      tooltip: (value) => numberFormat.format(Math.round(value)),
+      axis: (value) => compactFormat.format(value)
+    }
+  };
+
+  let panel = null;
+  let chart = null;
+  let breakdown = null;
+  let empty = null;
+  let layout = null;
+  let message = null;
+  let status = null;
+  let totalValue = null;
+  let averageValue = null;
+  let rangeLabel = null;
+  let lastData = null;
+  let requestId = 0;
+
+  function svgNode(name, attrs, text) {
+    const node = document.createElementNS(SVG_NS, name);
+    Object.entries(attrs || {}).forEach(([key, value]) => {
+      node.setAttribute(key, String(value));
+    });
+    if (text !== undefined) {
+      node.textContent = text;
+    }
+    return node;
+  }
+
+  function selectedValue(name, fallback) {
+    const input = panel.querySelector(`input[name="${name}"]:checked`);
+    return input ? input.value : fallback;
+  }
+
+  function granularityForDays(days) {
+    return days <= 2 ? "hour" : "day";
+  }
+
+  function currentState() {
+    const days = Number.parseInt(selectedValue("usage-days", "30"), 10);
+    const metric = selectedValue("usage-metric", "spend");
+    return {
+      days: Number.isFinite(days) ? days : 30,
+      metric: metrics[metric] ? metric : "spend"
+    };
+  }
+
+  function setStatus(text, tone) {
+    status.textContent = text;
+    status.classList.toggle("warn", tone === "warn");
+    status.classList.toggle("good", tone === "good");
+  }
+
+  function showMessage(text, tone) {
+    message.textContent = text;
+    message.hidden = !text;
+    message.classList.toggle("error", tone === "error");
+  }
+
+  function formatBucket(bucket, granularity) {
+    const value = String(bucket || "");
+    const date = new Date(granularity === "hour" ? `${value}:00:00Z` : `${value}T00:00:00Z`);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    if (granularity === "hour") {
+      return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", timeZone: "UTC" });
+    }
+    return date.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
+  }
+
+  function renderChart(series, metric, granularity, days) {
+    chart.replaceChildren();
+    const width = Math.max(chart.clientWidth || 0, 640, series.length * 24);
+    const height = 280;
+    const margin = { top: 14, right: 18, bottom: 42, left: 58 };
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+    const maxValue = Math.max(...series.map((point) => point.value), 0);
+    const yMax = maxValue > 0 ? maxValue : 1;
+    const step = plotWidth / Math.max(series.length, 1);
+    const barWidth = Math.max(4, Math.min(22, step - 4));
+    const svg = svgNode("svg", {
+      class: "usage-chart-svg",
+      role: "img",
+      "aria-label": `${metric.label} usage over the last ${days} days`,
+      viewBox: `0 0 ${width} ${height}`,
+      width,
+      height
+    });
+
+    [0, 0.25, 0.5, 0.75, 1].forEach((ratio) => {
+      const y = margin.top + plotHeight - (plotHeight * ratio);
+      svg.appendChild(svgNode("line", {
+        class: "usage-chart-grid",
+        x1: margin.left,
+        x2: width - margin.right,
+        y1: y,
+        y2: y
+      }));
+      svg.appendChild(svgNode("text", {
+        class: "usage-chart-axis",
+        x: margin.left - 10,
+        y: y + 4,
+        "text-anchor": "end"
+      }, metric.axis(yMax * ratio)));
+    });
+
+    const barGroup = svgNode("g", { class: "usage-chart-bars" });
+    series.forEach((point, index) => {
+      const x = margin.left + (step * index) + ((step - barWidth) / 2);
+      const barHeight = maxValue > 0 ? (point.value / yMax) * plotHeight : 0;
+      const renderedBarHeight = Math.max(barHeight, point.value > 0 ? 2 : 0);
+      const y = margin.top + plotHeight - renderedBarHeight;
+      const group = svgNode("g", {
+        class: "usage-chart-bar-group",
+        tabindex: "0",
+        "aria-label": `${formatBucket(point.bucket, granularity)} ${metric.tooltip(point.value)}`
+      });
+      const rect = svgNode("rect", {
+        class: "usage-chart-bar",
+        x,
+        y,
+        width: barWidth,
+        height: renderedBarHeight,
+        rx: Math.min(4, barWidth / 2)
+      });
+      group.appendChild(rect);
+      group.appendChild(svgNode("title", {}, `${formatBucket(point.bucket, granularity)}: ${metric.tooltip(point.value)}`));
+      barGroup.appendChild(group);
+    });
+    svg.appendChild(barGroup);
+
+    const labelEvery = Math.max(1, Math.ceil(series.length / 6));
+    series.forEach((point, index) => {
+      if (index % labelEvery !== 0 && index !== series.length - 1) {
+        return;
+      }
+      const x = margin.left + (step * index) + (step / 2);
+      svg.appendChild(svgNode("text", {
+        class: "usage-chart-axis usage-chart-x-axis",
+        x,
+        y: height - 14,
+        "text-anchor": "middle"
+      }, formatBucket(point.bucket, granularity)));
+    });
+
+    chart.replaceChildren(svg);
+  }
+
+  function modelTotals(byModel) {
+    return Object.entries(byModel || {}).map(([model, buckets]) => {
+      const rows = Array.isArray(buckets) ? buckets : [];
+      return rows.reduce((total, bucket) => {
+        total.model = model;
+        total.spend += Number(bucket.cost_micro || 0);
+        total.requests += Number(bucket.requests || 0);
+        total.tokens += tokenTotal(bucket);
+        return total;
+      }, { model, spend: 0, requests: 0, tokens: 0 });
+    }).filter((row) => row.spend > 0 || row.requests > 0 || row.tokens > 0);
+  }
+
+  function renderBreakdown(byModel) {
+    breakdown.replaceChildren();
+    const rows = modelTotals(byModel).sort((a, b) => b.spend - a.spend || b.requests - a.requests).slice(0, 5);
+    if (rows.length === 0) {
+      const note = document.createElement("p");
+      note.className = "usage-breakdown-empty";
+      note.textContent = "No model usage in this range.";
+      breakdown.appendChild(note);
+      return;
+    }
+    const list = document.createElement("div");
+    list.className = "usage-model-list";
+    const maxSpend = Math.max(...rows.map((row) => row.spend), 1);
+    rows.forEach((row, index) => {
+      const item = document.createElement("article");
+      item.className = "usage-model-row";
+
+      const swatch = document.createElement("span");
+      swatch.className = "usage-model-swatch";
+      swatch.style.background = modelColors[index % modelColors.length];
+
+      const body = document.createElement("div");
+      const name = document.createElement("strong");
+      name.textContent = row.model;
+      const meta = document.createElement("span");
+      meta.textContent = `${dollarsFormat.format(row.spend / 1000000)} spend | ${numberFormat.format(row.requests)} requests | ${compactFormat.format(row.tokens)} tokens`;
+      body.append(name, meta);
+
+      const meter = document.createElement("span");
+      meter.className = "usage-model-meter";
+      const fill = document.createElement("span");
+      fill.className = "usage-model-meter-fill";
+      fill.style.width = `${Math.max(3, (row.spend / maxSpend) * 100)}%`;
+      fill.style.background = modelColors[index % modelColors.length];
+      meter.appendChild(fill);
+      body.appendChild(meter);
+
+      item.append(swatch, body);
+      list.appendChild(item);
+    });
+    breakdown.appendChild(list);
+  }
+
+  function renderUsage(data) {
+    const state = currentState();
+    const metric = metrics[state.metric];
+    const buckets = Array.isArray(data.buckets) ? data.buckets : [];
+    rangeLabel.textContent = `Last ${state.days} days`;
+
+    if (buckets.length === 0) {
+      layout.hidden = true;
+      empty.hidden = false;
+      chart.replaceChildren();
+      breakdown.replaceChildren();
+      setStatus("empty", "warn");
+      showMessage(data.truncated ? "Showing partial data." : "", "");
+      return;
+    }
+
+    const series = buckets.map((bucket) => ({
+      bucket: bucket.bucket,
+      value: metric.value(bucket)
+    }));
+    const total = series.reduce((sum, point) => sum + point.value, 0);
+    totalValue.textContent = metric.format(total);
+    averageValue.textContent = `${metric.format(total / Math.max(series.length, 1))} avg / bucket`;
+    layout.hidden = false;
+    empty.hidden = true;
+    setStatus(`${buckets.length} ${data.granularity || granularityForDays(state.days)} buckets`, "good");
+    showMessage(data.truncated ? "Showing partial data; narrow the range if totals look lower than expected." : "", "");
+    renderChart(series, metric, data.granularity || granularityForDays(state.days), state.days);
+    renderBreakdown(data.by_model || {});
+  }
+
+  async function loadUsage() {
+    const state = currentState();
+    const token = ++requestId;
+    const params = new URLSearchParams({
+      days: String(state.days),
+      granularity: granularityForDays(state.days),
+      by_model: "1"
+    });
+    setStatus("loading", "");
+    showMessage("", "");
+    try {
+      const response = await fetch(`${ENDPOINT}?${params.toString()}`, {
+        headers: { Accept: "application/json" }
+      });
+      if (!response.ok) {
+        throw new Error(`usage endpoint returned ${response.status}`);
+      }
+      const data = await response.json();
+      if (token !== requestId) {
+        return;
+      }
+      lastData = data;
+      renderUsage(data);
+    } catch (error) {
+      if (token !== requestId) {
+        return;
+      }
+      setStatus("couldn't load", "warn");
+      showMessage("Couldn't load usage right now.", "error");
+      if (!lastData) {
+        layout.hidden = true;
+        empty.hidden = true;
+      }
+    }
+  }
+
+  function rerenderOnResize() {
+    if (lastData) {
+      renderUsage(lastData);
+    }
+  }
+
+  function initUsagePanel() {
+    panel = document.querySelector("[data-usage-panel]");
+    if (!panel) {
+      return;
+    }
+    chart = panel.querySelector("[data-usage-chart]");
+    breakdown = panel.querySelector("[data-usage-breakdown]");
+    empty = panel.querySelector("[data-usage-empty]");
+    layout = panel.querySelector("[data-usage-layout]");
+    message = panel.querySelector("[data-usage-message]");
+    status = panel.querySelector("[data-usage-status]");
+    totalValue = panel.querySelector("[data-usage-total]");
+    averageValue = panel.querySelector("[data-usage-average]");
+    rangeLabel = panel.querySelector("[data-usage-range-label]");
+
+    panel.querySelectorAll('input[name="usage-days"], input[name="usage-metric"]').forEach((input) => {
+      input.addEventListener("change", loadUsage);
+    });
+    if ("ResizeObserver" in window) {
+      new ResizeObserver(rerenderOnResize).observe(chart);
+    } else {
+      window.addEventListener("resize", rerenderOnResize);
+    }
+    loadUsage();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initUsagePanel);
+  } else {
+    initUsagePanel();
+  }
+})();
+</script>
+{% endblock %}
 {% block body %}
+<section class="panel usage-panel" data-usage-panel>
+  <div class="panel-head usage-panel-head">
+    <div>
+      <h2>Usage</h2>
+      <p class="panel-kicker">Spend, token, and request volume over time.</p>
+    </div>
+    <span class="pill" data-usage-status>loading</span>
+  </div>
+  <div class="panel-body">
+    <div class="usage-controls" aria-label="Usage chart controls">
+      <fieldset class="usage-segmented-control">
+        <legend>Range</legend>
+        <label>
+          <input type="radio" name="usage-days" value="7">
+          <span>7 days</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-days" value="30" checked>
+          <span>30 days</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-days" value="90">
+          <span>90 days</span>
+        </label>
+      </fieldset>
+      <fieldset class="usage-segmented-control">
+        <legend>Metric</legend>
+        <label>
+          <input type="radio" name="usage-metric" value="spend" checked>
+          <span>Spend</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-metric" value="tokens">
+          <span>Tokens</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-metric" value="requests">
+          <span>Requests</span>
+        </label>
+      </fieldset>
+    </div>
+    <p class="usage-message" data-usage-message role="status" hidden></p>
+    <div class="usage-layout" data-usage-layout hidden>
+      <div class="usage-chart-card">
+        <div class="usage-chart-summary">
+          <div>
+            <span data-usage-range-label>Last 30 days</span>
+            <strong data-usage-total>$0.00</strong>
+          </div>
+          <span data-usage-average>$0.00 avg / bucket</span>
+        </div>
+        <div class="usage-chart-scroll" data-usage-chart></div>
+      </div>
+      <aside class="usage-breakdown" aria-labelledby="usage-breakdown-title">
+        <div class="usage-breakdown-head">
+          <h3 id="usage-breakdown-title">Model breakdown</h3>
+          <span>Top models by spend</span>
+        </div>
+        <div data-usage-breakdown></div>
+      </aside>
+    </div>
+    <p class="empty" data-usage-empty hidden>No activity yet. Make a request with your API key to see it here.</p>
+  </div>
+</section>
+
 <section class="panel">
   <div class="panel-head"><h2>Recent activity</h2><span class="pill">metadata only</span></div>
   <div class="panel-body">

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -643,6 +643,24 @@ def test_console_root_redirects_to_api_keys(console_session: tuple[TestClient, s
     assert resp.headers["location"] == "/console/api-keys"
 
 
+def test_console_activity_renders_usage_panel(
+    console_session: tuple[TestClient, str],
+) -> None:
+    client, _ = console_session
+    resp = client.get("/console/activity")
+
+    assert resp.status_code == 200
+    assert '<section class="panel usage-panel" data-usage-panel>' in resp.text
+    assert 'data-usage-chart' in resp.text
+    assert 'data-usage-breakdown' in resp.text
+    assert "/console/activity/usage.json" in resp.text
+    assert 'by_model: "1"' in resp.text
+    assert "Spend" in resp.text
+    assert "Tokens" in resp.text
+    assert "Requests" in resp.text
+    assert resp.text.index("<h2>Usage</h2>") < resp.text.index("<h2>Recent activity</h2>")
+
+
 def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
     console_session: tuple[TestClient, str],
 ) -> None:


### PR DESCRIPTION
Frontend for the usage-graphs feature. Consumes the on-demand Bigtable aggregation endpoint shipped in #132.

## What
A **Usage** panel on `/console/activity`:
- Inline-SVG time series with a **Spend / Tokens / Requests** toggle and a **7 / 30 / 90-day** selector.
- Per-model breakdown (spend / requests / tokens, sorted, with a share meter).
- Totals + avg-per-bucket readout.

## Scalable & efficient (per the design steering)
- **Auto granularity**: hourly only for ≤2-day ranges, daily beyond — never over-fetches buckets. Backed by the range-scan aggregator (no cron rollups, no Spanner).
- One cached JSON fetch (`/console/activity/usage.json`, 60s per-worker cache) per view.

## Correctness
- Bucket labels rendered in **UTC** (`timeZone:"UTC"`) to match the endpoint's UTC keys — no off-by-one west of UTC.
- **Tokens = prompt + completion only** — reasoning tokens are a subset of completion, not an additional bucket, so they're not double-counted (chart and model breakdown share `tokenTotal()`).

## Safety
- Every dynamic value (model names, bucket keys) rendered via `textContent`/`setAttribute` — no `innerHTML`, so no HTML injection.

## Review
codex round-3 **PASS** (round-1 UTC label + round-2 token-double-count both fixed and confirmed; no new XSS/injection). Gates: ruff + mypy + `1334 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)