### PR TITLE
Usage graphs: minute + 5-min granularity for recent debugging windows

### DIFF
--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse, Response
 
 from trusted_router.auth import SettingsDep
@@ -15,7 +15,15 @@ from trusted_router.routes.console._shared import ConsoleDep, render
 from trusted_router.storage import STORE
 
 _USAGE_CACHE_TTL_SECONDS = 60.0
-_UsageCacheKey = tuple[str, int, str, bool, str | None]
+USAGE_RANGE_PRESETS: dict[str, tuple[int, str]] = {
+    "1h": (60, "minute"),
+    "6h": (360, "5min"),
+    "24h": (1440, "hour"),
+    "7d": (10080, "day"),
+    "30d": (43200, "day"),
+    "90d": (129600, "day"),
+}
+_UsageCacheKey = tuple[str, str, bool, str | None]
 _USAGE_CACHE: dict[_UsageCacheKey, tuple[float, dict[str, Any]]] = {}
 
 
@@ -39,19 +47,16 @@ def register(app: FastAPI) -> None:
     @app.get("/console/activity/usage.json")
     async def console_activity_usage(
         ctx: ConsoleDep,
-        days: int = 30,
-        granularity: str | None = None,
+        range_: str = Query("30d", alias="range"),
         by_model: bool = False,
         api_key_hash: str | None = None,
     ) -> dict[str, Any]:
-        clamped_days = min(90, max(1, days))
-        resolved_granularity = granularity or ("hour" if clamped_days <= 2 else "day")
-        if resolved_granularity not in {"hour", "day"}:
-            raise HTTPException(status_code=400, detail="granularity must be 'hour' or 'day'")
+        if range_ not in USAGE_RANGE_PRESETS:
+            raise HTTPException(status_code=400, detail="invalid range")
+        window_minutes, granularity = USAGE_RANGE_PRESETS[range_]
         cache_key = (
             ctx.workspace.id,
-            clamped_days,
-            resolved_granularity,
+            range_,
             by_model,
             api_key_hash,
         )
@@ -61,11 +66,13 @@ def register(app: FastAPI) -> None:
             return cached[1]
         result = STORE.usage_series(
             ctx.workspace.id,
-            days=clamped_days,
-            granularity=resolved_granularity,
+            window_minutes=window_minutes,
+            granularity=granularity,
             api_key_hash=api_key_hash,
             by_model=by_model,
         )
+        result = dict(result)
+        result["range"] = range_
         # A shared cache (Redis) is deferred; this per-worker TTL covers
         # occasional console reads and protects Bigtable from refresh bursts.
         _USAGE_CACHE[cache_key] = (now + _USAGE_CACHE_TTL_SECONDS, result)

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -886,14 +886,14 @@ class InMemoryStore:
         self,
         workspace_id: str,
         *,
-        days: int,
+        window_minutes: int,
         granularity: str,
         api_key_hash: str | None = None,
         by_model: bool = False,
     ) -> dict[str, Any]:
         return self.generation_store.usage_series(
             workspace_id,
-            days=days,
+            window_minutes=window_minutes,
             granularity=granularity,
             api_key_hash=api_key_hash,
             by_model=by_model,

--- a/src/trusted_router/storage_activity.py
+++ b/src/trusted_router/storage_activity.py
@@ -19,6 +19,18 @@ def generation_metrics(gen: Generation) -> dict[str, int]:
     }
 
 
+def usage_bucket_key(created_at: str, granularity: str) -> str:
+    if granularity == "minute":
+        return created_at[:16]
+    if granularity == "5min":
+        return created_at[:14] + f"{(int(created_at[14:16]) // 5) * 5:02d}"
+    if granularity == "hour":
+        return created_at[:13]
+    if granularity == "day":
+        return created_at[:10]
+    raise ValueError(f"unknown granularity: {granularity}")
+
+
 def filter_generations(
     generations: Iterable[Generation],
     *,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1423,23 +1423,23 @@ class SpannerBigtableStore:
         self,
         workspace_id: str,
         *,
-        days: int,
+        window_minutes: int,
         granularity: str,
         api_key_hash: str | None = None,
         by_model: bool = False,
     ) -> dict[str, Any]:
-        if granularity == "hour":
+        if granularity == "day":
+            days = max(1, window_minutes // 1440)
+            today = dt.datetime.now(dt.UTC).date()
+            start_day = (today - dt.timedelta(days=days - 1)).isoformat()
+            end_day = today.isoformat()
+            min_created_at = None
+        else:
             now = dt.datetime.now(dt.UTC)
-            window_hours = max(1, days) * 24
-            since = now - dt.timedelta(hours=window_hours)
+            since = now - dt.timedelta(minutes=max(1, window_minutes))
             start_day = since.date().isoformat()
             end_day = now.date().isoformat()
             min_created_at = since.strftime("%Y-%m-%dT%H:%M:%S")
-        else:
-            today = dt.datetime.now(dt.UTC).date()
-            start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
-            end_day = today.isoformat()
-            min_created_at = None
         return self.generation_store.usage_series(
             workspace_id,
             start_day=start_day,

--- a/src/trusted_router/storage_gcp_activity_index.py
+++ b/src/trusted_router/storage_gcp_activity_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from trusted_router.storage_activity import generation_metrics
+from trusted_router.storage_activity import generation_metrics, usage_bucket_key
 from trusted_router.storage_gcp_codec import json_body, reverse_time_key
 from trusted_router.storage_models import Generation
 
@@ -63,8 +63,8 @@ def usage_series(
     min_created_at: str | None = None,
     max_rows: int = 200_000,
 ) -> dict[str, Any]:
-    if granularity not in {"hour", "day"}:
-        raise ValueError("granularity must be 'hour' or 'day'")
+    if granularity not in {"minute", "5min", "hour", "day"}:
+        raise ValueError("granularity must be 'minute', '5min', 'hour', or 'day'")
 
     buckets: dict[str, dict[str, Any]] = {}
     model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
@@ -91,7 +91,7 @@ def usage_series(
             continue
         if min_created_at is not None and generation.created_at[:19] < min_created_at:
             continue
-        bucket = generation.created_at[:13] if granularity == "hour" else generation.created_at[:10]
+        bucket = usage_bucket_key(generation.created_at, granularity)
         metrics = generation_metrics(generation)
         _add_metrics(_bucket(buckets, bucket), metrics)
         if by_model:

--- a/src/trusted_router/storage_generations.py
+++ b/src/trusted_router/storage_generations.py
@@ -16,6 +16,7 @@ from trusted_router.storage_activity import (
     generation_events,
     generation_metrics,
     summarize_activity,
+    usage_bucket_key,
 )
 from trusted_router.storage_models import (
     Generation,
@@ -121,25 +122,25 @@ class InMemoryGenerations:
         self,
         workspace_id: str,
         *,
-        days: int,
+        window_minutes: int,
         granularity: str,
         api_key_hash: str | None = None,
         by_model: bool = False,
     ) -> dict[str, Any]:
-        if granularity not in {"hour", "day"}:
-            raise ValueError("granularity must be 'hour' or 'day'")
-        if granularity == "hour":
+        if granularity not in {"minute", "5min", "hour", "day"}:
+            raise ValueError("granularity must be 'minute', '5min', 'hour', or 'day'")
+        if granularity == "day":
+            days = max(1, window_minutes // 1440)
+            today = dt.datetime.now(dt.UTC).date()
+            start_day = (today - dt.timedelta(days=days - 1)).isoformat()
+            end_day = today.isoformat()
+            min_created_at = None
+        else:
             now = dt.datetime.now(dt.UTC)
-            window_hours = max(1, days) * 24
-            since = now - dt.timedelta(hours=window_hours)
+            since = now - dt.timedelta(minutes=max(1, window_minutes))
             start_day = since.date().isoformat()
             end_day = now.date().isoformat()
             min_created_at = since.strftime("%Y-%m-%dT%H:%M:%S")
-        else:
-            today = dt.datetime.now(dt.UTC).date()
-            start_day = (today - dt.timedelta(days=max(1, days) - 1)).isoformat()
-            end_day = today.isoformat()
-            min_created_at = None
         buckets: dict[str, dict[str, Any]] = {}
         model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
         with self._lock:
@@ -154,7 +155,7 @@ class InMemoryGenerations:
                 continue
             if min_created_at is not None and generation.created_at[:19] < min_created_at:
                 continue
-            bucket = generation.created_at[:13] if granularity == "hour" else day
+            bucket = usage_bucket_key(generation.created_at, granularity)
             metrics = generation_metrics(generation)
             _add_usage_metrics(_usage_bucket(buckets, bucket), metrics)
             if by_model:

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -432,7 +432,7 @@ class Store(Protocol):
         self,
         workspace_id: str,
         *,
-        days: int,
+        window_minutes: int,
         granularity: str,
         api_key_hash: str | None = ...,
         by_model: bool = ...,

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -18,6 +18,20 @@
     maximumFractionDigits: 2
   });
   const modelColors = ["var(--blue)", "var(--green)", "var(--amber)", "var(--rust)", "var(--red)"];
+  const rangeLabels = {
+    "1h": "Last hour",
+    "6h": "Last 6 hours",
+    "24h": "Last 24 hours",
+    "7d": "Last 7 days",
+    "30d": "Last 30 days",
+    "90d": "Last 90 days"
+  };
+  const granularityLabels = {
+    minute: "minute",
+    "5min": "5-minute",
+    hour: "hour",
+    day: "day"
+  };
 
   function tokenTotal(bucket) {
     return Number(bucket.prompt_tokens || 0) + Number(bucket.completion_tokens || 0);
@@ -76,15 +90,11 @@
     return input ? input.value : fallback;
   }
 
-  function granularityForDays(days) {
-    return days <= 2 ? "hour" : "day";
-  }
-
   function currentState() {
-    const days = Number.parseInt(selectedValue("usage-days", "30"), 10);
+    const range = selectedValue("usage-range", "30d");
     const metric = selectedValue("usage-metric", "spend");
     return {
-      days: Number.isFinite(days) ? days : 30,
+      range: rangeLabels[range] ? range : "30d",
       metric: metrics[metric] ? metric : "spend"
     };
   }
@@ -103,6 +113,11 @@
 
   function formatBucket(bucket, granularity) {
     const value = String(bucket || "");
+    if (granularity === "minute" || granularity === "5min") {
+      const date = new Date(`${value}:00Z`);
+      return Number.isNaN(date.getTime()) ? value
+        : date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZone: "UTC" });
+    }
     const date = new Date(granularity === "hour" ? `${value}:00:00Z` : `${value}T00:00:00Z`);
     if (Number.isNaN(date.getTime())) {
       return value;
@@ -113,7 +128,7 @@
     return date.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
   }
 
-  function renderChart(series, metric, granularity, days) {
+  function renderChart(series, metric, granularity, rangeText) {
     chart.replaceChildren();
     const width = Math.max(chart.clientWidth || 0, 640, series.length * 24);
     const height = 280;
@@ -127,7 +142,7 @@
     const svg = svgNode("svg", {
       class: "usage-chart-svg",
       role: "img",
-      "aria-label": `${metric.label} usage over the last ${days <= 2 ? days * 24 + " hours" : days + " days"}`,
+      "aria-label": `${metric.label} usage over ${rangeText.toLowerCase()}`,
       viewBox: `0 0 ${width} ${height}`,
       width,
       height
@@ -252,9 +267,9 @@
     const state = currentState();
     const metric = metrics[state.metric];
     const buckets = Array.isArray(data.buckets) ? data.buckets : [];
-    rangeLabel.textContent = state.days <= 2
-      ? `Last ${state.days * 24} hours`
-      : `Last ${state.days} days`;
+    const rangeText = rangeLabels[state.range] || rangeLabels["30d"];
+    const granularity = data.granularity || "day";
+    rangeLabel.textContent = rangeText;
 
     if (buckets.length === 0) {
       layout.hidden = true;
@@ -275,9 +290,9 @@
     averageValue.textContent = `${metric.format(total / Math.max(series.length, 1))} avg / bucket`;
     layout.hidden = false;
     empty.hidden = true;
-    setStatus(`${buckets.length} ${data.granularity || granularityForDays(state.days)} buckets`, "good");
+    setStatus(`${buckets.length} ${granularityLabels[granularity] || granularity} buckets`, "good");
     showMessage(data.truncated ? "Showing partial data; narrow the range if totals look lower than expected." : "", "");
-    renderChart(series, metric, data.granularity || granularityForDays(state.days), state.days);
+    renderChart(series, metric, granularity, rangeText);
     renderBreakdown(data.by_model || {});
   }
 
@@ -285,8 +300,7 @@
     const state = currentState();
     const token = ++requestId;
     const params = new URLSearchParams({
-      days: String(state.days),
-      granularity: granularityForDays(state.days),
+      range: state.range,
       by_model: "1"
     });
     setStatus("loading", "");
@@ -338,7 +352,7 @@
     averageValue = panel.querySelector("[data-usage-average]");
     rangeLabel = panel.querySelector("[data-usage-range-label]");
 
-    panel.querySelectorAll('input[name="usage-days"], input[name="usage-metric"]').forEach((input) => {
+    panel.querySelectorAll('input[name="usage-range"], input[name="usage-metric"]').forEach((input) => {
       input.addEventListener("change", loadUsage);
     });
     if ("ResizeObserver" in window) {
@@ -371,20 +385,28 @@
       <fieldset class="usage-segmented-control">
         <legend>Range</legend>
         <label>
-          <input type="radio" name="usage-days" value="1">
+          <input type="radio" name="usage-range" value="1h">
+          <span>1h</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-range" value="6h">
+          <span>6h</span>
+        </label>
+        <label>
+          <input type="radio" name="usage-range" value="24h">
           <span>24h</span>
         </label>
         <label>
-          <input type="radio" name="usage-days" value="7">
-          <span>7 days</span>
+          <input type="radio" name="usage-range" value="7d">
+          <span>7d</span>
         </label>
         <label>
-          <input type="radio" name="usage-days" value="30" checked>
-          <span>30 days</span>
+          <input type="radio" name="usage-range" value="30d" checked>
+          <span>30d</span>
         </label>
         <label>
-          <input type="radio" name="usage-days" value="90">
-          <span>90 days</span>
+          <input type="radio" name="usage-range" value="90d">
+          <span>90d</span>
         </label>
       </fieldset>
       <fieldset class="usage-segmented-control">

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -22,7 +22,8 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.storage import STORE, Generation
+from trusted_router.routes.console.activity import _USAGE_CACHE
+from trusted_router.storage import STORE, Generation, InMemoryStore
 
 
 @pytest.fixture
@@ -658,17 +659,82 @@ def test_console_activity_renders_usage_panel(
 
     assert resp.status_code == 200
     assert '<section class="panel usage-panel" data-usage-panel>' in resp.text
-    assert '<input type="radio" name="usage-days" value="1">' in resp.text
+    assert '<input type="radio" name="usage-range" value="1h">' in resp.text
+    assert '<input type="radio" name="usage-range" value="6h">' in resp.text
+    assert '<input type="radio" name="usage-range" value="24h">' in resp.text
+    assert '<input type="radio" name="usage-range" value="7d">' in resp.text
+    assert '<input type="radio" name="usage-range" value="30d" checked>' in resp.text
+    assert '<input type="radio" name="usage-range" value="90d">' in resp.text
+    assert 'name="usage-days"' not in resp.text
+    assert "<span>1h</span>" in resp.text
+    assert "<span>6h</span>" in resp.text
     assert "<span>24h</span>" in resp.text
+    assert "<span>7d</span>" in resp.text
+    assert "<span>30d</span>" in resp.text
+    assert "<span>90d</span>" in resp.text
     assert 'data-usage-chart' in resp.text
     assert 'data-usage-breakdown' in resp.text
     assert "/console/activity/usage.json" in resp.text
+    assert 'range: state.range' in resp.text
     assert 'by_model: "1"' in resp.text
     assert "Spend" in resp.text
     assert "Tokens" in resp.text
     assert "Requests" in resp.text
     assert resp.text.index("<h2>Usage</h2>") < resp.text.index("<h2>Recent activity</h2>")
     assert ".usage-layout[hidden]" in console_css
+
+
+def test_console_activity_usage_endpoint_uses_range_param(
+    console_session: tuple[TestClient, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _USAGE_CACHE.clear()
+    client, _ = console_session
+    user = STORE.find_user_by_email("alice@example.com")
+    assert user is not None
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    calls: list[tuple[str, int, str, str | None, bool]] = []
+
+    def spy_usage_series(
+        self: InMemoryStore,
+        workspace_id: str,
+        *,
+        window_minutes: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        _ = self
+        calls.append((workspace_id, window_minutes, granularity, api_key_hash, by_model))
+        return {
+            "granularity": granularity,
+            "start_day": "2026-07-08",
+            "end_day": "2026-07-08",
+            "truncated": False,
+            "buckets": [],
+            "by_model": {"model-a": []} if by_model else {},
+        }
+
+    monkeypatch.setattr(InMemoryStore, "usage_series", spy_usage_series)
+
+    response = client.get("/console/activity/usage.json?range=1h&by_model=1&api_key_hash=key_a")
+
+    assert response.status_code == 200
+    assert response.json()["range"] == "1h"
+    assert response.json()["granularity"] == "minute"
+    assert calls == [(workspace.id, 60, "minute", "key_a", True)]
+
+
+def test_console_activity_usage_endpoint_rejects_invalid_range(
+    console_session: tuple[TestClient, str],
+) -> None:
+    _USAGE_CACHE.clear()
+    client, _ = console_session
+
+    response = client.get("/console/activity/usage.json?range=2h")
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "invalid range"
 
 
 def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -11,7 +11,7 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.routes.console.activity import _USAGE_CACHE
 from trusted_router.storage import STORE, Generation, InMemoryStore
-from trusted_router.storage_activity import summarize_activity
+from trusted_router.storage_activity import summarize_activity, usage_bucket_key
 from trusted_router.storage_gcp_activity_index import usage_series, write_generation
 
 
@@ -49,6 +49,19 @@ def _generation(
     )
 
 
+def test_usage_bucket_key_all_granularities() -> None:
+    assert usage_bucket_key("2026-05-01T14:23:45Z", "minute") == "2026-05-01T14:23"
+    assert usage_bucket_key("2026-05-01T14:23:45Z", "5min") == "2026-05-01T14:20"
+    assert usage_bucket_key("2026-05-01T14:23:45Z", "hour") == "2026-05-01T14"
+    assert usage_bucket_key("2026-05-01T14:23:45Z", "day") == "2026-05-01"
+    assert usage_bucket_key("2026-05-01T14:00:00Z", "5min") == "2026-05-01T14:00"
+    assert usage_bucket_key("2026-05-01T14:04:00Z", "5min") == "2026-05-01T14:00"
+    assert usage_bucket_key("2026-05-01T14:05:00Z", "5min") == "2026-05-01T14:05"
+    assert usage_bucket_key("2026-05-01T14:59:00Z", "5min") == "2026-05-01T14:55"
+    with pytest.raises(ValueError, match="unknown granularity"):
+        usage_bucket_key("2026-05-01T14:23:45Z", "week")
+
+
 def test_memory_usage_series_hourly_uses_rolling_24h_window() -> None:
     store = InMemoryStore()
     user = store.ensure_user("rolling-usage@example.com")
@@ -78,8 +91,8 @@ def test_memory_usage_series_hourly_uses_rolling_24h_window() -> None:
             )
         )
 
-    hourly = store.usage_series(workspace.id, days=1, granularity="hour")
-    daily = store.usage_series(workspace.id, days=30, granularity="day")
+    hourly = store.usage_series(workspace.id, window_minutes=1440, granularity="hour")
+    daily = store.usage_series(workspace.id, window_minutes=43200, granularity="day")
 
     assert sum(int(bucket["requests"]) for bucket in hourly["buckets"]) == 2
     assert sum(int(bucket["cost_micro"]) for bucket in hourly["buckets"]) == 300
@@ -87,6 +100,50 @@ def test_memory_usage_series_hourly_uses_rolling_24h_window() -> None:
     assert all(len(str(bucket["bucket"])) == 13 for bucket in hourly["buckets"])
     assert sum(int(bucket["requests"]) for bucket in daily["buckets"]) == 3
     assert sum(int(bucket["cost_micro"]) for bucket in daily["buckets"]) == 600
+
+
+def test_memory_usage_series_minute_uses_rolling_60_minute_window() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("minute-usage@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    _raw_key, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="minute usage key",
+        creator_user_id=user.id,
+    )
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+    included_at = now - dt.timedelta(minutes=15)
+    excluded_at = now - dt.timedelta(minutes=75)
+    for generation_id, created_at, cost_micro in [
+        ("gen-15m", included_at, 100),
+        ("gen-75m", excluded_at, 200),
+    ]:
+        store.add_generation(
+            _generation(
+                generation_id,
+                workspace_id=workspace.id,
+                key_hash=api_key.hash,
+                created_at=created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                prompt_tokens=10,
+                completion_tokens=5,
+                reasoning_tokens=0,
+                cost_micro=cost_micro,
+            )
+        )
+
+    minute = store.usage_series(workspace.id, window_minutes=60, granularity="minute")
+
+    assert minute["buckets"] == [
+        {
+            "bucket": included_at.strftime("%Y-%m-%dT%H:%M"),
+            "requests": 1,
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "reasoning_tokens": 0,
+            "cost_micro": 100,
+            "byok_micro": 0,
+        }
+    ]
 
 
 def _seed_generations() -> tuple[Any, list[Generation]]:
@@ -219,24 +276,71 @@ def test_usage_series_hourly_and_daily_buckets() -> None:
     )
 
 
-def test_usage_series_hourly_cutoff_uses_start_key() -> None:
+def test_usage_series_minute_and_5min_buckets() -> None:
+    _store, _db, table = make_fake_store()
+    write_generation(
+        table,
+        "m",
+        _generation(
+            "gen-5min",
+            created_at="2026-05-01T14:23:00Z",
+            prompt_tokens=10,
+            completion_tokens=5,
+            reasoning_tokens=1,
+            cost_micro=100,
+        ),
+    )
+
+    minute = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-01",
+        granularity="minute",
+    )
+    five_min = usage_series(
+        table,
+        "m",
+        "ws_1",
+        start_day="2026-05-01",
+        end_day="2026-05-01",
+        granularity="5min",
+    )
+
+    assert minute["buckets"][0]["bucket"] == "2026-05-01T14:23"
+    assert five_min["buckets"][0]["bucket"] == "2026-05-01T14:20"
+
+
+@pytest.mark.parametrize(
+    ("granularity", "first_bucket"),
+    [
+        ("hour", "2026-05-01T10"),
+        ("minute", "2026-05-01T10:45"),
+        ("5min", "2026-05-01T10:45"),
+    ],
+)
+def test_usage_series_rolling_cutoff_uses_start_key(
+    granularity: str,
+    first_bucket: str,
+) -> None:
     table, _generations = _seed_generations()
 
-    hourly = usage_series(
+    series = usage_series(
         table,
         "m",
         "ws_1",
         start_day="2026-05-01",
         end_day="2026-05-02",
-        granularity="hour",
+        granularity=granularity,
         min_created_at="2026-05-01T10:30:00",
     )
 
     assert table.reads[-1][0] == b"ws#ws_1#2026-05-01#2026-05-01T10:30:00"
     assert table.reads[-1][1] == b"ws#ws_1#2026-05-02~"
-    assert sum(int(bucket["requests"]) for bucket in hourly["buckets"]) == 3
-    assert hourly["buckets"][0]["bucket"] == "2026-05-01T10"
-    assert hourly["buckets"][0]["requests"] == 1
+    assert sum(int(bucket["requests"]) for bucket in series["buckets"]) == 3
+    assert series["buckets"][0]["bucket"] == first_bucket
+    assert series["buckets"][0]["requests"] == 1
 
 
 def test_usage_series_by_model_breakdown() -> None:
@@ -410,13 +514,13 @@ def test_console_usage_series_endpoint_returns_json_and_uses_cache(
         self: InMemoryStore,
         workspace_id: str,
         *,
-        days: int,
+        window_minutes: int,
         granularity: str,
         api_key_hash: str | None = None,
         by_model: bool = False,
     ) -> dict[str, Any]:
         _ = self
-        calls.append((workspace_id, days, granularity, api_key_hash, by_model))
+        calls.append((workspace_id, window_minutes, granularity, api_key_hash, by_model))
         return {
             "granularity": granularity,
             "start_day": "2026-07-06",
@@ -428,17 +532,18 @@ def test_console_usage_series_endpoint_returns_json_and_uses_cache(
 
     monkeypatch.setattr(InMemoryStore, "usage_series", spy_usage_series)
 
-    first = client.get("/console/activity/usage.json?days=2&by_model=true&api_key_hash=key_a")
-    second = client.get("/console/activity/usage.json?days=2&by_model=true&api_key_hash=key_a")
+    first = client.get("/console/activity/usage.json?range=1h&by_model=true&api_key_hash=key_a")
+    second = client.get("/console/activity/usage.json?range=1h&by_model=true&api_key_hash=key_a")
 
     assert first.status_code == 200
     assert second.status_code == 200
-    assert first.json()["granularity"] == "hour"
+    assert first.json()["granularity"] == "minute"
+    assert first.json()["range"] == "1h"
     assert first.json() == second.json()
-    assert calls == [(workspace.id, 2, "hour", "key_a", True)]
+    assert calls == [(workspace.id, 60, "minute", "key_a", True)]
 
 
-def test_console_usage_series_endpoint_rejects_bad_granularity() -> None:
+def test_console_usage_series_endpoint_rejects_bad_range() -> None:
     _USAGE_CACHE.clear()
     app = create_app(Settings(environment="local"), init_observability=False)
     client = TestClient(app)
@@ -452,6 +557,7 @@ def test_console_usage_series_endpoint_rejects_bad_granularity() -> None:
     )
     client.cookies.set("tr_session", raw_token)
 
-    response = client.get("/console/activity/usage.json?granularity=minute")
+    response = client.get("/console/activity/usage.json?range=bad")
 
     assert response.status_code == 400
+    assert response.json()["error"]["message"] == "invalid range"


### PR DESCRIPTION
Follow-up to #132/#133/#134. Adds fine-grained **recent** presets — when chasing a live bug you want the freshest granularity, not a daily trend.

## Presets (range toggle: 1h · 6h · 24h · 7d · 30d · 90d)
| range | buckets | granularity |
|-------|---------|-------------|
| **1h**  | 60  | minute |
| **6h**  | 72  | 5-minute |
| 24h | 24 | hourly *(existing)* |
| 7d / 30d / 90d | — | daily *(existing)* |

## How
- Replaces the `days` query param with **named range presets**. `USAGE_RANGE_PRESETS` (token → `(window_minutes, granularity)`) in the endpoint is the single source of truth; the frontend radios mirror the tokens. Invalid `range` → 400.
- Public `usage_series` signature: `days:int` → `window_minutes:int` across the `Store` Protocol and both storage stacks.
- New `minute`/`5min` granularities reuse the rolling-window + Bigtable **start-key cutoff** from #134 (sub-day = rolling window ending now UTC; day presets keep calendar-day). A shared `usage_bucket_key()` helper in `storage_activity.py` derives keys for all four granularities so the two leaf aggregators can't diverge; 5-min buckets floor the minute to a multiple of 5.
- Frontend: minute/5-min x-axis labels (UTC `h:mm`), "Last hour" / "Last 6 hours" range labels, "N 5-minute buckets" status wording.

## Unchanged
`tokenTotal` (prompt+completion only), UTC formatting, the `.usage-layout[hidden]` empty state, model breakdown. 60s cache now keyed by range token.

## Verification
Both new views rendered headless from this branch's exact JS+CSS against schema-accurate payloads (incl. a mid-window request burst for the 1h view) and eyeballed — the toggle, minute/5-min axes, pills, and labels are correct.

## Tests
minute + 5-min aggregation, 5-min flooring edges (`:00→:00, :04→:00, :05→:05, :59→:55`), start-key cutoff for sub-day windows, range-param endpoint (valid resolves granularity, invalid → 400), `usage_bucket_key` unit coverage. ruff + mypy + **1343 passed**. codex review **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)