### PR TITLE
axiom: safety-wrap timer-thread flush; retry stale-keepalive posts

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -33,8 +33,12 @@ import os
 import re
 import sys
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
+
+from requests.adapters import HTTPAdapter  # type: ignore[import-untyped]
+from urllib3.util.retry import Retry
 
 from trusted_router.config import Settings
 from trusted_router.sentry_config import _scrub
@@ -79,13 +83,18 @@ def init_axiom(settings: Settings) -> None:
             axiom_url=settings.axiom_url,
         )
         client = axiom_py.Client(**client_kwargs)
+        _mount_axiom_retry_adapter(client)
     except Exception as exc:  # noqa: BLE001
         log.warning("axiom.disabled reason=client_init_failed err=%s", exc)
         return
 
     resolved_level = _resolve_level(settings.axiom_log_level)
-    raw_handler: logging.Handler = AxiomHandler(client, dataset)
+    raw_handler: Any = AxiomHandler(client, dataset)
     raw_handler.setLevel(logging.NOTSET)
+    # axiom-py's emit() recreates each threading.Timer with `self.flush` at
+    # Timer-creation time. Assigning the bound flush on this instance shadows
+    # the class method, so timer-thread flushes go through the safe wrapper too.
+    raw_handler.flush = _safe_flush_wrapper(raw_handler.flush)
     handler: logging.Handler = _SafeAxiomHandler(raw_handler)
     handler.setLevel(resolved_level)
     # Attach a filter that scrubs PII before the handler ships the
@@ -129,6 +138,44 @@ def _client_kwargs(*, token: str, org_id: str | None, axiom_url: str) -> dict[st
         else:
             client_kwargs["url"] = axiom_url
     return client_kwargs
+
+
+def _mount_axiom_retry_adapter(client: Any) -> None:
+    session = getattr(client, "session", None)
+    if session is None:
+        return
+
+    # Retrying log ingest can at worst duplicate a log batch; the common failure
+    # here is RemoteDisconnected on an idle keepalive socket.
+    session.mount(
+        "https://",
+        HTTPAdapter(
+            max_retries=Retry(
+                total=2,
+                connect=2,
+                read=1,
+                backoff_factor=0.2,
+                allowed_methods=frozenset({"POST"}),
+                raise_on_status=False,
+            )
+        ),
+    )
+
+
+def _safe_flush_wrapper(bound_flush: Callable[[], None]) -> Callable[[], None]:
+    last_error_log_at: float | None = None
+
+    def safe_flush() -> None:
+        nonlocal last_error_log_at
+        try:
+            bound_flush()
+        except Exception as exc:  # noqa: BLE001 - logging flushes must not break requests.
+            now = time.monotonic()
+            if last_error_log_at is None or now - last_error_log_at > 60:
+                last_error_log_at = now
+                sys.stderr.write(f"axiom.flush_failed dropped=true err={exc!r}\n")
+
+    return safe_flush
 
 
 def _resolve_level(name: str) -> int:

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 
 import axiom_py
 import axiom_py.logging as axiom_logging
 import pytest
+import requests
 from fastapi.testclient import TestClient
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 import trusted_router.axiom_config as axiom_config
 import trusted_router.routes.public as public_routes
@@ -79,6 +81,32 @@ class _CapturingHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         self.records.append(logging.makeLogRecord(record.__dict__.copy()))
+
+
+class _StubAxiomClient:
+    def __init__(self, *, fail_ingest: bool = False) -> None:
+        self.fail_ingest = fail_ingest
+        self.ingested: list[tuple[str, list[dict[str, object]]]] = []
+        self.session = requests.Session()
+        self.shutdown_callbacks: list[Callable[[], None]] = []
+
+    def before_shutdown(self, callback: Callable[[], None]) -> None:
+        self.shutdown_callbacks.append(callback)
+
+    def ingest_events(self, dataset: str, events: list[dict[str, object]]) -> None:
+        if self.fail_ingest:
+            raise RequestsConnectionError("stale keepalive socket")
+        self.ingested.append((dataset, list(events)))
+
+
+def _build_wrapped_raw_axiom_handler(
+    client: _StubAxiomClient,
+) -> axiom_logging.AxiomHandler:
+    raw_handler = axiom_logging.AxiomHandler(client, "test-logs", interval=60)
+    raw_handler.flush = axiom_config._safe_flush_wrapper(raw_handler.flush)
+    safe_handler = _SafeAxiomHandler(raw_handler)
+    assert safe_handler.inner is raw_handler
+    return raw_handler
 
 
 @contextmanager
@@ -188,6 +216,48 @@ def test_safe_axiom_handler_never_raises_from_emit(capsys) -> None:
     captured = capsys.readouterr()
     assert "axiom.emit_failed dropped=true" in captured.err
     assert captured.err.count("axiom.emit_failed") == 1
+
+
+def test_axiom_timer_flush_wrapper_never_raises_and_throttles(capsys) -> None:
+    client = _StubAxiomClient(fail_ingest=True)
+    raw_handler = _build_wrapped_raw_axiom_handler(client)
+
+    raw_handler.buffer.append({"message": "one"})
+    raw_handler.flush()
+    raw_handler.buffer.append({"message": "two"})
+    raw_handler.flush()
+
+    captured = capsys.readouterr()
+    assert "axiom.flush_failed dropped=true" in captured.err
+    assert captured.err.count("axiom.flush_failed") == 1
+
+
+def test_axiom_timer_flush_wrapper_success_delivers_buffer(capsys) -> None:
+    client = _StubAxiomClient()
+    raw_handler = _build_wrapped_raw_axiom_handler(client)
+
+    raw_handler.buffer.append({"message": "ok"})
+    raw_handler.flush()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert client.ingested == [("test-logs", [{"message": "ok"}])]
+    assert raw_handler.buffer == []
+
+
+def test_axiom_client_session_mounts_post_retry_adapter() -> None:
+    client = _StubAxiomClient()
+
+    axiom_config._mount_axiom_retry_adapter(client)
+    axiom_config._mount_axiom_retry_adapter(object())
+
+    adapter = client.session.get_adapter("https://api.axiom.co/v1/datasets/test/ingest")
+    retry = adapter.max_retries
+    assert retry.total == 2
+    assert retry.connect == 2
+    assert retry.read == 1
+    assert retry.backoff_factor == 0.2
+    assert retry.allowed_methods == frozenset({"POST"})
 
 
 def test_axiom_scrub_filter_collapses_and_redacts_positional_args() -> None:


### PR DESCRIPTION
Root-cause fix for Sentry `589b8581` (ConnectionError in gateway_settle, 2:10 AM). Not a settle bug: axiom-py's 1s flush **Timer thread** bypasses `_SafeAxiomHandler` (emit-only), so an overnight-stale keepalive socket turned the first quiet-second log flush into an unhandled thread exception — captured by Sentry with the inherited request scope, batch dropped. **No money impact** (verified: the exception never touches the settle txn; shipping self-heals on next emit).

Fix: instance-level safe wrapper over the bound `flush` (intercepts every timer/shutdown path — emit binds `self.flush` at Timer creation), throttled stderr breadcrumb, plus a guarded `Retry(total=2, POST)` mount for the stale-keepalive case (worst case: duplicate log batch).

Author: codex · Reviewer: Claude (PASS) · ruff+mypy+**1388 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)