### PR TITLE
Gateway robustness: map Aborted→503, tolerate unknown entity fields

### DIFF
--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
+from google.api_core.exceptions import Aborted
 
 from trusted_router.axiom_config import init_axiom
 from trusted_router.catalog import validate_auto_model_order
@@ -100,6 +101,18 @@ def create_app(
         )
         message = first.get("msg") or "Invalid request body"
         return error_response(400, f"{loc}: {message}", ErrorType.BAD_REQUEST)
+
+    @app.exception_handler(Aborted)
+    async def aborted_exception_handler(_request: Request, exc: Aborted) -> Response:
+        # A Spanner transaction exhausted its retry budget under contention. This is
+        # transient, so signal the caller to retry rather than surfacing a 500.
+        response = error_response(
+            503,
+            "The request was aborted due to transient database contention; retry.",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+        response.headers["Retry-After"] = "1"
+        return response
 
     register_public_routes(app, settings)
     api = _make_api_router(settings)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
 import json
 import logging
@@ -1856,6 +1857,14 @@ class SpannerBigtableStore:
         data = json.loads(rows[0][0])
         if cls is dict:
             return data
+        if dataclasses.is_dataclass(cls):
+            known = {f.name for f in dataclasses.fields(cls)}
+            unknown = data.keys() - known
+            if unknown:
+                # Forward/back-compat: newer releases may persist fields this
+                # class does not know yet; drop extras instead of 500ing.
+                data = {key: value for key, value in data.items() if key in known}
+            return cls(**data)
         return cls(**data)
 
     def _list_entities(

--- a/tests/test_gateway_aborted_handler.py
+++ b/tests/test_gateway_aborted_handler.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from google.api_core.exceptions import Aborted
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, InMemoryStore
+
+
+def _settings() -> Settings:
+    return Settings(environment="test", internal_gateway_token=None)
+
+
+def _seed_key() -> Any:
+    user = STORE.ensure_user("aborted-handler@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.credit_workspace_once(workspace.id, 50_000_000, "seed")
+    _raw, key = STORE.create_api_key(
+        workspace_id=workspace.id,
+        name="aborted-handler",
+        creator_user_id=user.id,
+    )
+    return key
+
+
+@pytest.mark.asyncio
+async def test_gateway_authorize_aborted_returns_retryable_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    def raise_aborted(_self: Any, _workspace_id: str) -> Any:
+        raise Aborted("deadlock")
+
+    monkeypatch.setattr(InMemoryStore, "get_workspace", raise_aborted)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        response = await ac.post(
+            "/v1/internal/gateway/authorize",
+            json={
+                "api_key_hash": key.hash,
+                "model": "anthropic/claude-haiku-4.5",
+                "estimated_input_tokens": 100,
+                "max_output_tokens": 100,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+    assert response.json()["error"]["type"] == "service_unavailable"

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -167,6 +167,40 @@ def test_gcp_api_key_lookup_uses_index_and_never_stores_raw_key() -> None:
     assert raw not in serialized
 
 
+def test_gcp_read_gateway_authorization_ignores_unknown_dataclass_fields() -> None:
+    store, db, _ = make_fake_store()
+    auth = store.create_gateway_authorization(
+        workspace_id="ws_1",
+        key_hash="key_1",
+        model_id="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        usage_type="Credits",
+        estimated_microdollars=123,
+        credit_reservation_id="res_1",
+        requested_model_id="anthropic/claude-haiku-4.5",
+        candidate_model_ids=["anthropic/claude-haiku-4.5"],
+        region="us",
+        endpoint_id="anthropic:claude-haiku-4.5",
+        candidate_endpoint_ids=["anthropic:claude-haiku-4.5"],
+        idempotency_key="idem_1",
+        tags={"team": "x"},
+        idempotency_fingerprint="fingerprint_1",
+    )
+    row = db.rows[("gateway_authorization", auth.id)]
+    body = json.loads(row.body)
+    body["some_future_field"] = 1
+    row.body = json.dumps(body, separators=(",", ":"), sort_keys=True)
+
+    refetched = store.get_gateway_authorization(auth.id)
+
+    assert refetched is not None
+    assert refetched.id == auth.id
+    assert refetched.workspace_id == "ws_1"
+    assert refetched.key_hash == "key_1"
+    assert refetched.tags == {"team": "x"}
+    assert refetched.idempotency_fingerprint == "fingerprint_1"
+
+
 def test_gcp_byok_upsert_updates_secret_ref_and_hint() -> None:
     store, db, _ = make_fake_store()
 


### PR DESCRIPTION
Two production paths were surfacing transient/compat conditions as unhandled **HTTP 500s** (visible in Sentry after today's rollout). Both are small, contained hardening.

## 1) Spanner `Aborted` → retryable 503
`run_in_transaction_with_retry` bounds retries to a wall-clock budget and, on exhaustion under sustained wound-wait contention, raises the final `Aborted`. Nothing caught it, so authorize/settle returned a **500 for a fully retryable condition**. Add a global `@app.exception_handler(Aborted)` mapping it to **`503 service_unavailable` + `Retry-After: 1`**, so the caller (enclave/SDK) retries instead of hard-failing. The handler only fires for an `Aborted` that escaped every internal retry; `run_in_transaction_with_retry` is unchanged.

## 2) Tolerate unknown JSON entity fields (rollback landmine)
`_read_entity_from` does `cls(**data)`. When a newer release persists a field an older-release reader (or a rollback) doesn't know — e.g. a stored `GatewayAuthorization` that gained a `tags` field — `cls(**data)` raised `TypeError` → 500 on settle. Drop unknown keys for dataclass entities before construction, so **additive** schema changes are forward/backward compatible. Only extra keys are dropped; missing required fields still fail loudly.

## Tests
- authorize under an `Aborted` returns 503 + `Retry-After` + `service_unavailable` envelope (drives the real handler through the ASGI route);
- a stored gateway-authorization body with an extra unknown field deserializes cleanly.
- 200 storage/billing/settle/gateway/auth tests pass locally; ruff + mypy clean.

## Follow-up (not in this PR)
This makes the control plane emit the correct retryable signal; whether the **enclave retries authorize internally on 503** (vs relaying to the user) is a separate enclave-side enhancement worth confirming. And the underlying **contention** (the P2 amplifier on sharded workspaces) remains the deeper item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)