### PR TITLE
Ops: guarded production billing shard activation

### DIFF
--- a/.github/workflows/reshard-billing-workspace.yml
+++ b/.github/workflows/reshard-billing-workspace.yml
@@ -1,0 +1,95 @@
+name: Reshard Billing Workspace
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Read status, pause/drain/split, or verify/unpause"
+        type: choice
+        required: true
+        options: [status, prepare, finish]
+        default: status
+      workspace_id:
+        description: "Exact workspace ID (preferred after initial lookup)"
+        type: string
+        required: false
+      owner_email:
+        description: "Owner email; accepted only when it has exactly one workspace"
+        type: string
+        required: false
+      shards:
+        description: "Target shard count; use 1 to consolidate"
+        type: choice
+        required: true
+        options: ["1", "4", "8", "16", "32", "64"]
+        default: "16"
+      confirmation:
+        description: "Type APPLY for prepare/finish; status is always read-only"
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+# Billing maintenance is globally serialized. A second dispatch waits instead
+# of racing a workspace that may be paused between prepare and finish.
+concurrency:
+  group: production-billing-workspace-reshard
+  cancel-in-progress: false
+
+jobs:
+  operate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
+      - name: Run guarded workspace operator
+        env:
+          OPERATION: ${{ inputs.operation }}
+          WORKSPACE_ID: ${{ inputs.workspace_id }}
+          OWNER_EMAIL: ${{ inputs.owner_email }}
+          SHARDS: ${{ inputs.shards }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WORKSPACE_ID}" ] && [ -n "${OWNER_EMAIL}" ]; then
+            echo "Provide workspace_id or owner_email, not both."
+            exit 2
+          fi
+          if [ -z "${WORKSPACE_ID}" ] && [ -z "${OWNER_EMAIL}" ]; then
+            echo "Provide workspace_id or owner_email."
+            exit 2
+          fi
+
+          args=("${OPERATION}" --shards "${SHARDS}")
+          if [ -n "${WORKSPACE_ID}" ]; then
+            args+=(--workspace "${WORKSPACE_ID}")
+          else
+            args+=(--owner-email "${OWNER_EMAIL}")
+          fi
+
+          case "${OPERATION}" in
+            status) ;;
+            prepare|finish)
+              if [ "${CONFIRMATION}" != "APPLY" ]; then
+                echo "Mutation refused: type APPLY in confirmation."
+                exit 2
+              fi
+              args+=(--apply)
+              ;;
+            *) echo "Unknown operation: ${OPERATION}"; exit 2 ;;
+          esac
+
+          PYTHONPATH=src uv run python scripts/shard_workspace.py "${args[@]}"

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -6,6 +6,9 @@ silently resume billing:
   # Pause, drain-check, and atomically split. Re-run while parked if draining.
   python scripts/shard_workspace.py prepare --workspace WS --shards 16 --apply
 
+  # Owner email is accepted only when it resolves to exactly one workspace.
+  python scripts/shard_workspace.py status --owner-email owner@example.com --shards 16
+
   # Verify the committed shape + global billing invariants, then unpause.
   python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 
@@ -45,6 +48,26 @@ from trusted_router.storage_gcp_key_shard_admin import (
     reshard_key_usage,
 )
 from trusted_router.storage_models import ApiKey
+
+
+def _resolve_workspace(store: Any, args: argparse.Namespace) -> str:
+    """Resolve the operator target without guessing among workspaces."""
+    if args.workspace:
+        return str(args.workspace)
+
+    user = store.find_user_by_email(str(args.owner_email))
+    if user is None:
+        raise ValueError("owner email does not match a user")
+    workspaces = [
+        workspace
+        for workspace in store.list_workspaces_for_user(user.id)
+        if workspace.owner_user_id == user.id
+    ]
+    if len(workspaces) != 1:
+        raise ValueError(
+            f"owner has {len(workspaces)} workspaces; select one with --workspace"
+        )
+    return str(workspaces[0].id)
 
 
 def _print_status(status: CreditReshardResult) -> None:
@@ -217,7 +240,9 @@ def _parser() -> argparse.ArgumentParser:
         ("finish", run_finish),
     ):
         command = sub.add_parser(name)
-        command.add_argument("--workspace", required=True)
+        target = command.add_mutually_exclusive_group(required=True)
+        target.add_argument("--workspace")
+        target.add_argument("--owner-email")
         command.add_argument("--shards", required=True, type=_shard_count_arg)
         if name != "status":
             command.add_argument("--apply", action="store_true")
@@ -228,6 +253,12 @@ def _parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = _parser().parse_args()
     store = create_store(Settings())
+    try:
+        args.workspace = _resolve_workspace(store, args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(f"resolved workspace: {args.workspace}")
     return int(args.handler(store, args))
 
 

--- a/tests/test_shard_workspace_operator.py
+++ b/tests/test_shard_workspace_operator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from scripts import shard_workspace
+from trusted_router.storage import InMemoryStore
+
+
+def _args(*, workspace: str | None = None, owner_email: str | None = None) -> argparse.Namespace:
+    return argparse.Namespace(workspace=workspace, owner_email=owner_email)
+
+
+def test_resolve_workspace_uses_explicit_id_without_lookup() -> None:
+    assert shard_workspace._resolve_workspace(object(), _args(workspace="ws-exact")) == "ws-exact"
+
+
+def test_resolve_workspace_accepts_owner_with_one_workspace() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("owner@example.com", email="owner@example.com")
+    expected = store.list_workspaces_for_user(user.id)[0].id
+
+    assert (
+        shard_workspace._resolve_workspace(store, _args(owner_email="owner@example.com"))
+        == expected
+    )
+
+
+def test_resolve_workspace_refuses_unknown_or_ambiguous_owner() -> None:
+    store = InMemoryStore()
+    with pytest.raises(ValueError, match="does not match"):
+        shard_workspace._resolve_workspace(store, _args(owner_email="missing@example.com"))
+
+    user = store.ensure_user("owner@example.com", email="owner@example.com")
+    store.create_workspace(user.id, "Second workspace")
+    with pytest.raises(ValueError, match="select one with --workspace"):
+        shard_workspace._resolve_workspace(store, _args(owner_email="owner@example.com"))
+
+
+def test_resolve_workspace_ignores_memberships_the_user_does_not_own() -> None:
+    store = InMemoryStore()
+    owner = store.ensure_user("owner@example.com", email="owner@example.com")
+    member = store.ensure_user("member@example.com", email="member@example.com")
+    owned = store.list_workspaces_for_user(member.id)[0]
+    foreign = store.list_workspaces_for_user(owner.id)[0]
+    store.add_members(foreign.id, ["member@example.com"])
+
+    assert (
+        shard_workspace._resolve_workspace(store, _args(owner_email="member@example.com"))
+        == owned.id
+    )
+
+
+def test_parser_requires_exactly_one_target() -> None:
+    parser = shard_workspace._parser()
+    parsed = parser.parse_args(
+        ["status", "--owner-email", "owner@example.com", "--shards", "16"]
+    )
+    assert parsed.owner_email == "owner@example.com"
+    assert parsed.workspace is None
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["status", "--shards", "16"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "status",
+                "--workspace",
+                "ws",
+                "--owner-email",
+                "owner@example.com",
+                "--shards",
+                "16",
+            ]
+        )


### PR DESCRIPTION
## Summary
Add a guarded GitHub Actions operator for the already-deployed credit/key row-sharding implementation.

- resolve an exact workspace ID or an owner email that owns exactly one workspace
- serialize all production reshard operations globally
- expose only read-only status, prepare, and finish
- require an explicit APPLY confirmation for mutations
- preserve the two-phase pause/drain/split then verify/unpause contract
- leave a workspace paused on every failure

## Verification
- 28 focused operator/reshard/key-shard tests passed
- ruff clean
- mypy clean
- workflow YAML parsed
- post-deploy production invariant audit remains CLEAN: credit 0/102 drift/orphans, key 0/152 drift/orphans