### PR TITLE
Billing-review follow-ups: truncation marker, runbook INFO correction, docstring

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -519,13 +519,15 @@ Outcome cheat-sheet:
 
 Monitoring signals:
 
-App log routing is a trap here, so know it exactly. INFO and above from
-`trusted_router.*` loggers now ship to AXIOM because `init_axiom()` lowers
-only the package logger to `TR_AXIOM_LOG_LEVEL` (default INFO) and leaves
-root at uvicorn's WARNING. Third-party INFO still does not ship because it
-gates on root's WARNING. App records still never appear in Cloud Logging:
-once `init_axiom()` attaches the root Axiom handler, `logging.lastResort`
-stops mirroring app records to stderr. Search alerts and app INFO in Axiom
+App log routing is a trap here, so know it exactly. INFO settle-outbox lines
+such as `reaped N expired reservations` and `recovered settle charge` do ship
+to Axiom via the scoped `trusted_router.*` package logger
+(`TR_AXIOM_LOG_LEVEL`, default INFO), so on-call can search for them there.
+`init_axiom()` lowers only the package logger and leaves root at uvicorn's
+WARNING. Third-party INFO still does not ship because it gates on root's
+WARNING. App records still never appear in Cloud Logging: once `init_axiom()`
+attaches the root Axiom handler, `logging.lastResort` stops mirroring app
+records to stderr. Search alerts and app INFO in Axiom
 (`TR_AXIOM_DATASET=trusted-router-logs`), not `gcloud logging`. Cloud Logging
 carries only platform request logs and uvicorn/unhandled-exception stderr
 tracebacks. Judge reap/drain health by state, never by log lines:

--- a/scripts/credit_grant_jay.py
+++ b/scripts/credit_grant_jay.py
@@ -1,4 +1,4 @@
-"""One-shot $40 credit grant for jayzalowitz@robotrobotandhuman.com (manual top-up).
+"""One-shot $10 credit grant for jayzalowitz@robotrobotandhuman.com (manual top-up).
 
 User (Joseph) asked on 2026-07-09 to give jay another $10 of credit.
 
@@ -8,7 +8,7 @@ TR_TYPED_COUNTER_MIRROR=1. Verifies the typed counter after.
 
 Usage:
     cd /Users/jperla/claude/qr-billing
-    PYTHONPATH=src uv run python scripts/credit_grant_david.py
+    PYTHONPATH=src uv run python scripts/credit_grant_jay.py
 """
 
 from __future__ import annotations

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -286,8 +286,14 @@
       value: metric.value(bucket)
     }));
     const total = series.reduce((sum, point) => sum + point.value, 0);
-    totalValue.textContent = metric.format(total);
-    averageValue.textContent = `${metric.format(total / Math.max(series.length, 1))} avg / bucket`;
+    const truncatedPrefix = data.truncated ? "≥" : "";
+    totalValue.textContent = `${truncatedPrefix}${metric.format(total)}`;
+    if (data.truncated) {
+      totalValue.title = "Partial data — some rows were not scanned; narrow the range for an exact total";
+    } else {
+      totalValue.removeAttribute("title");
+    }
+    averageValue.textContent = `${truncatedPrefix}${metric.format(total / Math.max(series.length, 1))} avg / bucket`;
     layout.hidden = false;
     empty.hidden = true;
     setStatus(`${buckets.length} ${granularityLabels[granularity] || granularity} buckets`, "good");

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -677,6 +677,11 @@ def test_console_activity_renders_usage_panel(
     assert "/console/activity/usage.json" in resp.text
     assert 'range: state.range' in resp.text
     assert 'by_model: "1"' in resp.text
+    assert 'const truncatedPrefix = data.truncated ? "≥" : "";' in resp.text
+    assert (
+        "Partial data — some rows were not scanned; narrow the range for an exact total"
+        in resp.text
+    )
     assert "Spend" in resp.text
     assert "Tokens" in resp.text
     assert "Requests" in resp.text


### PR DESCRIPTION
Findings 5+6 (+1 P3) from the 25-PR billing review. **Truncated usage totals now read as a lower bound** (`≥$412.18` + tooltip) instead of presenting a partial scan as exact; **runbook** no longer claims settle INFO lines are dropped (they ship to Axiom via the scoped package logger since #124); **jay grant-script docstring** corrected ($40→$10, right usage path — constants were always right).

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1360 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)