### PR TITLE
billing: dark credit-row sharding plumbing (increment 1)

### DIFF
--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -120,6 +120,7 @@ if table_exists tr_reservation; then log "tr_reservation exists, skip"; else
     workspace_id STRING(64),
     key_hash STRING(64),
     ws_shard INT64,
+    credit_shard INT64 NOT NULL DEFAULT (0),
     key_shard INT64,
     credit_reserved_micro INT64,
     key_reserved_micro INT64,
@@ -180,6 +181,11 @@ ensure_column tr_key_limit week_usage  "INT64 DEFAULT (0)"
 ensure_column tr_key_limit week_start  "TIMESTAMP"
 ensure_column tr_key_limit month_usage "INT64 DEFAULT (0)"
 ensure_column tr_key_limit month_start "TIMESTAMP"
+
+# Credit-row sharding increment 1. Existing reservations retain ws_shard=0;
+# old rows read NULL for the additive column and the application falls back to
+# ws_shard. New rows write both during the rolling-compatibility window.
+ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"
 
 # ── Durable settle outbox (docs/design/durable-settle-outbox.md) ────────────
 # Recovers completed-but-settle-lost charges. Additive + guarded; safe to apply

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -50,7 +50,11 @@ from trusted_router.storage_gcp_codec import (
     normalize_email as _normalize_email,
 )
 from trusted_router.storage_gcp_counter_dml import insert_entity_dml_at, update_entity_body_dml
-from trusted_router.storage_gcp_counters import UNSHARDED
+from trusted_router.storage_gcp_counters import (
+    UNSHARDED,
+    credit_shard_count,
+    distribute_credit_amount,
+)
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
@@ -761,29 +765,37 @@ class SpannerBigtableStore:
             account = self._require_credit_tx(transaction, workspace_id)
             amount = int(amount_microdollars)
             new_total = int(account.total_credits_microdollars) + amount
+            shard_count = credit_shard_count(account)
+            shard_deltas = distribute_credit_amount(amount, shard_count)
             now = dt.datetime.now(dt.UTC).replace(microsecond=0)
             created_at = now.isoformat().replace("+00:00", "Z")
             pt = self._param_types
 
-            updated = transaction.execute_update(
-                "UPDATE tr_credit_balance "
-                "SET total_credits = total_credits + @amount, "
-                "source_updated_at=@now, updated_at=@now "
-                "WHERE workspace_id=@ws AND shard=@shard",
-                params={
-                    "amount": amount,
-                    "now": now,
-                    "ws": workspace_id,
-                    "shard": UNSHARDED,
-                },
-                param_types={
-                    "amount": pt.INT64,
-                    "now": pt.TIMESTAMP,
-                    "ws": pt.STRING,
-                    "shard": pt.INT64,
-                },
-            )
-            if updated == 0:
+            for shard, shard_delta in enumerate(shard_deltas):
+                updated = transaction.execute_update(
+                    "UPDATE tr_credit_balance "
+                    "SET total_credits = total_credits + @amount, "
+                    "source_updated_at=@now, updated_at=@now "
+                    "WHERE workspace_id=@ws AND shard=@shard",
+                    params={
+                        "amount": shard_delta,
+                        "now": now,
+                        "ws": workspace_id,
+                        "shard": shard,
+                    },
+                    param_types={
+                        "amount": pt.INT64,
+                        "now": pt.TIMESTAMP,
+                        "ws": pt.STRING,
+                        "shard": pt.INT64,
+                    },
+                )
+                if updated != 0:
+                    continue
+                if shard_count != 1:
+                    raise RuntimeError(
+                        f"missing tr_credit_balance shard {shard} for sharded workspace"
+                    )
                 transaction.execute_update(
                     "INSERT INTO tr_credit_balance "
                     "(workspace_id, shard, total_credits, source_updated_at, updated_at) "
@@ -1299,23 +1311,39 @@ class SpannerBigtableStore:
         }
 
     def typed_credit_snapshot(self, workspace_id: str) -> tuple[int, int, int] | None:
-        """One point-read of the authoritative typed tr_credit_balance row:
-        (total_credits, total_usage, reserved) microdollars, or None when the
-        typed tables are off or the row isn't seeded. Lets typed-aware balance
-        reads use the Store contract instead of reaching into `_database`."""
+        """Sum the workspace's active authoritative credit sub-ledgers.
+
+        Returns (total_credits, total_usage, reserved) microdollars, or None
+        when the typed tables are off or a one-shard row is not seeded. A
+        configured multi-shard workspace fails closed if any active row is
+        missing; falling back to stale JSON usage would overstate availability.
+        """
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        with self._database.snapshot(multi_use=True) as snapshot:
+            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
+            if account is None:
+                return None
+            shard_count = credit_shard_count(account)
             rows = list(snapshot.execute_sql(
-                "SELECT total_credits, total_usage, reserved FROM tr_credit_balance "
-                "WHERE workspace_id=@pk AND shard=0",
-                params={"pk": workspace_id},
-                param_types={"pk": pt.STRING},
+                "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
+                "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             ))
         if not rows:
             return None
-        return (int(rows[0][0]), int(rows[0][1]), int(rows[0][2]))
+        observed_shards = [int(row[0]) for row in rows]
+        if observed_shards != list(range(shard_count)):
+            if shard_count == 1:
+                return None
+            raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+        return (
+            sum(int(row[1]) for row in rows),
+            sum(int(row[2]) for row in rows),
+            sum(int(row[3]) for row in rows),
+        )
 
     def read_typed_reservation(self, reservation_id: str) -> dict[str, Any] | None:
         """Point-read a typed reservation for outbox lost-claim disambiguation.

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -38,6 +38,7 @@ from trusted_router.storage_gcp_counter_dml import (
     reserve_credit,
     reserve_key,
 )
+from trusted_router.storage_gcp_counters import UNSHARDED
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
 
@@ -138,6 +139,7 @@ def authorize_atomic(
     idempotency_fingerprint: str | None,
     expires_at: Any,
     build_auth_body: Callable[[str, str], str],
+    credit_shard: int = UNSHARDED,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -153,6 +155,8 @@ def authorize_atomic(
     transaction exists to eliminate (codex #93 review).
     """
     pt = param_types
+    if credit_shard < 0:
+        raise ValueError("credit_shard must be non-negative")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -182,14 +186,16 @@ def authorize_atomic(
 
         credit_hold = 0
         if has_credit_candidate:
-            if not reserve_credit(transaction, pt, workspace_id, estimate):
+            if not reserve_credit(
+                transaction, pt, workspace_id, estimate, shard=credit_shard
+            ):
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=0, key_shard=0,
+            ws_shard=credit_shard, credit_shard=credit_shard, key_shard=0,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -365,6 +371,7 @@ def settle_atomic(
             credit_count = release_credit(
                 transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
                 credit_actual,
+                shard=res["credit_shard"],
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
@@ -538,6 +545,7 @@ def typed_finalize_atomic(
             credit_count = release_credit(
                 transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
                 credit_actual,
+                shard=res["credit_shard"],
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -252,7 +252,7 @@ def key_limit_exists(
 # DML-only authorize/settle transactions (no mutation mixing).
 
 RESERVATION_COLUMNS = (
-    "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+    "reservation_id", "workspace_id", "key_hash", "ws_shard", "credit_shard", "key_shard",
     "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
     "authorization_id", "idempotency_scope", "idempotency_fingerprint", "expires_at",
 )
@@ -269,7 +269,8 @@ def read_reservation_by_idempotency(
     rows = list(
         transaction.execute_sql(
             "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
-            "hold_usage_type, authorization_id, idempotency_fingerprint, settled "
+            "hold_usage_type, authorization_id, idempotency_fingerprint, settled, "
+            "credit_shard, ws_shard "
             "FROM tr_reservation WHERE idempotency_scope=@scope",
             params={"scope": idempotency_scope},
             param_types={"scope": param_types.STRING},
@@ -278,6 +279,7 @@ def read_reservation_by_idempotency(
     if not rows:
         return None
     r = rows[0]
+    credit_shard = r[7] if r[7] is not None else (r[8] or UNSHARDED)
     return {
         "reservation_id": r[0],
         "credit_reserved_micro": r[1],
@@ -286,6 +288,7 @@ def read_reservation_by_idempotency(
         "authorization_id": r[4],
         "idempotency_fingerprint": r[5],
         "settled": r[6],
+        "credit_shard": int(credit_shard),
     }
 
 
@@ -293,7 +296,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
     """Point-read a reservation by id (for settle/refund and the reaper)."""
     rows = list(
         transaction.execute_sql(
-            "SELECT reservation_id, workspace_id, key_hash, ws_shard, key_shard, "
+            "SELECT reservation_id, workspace_id, key_hash, ws_shard, credit_shard, key_shard, "
             "credit_reserved_micro, key_reserved_micro, hold_usage_type, "
             "settled_usage_type, actual_micro, authorization_id, settled "
             "FROM tr_reservation WHERE reservation_id=@rid",
@@ -305,11 +308,16 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
         return None
     r = rows[0]
     keys = (
-        "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+        "reservation_id", "workspace_id", "key_hash", "ws_shard", "credit_shard", "key_shard",
         "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
         "settled_usage_type", "actual_micro", "authorization_id", "settled",
     )
-    return dict(zip(keys, r, strict=True))
+    result = dict(zip(keys, r, strict=True))
+    raw_credit_shard = result.get("credit_shard")
+    result["credit_shard"] = int(
+        raw_credit_shard if raw_credit_shard is not None else (result.get("ws_shard") or UNSHARDED)
+    )
+    return result
 
 
 def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> None:
@@ -318,7 +326,7 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
     pt = param_types
     types = {
         "reservation_id": pt.STRING, "workspace_id": pt.STRING, "key_hash": pt.STRING,
-        "ws_shard": pt.INT64, "key_shard": pt.INT64,
+        "ws_shard": pt.INT64, "credit_shard": pt.INT64, "key_shard": pt.INT64,
         "credit_reserved_micro": pt.INT64, "key_reserved_micro": pt.INT64,
         "hold_usage_type": pt.STRING, "authorization_id": pt.STRING,
         "idempotency_scope": pt.STRING, "idempotency_fingerprint": pt.STRING,
@@ -326,9 +334,13 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
     }
     cols = ", ".join(RESERVATION_COLUMNS)
     binds = ", ".join(f"@{c}" for c in RESERVATION_COLUMNS)
+    values = {c: fields.get(c) for c in RESERVATION_COLUMNS}
+    values["credit_shard"] = fields.get(
+        "credit_shard", fields.get("ws_shard", UNSHARDED)
+    )
     transaction.execute_update(
         f"INSERT INTO tr_reservation ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
-        params={c: fields.get(c) for c in RESERVATION_COLUMNS},
+        params=values,
         param_types={c: types[c] for c in RESERVATION_COLUMNS},
     )
 

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -32,7 +32,7 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
 
 _CREDIT_TYPED_SCAN = (
-    "SELECT workspace_id, total_credits, total_usage, reserved FROM tr_credit_balance"
+    "SELECT workspace_id, shard, total_credits, total_usage, reserved FROM tr_credit_balance"
 )
 _KEY_TYPED_SCAN = (
     "SELECT key_hash, limit_micro, usage, byok_usage, reserved, include_byok, "
@@ -96,10 +96,14 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
     with store._database.snapshot(multi_use=True) as snapshot:
         json_credit = _scan_json(snapshot, "credit", "workspace_id", pt)
         json_key = _scan_json(snapshot, "api_key", "hash", pt)
-        typed_credit = {
-            r[0]: {"total_credits": r[1], "total_usage": r[2], "reserved": r[3]}
-            for r in snapshot.execute_sql(_CREDIT_TYPED_SCAN)
-        }
+        typed_credit: dict[str, dict[str, int]] = {}
+        for row in snapshot.execute_sql(_CREDIT_TYPED_SCAN):
+            aggregate = typed_credit.setdefault(
+                row[0], {"total_credits": 0, "total_usage": 0, "reserved": 0}
+            )
+            aggregate["total_credits"] += int(row[2])
+            aggregate["total_usage"] += int(row[3])
+            aggregate["reserved"] += int(row[4])
         typed_key = {
             r[0]: {
                 "limit_micro": r[1], "usage": r[2], "byok_usage": r[3],
@@ -373,8 +377,10 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
 # Shard-aware (the typed counter PK is (scope, shard); reservations carry the
 # per-scope shard), COALESCE so an empty SUM reads 0.
 _OPEN_CREDIT_HOLDS = (
-    "SELECT workspace_id, ws_shard, COALESCE(SUM(credit_reserved_micro), 0) "
-    "FROM tr_reservation WHERE settled = false GROUP BY workspace_id, ws_shard"
+    "SELECT workspace_id, credit_shard, ws_shard, "
+    "COALESCE(SUM(credit_reserved_micro), 0) "
+    "FROM tr_reservation WHERE settled = false "
+    "GROUP BY workspace_id, credit_shard, ws_shard"
 )
 _OPEN_KEY_HOLDS = (
     "SELECT key_hash, key_shard, COALESCE(SUM(key_reserved_micro), 0) "
@@ -421,9 +427,11 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
                 "SELECT key_hash, shard, reserved FROM tr_key_limit"
             )
         }
-        credit_holds = {
-            (r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_CREDIT_HOLDS)
-        }
+        credit_holds: dict[tuple[str, int], int] = {}
+        for row in snap.execute_sql(_OPEN_CREDIT_HOLDS):
+            shard = int(row[1] if row[1] is not None else (row[2] or 0))
+            scope = (str(row[0]), shard)
+            credit_holds[scope] = credit_holds.get(scope, 0) + int(row[3] or 0)
         key_holds = {(r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
 
     def _sample(key: str, value: dict) -> None:

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -67,10 +67,43 @@ def _field(value: Any, name: str, default: Any = None) -> Any:
     return getattr(value, name, default)
 
 
+def credit_shard_count(value: Any) -> int:
+    """Return the configured credit-ledger shard count.
+
+    Legacy CreditAccount JSON omits this field and therefore remains exactly
+    one-shard. Invalid persisted values fail closed instead of silently
+    changing which sub-ledgers enforce the workspace cap.
+    """
+    raw = _field(value, "shard_count", 1)
+    if isinstance(raw, bool):
+        raise ValueError("credit shard_count must be a positive integer")
+    count = int(raw)
+    if count < 1:
+        raise ValueError("credit shard_count must be a positive integer")
+    return count
+
+
+def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
+    """Evenly partition a grant delta, putting the remainder on shard zero."""
+    if shard_count < 1:
+        raise ValueError("credit shard_count must be a positive integer")
+    sign = -1 if amount < 0 else 1
+    per_shard, remainder = divmod(abs(int(amount)), shard_count)
+    values = [sign * per_shard for _ in range(shard_count)]
+    values[UNSHARDED] += sign * remainder
+    return tuple(values)
+
+
 def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> tuple:
     """Mirror the JSON-owned `total_credits` of a `credit` row into
     tr_credit_balance. reserved + total_usage are typed-DML-owned and are
-    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS)."""
+    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS).
+
+    This generic absolute-value mirror is intentionally one-shard only. Once a
+    workspace is explicitly sharded, credit deltas are distributed by
+    credit_workspace_typed_direct; replaying the global JSON total into shard 0
+    would multiply its budget.
+    """
     return (
         workspace_id,
         UNSHARDED,
@@ -110,6 +143,8 @@ def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: 
     writer, so the mirror commits atomically with it. No-op for other kinds.
     """
     if kind == "credit":
+        if credit_shard_count(value) != 1:
+            return
         writer.insert_or_update(
             table=CREDIT_BALANCE_TABLE,
             columns=CREDIT_BALANCE_COLUMNS,

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -248,6 +248,10 @@ class CreditAccount:
     total_credits_microdollars: int = 0
     total_usage_microdollars: int = 0
     reserved_microdollars: int = 0
+    # Number of independent tr_credit_balance sub-ledgers owned by this
+    # workspace. Increment 1 keeps every account at one shard; later increments
+    # add selection/rebalancing and an operator-only activation path.
+    shard_count: int = 1
     # Auto-refill: when available drops below threshold, charge the saved
     # Stripe payment method off-session for `auto_refill_amount_microdollars`.
     # All four are required to be non-zero/non-None for auto-refill to fire.

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -841,9 +841,16 @@ def _execute_sql(
         sums: dict[tuple, int] = {}
         for rec in db.reservations.values():
             if not rec.get("settled") and rec.get("workspace_id") is not None:
-                grp = (rec["workspace_id"], rec.get("ws_shard", 0))
+                grp = (
+                    rec["workspace_id"],
+                    rec.get("credit_shard"),
+                    rec.get("ws_shard", 0),
+                )
                 sums[grp] = sums.get(grp, 0) + (rec.get("credit_reserved_micro") or 0)
-        return [[ws, shard, total] for (ws, shard), total in sums.items()]
+        return [
+            [ws, credit_shard, ws_shard, total]
+            for (ws, credit_shard, ws_shard), total in sums.items()
+        ]
     if "SUM(key_reserved_micro)" in sql:
         ksums: dict[tuple, int] = {}
         for rec in db.reservations.values():
@@ -907,6 +914,13 @@ def _execute_sql(
                 recs = [r for r in recs if r.get(pk_col) == params["pk"]]
                 if "shard=0" in sql.replace(" ", ""):
                     recs = [r for r in recs if r.get("shard", 0) == 0]
+                if "shard<@shard_count" in sql.replace(" ", ""):
+                    recs = [
+                        r for r in recs
+                        if 0 <= int(r.get("shard", 0)) < int(params["shard_count"])
+                    ]
+                if "ORDER BY shard" in sql:
+                    recs.sort(key=lambda r: int(r.get("shard", 0)))
             return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]

--- a/tests/test_credit_row_sharding_increment1.py
+++ b/tests/test_credit_row_sharding_increment1.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    authorize_atomic,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants, compare
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    credit_shard_count,
+    distribute_credit_amount,
+)
+from trusted_router.storage_models import CreditAccount
+
+
+def _credit_row(
+    workspace_id: str,
+    shard: int,
+    *,
+    total_credits: int,
+    total_usage: int = 0,
+    reserved: int = 0,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "shard": shard,
+        "total_credits": total_credits,
+        "total_usage": total_usage,
+        "reserved": reserved,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _seed_sharded_credit(
+    store: object,
+    database: object,
+    workspace_id: str,
+    totals: list[int],
+) -> None:
+    account = CreditAccount(
+        workspace_id=workspace_id,
+        total_credits_microdollars=sum(totals),
+        shard_count=len(totals),
+    )
+    store._write_entity("credit", workspace_id, account)  # type: ignore[attr-defined]
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})  # type: ignore[attr-defined]
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = _credit_row(
+            workspace_id, shard, total_credits=total
+        )
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id, "model": "m"}
+    )
+
+
+def test_credit_shard_schema_is_additive_and_rolling_compatible() -> None:
+    migration = (
+        Path(__file__).parents[1] / "scripts/deploy/migrate_typed_counters.sh"
+    ).read_text()
+
+    assert "credit_shard INT64 NOT NULL DEFAULT (0)" in migration
+    assert 'ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"' in migration
+
+
+def test_legacy_credit_account_defaults_to_exactly_one_shard() -> None:
+    account = CreditAccount(workspace_id="ws")
+
+    assert account.shard_count == 1
+    assert credit_shard_count(account) == 1
+    assert credit_shard_count({"workspace_id": "legacy"}) == 1
+    assert distribute_credit_amount(17, 1) == (17,)
+
+
+@pytest.mark.parametrize("invalid", [0, -1, True])
+def test_invalid_credit_shard_count_fails_closed(invalid: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        credit_shard_count({"shard_count": invalid})
+
+
+def test_credit_grant_distribution_puts_remainder_on_shard_zero() -> None:
+    assert distribute_credit_amount(10, 3) == (4, 3, 3)
+    assert distribute_credit_amount(-10, 3) == (-4, -3, -3)
+
+
+def test_authorize_records_credit_shard_and_settle_releases_that_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-shard-plumbing"
+    _seed_sharded_credit(store, database, workspace_id, [2_000_000, 2_000_000, 2_000_000])
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="key",
+        creator_user_id=None,
+        limit_microdollars=6_000_000,
+    )
+
+    result = authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        estimate=500_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope="scope-shard-2",
+        idempotency_fingerprint="fingerprint",
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        credit_shard=2,
+    )
+
+    assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+    reservation = database.reservations[result["reservation_id"]]
+    assert reservation["credit_shard"] == 2
+    assert reservation["ws_shard"] == 2
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 500_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] == 0
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=result["reservation_id"],
+        actual_micro=450_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert settled["outcome"] == SettleOutcome.SETTLED
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 0
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["total_usage"] == 450_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_usage"] == 0
+
+
+def test_idempotent_replay_keeps_original_credit_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-shard-replay"
+    _seed_sharded_credit(store, database, workspace_id, [1_000_000, 1_000_000, 1_000_000])
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="key",
+        creator_user_id=None,
+        limit_microdollars=3_000_000,
+    )
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": workspace_id,
+        "key_hash": key.hash,
+        "estimate": 250_000,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": "same-scope",
+        "idempotency_fingerprint": "same-fingerprint",
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+
+    first = authorize_atomic(**common, credit_shard=2)
+    replay = authorize_atomic(**common, credit_shard=0)
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["reservation_id"] == first["reservation_id"]
+    assert database.reservations[first["reservation_id"]]["credit_shard"] == 2
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 250_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] == 0
+
+
+def test_pre_migration_reservation_falls_back_to_ws_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-old-reservation"
+    _seed_sharded_credit(store, database, workspace_id, [1_000_000])
+    database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] = 200_000
+    database.reservations["old-r"] = {
+        "reservation_id": "old-r",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 0,
+        "credit_shard": None,
+        "key_shard": 0,
+        "credit_reserved_micro": 200_000,
+        "key_reserved_micro": 0,
+        "hold_usage_type": "Credits",
+        "settled_usage_type": None,
+        "actual_micro": None,
+        "authorization_id": "old-a",
+        "settled": False,
+        "expires_at": "2026-12-01T00:00:00Z",
+    }
+
+    result = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id="old-r",
+        actual_micro=150_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    row = database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+    assert row["reserved"] == 0
+    assert row["total_usage"] == 150_000
+
+
+def test_typed_direct_grant_distributes_delta_and_is_idempotent() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-grant-shards"
+    _seed_sharded_credit(store, database, workspace_id, [40, 30, 30])
+
+    assert store.credit_workspace_typed_direct(workspace_id, 10, "evt-sharded") is True
+    assert store.credit_workspace_typed_direct(workspace_id, 10, "evt-sharded") is False
+
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert [rows[(workspace_id, shard)]["total_credits"] for shard in range(3)] == [44, 33, 33]
+    assert store.get_credit_account(workspace_id).total_credits_microdollars == 110
+
+
+def test_typed_direct_grant_rolls_back_when_active_shard_is_missing() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-grant-missing-shard"
+    _seed_sharded_credit(store, database, workspace_id, [50, 50])
+    del database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 1)]
+
+    with pytest.raises(RuntimeError, match="missing tr_credit_balance shard 1"):
+        store.credit_workspace_typed_direct(workspace_id, 10, "evt-missing")
+
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_credits"] == 50
+    assert store.get_credit_account(workspace_id).total_credits_microdollars == 100
+    assert ("stripe_event", "evt-missing") not in database.rows
+
+
+def test_typed_credit_snapshot_sums_only_configured_shards() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-summary-shards"
+    _seed_sharded_credit(store, database, workspace_id, [50, 30, 20])
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    rows[(workspace_id, 0)].update(total_usage=5, reserved=1)
+    rows[(workspace_id, 1)].update(total_usage=6, reserved=2)
+    rows[(workspace_id, 2)].update(total_usage=7, reserved=3)
+    rows[(workspace_id, 3)] = _credit_row(
+        workspace_id, 3, total_credits=999, total_usage=999, reserved=999
+    )
+
+    assert store.typed_credit_snapshot(workspace_id) == (100, 18, 6)
+
+
+def test_typed_credit_snapshot_fails_closed_on_missing_configured_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-summary-gap"
+    _seed_sharded_credit(store, database, workspace_id, [50, 50])
+    del database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 1)]
+
+    with pytest.raises(RuntimeError, match="shard set is incomplete"):
+        store.typed_credit_snapshot(workspace_id)
+
+
+def test_generic_credit_mirror_does_not_overwrite_sharded_sub_budgets() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-mirror-shards"
+    account = CreditAccount(
+        workspace_id=workspace_id,
+        total_credits_microdollars=100,
+        shard_count=2,
+    )
+
+    store._write_entity("credit", workspace_id, account)
+
+    assert database.typed.get(CREDIT_BALANCE_TABLE, {}) == {}
+
+
+def test_compare_and_invariant_audit_are_credit_shard_aware() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-audit-shards"
+    _seed_sharded_credit(store, database, workspace_id, [60, 40])
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    rows[(workspace_id, 0)]["reserved"] = 7
+    rows[(workspace_id, 1)]["reserved"] = 11
+    database.reservations["legacy"] = {
+        "reservation_id": "legacy",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 0,
+        "credit_shard": None,
+        "credit_reserved_micro": 7,
+        "key_reserved_micro": 0,
+        "settled": False,
+    }
+    database.reservations["new"] = {
+        "reservation_id": "new",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 1,
+        "credit_shard": 1,
+        "credit_reserved_micro": 11,
+        "key_reserved_micro": 0,
+        "settled": False,
+    }
+
+    drift = compare(store)
+    invariant = audit_typed_invariants(store)
+
+    assert drift.clean, drift.samples
+    assert invariant.clean, invariant.samples
+    assert invariant.credit_rows == 2


### PR DESCRIPTION
Implements Increment 1 from #155.

Scope:
- additive tr_reservation.credit_shard migration with rolling fallback to legacy ws_shard
- CreditAccount shard_count default 1
- reserve records the selected credit shard; settle/refund release that recorded shard
- direct grants split deltas evenly across configured shards, remainder on shard 0
- typed snapshots, drift comparison, and invariant audit aggregate credit shards
- generic absolute-value credit mirror refuses to overwrite sharded sub-budgets
- no shard selection, scan, rebalance, operator activation, or production workspace sharding

Dark behavior:
- every existing and new workspace remains shard_count=1
- authorize still selects shard 0
- external gateway/API response shapes are unchanged
- existing reservations with no credit_shard settle through ws_shard fallback

Rollout requirement:
1. Apply scripts/deploy/migrate_typed_counters.sh before deploying application code.
2. Deploy the control plane region by region.
3. Keep shard_count=1 everywhere.
4. Run the typed invariant auditor after each region.

Verification:
- 1423 passed, 33 skipped
- uv run ruff check .
- uv run mypy
- bash -n scripts/deploy/migrate_typed_counters.sh
- git diff --check

This intentionally does not mix in the retry-budget or event-loop emergency patches.