### PR TITLE
Fix credit-shard rebalance: negative headroom is not corruption (500→402)

### DIFF
--- a/src/trusted_router/storage_gcp_credit_rebalance.py
+++ b/src/trusted_router/storage_gcp_credit_rebalance.py
@@ -39,7 +39,11 @@ def rebalance_credit_for_estimate(
     if target_shard < 0 or target_shard >= count:
         raise ValueError("rebalance target shard is outside configured range")
     if estimate <= 0:
-        raise ValueError("rebalance estimate must be positive")
+        return {
+            "outcome": RebalanceOutcome.NOT_NEEDED,
+            "moved_micro": 0,
+            "target_shard": target_shard,
+        }
     pt = param_types
 
     def txn(transaction: Any) -> dict[str, int | str]:
@@ -63,10 +67,6 @@ def rebalance_credit_for_estimate(
         headroom: dict[int, int] = {}
         for shard, total_credits, total_usage, reserved in rows:
             available = int(total_credits) - int(total_usage) - int(reserved)
-            if available < 0:
-                raise _RebalanceInvariantError(
-                    f"credit shard {shard} exceeds its sub-budget"
-                )
             headroom[int(shard)] = available
 
         target_available = headroom[target_shard]
@@ -76,6 +76,13 @@ def rebalance_credit_for_estimate(
                 "moved_micro": 0,
                 "target_shard": target_shard,
             }
+        # Feasibility is the SIGNED global available — sum over every shard of
+        # (credits - usage - reserved), negatives included. An over-spent shard's
+        # debt must count against affordability, otherwise we would consolidate
+        # enough onto the target for reserve to succeed while the workspace is
+        # globally overdrawn (free spend). Donors below still pull only from
+        # POSITIVE headroom; when this passes, positive donor headroom is
+        # provably >= `needed`, so the plan always completes.
         if sum(headroom.values()) < estimate:
             return {
                 "outcome": RebalanceOutcome.INSUFFICIENT,

--- a/tests/test_credit_row_sharding_increment3.py
+++ b/tests/test_credit_row_sharding_increment3.py
@@ -102,6 +102,10 @@ def _typed_authorize(
     )
 
 
+def _available(row: dict[str, Any]) -> int:
+    return int(row["total_credits"]) - int(row["total_usage"]) - int(row["reserved"])
+
+
 def test_rebalance_moves_only_idle_budget_and_preserves_global_totals() -> None:
     store, database, _key = _seed([100, 100], usage=[60, 60])
 
@@ -154,16 +158,115 @@ def test_rebalance_distinguishes_not_needed_insufficient_and_incomplete() -> Non
     ] == RebalanceOutcome.INCOMPLETE
 
 
-def test_rebalance_fails_closed_on_preexisting_sub_budget_violation() -> None:
-    store, database, _key = _seed([100, 100], usage=[101, 0])
+def test_overage_settle_negative_shard_rebalance_returns_402_not_500() -> None:
+    store, database, key = _seed([100, 100], usage=[60, 60])
+
+    outcome, authorization = _typed_authorize(
+        store,
+        key,
+        estimate=60,
+        idempotency_key="pre-overage",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    [reservation] = database.reservations.values()
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation["reservation_id"],
+        actual_micro=80,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert settled["outcome"] == "settled"
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert any(_available(rows[("ws-fragmented", shard)]) < 0 for shard in range(2))
+    assert any(_available(rows[("ws-fragmented", shard)]) > 0 for shard in range(2))
+
+    outcome, authorization = _typed_authorize(
+        store,
+        key,
+        estimate=30,
+        idempotency_key="post-overage",
+    )
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+
+
+def test_rebalance_fills_negative_target_to_exact_estimate_and_preserves_total() -> None:
+    store, database, _key = _seed([100, 100, 100], usage=[120, 50, 50])
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    before_sum = sum(row["total_credits"] for row in rows.values())
+
+    result = _rebalance(store, shard_count=3, target_shard=0, estimate=40)
+
+    assert result == {
+        "outcome": RebalanceOutcome.MOVED,
+        "moved_micro": 60,
+        "target_shard": 0,
+    }
+    assert _available(rows[("ws-fragmented", 0)]) == 40
+    assert sum(row["total_credits"] for row in rows.values()) == before_sum
+
+
+def test_rebalance_negative_headroom_insufficient_returns_normal_outcome() -> None:
+    store, database, _key = _seed([100, 100, 100], usage=[130, 85, 95])
     before = {
         key: dict(value)
         for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
     }
 
-    with pytest.raises(RuntimeError, match="exceeds its sub-budget"):
-        _rebalance(store, shard_count=2, target_shard=0, estimate=50)
+    result = _rebalance(store, shard_count=3, target_shard=0, estimate=10)
 
+    assert result == {
+        "outcome": RebalanceOutcome.INSUFFICIENT,
+        "moved_micro": 0,
+        "target_shard": 0,
+    }
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+
+def test_rebalance_bystander_negative_shard_counts_against_affordability() -> None:
+    # Regression (overspend guard): a NON-TARGET over-spent shard's debt must
+    # count against global affordability. Target shard 0 has 0 idle; positive
+    # donors (shards 1,2) hold 60+40=100; shard 3 is overdrawn by 40. Global
+    # available is 100-40=60 < estimate 100, so the correct answer is
+    # INSUFFICIENT — NOT a MOVE that consolidates 100 onto the target and lets
+    # the workspace reserve credit it does not globally have. A feasibility
+    # check that summed only positive donor headroom would wrongly accept here.
+    store, database, _key = _seed([0, 60, 40, 0], usage=[0, 0, 0, 40])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    result = _rebalance(store, shard_count=4, target_shard=0, estimate=100)
+
+    assert result == {
+        "outcome": RebalanceOutcome.INSUFFICIENT,
+        "moved_micro": 0,
+        "target_shard": 0,
+    }
+    assert database.typed[CREDIT_BALANCE_TABLE] == before
+
+
+@pytest.mark.parametrize("estimate", [0, -1])
+def test_rebalance_nonpositive_estimate_returns_not_needed(estimate: int) -> None:
+    store, database, _key = _seed([100, 100], usage=[90, 0])
+    before = {
+        key: dict(value)
+        for key, value in database.typed[CREDIT_BALANCE_TABLE].items()
+    }
+
+    result = _rebalance(store, shard_count=2, target_shard=0, estimate=estimate)
+
+    assert result == {
+        "outcome": RebalanceOutcome.NOT_NEEDED,
+        "moved_micro": 0,
+        "target_shard": 0,
+    }
     assert database.typed[CREDIT_BALANCE_TABLE] == before
 
 


### PR DESCRIPTION
## What

`rebalance_credit_for_estimate` (the fragmentation-repair path added in #162) raised `_RebalanceInvariantError` for **any** shard whose `total_credits - total_usage - reserved` was negative. But negative per-shard headroom is a **normal** state, not corruption: a settle books `total_usage += actual` with only a `reserved >= hold` guard and no clamp of actual to the hold, so a request whose measured cost exceeds its authorize estimate (routine overage) drives a shard negative. Once that happened, **every** all-shard-rejected authorize for that workspace raised an unmapped `RuntimeError` → HTTP 500 (the caller catches only `INCOMPLETE`), persisting until a top-up. Fires only at `shard_count > 1`.

## Fix (contained to `rebalance_credit_for_estimate`)

- Stop raising on negative headroom; keep the true value. The target's true (possibly negative) available drives `needed = estimate - target_available`, so a shard in deficit is filled by the extra amount.
- Feasibility stays the **signed global available** `sum(headroom.values())` — an over-spent shard's debt must count against affordability, or we would consolidate enough onto the target for reserve to succeed while the workspace is globally overdrawn (free spend). The donor loop still pulls only from **positive** headroom; when the gate passes, positive donor headroom is provably `>= needed`, so the plan always completes and never trips the `needed != 0` invariant.
- `estimate <= 0` returns `NOT_NEEDED` instead of raising.

**Invariants:** `SUM(total_credits)` unchanged on every path; no hold exceeding global available can be approved.

## Verification

Design + review by Claude Fable; regression tests written to spec. Three independent adversarial verifiers ran against the diff — the **first pass caught a real overspend bug** in an earlier revision (a feasibility check that summed only positive donor headroom, excluding non-target debt, would have approved unaffordable holds); corrected, and a fresh verifier proved the final version sound (no overspend, no false-402, no reachable 500, conservation holds). Tests: overage-settle no longer 500s (→402), a bystander over-spent shard correctly blocks overspend, negative-target consolidation preserves the total, and `estimate <= 0`. Local gate: ruff + mypy clean, 91 sharding/billing tests pass.

Closes the P1 from the #159/#162 sharding review. (P2 repair-path latency amplifier and P3 exception-envelope mapping remain separate follow-ups.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)