### PR TITLE
Billing sharding increment 2: bounded reserve selection

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -57,6 +57,10 @@ from trusted_router.storage_gcp_counters import (
 )
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
+from trusted_router.storage_gcp_credit_shards import (
+    CreditShardCountCache,
+    randomized_credit_shards,
+)
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
 from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
 from trusted_router.storage_gcp_generations import SpannerGenerations
@@ -195,6 +199,14 @@ class SpannerBigtableStore:
         # TR_TYPED_COUNTER_MIRROR=1 only once tr_credit_balance / tr_key_limit
         # exist, or the mirror writes would fail the billing transactions.
         self._counter_mirror_enabled = os.environ.get("TR_TYPED_COUNTER_MIRROR", "") == "1"
+        self._credit_shard_counts = CreditShardCountCache(
+            ttl_seconds=float(
+                os.environ.get("TR_CREDIT_SHARD_COUNT_CACHE_SECONDS", "60")
+            ),
+            max_entries=int(
+                os.environ.get("TR_CREDIT_SHARD_COUNT_CACHE_ENTRIES", "10000")
+            ),
+        )
         io = SpannerIO(
             database=self._database,
             write_entity_batch=self._write_entity_batch,
@@ -396,6 +408,19 @@ class SpannerBigtableStore:
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
+
+    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+        def load() -> int:
+            account = self.get_credit_account(workspace_id)
+            if account is None:
+                # The typed balance cannot be administered safely without its
+                # control-plane account/config row. Treat this as drift, not as
+                # an implicit one-shard account.
+                raise RuntimeError("credit account not found while selecting shard")
+            return credit_shard_count(account)
+
+        shard_count = self._credit_shard_counts.get(workspace_id, load)
+        return randomized_credit_shards(shard_count)
 
     def add_members(self, workspace_id: str, emails: list[str], role: str = "member") -> list[Member]:
         members: list[Member] = []
@@ -1249,6 +1274,11 @@ class SpannerBigtableStore:
                 # gateway route splits on ':'.
                 return f"{AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED}:{blocked}", None
 
+        credit_shard_candidates = (
+            self._credit_shard_candidates(workspace_id)
+            if has_credit_candidate
+            else (UNSHARDED,)
+        )
         result = authorize_atomic(
             self._database,
             self._param_types,
@@ -1261,6 +1291,7 @@ class SpannerBigtableStore:
             idempotency_fingerprint=idempotency_fingerprint,
             expires_at=expires_at,
             build_auth_body=build_body,
+            credit_shard_candidates=credit_shard_candidates,
         )
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -140,6 +140,7 @@ def authorize_atomic(
     expires_at: Any,
     build_auth_body: Callable[[str, str], str],
     credit_shard: int = UNSHARDED,
+    credit_shard_candidates: tuple[int, ...] | None = None,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -147,6 +148,9 @@ def authorize_atomic(
     construct the gateway_authorization body once the ids are known.
     `reservation_usage_type` is the HOLD usage type (Credits if any credit
     candidate, else BYOK). `has_credit_candidate` gates the credit hold.
+    `credit_shard_candidates` is a bounded, pre-randomized order built outside
+    the transaction so Spanner retries use the same order. The first shard with
+    enough independent sub-budget is recorded durably on the reservation.
 
     Per-window key caps are checked by the CALLER via check_key_window_limits on
     a lock-free snapshot BEFORE this transaction — deliberately NOT in here: a
@@ -155,8 +159,21 @@ def authorize_atomic(
     transaction exists to eliminate (codex #93 review).
     """
     pt = param_types
-    if credit_shard < 0:
-        raise ValueError("credit_shard must be non-negative")
+    shard_candidates: tuple[int, ...]
+    if credit_shard_candidates is None:
+        shard_candidates = (credit_shard,)
+    else:
+        shard_candidates = tuple(credit_shard_candidates)
+        if credit_shard != UNSHARDED:
+            raise ValueError("pass credit_shard or credit_shard_candidates, not both")
+    if not shard_candidates:
+        raise ValueError("credit_shard_candidates must not be empty")
+    if any(shard < 0 for shard in shard_candidates):
+        raise ValueError("credit shards must be non-negative")
+    if len(set(shard_candidates)) != len(shard_candidates):
+        raise ValueError("credit_shard_candidates must be unique")
+    if not has_credit_candidate and shard_candidates != (UNSHARDED,):
+        raise ValueError("BYOK-only authorization must use credit shard zero")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -167,6 +184,7 @@ def authorize_atomic(
             "outcome": AuthorizeOutcome.REPLAY,
             "reservation_id": existing["reservation_id"],
             "authorization_id": existing["authorization_id"],
+            "credit_shard": int(existing.get("credit_shard", UNSHARDED)),
         }
 
     def txn(transaction: Any) -> dict:
@@ -185,17 +203,20 @@ def authorize_atomic(
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
         credit_hold = 0
+        selected_credit_shard = UNSHARDED
         if has_credit_candidate:
-            if not reserve_credit(
-                transaction, pt, workspace_id, estimate, shard=credit_shard
-            ):
+            for candidate in shard_candidates:
+                if reserve_credit(transaction, pt, workspace_id, estimate, shard=candidate):
+                    selected_credit_shard = candidate
+                    break
+            else:
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=credit_shard, credit_shard=credit_shard, key_shard=0,
+            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard, key_shard=0,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -209,6 +230,7 @@ def authorize_atomic(
             "outcome": AuthorizeOutcome.ACCEPTED,
             "reservation_id": reservation_id,
             "authorization_id": authorization_id,
+            "credit_shard": selected_credit_shard,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -27,6 +27,7 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 
 # Long tail lives entirely on shard 0; sharding a whale is a data change later.
 UNSHARDED = 0
+MAX_CREDIT_SHARDS = 64
 
 # OWNERSHIP SPLIT (2026-06-25 incident). The JSON->typed mirror writes ONLY the
 # columns JSON owns. `total_credits` is set by credit events (top-ups / grants /
@@ -80,6 +81,8 @@ def credit_shard_count(value: Any) -> int:
     count = int(raw)
     if count < 1:
         raise ValueError("credit shard_count must be a positive integer")
+    if count > MAX_CREDIT_SHARDS:
+        raise ValueError(f"credit shard_count must not exceed {MAX_CREDIT_SHARDS}")
     return count
 
 

--- a/src/trusted_router/storage_gcp_credit_shards.py
+++ b/src/trusted_router/storage_gcp_credit_shards.py
@@ -1,0 +1,117 @@
+"""Credit-ledger shard selection and allow-stale shard-count caching.
+
+The billing cap remains hard because each shard owns a disjoint sub-budget.
+This module only chooses the order in which those independent budgets are
+tried; it never changes balances or decides whether a reserve is affordable.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from trusted_router.storage_gcp_counters import credit_shard_count
+
+DEFAULT_CACHE_TTL_SECONDS = 60.0
+DEFAULT_CACHE_MAX_ENTRIES = 10_000
+_LOAD_LOCK_STRIPES = 64
+
+
+def randomized_credit_shards(
+    shard_count: int,
+    *,
+    rng: random.Random | None = None,
+) -> tuple[int, ...]:
+    """Return every configured shard exactly once in randomized order.
+
+    The one-shard path deliberately avoids the RNG so its behavior is exactly
+    the pre-sharding path. The returned tuple is built outside the Spanner
+    callback and is therefore stable if Spanner retries an aborted transaction.
+    """
+    count = credit_shard_count({"shard_count": shard_count})
+    if count == 1:
+        return (0,)
+    source = rng if rng is not None else random.SystemRandom()
+    return tuple(source.sample(range(count), count))
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    shard_count: int
+    expires_at: float
+
+
+class CreditShardCountCache:
+    """Bounded LRU/TTL cache for a workspace's allow-stale shard count.
+
+    A stale smaller value only reduces spreading and may reject early; a stale
+    larger value scans retired/missing rows before a live row. Neither can
+    create credit. Operator split/unshard still uses pause + drain + one atomic
+    data transition, and explicitly invalidates this cache in its process.
+
+    Striped miss locks prevent a burst for one workspace from stampeding the
+    Spanner JSON row while allowing unrelated cache misses to load in parallel.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        max_entries: int = DEFAULT_CACHE_MAX_ENTRIES,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("credit shard cache TTL must be positive")
+        if max_entries < 1:
+            raise ValueError("credit shard cache max_entries must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entries = int(max_entries)
+        self._clock = clock
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._lock = threading.Lock()
+        self._load_locks = tuple(threading.Lock() for _ in range(_LOAD_LOCK_STRIPES))
+
+    def get(self, workspace_id: str, loader: Callable[[], int]) -> int:
+        cached = self._get_fresh(workspace_id)
+        if cached is not None:
+            return cached
+
+        load_lock = self._load_locks[hash(workspace_id) % len(self._load_locks)]
+        with load_lock:
+            cached = self._get_fresh(workspace_id)
+            if cached is not None:
+                return cached
+            loaded = credit_shard_count({"shard_count": loader()})
+            self._put(workspace_id, loaded)
+            return loaded
+
+    def invalidate(self, workspace_id: str) -> None:
+        with self._lock:
+            self._entries.pop(workspace_id, None)
+
+    def _get_fresh(self, workspace_id: str) -> int | None:
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(workspace_id)
+            if entry is None:
+                return None
+            if entry.expires_at <= now:
+                self._entries.pop(workspace_id, None)
+                return None
+            self._entries.move_to_end(workspace_id)
+            return entry.shard_count
+
+    def _put(self, workspace_id: str, shard_count: int) -> None:
+        entry = _CacheEntry(
+            shard_count=shard_count,
+            expires_at=self._clock() + self._ttl_seconds,
+        )
+        with self._lock:
+            self._entries[workspace_id] = entry
+            self._entries.move_to_end(workspace_id)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -249,8 +249,8 @@ class CreditAccount:
     total_usage_microdollars: int = 0
     reserved_microdollars: int = 0
     # Number of independent tr_credit_balance sub-ledgers owned by this
-    # workspace. Increment 1 keeps every account at one shard; later increments
-    # add selection/rebalancing and an operator-only activation path.
+    # workspace. The default preserves the original one-row behavior; only the
+    # pause/drain operator path may activate more shards for a hot workspace.
     shard_count: int = 1
     # Auto-refill: when available drops below threshold, charge the saved
     # Stripe payment method off-session for `auto_refill_amount_microdollars`.

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1033,6 +1033,9 @@ def make_fake_store(
     store._database = db
     store._bt_table = bt
     store._counter_mirror_enabled = True  # exercise the Step-1 typed-counter mirror
+    from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+
+    store._credit_shard_counts = CreditShardCountCache()
     io = SpannerIO(
         database=db,
         write_entity_batch=store._write_entity_batch,

--- a/tests/test_credit_row_sharding_increment2.py
+++ b/tests/test_credit_row_sharding_increment2.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import random
+import threading
+import time
+from collections import Counter
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome, authorize_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_credit_shards import (
+    CreditShardCountCache,
+    randomized_credit_shards,
+)
+from trusted_router.storage_models import CreditAccount
+
+
+def _credit_row(
+    workspace_id: str,
+    shard: int,
+    total_credits: int,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "shard": shard,
+        "total_credits": total_credits,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _seed(
+    totals: list[int],
+    *,
+    workspace_id: str = "ws-sharded",
+    key_limit: int | None = None,
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(totals),
+            shard_count=len(totals),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = _credit_row(workspace_id, shard, total)
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="shard-test",
+        creator_user_id=None,
+        limit_microdollars=key_limit,
+    )
+    return store, database, key
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id}
+    )
+
+
+def _authorize(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int,
+    candidates: tuple[int, ...],
+    scope: str | None = None,
+) -> dict[str, Any]:
+    return authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=estimate,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope=scope,
+        idempotency_fingerprint="same-body" if scope else None,
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        credit_shard_candidates=candidates,
+    )
+
+
+def test_randomized_order_is_complete_unique_and_spreads_first_choice() -> None:
+    first_choices = Counter(
+        randomized_credit_shards(8, rng=random.Random(seed))[0]  # noqa: S311 - deterministic
+        for seed in range(256)
+    )
+
+    assert set(first_choices) == set(range(8))
+    assert all(count >= 20 for count in first_choices.values())
+    for seed in range(32):
+        order = randomized_credit_shards(8, rng=random.Random(seed))  # noqa: S311
+        assert len(order) == 8
+        assert set(order) == set(range(8))
+
+
+def test_one_shard_order_does_not_touch_rng() -> None:
+    class ExplodingRandom(random.Random):
+        def sample(self, population: Any, k: int, *, counts: Any = None) -> list[Any]:
+            raise AssertionError("one-shard path must not call RNG")
+
+    assert randomized_credit_shards(1, rng=ExplodingRandom()) == (0,)
+
+
+def test_invalid_or_unbounded_candidate_configuration_fails_closed() -> None:
+    with pytest.raises(ValueError, match="must not exceed"):
+        randomized_credit_shards(65)
+
+    store, _database, key = _seed([100])
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": "ws-sharded",
+        "key_hash": key.hash,
+        "estimate": 1,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": None,
+        "idempotency_fingerprint": None,
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+    with pytest.raises(ValueError, match="must not be empty"):
+        authorize_atomic(**common, credit_shard_candidates=())
+    with pytest.raises(ValueError, match="must be unique"):
+        authorize_atomic(**common, credit_shard_candidates=(0, 0))
+    with pytest.raises(ValueError, match="non-negative"):
+        authorize_atomic(**common, credit_shard_candidates=(-1,))
+
+
+def test_scan_skips_insufficient_shard_and_records_first_success() -> None:
+    store, database, key = _seed([100, 1_000], key_limit=2_000)
+
+    result = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=500,
+        candidates=(0, 1),
+    )
+
+    assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert result["credit_shard"] == 1
+    reservation = database.reservations[result["reservation_id"]]
+    assert reservation["credit_shard"] == 1
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 0)]["reserved"] == 0
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 1)]["reserved"] == 500
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 500
+
+
+def test_all_shards_insufficient_rolls_back_key_hold_and_writes_nothing() -> None:
+    store, database, key = _seed([100, 200, 300], key_limit=10_000)
+
+    result = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=500,
+        candidates=(2, 0, 1),
+    )
+
+    assert result == {"outcome": AuthorizeOutcome.INSUFFICIENT_CREDITS}
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+    assert all(
+        row["reserved"] == 0
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    )
+
+
+def test_replay_keeps_original_shard_when_candidate_order_changes() -> None:
+    store, database, key = _seed([1_000, 1_000, 1_000])
+
+    first = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=250,
+        candidates=(2, 1, 0),
+        scope="stable-replay",
+    )
+    replay = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=250,
+        candidates=(0, 1, 2),
+        scope="stable-replay",
+    )
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["credit_shard"] == first["credit_shard"] == 2
+    assert len(database.reservations) == 1
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 2)]["reserved"] == 250
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 0)]["reserved"] == 0
+
+
+def test_shard_count_cache_hits_expires_and_is_bounded() -> None:
+    now = [100.0]
+    cache = CreditShardCountCache(
+        ttl_seconds=10,
+        max_entries=2,
+        clock=lambda: now[0],
+    )
+    loads = Counter()
+
+    def load(name: str, value: int) -> int:
+        loads[name] += 1
+        return value
+
+    assert cache.get("a", lambda: load("a", 2)) == 2
+    assert cache.get("a", lambda: load("a", 3)) == 2
+    assert loads["a"] == 1
+
+    now[0] = 111
+    assert cache.get("a", lambda: load("a", 3)) == 3
+    assert loads["a"] == 2
+
+    assert cache.get("b", lambda: load("b", 1)) == 1
+    assert cache.get("c", lambda: load("c", 1)) == 1
+    assert cache.get("a", lambda: load("a", 4)) == 4  # evicted LRU
+    assert loads["a"] == 3
+
+
+def test_shard_count_cache_singleflights_same_workspace_miss() -> None:
+    cache = CreditShardCountCache(ttl_seconds=60, max_entries=100)
+    load_count = 0
+    load_lock = threading.Lock()
+    start = threading.Barrier(9)
+    results: list[int] = []
+
+    def loader() -> int:
+        nonlocal load_count
+        with load_lock:
+            load_count += 1
+        time.sleep(0.02)
+        return 16
+
+    def worker() -> None:
+        start.wait(timeout=5)
+        results.append(cache.get("hot-workspace", loader))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert results == [16] * 8
+    assert load_count == 1
+
+
+def test_store_byok_path_does_not_load_credit_shard_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _database, key = _seed([100, 100])
+
+    def fail_if_called(_workspace_id: str) -> tuple[int, ...]:
+        raise AssertionError("BYOK authorize must not load credit shard configuration")
+
+    monkeypatch.setattr(store, "_credit_shard_candidates", fail_if_called)
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=10,
+        has_credit_candidate=False,
+        reservation_usage_type="BYOK",
+        model_id="model",
+        provider="provider",
+        requested_model_id=None,
+        candidate_model_ids=["model"],
+        region="us",
+        endpoint_id="endpoint",
+        candidate_endpoint_ids=["endpoint"],
+        idempotency_key=None,
+        idempotency_fingerprint=None,
+    )
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+
+
+def test_concurrent_sharded_reserves_never_exceed_global_cap() -> None:
+    shard_count = 8
+    per_shard_credit = 40
+    estimate = 10
+    store, database, key = _seed([per_shard_credit] * shard_count)
+    start = threading.Barrier(65)
+    outcomes: list[str] = []
+    outcomes_lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        order = randomized_credit_shards(
+            shard_count,
+            rng=random.Random(index),  # noqa: S311 - deterministic test distribution
+        )
+        start.wait(timeout=10)
+        result = _authorize(
+            store,
+            workspace_id="ws-sharded",
+            key_hash=key.hash,
+            estimate=estimate,
+            candidates=order,
+            scope=f"request-{index}",
+        )
+        with outcomes_lock:
+            outcomes.append(result["outcome"])
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(64)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=10)
+    for thread in threads:
+        thread.join(timeout=15)
+        assert not thread.is_alive()
+
+    capacity = shard_count * per_shard_credit // estimate
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == capacity
+    assert outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS) == 64 - capacity
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert sum(row["reserved"] for row in rows.values()) == capacity * estimate
+    assert all(
+        row["reserved"] + row["total_usage"] <= row["total_credits"]
+        for row in rows.values()
+    )
+    assert len(database.reservations) == capacity


### PR DESCRIPTION
## Summary
- cache each workspace credit shard count with bounded LRU/TTL and striped miss singleflight
- randomize a stable bounded shard order outside Spanner retry callbacks
- scan each independent sub-budget at most once and durably record the selected shard
- preserve exact shard_count=1 and BYOK behavior
- fail closed on malformed or excessive shard configuration

## Billing safety
Each shard owns a disjoint sub-budget. Conditional DML still gates every hold against one shard, so the sum of accepted holds cannot exceed the partitioned global credit grant. If every shard rejects, the transaction rolls back the key hold and writes no reservation.

## Verification
- 1,433 passed, 33 skipped
- ruff clean
- mypy clean
- concurrent cap test: 64 requests against 32-request capacity accepted exactly 32

Stacked on #156. No workspace is activated above shard_count=1 by this PR.