### PR TITLE
Billing sharding increment 3: transactional fragmentation repair

### DIFF
--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -185,6 +185,10 @@ ensure_column tr_key_limit month_start "TIMESTAMP"
 # Credit-row sharding increment 1. Existing reservations retain ws_shard=0;
 # old rows read NULL for the additive column and the application falls back to
 # ws_shard. New rows write both during the rolling-compatibility window.
+# Existing databases intentionally add this as nullable: adding NOT NULL would
+# force a synchronous backfill. Fresh installs use NOT NULL DEFAULT(0); a later
+# post-backfill migration may tighten existing databases after the fallback is
+# retired. Do not "fix" this rolling-schema divergence in this additive step.
 ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"
 
 # ── Durable settle outbox (docs/design/durable-settle-outbox.md) ────────────

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -58,6 +58,7 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_credit_shards import (
+    CreditShardConfigurationMissingError,
     CreditShardCountCache,
     randomized_credit_shards,
 )
@@ -409,18 +410,22 @@ class SpannerBigtableStore:
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
 
-    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+    def _credit_shard_count(self, workspace_id: str) -> int:
         def load() -> int:
             account = self.get_credit_account(workspace_id)
             if account is None:
                 # The typed balance cannot be administered safely without its
                 # control-plane account/config row. Treat this as drift, not as
                 # an implicit one-shard account.
-                raise RuntimeError("credit account not found while selecting shard")
+                raise CreditShardConfigurationMissingError(
+                    "credit account not found while selecting shard"
+                )
             return credit_shard_count(account)
 
-        shard_count = self._credit_shard_counts.get(workspace_id, load)
-        return randomized_credit_shards(shard_count)
+        return self._credit_shard_counts.get(workspace_id, load)
+
+    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+        return randomized_credit_shards(self._credit_shard_count(workspace_id))
 
     def add_members(self, workspace_id: str, emails: list[str], role: str = "member") -> list[Member]:
         members: list[Member] = []
@@ -1279,20 +1284,66 @@ class SpannerBigtableStore:
             if has_credit_candidate
             else (UNSHARDED,)
         )
-        result = authorize_atomic(
-            self._database,
-            self._param_types,
-            workspace_id=workspace_id,
-            key_hash=key_hash,
-            estimate=estimate,
-            has_credit_candidate=has_credit_candidate,
-            reservation_usage_type=str(usage),
-            idempotency_scope=scope,
-            idempotency_fingerprint=idempotency_fingerprint,
-            expires_at=expires_at,
-            build_auth_body=build_body,
-            credit_shard_candidates=credit_shard_candidates,
-        )
+        def run_authorize(candidates: tuple[int, ...]) -> dict[str, Any]:
+            return authorize_atomic(
+                self._database,
+                self._param_types,
+                workspace_id=workspace_id,
+                key_hash=key_hash,
+                estimate=estimate,
+                has_credit_candidate=has_credit_candidate,
+                reservation_usage_type=str(usage),
+                idempotency_scope=scope,
+                idempotency_fingerprint=idempotency_fingerprint,
+                expires_at=expires_at,
+                build_auth_body=build_body,
+                credit_shard_candidates=candidates,
+            )
+
+        result = run_authorize(credit_shard_candidates)
+        if (
+            result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+            and has_credit_candidate
+        ):
+            from trusted_router.storage_gcp_credit_rebalance import (
+                RebalanceOutcome,
+                rebalance_credit_for_estimate,
+            )
+
+            # An all-shards rejection is cold. Refresh once so a remote
+            # pause/drain split or unshard cannot produce a false 402 until the
+            # normal TTL expires. The accepted hot path never pays this read.
+            previous_count = len(credit_shard_candidates)
+            self._credit_shard_counts.invalidate(workspace_id)
+            refreshed_candidates = self._credit_shard_candidates(workspace_id)
+            if len(refreshed_candidates) != previous_count:
+                credit_shard_candidates = refreshed_candidates
+                result = run_authorize(credit_shard_candidates)
+
+            def rebalance(candidates: tuple[int, ...]) -> dict[str, int | str]:
+                return rebalance_credit_for_estimate(
+                    self._database,
+                    self._param_types,
+                    workspace_id=workspace_id,
+                    shard_count=len(candidates),
+                    target_shard=candidates[0],
+                    estimate=estimate,
+                )
+
+            if (
+                result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+                and len(credit_shard_candidates) > 1
+            ):
+                rebalance_result = rebalance(credit_shard_candidates)
+                if rebalance_result["outcome"] == RebalanceOutcome.INCOMPLETE:
+                    raise RuntimeError(
+                        "configured credit shard set is incomplete after cache refresh"
+                    )
+                if rebalance_result["outcome"] in {
+                    RebalanceOutcome.MOVED,
+                    RebalanceOutcome.NOT_NEEDED,
+                }:
+                    result = run_authorize(credit_shard_candidates)
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
         if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
@@ -1352,11 +1403,11 @@ class SpannerBigtableStore:
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        with self._database.snapshot(multi_use=True) as snapshot:
-            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
-            if account is None:
-                return None
-            shard_count = credit_shard_count(account)
+        try:
+            shard_count = self._credit_shard_count(workspace_id)
+        except CreditShardConfigurationMissingError:
+            return None
+        with self._database.snapshot() as snapshot:
             rows = list(snapshot.execute_sql(
                 "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
                 "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -58,6 +58,60 @@ def reserve_credit(
     return count == 1
 
 
+def transfer_credit_budget(
+    transaction: Any,
+    param_types: Any,
+    workspace_id: str,
+    amount: int,
+    *,
+    donor_shard: int,
+    target_shard: int,
+) -> bool:
+    """Atomically move idle sub-budget from one credit shard to another.
+
+    The donor predicate permits moving only current headroom, never usage or a
+    live reservation. Both DML statements run in the caller's transaction; a
+    failure must make the caller roll the whole transaction back so the global
+    sum of ``total_credits`` cannot change.
+    """
+    if amount <= 0:
+        raise ValueError("credit budget transfer amount must be positive")
+    if donor_shard == target_shard:
+        raise ValueError("credit budget donor and target must differ")
+    donor_count = transaction.execute_update(
+        "UPDATE tr_credit_balance SET total_credits=total_credits-@move "
+        "WHERE workspace_id=@ws AND shard=@donor "
+        "AND (total_credits-total_usage-reserved)>=@move",
+        params={
+            "move": int(amount),
+            "ws": workspace_id,
+            "donor": donor_shard,
+        },
+        param_types={
+            "move": param_types.INT64,
+            "ws": param_types.STRING,
+            "donor": param_types.INT64,
+        },
+    )
+    if donor_count != 1:
+        return False
+    target_count = transaction.execute_update(
+        "UPDATE tr_credit_balance SET total_credits=total_credits+@move "
+        "WHERE workspace_id=@ws AND shard=@target",
+        params={
+            "move": int(amount),
+            "ws": workspace_id,
+            "target": target_shard,
+        },
+        param_types={
+            "move": param_types.INT64,
+            "ws": param_types.STRING,
+            "target": param_types.INT64,
+        },
+    )
+    return target_count == 1
+
+
 def release_credit(
     transaction: Any,
     param_types: Any,

--- a/src/trusted_router/storage_gcp_credit_rebalance.py
+++ b/src/trusted_router/storage_gcp_credit_rebalance.py
@@ -1,0 +1,121 @@
+"""Lazy, transactionally safe repair of fragmented credit sub-budgets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.storage_gcp_counter_dml import transfer_credit_budget
+from trusted_router.storage_gcp_counters import credit_shard_count
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+
+
+class RebalanceOutcome:
+    MOVED = "moved"
+    NOT_NEEDED = "not_needed"
+    INSUFFICIENT = "insufficient"
+    INCOMPLETE = "incomplete"
+
+
+class _RebalanceInvariantError(RuntimeError):
+    """Rollback a transfer plan if any guarded DML does not affect one row."""
+
+
+def rebalance_credit_for_estimate(
+    database: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    shard_count: int,
+    target_shard: int,
+    estimate: int,
+) -> dict[str, int | str]:
+    """Consolidate enough idle headroom onto ``target_shard`` for one hold.
+
+    This is a cold path after a bounded reserve scan rejected every shard. The
+    transaction moves only ``total_credits - total_usage - reserved`` and keeps
+    the global ``SUM(total_credits)`` byte-for-byte unchanged.
+    """
+    count = credit_shard_count({"shard_count": shard_count})
+    if target_shard < 0 or target_shard >= count:
+        raise ValueError("rebalance target shard is outside configured range")
+    if estimate <= 0:
+        raise ValueError("rebalance estimate must be positive")
+    pt = param_types
+
+    def txn(transaction: Any) -> dict[str, int | str]:
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        observed = [int(row[0]) for row in rows]
+        if observed != list(range(count)):
+            return {
+                "outcome": RebalanceOutcome.INCOMPLETE,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+
+        headroom: dict[int, int] = {}
+        for shard, total_credits, total_usage, reserved in rows:
+            available = int(total_credits) - int(total_usage) - int(reserved)
+            if available < 0:
+                raise _RebalanceInvariantError(
+                    f"credit shard {shard} exceeds its sub-budget"
+                )
+            headroom[int(shard)] = available
+
+        target_available = headroom[target_shard]
+        if target_available >= estimate:
+            return {
+                "outcome": RebalanceOutcome.NOT_NEEDED,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+        if sum(headroom.values()) < estimate:
+            return {
+                "outcome": RebalanceOutcome.INSUFFICIENT,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+
+        needed = estimate - target_available
+        moved = 0
+        donors = sorted(
+            (
+                (available, shard)
+                for shard, available in headroom.items()
+                if shard != target_shard and available > 0
+            ),
+            reverse=True,
+        )
+        for available, donor_shard in donors:
+            amount = min(available, needed)
+            if not transfer_credit_budget(
+                transaction,
+                pt,
+                workspace_id,
+                amount,
+                donor_shard=donor_shard,
+                target_shard=target_shard,
+            ):
+                raise _RebalanceInvariantError(
+                    "credit shard changed or disappeared during rebalance"
+                )
+            moved += amount
+            needed -= amount
+            if needed == 0:
+                break
+        if needed != 0:  # pragma: no cover - guarded by global headroom check.
+            raise _RebalanceInvariantError("rebalance plan did not satisfy estimate")
+        return {
+            "outcome": RebalanceOutcome.MOVED,
+            "moved_micro": moved,
+            "target_shard": target_shard,
+        }
+
+    return run_in_transaction_with_retry(database, txn)

--- a/src/trusted_router/storage_gcp_credit_shards.py
+++ b/src/trusted_router/storage_gcp_credit_shards.py
@@ -21,6 +21,10 @@ DEFAULT_CACHE_MAX_ENTRIES = 10_000
 _LOAD_LOCK_STRIPES = 64
 
 
+class CreditShardConfigurationMissingError(RuntimeError):
+    """The typed balance exists without its authoritative shard configuration."""
+
+
 def randomized_credit_shards(
     shard_count: int,
     *,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -329,6 +329,37 @@ class _FakeTransaction:
             )
             self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
             return 1
+        if "UPDATE tr_credit_balance SET total_credits=total_credits-@move" in sql:
+            _require_pred(
+                sql,
+                "(total_credits-total_usage-reserved)>=@move",
+                "credit-rebalance-donor",
+            )
+            pk = (p["ws"], p["donor"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            available = (
+                rec["total_credits"] - rec["total_usage"] - rec["reserved"]
+                if rec is not None
+                else -1
+            )
+            if rec is None or available < p["move"]:
+                return 0
+            new = dict(rec, total_credits=rec["total_credits"] - p["move"])
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
+        if "UPDATE tr_credit_balance SET total_credits=total_credits+@move" in sql:
+            _require_pred(
+                sql,
+                "WHERE workspace_id=@ws AND shard=@target",
+                "credit-rebalance-target",
+            )
+            pk = (p["ws"], p["target"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            if rec is None:
+                return 0
+            new = dict(rec, total_credits=rec["total_credits"] + p["move"])
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
         if sql.startswith("INSERT INTO tr_credit_balance"):
             pk = (p["ws"], p["shard"])
             if pk in self.db.typed.get("tr_credit_balance", {}):

--- a/tests/test_credit_row_sharding_increment3.py
+++ b/tests/test_credit_row_sharding_increment3.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome, settle_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_credit_rebalance import (
+    RebalanceOutcome,
+    rebalance_credit_for_estimate,
+)
+from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+from trusted_router.storage_models import CreditAccount
+
+
+def _seed(
+    totals: list[int],
+    *,
+    usage: list[int] | None = None,
+    reserved: list[int] | None = None,
+    workspace_id: str = "ws-fragmented",
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    usage = usage or [0] * len(totals)
+    reserved = reserved or [0] * len(totals)
+    assert len(usage) == len(totals)
+    assert len(reserved) == len(totals)
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(totals),
+            total_usage_microdollars=sum(usage),
+            reserved_microdollars=sum(reserved),
+            shard_count=len(totals),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": total,
+            "total_usage": usage[shard],
+            "reserved": reserved[shard],
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="fragmentation-test",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    return store, database, key
+
+
+def _rebalance(
+    store: Any,
+    *,
+    shard_count: int,
+    target_shard: int,
+    estimate: int,
+    workspace_id: str = "ws-fragmented",
+) -> dict[str, int | str]:
+    return rebalance_credit_for_estimate(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        shard_count=shard_count,
+        target_shard=target_shard,
+        estimate=estimate,
+    )
+
+
+def _typed_authorize(
+    store: Any,
+    key: Any,
+    *,
+    estimate: int,
+    idempotency_key: str | None = None,
+) -> tuple[str, Any]:
+    return store.authorize_gateway_typed(
+        workspace_id="ws-fragmented",
+        key_hash=key.hash,
+        estimate=estimate,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="model",
+        provider="provider",
+        requested_model_id=None,
+        candidate_model_ids=["model"],
+        region="us",
+        endpoint_id="endpoint",
+        candidate_endpoint_ids=["endpoint"],
+        idempotency_key=idempotency_key,
+        idempotency_fingerprint="same-body" if idempotency_key else None,
+    )
+
+
+def test_rebalance_moves_only_idle_budget_and_preserves_global_totals() -> None:
+    store, database, _key = _seed([100, 100], usage=[60, 60])
+
+    result = _rebalance(store, shard_count=2, target_shard=0, estimate=60)
+
+    assert result == {
+        "outcome": RebalanceOutcome.MOVED,
+        "moved_micro": 20,
+        "target_shard": 0,
+    }
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert rows[("ws-fragmented", 0)]["total_credits"] == 120
+    assert rows[("ws-fragmented", 1)]["total_credits"] == 80
+    assert [rows[("ws-fragmented", shard)]["total_usage"] for shard in range(2)] == [60, 60]
+    assert sum(row["total_credits"] for row in rows.values()) == 200
+    assert all(row["reserved"] == 0 for row in rows.values())
+
+
+def test_rebalance_can_consolidate_from_multiple_donors() -> None:
+    store, database, _key = _seed([100, 100, 100, 100], usage=[80, 80, 80, 80])
+
+    result = _rebalance(store, shard_count=4, target_shard=0, estimate=70)
+
+    assert result["outcome"] == RebalanceOutcome.MOVED
+    assert result["moved_micro"] == 50
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert rows[("ws-fragmented", 0)]["total_credits"] == 150
+    assert sum(row["total_credits"] for row in rows.values()) == 400
+    assert all(row["total_credits"] >= row["total_usage"] + row["reserved"] for row in rows.values())
+
+
+def test_rebalance_distinguishes_not_needed_insufficient_and_incomplete() -> None:
+    store, database, _key = _seed([100, 100], usage=[20, 60])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    assert _rebalance(store, shard_count=2, target_shard=0, estimate=60)[
+        "outcome"
+    ] == RebalanceOutcome.NOT_NEEDED
+    assert _rebalance(store, shard_count=2, target_shard=1, estimate=130)[
+        "outcome"
+    ] == RebalanceOutcome.INSUFFICIENT
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-fragmented", 1))
+    assert _rebalance(store, shard_count=2, target_shard=0, estimate=90)[
+        "outcome"
+    ] == RebalanceOutcome.INCOMPLETE
+
+
+def test_rebalance_fails_closed_on_preexisting_sub_budget_violation() -> None:
+    store, database, _key = _seed([100, 100], usage=[101, 0])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    with pytest.raises(RuntimeError, match="exceeds its sub-budget"):
+        _rebalance(store, shard_count=2, target_shard=0, estimate=50)
+
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+
+def test_store_rebalances_fragmentation_then_authorizes_and_settles_once() -> None:
+    store, database, key = _seed([100, 100], usage=[60, 60])
+
+    outcome, authorization = _typed_authorize(store, key, estimate=60)
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    [reservation] = database.reservations.values()
+    selected_shard = reservation["credit_shard"]
+    assert database.typed[CREDIT_BALANCE_TABLE][
+        ("ws-fragmented", selected_shard)
+    ]["reserved"] == 60
+    assert sum(
+        row["total_credits"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 200
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation["reservation_id"],
+        actual_micro=55,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert settled["outcome"] == "settled"
+    assert sum(
+        row["total_usage"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 175
+    assert sum(
+        row["reserved"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 0
+
+
+def test_true_insufficient_store_authorize_rolls_back_every_hold() -> None:
+    store, database, key = _seed([100, 100], usage=[70, 70])
+
+    outcome, authorization = _typed_authorize(store, key, estimate=70)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+    assert sum(
+        row["total_credits"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 200
+
+
+def test_stale_smaller_cache_refreshes_and_uses_newly_activated_shards() -> None:
+    store, database, key = _seed([0, 0, 100])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-fragmented", lambda: 1) == 1
+
+    outcome, authorization = _typed_authorize(store, key, estimate=50)
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    [reservation] = database.reservations.values()
+    assert reservation["credit_shard"] == 2
+
+
+def test_stale_larger_cache_refreshes_after_rejection_without_drift_error() -> None:
+    store, _database, key = _seed([40])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-fragmented", lambda: 3) == 3
+
+    outcome, authorization = _typed_authorize(store, key, estimate=60)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+
+
+def test_persistent_missing_configured_shard_raises_and_leaks_no_hold() -> None:
+    store, database, key = _seed([100, 100, 100], usage=[60, 60, 60])
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-fragmented", 2))
+
+    with pytest.raises(RuntimeError, match="configured credit shard set is incomplete"):
+        _typed_authorize(store, key, estimate=60)
+
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+
+
+def test_concurrent_fragmentation_repair_preserves_cap_and_accepts_at_most_one() -> None:
+    store, database, key = _seed([100, 100], usage=[60, 60])
+    start = threading.Barrier(3)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        start.wait(timeout=10)
+        outcome, _authorization = _typed_authorize(
+            store,
+            key,
+            estimate=60,
+            idempotency_key=f"concurrent-{index}",
+        )
+        with lock:
+            outcomes.append(outcome)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=10)
+    for thread in threads:
+        thread.join(timeout=15)
+        assert not thread.is_alive()
+
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1
+    assert outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS) == 1
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert sum(row["total_credits"] for row in rows.values()) == 200
+    assert sum(row["reserved"] for row in rows.values()) == 60
+    assert all(
+        row["total_usage"] + row["reserved"] <= row["total_credits"]
+        for row in rows.values()
+    )
+    assert len(database.reservations) == 1


### PR DESCRIPTION
## Summary
- distinguish true exhaustion from fragmented credit headroom after the bounded shard scan
- transactionally move only idle sub-budget to one target shard and retry authorize once
- preserve global deposited credits exactly; never move usage or live reservations
- refresh stale shard-count cache on all-shard rejection so remote split/unshard converges immediately
- fail closed on missing configured rows or violated shard invariants
- reuse the shard-count cache for balance snapshots and document rolling column nullability per Fable's P3 notes on #156

## Verification
- 1,443 passed, 33 skipped
- ruff clean
- mypy clean
- 10 new tests including multi-donor consolidation, true exhaustion, stale smaller/larger cache, missing rows, settle, and concurrent repair

Stacked on #158. No workspace is activated above shard_count=1 by this PR.