### PR TITLE
pricing: single-source request-rate resolution (kill the dual-cost-fn bug class)

### DIFF
--- a/src/trusted_router/pricing.py
+++ b/src/trusted_router/pricing.py
@@ -5,6 +5,9 @@ pricing, price-tier selection, and provider-manifest price parsing. Pure
 functions of the money primitives — NO dependency on the catalog data
 (PROVIDERS/MODELS) — so a pricing change is reviewable in isolation from the
 catalog. catalog.py re-exports these for backward compatibility.
+
+Request cost callers intentionally differ only in cache policy; tier selection
+and prompt/completion rate resolution must go through resolve_request_rates.
 """
 
 from __future__ import annotations
@@ -42,6 +45,15 @@ class PriceTier:
     completion_price_microdollars_per_million_tokens: int
     prompt_cached_price_microdollars_per_million_tokens: int | None = None
 
+
+@dataclass(frozen=True)
+class RequestRates:
+    prompt_price_microdollars_per_million_tokens: int
+    completion_price_microdollars_per_million_tokens: int
+    # Tier-declared cached-read rate; None when the selected tier declares none.
+    prompt_cached_price_microdollars_per_million_tokens: int | None
+
+
 def _flat_tier(
     prompt: int,
     completion: int,
@@ -73,6 +85,34 @@ def select_price_tier(tiers: tuple[PriceTier, ...], prompt_tokens: int) -> Price
     # Should be unreachable — the last tier always matches due to
     # max_prompt_tokens=None — but defend against malformed catalog data.
     return tiers[-1]
+
+
+def resolve_request_rates(
+    tiers: tuple[PriceTier, ...],
+    *,
+    headline_prompt_micro_per_m: int,
+    headline_completion_micro_per_m: int,
+    total_prompt_tokens: int,
+) -> RequestRates:
+    if tiers:
+        tier = select_price_tier(tiers, total_prompt_tokens)
+        return RequestRates(
+            prompt_price_microdollars_per_million_tokens=(
+                tier.prompt_price_microdollars_per_million_tokens
+            ),
+            completion_price_microdollars_per_million_tokens=(
+                tier.completion_price_microdollars_per_million_tokens
+            ),
+            prompt_cached_price_microdollars_per_million_tokens=(
+                tier.prompt_cached_price_microdollars_per_million_tokens
+            ),
+        )
+    return RequestRates(
+        prompt_price_microdollars_per_million_tokens=headline_prompt_micro_per_m,
+        completion_price_microdollars_per_million_tokens=headline_completion_micro_per_m,
+        prompt_cached_price_microdollars_per_million_tokens=None,
+    )
+
 
 class ModelPricingKwargs(TypedDict):
     prompt_price_microdollars_per_million_tokens: int

--- a/src/trusted_router/routes/helpers.py
+++ b/src/trusted_router/routes/helpers.py
@@ -5,13 +5,14 @@ from typing import Any
 
 from fastapi import Request
 
-from trusted_router.catalog import Model, select_price_tier
+from trusted_router.catalog import Model
 from trusted_router.errors import api_error
 from trusted_router.money import (
     dollars_to_microdollars,
     microdollars_to_float,
     token_cost_microdollars,
 )
+from trusted_router.pricing import resolve_request_rates
 
 
 async def json_body(request: Request) -> dict[str, Any]:
@@ -56,34 +57,37 @@ def cost_microdollars(
     cached_input_tokens = max(0, min(cached_input_tokens, input_tokens))
     uncached_input_tokens = input_tokens - cached_input_tokens
 
-    tiers = model.price_tiers
-    if tiers:
-        tier = select_price_tier(tiers, input_tokens)
-        cached_rate = (
-            tier.prompt_cached_price_microdollars_per_million_tokens
-            if tier.prompt_cached_price_microdollars_per_million_tokens is not None
-            else tier.prompt_price_microdollars_per_million_tokens
-        )
+    rates = resolve_request_rates(
+        model.price_tiers,
+        headline_prompt_micro_per_m=model.prompt_price_microdollars_per_million_tokens,
+        headline_completion_micro_per_m=model.completion_price_microdollars_per_million_tokens,
+        total_prompt_tokens=input_tokens,
+    )
+    if not model.price_tiers:
         return (
             token_cost_microdollars(
-                uncached_input_tokens,
-                tier.prompt_price_microdollars_per_million_tokens,
+                input_tokens,
+                rates.prompt_price_microdollars_per_million_tokens,
             )
-            + token_cost_microdollars(cached_input_tokens, cached_rate)
             + token_cost_microdollars(
                 output_tokens,
-                tier.completion_price_microdollars_per_million_tokens,
+                rates.completion_price_microdollars_per_million_tokens,
             )
         )
-    # Pre-tier flat-rate path. Cached tokens fall back to the same rate
-    # as uncached because there's no cached-rate field on Model.
+    cached_rate = (
+        rates.prompt_cached_price_microdollars_per_million_tokens
+        if rates.prompt_cached_price_microdollars_per_million_tokens is not None
+        else rates.prompt_price_microdollars_per_million_tokens
+    )
     return (
         token_cost_microdollars(
-            input_tokens, model.prompt_price_microdollars_per_million_tokens
+            uncached_input_tokens,
+            rates.prompt_price_microdollars_per_million_tokens,
         )
+        + token_cost_microdollars(cached_input_tokens, cached_rate)
         + token_cost_microdollars(
             output_tokens,
-            model.completion_price_microdollars_per_million_tokens,
+            rates.completion_price_microdollars_per_million_tokens,
         )
     )
 

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -35,7 +35,7 @@ from trusted_router.catalog import (
 from trusted_router.config import Settings
 from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import money_pair, token_cost_microdollars
-from trusted_router.pricing import select_price_tier
+from trusted_router.pricing import resolve_request_rates
 from trusted_router.provider_types import estimate_tokens_from_text
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.routes.internal._shared import require_internal_gateway
@@ -1078,20 +1078,21 @@ def _endpoint_cost_microdollars(
     """input_tokens must be the UNCACHED prompt tokens when cache counts
     are passed — cached reads/writes bill at the provider-specific
     multiple of the prompt price (see catalog.cache_token_prices_microdollars)."""
-    prompt_price = endpoint.prompt_price_microdollars_per_million_tokens
-    completion_price = endpoint.completion_price_microdollars_per_million_tokens
     total_prompt = input_tokens + cache_read_tokens + cache_creation_tokens
-    tiers = getattr(endpoint, "price_tiers", ()) or ()
-    if tiers:
-        tier = select_price_tier(tiers, total_prompt)
-        prompt_price = tier.prompt_price_microdollars_per_million_tokens
-        completion_price = tier.completion_price_microdollars_per_million_tokens
+    rates = resolve_request_rates(
+        getattr(endpoint, "price_tiers", ()) or (),
+        headline_prompt_micro_per_m=endpoint.prompt_price_microdollars_per_million_tokens,
+        headline_completion_micro_per_m=endpoint.completion_price_microdollars_per_million_tokens,
+        total_prompt_tokens=total_prompt,
+    )
+    prompt_price = rates.prompt_price_microdollars_per_million_tokens
 
     cost = token_cost_microdollars(input_tokens, prompt_price) + token_cost_microdollars(
         output_tokens,
-        completion_price,
+        rates.completion_price_microdollars_per_million_tokens,
     )
     if cache_read_tokens or cache_creation_tokens:
+        # Endpoint path prices cache via provider multipliers; the tier cached rate is the model-level path's policy.
         read_price, write_price = cache_token_prices_microdollars(
             endpoint.provider, prompt_price
         )

--- a/tests/test_catalog_cost_parity.py
+++ b/tests/test_catalog_cost_parity.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from trusted_router.catalog import MODELS, Model, ModelEndpoint, endpoints_for_model
+from trusted_router.routes.helpers import cost_microdollars
+from trusted_router.routes.internal.gateway import _endpoint_cost_microdollars
+
+
+def _aligned_credit_endpoints() -> list[tuple[Model, ModelEndpoint]]:
+    aligned: list[tuple[Model, ModelEndpoint]] = []
+    for model in MODELS.values():
+        if not model.supports_chat:
+            continue
+        for endpoint in endpoints_for_model(model.id):
+            if endpoint.usage_type != "Credits":
+                continue
+            if (
+                endpoint.prompt_price_microdollars_per_million_tokens
+                != model.prompt_price_microdollars_per_million_tokens
+            ):
+                continue
+            if (
+                endpoint.completion_price_microdollars_per_million_tokens
+                != model.completion_price_microdollars_per_million_tokens
+            ):
+                continue
+            if endpoint.price_tiers != model.price_tiers:
+                continue
+            aligned.append((model, endpoint))
+    return aligned
+
+
+def test_aligned_credit_endpoint_costs_match_model_helper_no_cache() -> None:
+    aligned = _aligned_credit_endpoints()
+    multi_tier_model_ids = {
+        model.id for model, _endpoint in aligned if len(model.price_tiers) > 1
+    }
+
+    assert aligned
+    assert multi_tier_model_ids
+
+    for model, endpoint in aligned:
+        for prompt_tokens in (1_000, 100_000, 300_000):
+            assert _endpoint_cost_microdollars(
+                endpoint,
+                prompt_tokens,
+                2_000,
+            ) == cost_microdollars(
+                model,
+                prompt_tokens,
+                2_000,
+            )

--- a/tests/test_pricing_tiers.py
+++ b/tests/test_pricing_tiers.py
@@ -13,6 +13,7 @@ from trusted_router.catalog import (
     PriceTier,
     select_price_tier,
 )
+from trusted_router.pricing import RequestRates, resolve_request_rates
 from trusted_router.routes.helpers import cost_microdollars
 
 # ----------------------------------------------------------------------
@@ -70,6 +71,85 @@ def test_select_price_tier_handles_single_uncapped_tier() -> None:
     for size in [0, 1_000, 1_000_000_000]:
         tier = select_price_tier(tiers, prompt_tokens=size)
         assert tier.max_prompt_tokens is None
+
+
+# ----------------------------------------------------------------------
+# resolve_request_rates — shared request-rate primitive
+# ----------------------------------------------------------------------
+
+
+def test_resolve_request_rates_empty_tiers_uses_headline_rates() -> None:
+    assert resolve_request_rates(
+        (),
+        headline_prompt_micro_per_m=123,
+        headline_completion_micro_per_m=456,
+        total_prompt_tokens=10_000,
+    ) == RequestRates(
+        prompt_price_microdollars_per_million_tokens=123,
+        completion_price_microdollars_per_million_tokens=456,
+        prompt_cached_price_microdollars_per_million_tokens=None,
+    )
+
+
+def test_resolve_request_rates_single_tier() -> None:
+    rates = resolve_request_rates(
+        (
+            PriceTier(
+                max_prompt_tokens=None,
+                prompt_price_microdollars_per_million_tokens=1_000_000,
+                completion_price_microdollars_per_million_tokens=2_000_000,
+                prompt_cached_price_microdollars_per_million_tokens=100_000,
+            ),
+        ),
+        headline_prompt_micro_per_m=123,
+        headline_completion_micro_per_m=456,
+        total_prompt_tokens=999_999,
+    )
+
+    assert rates == RequestRates(
+        prompt_price_microdollars_per_million_tokens=1_000_000,
+        completion_price_microdollars_per_million_tokens=2_000_000,
+        prompt_cached_price_microdollars_per_million_tokens=100_000,
+    )
+
+
+def test_resolve_request_rates_multi_tier_below_threshold() -> None:
+    assert resolve_request_rates(
+        _gemini_pro_tiers(),
+        headline_prompt_micro_per_m=123,
+        headline_completion_micro_per_m=456,
+        total_prompt_tokens=199_999,
+    ) == RequestRates(
+        prompt_price_microdollars_per_million_tokens=1_375_000,
+        completion_price_microdollars_per_million_tokens=11_000_000,
+        prompt_cached_price_microdollars_per_million_tokens=None,
+    )
+
+
+def test_resolve_request_rates_multi_tier_at_inclusive_threshold() -> None:
+    assert resolve_request_rates(
+        _gemini_pro_tiers(),
+        headline_prompt_micro_per_m=123,
+        headline_completion_micro_per_m=456,
+        total_prompt_tokens=200_000,
+    ) == RequestRates(
+        prompt_price_microdollars_per_million_tokens=1_375_000,
+        completion_price_microdollars_per_million_tokens=11_000_000,
+        prompt_cached_price_microdollars_per_million_tokens=None,
+    )
+
+
+def test_resolve_request_rates_multi_tier_above_threshold() -> None:
+    assert resolve_request_rates(
+        _gemini_pro_tiers(),
+        headline_prompt_micro_per_m=123,
+        headline_completion_micro_per_m=456,
+        total_prompt_tokens=200_001,
+    ) == RequestRates(
+        prompt_price_microdollars_per_million_tokens=2_750_000,
+        completion_price_microdollars_per_million_tokens=16_500_000,
+        prompt_cached_price_microdollars_per_million_tokens=None,
+    )
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Simplification 1 of 2 from the billing review retro. `resolve_request_rates()` in pricing.py is now the only place tier selection feeds billing; both cost functions delegate to it and keep only their documented cache policies. Outputs byte-identical (all existing tests unchanged). **Permanent guard**: catalog-wide parity test over every aligned model↔endpoint Credits pair at 1k/100k/300k prompts, with non-vacuousness asserts — the #140 bug class can't silently reopen.

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1376 passed** (+12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)