### PR TITLE
Run gateway/synthetic storage off the event loop

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -80,6 +80,24 @@ async def authorize_gateway(
     body: GatewayAuthorizeRequest,
     settings: Settings,
 ) -> dict[str, Any]:
+    """Async entrypoint for the authorize path.
+
+    The work below is entirely synchronous storage IO (no awaits), so run it in a
+    worker thread via ``run_in_threadpool``. Left on the event loop, ONE contended
+    workspace's slow authorize/reserve transaction stalls EVERY in-flight request
+    sharing the loop (head-of-line blocking) — so unrelated requests fail even
+    though they have nothing to do with the slow one. Offloading keeps the loop
+    free while this request's blocking storage runs; the response is byte-identical.
+    Kept ``async`` so callers/tests await it unchanged.
+    """
+    return await run_in_threadpool(_authorize_gateway_sync, request, body, settings)
+
+
+def _authorize_gateway_sync(
+    request: Request,
+    body: GatewayAuthorizeRequest,
+    settings: Settings,
+) -> dict[str, Any]:
     """Core gateway-authorize logic, extracted from the route closure so it is a
     named, directly unit-testable function (#40). The registered route handler is
     a thin wrapper; behavior is byte-identical to the prior inline handler."""
@@ -409,31 +427,103 @@ async def authorize_gateway(
     )
 
 
+def _gateway_validate_sync(
+    request: Request,
+    body: GatewayValidateRequest,
+    settings: Settings,
+) -> dict[str, Any]:
+    require_internal_gateway(request, settings)
+    api_key = _api_key_for_gateway_lookup(
+        api_key_hash=body.api_key_hash,
+        api_key_lookup_hash=body.api_key_lookup_hash,
+    )
+    if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
+        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+    workspace = STORE.get_workspace(api_key.workspace_id)
+    if workspace is None:
+        raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
+    assert_workspace_billing_active(workspace)
+    return {
+        "data": {
+            "workspace_id": workspace.id,
+            "api_key_hash": api_key.hash,
+            "route_type": body.route_type,
+        }
+    }
+
+
+def _gateway_key_info_sync(
+    request: Request,
+    body: GatewayValidateRequest,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Key self-introspection for the enclave: the /v1/key passthrough.
+
+    The enclave NEVER forwards the raw bearer to the control plane (the
+    attested contract; authorize sends a lookup hash) — so agent budget
+    reads come through here keyed by the same lookup hash + internal
+    token. Deliberately no billing-pause gate: reading your own limits
+    while paused is a harmless, useful read."""
+    require_internal_gateway(request, settings)
+    api_key = _api_key_for_gateway_lookup(
+        api_key_hash=body.api_key_hash,
+        api_key_lookup_hash=body.api_key_lookup_hash,
+    )
+    if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
+        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+    from trusted_router.routes.keys import _enriched_key_shape
+
+    return {"data": _enriched_key_shape(api_key)}
+
+
+def _gateway_resolve_custom_model_sync(
+    request: Request,
+    body: GatewayResolveCustomModelRequest,
+    settings: Settings,
+) -> dict[str, Any]:
+    require_internal_gateway(request, settings)
+    api_key = _api_key_for_gateway_lookup(
+        api_key_hash=body.api_key_hash,
+        api_key_lookup_hash=body.api_key_lookup_hash,
+    )
+    if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
+        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+    workspace = STORE.get_workspace(api_key.workspace_id)
+    if workspace is None:
+        raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
+    assert_workspace_billing_active(workspace)
+    if not is_custom_model_id(body.model):
+        raise api_error(400, "Model is not a custom model", ErrorType.BAD_REQUEST)
+    custom_model = STORE.get_custom_model(normalize_custom_model_id(body.model))
+    if custom_model is None or not custom_model.enabled:
+        raise api_error(404, "Custom model not found", ErrorType.NOT_FOUND)
+    return {
+        "data": {
+            "workspace_id": workspace.id,
+            "api_key_hash": api_key.hash,
+            "route_type": body.route_type,
+            "custom_model": {
+                "id": custom_model.id,
+                "name": custom_model.name,
+                "base_model_id": custom_model.base_model_id,
+                "hidden_prompt": custom_model.hidden_prompt,
+                "revision": custom_model.revision,
+            },
+        }
+    }
+
+
 def register(router: APIRouter) -> None:
+    # Every handler below does synchronous storage IO. They run it via
+    # run_in_threadpool so a slow/contended transaction on one request never
+    # blocks the shared event loop for all others.
     @router.post("/internal/gateway/validate")
     async def gateway_validate(
         request: Request,
         body: GatewayValidateRequest,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        require_internal_gateway(request, settings)
-        api_key = _api_key_for_gateway_lookup(
-            api_key_hash=body.api_key_hash,
-            api_key_lookup_hash=body.api_key_lookup_hash,
-        )
-        if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-            raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
-        workspace = STORE.get_workspace(api_key.workspace_id)
-        if workspace is None:
-            raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
-        assert_workspace_billing_active(workspace)
-        return {
-            "data": {
-                "workspace_id": workspace.id,
-                "api_key_hash": api_key.hash,
-                "route_type": body.route_type,
-            }
-        }
+        return await run_in_threadpool(_gateway_validate_sync, request, body, settings)
 
     @router.post("/internal/gateway/key")
     async def gateway_key_info(
@@ -441,23 +531,7 @@ def register(router: APIRouter) -> None:
         body: GatewayValidateRequest,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        """Key self-introspection for the enclave: the /v1/key passthrough.
-
-        The enclave NEVER forwards the raw bearer to the control plane (the
-        attested contract; authorize sends a lookup hash) — so agent budget
-        reads come through here keyed by the same lookup hash + internal
-        token. Deliberately no billing-pause gate: reading your own limits
-        while paused is a harmless, useful read."""
-        require_internal_gateway(request, settings)
-        api_key = _api_key_for_gateway_lookup(
-            api_key_hash=body.api_key_hash,
-            api_key_lookup_hash=body.api_key_lookup_hash,
-        )
-        if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-            raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
-        from trusted_router.routes.keys import _enriched_key_shape
-
-        return {"data": _enriched_key_shape(api_key)}
+        return await run_in_threadpool(_gateway_key_info_sync, request, body, settings)
 
     @router.post("/internal/gateway/resolve-custom-model")
     async def gateway_resolve_custom_model(
@@ -465,36 +539,9 @@ def register(router: APIRouter) -> None:
         body: GatewayResolveCustomModelRequest,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        require_internal_gateway(request, settings)
-        api_key = _api_key_for_gateway_lookup(
-            api_key_hash=body.api_key_hash,
-            api_key_lookup_hash=body.api_key_lookup_hash,
+        return await run_in_threadpool(
+            _gateway_resolve_custom_model_sync, request, body, settings
         )
-        if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-            raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
-        workspace = STORE.get_workspace(api_key.workspace_id)
-        if workspace is None:
-            raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
-        assert_workspace_billing_active(workspace)
-        if not is_custom_model_id(body.model):
-            raise api_error(400, "Model is not a custom model", ErrorType.BAD_REQUEST)
-        custom_model = STORE.get_custom_model(normalize_custom_model_id(body.model))
-        if custom_model is None or not custom_model.enabled:
-            raise api_error(404, "Custom model not found", ErrorType.NOT_FOUND)
-        return {
-            "data": {
-                "workspace_id": workspace.id,
-                "api_key_hash": api_key.hash,
-                "route_type": body.route_type,
-                "custom_model": {
-                    "id": custom_model.id,
-                    "name": custom_model.name,
-                    "base_model_id": custom_model.base_model_id,
-                    "hidden_prompt": custom_model.hidden_prompt,
-                    "revision": custom_model.revision,
-                },
-            }
-        }
 
     @router.post("/internal/gateway/authorize")
     async def gateway_authorize(
@@ -512,7 +559,10 @@ def register(router: APIRouter) -> None:
         background_tasks: BackgroundTasks,
     ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
-        return _settle_gateway_authorization(
+        # background_tasks.add_task is a plain list append inside the sync core;
+        # the tasks themselves still run on the loop after the response.
+        return await run_in_threadpool(
+            _settle_gateway_authorization,
             body,
             success=True,
             settings=settings,
@@ -527,7 +577,8 @@ def register(router: APIRouter) -> None:
         background_tasks: BackgroundTasks,
     ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
-        return _settle_gateway_authorization(
+        return await run_in_threadpool(
+            _settle_gateway_authorization,
             body,
             success=False,
             settings=settings,

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -517,6 +517,14 @@ def register(router: APIRouter) -> None:
     # Every handler below does synchronous storage IO. They run it via
     # run_in_threadpool so a slow/contended transaction on one request never
     # blocks the shared event loop for all others.
+    #
+    # These share AnyIO's default worker pool (40 tokens) with FastAPI's other
+    # sync dependencies — deliberately, NOT a dedicated CapacityLimiter. Cloud
+    # Run runs this service at --concurrency=2 (rollout.sh), so at most ~2
+    # offloads are ever in flight per instance (far under 40); load scales out
+    # across instances, not up per-instance, and prod inference never touches
+    # this service (it goes through the enclave). Give gateway storage its own
+    # limiter only if TR_CLOUD_RUN_CONCURRENCY is raised toward the pool size.
     @router.post("/internal/gateway/validate")
     async def gateway_validate(
         request: Request,

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Request
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
@@ -37,8 +38,9 @@ def register(router: APIRouter) -> None:
         if not isinstance(raw_samples, list):
             raise api_error(400, "samples must be an array", ErrorType.BAD_REQUEST)
         samples = [_sample_from_body(item) for item in raw_samples]
-        for sample in samples:
-            STORE.record_synthetic_probe_sample(sample)
+        # Offload the blocking storage writes so a slow write never stalls the
+        # shared event loop; still awaited so `recorded` stays truthful.
+        await run_in_threadpool(_record_probe_samples, samples)
         return {"data": {"recorded": len(samples)}}
 
     @router.post("/internal/synthetic/benchmark")
@@ -53,8 +55,7 @@ def register(router: APIRouter) -> None:
         if not isinstance(raw_samples, list):
             raise api_error(400, "samples must be an array", ErrorType.BAD_REQUEST)
         samples = [_benchmark_from_body(item) for item in raw_samples]
-        for sample in samples:
-            STORE.record_provider_benchmark(sample)
+        await run_in_threadpool(_record_benchmark_samples, samples)
         return {"data": {"recorded": len(samples)}}
 
     @router.post("/internal/synthetic/run")
@@ -94,9 +95,18 @@ def register(router: APIRouter) -> None:
                         model=settings.synthetic_monitor_model,
                     )
                 )
-        for sample in samples:
-            STORE.record_synthetic_probe_sample(sample)
+        await run_in_threadpool(_record_probe_samples, samples)
         return {"data": {"recorded": len(samples), "samples": [s.public_dict() for s in samples]}}
+
+
+def _record_probe_samples(samples: list[SyntheticProbeSample]) -> None:
+    for sample in samples:
+        STORE.record_synthetic_probe_sample(sample)
+
+
+def _record_benchmark_samples(samples: list[ProviderBenchmarkSample]) -> None:
+    for sample in samples:
+        STORE.record_provider_benchmark(sample)
 
 
 def _sample_from_body(body: Any) -> SyntheticProbeSample:

--- a/tests/test_gateway_event_loop_isolation.py
+++ b/tests/test_gateway_event_loop_isolation.py
@@ -1,0 +1,199 @@
+"""Patch B regression: the gateway/synthetic handlers must run their synchronous
+storage IO OFF the event loop (via run_in_threadpool).
+
+The failure mode was head-of-line blocking: one contended workspace's slow
+authorize/settle transaction ran on the shared FastAPI event loop, so EVERY other
+in-flight request stalled behind it. These tests prove the storage now runs in a
+worker thread and the loop stays free.
+
+Two properties are asserted:
+  * off-loop: the storage callback runs on a different thread than the loop
+    (deterministic — no timing).
+  * loop-responsive: while a storage call is blocked in its worker thread, other
+    coroutines keep making progress (would deadlock/time out on a regression).
+
+Storage methods are spied at the InMemoryStore CLASS level (not on the STORE
+proxy). The proxy forwards via __getattr__, so a proxy-level monkeypatch leaves a
+shadowing instance attribute that leaks across tests (same reasoning as the
+auto_credit_test_workspaces fixture in conftest). Class-level patches restore
+cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes.internal.gateway import authorize_gateway
+from trusted_router.schemas import GatewayAuthorizeRequest
+from trusted_router.storage import STORE, InMemoryStore
+
+
+def _req() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+
+
+def _settings() -> Settings:
+    return Settings(environment="test", internal_gateway_token=None)
+
+
+def _seed_key() -> Any:
+    user = STORE.ensure_user("loop@example.com")
+    ws = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.credit_workspace_once(ws.id, 50_000_000, "seed")
+    _raw, key = STORE.create_api_key(workspace_id=ws.id, name="k", creator_user_id=user.id)
+    return key
+
+
+def _authorize_body(key: Any) -> GatewayAuthorizeRequest:
+    return GatewayAuthorizeRequest(
+        api_key_hash=key.hash,
+        model="anthropic/claude-haiku-4.5",
+        estimated_input_tokens=100,
+        max_output_tokens=100,
+    )
+
+
+def test_authorize_gateway_does_not_block_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    key = _seed_key()
+    body = _authorize_body(key)
+
+    started = threading.Event()
+    release = threading.Event()
+    worker_tid: dict[str, int] = {}
+    original_get_workspace = InMemoryStore.get_workspace
+
+    def blocking_get_workspace(self: Any, workspace_id: str) -> Any:
+        worker_tid["tid"] = threading.get_ident()
+        started.set()
+        assert release.wait(timeout=5.0), "worker thread was never released"
+        return original_get_workspace(self, workspace_id)
+
+    monkeypatch.setattr(InMemoryStore, "get_workspace", blocking_get_workspace)
+
+    async def scenario() -> dict:
+        loop_tid = threading.get_ident()
+        task = asyncio.create_task(authorize_gateway(_req(), body, _settings()))
+
+        # The loop must stay responsive enough to observe the worker thread begin
+        # its blocking storage call. If authorize regressed to running storage on
+        # the loop, this poll could never advance and the test would time out.
+        for _ in range(1000):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert started.is_set(), "authorize blocked the loop before reaching storage"
+
+        # Other coroutines keep making progress while the storage call is blocked.
+        beats = 0
+        for _ in range(5):
+            beats += 1
+            await asyncio.sleep(0.005)
+        assert beats == 5
+
+        # The storage ran on a worker thread, not the event-loop thread.
+        assert worker_tid["tid"] != loop_tid
+
+        release.set()
+        return await asyncio.wait_for(task, timeout=5.0)
+
+    result = asyncio.run(asyncio.wait_for(scenario(), timeout=15.0))
+    assert result["data"]["authorization_id"]
+
+
+@pytest.mark.parametrize("path", ["settle", "refund"])
+def test_settle_and_refund_run_storage_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    seen: dict[str, int] = {}
+    original_get_auth = InMemoryStore.get_gateway_authorization
+
+    def spy_get_auth(self: Any, authorization_id: str) -> Any:
+        seen["tid"] = threading.get_ident()
+        return original_get_auth(self, authorization_id)
+
+    monkeypatch.setattr(InMemoryStore, "get_gateway_authorization", spy_get_auth)
+
+    async def scenario() -> int:
+        loop_tid = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            auth = await ac.post(
+                "/v1/internal/gateway/authorize",
+                json={
+                    "api_key_hash": key.hash,
+                    "model": "anthropic/claude-haiku-4.5",
+                    "estimated_input_tokens": 100,
+                    "max_output_tokens": 100,
+                },
+            )
+            assert auth.status_code == 200, auth.text
+            authorization_id = auth.json()["data"]["authorization_id"]
+            resp = await ac.post(
+                f"/v1/internal/gateway/{path}",
+                json={
+                    "authorization_id": authorization_id,
+                    "actual_input_tokens": 100,
+                    "actual_output_tokens": 50,
+                    "request_id": f"loop-iso-{path}",
+                    "elapsed_seconds": 0.1,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+        return loop_tid
+
+    loop_tid = asyncio.run(scenario())
+    assert "tid" in seen, f"{path} never reached get_gateway_authorization"
+    assert seen["tid"] != loop_tid
+
+
+def test_synthetic_samples_write_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+
+    seen: dict[str, int] = {}
+    original_record = InMemoryStore.record_synthetic_probe_sample
+
+    def spy_record(self: Any, sample: Any) -> None:
+        seen["tid"] = threading.get_ident()
+        original_record(self, sample)
+
+    monkeypatch.setattr(InMemoryStore, "record_synthetic_probe_sample", spy_record)
+
+    async def scenario() -> int:
+        loop_tid = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            resp = await ac.post(
+                "/v1/internal/synthetic/samples",
+                json={
+                    "samples": [
+                        {
+                            "id": "s1",
+                            "probe_type": "gateway",
+                            "target": "openai",
+                            "target_url": "https://example.invalid",
+                            "monitor_region": "us-central1",
+                            "status": "ok",
+                        }
+                    ]
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["data"]["recorded"] == 1
+        return loop_tid
+
+    loop_tid = asyncio.run(scenario())
+    assert "tid" in seen, "synthetic samples never reached the storage write"
+    assert seen["tid"] != loop_tid


### PR DESCRIPTION
## What

`authorize_gateway` and the gateway `settle` / `refund` / `validate` / `key-info` / `resolve-custom-model` routes, plus the synthetic ingestion routes, were `async` handlers doing their storage IO **synchronously on the shared event loop** (`authorize_gateway` has zero `await`s — 330 lines of blocking storage in an `async def`). Under sustained contention on one workspace, that single request's slow authorize/reserve/settle transaction stalled EVERY in-flight request on the loop (head-of-line blocking), failing unrelated requests that had nothing to do with the slow one.

## Fix

Offload the synchronous storage to a worker thread via `run_in_threadpool` (already the pattern for the settle-outbox drain), so the loop stays free while one request's blocking storage runs:

- `authorize_gateway` becomes a thin async wrapper over `_authorize_gateway_sync`; the async signature is preserved so callers/tests await it unchanged.
- validate / key-info / resolve-custom-model extract sync cores, run off-loop.
- settle / refund offload `_settle_gateway_authorization` (`background_tasks.add_task` is a list append inside the sync core; the tasks still run on the loop after the response).
- synthetic samples/benchmark/run offload their storage-write loops, still awaited so `recorded` stays truthful.

Responses are byte-identical.

## Tests

New `tests/test_gateway_event_loop_isolation.py` proves the storage runs on a worker thread (deterministic thread-id check) and the loop stays responsive while a storage call is blocked (would deadlock/time out on a regression), for authorize + settle + refund + synthetic. 181 gateway/billing/settle/synthetic tests pass locally.

## Review (codex-cli gpt-5.5 xhigh) — 2 follow-up findings, no blockers

- **MAJOR (follow-up):** gateway storage now shares the global AnyIO thread pool (default 40) with other routes' sync dependencies. A hot workspace could saturate the pool so unrelated requests queue before their sync auth dep. The loop stays free, so this is a *milder, bounded* degradation than the loop-freeze it replaces (and this PR's companion caps each txn at 20s, bounding thread-hold time). A dedicated limiter / backpressure for gateway storage is the proper fix — filed as follow-up.
- **MINOR (follow-up):** the isolation tests assert off-loop for authorize/settle/refund/synthetic but don't cover validate/key-info/resolve/benchmark. Each handler is offloaded as one atomic `run_in_threadpool` call, so a "offload the read but not the write" partial regression isn't structurally possible today; broader coverage is a nice-to-have.

Companion PR: #163 (bound the transaction retry wall-clock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)