### PR TITLE
Billing scale follow-up: shard uncapped API-key usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,8 +200,30 @@ jobs:
             sleep 5
           done
 
+  migrate-schema:
+    # Runs inside the same serialized deploy workflow, after CI and before any
+    # serving revision changes. The script is idempotent; normally this is only
+    # read-only INFORMATION_SCHEMA verification. A newly added column therefore
+    # always exists before code that writes it can receive traffic.
+    needs: [gate-on-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Apply idempotent Spanner schema prerequisites
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/migrate_typed_counters.sh
+
   deploy:
-    needs: [gate-on-ci, build-image]
+    needs: [gate-on-ci, build-image, migrate-schema]
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: quill-cloud-proxy

--- a/docs/design/key-usage-row-sharding.md
+++ b/docs/design/key-usage-row-sharding.md
@@ -1,0 +1,84 @@
+# Uncapped API-key usage-row sharding
+
+Date: 2026-07-11
+
+## Why this follows credit-row sharding
+
+Credit sub-ledgers remove the hot workspace row from authorize and settle, but
+every successful settle also books usage onto `tr_key_limit(key_hash, shard=0)`.
+A local 2,000-request lifecycle stress run at concurrency 128 confirmed the
+shape: sharded authorization completed, then unsharded settlement exhausted the
+fake Spanner retry budget on the one API-key row.
+
+The table and reservation schema already support `(key_hash, shard)` and
+`key_shard`. We use those fields to spread usage writes for high-throughput,
+fully uncapped keys.
+
+## Scope and hard safety boundary
+
+`ApiKey.usage_shard_count` defaults to 1. A value above 1 is valid only when all
+of these are unset:
+
+- lifetime spend limit
+- daily spend limit
+- weekly spend limit
+- monthly spend limit
+
+Capped keys remain byte-identical on shard zero. Code, management routes, the
+mirror, and the operator all fail closed if a sharded key acquires a limit.
+This deliberately avoids claiming that an unimplemented partitioned key budget
+is exact.
+
+## Request lifecycle
+
+1. The already-authenticated API key supplies its validated shard count to the
+   typed authorize path. There is no extra hot-path database read.
+2. TrustedRouter randomizes all key usage shards outside the Spanner retry
+   callback.
+3. An uncapped row returns `KEY_NO_HOLD`; authorize records the selected
+   `key_shard` on `tr_reservation`.
+4. Settle/refund books against exactly that recorded row.
+5. Idempotent replay returns the originally committed key shard.
+
+Credit and key shard choices are independent, so one unlucky mapping cannot
+recreate a combined hot row.
+
+## Activation and reversal
+
+`scripts/shard_workspace.py` operates credit rows and all eligible API-key rows
+under the same workspace pause:
+
+```bash
+python scripts/shard_workspace.py prepare --workspace WS --shards 16 --apply
+python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
+```
+
+Prepare pauses the workspace, refuses open typed or legacy requests, atomically
+partitions each ledger, verifies it, runs the invariant audit, and leaves the
+workspace paused. Finish re-verifies credit and key row sets before unpausing.
+Capped keys stay at one row. Reverse with `--shards 1` before any typed-to-JSON
+rollback or shard-zero repair; those older tools now refuse sharded state.
+
+Lifetime usage, BYOK usage, and current daily/weekly/monthly usage are preserved
+as exact global sums. Stale window epochs are discarded because they already
+read as zero under normal lazy-reset semantics.
+
+## Stress gate
+
+`scripts/stress_credit_shards.py` runs authorize and settle as separate phases
+and reports latency, throughput, simulated aborts, failures by type, credit
+invariants, and key usage distribution.
+
+The 2,000-request, concurrency-128, 16-shard local run after this change:
+
+- authorize: 2,000/2,000
+- settle: 2,000/2,000
+- credit reserved after settle: 0
+- credit usage: exactly 600,000,000 microdollars
+- key usage: exactly 600,000,000 microdollars across all 16 rows
+- simulated settle aborts: 0 in the final run (one earlier run had 1, recovered)
+
+This is a deterministic correctness/contention-shape gate, not a claim about
+production Spanner latency. Production activation still requires the additive
+reservation migration, staged deployment, a paused canary split, invariant
+audit, and live latency/abort monitoring.

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -1,4 +1,4 @@
-"""Safely split or consolidate one hot workspace's typed credit row.
+"""Safely split or consolidate a workspace's credit and uncapped key rows.
 
 The operation is intentionally two phase so a failed verification can never
 silently resume billing:
@@ -9,8 +9,10 @@ silently resume billing:
   # Verify the committed shape + global billing invariants, then unpause.
   python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 
-Reverse with the same commands and ``--shards 1``. Without ``--apply`` every
-command is read-only. A failed prepare/finish always leaves the workspace paused.
+Eligible uncapped API-key usage rows are split to the same count; capped keys
+remain on one exact row. Reverse with the same commands and ``--shards 1``.
+Without ``--apply`` every command is read-only. A failed prepare/finish always
+leaves the workspace paused.
 """
 
 from __future__ import annotations
@@ -37,6 +39,12 @@ from trusted_router.storage_gcp_credit_shard_admin import (
     inspect_credit_reshard,
     reshard_credit_account,
 )
+from trusted_router.storage_gcp_key_shard_admin import (
+    KeyUsageReshardResult,
+    inspect_key_usage_reshard,
+    reshard_key_usage,
+)
+from trusted_router.storage_models import ApiKey
 
 
 def _print_status(status: CreditReshardResult) -> None:
@@ -58,6 +66,55 @@ def _print_status(status: CreditReshardResult) -> None:
         print(f"  BLOCKED: {reason}")
 
 
+def _print_key_status(status: KeyUsageReshardResult) -> None:
+    print(
+        f"  key {status.key_hash}: current_shards={status.current_shard_count} "
+        f"target_shards={status.target_shard_count} ready={status.ready} "
+        f"applied={status.applied} usage={status.usage_micro} "
+        f"byok_usage={status.byok_usage_micro} reserved={status.reserved_micro}"
+    )
+    for reason in status.reasons:
+        print(f"    BLOCKED: {reason}")
+
+
+def _key_target(key: ApiKey, requested_shards: int) -> int:
+    has_limit = any(
+        value is not None
+        for value in (
+            key.limit_microdollars,
+            key.limit_daily_microdollars,
+            key.limit_weekly_microdollars,
+            key.limit_monthly_microdollars,
+        )
+    )
+    return 1 if has_limit else requested_shards
+
+
+def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+    clean = True
+    for key in store.api_keys.list_for_workspace(workspace_id):
+        target = _key_target(key, requested_shards)
+        if target != requested_shards:
+            print(f"  key {key.hash}: capped; keeping exact usage_shards=1")
+        status = reshard_key_usage(store, key.hash, target, apply=True)
+        _print_key_status(status)
+        clean = clean and status.ready
+    return clean
+
+
+def _verify_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+    clean = True
+    for key in store.api_keys.list_for_workspace(workspace_id):
+        status = inspect_key_usage_reshard(
+            store,
+            key.hash,
+            _key_target(key, requested_shards),
+        )
+        _print_key_status(status)
+        clean = clean and status.ready
+    return clean
+
+
 def _pause(store: Any, workspace_id: str) -> bool:
     updated = store.update_workspace(
         workspace_id,
@@ -69,6 +126,7 @@ def _pause(store: Any, workspace_id: str) -> bool:
 
 def run_status(store: Any, args: argparse.Namespace) -> int:
     _print_status(inspect_credit_reshard(store, args.workspace, args.shards))
+    _verify_keys(store, args.workspace, args.shards)
     return 0
 
 
@@ -76,6 +134,7 @@ def run_prepare(store: Any, args: argparse.Namespace) -> int:
     if not args.apply:
         status = inspect_credit_reshard(store, args.workspace, args.shards)
         _print_status(status)
+        _verify_keys(store, args.workspace, args.shards)
         print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
         return 0
     if not _pause(store, args.workspace):
@@ -87,6 +146,9 @@ def run_prepare(store: Any, args: argparse.Namespace) -> int:
         print("Workspace remains paused. Re-run prepare after holds drain.")
         draining = any("drain" in reason or "open" in reason for reason in status.reasons)
         return 2 if draining else 1
+    if not _prepare_keys(store, args.workspace, args.shards):
+        print("Workspace remains paused because an API-key reshard failed.", file=sys.stderr)
+        return 1
     audit = audit_typed_invariants(store)
     print(audit.summary())
     if not audit.clean:
@@ -105,6 +167,9 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     if not status.ready:
         print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
         return 1
+    if not _verify_keys(store, args.workspace, args.shards):
+        print("ERROR: refusing to unpause; API-key shard verification failed", file=sys.stderr)
+        return 1
     audit = audit_typed_invariants(store)
     print(audit.summary())
     if not audit.clean:
@@ -121,7 +186,10 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     if updated is None or updated.billing_paused:
         print("ERROR: failed to verify workspace unpause", file=sys.stderr)
         return 1
-    print(f"{args.workspace}: unpaused with {args.shards} credit shards")
+    print(
+        f"{args.workspace}: unpaused with {args.shards} credit shards and "
+        "eligible key usage shards"
+    )
     return 0
 
 

--- a/scripts/stress_credit_shards.py
+++ b/scripts/stress_credit_shards.py
@@ -1,0 +1,334 @@
+"""Run a deterministic 2,000-request credit-shard lifecycle stress test.
+
+This uses the concurrency-aware in-process Spanner fake, so it is a correctness
+and contention-shape test rather than a production latency benchmark. It reports
+authorize and settle separately to expose any remaining shared-row bottleneck.
+
+Usage:
+    PYTHONPATH=src:. uv run python scripts/stress_credit_shards.py
+    PYTHONPATH=src:. uv run python scripts/stress_credit_shards.py --requests 2000 --concurrency 128
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_models import CreditAccount
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    requests: int
+    successes: int
+    failures: int
+    elapsed_seconds: float
+    requests_per_second: float
+    p50_ms: float
+    p95_ms: float
+    aborts: int
+    error_types: dict[str, int]
+
+
+@dataclass(frozen=True)
+class StressResult:
+    request_count: int
+    concurrency: int
+    shard_count: int
+    estimate_micro: int
+    authorize: PhaseResult
+    settle: PhaseResult
+    final_reserved_micro: int
+    final_usage_micro: int
+    final_total_credits_micro: int
+    observed_key_shards: int
+    final_key_usage_micro: int
+    final_key_reserved_micro: int
+    nonzero_key_shards: int
+    max_key_shard_usage_micro: int
+    invariant_clean: bool
+
+
+def _percentile_ms(samples: list[float], percentile: float) -> float:
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    index = max(0, min(len(ordered) - 1, round((len(ordered) - 1) * percentile)))
+    return ordered[index] * 1000.0
+
+
+def _phase_result(
+    *,
+    requests: int,
+    successes: int,
+    elapsed: float,
+    latencies: list[float],
+    aborts: int,
+    error_types: Counter[str],
+) -> PhaseResult:
+    return PhaseResult(
+        requests=requests,
+        successes=successes,
+        failures=requests - successes,
+        elapsed_seconds=elapsed,
+        requests_per_second=requests / elapsed if elapsed > 0 else 0.0,
+        p50_ms=statistics.median(latencies) * 1000.0 if latencies else 0.0,
+        p95_ms=_percentile_ms(latencies, 0.95),
+        aborts=aborts,
+        error_types=dict(sorted(error_types.items())),
+    )
+
+
+def _seed(
+    *,
+    request_count: int,
+    shard_count: int,
+    estimate_micro: int,
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    workspace_id = "stress-workspace"
+    total_credits = request_count * estimate_micro
+    base, remainder = divmod(total_credits, shard_count)
+    shard_totals = [base] * shard_count
+    shard_totals[0] += remainder
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=total_credits,
+            shard_count=shard_count,
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(shard_totals):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": total,
+            "total_usage": 0,
+            "reserved": 0,
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="stress-key",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    key.usage_shard_count = shard_count
+    store._write_entity("api_key", key.hash, key)
+    return store, database, key
+
+
+def run_stress(
+    *,
+    request_count: int = 2_000,
+    concurrency: int = 128,
+    shard_count: int = 16,
+    estimate_micro: int = 300_000,
+) -> StressResult:
+    if request_count < 1 or concurrency < 1 or shard_count < 1 or estimate_micro < 1:
+        raise ValueError("stress arguments must be positive")
+    store, database, key = _seed(
+        request_count=request_count,
+        shard_count=shard_count,
+        estimate_micro=estimate_micro,
+    )
+    workspace_id = "stress-workspace"
+    store._credit_shard_count(workspace_id)  # warm the allow-stale config cache.
+    authorizations: list[Any] = []
+    authorization_lock = threading.Lock()
+    authorize_latencies: list[float] = []
+    authorize_errors: Counter[str] = Counter()
+    authorize_start_aborts = database.aborts
+
+    def authorize(index: int) -> bool:
+        started = time.perf_counter()
+        try:
+            outcome, authorization = store.authorize_gateway_typed(
+                workspace_id=workspace_id,
+                key_hash=key.hash,
+                estimate=estimate_micro,
+                has_credit_candidate=True,
+                reservation_usage_type="Credits",
+                model_id="stress-model",
+                provider="stress-provider",
+                requested_model_id=None,
+                candidate_model_ids=["stress-model"],
+                region="test",
+                endpoint_id="stress-endpoint",
+                candidate_endpoint_ids=["stress-endpoint"],
+                idempotency_key=f"stress-{index}",
+                idempotency_fingerprint="stress-body-v1",
+                key_usage_shards=key.usage_shard_count,
+            )
+        except Exception as exc:  # noqa: BLE001 - stress harness classifies failures.
+            elapsed = time.perf_counter() - started
+            with authorization_lock:
+                authorize_latencies.append(elapsed)
+                authorize_errors[type(exc).__name__] += 1
+            return False
+        elapsed = time.perf_counter() - started
+        with authorization_lock:
+            authorize_latencies.append(elapsed)
+            if authorization is not None:
+                authorizations.append(authorization)
+            if outcome != AuthorizeOutcome.ACCEPTED:
+                authorize_errors[str(outcome)] += 1
+        return outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        authorize_successes = sum(
+            1
+            for future in as_completed(
+                executor.submit(authorize, index) for index in range(request_count)
+            )
+            if future.result()
+        )
+    authorize_elapsed = time.perf_counter() - started
+    authorize_result = _phase_result(
+        requests=request_count,
+        successes=authorize_successes,
+        elapsed=authorize_elapsed,
+        latencies=authorize_latencies,
+        aborts=database.aborts - authorize_start_aborts,
+        error_types=authorize_errors,
+    )
+
+    settle_latencies: list[float] = []
+    settle_errors: Counter[str] = Counter()
+    settle_lock = threading.Lock()
+    settle_start_aborts = database.aborts
+
+    def settle(authorization: Any) -> bool:
+        started_at = time.perf_counter()
+        try:
+            result = settle_atomic(
+                store._database,
+                store._param_types,
+                reservation_id=authorization.credit_reservation_id,
+                actual_micro=estimate_micro,
+                settled_usage_type="Credits",
+                success=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - stress harness classifies failures.
+            elapsed = time.perf_counter() - started_at
+            with settle_lock:
+                settle_latencies.append(elapsed)
+                settle_errors[type(exc).__name__] += 1
+            return False
+        elapsed = time.perf_counter() - started_at
+        with settle_lock:
+            settle_latencies.append(elapsed)
+            if result["outcome"] != SettleOutcome.SETTLED:
+                settle_errors[str(result["outcome"])] += 1
+        return result["outcome"] == SettleOutcome.SETTLED
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        settle_successes = sum(
+            1
+            for future in as_completed(
+                executor.submit(settle, authorization)
+                for authorization in authorizations
+            )
+            if future.result()
+        )
+    settle_elapsed = time.perf_counter() - started
+    settle_result = _phase_result(
+        requests=len(authorizations),
+        successes=settle_successes,
+        elapsed=settle_elapsed,
+        latencies=settle_latencies,
+        aborts=database.aborts - settle_start_aborts,
+        error_types=settle_errors,
+    )
+
+    rows = list(database.typed[CREDIT_BALANCE_TABLE].values())
+    final_reserved = sum(int(row["reserved"]) for row in rows)
+    final_usage = sum(int(row["total_usage"]) for row in rows)
+    final_total = sum(int(row["total_credits"]) for row in rows)
+    key_rows = [
+        row
+        for (row_key_hash, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
+        if row_key_hash == key.hash
+    ]
+    final_key_usage = sum(int(row["usage"]) for row in key_rows)
+    final_key_reserved = sum(int(row["reserved"]) for row in key_rows)
+    invariant_clean = (
+        authorize_successes == request_count
+        and settle_successes == request_count
+        and final_reserved == 0
+        and final_usage == request_count * estimate_micro
+        and final_total == request_count * estimate_micro
+        and len(key_rows) == shard_count
+        and final_key_usage == request_count * estimate_micro
+        and final_key_reserved == 0
+        and all(
+            int(row["total_usage"]) + int(row["reserved"])
+            <= int(row["total_credits"])
+            for row in rows
+        )
+    )
+    return StressResult(
+        request_count=request_count,
+        concurrency=concurrency,
+        shard_count=shard_count,
+        estimate_micro=estimate_micro,
+        authorize=authorize_result,
+        settle=settle_result,
+        final_reserved_micro=final_reserved,
+        final_usage_micro=final_usage,
+        final_total_credits_micro=final_total,
+        observed_key_shards=len(key_rows),
+        final_key_usage_micro=final_key_usage,
+        final_key_reserved_micro=final_key_reserved,
+        nonzero_key_shards=sum(1 for row in key_rows if int(row["usage"]) > 0),
+        max_key_shard_usage_micro=max(
+            (int(row["usage"]) for row in key_rows),
+            default=0,
+        ),
+        invariant_clean=invariant_clean,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", type=int, default=2_000)
+    parser.add_argument("--concurrency", type=int, default=128)
+    parser.add_argument("--shards", type=int, default=16)
+    parser.add_argument("--estimate-micro", type=int, default=300_000)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = run_stress(
+        request_count=args.requests,
+        concurrency=args.concurrency,
+        shard_count=args.shards,
+        estimate_micro=args.estimate_micro,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return 0 if result.invariant_clean else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -132,7 +132,13 @@ def register(app: FastAPI) -> None:
                 patch[f"limit_{window}_microdollars"] = _parse_limit(value)
         except ValueError:
             return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
-        STORE.update_key(key_hash, patch)
+        try:
+            STORE.update_key(key_hash, patch)
+        except ValueError:
+            return RedirectResponse(
+                url="/console/api-keys?error=consolidate_key_usage",
+                status_code=303,
+            )
         return RedirectResponse(url="/console/api-keys?saved=limit", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/disable")

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -252,6 +252,7 @@ async def authorize_gateway(
             window_resets_at,
         )
         from trusted_router.storage_gcp_authorize import AuthorizeOutcome
+        from trusted_router.storage_gcp_counters import key_usage_shard_count
 
         # expires_at = generous execution deadline (> max stream + settle
         # retry window) so the reaper only reclaims genuinely-abandoned holds.
@@ -280,6 +281,7 @@ async def authorize_gateway(
             candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
             idempotency_key=request_idempotency_key,
             idempotency_fingerprint=request_fingerprint,
+            key_usage_shards=key_usage_shard_count(api_key),
             custom_model_id=custom_model.id if custom_model else None,
             custom_model_revision=custom_model.revision if custom_model else None,
             expires_at=expires_at,

--- a/src/trusted_router/routes/keys.py
+++ b/src/trusted_router/routes/keys.py
@@ -100,7 +100,10 @@ def register_key_routes(router: APIRouter) -> None:
                 if micro < 0:
                     raise api_error(400, "limit must be non-negative", ErrorType.BAD_REQUEST)
                 patch[f"limit_{window}_microdollars"] = micro
-        updated = STORE.update_key(hash, patch)
+        try:
+            updated = STORE.update_key(hash, patch)
+        except ValueError as exc:
+            raise api_error(409, str(exc), ErrorType.CONFLICT) from exc
         if updated is None:
             raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
         return {"data": key_shape(updated)}

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -54,6 +54,7 @@ from trusted_router.storage_gcp_counters import (
     UNSHARDED,
     credit_shard_count,
     distribute_credit_amount,
+    key_usage_shard_count,
 )
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
@@ -1212,6 +1213,7 @@ class SpannerBigtableStore:
         candidate_endpoint_ids: list[str],
         idempotency_key: str | None,
         idempotency_fingerprint: str | None,
+        key_usage_shards: int = 1,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         expires_at: Any = None,
@@ -1229,6 +1231,10 @@ class SpannerBigtableStore:
         )
 
         usage = UsageType.coerce(reservation_usage_type)
+        key_counter_shards = key_usage_shard_count(
+            {"usage_shard_count": key_usage_shards}
+        )
+        key_shard_candidates = randomized_credit_shards(key_counter_shards)
         scope = (
             _gateway_authorization_idempotency_index_id(workspace_id, key_hash, idempotency_key)
             if idempotency_key is not None
@@ -1298,6 +1304,7 @@ class SpannerBigtableStore:
                 expires_at=expires_at,
                 build_auth_body=build_body,
                 credit_shard_candidates=candidates,
+                key_shard_candidates=key_shard_candidates,
             )
 
         result = run_authorize(credit_shard_candidates)
@@ -1330,10 +1337,16 @@ class SpannerBigtableStore:
                     estimate=estimate,
                 )
 
-            if (
-                result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
-                and len(credit_shard_candidates) > 1
-            ):
+            # A concurrent request can consume the newly consolidated target
+            # between rebalance commit and our retry. Retry this cold path a
+            # small bounded number of times; true aggregate exhaustion returns
+            # INSUFFICIENT on the first rebalance and exits immediately.
+            for _attempt in range(3):
+                if (
+                    result["outcome"] != AuthorizeOutcome.INSUFFICIENT_CREDITS
+                    or len(credit_shard_candidates) <= 1
+                ):
+                    break
                 rebalance_result = rebalance(credit_shard_candidates)
                 if rebalance_result["outcome"] == RebalanceOutcome.INCOMPLETE:
                     raise RuntimeError(
@@ -1344,6 +1357,8 @@ class SpannerBigtableStore:
                     RebalanceOutcome.NOT_NEEDED,
                 }:
                     result = run_authorize(credit_shard_candidates)
+                    continue
+                break
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
         if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
@@ -1367,28 +1382,43 @@ class SpannerBigtableStore:
         from trusted_router.spend_windows import utcnow, window_floors
 
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        with self._database.snapshot(multi_use=True) as snapshot:
+            key = self._read_entity_from(snapshot, "api_key", key_hash, ApiKey)
+            if key is None:
+                return None
+            shard_count = key_usage_shard_count(key)
             rows = list(snapshot.execute_sql(
-                "SELECT usage, byok_usage, reserved, day_usage, day_start, "
+                "SELECT shard, usage, byok_usage, reserved, day_usage, day_start, "
                 "week_usage, week_start, month_usage, month_start "
-                "FROM tr_key_limit WHERE key_hash=@kh AND shard=0",
-                params={"kh": key_hash},
-                param_types={"kh": pt.STRING},
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             ))
         if not rows:
             return None
-        usage, byok, reserved, day_u, day_s, week_u, week_s, month_u, month_s = rows[0]
+        if [int(row[0]) for row in rows] != list(range(shard_count)):
+            raise RuntimeError("configured tr_key_limit usage shard set is incomplete")
         floors = window_floors(utcnow())
+        usage = sum(int(row[1]) for row in rows)
+        byok = sum(int(row[2]) for row in rows)
+        reserved = sum(int(row[3]) for row in rows)
+
+        def current_window_usage(usage_index: int, start_index: int, window: str) -> int:
+            return sum(
+                int(row[usage_index] or 0)
+                for row in rows
+                if row[start_index] is not None and row[start_index] >= floors[window]
+            )
+
         return {
-            "usage": int(usage),
-            "byok_usage": int(byok),
-            "reserved": int(reserved),
+            "usage": usage,
+            "byok_usage": byok,
+            "reserved": reserved,
             "windows": {
-                "daily": int(day_u) if day_s is not None and day_s >= floors["daily"] else 0,
-                "weekly": int(week_u) if week_s is not None and week_s >= floors["weekly"] else 0,
-                "monthly": (
-                    int(month_u) if month_s is not None and month_s >= floors["monthly"] else 0
-                ),
+                "daily": current_window_usage(4, 5, "daily"),
+                "weekly": current_window_usage(6, 7, "weekly"),
+                "monthly": current_window_usage(8, 9, "monthly"),
             },
         }
 

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -141,6 +141,7 @@ def authorize_atomic(
     build_auth_body: Callable[[str, str], str],
     credit_shard: int = UNSHARDED,
     credit_shard_candidates: tuple[int, ...] | None = None,
+    key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -174,6 +175,13 @@ def authorize_atomic(
         raise ValueError("credit_shard_candidates must be unique")
     if not has_credit_candidate and shard_candidates != (UNSHARDED,):
         raise ValueError("BYOK-only authorization must use credit shard zero")
+    key_candidates = tuple(key_shard_candidates)
+    if not key_candidates:
+        raise ValueError("key_shard_candidates must not be empty")
+    if any(shard < 0 for shard in key_candidates):
+        raise ValueError("key shards must be non-negative")
+    if len(set(key_candidates)) != len(key_candidates):
+        raise ValueError("key_shard_candidates must be unique")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -185,6 +193,7 @@ def authorize_atomic(
             "reservation_id": existing["reservation_id"],
             "authorization_id": existing["authorization_id"],
             "credit_shard": int(existing.get("credit_shard", UNSHARDED)),
+            "key_shard": int(existing.get("key_shard", UNSHARDED)),
         }
 
     def txn(transaction: Any) -> dict:
@@ -195,11 +204,32 @@ def authorize_atomic(
                     raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
                 return _replay(existing)
 
-        key_result = reserve_key(transaction, pt, key_hash, estimate, is_byok=is_byok)
-        if key_result == KEY_INSUFFICIENT:
-            raise _Reject(AuthorizeOutcome.KEY_LIMIT_EXCEEDED)
+        key_result = KEY_MISSING
+        selected_key_shard = UNSHARDED
+        saw_key_row = False
+        for candidate in key_candidates:
+            candidate_result = reserve_key(
+                transaction,
+                pt,
+                key_hash,
+                estimate,
+                is_byok=is_byok,
+                shard=candidate,
+            )
+            if candidate_result == KEY_MISSING:
+                continue
+            saw_key_row = True
+            if candidate_result == KEY_INSUFFICIENT:
+                continue
+            key_result = candidate_result
+            selected_key_shard = candidate
+            break
         if key_result == KEY_MISSING:
-            raise _Reject(AuthorizeOutcome.KEY_MISSING)
+            raise _Reject(
+                AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+                if saw_key_row
+                else AuthorizeOutcome.KEY_MISSING
+            )
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
         credit_hold = 0
@@ -216,7 +246,8 @@ def authorize_atomic(
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard, key_shard=0,
+            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard,
+            key_shard=selected_key_shard,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -231,6 +262,7 @@ def authorize_atomic(
             "reservation_id": reservation_id,
             "authorization_id": authorization_id,
             "credit_shard": selected_credit_shard,
+            "key_shard": selected_key_shard,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -324,7 +324,7 @@ def read_reservation_by_idempotency(
         transaction.execute_sql(
             "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
             "hold_usage_type, authorization_id, idempotency_fingerprint, settled, "
-            "credit_shard, ws_shard "
+            "credit_shard, ws_shard, key_shard "
             "FROM tr_reservation WHERE idempotency_scope=@scope",
             params={"scope": idempotency_scope},
             param_types={"scope": param_types.STRING},
@@ -343,6 +343,7 @@ def read_reservation_by_idempotency(
         "idempotency_fingerprint": r[5],
         "settled": r[6],
         "credit_shard": int(credit_shard),
+        "key_shard": int(r[9] or UNSHARDED),
     }
 
 

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -26,7 +26,9 @@ from typing import Any
 
 from trusted_router.storage_gcp_counters import (
     credit_drift,
+    credit_shard_count,
     key_drift,
+    key_usage_shard_count,
     mirror_write,
 )
 from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
@@ -35,7 +37,7 @@ _CREDIT_TYPED_SCAN = (
     "SELECT workspace_id, shard, total_credits, total_usage, reserved FROM tr_credit_balance"
 )
 _KEY_TYPED_SCAN = (
-    "SELECT key_hash, limit_micro, usage, byok_usage, reserved, include_byok, "
+    "SELECT key_hash, shard, limit_micro, usage, byok_usage, reserved, include_byok, "
     "day_limit_micro, week_limit_micro, month_limit_micro "
     "FROM tr_key_limit"
 )
@@ -104,15 +106,20 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
             aggregate["total_credits"] += int(row[2])
             aggregate["total_usage"] += int(row[3])
             aggregate["reserved"] += int(row[4])
-        typed_key = {
-            r[0]: {
-                "limit_micro": r[1], "usage": r[2], "byok_usage": r[3],
-                "reserved": r[4], "include_byok": r[5],
-                "day_limit_micro": r[6], "week_limit_micro": r[7],
-                "month_limit_micro": r[8],
-            }
-            for r in snapshot.execute_sql(_KEY_TYPED_SCAN)
-        }
+        typed_key: dict[str, dict[str, Any]] = {}
+        typed_key_counts: dict[str, int] = {}
+        for row in snapshot.execute_sql(_KEY_TYPED_SCAN):
+            key_hash = str(row[0])
+            typed_key_counts[key_hash] = typed_key_counts.get(key_hash, 0) + 1
+            typed_key.setdefault(
+                key_hash,
+                {
+                    "limit_micro": row[2], "usage": row[3], "byok_usage": row[4],
+                    "reserved": row[5], "include_byok": row[6],
+                    "day_limit_micro": row[7], "week_limit_micro": row[8],
+                    "month_limit_micro": row[9],
+                },
+            )
 
     def _sample(key: str, value: dict) -> None:
         if len(report.samples) < max_samples:
@@ -131,6 +138,10 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
     report.key_rows = len(json_key)
     for key_hash, body in json_key.items():
         drift = key_drift(body, typed_key.get(key_hash))
+        expected_shards = key_usage_shard_count(body)
+        observed_shards = typed_key_counts.get(key_hash, 0)
+        if observed_shards != expected_shards:
+            drift["usage_shard_count"] = (expected_shards, observed_shards)
         if drift:
             report.key_drift += 1
             _sample(f"api_key:{key_hash}", drift)
@@ -499,11 +510,13 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
     credit_sql = "SELECT total_usage, reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
     key_sql = "SELECT usage, byok_usage, reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0"
 
-    key_hashes = [
-        b["hash"] for b in store._list_entities("api_key", cls=dict)
+    key_bodies = [
+        b for b in store._list_entities("api_key", cls=dict)
         if b.get("workspace_id") == workspace_id
     ]
+    key_hashes = [str(body["hash"]) for body in key_bodies]
     workspace = store.get_workspace(workspace_id)
+    credit_account = store.get_credit_account(workspace_id)
     # multi_use: two reads on one snapshot (a single-use snapshot raises on the
     # second read on real Spanner — the fa9f5d4 class the fake now models).
     with store._database.snapshot(multi_use=True) as snap:
@@ -516,6 +529,10 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause (quiesce) it before rollback")
+    if credit_account is not None and credit_shard_count(credit_account) != 1:
+        res.reasons.append("credit ledger is sharded — consolidate to one shard before rollback")
+    if any(key_usage_shard_count(body) != 1 for body in key_bodies):
+        res.reasons.append("API-key usage is sharded — consolidate keys before rollback")
     if int(open_holds) != 0:
         res.reasons.append(f"{open_holds} open typed holds — drain before rollback backsync")
     if not credit_rows:
@@ -541,13 +558,15 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
             credit_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))
         credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if not tc or credit is None:
+        if not tc or credit is None or credit_shard_count(credit) != 1:
             return None
         plan: list[tuple] = []
         for kh in key_hashes:
             key_obj = store._read_entity_tx(transaction, "api_key", kh, ApiKey)
             if key_obj is None:
                 continue  # key deleted since assess (pause blocks creation, not deletion)
+            if key_usage_shard_count(key_obj) != 1:
+                return None
             kt = list(transaction.execute_sql(
                 key_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
             ))
@@ -629,10 +648,12 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     )
 
     workspace = store.get_workspace(workspace_id)
-    key_hashes = [
-        b["hash"] for b in store._list_entities("api_key", cls=dict)
+    credit_account = store.get_credit_account(workspace_id)
+    key_bodies = [
+        b for b in store._list_entities("api_key", cls=dict)
         if b.get("workspace_id") == workspace_id
     ]
+    key_hashes = [str(body["hash"]) for body in key_bodies]
     with store._database.snapshot(multi_use=True) as snap:  # 3 reads below — must be multi-use
         cb = list(snap.execute_sql(
             credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
@@ -646,6 +667,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause it before repair")
+    if credit_account is not None and credit_shard_count(credit_account) != 1:
+        res.reasons.append("credit ledger is sharded — consolidate before shard-zero repair")
+    if any(key_usage_shard_count(body) != 1 for body in key_bodies):
+        res.reasons.append("API-key usage is sharded — consolidate before shard-zero repair")
     if not cb:
         res.reasons.append("no typed credit row")
     if int(nonzero_shard) != 0:
@@ -666,6 +691,9 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
         if ws is None or not ws.billing_paused:
             return None
+        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if credit is not None and credit_shard_count(credit) != 1:
+            return None
         if int(list(transaction.execute_sql(
             nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]) != 0:
@@ -679,6 +707,9 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         ))[0][0]
         plan: list[tuple[str, int]] = []
         for kh in key_hashes:
+            key_obj = store._read_entity_tx(transaction, "api_key", kh, ApiKey)
+            if key_obj is None or key_usage_shard_count(key_obj) != 1:
+                return None
             if not list(transaction.execute_sql(
                 key_row_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
             )):

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -28,6 +28,7 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 # Long tail lives entirely on shard 0; sharding a whale is a data change later.
 UNSHARDED = 0
 MAX_CREDIT_SHARDS = 64
+MAX_KEY_USAGE_SHARDS = 64
 
 # OWNERSHIP SPLIT (2026-06-25 incident). The JSON->typed mirror writes ONLY the
 # columns JSON owns. `total_credits` is set by credit events (top-ups / grants /
@@ -86,6 +87,37 @@ def credit_shard_count(value: Any) -> int:
     return count
 
 
+def key_usage_shard_count(value: Any) -> int:
+    """Return and validate an API key's usage-counter shard count.
+
+    Only fully uncapped keys may fan usage writes across rows. Partitioning
+    spend limits needs separate sub-budget/rebalance semantics; accepting such
+    a mixed configuration here could weaken a hard user budget, so it fails
+    closed instead.
+    """
+    raw = _field(value, "usage_shard_count", 1)
+    if isinstance(raw, bool):
+        raise ValueError("key usage_shard_count must be a positive integer")
+    count = int(raw)
+    if count < 1:
+        raise ValueError("key usage_shard_count must be a positive integer")
+    if count > MAX_KEY_USAGE_SHARDS:
+        raise ValueError(
+            f"key usage_shard_count must not exceed {MAX_KEY_USAGE_SHARDS}"
+        )
+    if count > 1 and any(
+        _field(value, field_name, None) is not None
+        for field_name in (
+            "limit_microdollars",
+            "limit_daily_microdollars",
+            "limit_weekly_microdollars",
+            "limit_monthly_microdollars",
+        )
+    ):
+        raise ValueError("only uncapped API keys may use sharded usage counters")
+    return count
+
+
 def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
     """Evenly partition a grant delta, putting the remainder on shard zero."""
     if shard_count < 1:
@@ -138,6 +170,13 @@ def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:
     )
 
 
+def key_limit_mirror_rows(key_hash: str, value: Any, commit_ts: Any) -> list[tuple]:
+    """Mirror config to every active usage row without touching typed counters."""
+    shard_count = key_usage_shard_count(value)
+    base = key_limit_mirror_row(key_hash, value, commit_ts)
+    return [base[:1] + (shard,) + base[2:] for shard in range(shard_count)]
+
+
 def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: Any) -> None:
     """If `kind` is a hot counter, mirror it onto its typed table via `writer`.
 
@@ -157,7 +196,7 @@ def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: 
         writer.insert_or_update(
             table=KEY_LIMIT_TABLE,
             columns=KEY_LIMIT_COLUMNS,
-            values=[key_limit_mirror_row(entity_id, value, commit_ts)],
+            values=key_limit_mirror_rows(entity_id, value, commit_ts),
         )
 
 
@@ -179,9 +218,16 @@ def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module:
     table = _typed_table_for(kind)
     if table is None:
         return
+    max_shards = MAX_CREDIT_SHARDS if kind == "credit" else MAX_KEY_USAGE_SHARDS
     writer.delete(
         table,
-        spanner_module.KeySet(keys=[(entity_id, UNSHARDED) for entity_id in entity_ids]),
+        spanner_module.KeySet(
+            keys=[
+                (entity_id, shard)
+                for entity_id in entity_ids
+                for shard in range(max_shards)
+            ]
+        ),
     )
 
 

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -1,0 +1,305 @@
+"""Operator-only split/consolidation for uncapped API-key usage rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_counters import (
+    KEY_LIMIT_TABLE,
+    distribute_credit_amount,
+    key_usage_shard_count,
+)
+from trusted_router.storage_models import ApiKey, Reservation, Workspace, iso_now
+
+_KEY_RESHARD_COLUMNS = (
+    "key_hash",
+    "shard",
+    "limit_micro",
+    "usage",
+    "byok_usage",
+    "reserved",
+    "include_byok",
+    "day_limit_micro",
+    "week_limit_micro",
+    "month_limit_micro",
+    "day_usage",
+    "day_start",
+    "week_usage",
+    "week_start",
+    "month_usage",
+    "month_start",
+    "source_updated_at",
+    "updated_at",
+)
+
+
+@dataclass
+class KeyUsageReshardResult:
+    key_hash: str
+    workspace_id: str | None
+    target_shard_count: int
+    current_shard_count: int | None = None
+    usage_micro: int | None = None
+    byok_usage_micro: int | None = None
+    reserved_micro: int | None = None
+    typed_open_reservations: int = 0
+    legacy_open_reservations: int = 0
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return not self.reasons
+
+
+def _limits(key: ApiKey) -> tuple[int | None, int | None, int | None, int | None]:
+    return (
+        key.limit_microdollars,
+        key.limit_daily_microdollars,
+        key.limit_weekly_microdollars,
+        key.limit_monthly_microdollars,
+    )
+
+
+def _typed_key_state(
+    store: Any,
+    key_hash: str,
+    shard_count: int,
+) -> tuple[list[list[Any]], int]:
+    pt = store._param_types
+    with store._database.snapshot(multi_use=True) as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT shard, limit_micro, usage, byok_usage, reserved, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "day_usage, day_start, week_usage, week_start, month_usage, month_start "
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        open_reservations = int(
+            list(
+                snapshot.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE key_hash=@kh AND settled = false",
+                    params={"kh": key_hash},
+                    param_types={"kh": pt.STRING},
+                )
+            )[0][0]
+        )
+    return rows, open_reservations
+
+
+def inspect_key_usage_reshard(
+    store: Any,
+    key_hash: str,
+    target_shard_count: int,
+) -> KeyUsageReshardResult:
+    target_count = key_usage_shard_count({"usage_shard_count": target_shard_count})
+    key = store.api_keys.get_by_hash(key_hash)
+    result = KeyUsageReshardResult(
+        key_hash=key_hash,
+        workspace_id=key.workspace_id if key is not None else None,
+        target_shard_count=target_count,
+    )
+    if key is None:
+        result.reasons.append("API key not found")
+        return result
+    workspace = store.get_workspace(key.workspace_id)
+    if workspace is None:
+        result.reasons.append("workspace not found")
+    elif not workspace.billing_paused:
+        result.reasons.append("workspace not billing-paused")
+    if target_count > 1 and any(limit is not None for limit in _limits(key)):
+        result.reasons.append("capped API key must remain on one usage shard")
+
+    try:
+        current_count = key_usage_shard_count(key)
+    except ValueError as exc:
+        result.reasons.append(str(exc))
+        return result
+    result.current_shard_count = current_count
+    rows, typed_open = _typed_key_state(store, key_hash, current_count)
+    result.typed_open_reservations = typed_open
+    result.legacy_open_reservations = sum(
+        1
+        for reservation in store._list_entities("reservation", cls=Reservation)
+        if reservation.key_hash == key_hash and not reservation.settled
+    )
+    if [int(row[0]) for row in rows] != list(range(current_count)):
+        result.reasons.append("configured typed key usage shard set is incomplete")
+        return result
+
+    usage = sum(int(row[2]) for row in rows)
+    byok_usage = sum(int(row[3]) for row in rows)
+    reserved = sum(int(row[4]) for row in rows)
+    result.usage_micro = usage
+    result.byok_usage_micro = byok_usage
+    result.reserved_micro = reserved
+    if any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows):
+        result.reasons.append("typed key usage shard has a negative counter")
+    if reserved != 0:
+        result.reasons.append(f"typed key has reserved={reserved}; wait for drain")
+    if typed_open != 0:
+        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if result.legacy_open_reservations != 0:
+        result.reasons.append(
+            f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
+        )
+    return result
+
+
+def reshard_key_usage(
+    store: Any,
+    key_hash: str,
+    target_shard_count: int,
+    *,
+    apply: bool = False,
+) -> KeyUsageReshardResult:
+    status = inspect_key_usage_reshard(store, key_hash, target_shard_count)
+    if not status.ready or not apply:
+        return status
+    assert status.current_shard_count is not None
+    if status.current_shard_count == status.target_shard_count:
+        return status
+    target_count = status.target_shard_count
+    pt = store._param_types
+    floors = window_floors(utcnow())
+
+    def txn(transaction: Any) -> dict[str, int] | None:
+        key = store._read_entity_tx(transaction, "api_key", key_hash, ApiKey)
+        if key is None:
+            return None
+        workspace = store._read_entity_tx(
+            transaction,
+            "workspace",
+            key.workspace_id,
+            Workspace,
+        )
+        if workspace is None or not workspace.billing_paused:
+            return None
+        if target_count > 1 and any(limit is not None for limit in _limits(key)):
+            return None
+        current_count = key_usage_shard_count(key)
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, limit_micro, usage, byok_usage, reserved, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "day_usage, day_start, week_usage, week_start, month_usage, month_start "
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": current_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        if [int(row[0]) for row in rows] != list(range(current_count)):
+            return None
+        open_typed = int(
+            list(
+                transaction.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE key_hash=@kh AND settled = false",
+                    params={"kh": key_hash},
+                    param_types={"kh": pt.STRING},
+                )
+            )[0][0]
+        )
+        usage = sum(int(row[2]) for row in rows)
+        byok_usage = sum(int(row[3]) for row in rows)
+        reserved = sum(int(row[4]) for row in rows)
+        if (
+            open_typed != 0
+            or reserved != 0
+            or any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows)
+        ):
+            return None
+
+        def window_total(usage_index: int, start_index: int, window: str) -> int:
+            return sum(
+                int(row[usage_index] or 0)
+                for row in rows
+                if row[start_index] is not None and row[start_index] >= floors[window]
+            )
+
+        day_usage = window_total(9, 10, "daily")
+        week_usage = window_total(11, 12, "weekly")
+        month_usage = window_total(13, 14, "monthly")
+        usage_parts = distribute_credit_amount(usage, target_count)
+        byok_parts = distribute_credit_amount(byok_usage, target_count)
+        day_parts = distribute_credit_amount(day_usage, target_count)
+        week_parts = distribute_credit_amount(week_usage, target_count)
+        month_parts = distribute_credit_amount(month_usage, target_count)
+        commit_timestamp = store._spanner.COMMIT_TIMESTAMP
+        transaction.insert_or_update(
+            table=KEY_LIMIT_TABLE,
+            columns=_KEY_RESHARD_COLUMNS,
+            values=[
+                (
+                    key_hash,
+                    shard,
+                    None,
+                    usage_parts[shard],
+                    byok_parts[shard],
+                    0,
+                    key.include_byok_in_limit,
+                    None,
+                    None,
+                    None,
+                    day_parts[shard],
+                    floors["daily"],
+                    week_parts[shard],
+                    floors["weekly"],
+                    month_parts[shard],
+                    floors["monthly"],
+                    commit_timestamp,
+                    commit_timestamp,
+                )
+                for shard in range(target_count)
+            ],
+        )
+        if current_count > target_count:
+            transaction.delete(
+                KEY_LIMIT_TABLE,
+                store._spanner.KeySet(
+                    keys=[
+                        (key_hash, shard)
+                        for shard in range(target_count, current_count)
+                    ]
+                ),
+            )
+        key.usage_shard_count = target_count
+        key.usage_microdollars = usage
+        key.byok_usage_microdollars = byok_usage
+        key.reserved_microdollars = 0
+        key.updated_at = iso_now()
+        transaction.insert_or_update(
+            table=store.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    "api_key",
+                    key_hash,
+                    json_body(key),
+                    commit_timestamp,
+                )
+            ],
+        )
+        return {"usage": usage, "byok_usage": byok_usage}
+
+    changed = store._run_in_transaction(txn)
+    if changed is None:
+        status.reasons.append(
+            "atomic key reshard preconditions changed; workspace remains paused"
+        )
+        return status
+    verified = inspect_key_usage_reshard(store, key_hash, target_count)
+    if not verified.ready:
+        verified.reasons.append("post-commit key reshard verification failed")
+        return verified
+    verified.applied = True
+    return verified

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -138,6 +138,19 @@ class SpannerApiKeys:
         key = self.get_by_hash(key_hash)
         if key is None:
             return None
+        if key.usage_shard_count > 1:
+            requested_limits = [
+                patch.get("limit_microdollars"),
+                patch.get("limit_daily_microdollars"),
+                patch.get("limit_weekly_microdollars"),
+                patch.get("limit_monthly_microdollars"),
+            ]
+            if patch.get("limit") is not None or any(
+                value is not None for value in requested_limits
+            ):
+                raise ValueError(
+                    "consolidate API-key usage to one shard before adding a spend limit"
+                )
         if "name" in patch and patch["name"]:
             key.name = str(patch["name"])
         if "disabled" in patch:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -127,6 +127,10 @@ class ApiKey:
     created_at: str = field(default_factory=iso_now)
     updated_at: str | None = None
     reserved_microdollars: int = 0
+    # Independent usage-counter rows for a high-throughput UNCAPPED key. Keys
+    # with any lifetime/window spend limit must remain at one shard so their
+    # hard cap keeps its existing exact semantics.
+    usage_shard_count: int = 1
 
 
 @dataclass

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -485,6 +485,7 @@ class TypedBillingStore(Protocol):
         candidate_endpoint_ids: list[str],
         idempotency_key: str | None,
         idempotency_fingerprint: str | None,
+        key_usage_shards: int = ...,
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,
         expires_at: Any = ...,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -849,6 +849,12 @@ def _execute_sql(
             1 for rec in db.reservations.values()
             if rec.get("workspace_id") == ws and not rec.get("settled")
         )]]
+    if "COUNT(*) FROM tr_reservation WHERE key_hash=@kh AND settled = false" in sql:
+        kh = params["kh"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("key_hash") == kh and not rec.get("settled")
+        )]]
     # Flip-reconcile: does this workspace have ANY typed reservation history?
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]

--- a/tests/test_credit_row_sharding_stress.py
+++ b/tests/test_credit_row_sharding_stress.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from scripts.stress_credit_shards import run_stress
+
+
+def test_credit_shard_lifecycle_stress_preserves_every_invariant() -> None:
+    result = run_stress(
+        request_count=200,
+        concurrency=32,
+        shard_count=16,
+        estimate_micro=300_000,
+    )
+
+    assert result.invariant_clean
+    assert result.authorize.successes == 200
+    assert result.settle.successes == 200
+    assert result.final_reserved_micro == 0
+    assert result.final_usage_micro == 60_000_000
+    assert result.final_total_credits_micro == 60_000_000
+    assert result.observed_key_shards == 16
+    assert result.final_key_usage_micro == 60_000_000
+    assert result.final_key_reserved_micro == 0
+    assert result.authorize.error_types == {}
+    assert result.settle.error_types == {}

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    authorize_atomic,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counter_reconcile import (
+    backsync_typed_to_json,
+    compare,
+    repair_typed_reserved,
+)
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    KEY_LIMIT_TABLE,
+    key_usage_shard_count,
+)
+from trusted_router.storage_gcp_key_shard_admin import (
+    inspect_key_usage_reshard,
+    reshard_key_usage,
+)
+from trusted_router.storage_models import CreditAccount, Workspace
+
+
+def _seed(*, key_shards: int = 4) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-key-shards"
+    store._write_entity(
+        "workspace",
+        workspace_id,
+        Workspace(
+            id=workspace_id,
+            name="Key shard test",
+            owner_user_id="owner",
+            billing_paused=True,
+        ),
+    )
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=1_000_000,
+        ),
+    )
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="uncapped-sharded-key",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    key.usage_shard_count = key_shards
+    store._write_entity("api_key", key.hash, key)
+    return store, database, key
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id}
+    )
+
+
+def test_key_usage_shards_default_and_fail_closed_for_capped_keys() -> None:
+    assert key_usage_shard_count({}) == 1
+    assert key_usage_shard_count({"usage_shard_count": 16}) == 16
+    with pytest.raises(ValueError, match="positive integer"):
+        key_usage_shard_count({"usage_shard_count": 0})
+    with pytest.raises(ValueError, match="must not exceed"):
+        key_usage_shard_count({"usage_shard_count": 65})
+    with pytest.raises(ValueError, match="only uncapped"):
+        key_usage_shard_count(
+            {"usage_shard_count": 2, "limit_microdollars": 1_000_000}
+        )
+    with pytest.raises(ValueError, match="only uncapped"):
+        key_usage_shard_count(
+            {"usage_shard_count": 2, "limit_daily_microdollars": 1_000_000}
+        )
+
+
+def test_api_key_mirror_creates_every_usage_shard_without_clobbering_counters() -> None:
+    store, database, key = _seed(key_shards=4)
+    rows = database.typed[KEY_LIMIT_TABLE]
+
+    assert {(key.hash, shard) for shard in range(4)} <= set(rows)
+    for shard in range(4):
+        row = rows[(key.hash, shard)]
+        assert row["limit_micro"] is None
+        assert row["usage"] == 0
+        assert row["byok_usage"] == 0
+        assert row["reserved"] == 0
+
+    rows[(key.hash, 2)]["usage"] = 123
+    key.name = "renamed"
+    store._write_entity("api_key", key.hash, key)
+    assert rows[(key.hash, 2)]["usage"] == 123
+
+
+def test_authorize_records_key_shard_and_settle_spreads_exact_usage() -> None:
+    store, database, key = _seed(key_shards=4)
+    reservations: list[str] = []
+
+    for index in range(40):
+        first = index % 4
+        candidates = tuple((first + offset) % 4 for offset in range(4))
+        result = authorize_atomic(
+            store._database,
+            store._param_types,
+            workspace_id="ws-key-shards",
+            key_hash=key.hash,
+            estimate=1_000,
+            has_credit_candidate=True,
+            reservation_usage_type="Credits",
+            idempotency_scope=f"key-shard-{index}",
+            idempotency_fingerprint="same-body",
+            expires_at="2026-12-01T00:00:00Z",
+            build_auth_body=_auth_body,
+            key_shard_candidates=candidates,
+        )
+        assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+        assert result["key_shard"] == first
+        reservations.append(result["reservation_id"])
+
+    for reservation_id in reservations:
+        settled = settle_atomic(
+            store._database,
+            store._param_types,
+            reservation_id=reservation_id,
+            actual_micro=900,
+            settled_usage_type="Credits",
+            success=True,
+        )
+        assert settled["outcome"] == SettleOutcome.SETTLED
+
+    rows = database.typed[KEY_LIMIT_TABLE]
+    assert [rows[(key.hash, shard)]["usage"] for shard in range(4)] == [9_000] * 4
+    assert [rows[(key.hash, shard)]["reserved"] for shard in range(4)] == [0] * 4
+    assert sum(row["total_usage"] for row in database.typed[CREDIT_BALANCE_TABLE].values()) == 36_000
+
+
+def test_idempotent_replay_keeps_original_key_shard() -> None:
+    store, database, key = _seed(key_shards=4)
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": "ws-key-shards",
+        "key_hash": key.hash,
+        "estimate": 1_000,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": "same-key-shard-request",
+        "idempotency_fingerprint": "same-body",
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+
+    first = authorize_atomic(**common, key_shard_candidates=(3, 2, 1, 0))
+    replay = authorize_atomic(**common, key_shard_candidates=(0, 1, 2, 3))
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["key_shard"] == first["key_shard"] == 3
+    assert database.reservations[first["reservation_id"]]["key_shard"] == 3
+
+
+def test_typed_key_usage_sums_shards_and_current_windows() -> None:
+    store, database, key = _seed(key_shards=4)
+    floors = window_floors(utcnow())
+    rows = database.typed[KEY_LIMIT_TABLE]
+    for shard in range(4):
+        row = rows[(key.hash, shard)]
+        row["usage"] = 10 + shard
+        row["byok_usage"] = 2 + shard
+        row["reserved"] = shard
+        row["day_usage"] = 3 + shard
+        row["day_start"] = floors["daily"]
+        row["week_usage"] = 4 + shard
+        row["week_start"] = floors["weekly"]
+        row["month_usage"] = 5 + shard
+        row["month_start"] = floors["monthly"]
+
+    usage = store.typed_key_usage(key.hash)
+
+    assert usage == {
+        "usage": 46,
+        "byok_usage": 14,
+        "reserved": 6,
+        "windows": {"daily": 18, "weekly": 22, "monthly": 26},
+    }
+
+
+def test_compare_detects_a_missing_configured_key_usage_shard() -> None:
+    store, database, key = _seed(key_shards=4)
+    assert compare(store).clean
+
+    database.typed[KEY_LIMIT_TABLE].pop((key.hash, 3))
+    report = compare(store)
+
+    assert report.key_drift == 1
+    assert report.samples[f"api_key:{key.hash}"]["usage_shard_count"] == (4, 3)
+
+
+def test_deleting_sharded_key_removes_every_typed_usage_row() -> None:
+    store, database, key = _seed(key_shards=4)
+
+    assert store.api_keys.delete(key.hash)
+
+    assert not any(row_key == key.hash for row_key, _shard in database.typed[KEY_LIMIT_TABLE])
+
+
+def test_adding_a_limit_to_sharded_key_is_rejected_atomically() -> None:
+    store, _database, key = _seed(key_shards=4)
+
+    with pytest.raises(ValueError, match="consolidate API-key usage"):
+        store.api_keys.update(key.hash, {"limit_microdollars": 1_000_000})
+
+    persisted = store.api_keys.get_by_hash(key.hash)
+    assert persisted is not None
+    assert persisted.limit_microdollars is None
+    assert persisted.usage_shard_count == 4
+
+
+def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
+    store, database, key = _seed(key_shards=1)
+    floors = window_floors(utcnow())
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row.update(
+        usage=101,
+        byok_usage=37,
+        day_usage=19,
+        day_start=floors["daily"],
+        week_usage=23,
+        week_start=floors["weekly"],
+        month_usage=29,
+        month_start=floors["monthly"],
+    )
+
+    split = reshard_key_usage(store, key.hash, 16, apply=True)
+
+    assert split.ready and split.applied
+    assert split.current_shard_count == 16
+    assert split.usage_micro == 101
+    assert split.byok_usage_micro == 37
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(16)]
+    assert sum(row["usage"] for row in rows) == 101
+    assert sum(row["byok_usage"] for row in rows) == 37
+    assert sum(row["day_usage"] for row in rows) == 19
+    assert sum(row["week_usage"] for row in rows) == 23
+    assert sum(row["month_usage"] for row in rows) == 29
+    assert all(row["reserved"] == 0 for row in rows)
+
+    unshard = reshard_key_usage(store, key.hash, 1, apply=True)
+
+    assert unshard.ready and unshard.applied
+    [single] = [
+        row
+        for (row_key, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
+        if row_key == key.hash
+    ]
+    assert single["usage"] == 101
+    assert single["byok_usage"] == 37
+    assert single["day_usage"] == 19
+    assert single["week_usage"] == 23
+    assert single["month_usage"] == 29
+    persisted = store.api_keys.get_by_hash(key.hash)
+    assert persisted.usage_shard_count == 1
+    assert persisted.usage_microdollars == 101
+    assert persisted.byok_usage_microdollars == 37
+
+
+def test_key_usage_operator_refuses_capped_or_undrained_key() -> None:
+    store, database, key = _seed(key_shards=1)
+    key.limit_microdollars = 1_000_000
+    store._write_entity("api_key", key.hash, key)
+
+    capped = reshard_key_usage(store, key.hash, 4, apply=True)
+    assert not capped.ready
+    assert "capped API key must remain on one usage shard" in capped.reasons
+
+    key.limit_microdollars = None
+    store._write_entity("api_key", key.hash, key)
+    database.reservations["open-key-request"] = {
+        "reservation_id": "open-key-request",
+        "workspace_id": key.workspace_id,
+        "key_hash": key.hash,
+        "settled": False,
+    }
+    undrained = reshard_key_usage(store, key.hash, 4, apply=True)
+    assert not undrained.ready
+    assert any("open typed reservations" in reason for reason in undrained.reasons)
+
+
+def test_key_usage_operator_status_is_idempotent_after_split() -> None:
+    store, _database, key = _seed(key_shards=1)
+    assert reshard_key_usage(store, key.hash, 8, apply=True).applied
+
+    status = inspect_key_usage_reshard(store, key.hash, 8)
+    noop = reshard_key_usage(store, key.hash, 8, apply=True)
+
+    assert status.ready
+    assert status.current_shard_count == 8
+    assert noop.ready
+    assert not noop.applied
+
+
+def test_legacy_rollback_and_shard_zero_repair_refuse_sharded_key_usage() -> None:
+    store, _database, key = _seed(key_shards=4)
+
+    backsync = backsync_typed_to_json(store, key.workspace_id, apply=True)
+    repair = repair_typed_reserved(store, key.workspace_id, apply=True)
+
+    assert not backsync.ready
+    assert "API-key usage is sharded" in backsync.reasons[0]
+    assert not repair.ready
+    assert any("API-key usage is sharded" in reason for reason in repair.reasons)


### PR DESCRIPTION
## Summary
- remove the remaining per-key settle hotspot for explicitly activated, fully uncapped API keys
- record a randomized key usage shard on each reservation and settle on exactly that row
- preserve shard_count=1 behavior for every key by default
- fail closed if any lifetime/daily/weekly/monthly capped key is configured above one shard
- aggregate key usage/window reads exactly across configured rows
- extend the pause/drain operator to split eligible key rows and verify them before unpause
- make typed rollback/repair refuse sharded state until the operator consolidates to one
- add a phase-separated 2,000-request stress harness with error classification and ledger checks

## Safety boundary
This PR does NOT shard capped key budgets. Capped keys stay on one exact row. Limit management returns a conflict until an activated key is consolidated to one row. Workspace credit hard caps remain partitioned and exact.

## Verification
- 1,467 passed, 33 skipped
- ruff clean
- mypy clean
- local fake-Spanner lifecycle stress: 2,000/2,000 authorize, 2,000/2,000 settle at concurrency 128, all 16 credit/key rows used, exact 600,000,000 microdollars on both ledgers, reserved=0, no errors

Stacked on #160. No production workspace or API key is activated by this PR.