### PR TITLE
B1: display/API money reads use the live typed book (+ design-doc facts)

### DIFF
--- a/docs/design/retire-json-credit-ledger.md
+++ b/docs/design/retire-json-credit-ledger.md
@@ -6,14 +6,15 @@ resolution — shipped separately (#144).
 
 ## Verified current state (2026-07-10)
 
-- `scripts/deploy/rollout.sh` sets `TR_TYPED_COUNTER_MIRROR=1` and does **not** set
-  `TR_TYPED_BILLING_WORKSPACE_IDS` (config default `""`). Prod is therefore
-  **mirror-on, enforcement-legacy for every workspace**: the JSON `credit` entity is the
-  authoritative money book everywhere; typed `tr_credit_balance` rows carry a mirrored
-  `total_credits` and zero/unseeded `reserved`/`total_usage`.
-  - Checklist item before Phase A: confirm the SERVING revision's env agrees (bare env
-    edits don't survive here — traffic is pinned to named revisions; see the settle-outbox
-    rollout learnings in docs/runbook.md).
+- Prod has run with `TR_TYPED_BILLING_WORKSPACE_IDS=*` since 2026-06-26 via #88:
+  every workspace enforces against the typed book. That followed the #87 canary batch
+  and the #78 incident-revert recovery.
+  - The earlier "enforcement-legacy everywhere" finding was a verification error: a
+    truncated grep stopped in the mirror comment block and hid the live rollout.sh env
+    assignment around line 155.
+  - Keep checking the SERVING revision's env during rollouts (bare env edits don't
+    survive here — traffic is pinned to named revisions; see the settle-outbox rollout
+    learnings in docs/runbook.md).
 - Ownership split (2026-06-25 incident fallout) is already in code: the mirror writes
   ONLY `total_credits` (+ key config), never `reserved`/`total_usage`.
 - Full inventory of every reader/writer of both books, the mirror, and the repair
@@ -24,8 +25,9 @@ resolution — shipped separately (#144).
 Two books for the same money is the single biggest standing complexity in billing:
 per-column ownership rules, a mirror that must fire on every JSON write, documented
 "stale-low by design" fields, `backsync`/`backfill`/`compare`/`repair` operator tooling,
-and an ordering invariant that only holds within a process lifetime. All of it exists to
-support a migration that is 40% complete. Finishing the migration deletes the machinery.
+and an ordering invariant that only holds within a process lifetime. All of it now exists
+to support a migration whose enforcement cutover is complete but whose legacy book remains
+for rollback. Finishing the migration deletes the machinery.
 
 ## End state
 
@@ -39,11 +41,15 @@ support a migration that is 40% complete. Finishing the migration deletes the ma
   (`mirror_write`/`mirror_delete`), `backsync_typed_to_json`, `backfill`, `compare`,
   and their tests. `repair_typed_reserved` + `audit_typed_invariants` REMAIN (they audit
   the surviving book).
-- Console/display and `signup()` read `typed_credit_snapshot`.
+- Money display/API reads use the live typed snapshot; `signup()`'s trial-credit report
+  follows the surviving credit book once JSON money fields are deleted.
 
 ## Phases
 
-### Phase A — finish the enforcement cutover (operational; Joseph gates each ramp)
+### Phase A — finish the enforcement cutover (historical)
+Phase A was completed before this design was written; this section is retained for the
+historical record.
+
 A1. Flip tooling: a batch script wrapping the existing per-workspace runbook
     (`billing_paused` → drain to zero open holds → `reconcile_for_flip(apply=True)` →
     add to allowlist → unpause), plus a dry-run mode that reports per-workspace
@@ -60,10 +66,11 @@ Rollback story: per-workspace `pause → drain → backsync_typed_to_json → re
 allowlist → unpause` — the existing, tested runbook. This is why Phase A deletes nothing.
 
 ### Phase B — move the remaining JSON-money surfaces (code; one PR per step)
-B1. Reads: `signup()` trial-credit report, console credits/billing display, AND the MCP
-    `credits-get` tool (routes/mcp.py:172-187 — reads JSON total_credits/total_usage/
-    reserved/available; found in adversarial review) → `typed_credit_snapshot`. (Safe
-    once the workspace is typed; during the ramp, gate on membership like the routes do.)
+B1. Reads: console credits/billing display and the MCP `credits-get` tool
+    (routes/mcp.py:172-187 — reads JSON total_credits/total_usage/reserved/available;
+    found in adversarial review) → live typed snapshot with JSON/memory fallback.
+    `signup()`'s trial-credit report remains fine because JSON `total_credits` is still
+    the fresh mirrored field.
 B2. Writes: `credit_workspace_once`, stripe settlement, auto-refill outcome → typed
     `total_credits` becomes AUTHORITATIVE (idempotency event + typed write in one txn),
     but the JSON `total_credits` field is STILL written in the same txn ("kept warm").
@@ -105,9 +112,9 @@ C3. Runbook rewrite: single-book operations; keep `repair_typed_reserved` +
 - No auto-refill/stripe metadata redesign — those fields just stay JSON metadata.
 
 ## Appendix: inventory (2026-07-10; v2 additions from adversarial review marked ⊕)
-JSON readers: get_credit_account (storage_gcp.py:391) ← signup (280), console billing,
-grants verification, ⊕ MCP credits-get (routes/mcp.py:172-187),
-⊕ legacy authorize availability read (storage_gcp_keys.py:278-286).
+JSON readers: get_credit_account (storage_gcp.py:391) ← signup (280), grants
+verification, ⊕ legacy authorize availability read (storage_gcp_keys.py:278-286).
+B1 moved console billing and MCP credits-get to `live_credit_summary`.
 ⊕ JSON money writer missed in v1: SpannerApiKeys.reserve (storage_gcp_keys.py:278-295,
 called from the fallback authorize at routes/internal/gateway.py:343-351) — increments
 CreditAccount.reserved_microdollars on the legacy path; scheduled for deletion in C1. JSON writers (all mirror-firing via _write_entity_tx/batch):
@@ -128,43 +135,20 @@ Legend: [J] = Joseph's explicit go required · [C] = Claude runs autonomously (S
 · every mutating tool step uses `--apply` after a dry-run.
 
 - [x] Design merged (#145, v2 hardened after adversarial review)
-- [ ] A1 flip tool merged (#146)
-
-### A2 — canary
-1. [C] `PYTHONPATH=src uv run python scripts/typed_flip.py readiness --all`
-   (read-only) → report + canary candidates (low-traffic, verdict READY).
-2. [J] Pick the canary workspace(s).
-3. [C] `typed_flip.py prepare --workspace <id> --apply` → workspace parked PAUSED
-   (pause → drain → seed → verify). Exit 2 = still draining; re-run later.
-4. [J] THE FLIP: one-line rollout.sh edit adding the id to
-   TR_TYPED_BILLING_WORKSPACE_IDS → merge (deploy runs) → verify the SERVING
-   revision env carries it (bare env edits do not survive; traffic is
-   revision-pinned).
-5. [C] `typed_flip.py finish --workspace <id> --allowlist-deployed --apply` →
-   unpaused, typed-enforced.
-6. Bake 3-7 days: daily `audit_typed_invariants` + compare() drift + the
-   "release row-count != 1" alert. Any violation → rollback path below.
-
-### A3 / A4 — ramp
-7. Repeat 1-6 for cohorts (~10% → ~50% → all), audits clean between batches. [J]
-   gates each cohort.
-8. [J] A4: set TR_TYPED_BILLING_WORKSPACE_IDS=* in rollout.sh (config-as-code);
-   covers new signups from then on.
-
-### Phase B (each step: codex writes, Claude reviews, PR, CI, merge)
-9. B1 reads → typed_credit_snapshot, gated on allowlist membership during the
-   ramp: signup() trial report, console credits/billing, MCP credits-get.
-10. B2 writes: typed total_credits authoritative; JSON total_credits KEPT WARM
-    in the same txn (rollback safety — backsync never copies total_credits).
-11. B3 grant scripts verify against the typed snapshot.
-
-### Phase C (only after 100% flipped + 2 weeks clean audits) [J] go required
-12. C1 delete: legacy finalize, _require_credit_tx, SpannerApiKeys.reserve +
-    its gateway call site, and B2's warm-keeping write.
-13. C2 delete: mirror, backsync, backfill, compare; slim CreditAccount to
-    non-money metadata; memory-twin + test updates.
-14. C3 runbook rewrite (single book; keep repair_typed_reserved +
-    audit_typed_invariants as standing tripwires).
+- [x] A1 flip tool merged (#146)
+- [x] A2-A4 enforcement rollout completed historically: #67 synthetic canary →
+  #78 revert → #87 canary batch → #88 universal `TR_TYPED_BILLING_WORKSPACE_IDS=*`
+- [x] Orphan-hold reaper fix (#148)
+- [ ] B1 reads: live typed money snapshot for console credits/billing and MCP
+  `credits-get` (this PR)
+- [ ] B2 keep-warm writes: typed `total_credits` authoritative with JSON
+  `total_credits` still written in the same txn for rollback safety
+- [ ] B3 grant-script verification against the typed snapshot
+- [ ] Daily invariant audit scheduling
+- [ ] Stale legacy-hold cleanup for workspace `ea7dd3d8` (JSON reserved=29373,
+  3 open legacy reservations; display-only impact, fold into Phase C or a small cleanup)
+- [ ] Phase C deletions after 2 weeks of clean audits from 2026-07-10, the first
+  clean-audit day once #148 frees the orphan holds
 
 ### Rollback (any point through B)
 `typed_flip.py rollback --workspace <id> --apply` → allowlist-REMOVAL deploy →

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -29,7 +29,7 @@ from trusted_router.services.x402_billing import (
     x402_payment_required_response_body,
 )
 from trusted_router.storage import STORE
-from trusted_router.typed_balance import typed_aware_credit_account
+from trusted_router.typed_balance import live_credit_summary
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
@@ -37,23 +37,16 @@ log = logging.getLogger(__name__)
 
 def register_billing_routes(router: APIRouter) -> None:
     @router.get("/credits")
-    async def credits(
-        principal: ManagementPrincipal, settings: SettingsDep
-    ) -> dict[str, dict[str, Any]]:
-        account = typed_aware_credit_account(STORE, principal.workspace.id, settings=settings)
-        if account is None:
+    async def credits(principal: ManagementPrincipal) -> dict[str, dict[str, Any]]:
+        summary = live_credit_summary(principal.workspace.id)
+        if summary is None:
             raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
-        available_microdollars = (
-            account.total_credits_microdollars
-            - account.total_usage_microdollars
-            - account.reserved_microdollars
-        )
         return {
             "data": {
-                **money_pair("total_credits", account.total_credits_microdollars),
-                **money_pair("total_usage", account.total_usage_microdollars),
-                **money_pair("reserved", account.reserved_microdollars),
-                **money_pair("available", available_microdollars),
+                **money_pair("total_credits", summary["total_credits"]),
+                **money_pair("total_usage", summary["total_usage"]),
+                **money_pair("reserved", summary["reserved"]),
+                **money_pair("available", summary["available"]),
             }
         }
 

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -29,13 +29,14 @@ from trusted_router.services.stripe_billing import (
     remove_saved_payment_method,
 )
 from trusted_router.storage import STORE
-from trusted_router.typed_balance import typed_aware_credit_account
+from trusted_router.typed_balance import live_credit_summary
 
 
 def register(app: FastAPI) -> None:
     @app.get("/console/credits")
     async def console_credits(ctx: ConsoleDep, settings: SettingsDep) -> Response:
-        credit = typed_aware_credit_account(STORE, ctx.workspace.id, settings=settings)
+        credit = STORE.get_credit_account(ctx.workspace.id)
+        summary = live_credit_summary(ctx.workspace.id)
         # Pull the last 20 Stripe checkout sessions tagged with this
         # workspace_id from Stripe's Search API. Returns [] if Stripe is
         # unreachable / not configured / there are no payments yet — all
@@ -60,11 +61,8 @@ def register(app: FastAPI) -> None:
             active="credits",
             page_title="Credits",
             page_subtitle="Top up to keep prepaid routes flowing.",
-            credits_available=money(
-                (credit.total_credits_microdollars - credit.total_usage_microdollars - credit.reserved_microdollars)
-                if credit else 0
-            ),
-            credits_usage=money(credit.total_usage_microdollars if credit else 0),
+            credits_available=money(summary["available"] if summary else 0),
+            credits_usage=money(summary["total_usage"] if summary else 0),
             auto_refill_enabled=credit.auto_refill_enabled if credit else False,
             auto_refill_threshold_dollars=(
                 credit.auto_refill_threshold_microdollars // 1_000_000 if credit and credit.auto_refill_threshold_microdollars else 10

--- a/src/trusted_router/routes/mcp.py
+++ b/src/trusted_router/routes/mcp.py
@@ -18,6 +18,7 @@ from trusted_router.catalog import (
 from trusted_router.config import Settings
 from trusted_router.dashboard import docs_llms_full_txt
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
 
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MAX_MCP_CHAT_TOKENS = 512
@@ -169,22 +170,17 @@ class TrustedRouterMCP:
         api_key = STORE.get_key_by_raw(bearer)
         if api_key is None or api_key.disabled:
             raise MCPToolError("Invalid TrustedRouter API key")
-        account = STORE.get_credit_account(api_key.workspace_id)
-        if account is None:
+        summary = live_credit_summary(api_key.workspace_id)
+        if summary is None:
             raise MCPToolError("No credit account found for this workspace")
-        available = (
-            account.total_credits_microdollars
-            - account.total_usage_microdollars
-            - account.reserved_microdollars
-        )
         return _tool_json(
             {
                 "data": {
                     "workspace_id": api_key.workspace_id,
-                    "total_credits_microdollars": account.total_credits_microdollars,
-                    "total_usage_microdollars": account.total_usage_microdollars,
-                    "reserved_microdollars": account.reserved_microdollars,
-                    "available_microdollars": available,
+                    "total_credits_microdollars": summary["total_credits"],
+                    "total_usage_microdollars": summary["total_usage"],
+                    "reserved_microdollars": summary["reserved"],
+                    "available_microdollars": summary["available"],
                 }
             }
         )

--- a/src/trusted_router/typed_balance.py
+++ b/src/trusted_router/typed_balance.py
@@ -20,11 +20,18 @@ Routing decision = the same cohort gate the authorize path uses
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, TypedDict
 
-from trusted_router.storage import typed_billing_store
+from trusted_router.storage import STORE, typed_billing_store
 from trusted_router.storage_gcp_authorize import typed_billing_enabled_for_workspace
 from trusted_router.storage_models import CreditAccount
+
+
+class LiveCreditSummary(TypedDict):
+    total_credits: int
+    total_usage: int
+    reserved: int
+    available: int
 
 
 def _typed_enabled(workspace_id: str, settings: Any) -> bool:
@@ -63,6 +70,44 @@ def typed_aware_credit_account(
         total_usage_microdollars=int(typed[1]),
         reserved_microdollars=int(typed[2]),
     )
+
+
+def live_credit_summary(
+    workspace_id: str,
+    *,
+    store: Any | None = None,
+) -> LiveCreditSummary | None:
+    """Return the live money counters for display/API reads.
+
+    A typed counter row wins whenever it exists. Workspaces without a typed row
+    yet, plus the in-memory single-book store, fall back to the JSON
+    CreditAccount. Non-money JSON metadata remains the caller's responsibility.
+    """
+    active_store = STORE if store is None else store
+    typed_store = typed_billing_store(active_store)
+    if typed_store is not None:
+        typed = typed_store.typed_credit_snapshot(workspace_id)
+        if typed is not None:
+            return _summary(int(typed[0]), int(typed[1]), int(typed[2]))
+
+    account = active_store.get_credit_account(workspace_id)
+    if account is None:
+        return None
+    return _summary(
+        account.total_credits_microdollars,
+        account.total_usage_microdollars,
+        account.reserved_microdollars,
+    )
+
+
+def _summary(total_credits: int, total_usage: int, reserved: int) -> LiveCreditSummary:
+    return {
+        "total_credits": total_credits,
+        "total_usage": total_usage,
+        "reserved": reserved,
+        "available": max(0, total_credits - total_usage - reserved),
+    }
+
 
 # NOTE: the key-usage/remaining display overlay (typed_aware_key over tr_key_limit)
 # is the immediate follow-up — it threads Settings into the /v1/keys + console key

--- a/tests/test_live_credit_summary.py
+++ b/tests/test_live_credit_summary.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_models import CreditAccount
+from trusted_router.typed_balance import live_credit_summary
+
+
+@pytest.fixture
+def fake_spanner_client() -> Iterator[tuple[Any, Any, TestClient]]:
+    store, db, _ = make_fake_store()
+    configure_store(store)
+    app = create_app(
+        Settings(environment="local"),
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    try:
+        with TestClient(app) as client:
+            yield store, db, client
+    finally:
+        configure_store(InMemoryStore())
+
+
+def test_live_credit_summary_typed_row_wins() -> None:
+    store, db, _ = make_fake_store()
+    workspace_id = "ws_typed_summary"
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=10_000_000,
+            total_usage_microdollars=1_000_000,
+            reserved_microdollars=500_000,
+        ),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)].update({
+        "total_credits": 12_000_000,
+        "total_usage": 7_000_000,
+        "reserved": 1_000_000,
+    })
+
+    assert live_credit_summary(workspace_id, store=store) == {
+        "total_credits": 12_000_000,
+        "total_usage": 7_000_000,
+        "reserved": 1_000_000,
+        "available": 4_000_000,
+    }
+
+
+def test_live_credit_summary_typed_row_absent_falls_back_to_json() -> None:
+    store, _db, _ = make_fake_store()
+    store._counter_mirror_enabled = False
+    workspace_id = "ws_json_summary"
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=5_000_000,
+            total_usage_microdollars=1_500_000,
+            reserved_microdollars=500_000,
+        ),
+    )
+
+    assert live_credit_summary(workspace_id, store=store) == {
+        "total_credits": 5_000_000,
+        "total_usage": 1_500_000,
+        "reserved": 500_000,
+        "available": 3_000_000,
+    }
+
+
+def test_live_credit_summary_memory_store_uses_single_book() -> None:
+    store = InMemoryStore()
+    workspace_id = "ws_memory_summary"
+    store.credits[workspace_id] = CreditAccount(
+        workspace_id=workspace_id,
+        total_credits_microdollars=2_000_000,
+        total_usage_microdollars=1_500_000,
+        reserved_microdollars=750_000,
+    )
+
+    assert live_credit_summary(workspace_id, store=store) == {
+        "total_credits": 2_000_000,
+        "total_usage": 1_500_000,
+        "reserved": 750_000,
+        "available": 0,
+    }
+
+
+def test_mcp_credits_get_returns_typed_numbers(fake_spanner_client: tuple[Any, Any, TestClient]) -> None:
+    store, db, client = fake_spanner_client
+    user = store.ensure_user("mcp-live-summary@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    _seed_stale_json_live_typed(store, db, workspace.id)
+    raw_key, _ = store.create_api_key(
+        workspace_id=workspace.id,
+        name="mcp",
+        creator_user_id=user.id,
+    )
+
+    payload = _mcp_call(client, "credits-get", headers={"authorization": f"Bearer {raw_key}"})
+    data = _tool_json(payload)["data"]
+
+    assert data["workspace_id"] == workspace.id
+    assert data["total_credits_microdollars"] == 10_000_000
+    assert data["total_usage_microdollars"] == 7_000_000
+    assert data["reserved_microdollars"] == 1_000_000
+    assert data["available_microdollars"] == 2_000_000
+
+
+def test_console_credits_page_renders_typed_money(fake_spanner_client: tuple[Any, Any, TestClient]) -> None:
+    store, db, client = fake_spanner_client
+    user = store.ensure_user("console-live-summary@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    _seed_stale_json_live_typed(store, db, workspace.id)
+    raw_token, _ = store.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="console-live-summary@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+
+    response = client.get("/console/credits")
+
+    assert response.status_code == 200, response.text[:300]
+    assert '<div class="value">$2.00</div>' in response.text
+    assert '<div class="value">$7.00</div>' in response.text
+    assert '<div class="value">$8.50</div>' not in response.text
+    assert '<div class="value">$1.00</div>' not in response.text
+
+
+def _seed_stale_json_live_typed(store: Any, db: Any, workspace_id: str) -> None:
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=10_000_000,
+            total_usage_microdollars=1_000_000,
+            reserved_microdollars=500_000,
+        ),
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)].update({
+        "total_usage": 7_000_000,
+        "reserved": 1_000_000,
+    })
+
+
+def _mcp_call(
+    client: TestClient,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = client.post(
+        "/mcp",
+        headers=headers or {},
+        json={
+            "jsonrpc": "2.0",
+            "id": "call-1",
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _tool_json(payload: dict[str, Any]) -> dict[str, Any]:
+    result = payload["result"]
+    assert result["isError"] is False
+    return json.loads(result["content"][0]["text"])


### PR DESCRIPTION
Executing the ledger-retirement plan. Prod = universal typed enforcement since 2026-06-26 (#88), so JSON usage/reserved are stale-low — and **MCP `credits-get` was still serving them**, over-stating `available`. `live_credit_summary()` (typed-row-wins, JSON/memory fallback) now backs MCP, `/v1/credits`, and console credits; non-money metadata unchanged. Also corrects the design doc's wrong "enforcement-legacy" claim (truncated-grep verification error, owned in the doc) and re-scopes the checklist to the real remaining work.

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1390 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)