### PR TITLE
Settle outbox P3 sweep: single-source guard SQL; make the $0 reaper race loud

### DIFF
--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -48,6 +48,7 @@ _TRANSIENT_STORE_EXCS = (
 class ApplyOutcome:
     SETTLED_NOW = "settled_now"
     ALREADY_SETTLED_WITH_CHARGE = "already_settled_with_charge"
+    RESOLVED_ZERO_COST_ELSEWHERE = "resolved_zero_cost_elsewhere"
     # Legacy origin cannot disambiguate a charged replay from a refund/
     # failure-settle free release (legacy Reservation records no actual
     # amount). Increment 4: mark done; flag for low-priority review when a
@@ -248,16 +249,16 @@ def _apply_typed(
         if reservation is None:
             return ApplyOutcome.RESERVATION_MISSING
         actual_micro = int(reservation.get("actual_micro") or 0)
-        if actual_micro > 0 or row.actual_cost_micro == 0:
-            # Charged replay — or our own frozen cost is 0, in which case
-            # whatever resolved the hold produced a state identical to applying
-            # this row (booking 0 == booking nothing): nothing was lost, benign.
-            # Parity with the inline path's known post-commit index hole; the
-            # drain's retry-after-ambiguous-failure purpose makes it likelier.
+        if actual_micro > 0:
+            # Charged replay. Parity with the inline path's known post-commit
+            # index hole; the drain's retry-after-ambiguous-failure purpose
+            # makes it likelier.
             logger.info(
                 "drain replay of a charged settle; if the charge was committed by a finalize whose response was lost (park->retry), its Bigtable activity-index entry may be absent; repairable via reconcile_activity"
             )
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+        if row.actual_cost_micro == 0:
+            return ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE
         # Booked 0 while this row intended a real charge: the hold was resolved
         # WITHOUT our charge (reaper free-release, or a refund won the race).
         # For settle intent this is the §3 lost-charge signal; for refund intent

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -116,6 +116,21 @@ def _resolve_row(
             )
         return
 
+    if outcome == ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE:
+        outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
+        # Rare $0 race: money is correct and no alert is warranted, but this row
+        # did not write a Generation. reconcile_generation_activity can repair
+        # per-request records if needed; we intentionally avoid a bypass write
+        # primitive for this edge case.
+        logger.warning(
+            "settle outbox warning: settle intent found reservation already zero-resolved "
+            "authorization_id=%s reservation_id=%s likely reaper race; "
+            "no generation record was written by this row",
+            row.authorization_id,
+            row.reservation_id,
+        )
+        return
+
     if outcome == ApplyOutcome.ALREADY_SETTLED_LEGACY:
         outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
         if row.intent_kind == "settle" and outbox.get(row.authorization_id, "refund") is not None:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -38,7 +38,7 @@ from trusted_router.storage_gcp_counter_dml import (
     reserve_key,
 )
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
-from trusted_router.storage_gcp_settle_outbox import GUARD_COUNT_SQL
+from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
 
 
 class AuthorizeOutcome:
@@ -341,22 +341,21 @@ def _is_table_missing(exc: Exception) -> bool:
     )
 
 
-# Reaper scan, two forms. The guarded form excludes holds with a pending/dead
-# outbox row IN THE SCAN so frozen holds never consume @limit and cannot
+# Reaper scan, two forms. The guarded form excludes holds with an outbox row
+# whose status is in GUARD_STATUSES IN THE SCAN so frozen holds never consume @limit and cannot
 # starve unguarded expired holds behind them (PR #116 review P2). The NOT
 # EXISTS runs on a snapshot, so it is ADVISORY ONLY — the strong re-read
-# inside settle_atomic(guard_outbox=True) remains the MF2 interlock. Keep the
-# subquery predicates literally in sync with GUARD_COUNT_SQL / GUARD_STATUSES.
+# inside settle_atomic(guard_outbox=True) remains the MF2 interlock.
 _REAP_SCAN_SQL = (
     "SELECT reservation_id, authorization_id FROM tr_reservation "
     "WHERE settled=false AND expires_at < @now LIMIT @limit"
 )
 _REAP_SCAN_GUARDED_SQL = (
-    "SELECT reservation_id, authorization_id FROM tr_reservation "
+    "SELECT reservation_id, authorization_id FROM tr_reservation "  # noqa: S608
     "WHERE settled=false AND expires_at < @now "
     "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
     "WHERE o.authorization_id = tr_reservation.authorization_id "
-    "AND o.status IN ('pending', 'dead')) "
+    f"AND o.status IN ({_GUARD_STATUS_SQL})) "
     "LIMIT @limit"
 )
 
@@ -371,12 +370,12 @@ def reap_expired_reservations(
     reaper is safe — whoever claims the row first wins, the other no-ops.
 
     The outbox guard is live: advisory filtering happens in the scan SQL, so a
-    hold whose authorization has a pending/dead `tr_settle_outbox` row is
-    invisible to the scan and cannot starve later unguarded holds behind @limit
-    (PR #116 review P2). `settle_atomic(..., guard_outbox=True)` still does the
-    in-txn re-check; that strong read remains the MF2 interlock. `release_approved`
-    is the only human-set status that re-permits this free release. Returns the
-    count reaped.
+    hold whose authorization has a `tr_settle_outbox` row with status in
+    GUARD_STATUSES is invisible to the scan and cannot starve later unguarded
+    holds behind @limit (PR #116 review P2). `settle_atomic(..., guard_outbox=True)`
+    still does the in-txn re-check; that strong read remains the MF2 interlock.
+    `release_approved` is the only human-set status that re-permits this free
+    release. Returns the count reaped.
     """
     pt = param_types
     guard_active = True

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -49,16 +49,16 @@ OUTBOX_COLUMNS = [
 # `release_approved` is deliberately excluded: it is the human's explicit ok to
 # let the reaper free the hold. `done` means the charge already applied.
 GUARD_STATUSES = ("pending", "dead")
+_GUARD_STATUS_SQL = ", ".join(f"'{status}'" for status in GUARD_STATUSES)
 
 # The reaper-guard predicate. SINGLE SOURCE OF TRUTH for this SQL: it is
 # executed on a snapshot by has_intent (advisory pre-scan), on a snapshot by
 # the reaper's advisory skip, and INSIDE settle_atomic's read-write
-# transaction (the real interlock, MF2). The fake asserts both predicates
-# (`authorization_id=@aid`, `status IN ('pending', 'dead')`) — keep the
-# literal exactly in sync with GUARD_STATUSES.
+# transaction (the real interlock, MF2). Guard statuses come from
+# GUARD_STATUSES; update the tuple, not the SQL literals.
 GUARD_COUNT_SQL = (
-    "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "
-    "AND status IN ('pending', 'dead')"
+    "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "  # noqa: S608
+    f"AND status IN ({_GUARD_STATUS_SQL})"
 )
 
 # Enqueue outcomes.

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -6,7 +6,11 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from trusted_router.storage_gcp_settle_outbox import OUTBOX_COLUMNS
+from trusted_router.storage_gcp_settle_outbox import (
+    _GUARD_STATUS_SQL,
+    GUARD_STATUSES,
+    OUTBOX_COLUMNS,
+)
 
 
 class _ParamTypes:
@@ -687,13 +691,13 @@ def _execute_settle_outbox_sql(
         return [[rec.get(c) for c in OUTBOX_COLUMNS] for rec in rows[:limit]]
     if "SELECT COUNT(*) FROM tr_settle_outbox" in sql:  # reaper-guard predicate (has_intent)
         _require_pred(sql, "authorization_id=@aid", "has_intent")
-        _require_pred(sql, "status IN ('pending', 'dead')", "has_intent")
+        _require_pred(sql, f"status IN ({_GUARD_STATUS_SQL})", "has_intent")
         aid = p["aid"]
         # Committed-state read is correct for the in-txn guard too: enqueue
         # commits in its own txn, and the reaper txn never writes outbox rows.
         n = sum(
             1 for rec in db.settle_outbox.values()
-            if rec.get("authorization_id") == aid and rec.get("status") in ("pending", "dead")
+            if rec.get("authorization_id") == aid and rec.get("status") in GUARD_STATUSES
         )
         return [[n]]
     if "WHERE authorization_id=@aid AND intent_kind=@kind" in sql:  # get by PK
@@ -727,7 +731,7 @@ def _execute_sql(
                 "o.authorization_id = tr_reservation.authorization_id",
                 "reaper-scan-guard",
             )
-            _require_pred(sql, "o.status IN ('pending', 'dead')", "reaper-scan-guard")
+            _require_pred(sql, f"o.status IN ({_GUARD_STATUS_SQL})", "reaper-scan-guard")
         now = params["now"]
         limit = int(params.get("limit", 100))
         out: list[list] = []
@@ -742,7 +746,7 @@ def _execute_sql(
                 aid = rec.get("authorization_id")
                 if any(
                     row.get("authorization_id") == aid
-                    and row.get("status") in ("pending", "dead")
+                    and row.get("status") in GUARD_STATUSES
                     for row in db.settle_outbox.values()
                 ):
                     continue

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -243,7 +243,7 @@ def test_zero_cost_replay_is_benign(fake_store: tuple[Any, Any, Any]) -> None:
     row = _row(auth, cost=0)
 
     assert apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
-    assert apply_frozen_settle(row) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    assert apply_frozen_settle(row) == ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE
     assert _typed_credit(db, ws)["total_usage"] == 0
     assert len(_generation_bodies(db)) == 1
 

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -23,7 +23,7 @@ from trusted_router.storage_gcp_authorize import (
     reap_expired_reservations,
     settle_atomic,
 )
-from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_models import CreditAccount, GatewayAuthorization, SettleOutboxRow
 
@@ -79,6 +79,14 @@ def _make_key(store: Any, workspace_id: str, *, limit: int | None = TOTAL_CREDIT
 
 def _typed_credit(db: Any, workspace_id: str) -> dict[str, Any]:
     return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+
+
+def _typed_key(db: Any, key_hash: str) -> dict[str, Any]:
+    return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
+
+
+def _generation_count(db: Any) -> int:
+    return sum(1 for (kind, _entity_id) in db.rows if kind == "generation")
 
 
 def _typed_authorization(
@@ -592,6 +600,135 @@ def test_drain_reap_limit_respected(fake_store: tuple[Any, Any, Any]) -> None:
 
     again = drain_mod.drain_settle_outbox(10)
     assert again["reaped"] == 0
+
+
+def test_zero_cost_settle_reaper_race_resolves_done_with_warning(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, bt = fake_store
+    ws = "ws-drain-zero-reaper-race"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    freed = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=auth.credit_reservation_id,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+    )
+    assert freed["outcome"] == SettleOutcome.SETTLED
+    ob = _outbox(store)
+    ob.enqueue(_row(auth, cost=0))
+    credit_before = dict(_typed_credit(db, ws))
+    key_before = dict(_typed_key(db, key.hash))
+    assert _generation_count(db) == 0
+    caplog.set_level(logging.WARNING)
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1}
+    assert result["recovered_micro"] == 0
+    assert result["reaped"] == 0
+    assert ob.get(auth.id, "settle").status == "done"
+    assert _typed_credit(db, ws) == credit_before
+    assert _typed_key(db, key.hash) == key_before
+    assert _generation_count(db) == 0
+    assert bt.committed == []
+    messages = [rec.message for rec in caplog.records]
+    assert any(
+        "settle intent found reservation already zero-resolved" in msg
+        and f"authorization_id={auth.id}" in msg
+        and f"reservation_id={auth.credit_reservation_id}" in msg
+        and "likely reaper race" in msg
+        and "no generation record was written by this row" in msg
+        for msg in messages
+    )
+    assert not any("ALERT" in msg for msg in messages)
+
+
+def test_nonzero_settle_reaper_race_still_alerts_lost_charge(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-drain-nonzero-reaper-race"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    freed = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=auth.credit_reservation_id,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+    )
+    assert freed["outcome"] == SettleOutcome.SETTLED
+    ob = _outbox(store)
+    ob.enqueue(_row(auth, cost=777_777))
+    credit_before = dict(_typed_credit(db, ws))
+    key_before = dict(_typed_key(db, key.hash))
+    caplog.set_level(logging.WARNING)
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.ALREADY_RELEASED_FREE: 1}
+    assert result["recovered_micro"] == 0
+    assert result["reaped"] == 0
+    lost = ob.get(auth.id, "settle")
+    assert lost is not None
+    assert lost.status == "dead"
+    assert lost.last_error == "already_released_free: settle charge was lost"
+    assert _typed_credit(db, ws) == credit_before
+    assert _typed_key(db, key.hash) == key_before
+    assert any("ALERT settle outbox lost charge" in rec.message for rec in caplog.records)
+
+
+def test_duplicate_zero_cost_settle_replay_resolves_done_with_warning(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, bt = fake_store
+    ws = "ws-drain-zero-replay"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    row = _row(auth, cost=0)
+    ob = _outbox(store)
+    ob.enqueue(row)
+    assert apply_mod.apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
+    credit_before = dict(_typed_credit(db, ws))
+    key_before = dict(_typed_key(db, key.hash))
+    generation_count_before = _generation_count(db)
+    committed_before = list(bt.committed)
+    assert generation_count_before == 1
+    caplog.set_level(logging.WARNING)
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1}
+    assert result["recovered_micro"] == 0
+    assert result["reaped"] == 0
+    assert ob.get(auth.id, "settle").status == "done"
+    assert _typed_credit(db, ws) == credit_before
+    assert _typed_key(db, key.hash) == key_before
+    assert _generation_count(db) == generation_count_before
+    assert bt.committed == committed_before
+    messages = [rec.message for rec in caplog.records]
+    assert any(
+        "settle intent found reservation already zero-resolved" in msg
+        and f"authorization_id={auth.id}" in msg
+        and f"reservation_id={auth.credit_reservation_id}" in msg
+        and "no generation record was written by this row" in msg
+        for msg in messages
+    )
+    assert not any("ALERT" in msg for msg in messages)
 
 
 def test_lost_charge_recovery_end_to_end(

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -6,6 +6,7 @@ the outbox row builder style from test_settle_outbox_storage.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -26,7 +27,11 @@ from trusted_router.storage_gcp_authorize import (
     reap_expired_reservations,
     settle_atomic,
 )
-from trusted_router.storage_gcp_settle_outbox import GUARD_COUNT_SQL, SpannerSettleOutbox
+from trusted_router.storage_gcp_settle_outbox import (
+    GUARD_COUNT_SQL,
+    GUARD_STATUSES,
+    SpannerSettleOutbox,
+)
 from trusted_router.storage_models import SettleOutboxRow
 
 
@@ -104,6 +109,14 @@ def _assert_free_released(db: Any, ws: str, rid: str) -> None:
     assert _typed(db, ws)["total_usage"] == 0
     assert db.reservations[rid]["settled"] is True
     assert db.reservations[rid]["actual_micro"] == 0
+
+
+def test_guard_sql_literals_come_from_guard_statuses() -> None:
+    for sql in (GUARD_COUNT_SQL, _REAP_SCAN_GUARDED_SQL):
+        [fragment] = re.findall(r"\bstatus IN \(([^)]*)\)", sql)
+        quoted = re.findall(r"'([^']+)'", sql)
+        assert quoted == list(GUARD_STATUSES)
+        assert re.findall(r"'([^']+)'", fragment) == quoted
 
 
 def test_pending_row_freezes_hold() -> None:

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -12,6 +12,7 @@ import pytest
 
 from tests.fakes.spanner import _execute_settle_outbox_sql, _FakeTransaction, make_fake_store
 from trusted_router.storage_gcp_settle_outbox import (
+    _GUARD_STATUS_SQL,
     ENQ_EXISTS_TERMINAL,
     ENQ_INSERTED,
     ENQ_LEASED,
@@ -193,7 +194,7 @@ def test_fake_is_sql_sensitive_dropped_predicate_fails() -> None:
     with pytest.raises(AssertionError, match="has_intent"):
         _execute_settle_outbox_sql(
             db, None,
-            "SELECT COUNT(*) FROM tr_settle_outbox WHERE status IN ('pending', 'dead')",
+            f"SELECT COUNT(*) FROM tr_settle_outbox WHERE status IN ({_GUARD_STATUS_SQL})",  # noqa: S608
             {"aid": "gwa-12"},
         )
     # A claim query missing its `leased_until` lease fence must likewise FAIL.


### PR DESCRIPTION
The last two open findings from the 25-PR billing review (both P3):

1. **Guard SQL single-sourced** — `status IN ('pending', 'dead')` was hand-copied in 3 places; now derived from `GUARD_STATUSES` with a regression-lock test (asserts both SQL strings quote exactly the tuple, nothing else). Fake predicate assertions keep their strength against the derived fragment.
2. **$0 reaper race is loud** — new `RESOLVED_ZERO_COST_ELSEWHERE` outcome: resolves DONE (money correct on both paths; deliberately no alert, no new write primitive — `reconcile_generation_activity` covers record repair) but WARNs with authorization/reservation ids instead of silently collapsing into the benign bucket. Tests: reaper race, duplicate-$0 replay, nonzero control (still ALERTs).

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1364 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)