### PR TITLE
Billing: scalable credit and uncapped key row sharding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,8 +200,30 @@ jobs:
             sleep 5
           done
 
+  migrate-schema:
+    # Runs inside the same serialized deploy workflow, after CI and before any
+    # serving revision changes. The script is idempotent; normally this is only
+    # read-only INFORMATION_SCHEMA verification. A newly added column therefore
+    # always exists before code that writes it can receive traffic.
+    needs: [gate-on-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Apply idempotent Spanner schema prerequisites
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/migrate_typed_counters.sh
+
   deploy:
-    needs: [gate-on-ci, build-image]
+    needs: [gate-on-ci, build-image, migrate-schema]
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: quill-cloud-proxy

--- a/docs/design/key-usage-row-sharding.md
+++ b/docs/design/key-usage-row-sharding.md
@@ -1,0 +1,84 @@
+# Uncapped API-key usage-row sharding
+
+Date: 2026-07-11
+
+## Why this follows credit-row sharding
+
+Credit sub-ledgers remove the hot workspace row from authorize and settle, but
+every successful settle also books usage onto `tr_key_limit(key_hash, shard=0)`.
+A local 2,000-request lifecycle stress run at concurrency 128 confirmed the
+shape: sharded authorization completed, then unsharded settlement exhausted the
+fake Spanner retry budget on the one API-key row.
+
+The table and reservation schema already support `(key_hash, shard)` and
+`key_shard`. We use those fields to spread usage writes for high-throughput,
+fully uncapped keys.
+
+## Scope and hard safety boundary
+
+`ApiKey.usage_shard_count` defaults to 1. A value above 1 is valid only when all
+of these are unset:
+
+- lifetime spend limit
+- daily spend limit
+- weekly spend limit
+- monthly spend limit
+
+Capped keys remain byte-identical on shard zero. Code, management routes, the
+mirror, and the operator all fail closed if a sharded key acquires a limit.
+This deliberately avoids claiming that an unimplemented partitioned key budget
+is exact.
+
+## Request lifecycle
+
+1. The already-authenticated API key supplies its validated shard count to the
+   typed authorize path. There is no extra hot-path database read.
+2. TrustedRouter randomizes all key usage shards outside the Spanner retry
+   callback.
+3. An uncapped row returns `KEY_NO_HOLD`; authorize records the selected
+   `key_shard` on `tr_reservation`.
+4. Settle/refund books against exactly that recorded row.
+5. Idempotent replay returns the originally committed key shard.
+
+Credit and key shard choices are independent, so one unlucky mapping cannot
+recreate a combined hot row.
+
+## Activation and reversal
+
+`scripts/shard_workspace.py` operates credit rows and all eligible API-key rows
+under the same workspace pause:
+
+```bash
+python scripts/shard_workspace.py prepare --workspace WS --shards 16 --apply
+python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
+```
+
+Prepare pauses the workspace, refuses open typed or legacy requests, atomically
+partitions each ledger, verifies it, runs the invariant audit, and leaves the
+workspace paused. Finish re-verifies credit and key row sets before unpausing.
+Capped keys stay at one row. Reverse with `--shards 1` before any typed-to-JSON
+rollback or shard-zero repair; those older tools now refuse sharded state.
+
+Lifetime usage, BYOK usage, and current daily/weekly/monthly usage are preserved
+as exact global sums. Stale window epochs are discarded because they already
+read as zero under normal lazy-reset semantics.
+
+## Stress gate
+
+`scripts/stress_credit_shards.py` runs authorize and settle as separate phases
+and reports latency, throughput, simulated aborts, failures by type, credit
+invariants, and key usage distribution.
+
+The 2,000-request, concurrency-128, 16-shard local run after this change:
+
+- authorize: 2,000/2,000
+- settle: 2,000/2,000
+- credit reserved after settle: 0
+- credit usage: exactly 600,000,000 microdollars
+- key usage: exactly 600,000,000 microdollars across all 16 rows
+- simulated settle aborts: 0 in the final run (one earlier run had 1, recovered)
+
+This is a deterministic correctness/contention-shape gate, not a claim about
+production Spanner latency. Production activation still requires the additive
+reservation migration, staged deployment, a paused canary split, invariant
+audit, and live latency/abort monitoring.

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -185,6 +185,10 @@ ensure_column tr_key_limit month_start "TIMESTAMP"
 # Credit-row sharding increment 1. Existing reservations retain ws_shard=0;
 # old rows read NULL for the additive column and the application falls back to
 # ws_shard. New rows write both during the rolling-compatibility window.
+# Existing databases intentionally add this as nullable: adding NOT NULL would
+# force a synchronous backfill. Fresh installs use NOT NULL DEFAULT(0); a later
+# post-backfill migration may tighten existing databases after the fallback is
+# retired. Do not "fix" this rolling-schema divergence in this additive step.
 ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"
 
 # ── Durable settle outbox (docs/design/durable-settle-outbox.md) ────────────

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -120,6 +120,7 @@ if table_exists tr_reservation; then log "tr_reservation exists, skip"; else
     workspace_id STRING(64),
     key_hash STRING(64),
     ws_shard INT64,
+    credit_shard INT64 NOT NULL DEFAULT (0),
     key_shard INT64,
     credit_reserved_micro INT64,
     key_reserved_micro INT64,
@@ -180,6 +181,11 @@ ensure_column tr_key_limit week_usage  "INT64 DEFAULT (0)"
 ensure_column tr_key_limit week_start  "TIMESTAMP"
 ensure_column tr_key_limit month_usage "INT64 DEFAULT (0)"
 ensure_column tr_key_limit month_start "TIMESTAMP"
+
+# Credit-row sharding increment 1. Existing reservations retain ws_shard=0;
+# old rows read NULL for the additive column and the application falls back to
+# ws_shard. New rows write both during the rolling-compatibility window.
+ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"
 
 # ── Durable settle outbox (docs/design/durable-settle-outbox.md) ────────────
 # Recovers completed-but-settle-lost charges. Additive + guarded; safe to apply

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -1,0 +1,167 @@
+"""Safely split or consolidate one hot workspace's typed credit row.
+
+The operation is intentionally two phase so a failed verification can never
+silently resume billing:
+
+  # Pause, drain-check, and atomically split. Re-run while parked if draining.
+  python scripts/shard_workspace.py prepare --workspace WS --shards 16 --apply
+
+  # Verify the committed shape + global billing invariants, then unpause.
+  python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
+
+Reverse with the same commands and ``--shards 1``. Without ``--apply`` every
+command is read-only. A failed prepare/finish always leaves the workspace paused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+os.environ.setdefault("TR_TYPED_COUNTER_MIRROR", "1")
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
+from trusted_router.storage_gcp_counters import MAX_CREDIT_SHARDS
+from trusted_router.storage_gcp_credit_shard_admin import (
+    CreditReshardResult,
+    inspect_credit_reshard,
+    reshard_credit_account,
+)
+
+
+def _print_status(status: CreditReshardResult) -> None:
+    print(
+        f"{status.workspace_id}: current_shards={status.current_shard_count} "
+        f"target_shards={status.target_shard_count} ready={status.ready} "
+        f"applied={status.applied}"
+    )
+    print(
+        "  typed totals: "
+        f"credits={status.total_credits_micro} usage={status.total_usage_micro} "
+        f"reserved={status.reserved_micro}"
+    )
+    print(
+        "  open reservations: "
+        f"typed={status.typed_open_reservations} legacy={status.legacy_open_reservations}"
+    )
+    for reason in status.reasons:
+        print(f"  BLOCKED: {reason}")
+
+
+def _pause(store: Any, workspace_id: str) -> bool:
+    updated = store.update_workspace(
+        workspace_id,
+        billing_paused=True,
+        billing_pause_reason="credit-row reshard prepare",
+    )
+    return updated is not None and bool(updated.billing_paused)
+
+
+def run_status(store: Any, args: argparse.Namespace) -> int:
+    _print_status(inspect_credit_reshard(store, args.workspace, args.shards))
+    return 0
+
+
+def run_prepare(store: Any, args: argparse.Namespace) -> int:
+    if not args.apply:
+        status = inspect_credit_reshard(store, args.workspace, args.shards)
+        _print_status(status)
+        print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
+        return 0
+    if not _pause(store, args.workspace):
+        print("ERROR: could not pause workspace", file=sys.stderr)
+        return 1
+    status = reshard_credit_account(store, args.workspace, args.shards, apply=True)
+    _print_status(status)
+    if not status.ready:
+        print("Workspace remains paused. Re-run prepare after holds drain.")
+        draining = any("drain" in reason or "open" in reason for reason in status.reasons)
+        return 2 if draining else 1
+    audit = audit_typed_invariants(store)
+    print(audit.summary())
+    if not audit.clean:
+        print("Workspace remains paused because the invariant audit failed.", file=sys.stderr)
+        return 1
+    print(
+        "Prepared and verified. Workspace remains paused; run finish with the "
+        "same --shards value to resume billing."
+    )
+    return 0
+
+
+def run_finish(store: Any, args: argparse.Namespace) -> int:
+    status = inspect_credit_reshard(store, args.workspace, args.shards)
+    _print_status(status)
+    if not status.ready:
+        print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
+        return 1
+    audit = audit_typed_invariants(store)
+    print(audit.summary())
+    if not audit.clean:
+        print("ERROR: refusing to unpause; invariant audit failed", file=sys.stderr)
+        return 1
+    if not args.apply:
+        print("DRY-RUN: would unpause this verified workspace")
+        return 0
+    updated = store.update_workspace(
+        args.workspace,
+        billing_paused=False,
+        billing_pause_reason="",
+    )
+    if updated is None or updated.billing_paused:
+        print("ERROR: failed to verify workspace unpause", file=sys.stderr)
+        return 1
+    print(f"{args.workspace}: unpaused with {args.shards} credit shards")
+    return 0
+
+
+def _shard_count_arg(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("shards must be an integer") from exc
+    if value < 1 or value > MAX_CREDIT_SHARDS:
+        raise argparse.ArgumentTypeError(
+            f"shards must be between 1 and {MAX_CREDIT_SHARDS}"
+        )
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name, handler in (
+        ("status", run_status),
+        ("prepare", run_prepare),
+        ("finish", run_finish),
+    ):
+        command = sub.add_parser(name)
+        command.add_argument("--workspace", required=True)
+        command.add_argument("--shards", required=True, type=_shard_count_arg)
+        if name != "status":
+            command.add_argument("--apply", action="store_true")
+        command.set_defaults(handler=handler)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    store = create_store(Settings())
+    return int(args.handler(store, args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -1,4 +1,4 @@
-"""Safely split or consolidate one hot workspace's typed credit row.
+"""Safely split or consolidate a workspace's credit and uncapped key rows.
 
 The operation is intentionally two phase so a failed verification can never
 silently resume billing:
@@ -9,8 +9,10 @@ silently resume billing:
   # Verify the committed shape + global billing invariants, then unpause.
   python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 
-Reverse with the same commands and ``--shards 1``. Without ``--apply`` every
-command is read-only. A failed prepare/finish always leaves the workspace paused.
+Eligible uncapped API-key usage rows are split to the same count; capped keys
+remain on one exact row. Reverse with the same commands and ``--shards 1``.
+Without ``--apply`` every command is read-only. A failed prepare/finish always
+leaves the workspace paused.
 """
 
 from __future__ import annotations
@@ -37,6 +39,12 @@ from trusted_router.storage_gcp_credit_shard_admin import (
     inspect_credit_reshard,
     reshard_credit_account,
 )
+from trusted_router.storage_gcp_key_shard_admin import (
+    KeyUsageReshardResult,
+    inspect_key_usage_reshard,
+    reshard_key_usage,
+)
+from trusted_router.storage_models import ApiKey
 
 
 def _print_status(status: CreditReshardResult) -> None:
@@ -58,6 +66,55 @@ def _print_status(status: CreditReshardResult) -> None:
         print(f"  BLOCKED: {reason}")
 
 
+def _print_key_status(status: KeyUsageReshardResult) -> None:
+    print(
+        f"  key {status.key_hash}: current_shards={status.current_shard_count} "
+        f"target_shards={status.target_shard_count} ready={status.ready} "
+        f"applied={status.applied} usage={status.usage_micro} "
+        f"byok_usage={status.byok_usage_micro} reserved={status.reserved_micro}"
+    )
+    for reason in status.reasons:
+        print(f"    BLOCKED: {reason}")
+
+
+def _key_target(key: ApiKey, requested_shards: int) -> int:
+    has_limit = any(
+        value is not None
+        for value in (
+            key.limit_microdollars,
+            key.limit_daily_microdollars,
+            key.limit_weekly_microdollars,
+            key.limit_monthly_microdollars,
+        )
+    )
+    return 1 if has_limit else requested_shards
+
+
+def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+    clean = True
+    for key in store.api_keys.list_for_workspace(workspace_id):
+        target = _key_target(key, requested_shards)
+        if target != requested_shards:
+            print(f"  key {key.hash}: capped; keeping exact usage_shards=1")
+        status = reshard_key_usage(store, key.hash, target, apply=True)
+        _print_key_status(status)
+        clean = clean and status.ready
+    return clean
+
+
+def _verify_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+    clean = True
+    for key in store.api_keys.list_for_workspace(workspace_id):
+        status = inspect_key_usage_reshard(
+            store,
+            key.hash,
+            _key_target(key, requested_shards),
+        )
+        _print_key_status(status)
+        clean = clean and status.ready
+    return clean
+
+
 def _pause(store: Any, workspace_id: str) -> bool:
     updated = store.update_workspace(
         workspace_id,
@@ -69,6 +126,7 @@ def _pause(store: Any, workspace_id: str) -> bool:
 
 def run_status(store: Any, args: argparse.Namespace) -> int:
     _print_status(inspect_credit_reshard(store, args.workspace, args.shards))
+    _verify_keys(store, args.workspace, args.shards)
     return 0
 
 
@@ -76,6 +134,7 @@ def run_prepare(store: Any, args: argparse.Namespace) -> int:
     if not args.apply:
         status = inspect_credit_reshard(store, args.workspace, args.shards)
         _print_status(status)
+        _verify_keys(store, args.workspace, args.shards)
         print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
         return 0
     if not _pause(store, args.workspace):
@@ -87,6 +146,9 @@ def run_prepare(store: Any, args: argparse.Namespace) -> int:
         print("Workspace remains paused. Re-run prepare after holds drain.")
         draining = any("drain" in reason or "open" in reason for reason in status.reasons)
         return 2 if draining else 1
+    if not _prepare_keys(store, args.workspace, args.shards):
+        print("Workspace remains paused because an API-key reshard failed.", file=sys.stderr)
+        return 1
     audit = audit_typed_invariants(store)
     print(audit.summary())
     if not audit.clean:
@@ -105,6 +167,9 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     if not status.ready:
         print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
         return 1
+    if not _verify_keys(store, args.workspace, args.shards):
+        print("ERROR: refusing to unpause; API-key shard verification failed", file=sys.stderr)
+        return 1
     audit = audit_typed_invariants(store)
     print(audit.summary())
     if not audit.clean:
@@ -121,7 +186,10 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     if updated is None or updated.billing_paused:
         print("ERROR: failed to verify workspace unpause", file=sys.stderr)
         return 1
-    print(f"{args.workspace}: unpaused with {args.shards} credit shards")
+    print(
+        f"{args.workspace}: unpaused with {args.shards} credit shards and "
+        "eligible key usage shards"
+    )
     return 0
 
 

--- a/scripts/stress_credit_shards.py
+++ b/scripts/stress_credit_shards.py
@@ -1,0 +1,334 @@
+"""Run a deterministic 2,000-request credit-shard lifecycle stress test.
+
+This uses the concurrency-aware in-process Spanner fake, so it is a correctness
+and contention-shape test rather than a production latency benchmark. It reports
+authorize and settle separately to expose any remaining shared-row bottleneck.
+
+Usage:
+    PYTHONPATH=src:. uv run python scripts/stress_credit_shards.py
+    PYTHONPATH=src:. uv run python scripts/stress_credit_shards.py --requests 2000 --concurrency 128
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_models import CreditAccount
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    requests: int
+    successes: int
+    failures: int
+    elapsed_seconds: float
+    requests_per_second: float
+    p50_ms: float
+    p95_ms: float
+    aborts: int
+    error_types: dict[str, int]
+
+
+@dataclass(frozen=True)
+class StressResult:
+    request_count: int
+    concurrency: int
+    shard_count: int
+    estimate_micro: int
+    authorize: PhaseResult
+    settle: PhaseResult
+    final_reserved_micro: int
+    final_usage_micro: int
+    final_total_credits_micro: int
+    observed_key_shards: int
+    final_key_usage_micro: int
+    final_key_reserved_micro: int
+    nonzero_key_shards: int
+    max_key_shard_usage_micro: int
+    invariant_clean: bool
+
+
+def _percentile_ms(samples: list[float], percentile: float) -> float:
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    index = max(0, min(len(ordered) - 1, round((len(ordered) - 1) * percentile)))
+    return ordered[index] * 1000.0
+
+
+def _phase_result(
+    *,
+    requests: int,
+    successes: int,
+    elapsed: float,
+    latencies: list[float],
+    aborts: int,
+    error_types: Counter[str],
+) -> PhaseResult:
+    return PhaseResult(
+        requests=requests,
+        successes=successes,
+        failures=requests - successes,
+        elapsed_seconds=elapsed,
+        requests_per_second=requests / elapsed if elapsed > 0 else 0.0,
+        p50_ms=statistics.median(latencies) * 1000.0 if latencies else 0.0,
+        p95_ms=_percentile_ms(latencies, 0.95),
+        aborts=aborts,
+        error_types=dict(sorted(error_types.items())),
+    )
+
+
+def _seed(
+    *,
+    request_count: int,
+    shard_count: int,
+    estimate_micro: int,
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    workspace_id = "stress-workspace"
+    total_credits = request_count * estimate_micro
+    base, remainder = divmod(total_credits, shard_count)
+    shard_totals = [base] * shard_count
+    shard_totals[0] += remainder
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=total_credits,
+            shard_count=shard_count,
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(shard_totals):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": total,
+            "total_usage": 0,
+            "reserved": 0,
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="stress-key",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    key.usage_shard_count = shard_count
+    store._write_entity("api_key", key.hash, key)
+    return store, database, key
+
+
+def run_stress(
+    *,
+    request_count: int = 2_000,
+    concurrency: int = 128,
+    shard_count: int = 16,
+    estimate_micro: int = 300_000,
+) -> StressResult:
+    if request_count < 1 or concurrency < 1 or shard_count < 1 or estimate_micro < 1:
+        raise ValueError("stress arguments must be positive")
+    store, database, key = _seed(
+        request_count=request_count,
+        shard_count=shard_count,
+        estimate_micro=estimate_micro,
+    )
+    workspace_id = "stress-workspace"
+    store._credit_shard_count(workspace_id)  # warm the allow-stale config cache.
+    authorizations: list[Any] = []
+    authorization_lock = threading.Lock()
+    authorize_latencies: list[float] = []
+    authorize_errors: Counter[str] = Counter()
+    authorize_start_aborts = database.aborts
+
+    def authorize(index: int) -> bool:
+        started = time.perf_counter()
+        try:
+            outcome, authorization = store.authorize_gateway_typed(
+                workspace_id=workspace_id,
+                key_hash=key.hash,
+                estimate=estimate_micro,
+                has_credit_candidate=True,
+                reservation_usage_type="Credits",
+                model_id="stress-model",
+                provider="stress-provider",
+                requested_model_id=None,
+                candidate_model_ids=["stress-model"],
+                region="test",
+                endpoint_id="stress-endpoint",
+                candidate_endpoint_ids=["stress-endpoint"],
+                idempotency_key=f"stress-{index}",
+                idempotency_fingerprint="stress-body-v1",
+                key_usage_shards=key.usage_shard_count,
+            )
+        except Exception as exc:  # noqa: BLE001 - stress harness classifies failures.
+            elapsed = time.perf_counter() - started
+            with authorization_lock:
+                authorize_latencies.append(elapsed)
+                authorize_errors[type(exc).__name__] += 1
+            return False
+        elapsed = time.perf_counter() - started
+        with authorization_lock:
+            authorize_latencies.append(elapsed)
+            if authorization is not None:
+                authorizations.append(authorization)
+            if outcome != AuthorizeOutcome.ACCEPTED:
+                authorize_errors[str(outcome)] += 1
+        return outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        authorize_successes = sum(
+            1
+            for future in as_completed(
+                executor.submit(authorize, index) for index in range(request_count)
+            )
+            if future.result()
+        )
+    authorize_elapsed = time.perf_counter() - started
+    authorize_result = _phase_result(
+        requests=request_count,
+        successes=authorize_successes,
+        elapsed=authorize_elapsed,
+        latencies=authorize_latencies,
+        aborts=database.aborts - authorize_start_aborts,
+        error_types=authorize_errors,
+    )
+
+    settle_latencies: list[float] = []
+    settle_errors: Counter[str] = Counter()
+    settle_lock = threading.Lock()
+    settle_start_aborts = database.aborts
+
+    def settle(authorization: Any) -> bool:
+        started_at = time.perf_counter()
+        try:
+            result = settle_atomic(
+                store._database,
+                store._param_types,
+                reservation_id=authorization.credit_reservation_id,
+                actual_micro=estimate_micro,
+                settled_usage_type="Credits",
+                success=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - stress harness classifies failures.
+            elapsed = time.perf_counter() - started_at
+            with settle_lock:
+                settle_latencies.append(elapsed)
+                settle_errors[type(exc).__name__] += 1
+            return False
+        elapsed = time.perf_counter() - started_at
+        with settle_lock:
+            settle_latencies.append(elapsed)
+            if result["outcome"] != SettleOutcome.SETTLED:
+                settle_errors[str(result["outcome"])] += 1
+        return result["outcome"] == SettleOutcome.SETTLED
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        settle_successes = sum(
+            1
+            for future in as_completed(
+                executor.submit(settle, authorization)
+                for authorization in authorizations
+            )
+            if future.result()
+        )
+    settle_elapsed = time.perf_counter() - started
+    settle_result = _phase_result(
+        requests=len(authorizations),
+        successes=settle_successes,
+        elapsed=settle_elapsed,
+        latencies=settle_latencies,
+        aborts=database.aborts - settle_start_aborts,
+        error_types=settle_errors,
+    )
+
+    rows = list(database.typed[CREDIT_BALANCE_TABLE].values())
+    final_reserved = sum(int(row["reserved"]) for row in rows)
+    final_usage = sum(int(row["total_usage"]) for row in rows)
+    final_total = sum(int(row["total_credits"]) for row in rows)
+    key_rows = [
+        row
+        for (row_key_hash, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
+        if row_key_hash == key.hash
+    ]
+    final_key_usage = sum(int(row["usage"]) for row in key_rows)
+    final_key_reserved = sum(int(row["reserved"]) for row in key_rows)
+    invariant_clean = (
+        authorize_successes == request_count
+        and settle_successes == request_count
+        and final_reserved == 0
+        and final_usage == request_count * estimate_micro
+        and final_total == request_count * estimate_micro
+        and len(key_rows) == shard_count
+        and final_key_usage == request_count * estimate_micro
+        and final_key_reserved == 0
+        and all(
+            int(row["total_usage"]) + int(row["reserved"])
+            <= int(row["total_credits"])
+            for row in rows
+        )
+    )
+    return StressResult(
+        request_count=request_count,
+        concurrency=concurrency,
+        shard_count=shard_count,
+        estimate_micro=estimate_micro,
+        authorize=authorize_result,
+        settle=settle_result,
+        final_reserved_micro=final_reserved,
+        final_usage_micro=final_usage,
+        final_total_credits_micro=final_total,
+        observed_key_shards=len(key_rows),
+        final_key_usage_micro=final_key_usage,
+        final_key_reserved_micro=final_key_reserved,
+        nonzero_key_shards=sum(1 for row in key_rows if int(row["usage"]) > 0),
+        max_key_shard_usage_micro=max(
+            (int(row["usage"]) for row in key_rows),
+            default=0,
+        ),
+        invariant_clean=invariant_clean,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", type=int, default=2_000)
+    parser.add_argument("--concurrency", type=int, default=128)
+    parser.add_argument("--shards", type=int, default=16)
+    parser.add_argument("--estimate-micro", type=int, default=300_000)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = run_stress(
+        request_count=args.requests,
+        concurrency=args.concurrency,
+        shard_count=args.shards,
+        estimate_micro=args.estimate_micro,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return 0 if result.invariant_clean else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -132,7 +132,13 @@ def register(app: FastAPI) -> None:
                 patch[f"limit_{window}_microdollars"] = _parse_limit(value)
         except ValueError:
             return RedirectResponse(url="/console/api-keys?error=limit", status_code=303)
-        STORE.update_key(key_hash, patch)
+        try:
+            STORE.update_key(key_hash, patch)
+        except ValueError:
+            return RedirectResponse(
+                url="/console/api-keys?error=consolidate_key_usage",
+                status_code=303,
+            )
         return RedirectResponse(url="/console/api-keys?saved=limit", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/disable")

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -252,6 +252,7 @@ async def authorize_gateway(
             window_resets_at,
         )
         from trusted_router.storage_gcp_authorize import AuthorizeOutcome
+        from trusted_router.storage_gcp_counters import key_usage_shard_count
 
         # expires_at = generous execution deadline (> max stream + settle
         # retry window) so the reaper only reclaims genuinely-abandoned holds.
@@ -280,6 +281,7 @@ async def authorize_gateway(
             candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
             idempotency_key=request_idempotency_key,
             idempotency_fingerprint=request_fingerprint,
+            key_usage_shards=key_usage_shard_count(api_key),
             custom_model_id=custom_model.id if custom_model else None,
             custom_model_revision=custom_model.revision if custom_model else None,
             expires_at=expires_at,

--- a/src/trusted_router/routes/keys.py
+++ b/src/trusted_router/routes/keys.py
@@ -100,7 +100,10 @@ def register_key_routes(router: APIRouter) -> None:
                 if micro < 0:
                     raise api_error(400, "limit must be non-negative", ErrorType.BAD_REQUEST)
                 patch[f"limit_{window}_microdollars"] = micro
-        updated = STORE.update_key(hash, patch)
+        try:
+            updated = STORE.update_key(hash, patch)
+        except ValueError as exc:
+            raise api_error(409, str(exc), ErrorType.CONFLICT) from exc
         if updated is None:
             raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
         return {"data": key_shape(updated)}

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -57,6 +57,10 @@ from trusted_router.storage_gcp_counters import (
 )
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
+from trusted_router.storage_gcp_credit_shards import (
+    CreditShardCountCache,
+    randomized_credit_shards,
+)
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
 from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
 from trusted_router.storage_gcp_generations import SpannerGenerations
@@ -195,6 +199,14 @@ class SpannerBigtableStore:
         # TR_TYPED_COUNTER_MIRROR=1 only once tr_credit_balance / tr_key_limit
         # exist, or the mirror writes would fail the billing transactions.
         self._counter_mirror_enabled = os.environ.get("TR_TYPED_COUNTER_MIRROR", "") == "1"
+        self._credit_shard_counts = CreditShardCountCache(
+            ttl_seconds=float(
+                os.environ.get("TR_CREDIT_SHARD_COUNT_CACHE_SECONDS", "60")
+            ),
+            max_entries=int(
+                os.environ.get("TR_CREDIT_SHARD_COUNT_CACHE_ENTRIES", "10000")
+            ),
+        )
         io = SpannerIO(
             database=self._database,
             write_entity_batch=self._write_entity_batch,
@@ -396,6 +408,19 @@ class SpannerBigtableStore:
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
+
+    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+        def load() -> int:
+            account = self.get_credit_account(workspace_id)
+            if account is None:
+                # The typed balance cannot be administered safely without its
+                # control-plane account/config row. Treat this as drift, not as
+                # an implicit one-shard account.
+                raise RuntimeError("credit account not found while selecting shard")
+            return credit_shard_count(account)
+
+        shard_count = self._credit_shard_counts.get(workspace_id, load)
+        return randomized_credit_shards(shard_count)
 
     def add_members(self, workspace_id: str, emails: list[str], role: str = "member") -> list[Member]:
         members: list[Member] = []
@@ -1249,6 +1274,11 @@ class SpannerBigtableStore:
                 # gateway route splits on ':'.
                 return f"{AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED}:{blocked}", None
 
+        credit_shard_candidates = (
+            self._credit_shard_candidates(workspace_id)
+            if has_credit_candidate
+            else (UNSHARDED,)
+        )
         result = authorize_atomic(
             self._database,
             self._param_types,
@@ -1261,6 +1291,7 @@ class SpannerBigtableStore:
             idempotency_fingerprint=idempotency_fingerprint,
             expires_at=expires_at,
             build_auth_body=build_body,
+            credit_shard_candidates=credit_shard_candidates,
         )
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -58,6 +58,7 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_credit_shards import (
+    CreditShardConfigurationMissingError,
     CreditShardCountCache,
     randomized_credit_shards,
 )
@@ -409,18 +410,22 @@ class SpannerBigtableStore:
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
 
-    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+    def _credit_shard_count(self, workspace_id: str) -> int:
         def load() -> int:
             account = self.get_credit_account(workspace_id)
             if account is None:
                 # The typed balance cannot be administered safely without its
                 # control-plane account/config row. Treat this as drift, not as
                 # an implicit one-shard account.
-                raise RuntimeError("credit account not found while selecting shard")
+                raise CreditShardConfigurationMissingError(
+                    "credit account not found while selecting shard"
+                )
             return credit_shard_count(account)
 
-        shard_count = self._credit_shard_counts.get(workspace_id, load)
-        return randomized_credit_shards(shard_count)
+        return self._credit_shard_counts.get(workspace_id, load)
+
+    def _credit_shard_candidates(self, workspace_id: str) -> tuple[int, ...]:
+        return randomized_credit_shards(self._credit_shard_count(workspace_id))
 
     def add_members(self, workspace_id: str, emails: list[str], role: str = "member") -> list[Member]:
         members: list[Member] = []
@@ -1279,20 +1284,66 @@ class SpannerBigtableStore:
             if has_credit_candidate
             else (UNSHARDED,)
         )
-        result = authorize_atomic(
-            self._database,
-            self._param_types,
-            workspace_id=workspace_id,
-            key_hash=key_hash,
-            estimate=estimate,
-            has_credit_candidate=has_credit_candidate,
-            reservation_usage_type=str(usage),
-            idempotency_scope=scope,
-            idempotency_fingerprint=idempotency_fingerprint,
-            expires_at=expires_at,
-            build_auth_body=build_body,
-            credit_shard_candidates=credit_shard_candidates,
-        )
+        def run_authorize(candidates: tuple[int, ...]) -> dict[str, Any]:
+            return authorize_atomic(
+                self._database,
+                self._param_types,
+                workspace_id=workspace_id,
+                key_hash=key_hash,
+                estimate=estimate,
+                has_credit_candidate=has_credit_candidate,
+                reservation_usage_type=str(usage),
+                idempotency_scope=scope,
+                idempotency_fingerprint=idempotency_fingerprint,
+                expires_at=expires_at,
+                build_auth_body=build_body,
+                credit_shard_candidates=candidates,
+            )
+
+        result = run_authorize(credit_shard_candidates)
+        if (
+            result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+            and has_credit_candidate
+        ):
+            from trusted_router.storage_gcp_credit_rebalance import (
+                RebalanceOutcome,
+                rebalance_credit_for_estimate,
+            )
+
+            # An all-shards rejection is cold. Refresh once so a remote
+            # pause/drain split or unshard cannot produce a false 402 until the
+            # normal TTL expires. The accepted hot path never pays this read.
+            previous_count = len(credit_shard_candidates)
+            self._credit_shard_counts.invalidate(workspace_id)
+            refreshed_candidates = self._credit_shard_candidates(workspace_id)
+            if len(refreshed_candidates) != previous_count:
+                credit_shard_candidates = refreshed_candidates
+                result = run_authorize(credit_shard_candidates)
+
+            def rebalance(candidates: tuple[int, ...]) -> dict[str, int | str]:
+                return rebalance_credit_for_estimate(
+                    self._database,
+                    self._param_types,
+                    workspace_id=workspace_id,
+                    shard_count=len(candidates),
+                    target_shard=candidates[0],
+                    estimate=estimate,
+                )
+
+            if (
+                result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+                and len(credit_shard_candidates) > 1
+            ):
+                rebalance_result = rebalance(credit_shard_candidates)
+                if rebalance_result["outcome"] == RebalanceOutcome.INCOMPLETE:
+                    raise RuntimeError(
+                        "configured credit shard set is incomplete after cache refresh"
+                    )
+                if rebalance_result["outcome"] in {
+                    RebalanceOutcome.MOVED,
+                    RebalanceOutcome.NOT_NEEDED,
+                }:
+                    result = run_authorize(credit_shard_candidates)
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
         if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
@@ -1352,11 +1403,11 @@ class SpannerBigtableStore:
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        with self._database.snapshot(multi_use=True) as snapshot:
-            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
-            if account is None:
-                return None
-            shard_count = credit_shard_count(account)
+        try:
+            shard_count = self._credit_shard_count(workspace_id)
+        except CreditShardConfigurationMissingError:
+            return None
+        with self._database.snapshot() as snapshot:
             rows = list(snapshot.execute_sql(
                 "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
                 "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -50,7 +50,11 @@ from trusted_router.storage_gcp_codec import (
     normalize_email as _normalize_email,
 )
 from trusted_router.storage_gcp_counter_dml import insert_entity_dml_at, update_entity_body_dml
-from trusted_router.storage_gcp_counters import UNSHARDED
+from trusted_router.storage_gcp_counters import (
+    UNSHARDED,
+    credit_shard_count,
+    distribute_credit_amount,
+)
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
@@ -761,29 +765,37 @@ class SpannerBigtableStore:
             account = self._require_credit_tx(transaction, workspace_id)
             amount = int(amount_microdollars)
             new_total = int(account.total_credits_microdollars) + amount
+            shard_count = credit_shard_count(account)
+            shard_deltas = distribute_credit_amount(amount, shard_count)
             now = dt.datetime.now(dt.UTC).replace(microsecond=0)
             created_at = now.isoformat().replace("+00:00", "Z")
             pt = self._param_types
 
-            updated = transaction.execute_update(
-                "UPDATE tr_credit_balance "
-                "SET total_credits = total_credits + @amount, "
-                "source_updated_at=@now, updated_at=@now "
-                "WHERE workspace_id=@ws AND shard=@shard",
-                params={
-                    "amount": amount,
-                    "now": now,
-                    "ws": workspace_id,
-                    "shard": UNSHARDED,
-                },
-                param_types={
-                    "amount": pt.INT64,
-                    "now": pt.TIMESTAMP,
-                    "ws": pt.STRING,
-                    "shard": pt.INT64,
-                },
-            )
-            if updated == 0:
+            for shard, shard_delta in enumerate(shard_deltas):
+                updated = transaction.execute_update(
+                    "UPDATE tr_credit_balance "
+                    "SET total_credits = total_credits + @amount, "
+                    "source_updated_at=@now, updated_at=@now "
+                    "WHERE workspace_id=@ws AND shard=@shard",
+                    params={
+                        "amount": shard_delta,
+                        "now": now,
+                        "ws": workspace_id,
+                        "shard": shard,
+                    },
+                    param_types={
+                        "amount": pt.INT64,
+                        "now": pt.TIMESTAMP,
+                        "ws": pt.STRING,
+                        "shard": pt.INT64,
+                    },
+                )
+                if updated != 0:
+                    continue
+                if shard_count != 1:
+                    raise RuntimeError(
+                        f"missing tr_credit_balance shard {shard} for sharded workspace"
+                    )
                 transaction.execute_update(
                     "INSERT INTO tr_credit_balance "
                     "(workspace_id, shard, total_credits, source_updated_at, updated_at) "
@@ -1299,23 +1311,39 @@ class SpannerBigtableStore:
         }
 
     def typed_credit_snapshot(self, workspace_id: str) -> tuple[int, int, int] | None:
-        """One point-read of the authoritative typed tr_credit_balance row:
-        (total_credits, total_usage, reserved) microdollars, or None when the
-        typed tables are off or the row isn't seeded. Lets typed-aware balance
-        reads use the Store contract instead of reaching into `_database`."""
+        """Sum the workspace's active authoritative credit sub-ledgers.
+
+        Returns (total_credits, total_usage, reserved) microdollars, or None
+        when the typed tables are off or a one-shard row is not seeded. A
+        configured multi-shard workspace fails closed if any active row is
+        missing; falling back to stale JSON usage would overstate availability.
+        """
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        with self._database.snapshot(multi_use=True) as snapshot:
+            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
+            if account is None:
+                return None
+            shard_count = credit_shard_count(account)
             rows = list(snapshot.execute_sql(
-                "SELECT total_credits, total_usage, reserved FROM tr_credit_balance "
-                "WHERE workspace_id=@pk AND shard=0",
-                params={"pk": workspace_id},
-                param_types={"pk": pt.STRING},
+                "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
+                "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             ))
         if not rows:
             return None
-        return (int(rows[0][0]), int(rows[0][1]), int(rows[0][2]))
+        observed_shards = [int(row[0]) for row in rows]
+        if observed_shards != list(range(shard_count)):
+            if shard_count == 1:
+                return None
+            raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+        return (
+            sum(int(row[1]) for row in rows),
+            sum(int(row[2]) for row in rows),
+            sum(int(row[3]) for row in rows),
+        )
 
     def read_typed_reservation(self, reservation_id: str) -> dict[str, Any] | None:
         """Point-read a typed reservation for outbox lost-claim disambiguation.

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1403,11 +1403,14 @@ class SpannerBigtableStore:
         if not getattr(self, "_counter_mirror_enabled", False):
             return None
         pt = self._param_types
-        try:
-            shard_count = self._credit_shard_count(workspace_id)
-        except CreditShardConfigurationMissingError:
-            return None
-        with self._database.snapshot() as snapshot:
+        # This exact snapshot also feeds auto-refill decisions. Do not reuse the
+        # allow-stale authorize cache here: after a split, a stale smaller count
+        # could understate available credit and charge a card prematurely.
+        with self._database.snapshot(multi_use=True) as snapshot:
+            account = self._read_entity_from(snapshot, "credit", workspace_id, CreditAccount)
+            if account is None:
+                return None
+            shard_count = credit_shard_count(account)
             rows = list(snapshot.execute_sql(
                 "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
                 "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -54,6 +54,7 @@ from trusted_router.storage_gcp_counters import (
     UNSHARDED,
     credit_shard_count,
     distribute_credit_amount,
+    key_usage_shard_count,
 )
 from trusted_router.storage_gcp_counters import mirror_delete as mirror_counter_delete
 from trusted_router.storage_gcp_counters import mirror_write as mirror_counter_write
@@ -1212,6 +1213,7 @@ class SpannerBigtableStore:
         candidate_endpoint_ids: list[str],
         idempotency_key: str | None,
         idempotency_fingerprint: str | None,
+        key_usage_shards: int = 1,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         expires_at: Any = None,
@@ -1229,6 +1231,10 @@ class SpannerBigtableStore:
         )
 
         usage = UsageType.coerce(reservation_usage_type)
+        key_counter_shards = key_usage_shard_count(
+            {"usage_shard_count": key_usage_shards}
+        )
+        key_shard_candidates = randomized_credit_shards(key_counter_shards)
         scope = (
             _gateway_authorization_idempotency_index_id(workspace_id, key_hash, idempotency_key)
             if idempotency_key is not None
@@ -1298,6 +1304,7 @@ class SpannerBigtableStore:
                 expires_at=expires_at,
                 build_auth_body=build_body,
                 credit_shard_candidates=candidates,
+                key_shard_candidates=key_shard_candidates,
             )
 
         result = run_authorize(credit_shard_candidates)
@@ -1330,10 +1337,16 @@ class SpannerBigtableStore:
                     estimate=estimate,
                 )
 
-            if (
-                result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
-                and len(credit_shard_candidates) > 1
-            ):
+            # A concurrent request can consume the newly consolidated target
+            # between rebalance commit and our retry. Retry this cold path a
+            # small bounded number of times; true aggregate exhaustion returns
+            # INSUFFICIENT on the first rebalance and exits immediately.
+            for _attempt in range(3):
+                if (
+                    result["outcome"] != AuthorizeOutcome.INSUFFICIENT_CREDITS
+                    or len(credit_shard_candidates) <= 1
+                ):
+                    break
                 rebalance_result = rebalance(credit_shard_candidates)
                 if rebalance_result["outcome"] == RebalanceOutcome.INCOMPLETE:
                     raise RuntimeError(
@@ -1344,6 +1357,8 @@ class SpannerBigtableStore:
                     RebalanceOutcome.NOT_NEEDED,
                 }:
                     result = run_authorize(credit_shard_candidates)
+                    continue
+                break
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
         if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
@@ -1367,28 +1382,43 @@ class SpannerBigtableStore:
         from trusted_router.spend_windows import utcnow, window_floors
 
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        with self._database.snapshot(multi_use=True) as snapshot:
+            key = self._read_entity_from(snapshot, "api_key", key_hash, ApiKey)
+            if key is None:
+                return None
+            shard_count = key_usage_shard_count(key)
             rows = list(snapshot.execute_sql(
-                "SELECT usage, byok_usage, reserved, day_usage, day_start, "
+                "SELECT shard, usage, byok_usage, reserved, day_usage, day_start, "
                 "week_usage, week_start, month_usage, month_start "
-                "FROM tr_key_limit WHERE key_hash=@kh AND shard=0",
-                params={"kh": key_hash},
-                param_types={"kh": pt.STRING},
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             ))
         if not rows:
             return None
-        usage, byok, reserved, day_u, day_s, week_u, week_s, month_u, month_s = rows[0]
+        if [int(row[0]) for row in rows] != list(range(shard_count)):
+            raise RuntimeError("configured tr_key_limit usage shard set is incomplete")
         floors = window_floors(utcnow())
+        usage = sum(int(row[1]) for row in rows)
+        byok = sum(int(row[2]) for row in rows)
+        reserved = sum(int(row[3]) for row in rows)
+
+        def current_window_usage(usage_index: int, start_index: int, window: str) -> int:
+            return sum(
+                int(row[usage_index] or 0)
+                for row in rows
+                if row[start_index] is not None and row[start_index] >= floors[window]
+            )
+
         return {
-            "usage": int(usage),
-            "byok_usage": int(byok),
-            "reserved": int(reserved),
+            "usage": usage,
+            "byok_usage": byok,
+            "reserved": reserved,
             "windows": {
-                "daily": int(day_u) if day_s is not None and day_s >= floors["daily"] else 0,
-                "weekly": int(week_u) if week_s is not None and week_s >= floors["weekly"] else 0,
-                "monthly": (
-                    int(month_u) if month_s is not None and month_s >= floors["monthly"] else 0
-                ),
+                "daily": current_window_usage(4, 5, "daily"),
+                "weekly": current_window_usage(6, 7, "weekly"),
+                "monthly": current_window_usage(8, 9, "monthly"),
             },
         }
 

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -141,6 +141,7 @@ def authorize_atomic(
     build_auth_body: Callable[[str, str], str],
     credit_shard: int = UNSHARDED,
     credit_shard_candidates: tuple[int, ...] | None = None,
+    key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -174,6 +175,13 @@ def authorize_atomic(
         raise ValueError("credit_shard_candidates must be unique")
     if not has_credit_candidate and shard_candidates != (UNSHARDED,):
         raise ValueError("BYOK-only authorization must use credit shard zero")
+    key_candidates = tuple(key_shard_candidates)
+    if not key_candidates:
+        raise ValueError("key_shard_candidates must not be empty")
+    if any(shard < 0 for shard in key_candidates):
+        raise ValueError("key shards must be non-negative")
+    if len(set(key_candidates)) != len(key_candidates):
+        raise ValueError("key_shard_candidates must be unique")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -185,6 +193,7 @@ def authorize_atomic(
             "reservation_id": existing["reservation_id"],
             "authorization_id": existing["authorization_id"],
             "credit_shard": int(existing.get("credit_shard", UNSHARDED)),
+            "key_shard": int(existing.get("key_shard", UNSHARDED)),
         }
 
     def txn(transaction: Any) -> dict:
@@ -195,11 +204,32 @@ def authorize_atomic(
                     raise _Reject(AuthorizeOutcome.IDEMPOTENCY_MISMATCH)
                 return _replay(existing)
 
-        key_result = reserve_key(transaction, pt, key_hash, estimate, is_byok=is_byok)
-        if key_result == KEY_INSUFFICIENT:
-            raise _Reject(AuthorizeOutcome.KEY_LIMIT_EXCEEDED)
+        key_result = KEY_MISSING
+        selected_key_shard = UNSHARDED
+        saw_key_row = False
+        for candidate in key_candidates:
+            candidate_result = reserve_key(
+                transaction,
+                pt,
+                key_hash,
+                estimate,
+                is_byok=is_byok,
+                shard=candidate,
+            )
+            if candidate_result == KEY_MISSING:
+                continue
+            saw_key_row = True
+            if candidate_result == KEY_INSUFFICIENT:
+                continue
+            key_result = candidate_result
+            selected_key_shard = candidate
+            break
         if key_result == KEY_MISSING:
-            raise _Reject(AuthorizeOutcome.KEY_MISSING)
+            raise _Reject(
+                AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+                if saw_key_row
+                else AuthorizeOutcome.KEY_MISSING
+            )
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
         credit_hold = 0
@@ -216,7 +246,8 @@ def authorize_atomic(
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard, key_shard=0,
+            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard,
+            key_shard=selected_key_shard,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -231,6 +262,7 @@ def authorize_atomic(
             "reservation_id": reservation_id,
             "authorization_id": authorization_id,
             "credit_shard": selected_credit_shard,
+            "key_shard": selected_key_shard,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -140,6 +140,7 @@ def authorize_atomic(
     expires_at: Any,
     build_auth_body: Callable[[str, str], str],
     credit_shard: int = UNSHARDED,
+    credit_shard_candidates: tuple[int, ...] | None = None,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -147,6 +148,9 @@ def authorize_atomic(
     construct the gateway_authorization body once the ids are known.
     `reservation_usage_type` is the HOLD usage type (Credits if any credit
     candidate, else BYOK). `has_credit_candidate` gates the credit hold.
+    `credit_shard_candidates` is a bounded, pre-randomized order built outside
+    the transaction so Spanner retries use the same order. The first shard with
+    enough independent sub-budget is recorded durably on the reservation.
 
     Per-window key caps are checked by the CALLER via check_key_window_limits on
     a lock-free snapshot BEFORE this transaction — deliberately NOT in here: a
@@ -155,8 +159,21 @@ def authorize_atomic(
     transaction exists to eliminate (codex #93 review).
     """
     pt = param_types
-    if credit_shard < 0:
-        raise ValueError("credit_shard must be non-negative")
+    shard_candidates: tuple[int, ...]
+    if credit_shard_candidates is None:
+        shard_candidates = (credit_shard,)
+    else:
+        shard_candidates = tuple(credit_shard_candidates)
+        if credit_shard != UNSHARDED:
+            raise ValueError("pass credit_shard or credit_shard_candidates, not both")
+    if not shard_candidates:
+        raise ValueError("credit_shard_candidates must not be empty")
+    if any(shard < 0 for shard in shard_candidates):
+        raise ValueError("credit shards must be non-negative")
+    if len(set(shard_candidates)) != len(shard_candidates):
+        raise ValueError("credit_shard_candidates must be unique")
+    if not has_credit_candidate and shard_candidates != (UNSHARDED,):
+        raise ValueError("BYOK-only authorization must use credit shard zero")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -167,6 +184,7 @@ def authorize_atomic(
             "outcome": AuthorizeOutcome.REPLAY,
             "reservation_id": existing["reservation_id"],
             "authorization_id": existing["authorization_id"],
+            "credit_shard": int(existing.get("credit_shard", UNSHARDED)),
         }
 
     def txn(transaction: Any) -> dict:
@@ -185,17 +203,20 @@ def authorize_atomic(
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
         credit_hold = 0
+        selected_credit_shard = UNSHARDED
         if has_credit_candidate:
-            if not reserve_credit(
-                transaction, pt, workspace_id, estimate, shard=credit_shard
-            ):
+            for candidate in shard_candidates:
+                if reserve_credit(transaction, pt, workspace_id, estimate, shard=candidate):
+                    selected_credit_shard = candidate
+                    break
+            else:
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=credit_shard, credit_shard=credit_shard, key_shard=0,
+            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard, key_shard=0,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -209,6 +230,7 @@ def authorize_atomic(
             "outcome": AuthorizeOutcome.ACCEPTED,
             "reservation_id": reservation_id,
             "authorization_id": authorization_id,
+            "credit_shard": selected_credit_shard,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -38,6 +38,7 @@ from trusted_router.storage_gcp_counter_dml import (
     reserve_credit,
     reserve_key,
 )
+from trusted_router.storage_gcp_counters import UNSHARDED
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
 
@@ -138,6 +139,7 @@ def authorize_atomic(
     idempotency_fingerprint: str | None,
     expires_at: Any,
     build_auth_body: Callable[[str, str], str],
+    credit_shard: int = UNSHARDED,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -153,6 +155,8 @@ def authorize_atomic(
     transaction exists to eliminate (codex #93 review).
     """
     pt = param_types
+    if credit_shard < 0:
+        raise ValueError("credit_shard must be non-negative")
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
@@ -182,14 +186,16 @@ def authorize_atomic(
 
         credit_hold = 0
         if has_credit_candidate:
-            if not reserve_credit(transaction, pt, workspace_id, estimate):
+            if not reserve_credit(
+                transaction, pt, workspace_id, estimate, shard=credit_shard
+            ):
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=0, key_shard=0,
+            ws_shard=credit_shard, credit_shard=credit_shard, key_shard=0,
             credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
@@ -365,6 +371,7 @@ def settle_atomic(
             credit_count = release_credit(
                 transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
                 credit_actual,
+                shard=res["credit_shard"],
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
@@ -538,6 +545,7 @@ def typed_finalize_atomic(
             credit_count = release_credit(
                 transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
                 credit_actual,
+                shard=res["credit_shard"],
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -58,6 +58,60 @@ def reserve_credit(
     return count == 1
 
 
+def transfer_credit_budget(
+    transaction: Any,
+    param_types: Any,
+    workspace_id: str,
+    amount: int,
+    *,
+    donor_shard: int,
+    target_shard: int,
+) -> bool:
+    """Atomically move idle sub-budget from one credit shard to another.
+
+    The donor predicate permits moving only current headroom, never usage or a
+    live reservation. Both DML statements run in the caller's transaction; a
+    failure must make the caller roll the whole transaction back so the global
+    sum of ``total_credits`` cannot change.
+    """
+    if amount <= 0:
+        raise ValueError("credit budget transfer amount must be positive")
+    if donor_shard == target_shard:
+        raise ValueError("credit budget donor and target must differ")
+    donor_count = transaction.execute_update(
+        "UPDATE tr_credit_balance SET total_credits=total_credits-@move "
+        "WHERE workspace_id=@ws AND shard=@donor "
+        "AND (total_credits-total_usage-reserved)>=@move",
+        params={
+            "move": int(amount),
+            "ws": workspace_id,
+            "donor": donor_shard,
+        },
+        param_types={
+            "move": param_types.INT64,
+            "ws": param_types.STRING,
+            "donor": param_types.INT64,
+        },
+    )
+    if donor_count != 1:
+        return False
+    target_count = transaction.execute_update(
+        "UPDATE tr_credit_balance SET total_credits=total_credits+@move "
+        "WHERE workspace_id=@ws AND shard=@target",
+        params={
+            "move": int(amount),
+            "ws": workspace_id,
+            "target": target_shard,
+        },
+        param_types={
+            "move": param_types.INT64,
+            "ws": param_types.STRING,
+            "target": param_types.INT64,
+        },
+    )
+    return target_count == 1
+
+
 def release_credit(
     transaction: Any,
     param_types: Any,

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -252,7 +252,7 @@ def key_limit_exists(
 # DML-only authorize/settle transactions (no mutation mixing).
 
 RESERVATION_COLUMNS = (
-    "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+    "reservation_id", "workspace_id", "key_hash", "ws_shard", "credit_shard", "key_shard",
     "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
     "authorization_id", "idempotency_scope", "idempotency_fingerprint", "expires_at",
 )
@@ -269,7 +269,8 @@ def read_reservation_by_idempotency(
     rows = list(
         transaction.execute_sql(
             "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
-            "hold_usage_type, authorization_id, idempotency_fingerprint, settled "
+            "hold_usage_type, authorization_id, idempotency_fingerprint, settled, "
+            "credit_shard, ws_shard "
             "FROM tr_reservation WHERE idempotency_scope=@scope",
             params={"scope": idempotency_scope},
             param_types={"scope": param_types.STRING},
@@ -278,6 +279,7 @@ def read_reservation_by_idempotency(
     if not rows:
         return None
     r = rows[0]
+    credit_shard = r[7] if r[7] is not None else (r[8] or UNSHARDED)
     return {
         "reservation_id": r[0],
         "credit_reserved_micro": r[1],
@@ -286,6 +288,7 @@ def read_reservation_by_idempotency(
         "authorization_id": r[4],
         "idempotency_fingerprint": r[5],
         "settled": r[6],
+        "credit_shard": int(credit_shard),
     }
 
 
@@ -293,7 +296,7 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
     """Point-read a reservation by id (for settle/refund and the reaper)."""
     rows = list(
         transaction.execute_sql(
-            "SELECT reservation_id, workspace_id, key_hash, ws_shard, key_shard, "
+            "SELECT reservation_id, workspace_id, key_hash, ws_shard, credit_shard, key_shard, "
             "credit_reserved_micro, key_reserved_micro, hold_usage_type, "
             "settled_usage_type, actual_micro, authorization_id, settled "
             "FROM tr_reservation WHERE reservation_id=@rid",
@@ -305,11 +308,16 @@ def read_reservation(transaction: Any, param_types: Any, reservation_id: str) ->
         return None
     r = rows[0]
     keys = (
-        "reservation_id", "workspace_id", "key_hash", "ws_shard", "key_shard",
+        "reservation_id", "workspace_id", "key_hash", "ws_shard", "credit_shard", "key_shard",
         "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
         "settled_usage_type", "actual_micro", "authorization_id", "settled",
     )
-    return dict(zip(keys, r, strict=True))
+    result = dict(zip(keys, r, strict=True))
+    raw_credit_shard = result.get("credit_shard")
+    result["credit_shard"] = int(
+        raw_credit_shard if raw_credit_shard is not None else (result.get("ws_shard") or UNSHARDED)
+    )
+    return result
 
 
 def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> None:
@@ -318,7 +326,7 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
     pt = param_types
     types = {
         "reservation_id": pt.STRING, "workspace_id": pt.STRING, "key_hash": pt.STRING,
-        "ws_shard": pt.INT64, "key_shard": pt.INT64,
+        "ws_shard": pt.INT64, "credit_shard": pt.INT64, "key_shard": pt.INT64,
         "credit_reserved_micro": pt.INT64, "key_reserved_micro": pt.INT64,
         "hold_usage_type": pt.STRING, "authorization_id": pt.STRING,
         "idempotency_scope": pt.STRING, "idempotency_fingerprint": pt.STRING,
@@ -326,9 +334,13 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
     }
     cols = ", ".join(RESERVATION_COLUMNS)
     binds = ", ".join(f"@{c}" for c in RESERVATION_COLUMNS)
+    values = {c: fields.get(c) for c in RESERVATION_COLUMNS}
+    values["credit_shard"] = fields.get(
+        "credit_shard", fields.get("ws_shard", UNSHARDED)
+    )
     transaction.execute_update(
         f"INSERT INTO tr_reservation ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
-        params={c: fields.get(c) for c in RESERVATION_COLUMNS},
+        params=values,
         param_types={c: types[c] for c in RESERVATION_COLUMNS},
     )
 

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -324,7 +324,7 @@ def read_reservation_by_idempotency(
         transaction.execute_sql(
             "SELECT reservation_id, credit_reserved_micro, key_reserved_micro, "
             "hold_usage_type, authorization_id, idempotency_fingerprint, settled, "
-            "credit_shard, ws_shard "
+            "credit_shard, ws_shard, key_shard "
             "FROM tr_reservation WHERE idempotency_scope=@scope",
             params={"scope": idempotency_scope},
             param_types={"scope": param_types.STRING},
@@ -343,6 +343,7 @@ def read_reservation_by_idempotency(
         "idempotency_fingerprint": r[5],
         "settled": r[6],
         "credit_shard": int(credit_shard),
+        "key_shard": int(r[9] or UNSHARDED),
     }
 
 

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -32,7 +32,7 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
 
 _CREDIT_TYPED_SCAN = (
-    "SELECT workspace_id, total_credits, total_usage, reserved FROM tr_credit_balance"
+    "SELECT workspace_id, shard, total_credits, total_usage, reserved FROM tr_credit_balance"
 )
 _KEY_TYPED_SCAN = (
     "SELECT key_hash, limit_micro, usage, byok_usage, reserved, include_byok, "
@@ -96,10 +96,14 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
     with store._database.snapshot(multi_use=True) as snapshot:
         json_credit = _scan_json(snapshot, "credit", "workspace_id", pt)
         json_key = _scan_json(snapshot, "api_key", "hash", pt)
-        typed_credit = {
-            r[0]: {"total_credits": r[1], "total_usage": r[2], "reserved": r[3]}
-            for r in snapshot.execute_sql(_CREDIT_TYPED_SCAN)
-        }
+        typed_credit: dict[str, dict[str, int]] = {}
+        for row in snapshot.execute_sql(_CREDIT_TYPED_SCAN):
+            aggregate = typed_credit.setdefault(
+                row[0], {"total_credits": 0, "total_usage": 0, "reserved": 0}
+            )
+            aggregate["total_credits"] += int(row[2])
+            aggregate["total_usage"] += int(row[3])
+            aggregate["reserved"] += int(row[4])
         typed_key = {
             r[0]: {
                 "limit_micro": r[1], "usage": r[2], "byok_usage": r[3],
@@ -373,8 +377,10 @@ def reconcile_for_flip(store: Any, workspace_id: str, *, apply: bool = False) ->
 # Shard-aware (the typed counter PK is (scope, shard); reservations carry the
 # per-scope shard), COALESCE so an empty SUM reads 0.
 _OPEN_CREDIT_HOLDS = (
-    "SELECT workspace_id, ws_shard, COALESCE(SUM(credit_reserved_micro), 0) "
-    "FROM tr_reservation WHERE settled = false GROUP BY workspace_id, ws_shard"
+    "SELECT workspace_id, credit_shard, ws_shard, "
+    "COALESCE(SUM(credit_reserved_micro), 0) "
+    "FROM tr_reservation WHERE settled = false "
+    "GROUP BY workspace_id, credit_shard, ws_shard"
 )
 _OPEN_KEY_HOLDS = (
     "SELECT key_hash, key_shard, COALESCE(SUM(key_reserved_micro), 0) "
@@ -421,9 +427,11 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
                 "SELECT key_hash, shard, reserved FROM tr_key_limit"
             )
         }
-        credit_holds = {
-            (r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_CREDIT_HOLDS)
-        }
+        credit_holds: dict[tuple[str, int], int] = {}
+        for row in snap.execute_sql(_OPEN_CREDIT_HOLDS):
+            shard = int(row[1] if row[1] is not None else (row[2] or 0))
+            scope = (str(row[0]), shard)
+            credit_holds[scope] = credit_holds.get(scope, 0) + int(row[3] or 0)
         key_holds = {(r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
 
     def _sample(key: str, value: dict) -> None:

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -26,7 +26,9 @@ from typing import Any
 
 from trusted_router.storage_gcp_counters import (
     credit_drift,
+    credit_shard_count,
     key_drift,
+    key_usage_shard_count,
     mirror_write,
 )
 from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
@@ -35,7 +37,7 @@ _CREDIT_TYPED_SCAN = (
     "SELECT workspace_id, shard, total_credits, total_usage, reserved FROM tr_credit_balance"
 )
 _KEY_TYPED_SCAN = (
-    "SELECT key_hash, limit_micro, usage, byok_usage, reserved, include_byok, "
+    "SELECT key_hash, shard, limit_micro, usage, byok_usage, reserved, include_byok, "
     "day_limit_micro, week_limit_micro, month_limit_micro "
     "FROM tr_key_limit"
 )
@@ -104,15 +106,20 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
             aggregate["total_credits"] += int(row[2])
             aggregate["total_usage"] += int(row[3])
             aggregate["reserved"] += int(row[4])
-        typed_key = {
-            r[0]: {
-                "limit_micro": r[1], "usage": r[2], "byok_usage": r[3],
-                "reserved": r[4], "include_byok": r[5],
-                "day_limit_micro": r[6], "week_limit_micro": r[7],
-                "month_limit_micro": r[8],
-            }
-            for r in snapshot.execute_sql(_KEY_TYPED_SCAN)
-        }
+        typed_key: dict[str, dict[str, Any]] = {}
+        typed_key_counts: dict[str, int] = {}
+        for row in snapshot.execute_sql(_KEY_TYPED_SCAN):
+            key_hash = str(row[0])
+            typed_key_counts[key_hash] = typed_key_counts.get(key_hash, 0) + 1
+            typed_key.setdefault(
+                key_hash,
+                {
+                    "limit_micro": row[2], "usage": row[3], "byok_usage": row[4],
+                    "reserved": row[5], "include_byok": row[6],
+                    "day_limit_micro": row[7], "week_limit_micro": row[8],
+                    "month_limit_micro": row[9],
+                },
+            )
 
     def _sample(key: str, value: dict) -> None:
         if len(report.samples) < max_samples:
@@ -131,6 +138,10 @@ def compare(store: Any, *, max_samples: int = 20) -> DriftReport:
     report.key_rows = len(json_key)
     for key_hash, body in json_key.items():
         drift = key_drift(body, typed_key.get(key_hash))
+        expected_shards = key_usage_shard_count(body)
+        observed_shards = typed_key_counts.get(key_hash, 0)
+        if observed_shards != expected_shards:
+            drift["usage_shard_count"] = (expected_shards, observed_shards)
         if drift:
             report.key_drift += 1
             _sample(f"api_key:{key_hash}", drift)
@@ -499,11 +510,13 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
     credit_sql = "SELECT total_usage, reserved FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
     key_sql = "SELECT usage, byok_usage, reserved FROM tr_key_limit WHERE key_hash=@pk AND shard=0"
 
-    key_hashes = [
-        b["hash"] for b in store._list_entities("api_key", cls=dict)
+    key_bodies = [
+        b for b in store._list_entities("api_key", cls=dict)
         if b.get("workspace_id") == workspace_id
     ]
+    key_hashes = [str(body["hash"]) for body in key_bodies]
     workspace = store.get_workspace(workspace_id)
+    credit_account = store.get_credit_account(workspace_id)
     # multi_use: two reads on one snapshot (a single-use snapshot raises on the
     # second read on real Spanner — the fa9f5d4 class the fake now models).
     with store._database.snapshot(multi_use=True) as snap:
@@ -516,6 +529,10 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause (quiesce) it before rollback")
+    if credit_account is not None and credit_shard_count(credit_account) != 1:
+        res.reasons.append("credit ledger is sharded — consolidate to one shard before rollback")
+    if any(key_usage_shard_count(body) != 1 for body in key_bodies):
+        res.reasons.append("API-key usage is sharded — consolidate keys before rollback")
     if int(open_holds) != 0:
         res.reasons.append(f"{open_holds} open typed holds — drain before rollback backsync")
     if not credit_rows:
@@ -541,13 +558,15 @@ def backsync_typed_to_json(store: Any, workspace_id: str, *, apply: bool = False
             credit_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))
         credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if not tc or credit is None:
+        if not tc or credit is None or credit_shard_count(credit) != 1:
             return None
         plan: list[tuple] = []
         for kh in key_hashes:
             key_obj = store._read_entity_tx(transaction, "api_key", kh, ApiKey)
             if key_obj is None:
                 continue  # key deleted since assess (pause blocks creation, not deletion)
+            if key_usage_shard_count(key_obj) != 1:
+                return None
             kt = list(transaction.execute_sql(
                 key_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
             ))
@@ -629,10 +648,12 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     )
 
     workspace = store.get_workspace(workspace_id)
-    key_hashes = [
-        b["hash"] for b in store._list_entities("api_key", cls=dict)
+    credit_account = store.get_credit_account(workspace_id)
+    key_bodies = [
+        b for b in store._list_entities("api_key", cls=dict)
         if b.get("workspace_id") == workspace_id
     ]
+    key_hashes = [str(body["hash"]) for body in key_bodies]
     with store._database.snapshot(multi_use=True) as snap:  # 3 reads below — must be multi-use
         cb = list(snap.execute_sql(
             credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
@@ -646,6 +667,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
         res.reasons.append("workspace not billing-paused — pause it before repair")
+    if credit_account is not None and credit_shard_count(credit_account) != 1:
+        res.reasons.append("credit ledger is sharded — consolidate before shard-zero repair")
+    if any(key_usage_shard_count(body) != 1 for body in key_bodies):
+        res.reasons.append("API-key usage is sharded — consolidate before shard-zero repair")
     if not cb:
         res.reasons.append("no typed credit row")
     if int(nonzero_shard) != 0:
@@ -666,6 +691,9 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
         if ws is None or not ws.billing_paused:
             return None
+        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if credit is not None and credit_shard_count(credit) != 1:
+            return None
         if int(list(transaction.execute_sql(
             nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
         ))[0][0]) != 0:
@@ -679,6 +707,9 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         ))[0][0]
         plan: list[tuple[str, int]] = []
         for kh in key_hashes:
+            key_obj = store._read_entity_tx(transaction, "api_key", kh, ApiKey)
+            if key_obj is None or key_usage_shard_count(key_obj) != 1:
+                return None
             if not list(transaction.execute_sql(
                 key_row_sql, params={"pk": kh}, param_types={"pk": pt.STRING},
             )):

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -27,6 +27,7 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 
 # Long tail lives entirely on shard 0; sharding a whale is a data change later.
 UNSHARDED = 0
+MAX_CREDIT_SHARDS = 64
 
 # OWNERSHIP SPLIT (2026-06-25 incident). The JSON->typed mirror writes ONLY the
 # columns JSON owns. `total_credits` is set by credit events (top-ups / grants /
@@ -80,6 +81,8 @@ def credit_shard_count(value: Any) -> int:
     count = int(raw)
     if count < 1:
         raise ValueError("credit shard_count must be a positive integer")
+    if count > MAX_CREDIT_SHARDS:
+        raise ValueError(f"credit shard_count must not exceed {MAX_CREDIT_SHARDS}")
     return count
 
 

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -67,10 +67,43 @@ def _field(value: Any, name: str, default: Any = None) -> Any:
     return getattr(value, name, default)
 
 
+def credit_shard_count(value: Any) -> int:
+    """Return the configured credit-ledger shard count.
+
+    Legacy CreditAccount JSON omits this field and therefore remains exactly
+    one-shard. Invalid persisted values fail closed instead of silently
+    changing which sub-ledgers enforce the workspace cap.
+    """
+    raw = _field(value, "shard_count", 1)
+    if isinstance(raw, bool):
+        raise ValueError("credit shard_count must be a positive integer")
+    count = int(raw)
+    if count < 1:
+        raise ValueError("credit shard_count must be a positive integer")
+    return count
+
+
+def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
+    """Evenly partition a grant delta, putting the remainder on shard zero."""
+    if shard_count < 1:
+        raise ValueError("credit shard_count must be a positive integer")
+    sign = -1 if amount < 0 else 1
+    per_shard, remainder = divmod(abs(int(amount)), shard_count)
+    values = [sign * per_shard for _ in range(shard_count)]
+    values[UNSHARDED] += sign * remainder
+    return tuple(values)
+
+
 def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> tuple:
     """Mirror the JSON-owned `total_credits` of a `credit` row into
     tr_credit_balance. reserved + total_usage are typed-DML-owned and are
-    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS)."""
+    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS).
+
+    This generic absolute-value mirror is intentionally one-shard only. Once a
+    workspace is explicitly sharded, credit deltas are distributed by
+    credit_workspace_typed_direct; replaying the global JSON total into shard 0
+    would multiply its budget.
+    """
     return (
         workspace_id,
         UNSHARDED,
@@ -110,6 +143,8 @@ def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: 
     writer, so the mirror commits atomically with it. No-op for other kinds.
     """
     if kind == "credit":
+        if credit_shard_count(value) != 1:
+            return
         writer.insert_or_update(
             table=CREDIT_BALANCE_TABLE,
             columns=CREDIT_BALANCE_COLUMNS,

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -28,6 +28,7 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 # Long tail lives entirely on shard 0; sharding a whale is a data change later.
 UNSHARDED = 0
 MAX_CREDIT_SHARDS = 64
+MAX_KEY_USAGE_SHARDS = 64
 
 # OWNERSHIP SPLIT (2026-06-25 incident). The JSON->typed mirror writes ONLY the
 # columns JSON owns. `total_credits` is set by credit events (top-ups / grants /
@@ -86,6 +87,37 @@ def credit_shard_count(value: Any) -> int:
     return count
 
 
+def key_usage_shard_count(value: Any) -> int:
+    """Return and validate an API key's usage-counter shard count.
+
+    Only fully uncapped keys may fan usage writes across rows. Partitioning
+    spend limits needs separate sub-budget/rebalance semantics; accepting such
+    a mixed configuration here could weaken a hard user budget, so it fails
+    closed instead.
+    """
+    raw = _field(value, "usage_shard_count", 1)
+    if isinstance(raw, bool):
+        raise ValueError("key usage_shard_count must be a positive integer")
+    count = int(raw)
+    if count < 1:
+        raise ValueError("key usage_shard_count must be a positive integer")
+    if count > MAX_KEY_USAGE_SHARDS:
+        raise ValueError(
+            f"key usage_shard_count must not exceed {MAX_KEY_USAGE_SHARDS}"
+        )
+    if count > 1 and any(
+        _field(value, field_name, None) is not None
+        for field_name in (
+            "limit_microdollars",
+            "limit_daily_microdollars",
+            "limit_weekly_microdollars",
+            "limit_monthly_microdollars",
+        )
+    ):
+        raise ValueError("only uncapped API keys may use sharded usage counters")
+    return count
+
+
 def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
     """Evenly partition a grant delta, putting the remainder on shard zero."""
     if shard_count < 1:
@@ -138,6 +170,13 @@ def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:
     )
 
 
+def key_limit_mirror_rows(key_hash: str, value: Any, commit_ts: Any) -> list[tuple]:
+    """Mirror config to every active usage row without touching typed counters."""
+    shard_count = key_usage_shard_count(value)
+    base = key_limit_mirror_row(key_hash, value, commit_ts)
+    return [base[:1] + (shard,) + base[2:] for shard in range(shard_count)]
+
+
 def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: Any) -> None:
     """If `kind` is a hot counter, mirror it onto its typed table via `writer`.
 
@@ -157,7 +196,7 @@ def mirror_write(writer: Any, kind: str, entity_id: str, value: Any, commit_ts: 
         writer.insert_or_update(
             table=KEY_LIMIT_TABLE,
             columns=KEY_LIMIT_COLUMNS,
-            values=[key_limit_mirror_row(entity_id, value, commit_ts)],
+            values=key_limit_mirror_rows(entity_id, value, commit_ts),
         )
 
 
@@ -179,9 +218,16 @@ def mirror_delete(writer: Any, kind: str, entity_ids: list[str], spanner_module:
     table = _typed_table_for(kind)
     if table is None:
         return
+    max_shards = MAX_CREDIT_SHARDS if kind == "credit" else MAX_KEY_USAGE_SHARDS
     writer.delete(
         table,
-        spanner_module.KeySet(keys=[(entity_id, UNSHARDED) for entity_id in entity_ids]),
+        spanner_module.KeySet(
+            keys=[
+                (entity_id, shard)
+                for entity_id in entity_ids
+                for shard in range(max_shards)
+            ]
+        ),
     )
 
 

--- a/src/trusted_router/storage_gcp_credit_rebalance.py
+++ b/src/trusted_router/storage_gcp_credit_rebalance.py
@@ -1,0 +1,121 @@
+"""Lazy, transactionally safe repair of fragmented credit sub-budgets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.storage_gcp_counter_dml import transfer_credit_budget
+from trusted_router.storage_gcp_counters import credit_shard_count
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+
+
+class RebalanceOutcome:
+    MOVED = "moved"
+    NOT_NEEDED = "not_needed"
+    INSUFFICIENT = "insufficient"
+    INCOMPLETE = "incomplete"
+
+
+class _RebalanceInvariantError(RuntimeError):
+    """Rollback a transfer plan if any guarded DML does not affect one row."""
+
+
+def rebalance_credit_for_estimate(
+    database: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    shard_count: int,
+    target_shard: int,
+    estimate: int,
+) -> dict[str, int | str]:
+    """Consolidate enough idle headroom onto ``target_shard`` for one hold.
+
+    This is a cold path after a bounded reserve scan rejected every shard. The
+    transaction moves only ``total_credits - total_usage - reserved`` and keeps
+    the global ``SUM(total_credits)`` byte-for-byte unchanged.
+    """
+    count = credit_shard_count({"shard_count": shard_count})
+    if target_shard < 0 or target_shard >= count:
+        raise ValueError("rebalance target shard is outside configured range")
+    if estimate <= 0:
+        raise ValueError("rebalance estimate must be positive")
+    pt = param_types
+
+    def txn(transaction: Any) -> dict[str, int | str]:
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        observed = [int(row[0]) for row in rows]
+        if observed != list(range(count)):
+            return {
+                "outcome": RebalanceOutcome.INCOMPLETE,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+
+        headroom: dict[int, int] = {}
+        for shard, total_credits, total_usage, reserved in rows:
+            available = int(total_credits) - int(total_usage) - int(reserved)
+            if available < 0:
+                raise _RebalanceInvariantError(
+                    f"credit shard {shard} exceeds its sub-budget"
+                )
+            headroom[int(shard)] = available
+
+        target_available = headroom[target_shard]
+        if target_available >= estimate:
+            return {
+                "outcome": RebalanceOutcome.NOT_NEEDED,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+        if sum(headroom.values()) < estimate:
+            return {
+                "outcome": RebalanceOutcome.INSUFFICIENT,
+                "moved_micro": 0,
+                "target_shard": target_shard,
+            }
+
+        needed = estimate - target_available
+        moved = 0
+        donors = sorted(
+            (
+                (available, shard)
+                for shard, available in headroom.items()
+                if shard != target_shard and available > 0
+            ),
+            reverse=True,
+        )
+        for available, donor_shard in donors:
+            amount = min(available, needed)
+            if not transfer_credit_budget(
+                transaction,
+                pt,
+                workspace_id,
+                amount,
+                donor_shard=donor_shard,
+                target_shard=target_shard,
+            ):
+                raise _RebalanceInvariantError(
+                    "credit shard changed or disappeared during rebalance"
+                )
+            moved += amount
+            needed -= amount
+            if needed == 0:
+                break
+        if needed != 0:  # pragma: no cover - guarded by global headroom check.
+            raise _RebalanceInvariantError("rebalance plan did not satisfy estimate")
+        return {
+            "outcome": RebalanceOutcome.MOVED,
+            "moved_micro": moved,
+            "target_shard": target_shard,
+        }
+
+    return run_in_transaction_with_retry(database, txn)

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -1,0 +1,269 @@
+"""Fail-closed operator primitives for splitting and consolidating credit rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    credit_shard_count,
+    distribute_credit_amount,
+)
+from trusted_router.storage_models import CreditAccount, Reservation, Workspace
+
+_RESHARD_COLUMNS = (
+    "workspace_id",
+    "shard",
+    "total_credits",
+    "total_usage",
+    "reserved",
+    "source_updated_at",
+    "updated_at",
+)
+
+
+@dataclass
+class CreditReshardResult:
+    workspace_id: str
+    target_shard_count: int
+    current_shard_count: int | None = None
+    total_credits_micro: int | None = None
+    total_usage_micro: int | None = None
+    reserved_micro: int | None = None
+    typed_open_reservations: int = 0
+    legacy_open_reservations: int = 0
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return not self.reasons
+
+
+def _typed_state(
+    store: Any,
+    workspace_id: str,
+    shard_count: int,
+) -> tuple[list[list[Any]], int]:
+    pt = store._param_types
+    with store._database.snapshot(multi_use=True) as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        open_reservations = int(
+            list(
+                snapshot.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE workspace_id=@ws AND settled = false",
+                    params={"ws": workspace_id},
+                    param_types={"ws": pt.STRING},
+                )
+            )[0][0]
+        )
+    return rows, open_reservations
+
+
+def inspect_credit_reshard(
+    store: Any,
+    workspace_id: str,
+    target_shard_count: int,
+) -> CreditReshardResult:
+    """Read-only readiness check for a paused, fully drained reshard."""
+    target_count = credit_shard_count({"shard_count": target_shard_count})
+    result = CreditReshardResult(
+        workspace_id=workspace_id,
+        target_shard_count=target_count,
+    )
+    workspace = store.get_workspace(workspace_id)
+    account = store.get_credit_account(workspace_id)
+    if workspace is None:
+        result.reasons.append("workspace not found")
+    elif not workspace.billing_paused:
+        result.reasons.append("workspace not billing-paused")
+    if account is None:
+        result.reasons.append("credit account not found")
+        return result
+
+    current_count = credit_shard_count(account)
+    result.current_shard_count = current_count
+    rows, typed_open = _typed_state(store, workspace_id, current_count)
+    result.typed_open_reservations = typed_open
+    result.legacy_open_reservations = sum(
+        1
+        for reservation in store._list_entities("reservation", cls=Reservation)
+        if reservation.workspace_id == workspace_id and not reservation.settled
+    )
+    observed = [int(row[0]) for row in rows]
+    if observed != list(range(current_count)):
+        result.reasons.append("configured typed credit shard set is incomplete")
+        return result
+
+    total_credits = sum(int(row[1]) for row in rows)
+    total_usage = sum(int(row[2]) for row in rows)
+    reserved = sum(int(row[3]) for row in rows)
+    result.total_credits_micro = total_credits
+    result.total_usage_micro = total_usage
+    result.reserved_micro = reserved
+    if any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows):
+        result.reasons.append("typed credit shard has a negative counter")
+    if any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows):
+        result.reasons.append("typed credit shard exceeds its sub-budget")
+    if reserved != 0:
+        result.reasons.append(f"typed credit has reserved={reserved}; wait for drain")
+    if typed_open != 0:
+        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if result.legacy_open_reservations != 0:
+        result.reasons.append(
+            f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
+        )
+    if int(account.reserved_microdollars) != 0:
+        result.reasons.append(
+            f"JSON credit has reserved={account.reserved_microdollars}; wait for drain"
+        )
+    if total_credits != int(account.total_credits_microdollars):
+        result.reasons.append(
+            "typed/JSON deposited-credit totals differ; reconcile before reshard"
+        )
+    return result
+
+
+def reshard_credit_account(
+    store: Any,
+    workspace_id: str,
+    target_shard_count: int,
+    *,
+    apply: bool = False,
+) -> CreditReshardResult:
+    """Atomically repartition a paused and drained workspace's credit ledger.
+
+    Both splitting and consolidation use this function. A dry run never writes.
+    The JSON shard configuration and every typed row commit in one transaction.
+    """
+    status = inspect_credit_reshard(store, workspace_id, target_shard_count)
+    if not status.ready or not apply:
+        return status
+    assert status.current_shard_count is not None
+    if status.current_shard_count == status.target_shard_count:
+        return status
+
+    pt = store._param_types
+    target_count = status.target_shard_count
+
+    def txn(transaction: Any) -> dict[str, int] | None:
+        workspace = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        account = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if workspace is None or not workspace.billing_paused or account is None:
+            return None
+        current_count = credit_shard_count(account)
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@pk "
+                "AND shard>=0 AND shard<@shard_count ORDER BY shard",
+                params={"pk": workspace_id, "shard_count": current_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        observed = [int(row[0]) for row in rows]
+        if observed != list(range(current_count)):
+            return None
+        open_typed = int(
+            list(
+                transaction.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE workspace_id=@ws AND settled = false",
+                    params={"ws": workspace_id},
+                    param_types={"ws": pt.STRING},
+                )
+            )[0][0]
+        )
+        total_credits = sum(int(row[1]) for row in rows)
+        total_usage = sum(int(row[2]) for row in rows)
+        reserved = sum(int(row[3]) for row in rows)
+        if (
+            open_typed != 0
+            or reserved != 0
+            or int(account.reserved_microdollars) != 0
+            or total_credits != int(account.total_credits_microdollars)
+            or any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows)
+            or any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows)
+        ):
+            return None
+
+        credit_parts = distribute_credit_amount(total_credits, target_count)
+        usage_parts = distribute_credit_amount(total_usage, target_count)
+        if any(usage > credit for usage, credit in zip(usage_parts, credit_parts, strict=True)):
+            return None  # defensive; global usage<=credits should make this impossible.
+        commit_timestamp = store._spanner.COMMIT_TIMESTAMP
+        transaction.insert_or_update(
+            table=CREDIT_BALANCE_TABLE,
+            columns=_RESHARD_COLUMNS,
+            values=[
+                (
+                    workspace_id,
+                    shard,
+                    credit_parts[shard],
+                    usage_parts[shard],
+                    0,
+                    commit_timestamp,
+                    commit_timestamp,
+                )
+                for shard in range(target_count)
+            ],
+        )
+        if current_count > target_count:
+            transaction.delete(
+                CREDIT_BALANCE_TABLE,
+                store._spanner.KeySet(
+                    keys=[
+                        (workspace_id, shard)
+                        for shard in range(target_count, current_count)
+                    ]
+                ),
+            )
+
+        account.shard_count = target_count
+        account.total_credits_microdollars = total_credits
+        account.total_usage_microdollars = total_usage
+        account.reserved_microdollars = 0
+        # Deliberately bypass _write_entity_tx: when consolidating to one shard,
+        # its generic credit mirror would emit a second mutation for shard zero.
+        transaction.insert_or_update(
+            table=store.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    "credit",
+                    workspace_id,
+                    json_body(account),
+                    commit_timestamp,
+                )
+            ],
+        )
+        return {
+            "current_count": current_count,
+            "total_credits": total_credits,
+            "total_usage": total_usage,
+        }
+
+    changed = store._run_in_transaction(txn)
+    if changed is None:
+        status.reasons.append(
+            "atomic reshard preconditions changed; workspace remains paused"
+        )
+        return status
+    store._credit_shard_counts.invalidate(workspace_id)
+    verified = inspect_credit_reshard(store, workspace_id, target_count)
+    if not verified.ready:
+        verified.reasons.append("post-commit reshard verification failed")
+        return verified
+    verified.applied = True
+    return verified

--- a/src/trusted_router/storage_gcp_credit_shards.py
+++ b/src/trusted_router/storage_gcp_credit_shards.py
@@ -21,6 +21,10 @@ DEFAULT_CACHE_MAX_ENTRIES = 10_000
 _LOAD_LOCK_STRIPES = 64
 
 
+class CreditShardConfigurationMissingError(RuntimeError):
+    """The typed balance exists without its authoritative shard configuration."""
+
+
 def randomized_credit_shards(
     shard_count: int,
     *,

--- a/src/trusted_router/storage_gcp_credit_shards.py
+++ b/src/trusted_router/storage_gcp_credit_shards.py
@@ -1,0 +1,117 @@
+"""Credit-ledger shard selection and allow-stale shard-count caching.
+
+The billing cap remains hard because each shard owns a disjoint sub-budget.
+This module only chooses the order in which those independent budgets are
+tried; it never changes balances or decides whether a reserve is affordable.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from trusted_router.storage_gcp_counters import credit_shard_count
+
+DEFAULT_CACHE_TTL_SECONDS = 60.0
+DEFAULT_CACHE_MAX_ENTRIES = 10_000
+_LOAD_LOCK_STRIPES = 64
+
+
+def randomized_credit_shards(
+    shard_count: int,
+    *,
+    rng: random.Random | None = None,
+) -> tuple[int, ...]:
+    """Return every configured shard exactly once in randomized order.
+
+    The one-shard path deliberately avoids the RNG so its behavior is exactly
+    the pre-sharding path. The returned tuple is built outside the Spanner
+    callback and is therefore stable if Spanner retries an aborted transaction.
+    """
+    count = credit_shard_count({"shard_count": shard_count})
+    if count == 1:
+        return (0,)
+    source = rng if rng is not None else random.SystemRandom()
+    return tuple(source.sample(range(count), count))
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    shard_count: int
+    expires_at: float
+
+
+class CreditShardCountCache:
+    """Bounded LRU/TTL cache for a workspace's allow-stale shard count.
+
+    A stale smaller value only reduces spreading and may reject early; a stale
+    larger value scans retired/missing rows before a live row. Neither can
+    create credit. Operator split/unshard still uses pause + drain + one atomic
+    data transition, and explicitly invalidates this cache in its process.
+
+    Striped miss locks prevent a burst for one workspace from stampeding the
+    Spanner JSON row while allowing unrelated cache misses to load in parallel.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        max_entries: int = DEFAULT_CACHE_MAX_ENTRIES,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("credit shard cache TTL must be positive")
+        if max_entries < 1:
+            raise ValueError("credit shard cache max_entries must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entries = int(max_entries)
+        self._clock = clock
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._lock = threading.Lock()
+        self._load_locks = tuple(threading.Lock() for _ in range(_LOAD_LOCK_STRIPES))
+
+    def get(self, workspace_id: str, loader: Callable[[], int]) -> int:
+        cached = self._get_fresh(workspace_id)
+        if cached is not None:
+            return cached
+
+        load_lock = self._load_locks[hash(workspace_id) % len(self._load_locks)]
+        with load_lock:
+            cached = self._get_fresh(workspace_id)
+            if cached is not None:
+                return cached
+            loaded = credit_shard_count({"shard_count": loader()})
+            self._put(workspace_id, loaded)
+            return loaded
+
+    def invalidate(self, workspace_id: str) -> None:
+        with self._lock:
+            self._entries.pop(workspace_id, None)
+
+    def _get_fresh(self, workspace_id: str) -> int | None:
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(workspace_id)
+            if entry is None:
+                return None
+            if entry.expires_at <= now:
+                self._entries.pop(workspace_id, None)
+                return None
+            self._entries.move_to_end(workspace_id)
+            return entry.shard_count
+
+    def _put(self, workspace_id: str, shard_count: int) -> None:
+        entry = _CacheEntry(
+            shard_count=shard_count,
+            expires_at=self._clock() + self._ttl_seconds,
+        )
+        with self._lock:
+            self._entries[workspace_id] = entry
+            self._entries.move_to_end(workspace_id)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -1,0 +1,305 @@
+"""Operator-only split/consolidation for uncapped API-key usage rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_counters import (
+    KEY_LIMIT_TABLE,
+    distribute_credit_amount,
+    key_usage_shard_count,
+)
+from trusted_router.storage_models import ApiKey, Reservation, Workspace, iso_now
+
+_KEY_RESHARD_COLUMNS = (
+    "key_hash",
+    "shard",
+    "limit_micro",
+    "usage",
+    "byok_usage",
+    "reserved",
+    "include_byok",
+    "day_limit_micro",
+    "week_limit_micro",
+    "month_limit_micro",
+    "day_usage",
+    "day_start",
+    "week_usage",
+    "week_start",
+    "month_usage",
+    "month_start",
+    "source_updated_at",
+    "updated_at",
+)
+
+
+@dataclass
+class KeyUsageReshardResult:
+    key_hash: str
+    workspace_id: str | None
+    target_shard_count: int
+    current_shard_count: int | None = None
+    usage_micro: int | None = None
+    byok_usage_micro: int | None = None
+    reserved_micro: int | None = None
+    typed_open_reservations: int = 0
+    legacy_open_reservations: int = 0
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return not self.reasons
+
+
+def _limits(key: ApiKey) -> tuple[int | None, int | None, int | None, int | None]:
+    return (
+        key.limit_microdollars,
+        key.limit_daily_microdollars,
+        key.limit_weekly_microdollars,
+        key.limit_monthly_microdollars,
+    )
+
+
+def _typed_key_state(
+    store: Any,
+    key_hash: str,
+    shard_count: int,
+) -> tuple[list[list[Any]], int]:
+    pt = store._param_types
+    with store._database.snapshot(multi_use=True) as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT shard, limit_micro, usage, byok_usage, reserved, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "day_usage, day_start, week_usage, week_start, month_usage, month_start "
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": shard_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        open_reservations = int(
+            list(
+                snapshot.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE key_hash=@kh AND settled = false",
+                    params={"kh": key_hash},
+                    param_types={"kh": pt.STRING},
+                )
+            )[0][0]
+        )
+    return rows, open_reservations
+
+
+def inspect_key_usage_reshard(
+    store: Any,
+    key_hash: str,
+    target_shard_count: int,
+) -> KeyUsageReshardResult:
+    target_count = key_usage_shard_count({"usage_shard_count": target_shard_count})
+    key = store.api_keys.get_by_hash(key_hash)
+    result = KeyUsageReshardResult(
+        key_hash=key_hash,
+        workspace_id=key.workspace_id if key is not None else None,
+        target_shard_count=target_count,
+    )
+    if key is None:
+        result.reasons.append("API key not found")
+        return result
+    workspace = store.get_workspace(key.workspace_id)
+    if workspace is None:
+        result.reasons.append("workspace not found")
+    elif not workspace.billing_paused:
+        result.reasons.append("workspace not billing-paused")
+    if target_count > 1 and any(limit is not None for limit in _limits(key)):
+        result.reasons.append("capped API key must remain on one usage shard")
+
+    try:
+        current_count = key_usage_shard_count(key)
+    except ValueError as exc:
+        result.reasons.append(str(exc))
+        return result
+    result.current_shard_count = current_count
+    rows, typed_open = _typed_key_state(store, key_hash, current_count)
+    result.typed_open_reservations = typed_open
+    result.legacy_open_reservations = sum(
+        1
+        for reservation in store._list_entities("reservation", cls=Reservation)
+        if reservation.key_hash == key_hash and not reservation.settled
+    )
+    if [int(row[0]) for row in rows] != list(range(current_count)):
+        result.reasons.append("configured typed key usage shard set is incomplete")
+        return result
+
+    usage = sum(int(row[2]) for row in rows)
+    byok_usage = sum(int(row[3]) for row in rows)
+    reserved = sum(int(row[4]) for row in rows)
+    result.usage_micro = usage
+    result.byok_usage_micro = byok_usage
+    result.reserved_micro = reserved
+    if any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows):
+        result.reasons.append("typed key usage shard has a negative counter")
+    if reserved != 0:
+        result.reasons.append(f"typed key has reserved={reserved}; wait for drain")
+    if typed_open != 0:
+        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if result.legacy_open_reservations != 0:
+        result.reasons.append(
+            f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
+        )
+    return result
+
+
+def reshard_key_usage(
+    store: Any,
+    key_hash: str,
+    target_shard_count: int,
+    *,
+    apply: bool = False,
+) -> KeyUsageReshardResult:
+    status = inspect_key_usage_reshard(store, key_hash, target_shard_count)
+    if not status.ready or not apply:
+        return status
+    assert status.current_shard_count is not None
+    if status.current_shard_count == status.target_shard_count:
+        return status
+    target_count = status.target_shard_count
+    pt = store._param_types
+    floors = window_floors(utcnow())
+
+    def txn(transaction: Any) -> dict[str, int] | None:
+        key = store._read_entity_tx(transaction, "api_key", key_hash, ApiKey)
+        if key is None:
+            return None
+        workspace = store._read_entity_tx(
+            transaction,
+            "workspace",
+            key.workspace_id,
+            Workspace,
+        )
+        if workspace is None or not workspace.billing_paused:
+            return None
+        if target_count > 1 and any(limit is not None for limit in _limits(key)):
+            return None
+        current_count = key_usage_shard_count(key)
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, limit_micro, usage, byok_usage, reserved, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "day_usage, day_start, week_usage, week_start, month_usage, month_start "
+                "FROM tr_key_limit WHERE key_hash=@pk AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"pk": key_hash, "shard_count": current_count},
+                param_types={"pk": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        if [int(row[0]) for row in rows] != list(range(current_count)):
+            return None
+        open_typed = int(
+            list(
+                transaction.execute_sql(
+                    "SELECT COUNT(*) FROM tr_reservation "
+                    "WHERE key_hash=@kh AND settled = false",
+                    params={"kh": key_hash},
+                    param_types={"kh": pt.STRING},
+                )
+            )[0][0]
+        )
+        usage = sum(int(row[2]) for row in rows)
+        byok_usage = sum(int(row[3]) for row in rows)
+        reserved = sum(int(row[4]) for row in rows)
+        if (
+            open_typed != 0
+            or reserved != 0
+            or any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows)
+        ):
+            return None
+
+        def window_total(usage_index: int, start_index: int, window: str) -> int:
+            return sum(
+                int(row[usage_index] or 0)
+                for row in rows
+                if row[start_index] is not None and row[start_index] >= floors[window]
+            )
+
+        day_usage = window_total(9, 10, "daily")
+        week_usage = window_total(11, 12, "weekly")
+        month_usage = window_total(13, 14, "monthly")
+        usage_parts = distribute_credit_amount(usage, target_count)
+        byok_parts = distribute_credit_amount(byok_usage, target_count)
+        day_parts = distribute_credit_amount(day_usage, target_count)
+        week_parts = distribute_credit_amount(week_usage, target_count)
+        month_parts = distribute_credit_amount(month_usage, target_count)
+        commit_timestamp = store._spanner.COMMIT_TIMESTAMP
+        transaction.insert_or_update(
+            table=KEY_LIMIT_TABLE,
+            columns=_KEY_RESHARD_COLUMNS,
+            values=[
+                (
+                    key_hash,
+                    shard,
+                    None,
+                    usage_parts[shard],
+                    byok_parts[shard],
+                    0,
+                    key.include_byok_in_limit,
+                    None,
+                    None,
+                    None,
+                    day_parts[shard],
+                    floors["daily"],
+                    week_parts[shard],
+                    floors["weekly"],
+                    month_parts[shard],
+                    floors["monthly"],
+                    commit_timestamp,
+                    commit_timestamp,
+                )
+                for shard in range(target_count)
+            ],
+        )
+        if current_count > target_count:
+            transaction.delete(
+                KEY_LIMIT_TABLE,
+                store._spanner.KeySet(
+                    keys=[
+                        (key_hash, shard)
+                        for shard in range(target_count, current_count)
+                    ]
+                ),
+            )
+        key.usage_shard_count = target_count
+        key.usage_microdollars = usage
+        key.byok_usage_microdollars = byok_usage
+        key.reserved_microdollars = 0
+        key.updated_at = iso_now()
+        transaction.insert_or_update(
+            table=store.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    "api_key",
+                    key_hash,
+                    json_body(key),
+                    commit_timestamp,
+                )
+            ],
+        )
+        return {"usage": usage, "byok_usage": byok_usage}
+
+    changed = store._run_in_transaction(txn)
+    if changed is None:
+        status.reasons.append(
+            "atomic key reshard preconditions changed; workspace remains paused"
+        )
+        return status
+    verified = inspect_key_usage_reshard(store, key_hash, target_count)
+    if not verified.ready:
+        verified.reasons.append("post-commit key reshard verification failed")
+        return verified
+    verified.applied = True
+    return verified

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -138,6 +138,19 @@ class SpannerApiKeys:
         key = self.get_by_hash(key_hash)
         if key is None:
             return None
+        if key.usage_shard_count > 1:
+            requested_limits = [
+                patch.get("limit_microdollars"),
+                patch.get("limit_daily_microdollars"),
+                patch.get("limit_weekly_microdollars"),
+                patch.get("limit_monthly_microdollars"),
+            ]
+            if patch.get("limit") is not None or any(
+                value is not None for value in requested_limits
+            ):
+                raise ValueError(
+                    "consolidate API-key usage to one shard before adding a spend limit"
+                )
         if "name" in patch and patch["name"]:
             key.name = str(patch["name"])
         if "disabled" in patch:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -248,6 +248,10 @@ class CreditAccount:
     total_credits_microdollars: int = 0
     total_usage_microdollars: int = 0
     reserved_microdollars: int = 0
+    # Number of independent tr_credit_balance sub-ledgers owned by this
+    # workspace. Increment 1 keeps every account at one shard; later increments
+    # add selection/rebalancing and an operator-only activation path.
+    shard_count: int = 1
     # Auto-refill: when available drops below threshold, charge the saved
     # Stripe payment method off-session for `auto_refill_amount_microdollars`.
     # All four are required to be non-zero/non-None for auto-refill to fire.

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -127,6 +127,10 @@ class ApiKey:
     created_at: str = field(default_factory=iso_now)
     updated_at: str | None = None
     reserved_microdollars: int = 0
+    # Independent usage-counter rows for a high-throughput UNCAPPED key. Keys
+    # with any lifetime/window spend limit must remain at one shard so their
+    # hard cap keeps its existing exact semantics.
+    usage_shard_count: int = 1
 
 
 @dataclass

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -249,8 +249,8 @@ class CreditAccount:
     total_usage_microdollars: int = 0
     reserved_microdollars: int = 0
     # Number of independent tr_credit_balance sub-ledgers owned by this
-    # workspace. Increment 1 keeps every account at one shard; later increments
-    # add selection/rebalancing and an operator-only activation path.
+    # workspace. The default preserves the original one-row behavior; only the
+    # pause/drain operator path may activate more shards for a hot workspace.
     shard_count: int = 1
     # Auto-refill: when available drops below threshold, charge the saved
     # Stripe payment method off-session for `auto_refill_amount_microdollars`.

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -485,6 +485,7 @@ class TypedBillingStore(Protocol):
         candidate_endpoint_ids: list[str],
         idempotency_key: str | None,
         idempotency_fingerprint: str | None,
+        key_usage_shards: int = ...,
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,
         expires_at: Any = ...,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -849,6 +849,12 @@ def _execute_sql(
             1 for rec in db.reservations.values()
             if rec.get("workspace_id") == ws and not rec.get("settled")
         )]]
+    if "COUNT(*) FROM tr_reservation WHERE key_hash=@kh AND settled = false" in sql:
+        kh = params["kh"]
+        return [[sum(
+            1 for rec in db.reservations.values()
+            if rec.get("key_hash") == kh and not rec.get("settled")
+        )]]
     # Flip-reconcile: does this workspace have ANY typed reservation history?
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws" in sql:
         ws = params["ws"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -329,6 +329,37 @@ class _FakeTransaction:
             )
             self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
             return 1
+        if "UPDATE tr_credit_balance SET total_credits=total_credits-@move" in sql:
+            _require_pred(
+                sql,
+                "(total_credits-total_usage-reserved)>=@move",
+                "credit-rebalance-donor",
+            )
+            pk = (p["ws"], p["donor"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            available = (
+                rec["total_credits"] - rec["total_usage"] - rec["reserved"]
+                if rec is not None
+                else -1
+            )
+            if rec is None or available < p["move"]:
+                return 0
+            new = dict(rec, total_credits=rec["total_credits"] - p["move"])
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
+        if "UPDATE tr_credit_balance SET total_credits=total_credits+@move" in sql:
+            _require_pred(
+                sql,
+                "WHERE workspace_id=@ws AND shard=@target",
+                "credit-rebalance-target",
+            )
+            pk = (p["ws"], p["target"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            if rec is None:
+                return 0
+            new = dict(rec, total_credits=rec["total_credits"] + p["move"])
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
         if sql.startswith("INSERT INTO tr_credit_balance"):
             pk = (p["ws"], p["shard"])
             if pk in self.db.typed.get("tr_credit_balance", {}):

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -841,9 +841,16 @@ def _execute_sql(
         sums: dict[tuple, int] = {}
         for rec in db.reservations.values():
             if not rec.get("settled") and rec.get("workspace_id") is not None:
-                grp = (rec["workspace_id"], rec.get("ws_shard", 0))
+                grp = (
+                    rec["workspace_id"],
+                    rec.get("credit_shard"),
+                    rec.get("ws_shard", 0),
+                )
                 sums[grp] = sums.get(grp, 0) + (rec.get("credit_reserved_micro") or 0)
-        return [[ws, shard, total] for (ws, shard), total in sums.items()]
+        return [
+            [ws, credit_shard, ws_shard, total]
+            for (ws, credit_shard, ws_shard), total in sums.items()
+        ]
     if "SUM(key_reserved_micro)" in sql:
         ksums: dict[tuple, int] = {}
         for rec in db.reservations.values():
@@ -907,6 +914,13 @@ def _execute_sql(
                 recs = [r for r in recs if r.get(pk_col) == params["pk"]]
                 if "shard=0" in sql.replace(" ", ""):
                     recs = [r for r in recs if r.get("shard", 0) == 0]
+                if "shard<@shard_count" in sql.replace(" ", ""):
+                    recs = [
+                        r for r in recs
+                        if 0 <= int(r.get("shard", 0)) < int(params["shard_count"])
+                    ]
+                if "ORDER BY shard" in sql:
+                    recs.sort(key=lambda r: int(r.get("shard", 0)))
             return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -939,19 +939,24 @@ def _execute_sql(
     for typed_table in ("tr_credit_balance", "tr_key_limit"):
         if f"FROM {typed_table}" in sql:
             cols = [c.strip() for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
-            recs = list(db.typed.get(typed_table, {}).values())
+            items = list(db.typed.get(typed_table, {}).items())
             if "@pk" in sql and "pk" in params:
                 pk_col = "workspace_id" if typed_table == "tr_credit_balance" else "key_hash"
-                recs = [r for r in recs if r.get(pk_col) == params["pk"]]
+                items = [(pk, rec) for pk, rec in items if rec.get(pk_col) == params["pk"]]
                 if "shard=0" in sql.replace(" ", ""):
-                    recs = [r for r in recs if r.get("shard", 0) == 0]
+                    items = [(pk, rec) for pk, rec in items if rec.get("shard", 0) == 0]
                 if "shard<@shard_count" in sql.replace(" ", ""):
-                    recs = [
-                        r for r in recs
-                        if 0 <= int(r.get("shard", 0)) < int(params["shard_count"])
+                    items = [
+                        (pk, rec) for pk, rec in items
+                        if 0 <= int(rec.get("shard", 0)) < int(params["shard_count"])
                     ]
                 if "ORDER BY shard" in sql:
-                    recs.sort(key=lambda r: int(r.get("shard", 0)))
+                    items.sort(key=lambda item: int(item[1].get("shard", 0)))
+            recs = [
+                txn._typed_current(typed_table, pk) if txn is not None else dict(rec)
+                for pk, rec in items
+            ]
+            recs = [rec for rec in recs if rec is not None]
             return [[rec.get(c) for c in cols] for rec in recs]
     if "AND id=@id" in sql:
         entity_id = params["id"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1033,6 +1033,9 @@ def make_fake_store(
     store._database = db
     store._bt_table = bt
     store._counter_mirror_enabled = True  # exercise the Step-1 typed-counter mirror
+    from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+
+    store._credit_shard_counts = CreditShardCountCache()
     io = SpannerIO(
         database=db,
         write_entity_batch=store._write_entity_batch,

--- a/tests/test_credit_row_sharding_increment1.py
+++ b/tests/test_credit_row_sharding_increment1.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    authorize_atomic,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants, compare
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    credit_shard_count,
+    distribute_credit_amount,
+)
+from trusted_router.storage_models import CreditAccount
+
+
+def _credit_row(
+    workspace_id: str,
+    shard: int,
+    *,
+    total_credits: int,
+    total_usage: int = 0,
+    reserved: int = 0,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "shard": shard,
+        "total_credits": total_credits,
+        "total_usage": total_usage,
+        "reserved": reserved,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _seed_sharded_credit(
+    store: object,
+    database: object,
+    workspace_id: str,
+    totals: list[int],
+) -> None:
+    account = CreditAccount(
+        workspace_id=workspace_id,
+        total_credits_microdollars=sum(totals),
+        shard_count=len(totals),
+    )
+    store._write_entity("credit", workspace_id, account)  # type: ignore[attr-defined]
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})  # type: ignore[attr-defined]
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = _credit_row(
+            workspace_id, shard, total_credits=total
+        )
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id, "model": "m"}
+    )
+
+
+def test_credit_shard_schema_is_additive_and_rolling_compatible() -> None:
+    migration = (
+        Path(__file__).parents[1] / "scripts/deploy/migrate_typed_counters.sh"
+    ).read_text()
+
+    assert "credit_shard INT64 NOT NULL DEFAULT (0)" in migration
+    assert 'ensure_column tr_reservation credit_shard "INT64 DEFAULT (0)"' in migration
+
+
+def test_legacy_credit_account_defaults_to_exactly_one_shard() -> None:
+    account = CreditAccount(workspace_id="ws")
+
+    assert account.shard_count == 1
+    assert credit_shard_count(account) == 1
+    assert credit_shard_count({"workspace_id": "legacy"}) == 1
+    assert distribute_credit_amount(17, 1) == (17,)
+
+
+@pytest.mark.parametrize("invalid", [0, -1, True])
+def test_invalid_credit_shard_count_fails_closed(invalid: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        credit_shard_count({"shard_count": invalid})
+
+
+def test_credit_grant_distribution_puts_remainder_on_shard_zero() -> None:
+    assert distribute_credit_amount(10, 3) == (4, 3, 3)
+    assert distribute_credit_amount(-10, 3) == (-4, -3, -3)
+
+
+def test_authorize_records_credit_shard_and_settle_releases_that_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-shard-plumbing"
+    _seed_sharded_credit(store, database, workspace_id, [2_000_000, 2_000_000, 2_000_000])
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="key",
+        creator_user_id=None,
+        limit_microdollars=6_000_000,
+    )
+
+    result = authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        estimate=500_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope="scope-shard-2",
+        idempotency_fingerprint="fingerprint",
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        credit_shard=2,
+    )
+
+    assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+    reservation = database.reservations[result["reservation_id"]]
+    assert reservation["credit_shard"] == 2
+    assert reservation["ws_shard"] == 2
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 500_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] == 0
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=result["reservation_id"],
+        actual_micro=450_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert settled["outcome"] == SettleOutcome.SETTLED
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 0
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["total_usage"] == 450_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_usage"] == 0
+
+
+def test_idempotent_replay_keeps_original_credit_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-shard-replay"
+    _seed_sharded_credit(store, database, workspace_id, [1_000_000, 1_000_000, 1_000_000])
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="key",
+        creator_user_id=None,
+        limit_microdollars=3_000_000,
+    )
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": workspace_id,
+        "key_hash": key.hash,
+        "estimate": 250_000,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": "same-scope",
+        "idempotency_fingerprint": "same-fingerprint",
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+
+    first = authorize_atomic(**common, credit_shard=2)
+    replay = authorize_atomic(**common, credit_shard=0)
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["reservation_id"] == first["reservation_id"]
+    assert database.reservations[first["reservation_id"]]["credit_shard"] == 2
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 2)]["reserved"] == 250_000
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] == 0
+
+
+def test_pre_migration_reservation_falls_back_to_ws_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-old-reservation"
+    _seed_sharded_credit(store, database, workspace_id, [1_000_000])
+    database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["reserved"] = 200_000
+    database.reservations["old-r"] = {
+        "reservation_id": "old-r",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 0,
+        "credit_shard": None,
+        "key_shard": 0,
+        "credit_reserved_micro": 200_000,
+        "key_reserved_micro": 0,
+        "hold_usage_type": "Credits",
+        "settled_usage_type": None,
+        "actual_micro": None,
+        "authorization_id": "old-a",
+        "settled": False,
+        "expires_at": "2026-12-01T00:00:00Z",
+    }
+
+    result = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id="old-r",
+        actual_micro=150_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    row = database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+    assert row["reserved"] == 0
+    assert row["total_usage"] == 150_000
+
+
+def test_typed_direct_grant_distributes_delta_and_is_idempotent() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-grant-shards"
+    _seed_sharded_credit(store, database, workspace_id, [40, 30, 30])
+
+    assert store.credit_workspace_typed_direct(workspace_id, 10, "evt-sharded") is True
+    assert store.credit_workspace_typed_direct(workspace_id, 10, "evt-sharded") is False
+
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert [rows[(workspace_id, shard)]["total_credits"] for shard in range(3)] == [44, 33, 33]
+    assert store.get_credit_account(workspace_id).total_credits_microdollars == 110
+
+
+def test_typed_direct_grant_rolls_back_when_active_shard_is_missing() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-grant-missing-shard"
+    _seed_sharded_credit(store, database, workspace_id, [50, 50])
+    del database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 1)]
+
+    with pytest.raises(RuntimeError, match="missing tr_credit_balance shard 1"):
+        store.credit_workspace_typed_direct(workspace_id, 10, "evt-missing")
+
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_credits"] == 50
+    assert store.get_credit_account(workspace_id).total_credits_microdollars == 100
+    assert ("stripe_event", "evt-missing") not in database.rows
+
+
+def test_typed_credit_snapshot_sums_only_configured_shards() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-summary-shards"
+    _seed_sharded_credit(store, database, workspace_id, [50, 30, 20])
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    rows[(workspace_id, 0)].update(total_usage=5, reserved=1)
+    rows[(workspace_id, 1)].update(total_usage=6, reserved=2)
+    rows[(workspace_id, 2)].update(total_usage=7, reserved=3)
+    rows[(workspace_id, 3)] = _credit_row(
+        workspace_id, 3, total_credits=999, total_usage=999, reserved=999
+    )
+
+    assert store.typed_credit_snapshot(workspace_id) == (100, 18, 6)
+
+
+def test_typed_credit_snapshot_fails_closed_on_missing_configured_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-summary-gap"
+    _seed_sharded_credit(store, database, workspace_id, [50, 50])
+    del database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 1)]
+
+    with pytest.raises(RuntimeError, match="shard set is incomplete"):
+        store.typed_credit_snapshot(workspace_id)
+
+
+def test_generic_credit_mirror_does_not_overwrite_sharded_sub_budgets() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-mirror-shards"
+    account = CreditAccount(
+        workspace_id=workspace_id,
+        total_credits_microdollars=100,
+        shard_count=2,
+    )
+
+    store._write_entity("credit", workspace_id, account)
+
+    assert database.typed.get(CREDIT_BALANCE_TABLE, {}) == {}
+
+
+def test_compare_and_invariant_audit_are_credit_shard_aware() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-audit-shards"
+    _seed_sharded_credit(store, database, workspace_id, [60, 40])
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    rows[(workspace_id, 0)]["reserved"] = 7
+    rows[(workspace_id, 1)]["reserved"] = 11
+    database.reservations["legacy"] = {
+        "reservation_id": "legacy",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 0,
+        "credit_shard": None,
+        "credit_reserved_micro": 7,
+        "key_reserved_micro": 0,
+        "settled": False,
+    }
+    database.reservations["new"] = {
+        "reservation_id": "new",
+        "workspace_id": workspace_id,
+        "key_hash": None,
+        "ws_shard": 1,
+        "credit_shard": 1,
+        "credit_reserved_micro": 11,
+        "key_reserved_micro": 0,
+        "settled": False,
+    }
+
+    drift = compare(store)
+    invariant = audit_typed_invariants(store)
+
+    assert drift.clean, drift.samples
+    assert invariant.clean, invariant.samples
+    assert invariant.credit_rows == 2

--- a/tests/test_credit_row_sharding_increment2.py
+++ b/tests/test_credit_row_sharding_increment2.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import random
+import threading
+import time
+from collections import Counter
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome, authorize_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_credit_shards import (
+    CreditShardCountCache,
+    randomized_credit_shards,
+)
+from trusted_router.storage_models import CreditAccount
+
+
+def _credit_row(
+    workspace_id: str,
+    shard: int,
+    total_credits: int,
+) -> dict[str, object]:
+    return {
+        "workspace_id": workspace_id,
+        "shard": shard,
+        "total_credits": total_credits,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _seed(
+    totals: list[int],
+    *,
+    workspace_id: str = "ws-sharded",
+    key_limit: int | None = None,
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(totals),
+            shard_count=len(totals),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = _credit_row(workspace_id, shard, total)
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="shard-test",
+        creator_user_id=None,
+        limit_microdollars=key_limit,
+    )
+    return store, database, key
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id}
+    )
+
+
+def _authorize(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    estimate: int,
+    candidates: tuple[int, ...],
+    scope: str | None = None,
+) -> dict[str, Any]:
+    return authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=estimate,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope=scope,
+        idempotency_fingerprint="same-body" if scope else None,
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        credit_shard_candidates=candidates,
+    )
+
+
+def test_randomized_order_is_complete_unique_and_spreads_first_choice() -> None:
+    first_choices = Counter(
+        randomized_credit_shards(8, rng=random.Random(seed))[0]  # noqa: S311 - deterministic
+        for seed in range(256)
+    )
+
+    assert set(first_choices) == set(range(8))
+    assert all(count >= 20 for count in first_choices.values())
+    for seed in range(32):
+        order = randomized_credit_shards(8, rng=random.Random(seed))  # noqa: S311
+        assert len(order) == 8
+        assert set(order) == set(range(8))
+
+
+def test_one_shard_order_does_not_touch_rng() -> None:
+    class ExplodingRandom(random.Random):
+        def sample(self, population: Any, k: int, *, counts: Any = None) -> list[Any]:
+            raise AssertionError("one-shard path must not call RNG")
+
+    assert randomized_credit_shards(1, rng=ExplodingRandom()) == (0,)
+
+
+def test_invalid_or_unbounded_candidate_configuration_fails_closed() -> None:
+    with pytest.raises(ValueError, match="must not exceed"):
+        randomized_credit_shards(65)
+
+    store, _database, key = _seed([100])
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": "ws-sharded",
+        "key_hash": key.hash,
+        "estimate": 1,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": None,
+        "idempotency_fingerprint": None,
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+    with pytest.raises(ValueError, match="must not be empty"):
+        authorize_atomic(**common, credit_shard_candidates=())
+    with pytest.raises(ValueError, match="must be unique"):
+        authorize_atomic(**common, credit_shard_candidates=(0, 0))
+    with pytest.raises(ValueError, match="non-negative"):
+        authorize_atomic(**common, credit_shard_candidates=(-1,))
+
+
+def test_scan_skips_insufficient_shard_and_records_first_success() -> None:
+    store, database, key = _seed([100, 1_000], key_limit=2_000)
+
+    result = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=500,
+        candidates=(0, 1),
+    )
+
+    assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert result["credit_shard"] == 1
+    reservation = database.reservations[result["reservation_id"]]
+    assert reservation["credit_shard"] == 1
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 0)]["reserved"] == 0
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 1)]["reserved"] == 500
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 500
+
+
+def test_all_shards_insufficient_rolls_back_key_hold_and_writes_nothing() -> None:
+    store, database, key = _seed([100, 200, 300], key_limit=10_000)
+
+    result = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=500,
+        candidates=(2, 0, 1),
+    )
+
+    assert result == {"outcome": AuthorizeOutcome.INSUFFICIENT_CREDITS}
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+    assert all(
+        row["reserved"] == 0
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    )
+
+
+def test_replay_keeps_original_shard_when_candidate_order_changes() -> None:
+    store, database, key = _seed([1_000, 1_000, 1_000])
+
+    first = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=250,
+        candidates=(2, 1, 0),
+        scope="stable-replay",
+    )
+    replay = _authorize(
+        store,
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=250,
+        candidates=(0, 1, 2),
+        scope="stable-replay",
+    )
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["credit_shard"] == first["credit_shard"] == 2
+    assert len(database.reservations) == 1
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 2)]["reserved"] == 250
+    assert database.typed[CREDIT_BALANCE_TABLE][("ws-sharded", 0)]["reserved"] == 0
+
+
+def test_shard_count_cache_hits_expires_and_is_bounded() -> None:
+    now = [100.0]
+    cache = CreditShardCountCache(
+        ttl_seconds=10,
+        max_entries=2,
+        clock=lambda: now[0],
+    )
+    loads = Counter()
+
+    def load(name: str, value: int) -> int:
+        loads[name] += 1
+        return value
+
+    assert cache.get("a", lambda: load("a", 2)) == 2
+    assert cache.get("a", lambda: load("a", 3)) == 2
+    assert loads["a"] == 1
+
+    now[0] = 111
+    assert cache.get("a", lambda: load("a", 3)) == 3
+    assert loads["a"] == 2
+
+    assert cache.get("b", lambda: load("b", 1)) == 1
+    assert cache.get("c", lambda: load("c", 1)) == 1
+    assert cache.get("a", lambda: load("a", 4)) == 4  # evicted LRU
+    assert loads["a"] == 3
+
+
+def test_shard_count_cache_singleflights_same_workspace_miss() -> None:
+    cache = CreditShardCountCache(ttl_seconds=60, max_entries=100)
+    load_count = 0
+    load_lock = threading.Lock()
+    start = threading.Barrier(9)
+    results: list[int] = []
+
+    def loader() -> int:
+        nonlocal load_count
+        with load_lock:
+            load_count += 1
+        time.sleep(0.02)
+        return 16
+
+    def worker() -> None:
+        start.wait(timeout=5)
+        results.append(cache.get("hot-workspace", loader))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert results == [16] * 8
+    assert load_count == 1
+
+
+def test_store_byok_path_does_not_load_credit_shard_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _database, key = _seed([100, 100])
+
+    def fail_if_called(_workspace_id: str) -> tuple[int, ...]:
+        raise AssertionError("BYOK authorize must not load credit shard configuration")
+
+    monkeypatch.setattr(store, "_credit_shard_candidates", fail_if_called)
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id="ws-sharded",
+        key_hash=key.hash,
+        estimate=10,
+        has_credit_candidate=False,
+        reservation_usage_type="BYOK",
+        model_id="model",
+        provider="provider",
+        requested_model_id=None,
+        candidate_model_ids=["model"],
+        region="us",
+        endpoint_id="endpoint",
+        candidate_endpoint_ids=["endpoint"],
+        idempotency_key=None,
+        idempotency_fingerprint=None,
+    )
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+
+
+def test_concurrent_sharded_reserves_never_exceed_global_cap() -> None:
+    shard_count = 8
+    per_shard_credit = 40
+    estimate = 10
+    store, database, key = _seed([per_shard_credit] * shard_count)
+    start = threading.Barrier(65)
+    outcomes: list[str] = []
+    outcomes_lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        order = randomized_credit_shards(
+            shard_count,
+            rng=random.Random(index),  # noqa: S311 - deterministic test distribution
+        )
+        start.wait(timeout=10)
+        result = _authorize(
+            store,
+            workspace_id="ws-sharded",
+            key_hash=key.hash,
+            estimate=estimate,
+            candidates=order,
+            scope=f"request-{index}",
+        )
+        with outcomes_lock:
+            outcomes.append(result["outcome"])
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(64)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=10)
+    for thread in threads:
+        thread.join(timeout=15)
+        assert not thread.is_alive()
+
+    capacity = shard_count * per_shard_credit // estimate
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == capacity
+    assert outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS) == 64 - capacity
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert sum(row["reserved"] for row in rows.values()) == capacity * estimate
+    assert all(
+        row["reserved"] + row["total_usage"] <= row["total_credits"]
+        for row in rows.values()
+    )
+    assert len(database.reservations) == capacity

--- a/tests/test_credit_row_sharding_increment3.py
+++ b/tests/test_credit_row_sharding_increment3.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome, settle_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_credit_rebalance import (
+    RebalanceOutcome,
+    rebalance_credit_for_estimate,
+)
+from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+from trusted_router.storage_models import CreditAccount
+
+
+def _seed(
+    totals: list[int],
+    *,
+    usage: list[int] | None = None,
+    reserved: list[int] | None = None,
+    workspace_id: str = "ws-fragmented",
+) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    usage = usage or [0] * len(totals)
+    reserved = reserved or [0] * len(totals)
+    assert len(usage) == len(totals)
+    assert len(reserved) == len(totals)
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(totals),
+            total_usage_microdollars=sum(usage),
+            reserved_microdollars=sum(reserved),
+            shard_count=len(totals),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, total in enumerate(totals):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": total,
+            "total_usage": usage[shard],
+            "reserved": reserved[shard],
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="fragmentation-test",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    return store, database, key
+
+
+def _rebalance(
+    store: Any,
+    *,
+    shard_count: int,
+    target_shard: int,
+    estimate: int,
+    workspace_id: str = "ws-fragmented",
+) -> dict[str, int | str]:
+    return rebalance_credit_for_estimate(
+        store._database,
+        store._param_types,
+        workspace_id=workspace_id,
+        shard_count=shard_count,
+        target_shard=target_shard,
+        estimate=estimate,
+    )
+
+
+def _typed_authorize(
+    store: Any,
+    key: Any,
+    *,
+    estimate: int,
+    idempotency_key: str | None = None,
+) -> tuple[str, Any]:
+    return store.authorize_gateway_typed(
+        workspace_id="ws-fragmented",
+        key_hash=key.hash,
+        estimate=estimate,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="model",
+        provider="provider",
+        requested_model_id=None,
+        candidate_model_ids=["model"],
+        region="us",
+        endpoint_id="endpoint",
+        candidate_endpoint_ids=["endpoint"],
+        idempotency_key=idempotency_key,
+        idempotency_fingerprint="same-body" if idempotency_key else None,
+    )
+
+
+def test_rebalance_moves_only_idle_budget_and_preserves_global_totals() -> None:
+    store, database, _key = _seed([100, 100], usage=[60, 60])
+
+    result = _rebalance(store, shard_count=2, target_shard=0, estimate=60)
+
+    assert result == {
+        "outcome": RebalanceOutcome.MOVED,
+        "moved_micro": 20,
+        "target_shard": 0,
+    }
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert rows[("ws-fragmented", 0)]["total_credits"] == 120
+    assert rows[("ws-fragmented", 1)]["total_credits"] == 80
+    assert [rows[("ws-fragmented", shard)]["total_usage"] for shard in range(2)] == [60, 60]
+    assert sum(row["total_credits"] for row in rows.values()) == 200
+    assert all(row["reserved"] == 0 for row in rows.values())
+
+
+def test_rebalance_can_consolidate_from_multiple_donors() -> None:
+    store, database, _key = _seed([100, 100, 100, 100], usage=[80, 80, 80, 80])
+
+    result = _rebalance(store, shard_count=4, target_shard=0, estimate=70)
+
+    assert result["outcome"] == RebalanceOutcome.MOVED
+    assert result["moved_micro"] == 50
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert rows[("ws-fragmented", 0)]["total_credits"] == 150
+    assert sum(row["total_credits"] for row in rows.values()) == 400
+    assert all(row["total_credits"] >= row["total_usage"] + row["reserved"] for row in rows.values())
+
+
+def test_rebalance_distinguishes_not_needed_insufficient_and_incomplete() -> None:
+    store, database, _key = _seed([100, 100], usage=[20, 60])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    assert _rebalance(store, shard_count=2, target_shard=0, estimate=60)[
+        "outcome"
+    ] == RebalanceOutcome.NOT_NEEDED
+    assert _rebalance(store, shard_count=2, target_shard=1, estimate=130)[
+        "outcome"
+    ] == RebalanceOutcome.INSUFFICIENT
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-fragmented", 1))
+    assert _rebalance(store, shard_count=2, target_shard=0, estimate=90)[
+        "outcome"
+    ] == RebalanceOutcome.INCOMPLETE
+
+
+def test_rebalance_fails_closed_on_preexisting_sub_budget_violation() -> None:
+    store, database, _key = _seed([100, 100], usage=[101, 0])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    with pytest.raises(RuntimeError, match="exceeds its sub-budget"):
+        _rebalance(store, shard_count=2, target_shard=0, estimate=50)
+
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+
+def test_store_rebalances_fragmentation_then_authorizes_and_settles_once() -> None:
+    store, database, key = _seed([100, 100], usage=[60, 60])
+
+    outcome, authorization = _typed_authorize(store, key, estimate=60)
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    [reservation] = database.reservations.values()
+    selected_shard = reservation["credit_shard"]
+    assert database.typed[CREDIT_BALANCE_TABLE][
+        ("ws-fragmented", selected_shard)
+    ]["reserved"] == 60
+    assert sum(
+        row["total_credits"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 200
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation["reservation_id"],
+        actual_micro=55,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert settled["outcome"] == "settled"
+    assert sum(
+        row["total_usage"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 175
+    assert sum(
+        row["reserved"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 0
+
+
+def test_true_insufficient_store_authorize_rolls_back_every_hold() -> None:
+    store, database, key = _seed([100, 100], usage=[70, 70])
+
+    outcome, authorization = _typed_authorize(store, key, estimate=70)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+    assert sum(
+        row["total_credits"]
+        for row in database.typed[CREDIT_BALANCE_TABLE].values()
+    ) == 200
+
+
+def test_stale_smaller_cache_refreshes_and_uses_newly_activated_shards() -> None:
+    store, database, key = _seed([0, 0, 100])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-fragmented", lambda: 1) == 1
+
+    outcome, authorization = _typed_authorize(store, key, estimate=50)
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    [reservation] = database.reservations.values()
+    assert reservation["credit_shard"] == 2
+
+
+def test_stale_larger_cache_refreshes_after_rejection_without_drift_error() -> None:
+    store, _database, key = _seed([40])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-fragmented", lambda: 3) == 3
+
+    outcome, authorization = _typed_authorize(store, key, estimate=60)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+
+
+def test_persistent_missing_configured_shard_raises_and_leaks_no_hold() -> None:
+    store, database, key = _seed([100, 100, 100], usage=[60, 60, 60])
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-fragmented", 2))
+
+    with pytest.raises(RuntimeError, match="configured credit shard set is incomplete"):
+        _typed_authorize(store, key, estimate=60)
+
+    assert database.reservations == {}
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["reserved"] == 0
+
+
+def test_concurrent_fragmentation_repair_preserves_cap_and_accepts_at_most_one() -> None:
+    store, database, key = _seed([100, 100], usage=[60, 60])
+    start = threading.Barrier(3)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        start.wait(timeout=10)
+        outcome, _authorization = _typed_authorize(
+            store,
+            key,
+            estimate=60,
+            idempotency_key=f"concurrent-{index}",
+        )
+        with lock:
+            outcomes.append(outcome)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=10)
+    for thread in threads:
+        thread.join(timeout=15)
+        assert not thread.is_alive()
+
+    assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1
+    assert outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS) == 1
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert sum(row["total_credits"] for row in rows.values()) == 200
+    assert sum(row["reserved"] for row in rows.values()) == 60
+    assert all(
+        row["total_usage"] + row["reserved"] <= row["total_credits"]
+        for row in rows.values()
+    )
+    assert len(database.reservations) == 1

--- a/tests/test_credit_row_sharding_increment4.py
+++ b/tests/test_credit_row_sharding_increment4.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_credit_shard_admin import (
+    inspect_credit_reshard,
+    reshard_credit_account,
+)
+from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
+from trusted_router.storage_models import CreditAccount, Reservation, Workspace
+
+
+def _seed(
+    *,
+    shard_credits: list[int],
+    shard_usage: list[int],
+    shard_reserved: list[int] | None = None,
+    paused: bool = True,
+    workspace_id: str = "ws-reshard",
+) -> tuple[Any, Any]:
+    store, database, _ = make_fake_store()
+    shard_reserved = shard_reserved or [0] * len(shard_credits)
+    store._write_entity(
+        "workspace",
+        workspace_id,
+        Workspace(
+            id=workspace_id,
+            name="Reshard test",
+            owner_user_id="owner",
+            billing_paused=paused,
+        ),
+    )
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=sum(shard_credits),
+            total_usage_microdollars=sum(shard_usage),
+            reserved_microdollars=sum(shard_reserved),
+            shard_count=len(shard_credits),
+        ),
+    )
+    table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    for shard, credits in enumerate(shard_credits):
+        table[(workspace_id, shard)] = {
+            "workspace_id": workspace_id,
+            "shard": shard,
+            "total_credits": credits,
+            "total_usage": shard_usage[shard],
+            "reserved": shard_reserved[shard],
+            "source_updated_at": None,
+            "updated_at": None,
+        }
+    return store, database
+
+
+def _rows(database: Any, workspace_id: str = "ws-reshard") -> list[dict[str, Any]]:
+    table = database.typed[CREDIT_BALANCE_TABLE]
+    return [
+        table[(workspace_id, shard)]
+        for shard in sorted(key[1] for key in table if key[0] == workspace_id)
+    ]
+
+
+def test_dry_run_is_read_only_and_requires_pause() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37], paused=False)
+    before_rows = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=False)
+
+    assert not result.ready
+    assert result.applied is False
+    assert "workspace not billing-paused" in result.reasons
+    assert _rows(database) == before_rows
+    assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_split_is_atomic_even_partitioned_and_invalidates_cached_count() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37])
+    store._credit_shard_counts = CreditShardCountCache(ttl_seconds=600)
+    assert store._credit_shard_counts.get("ws-reshard", lambda: 1) == 1
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert result.ready
+    assert result.applied
+    assert result.current_shard_count == 4
+    rows = _rows(database)
+    assert [row["total_credits"] for row in rows] == [26, 25, 25, 25]
+    assert [row["total_usage"] for row in rows] == [10, 9, 9, 9]
+    assert [row["reserved"] for row in rows] == [0, 0, 0, 0]
+    assert sum(row["total_credits"] for row in rows) == 101
+    assert sum(row["total_usage"] for row in rows) == 37
+    account = store.get_credit_account("ws-reshard")
+    assert account.shard_count == 4
+    assert account.total_credits_microdollars == 101
+    assert account.total_usage_microdollars == 37
+    assert store._credit_shard_count("ws-reshard") == 4
+
+
+def test_split_then_unshard_round_trip_preserves_every_global_counter() -> None:
+    store, database = _seed(shard_credits=[101], shard_usage=[37])
+    split = reshard_credit_account(store, "ws-reshard", 16, apply=True)
+    assert split.ready and split.applied
+
+    unshard = reshard_credit_account(store, "ws-reshard", 1, apply=True)
+
+    assert unshard.ready and unshard.applied
+    rows = _rows(database)
+    assert rows == [
+        {
+            "workspace_id": "ws-reshard",
+            "shard": 0,
+            "total_credits": 101,
+            "total_usage": 37,
+            "reserved": 0,
+            "source_updated_at": store._spanner.COMMIT_TIMESTAMP,
+            "updated_at": store._spanner.COMMIT_TIMESTAMP,
+        }
+    ]
+    account = store.get_credit_account("ws-reshard")
+    assert account.shard_count == 1
+    assert account.total_credits_microdollars == 101
+    assert account.total_usage_microdollars == 37
+
+
+def test_same_target_is_verified_idempotent_noop() -> None:
+    store, database = _seed(
+        shard_credits=[40, 30, 30],
+        shard_usage=[4, 3, 3],
+    )
+    before = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 3, apply=True)
+
+    assert result.ready
+    assert result.applied is False
+    assert _rows(database) == before
+
+
+@pytest.mark.parametrize(
+    ("reserved", "typed_open", "legacy_open"),
+    [
+        (10, False, False),
+        (0, True, False),
+        (0, False, True),
+    ],
+)
+def test_reshard_refuses_any_undrained_hold(
+    reserved: int,
+    typed_open: bool,
+    legacy_open: bool,
+) -> None:
+    store, database = _seed(
+        shard_credits=[100],
+        shard_usage=[20],
+        shard_reserved=[reserved],
+    )
+    if typed_open:
+        database.reservations["typed-open"] = {
+            "reservation_id": "typed-open",
+            "workspace_id": "ws-reshard",
+            "settled": False,
+        }
+    if legacy_open:
+        store._write_entity(
+            "reservation",
+            "legacy-open",
+                Reservation(
+                    id="legacy-open",
+                    workspace_id="ws-reshard",
+                    key_hash="key",
+                    amount_microdollars=1,
+            ),
+        )
+    before = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert not result.ready
+    assert not result.applied
+    assert any("drain" in reason for reason in result.reasons)
+    assert _rows(database) == before
+    assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_reshard_refuses_incomplete_rows_and_deposited_credit_drift() -> None:
+    store, database = _seed(
+        shard_credits=[50, 50],
+        shard_usage=[10, 10],
+    )
+    database.typed[CREDIT_BALANCE_TABLE].pop(("ws-reshard", 1))
+
+    incomplete = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+    assert not incomplete.ready
+    assert "configured typed credit shard set is incomplete" in incomplete.reasons
+
+    database.typed[CREDIT_BALANCE_TABLE][("ws-reshard", 1)] = {
+        "workspace_id": "ws-reshard",
+        "shard": 1,
+        "total_credits": 40,
+        "total_usage": 10,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    drift = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+    assert not drift.ready
+    assert any(
+        reason.startswith("typed/JSON deposited-credit totals differ")
+        for reason in drift.reasons
+    )
+    assert store.get_credit_account("ws-reshard").shard_count == 2
+
+
+def test_reshard_refreshes_stale_json_usage_from_authoritative_typed_sum() -> None:
+    store, _database = _seed(shard_credits=[100], shard_usage=[60])
+    account = store.get_credit_account("ws-reshard")
+    account.total_usage_microdollars = 1
+    store._write_entity("credit", "ws-reshard", account)
+
+    result = reshard_credit_account(store, "ws-reshard", 2, apply=True)
+
+    assert result.ready and result.applied
+    refreshed = store.get_credit_account("ws-reshard")
+    assert refreshed.total_usage_microdollars == 60
+    assert refreshed.shard_count == 2
+
+
+def test_post_commit_inspection_reports_exact_partition() -> None:
+    store, _database = _seed(shard_credits=[75], shard_usage=[25])
+    assert reshard_credit_account(store, "ws-reshard", 8, apply=True).applied
+
+    status = inspect_credit_reshard(store, "ws-reshard", 8)
+
+    assert status.ready
+    assert status.current_shard_count == 8
+    assert status.total_credits_micro == 75
+    assert status.total_usage_micro == 25
+    assert status.reserved_micro == 0
+
+
+def test_transaction_rechecks_drain_after_preflight_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database = _seed(shard_credits=[100], shard_usage=[20])
+    before = [dict(row) for row in _rows(database)]
+    original_run = store._run_in_transaction
+
+    def inject_open_hold(callback: Any, *, attempts: int = 8) -> Any:
+        database.reservations["arrived-after-preflight"] = {
+            "reservation_id": "arrived-after-preflight",
+            "workspace_id": "ws-reshard",
+            "settled": False,
+        }
+        return original_run(callback, attempts=attempts)
+
+    monkeypatch.setattr(store, "_run_in_transaction", inject_open_hold)
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert not result.ready
+    assert not result.applied
+    assert "atomic reshard preconditions changed" in result.reasons[0]
+    assert _rows(database) == before
+    assert store.get_credit_account("ws-reshard").shard_count == 1

--- a/tests/test_credit_row_sharding_stress.py
+++ b/tests/test_credit_row_sharding_stress.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from scripts.stress_credit_shards import run_stress
+
+
+def test_credit_shard_lifecycle_stress_preserves_every_invariant() -> None:
+    result = run_stress(
+        request_count=200,
+        concurrency=32,
+        shard_count=16,
+        estimate_micro=300_000,
+    )
+
+    assert result.invariant_clean
+    assert result.authorize.successes == 200
+    assert result.settle.successes == 200
+    assert result.final_reserved_micro == 0
+    assert result.final_usage_micro == 60_000_000
+    assert result.final_total_credits_micro == 60_000_000
+    assert result.observed_key_shards == 16
+    assert result.final_key_usage_micro == 60_000_000
+    assert result.final_key_reserved_micro == 0
+    assert result.authorize.error_types == {}
+    assert result.settle.error_types == {}

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    SettleOutcome,
+    authorize_atomic,
+    settle_atomic,
+)
+from trusted_router.storage_gcp_counter_reconcile import (
+    backsync_typed_to_json,
+    compare,
+    repair_typed_reserved,
+)
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    KEY_LIMIT_TABLE,
+    key_usage_shard_count,
+)
+from trusted_router.storage_gcp_key_shard_admin import (
+    inspect_key_usage_reshard,
+    reshard_key_usage,
+)
+from trusted_router.storage_models import CreditAccount, Workspace
+
+
+def _seed(*, key_shards: int = 4) -> tuple[Any, Any, Any]:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-key-shards"
+    store._write_entity(
+        "workspace",
+        workspace_id,
+        Workspace(
+            id=workspace_id,
+            name="Key shard test",
+            owner_user_id="owner",
+            billing_paused=True,
+        ),
+    )
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(
+            workspace_id=workspace_id,
+            total_credits_microdollars=1_000_000,
+        ),
+    )
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="uncapped-sharded-key",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    key.usage_shard_count = key_shards
+    store._write_entity("api_key", key.hash, key)
+    return store, database, key
+
+
+def _auth_body(authorization_id: str, reservation_id: str) -> str:
+    return json.dumps(
+        {"id": authorization_id, "credit_reservation_id": reservation_id}
+    )
+
+
+def test_key_usage_shards_default_and_fail_closed_for_capped_keys() -> None:
+    assert key_usage_shard_count({}) == 1
+    assert key_usage_shard_count({"usage_shard_count": 16}) == 16
+    with pytest.raises(ValueError, match="positive integer"):
+        key_usage_shard_count({"usage_shard_count": 0})
+    with pytest.raises(ValueError, match="must not exceed"):
+        key_usage_shard_count({"usage_shard_count": 65})
+    with pytest.raises(ValueError, match="only uncapped"):
+        key_usage_shard_count(
+            {"usage_shard_count": 2, "limit_microdollars": 1_000_000}
+        )
+    with pytest.raises(ValueError, match="only uncapped"):
+        key_usage_shard_count(
+            {"usage_shard_count": 2, "limit_daily_microdollars": 1_000_000}
+        )
+
+
+def test_api_key_mirror_creates_every_usage_shard_without_clobbering_counters() -> None:
+    store, database, key = _seed(key_shards=4)
+    rows = database.typed[KEY_LIMIT_TABLE]
+
+    assert {(key.hash, shard) for shard in range(4)} <= set(rows)
+    for shard in range(4):
+        row = rows[(key.hash, shard)]
+        assert row["limit_micro"] is None
+        assert row["usage"] == 0
+        assert row["byok_usage"] == 0
+        assert row["reserved"] == 0
+
+    rows[(key.hash, 2)]["usage"] = 123
+    key.name = "renamed"
+    store._write_entity("api_key", key.hash, key)
+    assert rows[(key.hash, 2)]["usage"] == 123
+
+
+def test_authorize_records_key_shard_and_settle_spreads_exact_usage() -> None:
+    store, database, key = _seed(key_shards=4)
+    reservations: list[str] = []
+
+    for index in range(40):
+        first = index % 4
+        candidates = tuple((first + offset) % 4 for offset in range(4))
+        result = authorize_atomic(
+            store._database,
+            store._param_types,
+            workspace_id="ws-key-shards",
+            key_hash=key.hash,
+            estimate=1_000,
+            has_credit_candidate=True,
+            reservation_usage_type="Credits",
+            idempotency_scope=f"key-shard-{index}",
+            idempotency_fingerprint="same-body",
+            expires_at="2026-12-01T00:00:00Z",
+            build_auth_body=_auth_body,
+            key_shard_candidates=candidates,
+        )
+        assert result["outcome"] == AuthorizeOutcome.ACCEPTED
+        assert result["key_shard"] == first
+        reservations.append(result["reservation_id"])
+
+    for reservation_id in reservations:
+        settled = settle_atomic(
+            store._database,
+            store._param_types,
+            reservation_id=reservation_id,
+            actual_micro=900,
+            settled_usage_type="Credits",
+            success=True,
+        )
+        assert settled["outcome"] == SettleOutcome.SETTLED
+
+    rows = database.typed[KEY_LIMIT_TABLE]
+    assert [rows[(key.hash, shard)]["usage"] for shard in range(4)] == [9_000] * 4
+    assert [rows[(key.hash, shard)]["reserved"] for shard in range(4)] == [0] * 4
+    assert sum(row["total_usage"] for row in database.typed[CREDIT_BALANCE_TABLE].values()) == 36_000
+
+
+def test_idempotent_replay_keeps_original_key_shard() -> None:
+    store, database, key = _seed(key_shards=4)
+    common = {
+        "database": store._database,
+        "param_types": store._param_types,
+        "workspace_id": "ws-key-shards",
+        "key_hash": key.hash,
+        "estimate": 1_000,
+        "has_credit_candidate": True,
+        "reservation_usage_type": "Credits",
+        "idempotency_scope": "same-key-shard-request",
+        "idempotency_fingerprint": "same-body",
+        "expires_at": "2026-12-01T00:00:00Z",
+        "build_auth_body": _auth_body,
+    }
+
+    first = authorize_atomic(**common, key_shard_candidates=(3, 2, 1, 0))
+    replay = authorize_atomic(**common, key_shard_candidates=(0, 1, 2, 3))
+
+    assert first["outcome"] == AuthorizeOutcome.ACCEPTED
+    assert replay["outcome"] == AuthorizeOutcome.REPLAY
+    assert replay["key_shard"] == first["key_shard"] == 3
+    assert database.reservations[first["reservation_id"]]["key_shard"] == 3
+
+
+def test_typed_key_usage_sums_shards_and_current_windows() -> None:
+    store, database, key = _seed(key_shards=4)
+    floors = window_floors(utcnow())
+    rows = database.typed[KEY_LIMIT_TABLE]
+    for shard in range(4):
+        row = rows[(key.hash, shard)]
+        row["usage"] = 10 + shard
+        row["byok_usage"] = 2 + shard
+        row["reserved"] = shard
+        row["day_usage"] = 3 + shard
+        row["day_start"] = floors["daily"]
+        row["week_usage"] = 4 + shard
+        row["week_start"] = floors["weekly"]
+        row["month_usage"] = 5 + shard
+        row["month_start"] = floors["monthly"]
+
+    usage = store.typed_key_usage(key.hash)
+
+    assert usage == {
+        "usage": 46,
+        "byok_usage": 14,
+        "reserved": 6,
+        "windows": {"daily": 18, "weekly": 22, "monthly": 26},
+    }
+
+
+def test_compare_detects_a_missing_configured_key_usage_shard() -> None:
+    store, database, key = _seed(key_shards=4)
+    assert compare(store).clean
+
+    database.typed[KEY_LIMIT_TABLE].pop((key.hash, 3))
+    report = compare(store)
+
+    assert report.key_drift == 1
+    assert report.samples[f"api_key:{key.hash}"]["usage_shard_count"] == (4, 3)
+
+
+def test_deleting_sharded_key_removes_every_typed_usage_row() -> None:
+    store, database, key = _seed(key_shards=4)
+
+    assert store.api_keys.delete(key.hash)
+
+    assert not any(row_key == key.hash for row_key, _shard in database.typed[KEY_LIMIT_TABLE])
+
+
+def test_adding_a_limit_to_sharded_key_is_rejected_atomically() -> None:
+    store, _database, key = _seed(key_shards=4)
+
+    with pytest.raises(ValueError, match="consolidate API-key usage"):
+        store.api_keys.update(key.hash, {"limit_microdollars": 1_000_000})
+
+    persisted = store.api_keys.get_by_hash(key.hash)
+    assert persisted is not None
+    assert persisted.limit_microdollars is None
+    assert persisted.usage_shard_count == 4
+
+
+def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
+    store, database, key = _seed(key_shards=1)
+    floors = window_floors(utcnow())
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row.update(
+        usage=101,
+        byok_usage=37,
+        day_usage=19,
+        day_start=floors["daily"],
+        week_usage=23,
+        week_start=floors["weekly"],
+        month_usage=29,
+        month_start=floors["monthly"],
+    )
+
+    split = reshard_key_usage(store, key.hash, 16, apply=True)
+
+    assert split.ready and split.applied
+    assert split.current_shard_count == 16
+    assert split.usage_micro == 101
+    assert split.byok_usage_micro == 37
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(16)]
+    assert sum(row["usage"] for row in rows) == 101
+    assert sum(row["byok_usage"] for row in rows) == 37
+    assert sum(row["day_usage"] for row in rows) == 19
+    assert sum(row["week_usage"] for row in rows) == 23
+    assert sum(row["month_usage"] for row in rows) == 29
+    assert all(row["reserved"] == 0 for row in rows)
+
+    unshard = reshard_key_usage(store, key.hash, 1, apply=True)
+
+    assert unshard.ready and unshard.applied
+    [single] = [
+        row
+        for (row_key, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
+        if row_key == key.hash
+    ]
+    assert single["usage"] == 101
+    assert single["byok_usage"] == 37
+    assert single["day_usage"] == 19
+    assert single["week_usage"] == 23
+    assert single["month_usage"] == 29
+    persisted = store.api_keys.get_by_hash(key.hash)
+    assert persisted.usage_shard_count == 1
+    assert persisted.usage_microdollars == 101
+    assert persisted.byok_usage_microdollars == 37
+
+
+def test_key_usage_operator_refuses_capped_or_undrained_key() -> None:
+    store, database, key = _seed(key_shards=1)
+    key.limit_microdollars = 1_000_000
+    store._write_entity("api_key", key.hash, key)
+
+    capped = reshard_key_usage(store, key.hash, 4, apply=True)
+    assert not capped.ready
+    assert "capped API key must remain on one usage shard" in capped.reasons
+
+    key.limit_microdollars = None
+    store._write_entity("api_key", key.hash, key)
+    database.reservations["open-key-request"] = {
+        "reservation_id": "open-key-request",
+        "workspace_id": key.workspace_id,
+        "key_hash": key.hash,
+        "settled": False,
+    }
+    undrained = reshard_key_usage(store, key.hash, 4, apply=True)
+    assert not undrained.ready
+    assert any("open typed reservations" in reason for reason in undrained.reasons)
+
+
+def test_key_usage_operator_status_is_idempotent_after_split() -> None:
+    store, _database, key = _seed(key_shards=1)
+    assert reshard_key_usage(store, key.hash, 8, apply=True).applied
+
+    status = inspect_key_usage_reshard(store, key.hash, 8)
+    noop = reshard_key_usage(store, key.hash, 8, apply=True)
+
+    assert status.ready
+    assert status.current_shard_count == 8
+    assert noop.ready
+    assert not noop.applied
+
+
+def test_legacy_rollback_and_shard_zero_repair_refuse_sharded_key_usage() -> None:
+    store, _database, key = _seed(key_shards=4)
+
+    backsync = backsync_typed_to_json(store, key.workspace_id, apply=True)
+    repair = repair_typed_reserved(store, key.workspace_id, apply=True)
+
+    assert not backsync.ready
+    assert "API-key usage is sharded" in backsync.reasons[0]
+    assert not repair.ready
+    assert any("API-key usage is sharded" in reason for reason in repair.reasons)


### PR DESCRIPTION
## Full review rollup
This PR presents the complete credit and uncapped-key sharding stack against main in one diff for final integration review.

Incremental development sequence:
1. #156 additive schema and dark plumbing
2. #158 bounded randomized credit reserve selection
3. #159 transactional fragmentation repair
4. #160 reversible pause, drain, split, and unshard operator
5. #161 uncapped API-key usage sharding and 2,000-request lifecycle stress

## Safety properties
- shard_count=1 remains the default and preserves existing behavior
- workspace credit caps remain exact disjoint sub-budgets; global overspend is impossible
- reservations durably record selected credit and key shards
- split and unshard is paused, drained, atomic, verified, and reversible
- capped API keys are never sharded; lifetime and window budget semantics are unchanged
- old rollback and repair paths refuse sharded state until consolidation
- no production account is activated by code merge
- the serialized deploy workflow applies the idempotent Spanner migration before any new serving revision can start

## Gates
- 1,467 passed, 33 skipped
- ruff clean
- mypy clean
- 2,000/2,000 authorize and settle at concurrency 128 in the deterministic contention-shape harness, exact ledgers and zero residual holds

## Rollout
The deploy workflow now runs `scripts/deploy/migrate_typed_counters.sh` after CI and before rollout. All accounts remain at `shard_count=1` until the code is deployed and audited. Activating a high-volume workspace remains a separate explicit pause, drain, split, verify, and unpause operator action.

## Fable review
Claude Fable approved #156 and found no correctness defects. Its two P3 notes are addressed in this rollup: migration nullability divergence is explicitly documented, and the exact balance-path read is retained because it also gates auto-refill and must not use the allow-stale hot-path cache.