### PR TITLE
Billing sharding increment 4: safe split and unshard operator

### DIFF
--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -1,0 +1,167 @@
+"""Safely split or consolidate one hot workspace's typed credit row.
+
+The operation is intentionally two phase so a failed verification can never
+silently resume billing:
+
+  # Pause, drain-check, and atomically split. Re-run while parked if draining.
+  python scripts/shard_workspace.py prepare --workspace WS --shards 16 --apply
+
+  # Verify the committed shape + global billing invariants, then unpause.
+  python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
+
+Reverse with the same commands and ``--shards 1``. Without ``--apply`` every
+command is read-only. A failed prepare/finish always leaves the workspace paused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+os.environ.setdefault("TR_TYPED_COUNTER_MIRROR", "1")
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
+from trusted_router.storage_gcp_counters import MAX_CREDIT_SHARDS
+from trusted_router.storage_gcp_credit_shard_admin import (
+    CreditReshardResult,
+    inspect_credit_reshard,
+    reshard_credit_account,
+)
+
+
+def _print_status(status: CreditReshardResult) -> None:
+    print(
+        f"{status.workspace_id}: current_shards={status.current_shard_count} "
+        f"target_shards={status.target_shard_count} ready={status.ready} "
+        f"applied={status.applied}"
+    )
+    print(
+        "  typed totals: "
+        f"credits={status.total_credits_micro} usage={status.total_usage_micro} "
+        f"reserved={status.reserved_micro}"
+    )
+    print(
+        "  open reservations: "
+        f"typed={status.typed_open_reservations} legacy={status.legacy_open_reservations}"
+    )
+    for reason in status.reasons:
+        print(f"  BLOCKED: {reason}")
+
+
+def _pause(store: Any, workspace_id: str) -> bool:
+    updated = store.update_workspace(
+        workspace_id,
+        billing_paused=True,
+        billing_pause_reason="credit-row reshard prepare",
+    )
+    return updated is not None and bool(updated.billing_paused)
+
+
+def run_status(store: Any, args: argparse.Namespace) -> int:
+    _print_status(inspect_credit_reshard(store, args.workspace, args.shards))
+    return 0
+
+
+def run_prepare(store: Any, args: argparse.Namespace) -> int:
+    if not args.apply:
+        status = inspect_credit_reshard(store, args.workspace, args.shards)
+        _print_status(status)
+        print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
+        return 0
+    if not _pause(store, args.workspace):
+        print("ERROR: could not pause workspace", file=sys.stderr)
+        return 1
+    status = reshard_credit_account(store, args.workspace, args.shards, apply=True)
+    _print_status(status)
+    if not status.ready:
+        print("Workspace remains paused. Re-run prepare after holds drain.")
+        draining = any("drain" in reason or "open" in reason for reason in status.reasons)
+        return 2 if draining else 1
+    audit = audit_typed_invariants(store)
+    print(audit.summary())
+    if not audit.clean:
+        print("Workspace remains paused because the invariant audit failed.", file=sys.stderr)
+        return 1
+    print(
+        "Prepared and verified. Workspace remains paused; run finish with the "
+        "same --shards value to resume billing."
+    )
+    return 0
+
+
+def run_finish(store: Any, args: argparse.Namespace) -> int:
+    status = inspect_credit_reshard(store, args.workspace, args.shards)
+    _print_status(status)
+    if not status.ready:
+        print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
+        return 1
+    audit = audit_typed_invariants(store)
+    print(audit.summary())
+    if not audit.clean:
+        print("ERROR: refusing to unpause; invariant audit failed", file=sys.stderr)
+        return 1
+    if not args.apply:
+        print("DRY-RUN: would unpause this verified workspace")
+        return 0
+    updated = store.update_workspace(
+        args.workspace,
+        billing_paused=False,
+        billing_pause_reason="",
+    )
+    if updated is None or updated.billing_paused:
+        print("ERROR: failed to verify workspace unpause", file=sys.stderr)
+        return 1
+    print(f"{args.workspace}: unpaused with {args.shards} credit shards")
+    return 0
+
+
+def _shard_count_arg(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shards must be an integer") from exc
+    if value < 1 or value > MAX_CREDIT_SHARDS:
+        raise argparse.ArgumentTypeError(
+            f"shards must be between 1 and {MAX_CREDIT_SHARDS}"
+        )
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name, handler in (
+        ("status", run_status),
+        ("prepare", run_prepare),
+        ("finish", run_finish),
+    ):
+        command = sub.add_parser(name)
+        command.add_argument("--workspace", required=True)
+        command.add_argument("--shards", required=True, type=_shard_count_arg)
+        if name != "status":
+            command.add_argument("--apply", action="store_true")
+        command.set_defaults(handler=handler)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    store = create_store(Settings())
+    return int(args.handler(store, args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1403,11 +1403,14 @@ class SpannerBigtableStore:
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        try:
-            shard_count = self._credit_shard_count(workspace_id)
-        except CreditShardConfigurationMissingError:
-            return None
-        with self._database.snapshot() as snapshot:
+        # This exact snapshot also feeds auto-refill decisions. Do not reuse the
+        # allow-stale authorize cache here: after a split, a stale smaller count
+        # could understate available credit and charge a card prematurely.
+        with self._database.snapshot(multi_use=True) as snapshot:
+            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
+            if account is None:
+                return None
+            shard_count = credit_shard_count(account)
             rows = list(snapshot.execute_sql(
                 "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
                 "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -1,0 +1,269 @@
+"""Fail-closed operator primitives for splitting and consolidating credit rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    credit_shard_count,
+    distribute_credit_amount,
+)
+from trusted_router.storage_models import CreditAccount, Reservation, Workspace
+
+_RESHARD_COLUMNS = (
+    "workspace_id",
+    "shard",
+    "total_credits",
+    "total_usage",
+    "reserved",
+    "source_updated_at",
+    "updated_at",
+)
+
+
+@dataclass
+class CreditReshardResult:
+    workspace_id: str
+    target_shard_count: int
+    current_shard_count: int | None = None
+    total_credits_micro: int | None = None
+    total_usage_micro: int | None = None
+    reserved_micro: int | None = None
+    typed_open_reservations: int = 0
+    legacy_open_reservations: int = 0
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return not self.reasons
+
+
+def _typed_state(
+    store: Any,
+    workspace_id: str,
+    shard_count: int,
+) -> tuple[list[list[Any]], int]:
+    pt = store._param_types
+    with store._database.snapshot(multi_use=True) as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        open_reservations = int(
+            list(
+                snapshot.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE workspace_id=@ws AND settled = false",
+                    params={"ws": workspace_id},
+                    param_types={"ws": pt.STRING},
+                )
+            )[0][0]
+        )
+    return rows, open_reservations
+
+
+def inspect_credit_reshard(
+    store: Any,
+    workspace_id: str,
+    target_shard_count: int,
+) -> CreditReshardResult:
+    """Read-only readiness check for a paused, fully drained reshard."""
+    target_count = credit_shard_count({"shard_count": target_shard_count})
+    result = CreditReshardResult(
+        workspace_id=workspace_id,
+        target_shard_count=target_count,
+    )
+    workspace = store.get_workspace(workspace_id)
+    account = store.get_credit_account(workspace_id)
+    if workspace is None:
+        result.reasons.append("workspace not found")
+    elif not workspace.billing_paused:
+        result.reasons.append("workspace not billing-paused")
+    if account is None:
+        result.reasons.append("credit account not found")
+        return result
+
+    current_count = credit_shard_count(account)
+    result.current_shard_count = current_count
+    rows, typed_open = _typed_state(store, workspace_id, current_count)
+    result.typed_open_reservations = typed_open
+    result.legacy_open_reservations = sum(
+        1
+        for reservation in store._list_entities("reservation", cls=Reservation)
+        if reservation.workspace_id == workspace_id and not reservation.settled
+    )
+    observed = [int(row[0]) for row in rows]
+    if observed != list(range(current_count)):
+        result.reasons.append("configured typed credit shard set is incomplete")
+        return result
+
+    total_credits = sum(int(row[1]) for row in rows)
+    total_usage = sum(int(row[2]) for row in rows)
+    reserved = sum(int(row[3]) for row in rows)
+    result.total_credits_micro = total_credits
+    result.total_usage_micro = total_usage
+    result.reserved_micro = reserved
+    if any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows):
+        result.reasons.append("typed credit shard has a negative counter")
+    if any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows):
+        result.reasons.append("typed credit shard exceeds its sub-budget")
+    if reserved != 0:
+        result.reasons.append(f"typed credit has reserved={reserved}; wait for drain")
+    if typed_open != 0:
+        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if result.legacy_open_reservations != 0:
+        result.reasons.append(
+            f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
+        )
+    if int(account.reserved_microdollars) != 0:
+        result.reasons.append(
+            f"JSON credit has reserved={account.reserved_microdollars}; wait for drain"
+        )
+    if total_credits != int(account.total_credits_microdollars):
+        result.reasons.append(
+            "typed/JSON deposited-credit totals differ; reconcile before reshard"
+        )
+    return result
+
+
+def reshard_credit_account(
+    store: Any,
+    workspace_id: str,
+    target_shard_count: int,
+    *,
+    apply: bool = False,
+) -> CreditReshardResult:
+    """Atomically repartition a paused and drained workspace's credit ledger.
+
+    Both splitting and consolidation use this function. A dry run never writes.
+    The JSON shard configuration and every typed row commit in one transaction.
+    """
+    status = inspect_credit_reshard(store, workspace_id, target_shard_count)
+    if not status.ready or not apply:
+        return status
+    assert status.current_shard_count is not None
+    if status.current_shard_count == status.target_shard_count:
+        return status
+
+    pt = store._param_types
+    target_count = status.target_shard_count
+
+    def txn(transaction: Any) -> dict[str, int] | None:
+        workspace = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        account = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if workspace is None or not workspace.billing_paused or account is None:
+            return None
+        current_count = credit_shard_count(account)
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": current_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        observed = [int(row[0]) for row in rows]
+        if observed != list(range(current_count)):
+            return None
+        open_typed = int(
+            list(
+                transaction.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE workspace_id=@ws AND settled = false",
+                    params={"ws": workspace_id},
+                    param_types={"ws": pt.STRING},
+                )
+            )[0][0]
+        )
+        total_credits = sum(int(row[1]) for row in rows)
+        total_usage = sum(int(row[2]) for row in rows)
+        reserved = sum(int(row[3]) for row in rows)
+        if (
+            open_typed != 0
+            or reserved != 0
+            or int(account.reserved_microdollars) != 0
+            or total_credits != int(account.total_credits_microdollars)
+            or any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows)
+            or any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows)
+        ):
+            return None
+
+        credit_parts = distribute_credit_amount(total_credits, target_count)
+        usage_parts = distribute_credit_amount(total_usage, target_count)
+        if any(usage > credit for usage, credit in zip(usage_parts, credit_parts, strict=True)):
+            return None  # defensive; global usage<=credits should make this impossible.
+        commit_timestamp = store._spanner.COMMIT_TIMESTAMP
+        transaction.insert_or_update(
+            table=CREDIT_BALANCE_TABLE,
+            columns=_RESHARD_COLUMNS,
+            values=[
+                (
+                    workspace_id,
+                    shard,
+                    credit_parts[shard],
+                    usage_parts[shard],
+                    0,
+                    commit_timestamp,
+                    commit_timestamp,
+                )
+                for shard in range(target_count)
+            ],
+        )
+        if current_count > target_count:
+            transaction.delete(
+                CREDIT_BALANCE_TABLE,
+                store._spanner.KeySet(
+                    keys=[
+                        (workspace_id, shard)
+                        for shard in range(target_count, current_count)
+                    ]
+                ),
+            )
+
+        account.shard_count = target_count
+        account.total_credits_microdollars = total_credits
+        account.total_usage_microdollars = total_usage
+        account.reserved_microdollars = 0
+        # Deliberately bypass _write_entity_tx: when consolidating to one shard,
+        # its generic credit mirror would emit a second mutation for shard zero.
+        transaction.insert_or_update(
+            table=store.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    "credit",
+                    workspace_id,
+                    json_body(account),
+                    commit_timestamp,
+                )
+            ],
+        )
+        return {
+            "current_count": current_count,
+            "total_credits": total_credits,
+            "total_usage": total_usage,
+        }
+
+    changed = store._run_in_transaction(txn)
+    if changed is None:
+        status.reasons.append(
+            "atomic reshard preconditions changed; workspace remains paused"
+        )
+        return status
+    store._credit_shard_counts.invalidate(workspace_id)
+    verified = inspect_credit_reshard(store, workspace_id, target_count)
+    if not verified.ready:
+        verified.reasons.append("post-commit reshard verification failed")
+        return verified
+    verified.applied = True
+    return verified

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -939,19 +939,24 @@ def _execute_sql(
     for typed_table in ("tr_credit_balance", "tr_key_limit"):
         if f"FROM {typed_table}" in sql:
             cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
-            recs = list(db.typed.get(typed_table, {}).values())
+            items = list(db.typed.get(typed_table, {}).items())
             if "@pk" in sql and "pk" in params:
                 pk_col = "workspace_id" if typed_table == "tr_credit_balance" else "key_hash"
-                recs = [r for r in recs if r.get(pk_col) == params["pk"]]
+                items = [(pk, rec) for pk, rec in items if rec.get(pk_col) == params["pk"]]
                 if "shard=0" in sql.replace(" ", ""):
-                    recs = [r for r in recs if r.get("shard", 0) == 0]
+                    items = [(pk, rec) for pk, rec in items if rec.get("shard", 0) == 0]
                 if "shard<@shard_count" in sql.replace(" ", ""):
-                    recs = [
-                        r for r in recs
-                        if 0 <= int(r.get("shard", 0)) < int(params["shard_count"])
+                    items = [
+                        (pk, rec) for pk, rec in items
+                        if 0 <= int(rec.get("shard", 0)) < int(params["shard_count"])
                     ]
                 if "ORDER BY shard" in sql:
-                    recs.sort(key=lambda r: int(r.get("shard", 0)))
+                    items.sort(key=lambda item: int(item[1].get("shard", 0)))
+            recs = [
+                txn._typed_current(typed_table, pk) if txn is not None else dict(rec)
+                for pk, rec in items
+            ]
+            recs = [rec for rec in recs if rec is not None]
             return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]

--- a/tests/test_credit_row_sharding_increment4.py
+++ b/tests/test_credit_row_sharding_increment4.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_credit_shard_admin import (
+    inspect_credit_reshard,
+    reshard_credit_account,
+)
+from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+from trusted_router.storage_models import CreditAccount, Reservation, Workspace
+
+
+def _seed(
+    *,
+    shard_credits: list[int],
+    shard_usage: list[int],
+    shard_reserved: list[int] | None = None,
+    paused: bool = True,
+    workspace_id: str = "ws-reshard",
+) -> tuple[Any, Any]:
+    store, database, _ = make_fake_store()
+    shard_reserved = shard_reserved or [0] * len(shard_credits)
+    store._write_entity(
+        "workspace",
+        workspace_id,
+        Workspace(
+            id=workspace_id,
+            name="Reshard test",
+            owner_user_id="owner",
+            billing_paused=paused,
+        ),
+    )
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(shard_credits),
+            total_usage_microdollars=sum(shard_usage),
+            reserved_microdollars=sum(shard_reserved),
+            shard_count=len(shard_credits),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, credits in enumerate(shard_credits):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": credits,
+            "total_usage": shard_usage[shard],
+            "reserved": shard_reserved[shard],
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    return store, database
+
+
+def _rows(database: Any, workspace_id: str = "ws-reshard") -> list[dict[str, Any]]:
+    table = database.typed[CREDIT_BALANCE_TABLE]
+    return [
+        table[(workspace_id, shard)]
+        for shard in sorted(key[1] for key in table if key[0] == workspace_id)
+    ]
+
+
+def test_dry_run_is_read_only_and_requires_pause() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37], paused=False)
+    before_rows = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=False)
+
+    assert not result.ready
+    assert result.applied is False
+    assert "workspace not billing-paused" in result.reasons
+    assert _rows(database) == before_rows
+    assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_split_is_atomic_even_partitioned_and_invalidates_cached_count() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-reshard", lambda: 1) == 1
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert result.ready
+    assert result.applied
+    assert result.current_shard_count == 4
+    rows = _rows(database)
+    assert [row["total_credits"] for row in rows] == [26, 25, 25, 25]
+    assert [row["total_usage"] for row in rows] == [10, 9, 9, 9]
+    assert [row["reserved"] for row in rows] == [0, 0, 0, 0]
+    assert sum(row["total_credits"] for row in rows) == 101
+    assert sum(row["total_usage"] for row in rows) == 37
+    account = store.get_credit_account("ws-reshard")
+    assert account.shard_count == 4
+    assert account.total_credits_microdollars == 101
+    assert account.total_usage_microdollars == 37
+    assert store._credit_shard_count("ws-reshard") == 4
+
+
+def test_split_then_unshard_round_trip_preserves_every_global_counter() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37])
+    split = reshard_credit_account(store, "ws-reshard", 16, apply=True)
+    assert split.ready and split.applied
+
+    unshard = reshard_credit_account(store, "ws-reshard", 1, apply=True)
+
+    assert unshard.ready and unshard.applied
+    rows = _rows(database)
+    assert rows == [
+        {
+            "workspace_id": "ws-reshard",
+            "shard": 0,
+            "total_credits": 101,
+            "total_usage": 37,
+            "reserved": 0,
+            "source_updated_at": store._spanner.COMMIT_TIMESTAMP,
+            "updated_at": store._spanner.COMMIT_TIMESTAMP,
+        }
+    ]
+    account = store.get_credit_account("ws-reshard")
+    assert account.shard_count == 1
+    assert account.total_credits_microdollars == 101
+    assert account.total_usage_microdollars == 37
+
+
+def test_same_target_is_verified_idempotent_noop() -> None:
+    store, database = _seed(
+        shard_credits=[40, 30, 30],
+        shard_usage=[4, 3, 3],
+    )
+    before = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 3, apply=True)
+
+    assert result.ready
+    assert result.applied is False
+    assert _rows(database) == before
+
+
+@pytest.mark.parametrize(
+    ("reserved", "typed_open", "legacy_open"),
+    [
+        (10, False, False),
+        (0, True, False),
+        (0, False, True),
+    ],
+)
+def test_reshard_refuses_any_undrained_hold(
+    reserved: int,
+    typed_open: bool,
+    legacy_open: bool,
+) -> None:
+    store, database = _seed(
+        shard_credits=[100],
+        shard_usage=[20],
+        shard_reserved=[reserved],
+    )
+    if typed_open:
+        database.reservations["typed-open"] = {
+            "reservation_id": "typed-open",
+            "workspace_id": "ws-reshard",
+            "settled": False,
+        }
+    if legacy_open:
+        store._write_entity(
+            "reservation",
+            "legacy-open",
+                Reservation(
+                    id="legacy-open",
+                    workspace_id="ws-reshard",
+                    key_hash="key",
+                    amount_microdollars=1,
+            ),
+        )
+    before = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert not result.ready
+    assert not result.applied
+    assert any("drain" in reason for reason in result.reasons)
+    assert _rows(database) == before
+    assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_reshard_refuses_incomplete_rows_and_deposited_credit_drift() -> None:
+    store, database = _seed(
+        shard_credits=[50, 50],
+        shard_usage=[10, 10],
+    )
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-reshard", 1))
+
+    incomplete = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+    assert not incomplete.ready
+    assert "configured typed credit shard set is incomplete" in incomplete.reasons
+
+    database.typed[CREDIT_BALANCE_TABLE][("ws-reshard", 1)] = {
+        "workspace_id": "ws-reshard",
+        "shard": 1,
+        "total_credits": 40,
+        "total_usage": 10,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    drift = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+    assert not drift.ready
+    assert any(
+        reason.startswith("typed/JSON deposited-credit totals differ")
+        for reason in drift.reasons
+    )
+    assert store.get_credit_account("ws-reshard").shard_count == 2
+
+
+def test_reshard_refreshes_stale_json_usage_from_authoritative_typed_sum() -> None:
+    store, _database = _seed(shard_credits=[100], shard_usage=[60])
+    account = store.get_credit_account("ws-reshard")
+    account.total_usage_microdollars = 1
+    store._write_entity("credit", "ws-reshard", account)
+
+    result = reshard_credit_account(store, "ws-reshard", 2, apply=True)
+
+    assert result.ready and result.applied
+    refreshed = store.get_credit_account("ws-reshard")
+    assert refreshed.total_usage_microdollars == 60
+    assert refreshed.shard_count == 2
+
+
+def test_post_commit_inspection_reports_exact_partition() -> None:
+    store, _database = _seed(shard_credits=[75], shard_usage=[25])
+    assert reshard_credit_account(store, "ws-reshard", 8, apply=True).applied
+
+    status = inspect_credit_reshard(store, "ws-reshard", 8)
+
+    assert status.ready
+    assert status.current_shard_count == 8
+    assert status.total_credits_micro == 75
+    assert status.total_usage_micro == 25
+    assert status.reserved_micro == 0
+
+
+def test_transaction_rechecks_drain_after_preflight_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database = _seed(shard_credits=[100], shard_usage=[20])
+    before = [dict(row) for row in _rows(database)]
+    original_run = store._run_in_transaction
+
+    def inject_open_hold(callback: Any, *, attempts: int = 8) -> Any:
+        database.reservations["arrived-after-preflight"] = {
+            "reservation_id": "arrived-after-preflight",
+            "workspace_id": "ws-reshard",
+            "settled": False,
+        }
+        return original_run(callback, attempts=attempts)
+
+    monkeypatch.setattr(store, "_run_in_transaction", inject_open_hold)
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert not result.ready
+    assert not result.applied
+    assert "atomic reshard preconditions changed" in result.reasons[0]
+    assert _rows(database) == before
+    assert store.get_credit_account("ws-reshard").shard_count == 1


### PR DESCRIPTION
## Summary
- add a two-phase operator CLI: prepare pauses/drains/reshards; finish independently verifies and unpauses
- atomically repartition typed credits, usage, JSON shard configuration, and row set in one Spanner transaction
- use the same path to split and to consolidate back to shard_count=1
- fail closed on open typed or legacy reservations, reserved holds, missing rows, sub-budget violations, or JSON/typed deposited-credit drift
- invalidate local config cache after commit and verify the resulting partition before returning
- preserve exact global deposited credits and accumulated usage across a 1 -> 16 -> 1 round trip

## Verification
- 1,454 passed, 33 skipped
- ruff clean
- mypy clean
- 11 new operator tests, including injected preflight/transaction race

Stacked on #159. This adds activation tooling but does not activate any production workspace.