### PR TITLE
Usage graphs: reachable rolling-24h hourly preset + empty-state fix

### DIFF
--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -352,6 +352,10 @@ body.console {
   align-items: stretch;
 }
 
+.usage-layout[hidden] {
+  display: none;
+}
+
 .usage-chart-card,
 .usage-breakdown {
   min-width: 0;

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1428,15 +1428,26 @@ class SpannerBigtableStore:
         api_key_hash: str | None = None,
         by_model: bool = False,
     ) -> dict[str, Any]:
-        today = dt.datetime.now(dt.UTC).date()
-        start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
+        if granularity == "hour":
+            now = dt.datetime.now(dt.UTC)
+            window_hours = max(1, days) * 24
+            since = now - dt.timedelta(hours=window_hours)
+            start_day = since.date().isoformat()
+            end_day = now.date().isoformat()
+            min_created_at = since.strftime("%Y-%m-%dT%H:%M:%S")
+        else:
+            today = dt.datetime.now(dt.UTC).date()
+            start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
+            end_day = today.isoformat()
+            min_created_at = None
         return self.generation_store.usage_series(
             workspace_id,
             start_day=start_day,
-            end_day=today.isoformat(),
+            end_day=end_day,
             granularity=granularity,
             api_key_hash=api_key_hash,
             by_model=by_model,
+            min_created_at=min_created_at,
         )
 
     def reconcile_generation_activity(

--- a/src/trusted_router/storage_gcp_activity_index.py
+++ b/src/trusted_router/storage_gcp_activity_index.py
@@ -60,6 +60,7 @@ def usage_series(
     granularity: str,
     api_key_hash: str | None = None,
     by_model: bool = False,
+    min_created_at: str | None = None,
     max_rows: int = 200_000,
 ) -> dict[str, Any]:
     if granularity not in {"hour", "day"}:
@@ -67,8 +68,12 @@ def usage_series(
 
     buckets: dict[str, dict[str, Any]] = {}
     model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
+    if min_created_at is not None:
+        start_key = f"ws#{workspace_id}#{start_day}#{min_created_at}".encode()
+    else:
+        start_key = f"ws#{workspace_id}#{start_day}".encode()
     rows = table.read_rows(
-        start_key=f"ws#{workspace_id}#{start_day}".encode(),
+        start_key=start_key,
         end_key=f"ws#{workspace_id}#{end_day}~".encode(),
         limit=max_rows,
     )
@@ -83,6 +88,8 @@ def usage_series(
         if generation is None:
             continue
         if api_key_hash is not None and generation.key_hash != api_key_hash:
+            continue
+        if min_created_at is not None and generation.created_at[:19] < min_created_at:
             continue
         bucket = generation.created_at[:13] if granularity == "hour" else generation.created_at[:10]
         metrics = generation_metrics(generation)

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -184,6 +184,7 @@ class SpannerGenerations:
         granularity: str,
         api_key_hash: str | None = None,
         by_model: bool = False,
+        min_created_at: str | None = None,
     ) -> dict[str, Any]:
         return _bt_usage_series(
             self._bt_table,
@@ -194,6 +195,7 @@ class SpannerGenerations:
             granularity=granularity,
             api_key_hash=api_key_hash,
             by_model=by_model,
+            min_created_at=min_created_at,
         )
 
     def reconcile_activity(

--- a/src/trusted_router/storage_generations.py
+++ b/src/trusted_router/storage_generations.py
@@ -128,9 +128,18 @@ class InMemoryGenerations:
     ) -> dict[str, Any]:
         if granularity not in {"hour", "day"}:
             raise ValueError("granularity must be 'hour' or 'day'")
-        today = dt.datetime.now(dt.UTC).date()
-        start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
-        end_day = today.isoformat()
+        if granularity == "hour":
+            now = dt.datetime.now(dt.UTC)
+            window_hours = max(1, days) * 24
+            since = now - dt.timedelta(hours=window_hours)
+            start_day = since.date().isoformat()
+            end_day = now.date().isoformat()
+            min_created_at = since.strftime("%Y-%m-%dT%H:%M:%S")
+        else:
+            today = dt.datetime.now(dt.UTC).date()
+            start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
+            end_day = today.isoformat()
+            min_created_at = None
         buckets: dict[str, dict[str, Any]] = {}
         model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
         with self._lock:
@@ -142,6 +151,8 @@ class InMemoryGenerations:
             if api_key_hash is not None and generation.key_hash != api_key_hash:
                 continue
             if day < start_day or day > end_day:
+                continue
+            if min_created_at is not None and generation.created_at[:19] < min_created_at:
                 continue
             bucket = generation.created_at[:13] if granularity == "hour" else day
             metrics = generation_metrics(generation)

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -127,7 +127,7 @@
     const svg = svgNode("svg", {
       class: "usage-chart-svg",
       role: "img",
-      "aria-label": `${metric.label} usage over the last ${days} days`,
+      "aria-label": `${metric.label} usage over the last ${days <= 2 ? days * 24 + " hours" : days + " days"}`,
       viewBox: `0 0 ${width} ${height}`,
       width,
       height
@@ -252,7 +252,9 @@
     const state = currentState();
     const metric = metrics[state.metric];
     const buckets = Array.isArray(data.buckets) ? data.buckets : [];
-    rangeLabel.textContent = `Last ${state.days} days`;
+    rangeLabel.textContent = state.days <= 2
+      ? `Last ${state.days * 24} hours`
+      : `Last ${state.days} days`;
 
     if (buckets.length === 0) {
       layout.hidden = true;
@@ -368,6 +370,10 @@
     <div class="usage-controls" aria-label="Usage chart controls">
       <fieldset class="usage-segmented-control">
         <legend>Range</legend>
+        <label>
+          <input type="radio" name="usage-days" value="1">
+          <span>24h</span>
+        </label>
         <label>
           <input type="radio" name="usage-days" value="7">
           <span>7 days</span>

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -648,9 +648,18 @@ def test_console_activity_renders_usage_panel(
 ) -> None:
     client, _ = console_session
     resp = client.get("/console/activity")
+    console_css = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "trusted_router"
+        / "static"
+        / "console.css"
+    ).read_text(encoding="utf-8")
 
     assert resp.status_code == 200
     assert '<section class="panel usage-panel" data-usage-panel>' in resp.text
+    assert '<input type="radio" name="usage-days" value="1">' in resp.text
+    assert "<span>24h</span>" in resp.text
     assert 'data-usage-chart' in resp.text
     assert 'data-usage-breakdown' in resp.text
     assert "/console/activity/usage.json" in resp.text
@@ -659,6 +668,7 @@ def test_console_activity_renders_usage_panel(
     assert "Tokens" in resp.text
     assert "Requests" in resp.text
     assert resp.text.index("<h2>Usage</h2>") < resp.text.index("<h2>Recent activity</h2>")
+    assert ".usage-layout[hidden]" in console_css
 
 
 def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 from typing import Any
 
 import pytest
@@ -46,6 +47,46 @@ def _generation(
         streamed=False,
         created_at=created_at,
     )
+
+
+def test_memory_usage_series_hourly_uses_rolling_24h_window() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("rolling-usage@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    _raw_key, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="rolling usage key",
+        creator_user_id=user.id,
+    )
+    now = dt.datetime.now(dt.UTC)
+    rows = [
+        ("gen-2h", now - dt.timedelta(hours=2), 100),
+        ("gen-10h", now - dt.timedelta(hours=10), 200),
+        ("gen-30h", now - dt.timedelta(hours=30), 300),
+    ]
+    for generation_id, created_at, cost_micro in rows:
+        store.add_generation(
+            _generation(
+                generation_id,
+                workspace_id=workspace.id,
+                key_hash=api_key.hash,
+                created_at=created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                prompt_tokens=10,
+                completion_tokens=5,
+                reasoning_tokens=0,
+                cost_micro=cost_micro,
+            )
+        )
+
+    hourly = store.usage_series(workspace.id, days=1, granularity="hour")
+    daily = store.usage_series(workspace.id, days=30, granularity="day")
+
+    assert sum(int(bucket["requests"]) for bucket in hourly["buckets"]) == 2
+    assert sum(int(bucket["cost_micro"]) for bucket in hourly["buckets"]) == 300
+    assert all("T" in str(bucket["bucket"]) for bucket in hourly["buckets"])
+    assert all(len(str(bucket["bucket"])) == 13 for bucket in hourly["buckets"])
+    assert sum(int(bucket["requests"]) for bucket in daily["buckets"]) == 3
+    assert sum(int(bucket["cost_micro"]) for bucket in daily["buckets"]) == 600
 
 
 def _seed_generations() -> tuple[Any, list[Generation]]:
@@ -176,6 +217,26 @@ def test_usage_series_hourly_and_daily_buckets() -> None:
         b"ws#ws_1#2026-05-02~",
         200_000,
     )
+
+
+def test_usage_series_hourly_cutoff_uses_start_key() -> None:
+    table, _generations = _seed_generations()
+
+    hourly = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-02",
+        granularity="hour",
+        min_created_at="2026-05-01T10:30:00",
+    )
+
+    assert table.reads[-1][0] == b"ws#ws_1#2026-05-01#2026-05-01T10:30:00"
+    assert table.reads[-1][1] == b"ws#ws_1#2026-05-02~"
+    assert sum(int(bucket["requests"]) for bucket in hourly["buckets"]) == 3
+    assert hourly["buckets"][0]["bucket"] == "2026-05-01T10"
+    assert hourly["buckets"][0]["requests"] == 1
 
 
 def test_usage_series_by_model_breakdown() -> None:


### PR DESCRIPTION
Follow-up to the console usage graphs (#132 backend, #133 frontend). Closes the two gaps found while verifying the shipped feature.

## 1. Surface the hourly view (you asked for hourly graphs)
The component rendered hourly beautifully but it was **unreachable** — the smallest range preset was "7 days", and `granularityForDays` only returns hourly for ranges ≤2 days. Adds a **24h** preset.

Crucially, hourly is now a **true rolling window** of `days*24` hours ending now (UTC), not the current UTC *calendar day*. (The calendar-day version would show a near-empty chart just after UTC midnight while claiming "Last 24 hours".) Implemented in **both** storage stacks (memory + GCP) by computing a since-cutoff and passing an internal `min_created_at` to the leaf aggregators; daily granularity is unchanged. Range label reads "Last 24 hours" / "Last 48 hours" for short ranges. The public `usage_series` signature and the store `Protocol` are unchanged.

The GCP hourly scan pushes the cutoff into the **Bigtable start key** (`ws#{ws}#{day}#{min_created_at}`) so a high-volume workspace can't exhaust the 200k row-scan limit on pre-cutoff rows and undercount the window (caught in review).

## 2. Fix the empty state (you asked me to check it)
`.usage-layout { display: grid }` tied specificity with the UA `[hidden]` rule and won, so `layout.hidden = true` never took effect — a brand-new workspace saw a ghost `$0.00` card + empty model panel *under* the "No activity yet" message. Adds a `.usage-layout[hidden]` guard. Now the empty state is just the friendly centered message.

## Verification
Both the 24h view (real rolling flow) and the fixed empty state were rendered headless from this branch's exact JS+CSS against schema-accurate payloads and eyeballed.

## Tests
- `test_usage_series.py`: rolling-24h window (30h-ago row excluded from hourly, included in daily) + start-key cutoff (pre-cutoff rows excluded at the read boundary).
- `test_oauth_and_console.py`: 24h radio present + `.usage-layout[hidden]` guard present.
- Gates: ruff + mypy + **1336 passed**. codex review **PASS** (2 review rounds; a calendar-day-vs-rolling P2 and a Bigtable-truncation P2 both found and fixed before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)