### PR TITLE
routing: treat provider.data_collection="deny" as a soft filter

### DIFF
--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 from trusted_router.catalog import (
     AUTO_MODEL_ID,
@@ -156,6 +157,8 @@ _PROVIDER_PREFERENCE = {
     "gmi": 5,
 }
 
+_CandidateT = TypeVar("_CandidateT")
+
 
 def chat_route_candidates(body: dict[str, Any], settings: Settings) -> list[Model]:
     raw_ids, prefs = _routing_for_body(body, settings)
@@ -173,7 +176,7 @@ def chat_route_candidates(body: dict[str, Any], settings: Settings) -> list[Mode
             candidates.append(model)
             seen.add(model.id)
 
-    candidates = _apply_provider_filters(candidates, prefs)
+    candidates = _filter_candidates_soft_data_collection(candidates, prefs, _apply_provider_filters)
     if not candidates:
         raise api_error(
             400,
@@ -206,7 +209,9 @@ def chat_route_endpoint_candidates(
             candidates.append((model, endpoint))
             seen.add(endpoint.id)
 
-    candidates = _apply_endpoint_provider_filters(candidates, prefs)
+    candidates = _filter_candidates_soft_data_collection(
+        candidates, prefs, _apply_endpoint_provider_filters
+    )
     if not candidates:
         raise api_error(
             400,
@@ -499,6 +504,24 @@ def _expand_model_id(model_id: str, settings: Settings) -> list[str]:
     if meta_candidates:
         return [candidate.id for candidate in meta_candidates]
     return [model_id]
+
+
+def _filter_candidates_soft_data_collection(
+    candidates: list[_CandidateT],
+    prefs: RoutePreferences,
+    apply_fn: Callable[[list[_CandidateT], RoutePreferences], list[_CandidateT]],
+) -> list[_CandidateT]:
+    """Apply provider filters with data_collection='deny' as a soft preference.
+
+    Some OpenRouter-migrated clients send this compatibility flag on every request
+    unconditionally, so it must not hard-fail routing when it is the only filter
+    emptying an otherwise valid route. Explicit privacy floors and provider
+    inclusion/exclusion filters remain hard.
+    """
+    filtered = apply_fn(candidates, prefs)
+    if not filtered and prefs.data_collection == "deny":
+        filtered = apply_fn(candidates, dataclasses.replace(prefs, data_collection=None))
+    return filtered
 
 
 def _apply_provider_filters(candidates: list[Model], prefs: RoutePreferences) -> list[Model]:

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -18,6 +18,7 @@ from trusted_router.config import Settings
 from trusted_router.routing import (
     _sort_endpoint_candidates,
     chat_route_candidates,
+    chat_route_endpoint_candidates,
     provider_route_preferences,
 )
 
@@ -369,26 +370,89 @@ def test_model_shape_exposes_privacy_tier() -> None:
     assert tr["privacy_tier"] >= 2  # zero retention or better
 
 
-def test_data_collection_deny_keeps_zdr_drops_standard() -> None:
-    # deny == "no data collection" → require >= no-store tier. A model on a
-    # no-store+ provider (deepseek via phala/tinfoil) must be KEPT; a model only
-    # on standard providers must be dropped. NOTE: anthropic/openai/google were
-    # downgraded from ZDR to standard in 4faa10d ("excluded from trustedrouter/zdr
-    # until reverified"), so they are no longer the ZDR example.
-    from trusted_router.catalog import PRIVACY_TIER_NO_STORE, model_max_privacy_tier
+def test_data_collection_deny_soft_fallback_keeps_standard_only_model_and_endpoints() -> None:
+    from trusted_router.catalog import (
+        MODELS,
+        PRIVACY_TIER_NO_STORE,
+        endpoint_privacy_tier,
+        endpoints_for_model,
+        model_max_privacy_tier,
+    )
 
-    kept = chat_route_candidates(
-        {"model": "deepseek/deepseek-v3.2", "provider": {"data_collection": "deny"}},
+    model_id = "mistralai/mistral-small-2603"
+    catalog_endpoints = endpoints_for_model(model_id)
+    assert model_max_privacy_tier(MODELS[model_id]) < PRIVACY_TIER_NO_STORE
+    assert all(endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE for endpoint in catalog_endpoints)
+
+    body = {"model": model_id, "provider": {"data_collection": "deny"}}
+    candidates = chat_route_candidates(body, _settings())
+    endpoint_candidates = chat_route_endpoint_candidates(body, _settings())
+
+    assert [model.id for model in candidates] == [model_id]
+    assert {endpoint.id for _model, endpoint in endpoint_candidates} == {
+        endpoint.id for endpoint in catalog_endpoints
+    }
+
+
+def test_data_collection_deny_still_filters_when_satisfiable() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_NO_STORE,
+        endpoint_privacy_tier,
+        endpoints_for_model,
+        model_max_privacy_tier,
+    )
+
+    standard_model_id = "mistralai/mistral-small-2603"
+    private_model_id = "deepseek/deepseek-v3.2"
+    candidates = chat_route_candidates(
+        {
+            "models": [standard_model_id, private_model_id],
+            "provider": {"data_collection": "deny"},
+        },
         _settings(),
     )
-    assert kept and all(model_max_privacy_tier(m) >= PRIVACY_TIER_NO_STORE for m in kept)
+    assert [model.id for model in candidates] == [private_model_id]
+    assert all(model_max_privacy_tier(model) >= PRIVACY_TIER_NO_STORE for model in candidates)
 
+    endpoint_candidates = chat_route_endpoint_candidates(
+        {"model": private_model_id, "provider": {"data_collection": "deny"}},
+        _settings(),
+    )
+    assert endpoint_candidates
+    assert any(
+        endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE
+        for endpoint in endpoints_for_model(private_model_id)
+    )
+    assert all(
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
+        for _model, endpoint in endpoint_candidates
+    )
+
+
+def test_provider_only_stays_hard_when_data_collection_soft_falls_back() -> None:
     with pytest.raises(HTTPException) as exc:
         chat_route_candidates(
-            {"model": "mistralai/mistral-small-2603", "provider": {"data_collection": "deny"}},
+            {
+                "model": "mistralai/mistral-small-2603",
+                "provider": {"only": ["openai"], "data_collection": "deny"},
+            },
             _settings(),
         )
     assert exc.value.status_code == 400
+    assert "filters" in exc.value.detail["error"]["message"].lower()
+
+
+def test_min_privacy_stays_hard_when_data_collection_soft_falls_back() -> None:
+    with pytest.raises(HTTPException) as exc:
+        chat_route_candidates(
+            {
+                "model": "mistralai/mistral-small-2603",
+                "provider": {"data_collection": "deny", "min_privacy": "no_store"},
+            },
+            _settings(),
+        )
+    assert exc.value.status_code == 400
+    assert "filters" in exc.value.detail["error"]["message"].lower()
 
 
 def test_unverified_provider_defaults_to_stores_content() -> None:


### PR DESCRIPTION
## Bug
A client migrated from OpenRouter (#1704) sends `provider: {data_collection: "deny"}` on **every** request, unconditionally. In `routing.py` that was a **hard** filter — any model/endpoint below the no-store privacy tier is dropped, so a model served only by open-tier providers ends up with an empty candidate set → 400 **"No route candidates match the requested provider filters"** → discovery / normal calls fail. (The identical request *without* the flag succeeds.)

## Fix
Make `data_collection: "deny"` a **soft** preference: honor it when it leaves ≥1 candidate, but fall back to serving without it instead of failing when it's the only thing emptying the route. Shared helper `_filter_candidates_soft_data_collection` wraps both the model-level (`chat_route_candidates`) and endpoint-level (`chat_route_endpoint_candidates`) filters.

**Still hard** (unchanged): `provider.only` / `ignore` / jurisdiction, and the explicit `min_privacy_rank` floor — that's TrustedRouter's own privacy control, distinct from the OpenRouter compat flag some clients send blindly.

## Tests
- below-no-store model + `deny` → candidates returned (soft fallback), no 400
- `deny` still narrows to qualifying providers when satisfiable (not weakened)
- `provider.only` unsatisfiable + `deny` → still 400
- `min_privacy` above all candidates + `deny` → still 400

ruff + mypy + **1346 passed**. codex review **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)