### PR TITLE
Daily typed-billing invariant audit cron + checklist ticks

### DIFF
--- a/.github/workflows/typed-audit.yml
+++ b/.github/workflows/typed-audit.yml
@@ -1,0 +1,30 @@
+name: Typed Billing Invariant Audit
+
+on:
+  schedule:
+    - cron: "43 11 * * *" # 11:43 UTC daily, away from top-of-hour deploy/cron load.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # for google-github-actions/auth (Workload Identity Federation)
+
+jobs:
+  typed-billing-invariant-audit:
+    name: typed-billing-invariant-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
+      - name: Run typed billing audit
+        run: PYTHONPATH=src uv run python scripts/audit_typed_counters.py

--- a/docs/design/retire-json-credit-ledger.md
+++ b/docs/design/retire-json-credit-ledger.md
@@ -139,12 +139,12 @@ Legend: [J] = Joseph's explicit go required · [C] = Claude runs autonomously (S
 - [x] A2-A4 enforcement rollout completed historically: #67 synthetic canary →
   #78 revert → #87 canary batch → #88 universal `TR_TYPED_BILLING_WORKSPACE_IDS=*`
 - [x] Orphan-hold reaper fix (#148)
-- [ ] B1 reads: live typed money snapshot for console credits/billing and MCP
+- [x] B1 reads (#149): live typed money snapshot for console credits/billing and MCP
   `credits-get` (this PR)
-- [ ] B2 keep-warm writes: typed `total_credits` authoritative with JSON
+- [x] B2 keep-warm writes (#150): typed `total_credits` authoritative with JSON
   `total_credits` still written in the same txn for rollback safety
-- [ ] B3 grant-script verification against the typed snapshot
-- [ ] Daily invariant audit scheduling
+- [x] B3 grant-script verification against the typed snapshot — already satisfied: scripts/credit_grant_*.py have verified the typed counter since inception
+- [x] Daily invariant audit scheduling (.github/workflows/typed-audit.yml, 11:43 UTC; failing run = alert)
 - [ ] Stale legacy-hold cleanup for workspace `ea7dd3d8` (JSON reserved=29373,
   3 open legacy reservations; display-only impact, fold into Phase C or a small cleanup)
 - [ ] Phase C deletions after 2 weeks of clean audits from 2026-07-10, the first

--- a/scripts/audit_typed_counters.py
+++ b/scripts/audit_typed_counters.py
@@ -1,0 +1,106 @@
+"""Daily read-only typed-billing invariant audit.
+
+Runs the typed-side reserved invariant auditor and the JSON-vs-typed comparator
+against the production Spanner/Bigtable store. Exit codes are intentionally
+distinct for scheduled workflow alerting:
+
+  0: both reports clean
+  1: invariant violation or comparator drift
+  2: infrastructure/configuration failure
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants, compare
+
+_DEFAULT_ENV = {
+    "TR_STORAGE_BACKEND": "spanner-bigtable",
+    "TR_GCP_PROJECT_ID": "quill-cloud-proxy",
+    "TR_SPANNER_INSTANCE_ID": "trusted-router-nam6",
+    "TR_SPANNER_DATABASE_ID": "trusted-router",
+    "TR_BIGTABLE_INSTANCE_ID": "trusted-router-logs",
+    "TR_BIGTABLE_GENERATION_TABLE": "trustedrouter-generations",
+    "TR_TYPED_COUNTER_MIRROR": "1",
+}
+_MAX_SAMPLES = 100_000
+
+
+class AuditReport(Protocol):
+    samples: Mapping[str, object]
+
+    @property
+    def clean(self) -> bool: ...
+
+    def summary(self) -> str: ...
+
+
+class AuditFunc(Protocol):
+    def __call__(self, store: Any, *, max_samples: int = ...) -> AuditReport: ...
+
+
+def _bootstrap_prod_env() -> None:
+    for key, value in _DEFAULT_ENV.items():
+        os.environ.setdefault(key, value)
+
+
+def _print_report(name: str, sample_label: str, report: AuditReport) -> None:
+    print(f"{name}: {report.summary()}")
+    for scope, detail in report.samples.items():
+        print(f"  {sample_label} {scope}: {detail}")
+
+
+def run_audit(
+    store: Any,
+    *,
+    invariant_audit: AuditFunc = audit_typed_invariants,
+    drift_compare: AuditFunc = compare,
+) -> int:
+    invariant_report = invariant_audit(store, max_samples=_MAX_SAMPLES)
+    _print_report("audit_typed_invariants", "VIOLATION", invariant_report)
+
+    drift_report = drift_compare(store, max_samples=_MAX_SAMPLES)
+    _print_report("compare", "DRIFT", drift_report)
+
+    return 0 if invariant_report.clean and drift_report.clean else 1
+
+
+def main(
+    *,
+    store: Any | None = None,
+    settings_factory: Callable[[], Any] = Settings,
+    store_factory: Callable[[Any], Any] = create_store,
+    invariant_audit: AuditFunc = audit_typed_invariants,
+    drift_compare: AuditFunc = compare,
+) -> int:
+    _bootstrap_prod_env()
+    try:
+        settings = settings_factory()
+        backend = str(getattr(settings, "storage_backend", "")).lower()
+        if backend != "spanner-bigtable":
+            print(
+                "ERROR: refusing to audit because TR_STORAGE_BACKEND is not "
+                f"spanner-bigtable (resolved {backend or '<empty>'})",
+                file=sys.stderr,
+            )
+            return 2
+        if store is None:
+            store = store_factory(settings)
+        return run_audit(
+            store,
+            invariant_audit=invariant_audit,
+            drift_compare=drift_compare,
+        )
+    except Exception as exc:
+        print(f"ERROR: infrastructure failure during typed-counter audit: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
 import functools
+import os
 
 import pytest
 from fastapi.testclient import TestClient
 
+# The developer/operator shell may export production storage settings. Unit tests
+# must stay offline unless a test explicitly opts into a spanner-shaped Settings
+# object with configure_store_arg=False or a fake store.
+os.environ["TR_STORAGE_BACKEND"] = "memory"
+
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.money import DEFAULT_TRIAL_CREDIT_MICRODOLLARS
-from trusted_router.storage import STORE, InMemoryStore
+from trusted_router.storage import STORE, InMemoryStore, configure_store
 
 
 @pytest.fixture(autouse=True)
 def reset_store() -> None:
+    if not isinstance(STORE.target, InMemoryStore):
+        configure_store(InMemoryStore())
     STORE.reset()
 
 

--- a/tests/test_audit_typed_counters_script.py
+++ b/tests/test_audit_typed_counters_script.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from scripts import audit_typed_counters
+
+
+@dataclass
+class _Report:
+    clean: bool
+    label: str
+    samples: dict[str, object] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        return self.label
+
+
+class _Settings:
+    storage_backend = "spanner-bigtable"
+
+
+def _report_func(report: _Report) -> audit_typed_counters.AuditFunc:
+    def inner(_store: Any, *, max_samples: int = 20) -> _Report:
+        assert max_samples == 100_000
+        return report
+
+    return inner
+
+
+def test_audit_script_exits_zero_when_both_reports_clean(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("TR_STORAGE_BACKEND", raising=False)
+    rc = audit_typed_counters.main(
+        store=object(),
+        settings_factory=_Settings,
+        invariant_audit=_report_func(_Report(True, "invariants clean")),
+        drift_compare=_report_func(_Report(True, "drift clean")),
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "audit_typed_invariants: invariants clean" in out
+    assert "compare: drift clean" in out
+
+
+def test_audit_script_exits_one_on_invariant_violation(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = audit_typed_counters.main(
+        store=object(),
+        settings_factory=_Settings,
+        invariant_audit=_report_func(
+            _Report(False, "invariants bad", {"credit:ws:0": {"typed_reserved": 10}})
+        ),
+        drift_compare=_report_func(_Report(True, "drift clean")),
+    )
+
+    assert rc == 1
+    assert "VIOLATION credit:ws:0" in capsys.readouterr().out
+
+
+def test_audit_script_exits_one_on_compare_drift(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = audit_typed_counters.main(
+        store=object(),
+        settings_factory=_Settings,
+        invariant_audit=_report_func(_Report(True, "invariants clean")),
+        drift_compare=_report_func(_Report(False, "drift bad", {"api_key:key": {"limit": 1}})),
+    )
+
+    assert rc == 1
+    assert "DRIFT api_key:key" in capsys.readouterr().out
+
+
+def test_audit_script_refuses_non_spanner_bigtable_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "memory")
+
+    rc = audit_typed_counters.main(
+        store=object(),
+        invariant_audit=_report_func(_Report(True, "unused")),
+        drift_compare=_report_func(_Report(True, "unused")),
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "refusing to audit" in captured.err
+    assert "memory" in captured.err
+
+
+def test_audit_script_exits_two_on_infrastructure_error(capsys: pytest.CaptureFixture[str]) -> None:
+    def broken_audit(_store: Any, *, max_samples: int = 20) -> _Report:
+        raise RuntimeError("credentials unavailable")
+
+    rc = audit_typed_counters.main(
+        store=object(),
+        settings_factory=_Settings,
+        invariant_audit=broken_audit,
+        drift_compare=_report_func(_Report(True, "unused")),
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "infrastructure failure" in captured.err

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -535,6 +535,9 @@ def test_production_config_fails_closed() -> None:
             stripe_secret_key=stripe_key,
             sentry_dsn=sentry_dsn,
             storage_backend="spanner-bigtable",
+            spanner_instance_id=None,
+            spanner_database_id=None,
+            bigtable_instance_id=None,
             byok_kms_key_name=TEST_BYOK_KMS_KEY_NAME,
         )
 

--- a/tests/test_typed_flip_tool.py
+++ b/tests/test_typed_flip_tool.py
@@ -11,6 +11,11 @@ from trusted_router.storage import CreditAccount, Workspace
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 
 
+@pytest.fixture(autouse=True)
+def _typed_flip_apply_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+
+
 def _seed_workspace(
     store: Any,
     ws: str,


### PR DESCRIPTION
Final build item of today's ledger-retirement execution: daily read-only `audit_typed_invariants` + `compare` against prod (WIF + tr-deploy, cloned from the embeddings-probe pattern; failing run = alert). Distinguishes violation (exit 1) from infra failure (exit 2). Plus a real hardening: conftest pins unit tests to the memory backend so operator-shell prod env can't leak into test runs. Checklist updated — remaining work is the ea7dd3d8 legacy-hold cleanup and Phase C (eligible **2026-07-24** after two clean-audit weeks).

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1390 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)