### PR TITLE
routing: finish #137 — soft data_collection for embeddings + catalog paths

### DIFF
--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -235,7 +235,9 @@ def catalog_endpoint_candidates(
     to describe any served model while still honoring provider filters.
     """
     candidates = [(model, endpoint) for endpoint in endpoints_for_model(model.id)]
-    candidates = _apply_endpoint_provider_filters(candidates, prefs)
+    candidates = _filter_candidates_soft_data_collection(
+        candidates, prefs, _apply_endpoint_provider_filters
+    )
     candidates = _sort_endpoint_candidates(candidates, prefs)
     if not prefs.allow_fallbacks:
         return candidates[:1]
@@ -267,7 +269,9 @@ def embeddings_route_endpoint_candidates(
             candidates.append((model, endpoint))
             seen.add(endpoint.id)
 
-    candidates = _apply_endpoint_provider_filters(candidates, prefs)
+    candidates = _filter_candidates_soft_data_collection(
+        candidates, prefs, _apply_endpoint_provider_filters
+    )
     if not candidates:
         raise api_error(
             400,

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -17,8 +17,10 @@ from trusted_router.catalog import PROVIDER_JURISDICTION_US
 from trusted_router.config import Settings
 from trusted_router.routing import (
     _sort_endpoint_candidates,
+    catalog_endpoint_candidates,
     chat_route_candidates,
     chat_route_endpoint_candidates,
+    embeddings_route_endpoint_candidates,
     provider_route_preferences,
 )
 
@@ -427,6 +429,77 @@ def test_data_collection_deny_still_filters_when_satisfiable() -> None:
         endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
         for _model, endpoint in endpoint_candidates
     )
+
+
+def test_embeddings_data_collection_deny_soft_fallback_keeps_standard_model_endpoints() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_NO_STORE,
+        endpoint_privacy_tier,
+        endpoints_for_model,
+    )
+
+    model_id = "openai/text-embedding-3-large"
+    catalog_endpoints = endpoints_for_model(model_id)
+    assert catalog_endpoints
+    assert all(endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE for endpoint in catalog_endpoints)
+
+    candidates_without_deny = embeddings_route_endpoint_candidates({"model": model_id}, _settings())
+    candidates_with_deny = embeddings_route_endpoint_candidates(
+        {"model": model_id, "provider": {"data_collection": "deny"}},
+        _settings(),
+    )
+
+    assert [endpoint.id for _model, endpoint in candidates_with_deny] == [
+        endpoint.id for _model, endpoint in candidates_without_deny
+    ]
+
+
+def test_embeddings_provider_only_stays_hard_when_data_collection_soft_falls_back() -> None:
+    with pytest.raises(HTTPException) as exc:
+        embeddings_route_endpoint_candidates(
+            {
+                "model": "openai/text-embedding-3-large",
+                "provider": {"only": ["cohere"], "data_collection": "deny"},
+            },
+            _settings(),
+        )
+    assert exc.value.status_code == 400
+    assert "filters" in exc.value.detail["error"]["message"].lower()
+
+
+def test_catalog_data_collection_deny_soft_fallback_and_satisfiable_filtering() -> None:
+    from trusted_router.catalog import (
+        MODELS,
+        PRIVACY_TIER_NO_STORE,
+        endpoint_privacy_tier,
+        endpoints_for_model,
+    )
+
+    standard_model_id = "openai/text-embedding-3-large"
+    standard_endpoints = endpoints_for_model(standard_model_id)
+    assert standard_endpoints
+    assert all(
+        endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE for endpoint in standard_endpoints
+    )
+
+    deny_prefs = provider_route_preferences({"provider": {"data_collection": "deny"}})
+    standard_candidates = catalog_endpoint_candidates(MODELS[standard_model_id], deny_prefs)
+    assert {endpoint.id for _model, endpoint in standard_candidates} == {
+        endpoint.id for endpoint in standard_endpoints
+    }
+
+    private_model_id = "cohere/embed-v4.0"
+    private_candidates = catalog_endpoint_candidates(MODELS[private_model_id], deny_prefs)
+    assert private_candidates
+    assert all(
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
+        for _model, endpoint in private_candidates
+    )
+    assert {endpoint.id for _model, endpoint in private_candidates} == {
+        endpoint.id
+        for endpoint in endpoints_for_model(private_model_id)
+        if endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
+    }
 
 
 def test_provider_only_stays_hard_when_data_collection_soft_falls_back() -> None:

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -488,18 +488,31 @@ def test_catalog_data_collection_deny_soft_fallback_and_satisfiable_filtering() 
         endpoint.id for endpoint in standard_endpoints
     }
 
-    private_model_id = "cohere/embed-v4.0"
-    private_candidates = catalog_endpoint_candidates(MODELS[private_model_id], deny_prefs)
-    assert private_candidates
-    assert all(
-        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
-        for _model, endpoint in private_candidates
-    )
-    assert {endpoint.id for _model, endpoint in private_candidates} == {
-        endpoint.id
-        for endpoint in endpoints_for_model(private_model_id)
-        if endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
-    }
+    mixed_model_id = None
+    mixed_endpoints = []
+    mixed_qualifying_endpoints = []
+    for model_id in MODELS:
+        endpoints = endpoints_for_model(model_id)
+        qualifying_endpoints = [
+            endpoint
+            for endpoint in endpoints
+            if endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_NO_STORE
+        ]
+        if qualifying_endpoints and len(qualifying_endpoints) < len(endpoints):
+            mixed_model_id = model_id
+            mixed_endpoints = endpoints
+            mixed_qualifying_endpoints = qualifying_endpoints
+            break
+
+    assert mixed_model_id is not None
+    mixed_candidates = catalog_endpoint_candidates(MODELS[mixed_model_id], deny_prefs)
+    mixed_candidate_ids = {endpoint.id for _model, endpoint in mixed_candidates}
+    mixed_endpoint_ids = {endpoint.id for endpoint in mixed_endpoints}
+    mixed_qualifying_endpoint_ids = {endpoint.id for endpoint in mixed_qualifying_endpoints}
+
+    assert mixed_candidate_ids == mixed_qualifying_endpoint_ids
+    assert mixed_candidate_ids
+    assert mixed_candidate_ids < mixed_endpoint_ids
 
 
 def test_provider_only_stays_hard_when_data_collection_soft_falls_back() -> None:


### PR DESCRIPTION
Post-merge adversarial review of #137 found (and live-reproduced) that the soft-filter fix only covered the chat paths. `embeddings_route_endpoint_candidates` still hard-failed `data_collection:"deny"` (e.g. `text-embedding-3-large` + deny → 400, without deny → 2 candidates), and the public catalog endpoints route showed zero endpoints for models routing actually serves under deny.

Both call sites now use `_filter_candidates_soft_data_collection`, byte-identical to the chat wiring. Hard filters unchanged. +3 tests (embeddings fallback, embeddings `only` stays hard, catalog fallback + satisfiable narrowing). ruff + mypy + **1349 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)