### PR TITLE
B2: top-up writers typed-direct with JSON kept warm (one txn)

### DIFF
--- a/scripts/credit_makeup.py
+++ b/scripts/credit_makeup.py
@@ -4,7 +4,7 @@ Reason: Stripe webhook was firing on $5+$2 checkouts (verified via
 events evt_1TaKM6QuWGscJyRc and evt_1TaKNXQuWGscJyRc) but TR's
 handler was not crediting the ledger. Customer paid, balance stayed
 $0. Granting $107 manually ($5 + $2 makeup + $100 goodwill) via the
-production Spanner backend's `credit_workspace_once`, which is the
+production Spanner backend's `credit_workspace_typed_direct`, which is the
 SAME code path the working webhook would have used — so the credit
 appears in the ledger indistinguishably from a real grant + the
 stripe_event row is recorded for idempotency.
@@ -30,8 +30,7 @@ os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
 os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
 os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
 # Keep production manual credits safe during the typed-billing cutover. This
-# uses the normal STORE.credit_workspace_once path, but it must also update the
-# typed counter mirror that the cohort-enforced authorize path reads.
+# uses the same typed-direct top-up path as the webhook.
 os.environ["TR_TYPED_COUNTER_MIRROR"] = "1"
 
 from trusted_router.config import Settings
@@ -58,7 +57,7 @@ def main() -> int:
         return 1
     print(f"before: total_credits_microdollars = {before.total_credits_microdollars}")
 
-    granted = STORE.credit_workspace_once(
+    granted = STORE.credit_workspace_typed_direct(
         workspace_id=WORKSPACE_ID,
         amount_microdollars=AMOUNT_MICRODOLLARS,
         event_id=EVENT_ID,
@@ -76,7 +75,7 @@ def main() -> int:
     after = STORE.get_credit_account(WORKSPACE_ID)
     if after is None:
         print(
-            "ERROR: credit_workspace_once returned True but get_credit_account "
+            "ERROR: credit_workspace_typed_direct returned True but get_credit_account "
             "returned None on re-read. Inconsistent state.",
             file=sys.stderr,
         )

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -38,8 +38,8 @@ def _grant_trial_credit_on_card_attach(
     configured trial credit (settings.signup_trial_credit_microdollars).
     Idempotent across webhook replays + repeat setup_intents (e.g. user adds a
     second card later) by using a deterministic per-workspace event_id —
-    credit_workspace_once dedupes via the stripe_events ledger so the trial only
-    ever lands once.
+    credit_workspace_typed_direct dedupes via the stripe_events ledger so the
+    trial only ever lands once.
 
     Returns the amount actually credited: 0 if already granted previously, if
     the grant is disabled (amount_microdollars <= 0 — the default policy as of
@@ -54,7 +54,7 @@ def _grant_trial_credit_on_card_attach(
     if amount_microdollars <= 0:
         return 0
     event_id = f"trial:{workspace_id}"
-    if STORE.credit_workspace_once(workspace_id, amount_microdollars, event_id):
+    if STORE.credit_workspace_typed_direct(workspace_id, amount_microdollars, event_id):
         return amount_microdollars
     return 0
 
@@ -114,7 +114,7 @@ def register(router: APIRouter) -> None:
                             "trial_credit_granted_microdollars": 0,
                         }
                     }
-                credited = STORE.credit_workspace_once(
+                credited = STORE.credit_workspace_typed_direct(
                     workspace_id, amount_total * MICRODOLLARS_PER_CENT, event_id
                 )
                 # Capture the Stripe customer the first time they pay so
@@ -205,7 +205,7 @@ def register(router: APIRouter) -> None:
                 and isinstance(amount_microdollars_raw, str)
             ):
                 amount_microdollars = int(amount_microdollars_raw)
-                credited = STORE.credit_workspace_once(
+                credited = STORE.credit_workspace_typed_direct(
                     workspace_id, amount_microdollars, event_id
                 )
                 STORE.record_auto_refill_outcome(workspace_id, status="succeeded")

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -145,7 +145,7 @@ def credit_paypal_capture(
         raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
     amount_microdollars = parsed["amount_microdollars"]
     capture_id = parsed["capture_id"]
-    credited = STORE.credit_workspace_once(
+    credited = STORE.credit_workspace_typed_direct(
         workspace_id,
         amount_microdollars,
         f"paypal_capture:{capture_id}",

--- a/src/trusted_router/services/x402_billing.py
+++ b/src/trusted_router/services/x402_billing.py
@@ -163,7 +163,7 @@ def credit_x402_payment_intent(
     payment_intent_id = str(payment_intent.get("id") or "")
     if not payment_intent_id:
         raise api_error(400, "PaymentIntent is missing an id", ErrorType.BAD_REQUEST)
-    credited = STORE.credit_workspace_once(
+    credited = STORE.credit_workspace_typed_direct(
         workspace_id,
         amount_microdollars,
         x402_event_id(payment_intent_id),

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -615,6 +615,11 @@ class InMemoryStore:
             account.total_credits_microdollars += amount_microdollars
             return True
 
+    def credit_workspace_typed_direct(
+        self, workspace_id: str, amount_microdollars: int, event_id: str
+    ) -> bool:
+        return self.credit_workspace_once(workspace_id, amount_microdollars, event_id)
+
     def update_auto_refill_settings(
         self,
         workspace_id: str,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -49,6 +49,8 @@ from trusted_router.storage_gcp_codec import (
 from trusted_router.storage_gcp_codec import (
     normalize_email as _normalize_email,
 )
+from trusted_router.storage_gcp_counter_dml import insert_entity_dml_at, update_entity_body_dml
+from trusted_router.storage_gcp_counters import UNSHARDED
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
@@ -750,17 +752,83 @@ class SpannerBigtableStore:
             lease_owner=lease_owner,
         )
 
-    def credit_workspace_once(self, workspace_id: str, amount_microdollars: int, event_id: str) -> bool:
+    def credit_workspace_typed_direct(
+        self, workspace_id: str, amount_microdollars: int, event_id: str
+    ) -> bool:
         def txn(transaction: Any) -> bool:
             if self._read_entity_tx(transaction, "stripe_event", event_id, dict) is not None:
                 return False
             account = self._require_credit_tx(transaction, workspace_id)
-            account.total_credits_microdollars += amount_microdollars
-            self._write_entity_tx(transaction, "credit", workspace_id, account)
-            self._write_entity_tx(transaction, "stripe_event", event_id, {"created_at": iso_now()})
+            amount = int(amount_microdollars)
+            new_total = int(account.total_credits_microdollars) + amount
+            now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+            created_at = now.isoformat().replace("+00:00", "Z")
+            pt = self._param_types
+
+            updated = transaction.execute_update(
+                "UPDATE tr_credit_balance "
+                "SET total_credits = total_credits + @amount, "
+                "source_updated_at=@now, updated_at=@now "
+                "WHERE workspace_id=@ws AND shard=@shard",
+                params={
+                    "amount": amount,
+                    "now": now,
+                    "ws": workspace_id,
+                    "shard": UNSHARDED,
+                },
+                param_types={
+                    "amount": pt.INT64,
+                    "now": pt.TIMESTAMP,
+                    "ws": pt.STRING,
+                    "shard": pt.INT64,
+                },
+            )
+            if updated == 0:
+                transaction.execute_update(
+                    "INSERT INTO tr_credit_balance "
+                    "(workspace_id, shard, total_credits, source_updated_at, updated_at) "
+                    "VALUES (@ws, @shard, @total, @now, @now)",
+                    params={
+                        "ws": workspace_id,
+                        "shard": UNSHARDED,
+                        "total": new_total,
+                        "now": now,
+                    },
+                    param_types={
+                        "ws": pt.STRING,
+                        "shard": pt.INT64,
+                        "total": pt.INT64,
+                        "now": pt.TIMESTAMP,
+                    },
+                )
+
+            account.total_credits_microdollars = new_total
+            # Post-B2 authoritative top-up path: typed total_credits is updated
+            # explicitly above, and JSON is kept warm directly. Do not call
+            # _write_entity_tx here or the generic mirror would double-apply.
+            if update_entity_body_dml(
+                transaction,
+                pt,
+                "credit",
+                workspace_id,
+                _json_body(account),
+                now,
+            ) != 1:
+                raise ValueError("credit account not found")
+            insert_entity_dml_at(
+                transaction,
+                pt,
+                "stripe_event",
+                event_id,
+                _json_body({"created_at": created_at}),
+                now,
+            )
             return True
 
         return self._run_in_transaction(txn)
+
+    def credit_workspace_once(self, workspace_id: str, amount_microdollars: int, event_id: str) -> bool:
+        return self.credit_workspace_typed_direct(workspace_id, amount_microdollars, event_id)
 
     def update_auto_refill_settings(
         self,

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -304,6 +304,9 @@ class Store(Protocol):
 
     # Credit ledger -----------------------------------------------------------
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None: ...
+    def credit_workspace_typed_direct(
+        self, workspace_id: str, amount_microdollars: int, event_id: str
+    ) -> bool: ...
     def credit_workspace_once(
         self, workspace_id: str, amount_microdollars: int, event_id: str
     ) -> bool: ...

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -194,6 +194,10 @@ class FakeSpannerDatabase:
                     _, table, pk, record = op
                     self.typed.setdefault(table, {})[pk] = record
                     self.typed_versions[(table, pk)] = new_version
+                elif op[0] == "insert_typed_dml":
+                    _, table, pk, record = op
+                    self.typed.setdefault(table, {})[pk] = record
+                    self.typed_versions[(table, pk)] = new_version
                 elif op[0] == "delete_typed":
                     _, table, pk = op
                     self.typed.get(table, {}).pop(pk, None)
@@ -311,6 +315,39 @@ class _FakeTransaction:
             )
         self._did_dml = True
         p = params or {}
+        if "UPDATE tr_credit_balance SET total_credits = total_credits + @amount" in sql:
+            _require_pred(sql, "WHERE workspace_id=@ws AND shard=@shard", "credit-top-up")
+            pk = (p["ws"], p["shard"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            if rec is None:
+                return 0
+            new = dict(
+                rec,
+                total_credits=rec["total_credits"] + p["amount"],
+                source_updated_at=p["now"],
+                updated_at=p["now"],
+            )
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
+        if sql.startswith("INSERT INTO tr_credit_balance"):
+            pk = (p["ws"], p["shard"])
+            if pk in self.db.typed.get("tr_credit_balance", {}):
+                raise FakeAlreadyExists(f"tr_credit_balance/{pk}")
+            version_key = ("typed", "tr_credit_balance", pk)
+            if version_key not in self.read_versions:
+                self.read_versions[version_key] = 0
+            record = dict(_TYPED_DEFAULTS["tr_credit_balance"])
+            record.update(
+                {
+                    "workspace_id": p["ws"],
+                    "shard": p["shard"],
+                    "total_credits": p["total"],
+                    "source_updated_at": p["now"],
+                    "updated_at": p["now"],
+                }
+            )
+            self.pending_writes.append(("insert_typed_dml", "tr_credit_balance", pk, record))
+            return 1
         if "UPDATE tr_credit_balance SET reserved = reserved + @est" in sql:
             pk = (p["ws"], p["shard"])
             rec = self._typed_current("tr_credit_balance", pk)

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -76,9 +76,29 @@ def test_credit_total_credits_is_mirrored() -> None:
     )
     assert_credit_total_mirrored(db, ws)
     assert _typed_credit(db, ws)["total_credits"] == 1_000_000
-    # A later credit event (top-up) re-mirrors the new total_credits.
+    # A later credit event keeps the typed total warm through the B2 direct path.
     store.credit_workspace_once(ws, 500_000, "evt_topup")
     assert _typed_credit(db, ws)["total_credits"] == 1_500_000
+
+
+def test_other_json_credit_writes_still_fire_mirror() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_credit_config_mirror"
+    store._write_entity(
+        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
+    )
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_credits"] = 123
+
+    updated = store.update_auto_refill_settings(
+        ws,
+        enabled=True,
+        threshold_microdollars=250_000,
+        amount_microdollars=2_000_000,
+    )
+
+    assert updated is not None
+    assert _typed_credit(db, ws)["total_credits"] == 1_000_000
+    assert _typed_credit(db, ws)["reserved"] == 0
 
 
 def test_json_credit_reserve_does_not_propagate_to_typed_reserved() -> None:

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount, InMemoryStore
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+
+def _seed_credit(store, workspace_id: str, total: int) -> None:
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id, total_credits_microdollars=total),
+    )
+
+
+def _json_credit(db, workspace_id: str) -> dict:
+    return json.loads(db.rows[("credit", workspace_id)].body)
+
+
+def _typed_credit(db, workspace_id: str) -> dict:
+    return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+
+
+def test_credit_workspace_typed_direct_applies_once_in_one_transaction() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_b2_apply"
+    event_id = "evt_b2_apply"
+    _seed_credit(store, ws, 1_000_000)
+
+    assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is True
+
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_500_000
+    assert _typed_credit(db, ws)["total_credits"] == 1_500_000
+    assert ("stripe_event", event_id) in db.rows
+    commit_version = db.rows[("credit", ws)].version
+    assert db.rows[("stripe_event", event_id)].version == commit_version
+    assert db.typed_versions[(CREDIT_BALANCE_TABLE, (ws, 0))] == commit_version
+
+    assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is False
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_500_000
+    assert _typed_credit(db, ws)["total_credits"] == 1_500_000
+
+
+def test_credit_workspace_typed_direct_creates_missing_typed_row_from_json() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_b2_missing_typed"
+    store._counter_mirror_enabled = False
+    _seed_credit(store, ws, 2_000_000)
+    store._counter_mirror_enabled = True
+    assert (ws, 0) not in db.typed.get(CREDIT_BALANCE_TABLE, {})
+
+    assert store.credit_workspace_typed_direct(ws, 750_000, "evt_b2_seed") is True
+
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 2_750_000
+    typed = _typed_credit(db, ws)
+    assert typed["total_credits"] == 2_750_000
+    assert typed["total_usage"] == 0
+    assert typed["reserved"] == 0
+
+
+def test_credit_workspace_once_wrapper_cross_path_idempotency() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_b2_wrapper"
+    _seed_credit(store, ws, 1_000_000)
+
+    assert store.credit_workspace_typed_direct(ws, 400_000, "evt_new_path") is True
+    assert store.credit_workspace_once(ws, 400_000, "evt_new_path") is False
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_400_000
+    assert _typed_credit(db, ws)["total_credits"] == 1_400_000
+
+    store._write_entity("stripe_event", "evt_old_marker", {"created_at": "2026-07-10T00:00:00Z"})
+    assert store.credit_workspace_once(ws, 900_000, "evt_old_marker") is False
+    assert store.credit_workspace_typed_direct(ws, 900_000, "evt_old_marker") is False
+    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_400_000
+    assert _typed_credit(db, ws)["total_credits"] == 1_400_000
+
+
+def test_stripe_checkout_webhook_routes_topup_through_typed_direct(
+    client: TestClient,
+    user_headers: dict[str, str],
+    monkeypatch,
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    calls: list[tuple[str, int, str]] = []
+
+    def typed_direct(
+        _store: InMemoryStore, workspace_id_arg: str, amount: int, event_id: str
+    ) -> bool:
+        calls.append((workspace_id_arg, amount, event_id))
+        return True
+
+    def old_path(_store: InMemoryStore, *_args, **_kwargs) -> bool:
+        raise AssertionError("checkout webhook used credit_workspace_once")
+
+    monkeypatch.setattr(InMemoryStore, "credit_workspace_typed_direct", typed_direct)
+    monkeypatch.setattr(InMemoryStore, "credit_workspace_once", old_path)
+    monkeypatch.setattr(client.app.state.settings, "signup_trial_credit_microdollars", 0)
+
+    resp = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_checkout_typed_direct",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "mode": "payment",
+                    "amount_total": 123,
+                    "customer": "cus_test",
+                    "metadata": {"workspace_id": workspace_id},
+                }
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert calls == [(workspace_id, 1_230_000, "evt_checkout_typed_direct")]
+
+
+def test_stripe_auto_refill_webhook_routes_topup_through_typed_direct(
+    client: TestClient,
+    user_headers: dict[str, str],
+    monkeypatch,
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    calls: list[tuple[str, int, str]] = []
+
+    def typed_direct(
+        _store: InMemoryStore, workspace_id_arg: str, amount: int, event_id: str
+    ) -> bool:
+        calls.append((workspace_id_arg, amount, event_id))
+        return True
+
+    def old_path(_store: InMemoryStore, *_args, **_kwargs) -> bool:
+        raise AssertionError("auto-refill webhook used credit_workspace_once")
+
+    monkeypatch.setattr(InMemoryStore, "credit_workspace_typed_direct", typed_direct)
+    monkeypatch.setattr(InMemoryStore, "credit_workspace_once", old_path)
+
+    resp = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_auto_refill_typed_direct",
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "customer": "cus_test",
+                    "payment_method": "pm_test",
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "auto_refill": "true",
+                        "amount_microdollars": "2000000",
+                    },
+                }
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert calls == [(workspace_id, 2_000_000, "evt_auto_refill_typed_direct")]


### PR DESCRIPTION
Phase B2 of the [ledger-retirement design](docs/design/retire-json-credit-ledger.md). Byte-identical behavior; the value is **decoupling** — writers stop depending on the generic mirror so Phase C can delete it without another writer rewrite. One-txn idempotent dual write (typed first-class, JSON warm for rollback per the design's P1 note); `credit_workspace_once` becomes a thin wrapper; Stripe/PayPal/x402/makeup callers switched; cross-path idempotency proven in tests.

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1391 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)