### PR TITLE
Bound Spanner transaction retry to a wall-clock budget

### DIFF
--- a/src/trusted_router/storage_gcp_io.py
+++ b/src/trusted_router/storage_gcp_io.py
@@ -22,22 +22,41 @@ from typing import Any, TypeVar
 T = TypeVar("T")
 
 
+# Total wall-clock budget for a retried transaction. Must sit safely BELOW the
+# upstream HTTP client timeout (30s) so a contended hot-path txn fails RETRYABLY
+# inside the caller's budget instead of hanging past it and surfacing as an
+# upstream 502. Previously up to 8 outer attempts each carried the Spanner
+# client's own ~30s internal retry deadline, with no timeout_secs ever passed
+# inward — so sustained hot-row contention could stall a call for minutes. 20s
+# leaves room for serialization + transit + an actionable error. Maintenance
+# txns (grants/reconcile) normally finish in well under a second, so this cap
+# does not affect them in practice; it only truncates the contended tail.
+TXN_BUDGET_SECONDS = 20.0
+_MIN_INNER_TIMEOUT_SECONDS = 0.5
+
+
 def run_in_transaction_with_retry(
     database: Any,
     func: Callable[..., T],
     *,
     attempts: int = 8,
     attempts_out: list[int] | None = None,
+    total_budget_seconds: float = TXN_BUDGET_SECONDS,
 ) -> T:
-    """Run a Spanner transaction, retrying on ABORTED with backoff + jitter.
+    """Run a Spanner transaction, retrying on ABORTED within a wall-clock budget.
 
     Spanner already retries ABORTED to an internal deadline, but sustained
-    hot-row contention — e.g. many concurrent /internal/gateway/settle calls
-    for one high-QPS api_key all read-modify-writing its usage/reserved
-    counters, or the per-key limit counters in storage_gcp_keys
+    hot-row contention — e.g. many concurrent /internal/gateway/authorize or
+    settle calls for one high-QPS workspace all read-modify-writing its single
+    tr_credit_balance row, or the per-key limit counters in storage_gcp_keys
     (reserve_key_limit / _release_limit / add_usage) — can exhaust that
-    deadline and surface ``Aborted: Transaction was aborted`` to the caller
-    (observed on finalize_gateway_authorization, 2026-06-19).
+    deadline and surface ``Aborted`` to the caller.
+
+    ``total_budget_seconds`` bounds the ENTIRE retry loop (monotonic clock), and
+    each ``database.run_in_transaction`` receives ``timeout_secs`` set to the
+    remaining budget so the client's own internal retry can never run past it.
+    Without this, up to ``attempts`` outer tries each carried a fresh ~30s inner
+    deadline, producing multi-minute hangs past the upstream 30s HTTP timeout.
 
     Retrying is safe ONLY for idempotent transactions. Spanner already
     re-invokes ``func`` on its own internal retries, so callers already write
@@ -48,24 +67,42 @@ def run_in_transaction_with_retry(
     callback performs a non-idempotent side effect. Exponential backoff with
     jitter de-synchronizes contenders so they stop lockstepping on the row.
 
-    Unlike the rate limiter (middleware._enforce_rate_limit), which fails OPEN
-    on this same contention, billing transactions must not be dropped — so we
-    retry rather than swallow the abort.
+    Only ``Aborted`` is retried; every other callback exception (including
+    ``TypeError``) propagates unchanged and is never mistaken for a signature
+    mismatch. On budget exhaustion the final ``Aborted`` is raised so callers
+    can map it to a retryable error rather than a multi-minute hang.
 
     ``attempts_out``, if given, receives the winning attempt number (1 = no
     retry) — used to attribute finalize latency to contention.
     """
     from google.api_core.exceptions import Aborted
 
+    deadline = time.monotonic() + max(total_budget_seconds, _MIN_INNER_TIMEOUT_SECONDS)
     delay = 0.05
+    last_aborted: Aborted | None = None
     for attempt in range(1, attempts + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 and last_aborted is not None:
+            # Budget spent between the last abort's backoff and here.
+            raise last_aborted
+        # Cap the client's internal retry to what's left of our wall-clock so a
+        # single attempt cannot outlive the caller's budget (min floor keeps a
+        # valid positive deadline for the final sliver).
+        inner_timeout = max(remaining, _MIN_INNER_TIMEOUT_SECONDS)
         try:
-            result = database.run_in_transaction(func)
-        except Aborted:
+            result = database.run_in_transaction(func, timeout_secs=inner_timeout)
+        except Aborted as exc:
+            last_aborted = exc
             if attempt >= attempts:
                 raise
+            remaining_after = deadline - time.monotonic()
+            if remaining_after <= _MIN_INNER_TIMEOUT_SECONDS:
+                # No room for another attempt within budget — fail now.
+                raise
             jitter = secrets.randbelow(1_000_000) / 1_000_000 * delay
-            time.sleep(delay + jitter)
+            sleep_for = min(delay + jitter, remaining_after - _MIN_INNER_TIMEOUT_SECONDS)
+            if sleep_for > 0:
+                time.sleep(sleep_for)
             delay = min(delay * 2.0, 2.0)
             continue
         if attempts_out is not None:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -138,8 +138,14 @@ class FakeSpannerDatabase:
         self._ready_barrier = ready_barrier
         self.aborts = 0
         self.commits = 0
+        self.last_timeout_secs: float | None = None
 
-    def run_in_transaction(self, fn: Any) -> Any:
+    def run_in_transaction(self, fn: Any, *, timeout_secs: float | None = None) -> Any:
+        # timeout_secs mirrors google-cloud-spanner's Database.run_in_transaction
+        # kwarg (passed by run_in_transaction_with_retry to bound the inner retry
+        # to the caller's remaining wall-clock budget). The fake commits
+        # synchronously, so it records the value for assertions but does not sleep.
+        self.last_timeout_secs = timeout_secs
         for attempt in range(50):
             txn = _FakeTransaction(self)
             try:

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -73,8 +73,8 @@ class _ProxyDatabase:
     def snapshot(self, **kwargs: Any) -> _ProxySnapshot:
         return _ProxySnapshot(self._inner.snapshot(**kwargs), self._on_execute)
 
-    def run_in_transaction(self, fn: Any) -> Any:
-        return self._inner.run_in_transaction(fn)
+    def run_in_transaction(self, fn: Any, *, timeout_secs: Any = None) -> Any:
+        return self._inner.run_in_transaction(fn, timeout_secs=timeout_secs)
 
 
 def _row(aid: str, rid: str, *, cost: int = 900_000) -> SettleOutboxRow:

--- a/tests/test_storage_gcp_io.py
+++ b/tests/test_storage_gcp_io.py
@@ -5,16 +5,23 @@ from collections.abc import Callable
 import pytest
 from google.api_core.exceptions import Aborted
 
-from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_io import (
+    TXN_BUDGET_SECONDS,
+    run_in_transaction_with_retry,
+)
 
 
 class _RetryingDatabase:
     def __init__(self, aborts_before_success: int) -> None:
         self.aborts_before_success = aborts_before_success
         self.calls = 0
+        self.timeouts: list[float | None] = []
 
-    def run_in_transaction(self, func: Callable[..., str]) -> str:
+    def run_in_transaction(
+        self, func: Callable[..., str], *, timeout_secs: float | None = None
+    ) -> str:
         self.calls += 1
+        self.timeouts.append(timeout_secs)
         if self.calls <= self.aborts_before_success:
             raise Aborted("spanner aborted")
         return func("txn")
@@ -22,6 +29,24 @@ class _RetryingDatabase:
 
 def _txn(_transaction: object) -> str:
     return "ok"
+
+
+class _Clock:
+    """Deterministic monotonic clock; ``sleep`` advances it so backoff spends budget."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _install_clock(monkeypatch: pytest.MonkeyPatch, clock: _Clock) -> None:
+    monkeypatch.setattr("trusted_router.storage_gcp_io.time.monotonic", clock.monotonic)
+    monkeypatch.setattr("trusted_router.storage_gcp_io.time.sleep", clock.sleep)
 
 
 def test_run_in_transaction_with_retry_records_winning_attempt(
@@ -57,3 +82,125 @@ def test_run_in_transaction_with_retry_does_not_record_exhausted_attempts(
         run_in_transaction_with_retry(database, _txn, attempts=3, attempts_out=attempts_out)
 
     assert attempts_out == []
+
+
+def test_passes_remaining_budget_as_inner_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The first inner attempt is handed ~the full budget as timeout_secs."""
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+
+    database = _RetryingDatabase(aborts_before_success=0)
+    assert run_in_transaction_with_retry(database, _txn, total_budget_seconds=17.0) == "ok"
+    assert database.timeouts == [pytest.approx(17.0)]
+
+
+def test_default_budget_is_below_http_timeout() -> None:
+    # The whole point of the cap: it must fail retryably before the upstream 30s
+    # HTTP timeout turns the hang into an upstream 502.
+    assert TXN_BUDGET_SECONDS < 30.0
+
+
+class _TimedAbortingDatabase:
+    """Aborts every attempt, advancing the clock to simulate a contended txn and
+    recording the ``timeout_secs`` it was handed each call."""
+
+    def __init__(self, clock: _Clock, attempt_cost: float) -> None:
+        self.clock = clock
+        self.attempt_cost = attempt_cost
+        self.calls = 0
+        self.timeouts: list[float | None] = []
+
+    def run_in_transaction(
+        self, func: Callable[..., str], *, timeout_secs: float | None = None
+    ) -> str:
+        self.calls += 1
+        self.timeouts.append(timeout_secs)
+        budget = timeout_secs if timeout_secs is not None else self.attempt_cost
+        self.clock.now += min(self.attempt_cost, budget)
+        raise Aborted("contended")
+
+
+def test_budget_bounds_total_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+
+    start = clock.now
+    budget = 10.0
+    attempt_cost = 3.0
+    database = _TimedAbortingDatabase(clock, attempt_cost=attempt_cost)
+
+    with pytest.raises(Aborted):
+        # attempts far exceeds what the budget can fit — the wall-clock, not the
+        # attempt count, must be what stops the loop.
+        run_in_transaction_with_retry(
+            database, _txn, attempts=1000, total_budget_seconds=budget
+        )
+
+    elapsed = clock.now - start
+    # A single in-flight attempt may overrun the deadline by at most its own cost.
+    assert elapsed <= budget + attempt_cost
+    # Budget, not the 1000 attempt cap, terminated the loop.
+    assert database.calls < 1000
+    # Every inner attempt got a positive deadline that never exceeded the budget.
+    assert database.timeouts
+    assert all(t is not None and 0.0 < t <= budget + 1e-9 for t in database.timeouts)
+
+
+def test_backoff_never_sleeps_past_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+
+    start = clock.now
+    budget = 5.0
+    # attempt_cost 0 => all elapsed time comes from backoff sleeps; if backoff ever
+    # slept past the deadline this would overrun.
+    database = _TimedAbortingDatabase(clock, attempt_cost=0.0)
+
+    with pytest.raises(Aborted):
+        run_in_transaction_with_retry(
+            database, _txn, attempts=1000, total_budget_seconds=budget
+        )
+
+    assert clock.now - start <= budget
+
+
+def test_non_aborted_exceptions_are_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("trusted_router.storage_gcp_io.time.sleep", lambda _seconds: None)
+
+    class _Boom:
+        def __init__(self, exc: Exception) -> None:
+            self.exc = exc
+            self.calls = 0
+
+        def run_in_transaction(
+            self, func: Callable[..., str], *, timeout_secs: float | None = None
+        ) -> str:
+            self.calls += 1
+            raise self.exc
+
+    for exc in (ValueError("boom"), TypeError("bad signature"), RuntimeError("x")):
+        database = _Boom(exc)
+        with pytest.raises(type(exc)):
+            run_in_transaction_with_retry(database, _txn, attempts=5)
+        assert database.calls == 1
+
+
+def test_aborted_retries_then_succeeds_within_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+
+    database = _RetryingDatabase(aborts_before_success=3)
+    attempts_box: list[int] = []
+    assert (
+        run_in_transaction_with_retry(
+            database, _txn, attempts=8, attempts_out=attempts_box, total_budget_seconds=20.0
+        )
+        == "ok"
+    )
+    assert attempts_box == [4]
+    assert database.calls == 4
+    # Each attempt's inner deadline shrank as the shared budget was consumed by backoff.
+    handed = [t for t in database.timeouts if t is not None]
+    assert handed[0] == pytest.approx(20.0)
+    assert all(0.0 < t <= 20.0 + 1e-9 for t in handed)
+    assert handed == sorted(handed, reverse=True)


### PR DESCRIPTION
## What

`run_in_transaction_with_retry` could run up to 8 outer attempts, each carrying the Spanner client's own ~30s internal ABORTED-retry deadline, and never passed `timeout_secs` inward. Under sustained hot-row contention (many concurrent authorize/settle calls read-modify-writing one workspace's balance row, or per-key limit counters) a single call could therefore hang for minutes — past the upstream 30s HTTP timeout — and surface as an upstream 502.

## Fix

Add a monotonic wall-clock budget (`TXN_BUDGET_SECONDS = 20`, safely below the 30s HTTP timeout) that bounds the ENTIRE retry loop. Each inner `run_in_transaction` now receives `timeout_secs = remaining budget`, so the client's own retry can't outlive it; backoff is capped so a sleep can't cross the deadline; only `Aborted` is retried; the final `Aborted` is raised on exhaustion so callers map it to a retryable error instead of hanging. Default-only change — no call-site edits.

## Tests

`tests/test_storage_gcp_io.py` gains coverage for budget bounding, inner-timeout propagation, backoff-never-past-deadline, Aborted-retry-then-succeed, non-Aborted (incl. TypeError) pass-through, and exhaustion. Fakes accept/record `timeout_secs`. 241 storage/billing/settle tests pass locally.

## Review

codex-cli (gpt-5.5 xhigh) adversarial review: **PASS, no findings** (independently confirmed the Spanner Python client's `run_in_transaction` accepts `timeout_secs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)