### PR TITLE
billing: free holds stranded by api-key deletion (reaper jam)

### DIFF
--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -20,6 +20,7 @@ debit. Replay is resume/no-execute: the caller must NOT re-run the LLM call
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -39,6 +40,8 @@ from trusted_router.storage_gcp_counter_dml import (
 )
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
+
+log = logging.getLogger(__name__)
 
 
 class AuthorizeOutcome:
@@ -243,6 +246,54 @@ class _SettleError(Exception):
     reservation claimed with the hold unreleased / charge unbooked)."""
 
 
+def _release_key_or_skip_deleted(
+    transaction: Any,
+    param_types: Any,
+    res: dict[str, Any],
+    actual_micro: int,
+    *,
+    book_to_byok: bool,
+) -> tuple[int, dict[str, Any] | None]:
+    """Shared key-release classification for settle, reaper, and drain paths.
+
+    `release_key` deliberately returns the raw UPDATE count. A 0 count is
+    ambiguous only here, after the reservation has been claimed: the key row may
+    have been deleted, or the `reserved >= hold` corruption guard may have fired.
+    Missing row is a committed-success warning; present row keeps the loud
+    row-count failure path.
+    """
+    from trusted_router.storage_gcp_counter_dml import key_limit_exists, release_key
+
+    key_hash = str(res["key_hash"])
+    key_hold = int(res["key_reserved_micro"])
+    key_shard = int(res.get("key_shard", 0) or 0)
+    count = release_key(
+        transaction,
+        param_types,
+        key_hash,
+        key_hold,
+        int(actual_micro),
+        book_to_byok=book_to_byok,
+        window_floors=window_floors(utcnow()),
+        shard=key_shard,
+    )
+    if count == 1:
+        return count, None
+    if key_limit_exists(transaction, param_types, key_hash, shard=key_shard):
+        return count, None
+    return 1, {"key_hash": key_hash, "hold_micro": key_hold}
+
+
+def _log_missing_key_releases(result: dict[str, Any]) -> None:
+    warnings = result.pop("missing_key_releases", ())
+    for warning in warnings:
+        log.warning(
+            "skipped key release for missing tr_key_limit row key_hash=%s hold_micro=%s",
+            warning["key_hash"],
+            warning["hold_micro"],
+        )
+
+
 def settle_atomic(
     database: Any,
     param_types: Any,
@@ -265,7 +316,6 @@ def settle_atomic(
         claim_reservation,
         read_reservation,
         release_credit,
-        release_key,
     )
 
     pt = param_types
@@ -299,10 +349,12 @@ def settle_atomic(
 
         # key first, then credit (single lock order everywhere — codex#2 #2).
         key_actual = book_actual  # key usage counts under both Credits and BYOK
-        key_count = release_key(
-            transaction, pt, res["key_hash"], res["key_reserved_micro"],
-            key_actual, book_to_byok=book_to_byok, window_floors=window_floors(utcnow()),
+        missing_key_releases = []
+        key_count, warning = _release_key_or_skip_deleted(
+            transaction, pt, res, key_actual, book_to_byok=book_to_byok
         )
+        if warning is not None:
+            missing_key_releases.append(warning)
         # A recorded hold MUST release; an uncapped/no-hold row (key_reserved==0)
         # may 0-row and is tolerated (best-effort usage tracking).
         if res["key_reserved_micro"] > 0 and key_count != 1:
@@ -316,10 +368,15 @@ def settle_atomic(
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
-        return {"outcome": SettleOutcome.SETTLED}
+        return {
+            "outcome": SettleOutcome.SETTLED,
+            "missing_key_releases": missing_key_releases,
+        }
 
     try:
-        return run_in_transaction_with_retry(database, txn)
+        result = run_in_transaction_with_retry(database, txn)
+        _log_missing_key_releases(result)
+        return result
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
 
@@ -448,7 +505,6 @@ def typed_finalize_atomic(
         insert_entity_dml_at,
         read_reservation,
         release_credit,
-        release_key,
         update_entity_body_dml,
     )
 
@@ -468,10 +524,12 @@ def typed_finalize_atomic(
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}
 
-        key_count = release_key(
-            transaction, pt, res["key_hash"], res["key_reserved_micro"],
-            book_actual, book_to_byok=book_to_byok, window_floors=window_floors(utcnow()),
+        missing_key_releases = []
+        key_count, warning = _release_key_or_skip_deleted(
+            transaction, pt, res, book_actual, book_to_byok=book_to_byok
         )
+        if warning is not None:
+            missing_key_releases.append(warning)
         if res["key_reserved_micro"] > 0 and key_count != 1:
             raise _SettleError("key release row-count != 1")
 
@@ -494,12 +552,16 @@ def typed_finalize_atomic(
         )
         if marked != 1:
             raise _SettleError("gateway_authorization update row-count != 1")
-        return {"outcome": SettleOutcome.SETTLED}
+        return {
+            "outcome": SettleOutcome.SETTLED,
+            "missing_key_releases": missing_key_releases,
+        }
 
     try:
         attempts_box: list[int] = []
         result = run_in_transaction_with_retry(database, txn, attempts_out=attempts_box)
         result["attempts"] = attempts_box[0] if attempts_box else 1
+        _log_missing_key_releases(result)
         return result
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -226,6 +226,24 @@ def release_key(
     )
 
 
+def key_limit_exists(
+    transaction: Any,
+    param_types: Any,
+    key_hash: str,
+    *,
+    shard: int = UNSHARDED,
+) -> bool:
+    """Classify a 0-row key release inside the same read-write transaction."""
+    rows = list(
+        transaction.execute_sql(
+            "SELECT 1 FROM tr_key_limit WHERE key_hash=@kh AND shard=@shard",
+            params={"kh": key_hash, "shard": shard},
+            param_types={"kh": param_types.STRING, "shard": param_types.INT64},
+        )
+    )
+    return bool(rows)
+
+
 # ── tr_reservation: durable hold record + scoped idempotency + settle claim ──
 # The reservation row records the EXACT holds taken at authorize (so settle
 # releases exactly those, codex#1 #5), the resolved usage types (hold vs settled,

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -21,6 +21,7 @@ from tests.fakes.spanner import make_fake_store
 from trusted_router.spend_windows import utcnow, window_floors
 from trusted_router.storage import CreditAccount
 from trusted_router.storage_gcp_counter_dml import release_credit, reserve_credit
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.storage_models import Generation
 
@@ -830,6 +831,125 @@ def _typed_finalize(store, *, rid, aid, actual, settled_ut="Credits", success=Tr
         actual_micro=actual, settled_usage_type=settled_ut, now=_TS,
         auth_body_settled=auth_settled, generation_writes=writes,
     )
+
+
+def _missing_key_release_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == "trusted_router.storage_gcp_authorize"
+        and "missing tr_key_limit row" in record.getMessage()
+    ]
+
+
+def test_reaper_reclaims_hold_after_api_key_deletion(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_reap_deleted_key"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    assert auth["outcome"] == AuthorizeOutcome.ACCEPTED
+
+    assert store.api_keys.delete(key.hash) is True
+    assert (key.hash, 0) not in db.typed.get(_KLT, {})
+    before = audit_typed_invariants(store)
+    assert not before.clean
+    assert before.samples[f"api_key-orphan-hold:{key.hash}:0"] == {
+        "typed_reserved": None,
+        "open_holds": 1_000_000,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="trusted_router.storage_gcp_authorize"):
+        reaped = reap_expired_reservations(store._database, store._param_types, now=_NOW)
+
+    assert reaped == 1
+    assert db.reservations[auth["reservation_id"]]["settled"] is True
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 0
+    assert (key.hash, 0) not in db.typed.get(_KLT, {})
+    warnings = _missing_key_release_warnings(caplog)
+    assert len(warnings) == 1
+    assert key.hash in warnings[0].getMessage()
+    assert "hold_micro=1000000" in warnings[0].getMessage()
+    assert audit_typed_invariants(store).clean
+
+
+def test_typed_finalize_charges_credit_after_api_key_deletion(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_finalize_deleted_key"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    assert store.api_keys.delete(key.hash) is True
+
+    with caplog.at_level(logging.WARNING, logger="trusted_router.storage_gcp_authorize"):
+        result = _typed_finalize(store, rid=rid, aid=aid, actual=900_000)
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 900_000
+    assert (key.hash, 0) not in db.typed.get(_KLT, {})
+    assert ("generation", f"gen-{rid}") in db.rows
+    assert _json.loads(db.rows[("gateway_authorization", aid)].body)["settled"] is True
+    warnings = _missing_key_release_warnings(caplog)
+    assert len(warnings) == 1
+    assert key.hash in warnings[0].getMessage()
+    assert "hold_micro=1000000" in warnings[0].getMessage()
+
+
+def test_key_release_guard_failure_stays_loud(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_key_guard_loud"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+    rid = auth["reservation_id"]
+    db.typed[_KLT][(key.hash, 0)]["reserved"] = 500_000
+
+    with caplog.at_level(logging.WARNING, logger="trusted_router.storage_gcp_authorize"):
+        result = _settle(store, rid=rid, actual=900_000)
+
+    assert result["outcome"] == SettleOutcome.ERROR
+    assert db.reservations[rid]["settled"] is False
+    assert _typed(db, ws)["reserved"] == 1_000_000
+    assert db.typed[_KLT][(key.hash, 0)]["reserved"] == 500_000
+    assert _missing_key_release_warnings(caplog) == []
+
+
+def test_normal_key_release_row_count_one_path_does_not_probe_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from trusted_router import storage_gcp_counter_dml
+
+    def fail_if_called(*_args, **_kwargs) -> bool:
+        raise AssertionError("row-count 1 release must not run the missing-row probe")
+
+    monkeypatch.setattr(storage_gcp_counter_dml, "key_limit_exists", fail_if_called)
+    store, db, _ = make_fake_store()
+    ws = "ws_key_release_regression"
+    _seed_credit(store, ws, 5_000_000)
+    key = _make_key(store, ws, limit=5_000_000)
+    auth = _authorize(store, ws=ws, key_hash=key.hash, estimate=1_000_000)
+
+    with caplog.at_level(logging.WARNING, logger="trusted_router.storage_gcp_authorize"):
+        result = _settle(store, rid=auth["reservation_id"], actual=900_000)
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert _typed(db, ws)["reserved"] == 0
+    assert _typed(db, ws)["total_usage"] == 900_000
+    krow = db.typed[_KLT][(key.hash, 0)]
+    assert krow["reserved"] == 0
+    assert krow["usage"] == 900_000
+    assert krow["byok_usage"] == 0
+    assert _missing_key_release_warnings(caplog) == []
 
 
 def test_typed_finalize_full_success() -> None:


### PR DESCRIPTION
Found while executing the ledger-retirement plan: the prod invariant audit flagged `api_key-orphan-hold` — alex@fralex.art deleted his benchmark key with 18 open holds (2026-06-25); the tr_key_limit row went with it, and the reaper has failed to free them for 14 days (~$0.05 reserved forever) because release_key's row-count-0 is ambiguous between missing-row and the corruption guard.

Fix: in-txn existence probe disambiguates — missing row = skip key-side release with a WARNING (credit release + claim proceed); present row = guard stays loud. Shared by reaper, finalize, and drain paths; warnings logged post-commit (retry-safe). Tests reproduce the prod incident exactly, through to a clean audit.

After deploy, the next reaper tick should free the 18 prod holds — will verify empirically.

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1389 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)