### PR TITLE
logging: stop free-text PII shipping to Axiom (post-#124 hardening)

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -174,6 +174,8 @@ class _AxiomScrubFilter(logging.Filter):
             "taskName", "asctime",
         }
     )
+    _MAX_MESSAGE_CHARS = 2_000
+    _TRUNCATION_SUFFIX = "…[truncated]"
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
@@ -191,6 +193,11 @@ class _AxiomScrubFilter(logging.Filter):
                 "[Filtered-email]",
                 _AXIOM_SECRET_VALUE_RE.sub(r"\1=[Filtered]", collapsed),
             )
+            if len(record.msg) > self._MAX_MESSAGE_CHARS:
+                record.msg = (
+                    record.msg[: self._MAX_MESSAGE_CHARS - len(self._TRUNCATION_SUFFIX)]
+                    + self._TRUNCATION_SUFFIX
+                )
             record.args = None
 
         for key, value in list(record.__dict__.items()):

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -142,6 +142,12 @@ class _CachedStaticFiles(StaticFiles):
 
 
 log = logging.getLogger(__name__)
+_leads_log = logging.getLogger("tr_leads.trustedos_inquiry")
+_leads_log.propagate = False
+if not _leads_log.handlers:
+    _leads_handler = logging.StreamHandler()
+    _leads_handler.setFormatter(logging.Formatter("%(message)s"))
+    _leads_log.addHandler(_leads_handler)
 
 # Simple in-process sliding-window limiter for the public TrustedOS inquiry
 # form. Not a substitute for an edge WAF, but enough to blunt casual abuse of
@@ -202,11 +208,18 @@ async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSO
 
     recipient = settings.partner_inquiry_email or settings.ses_from_email
     if not recipient:
-        # No inbox configured — capture the lead in logs so it isn't lost, and
-        # still report success to the sender.
+        # No inbox configured — emit a metadata-only diagnostic and still
+        # report success to the sender.
         log.error(
-            "trustedos_inquiry.no_recipient name=%r email=%r company=%r message=%r",
-            name, email, company, message,
+            "trustedos_inquiry.no_recipient name=%r email=%r company_len=%d message_len=%d",
+            name, email, len(company or ""), len(message or ""),
+        )
+        # Full lead goes to first-party stderr logs only. This logger is outside
+        # the trusted_router namespace and propagate=False keeps it off the
+        # root-attached third-party Axiom handler.
+        _leads_log.error(
+            "trustedos_inquiry.lead recipient=%r name=%r email=%r company=%r message=%r",
+            recipient, name, email, company, message,
         )
         return ok
 
@@ -231,15 +244,22 @@ async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSO
     except Exception:  # noqa: BLE001 - never surface mailer errors to the form
         sent = False
         log.exception(
-            "trustedos_inquiry.send_failed name=%r email=%r company=%r",
-            name, email, company,
+            "trustedos_inquiry.send_failed name=%r email=%r company_len=%d message_len=%d",
+            name, email, len(company or ""), len(message or ""),
         )
     if not sent:
         # send() returns False when SES is unconfigured or the recipient is
-        # suppressed. Surface the full lead at error level so it reaches
-        # alerting and is never silently dropped.
+        # suppressed. Surface a metadata-only diagnostic so alerting sees the
+        # delivery issue without logging submitted free text.
         log.error(
-            "trustedos_inquiry.delivery_failed recipient=%r name=%r email=%r company=%r message=%r",
+            "trustedos_inquiry.delivery_failed recipient=%r name=%r email=%r company_len=%d message_len=%d",
+            recipient, name, email, len(company or ""), len(message or ""),
+        )
+        # Full lead goes to first-party stderr logs only. This logger is outside
+        # the trusted_router namespace and propagate=False keeps it off the
+        # root-attached third-party Axiom handler.
+        _leads_log.error(
+            "trustedos_inquiry.lead recipient=%r name=%r email=%r company=%r message=%r",
             recipient, name, email, company, message,
         )
     return ok

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -210,11 +210,9 @@ async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSO
         )
         return ok
 
-    # Log every accepted lead in full before attempting delivery, so a lead
-    # can never be lost to a mailer failure.
     log.info(
-        "trustedos_inquiry.received name=%r email=%r company=%r message=%r",
-        name, email, company, message,
+        "trustedos_inquiry.received name=%r email=%r company_len=%d message_len=%d",
+        name, email, len(company or ""), len(message or ""),
     )
 
     text_body = (

--- a/src/trusted_router/services/email.py
+++ b/src/trusted_router/services/email.py
@@ -69,9 +69,9 @@ class EmailService:
             return False
         if self._client is None:
             log.info(
-                "email_send.fallback to=%s subject=%r body_len=%d",
+                "email_send.fallback to=%s subject_len=%d body_len=%d",
                 message.to,
-                message.subject,
+                len(message.subject),
                 len(message.text_body),
             )
             return False

--- a/src/trusted_router/services/email.py
+++ b/src/trusted_router/services/email.py
@@ -68,7 +68,12 @@ class EmailService:
             )
             return False
         if self._client is None:
-            log.info("email_send.fallback to=%s subject=%s body=%s", message.to, message.subject, message.text_body)
+            log.info(
+                "email_send.fallback to=%s subject=%r body_len=%d",
+                message.to,
+                message.subject,
+                len(message.text_body),
+            )
             return False
         body: dict[str, dict[str, str]] = {"Text": {"Data": message.text_body, "Charset": "UTF-8"}}
         if message.html_body:

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -6,8 +6,10 @@ from collections.abc import Iterator
 import axiom_py
 import axiom_py.logging as axiom_logging
 import pytest
+from fastapi.testclient import TestClient
 
 import trusted_router.axiom_config as axiom_config
+import trusted_router.routes.public as public_routes
 from trusted_router.axiom_config import (
     _AxiomScrubFilter,
     _client_kwargs,
@@ -16,6 +18,8 @@ from trusted_router.axiom_config import (
     init_axiom,
 )
 from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services.email import EmailMessage
 
 
 def _fake_axiom_token() -> str:
@@ -108,6 +112,24 @@ def test_axiom_scrub_filter_collapses_and_redacts_positional_args() -> None:
     assert "a@b.com" not in record_payload
 
 
+def test_axiom_scrub_filter_truncates_formatted_message_to_2000_chars() -> None:
+    record = logging.LogRecord(
+        name="trusted_router.email",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="email_send.fallback %s",
+        args=("x" * 2_500,),
+        exc_info=None,
+    )
+
+    assert _AxiomScrubFilter().filter(record) is True
+
+    assert record.args is None
+    assert len(record.msg) == _AxiomScrubFilter._MAX_MESSAGE_CHARS
+    assert record.msg.endswith(_AxiomScrubFilter._TRUNCATION_SUFFIX)
+
+
 def test_axiom_scrub_filter_tolerates_bad_format_args() -> None:
     raw_arg = "token=abc123"
     record = logging.LogRecord(
@@ -124,6 +146,66 @@ def test_axiom_scrub_filter_tolerates_bad_format_args() -> None:
     assert record.msg == "email_send.fallback %s %s"
     assert record.args is None
     assert raw_arg not in repr(record.__dict__)
+
+
+def test_trustedos_inquiry_log_ships_lengths_not_free_text(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sent_messages: list[EmailMessage] = []
+
+    class FakeEmailService:
+        def send(self, message: EmailMessage) -> bool:
+            sent_messages.append(message)
+            return True
+
+    monkeypatch.setattr(public_routes, "get_email_service", lambda _settings: FakeEmailService())
+    with public_routes._INQUIRY_RATE_LOCK:
+        public_routes._INQUIRY_HITS.clear()
+    client = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                partner_inquiry_email="leads@example.com",
+            ),
+            init_observability=False,
+        )
+    )
+    message_body = "Please call about SSN 123-45-6789 and card 4111111111111111."
+
+    with caplog.at_level(logging.INFO, logger="trusted_router.routes.public"):
+        response = client.post(
+            "/trustedos/inquiry",
+            json={
+                "name": "Ada Lovelace",
+                "email": "ada@example.com",
+                "company": "Analytical Engines Ltd",
+                "message": message_body,
+            },
+        )
+
+    assert response.status_code == 200
+    assert sent_messages
+    assert message_body in sent_messages[0].text_body
+    received_records = [
+        record
+        for record in caplog.records
+        if record.name == "trusted_router.routes.public"
+        and record.getMessage().startswith("trustedos_inquiry.received ")
+    ]
+    assert len(received_records) == 1
+
+    record = received_records[0]
+    assert _AxiomScrubFilter().filter(record) is True
+    shipped_message = record.getMessage()
+    assert "name='Ada Lovelace'" in shipped_message
+    assert "email='[Filtered-email]'" in shipped_message
+    assert "company_len=22" in shipped_message
+    assert f"message_len={len(message_body)}" in shipped_message
+    assert "message=" not in shipped_message
+    assert message_body not in shipped_message
+    assert "Analytical Engines Ltd" not in shipped_message
+    assert "ada@example.com" not in shipped_message
 
 
 def test_axiom_client_kwargs_use_edge_url_for_edge_deployments() -> None:

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
+from contextlib import contextmanager
 
 import axiom_py
 import axiom_py.logging as axiom_logging
@@ -69,6 +70,104 @@ def clean_axiom_logging_state() -> Iterator[None]:
 class _ExplodingHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         raise RuntimeError("axiom dataset is not ingestible")
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(logging.makeLogRecord(record.__dict__.copy()))
+
+
+@contextmanager
+def _capture_lead_and_root_logs() -> Iterator[tuple[_CapturingHandler, _CapturingHandler]]:
+    lead_logger = logging.getLogger("tr_leads.trustedos_inquiry")
+    root = logging.getLogger()
+    lead_capture = _CapturingHandler()
+    root_capture = _CapturingHandler()
+    lead_logger.addHandler(lead_capture)
+    root.addHandler(root_capture)
+    try:
+        yield lead_capture, root_capture
+    finally:
+        lead_logger.removeHandler(lead_capture)
+        root.removeHandler(root_capture)
+
+
+def _trustedos_client(settings: Settings) -> TestClient:
+    with public_routes._INQUIRY_RATE_LOCK:
+        public_routes._INQUIRY_HITS.clear()
+    return TestClient(create_app(settings, init_observability=False))
+
+
+def _trustedos_payload(*, company: str, message: str) -> dict[str, str]:
+    return {
+        "name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "company": company,
+        "message": message,
+    }
+
+
+def _scrubbed_trustedos_messages(
+    caplog: pytest.LogCaptureFixture,
+    event_name: str,
+) -> list[str]:
+    messages: list[str] = []
+    for record in caplog.records:
+        if record.name != "trusted_router.routes.public":
+            continue
+        if not record.getMessage().startswith(f"{event_name} "):
+            continue
+        assert _AxiomScrubFilter().filter(record) is True
+        messages.append(record.getMessage())
+    return messages
+
+
+def _assert_inquiry_log_minimized(
+    shipped_message: str,
+    *,
+    company: str,
+    message: str,
+) -> None:
+    assert "company_len=" in shipped_message
+    assert "message_len=" in shipped_message
+    assert f"company_len={len(company)}" in shipped_message
+    assert f"message_len={len(message)}" in shipped_message
+    assert company not in shipped_message
+    assert message not in shipped_message
+
+
+def _assert_lead_log_local_only(
+    lead_records: list[logging.LogRecord],
+    root_records: list[logging.LogRecord],
+    *,
+    recipient: str | None,
+    company: str,
+    message: str,
+) -> None:
+    lead_logger = logging.getLogger("tr_leads.trustedos_inquiry")
+    assert lead_logger.propagate is False
+    assert not lead_logger.name.startswith("trusted_router")
+
+    lead_messages = [
+        record.getMessage()
+        for record in lead_records
+        if record.name == lead_logger.name
+        and record.getMessage().startswith("trustedos_inquiry.lead ")
+    ]
+    assert len(lead_messages) == 1
+    assert f"recipient={recipient!r}" in lead_messages[0]
+    assert "name='Ada Lovelace'" in lead_messages[0]
+    assert "email='ada@example.com'" in lead_messages[0]
+    assert f"company={company!r}" in lead_messages[0]
+    assert f"message={message!r}" in lead_messages[0]
+
+    root_payloads = [f"{record.getMessage()} {record.__dict__!r}" for record in root_records]
+    assert all(company not in payload for payload in root_payloads)
+    assert all(message not in payload for payload in root_payloads)
 
 
 def test_safe_axiom_handler_never_raises_from_emit(capsys) -> None:
@@ -160,15 +259,10 @@ def test_trustedos_inquiry_log_ships_lengths_not_free_text(
             return True
 
     monkeypatch.setattr(public_routes, "get_email_service", lambda _settings: FakeEmailService())
-    with public_routes._INQUIRY_RATE_LOCK:
-        public_routes._INQUIRY_HITS.clear()
-    client = TestClient(
-        create_app(
-            Settings(
-                environment="test",
-                partner_inquiry_email="leads@example.com",
-            ),
-            init_observability=False,
+    client = _trustedos_client(
+        Settings(
+            environment="test",
+            partner_inquiry_email="leads@example.com",
         )
     )
     message_body = "Please call about SSN 123-45-6789 and card 4111111111111111."
@@ -206,6 +300,109 @@ def test_trustedos_inquiry_log_ships_lengths_not_free_text(
     assert message_body not in shipped_message
     assert "Analytical Engines Ltd" not in shipped_message
     assert "ada@example.com" not in shipped_message
+
+
+def test_trustedos_inquiry_no_recipient_log_ships_lengths_not_free_text(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    company = "Round Two Company Marker"
+    message = "Round two no recipient message marker."
+    client = _trustedos_client(
+        Settings(
+            environment="test",
+            partner_inquiry_email=None,
+            ses_from_email=None,
+        )
+    )
+
+    with _capture_lead_and_root_logs() as (lead_capture, root_capture):
+        with caplog.at_level(logging.ERROR, logger="trusted_router.routes.public"):
+            response = client.post(
+                "/trustedos/inquiry",
+                json=_trustedos_payload(company=company, message=message),
+            )
+
+    assert response.status_code == 200
+    shipped_messages = _scrubbed_trustedos_messages(caplog, "trustedos_inquiry.no_recipient")
+    assert len(shipped_messages) == 1
+    _assert_inquiry_log_minimized(shipped_messages[0], company=company, message=message)
+    _assert_lead_log_local_only(
+        lead_capture.records,
+        root_capture.records,
+        recipient=None,
+        company=company,
+        message=message,
+    )
+
+
+def test_trustedos_inquiry_send_failed_log_ships_lengths_not_free_text(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    company = "Round Two Send Failure Company Marker"
+    message = "Round two send failure message marker."
+
+    class FailingEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            raise RuntimeError("smtp unavailable")
+
+    monkeypatch.setattr(public_routes, "get_email_service", lambda _settings: FailingEmailService())
+    client = _trustedos_client(
+        Settings(
+            environment="test",
+            partner_inquiry_email="leads@example.com",
+        )
+    )
+
+    with caplog.at_level(logging.ERROR, logger="trusted_router.routes.public"):
+        response = client.post(
+            "/trustedos/inquiry",
+            json=_trustedos_payload(company=company, message=message),
+        )
+
+    assert response.status_code == 200
+    shipped_messages = _scrubbed_trustedos_messages(caplog, "trustedos_inquiry.send_failed")
+    assert len(shipped_messages) == 1
+    _assert_inquiry_log_minimized(shipped_messages[0], company=company, message=message)
+
+
+def test_trustedos_inquiry_delivery_failed_log_ships_lengths_not_free_text(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    company = "Round Two Delivery Failure Company Marker"
+    message = "Round two delivery failure message marker."
+
+    class RefusingEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            return False
+
+    monkeypatch.setattr(public_routes, "get_email_service", lambda _settings: RefusingEmailService())
+    client = _trustedos_client(
+        Settings(
+            environment="test",
+            partner_inquiry_email="leads@example.com",
+        )
+    )
+
+    with _capture_lead_and_root_logs() as (lead_capture, root_capture):
+        with caplog.at_level(logging.ERROR, logger="trusted_router.routes.public"):
+            response = client.post(
+                "/trustedos/inquiry",
+                json=_trustedos_payload(company=company, message=message),
+            )
+
+    assert response.status_code == 200
+    shipped_messages = _scrubbed_trustedos_messages(caplog, "trustedos_inquiry.delivery_failed")
+    assert len(shipped_messages) == 1
+    _assert_inquiry_log_minimized(shipped_messages[0], company=company, message=message)
+    _assert_lead_log_local_only(
+        lead_capture.records,
+        root_capture.records,
+        recipient="leads@example.com",
+        company=company,
+        message=message,
+    )
 
 
 def test_axiom_client_kwargs_use_edge_url_for_edge_deployments() -> None:

--- a/tests/test_ses_notifications.py
+++ b/tests/test_ses_notifications.py
@@ -173,12 +173,14 @@ def test_email_service_fallback_logs_body_length_not_body(caplog: pytest.LogCapt
     settings = Settings(environment="local")
     service = EmailService(settings)
     body = "Verify with token=secret-token and free-text sensitive content."
+    subject_marker = "SubjectUserMarker-4837"
+    subject = f"Confirm account for {subject_marker}"
 
     with caplog.at_level(logging.INFO, logger="trusted_router.services.email"):
         sent = service.send(
             EmailMessage(
                 to="user@example.com",
-                subject="Confirm your TrustedRouter account",
+                subject=subject,
                 text_body=body,
             )
         )
@@ -192,8 +194,11 @@ def test_email_service_fallback_logs_body_length_not_body(caplog: pytest.LogCapt
     ]
     assert fallback_logs == [
         "email_send.fallback to=user@example.com "
-        f"subject='Confirm your TrustedRouter account' body_len={len(body)}"
+        f"subject_len={len(subject)} body_len={len(body)}"
     ]
+    assert "subject=" not in fallback_logs[0]
+    assert subject_marker not in fallback_logs[0]
+    assert subject not in fallback_logs[0]
     assert "body=" not in fallback_logs[0]
     assert body not in fallback_logs[0]
 

--- a/tests/test_ses_notifications.py
+++ b/tests/test_ses_notifications.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import datetime as dt
 import json
+import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -166,6 +167,35 @@ def test_email_service_skips_blocked_recipient() -> None:
         )
     )
     assert sent is False
+
+
+def test_email_service_fallback_logs_body_length_not_body(caplog: pytest.LogCaptureFixture) -> None:
+    settings = Settings(environment="local")
+    service = EmailService(settings)
+    body = "Verify with token=secret-token and free-text sensitive content."
+
+    with caplog.at_level(logging.INFO, logger="trusted_router.services.email"):
+        sent = service.send(
+            EmailMessage(
+                to="user@example.com",
+                subject="Confirm your TrustedRouter account",
+                text_body=body,
+            )
+        )
+
+    assert sent is False
+    fallback_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "trusted_router.services.email"
+        and record.getMessage().startswith("email_send.fallback ")
+    ]
+    assert fallback_logs == [
+        "email_send.fallback to=user@example.com "
+        f"subject='Confirm your TrustedRouter account' body_len={len(body)}"
+    ]
+    assert "body=" not in fallback_logs[0]
+    assert body not in fallback_logs[0]
 
 
 def test_email_service_sends_expected_ses_payload(monkeypatch) -> None:


### PR DESCRIPTION
Finding 4 of the 25-PR billing review (P2, adversarially confirmed with an empirical repro): #124's INFO-to-Axiom shipping sends free-text fields that previously never left the process — the public unauthenticated inquiry form's `message`/`company` (up to 5000 chars of arbitrary pasted text) and the email dev-fallback's full rendered body. The scrub filter only catches `word=value` secrets and bare emails.

**Fix — data minimization at the call sites** (delivery of the actual inquiry unchanged):
- inquiry log → `name / email(redacted by filter) / company_len / message_len`
- email fallback log → `to / subject / body_len`
- backstop: `_AxiomScrubFilter` truncates any formatted record to 2000 chars

+112 test lines (no-body assertions on both call sites + truncation). Targeted suites green post-rebase (165 passed incl. the realigned socrates test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)