### PR TITLE
Tagging efficiency: elide empty defaults, bound tag-filtered scans

### DIFF
--- a/src/trusted_router/routes/activity.py
+++ b/src/trusted_router/routes/activity.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import AuthenticatedPrincipal, ManagementPrincipal
 from trusted_router.errors import api_error, error_response
@@ -39,7 +40,8 @@ def register_activity_routes(router: APIRouter) -> None:
             raise api_error(400, str(exc), ErrorType.INVALID_TAGS) from exc
         if group_by in {"none", "request", "generation"}:
             normalized_limit = max(1, min(limit, 1000))
-            result = STORE.activity_events_result(
+            result = await run_in_threadpool(
+                STORE.activity_events_result,
                 principal.workspace.id,
                 api_key_hash=api_key_hash,
                 date=date,
@@ -51,7 +53,8 @@ def register_activity_routes(router: APIRouter) -> None:
                 "data": result.data,
                 "meta": _activity_meta(result, tag_filter=tag_key is not None),
             }
-        result = STORE.activity_result(
+        result = await run_in_threadpool(
+            STORE.activity_result,
             principal.workspace.id,
             api_key_hash=api_key_hash,
             date=date,

--- a/src/trusted_router/storage_activity.py
+++ b/src/trusted_router/storage_activity.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from collections import Counter
-from collections.abc import Iterable
+import copy
+import dataclasses
+import threading
+import time
+from collections import Counter, OrderedDict
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -9,6 +13,18 @@ from trusted_router.money import microdollars_to_float
 from trusted_router.storage_models import Generation, _is_byok
 
 MAX_TAG_GROUP_VALUES = 100
+ACTIVITY_TAG_CACHE_TTL_SECONDS = 15.0
+ACTIVITY_TAG_CACHE_MAX_ENTRIES = 512
+
+ActivityTagCacheKey = tuple[
+    str,
+    str | None,
+    str | None,
+    str | None,
+    int | None,
+    str,
+    str | None,
+]
 
 
 @dataclass(frozen=True)
@@ -18,6 +34,69 @@ class ActivityResult:
     groups_truncated: bool = False
     scanned: int = 0
     scan_limit: int | None = None
+
+
+@dataclass(frozen=True)
+class _ActivityTagCacheEntry:
+    result: ActivityResult
+    expires_at: float
+
+
+class ActivityTagCache:
+    """Small per-process cache for repeated tag-filtered dashboard polls."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = ACTIVITY_TAG_CACHE_TTL_SECONDS,
+        max_entries: int = ACTIVITY_TAG_CACHE_MAX_ENTRIES,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("activity tag cache TTL must be positive")
+        if max_entries < 1:
+            raise ValueError("activity tag cache max_entries must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entries = int(max_entries)
+        self._clock = clock
+        self._entries: OrderedDict[ActivityTagCacheKey, _ActivityTagCacheEntry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: ActivityTagCacheKey) -> ActivityResult | None:
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at <= now:
+                self._entries.pop(key, None)
+                return None
+            self._entries.move_to_end(key)
+            result = entry.result
+        # Hand every hit its own copy of the payload: callers mutate returned
+        # event dicts in place (e.g. console cost_display annotation), and a
+        # shared cached list would leak one caller's mutations into the next.
+        return dataclasses.replace(result, data=copy.deepcopy(result.data))
+
+    def put(self, key: ActivityTagCacheKey, result: ActivityResult) -> None:
+        entry = _ActivityTagCacheEntry(
+            result=result,
+            expires_at=self._clock() + self._ttl_seconds,
+        )
+        with self._lock:
+            self._entries[key] = entry
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+# 15s staleness is acceptable for analytics polling and avoids repeated
+# tag-filtered Bigtable scans. Mutating writes do not invalidate this cache.
+ACTIVITY_TAG_CACHE = ActivityTagCache()
 
 
 def generation_metrics(gen: Generation) -> dict[str, int]:
@@ -56,12 +135,33 @@ def filter_generations(
     return [
         gen
         for gen in generations
-        if gen.workspace_id == workspace_id
+        if generation_matches_filter(
+            gen,
+            workspace_id=workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            tag_key=tag_key,
+            tag_value=tag_value,
+        )
+    ]
+
+
+def generation_matches_filter(
+    gen: Generation,
+    *,
+    workspace_id: str,
+    api_key_hash: str | None = None,
+    date: str | None = None,
+    tag_key: str | None = None,
+    tag_value: str | None = None,
+) -> bool:
+    return (
+        gen.workspace_id == workspace_id
         and (api_key_hash is None or gen.key_hash == api_key_hash)
         and (date is None or gen.created_at.startswith(date))
         and (tag_key is None or tag_key in gen.tags)
         and (tag_value is None or gen.tags.get(tag_key or "") == tag_value)
-    ]
+    )
 
 
 def summarize_activity(

--- a/src/trusted_router/storage_gcp_activity_index.py
+++ b/src/trusted_router/storage_gcp_activity_index.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 from trusted_router.storage_activity import generation_metrics, usage_bucket_key
@@ -48,6 +49,43 @@ def activity_generations(
         generations.extend(_generations_from_rows(legacy_rows, family, api_key_hash=api_key_hash))
     generations.sort(key=lambda item: item.created_at, reverse=True)
     return generations[:limit]
+
+
+def iter_activity_generations(
+    table: Any,
+    family: str,
+    workspace_id: str,
+    *,
+    api_key_hash: str | None,
+    date: str | None,
+    limit: int,
+) -> Iterator[Generation]:
+    if date is None:
+        prefix = f"ws_recent#{workspace_id}#".encode()
+        rows = table.read_rows(start_key=prefix, end_key=prefix + b"~", limit=limit)
+        yielded = 0
+        for generation in _iter_generations_from_rows(rows, family, api_key_hash=api_key_hash):
+            yielded += 1
+            yield generation
+        if yielded == 0:
+            legacy_prefix = f"ws#{workspace_id}#".encode()
+            legacy_rows = table.read_rows(
+                start_key=legacy_prefix,
+                end_key=legacy_prefix + b"~",
+                limit=limit,
+            )
+            legacy_generations = _generations_from_rows(
+                legacy_rows,
+                family,
+                api_key_hash=api_key_hash,
+            )
+            legacy_generations.sort(key=lambda item: item.created_at, reverse=True)
+            yield from legacy_generations[:limit]
+        return
+
+    prefix = f"ws#{workspace_id}#{date}#".encode()
+    rows = table.read_rows(start_key=prefix, end_key=prefix + b"~", limit=limit)
+    yield from _iter_generations_from_rows(rows, family, api_key_hash=api_key_hash)
 
 
 def usage_series(
@@ -119,15 +157,22 @@ def _generations_from_rows(
     *,
     api_key_hash: str | None,
 ) -> list[Generation]:
-    generations: list[Generation] = []
+    return list(_iter_generations_from_rows(rows, family, api_key_hash=api_key_hash))
+
+
+def _iter_generations_from_rows(
+    rows: Any,
+    family: str,
+    *,
+    api_key_hash: str | None,
+) -> Iterator[Generation]:
     for row in rows:
         cells = row.cells.get(family, {}).get(b"body", [])
         if not cells:
             continue
         generation = Generation(**json.loads(cells[0].value.decode("utf-8")))
         if api_key_hash is None or generation.key_hash == api_key_hash:
-            generations.append(generation)
-    return generations
+            yield generation
 
 
 def _generation_from_row(row: Any, family: str) -> Generation | None:

--- a/src/trusted_router/storage_gcp_codec.py
+++ b/src/trusted_router/storage_gcp_codec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
 import json
 from dataclasses import asdict
@@ -7,10 +8,21 @@ from typing import Any
 
 from trusted_router.storage_models import Generation
 
+_SENTINEL = object()
+
 
 def json_body(value: Any) -> str:
     if hasattr(value, "__dataclass_fields__"):
-        value = asdict(value)
+        data = asdict(value)
+        for field in dataclasses.fields(value):
+            field_value = data.get(field.name, _SENTINEL)
+            if field_value is None and field.default is None:
+                data.pop(field.name)
+            elif field_value == [] and field.default_factory is list:
+                data.pop(field.name)
+            elif field_value == {} and field.default_factory is dict:
+                data.pop(field.name)
+        value = data
     return json.dumps(value, separators=(",", ":"), sort_keys=True)
 
 

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -12,17 +12,23 @@ index, not Spanner."""
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import Any, Protocol
 
+import trusted_router.storage_activity as storage_activity
 from trusted_router.storage_activity import (
     ActivityResult,
     filter_generations,
     generation_events,
+    generation_matches_filter,
     summarize_activity,
     summarize_activity_result,
 )
 from trusted_router.storage_gcp_activity_index import (
     activity_generations as _bt_activity_generations,
+)
+from trusted_router.storage_gcp_activity_index import (
+    iter_activity_generations as _bt_iter_activity_generations,
 )
 from trusted_router.storage_gcp_activity_index import (
     usage_series as _bt_usage_series,
@@ -164,6 +170,15 @@ class SpannerGenerations:
         tag_value: str | None = None,
         group_by_tag: str | None = None,
     ) -> list[dict[str, Any]]:
+        if tag_key is not None:
+            return self.activity_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                tag_key=tag_key,
+                tag_value=tag_value,
+                group_by_tag=group_by_tag,
+            ).data
         rows = self._activity_generations(
             workspace_id, api_key_hash=api_key_hash, date=date, limit=ACTIVITY_SCAN_LIMIT
         )
@@ -187,6 +202,30 @@ class SpannerGenerations:
         tag_value: str | None = None,
         group_by_tag: str | None = None,
     ) -> ActivityResult:
+        if tag_key is not None:
+            cache_key = _activity_tag_cache_key(
+                workspace_id=workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                group_by=group_by_tag,
+                limit=None,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            )
+            cached = storage_activity.ACTIVITY_TAG_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+            result = self._tagged_activity_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                tag_key=tag_key,
+                tag_value=tag_value,
+                group_by_tag=group_by_tag,
+            )
+            storage_activity.ACTIVITY_TAG_CACHE.put(cache_key, result)
+            return result
+
         rows = self._activity_generations(
             workspace_id,
             api_key_hash=api_key_hash,
@@ -228,6 +267,15 @@ class SpannerGenerations:
         tag_key: str | None = None,
         tag_value: str | None = None,
     ) -> list[dict[str, Any]]:
+        if tag_key is not None:
+            return self.activity_events_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                limit=limit,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            ).data
         rows = self._activity_generations(
             workspace_id,
             api_key_hash=api_key_hash,
@@ -254,6 +302,30 @@ class SpannerGenerations:
         tag_key: str | None = None,
         tag_value: str | None = None,
     ) -> ActivityResult:
+        if tag_key is not None:
+            cache_key = _activity_tag_cache_key(
+                workspace_id=workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                group_by="events",
+                limit=limit,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            )
+            cached = storage_activity.ACTIVITY_TAG_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+            result = self._tagged_activity_events_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                limit=limit,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            )
+            storage_activity.ACTIVITY_TAG_CACHE.put(cache_key, result)
+            return result
+
         scan_limit = ACTIVITY_SCAN_LIMIT if tag_key is not None else limit
         rows = self._activity_generations(
             workspace_id,
@@ -352,3 +424,134 @@ class SpannerGenerations:
             date=date,
             limit=limit,
         )
+
+    def _iter_activity_generations(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        limit: int,
+    ) -> Iterator[Generation]:
+        return _bt_iter_activity_generations(
+            self._bt_table,
+            self._family,
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            limit=limit,
+        )
+
+    def _tagged_activity_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        tag_key: str,
+        tag_value: str | None,
+        group_by_tag: str | None,
+    ) -> ActivityResult:
+        rows, truncated, scanned = self._tagged_activity_generations(
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            tag_key=tag_key,
+            tag_value=tag_value,
+            stop_after_matches=None,
+        )
+        result = summarize_activity_result(
+            rows,
+            group_by_tag=group_by_tag,
+            truncated=truncated,
+            scan_limit=ACTIVITY_SCAN_LIMIT,
+        )
+        return ActivityResult(
+            data=result.data,
+            truncated=result.truncated,
+            groups_truncated=result.groups_truncated,
+            scanned=scanned,
+            scan_limit=result.scan_limit,
+        )
+
+    def _tagged_activity_events_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        limit: int,
+        tag_key: str,
+        tag_value: str | None,
+    ) -> ActivityResult:
+        # Early-exit is only correct on the ws_recent (date=None) path, whose
+        # reverse-time keys stream newest-first, so the first `limit` matches
+        # are exactly the rows the full-scan-then-truncate would return. The
+        # date-scoped prefix streams OLDEST-first; early-exiting there would
+        # return the oldest matches of the day instead of the newest, so it
+        # scans the full bounded window and sorts downstream (old behavior).
+        rows, truncated, scanned = self._tagged_activity_generations(
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            tag_key=tag_key,
+            tag_value=tag_value,
+            stop_after_matches=limit + 1 if date is None else None,
+        )
+        return ActivityResult(
+            data=generation_events(rows, limit=limit),
+            truncated=truncated,
+            scanned=scanned,
+            scan_limit=ACTIVITY_SCAN_LIMIT,
+        )
+
+    def _tagged_activity_generations(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        tag_key: str,
+        tag_value: str | None,
+        stop_after_matches: int | None,
+    ) -> tuple[list[Generation], bool, int]:
+        rows: list[Generation] = []
+        scanned = 0
+        truncated = False
+        for generation in self._iter_activity_generations(
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            limit=ACTIVITY_SCAN_LIMIT + 1,
+        ):
+            if scanned >= ACTIVITY_SCAN_LIMIT:
+                truncated = True
+                break
+            scanned += 1
+            if not generation_matches_filter(
+                generation,
+                workspace_id=workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            ):
+                continue
+            rows.append(generation)
+            if stop_after_matches is not None and len(rows) >= stop_after_matches:
+                truncated = True
+                break
+        return rows, truncated, scanned
+
+
+def _activity_tag_cache_key(
+    *,
+    workspace_id: str,
+    api_key_hash: str | None,
+    date: str | None,
+    group_by: str | None,
+    limit: int | None,
+    tag_key: str,
+    tag_value: str | None,
+) -> storage_activity.ActivityTagCacheKey:
+    return (workspace_id, api_key_hash, date, group_by, limit, tag_key, tag_value)

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -63,7 +63,7 @@ def assert_key_config_mirrored(db, key_hash: str) -> None:
     include_byok). usage / byok_usage / reserved are typed-DML-owned."""
     j = _json_key(db, key_hash)
     t = _typed_key(db, key_hash)
-    assert t["limit_micro"] == j["limit_microdollars"], (j, t)
+    assert t["limit_micro"] == j.get("limit_microdollars"), (j, t)
     assert t["include_byok"] == j["include_byok_in_limit"], (j, t)
     assert t["shard"] == 0
 

--- a/tests/test_tagging_efficiency.py
+++ b/tests/test_tagging_efficiency.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import asdict
+from typing import Any
+
+import httpx
+import pytest
+
+import trusted_router.storage_activity as storage_activity
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_generations import SpannerGenerations
+from trusted_router.storage_models import ApiKey, CreditAccount, GatewayAuthorization, Generation
+from trusted_router.types import UsageType
+
+
+@pytest.fixture(autouse=True)
+def clear_activity_tag_cache() -> None:
+    storage_activity.ACTIVITY_TAG_CACHE.clear()
+
+
+def _generation(
+    index: int = 0,
+    *,
+    workspace_id: str = "ws-eff",
+    key_hash: str = "key-eff",
+    tags: dict[str, str] | None = None,
+) -> Generation:
+    return Generation(
+        id=f"gen-{index}",
+        request_id=f"req-{index}",
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        model="openai/gpt-5.4-nano",
+        provider_name="OpenAI",
+        app="test",
+        tokens_prompt=10,
+        tokens_completion=5,
+        total_cost_microdollars=100,
+        usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=10.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        created_at=f"2026-07-11T12:{index:02d}:00Z",
+        tags=tags or {},
+    )
+
+
+def test_json_body_elides_only_round_trip_safe_dataclass_defaults() -> None:
+    untagged = _generation()
+    tagged = _generation(1, tags={"team": "legal", "request": "r1"})
+    empty_auth = GatewayAuthorization(
+        id="auth-empty",
+        workspace_id="ws-eff",
+        key_hash="key-eff",
+        model_id="openai/gpt-5.4-nano",
+        provider="openai",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=123,
+        created_at="2026-07-11T12:00:00Z",
+    )
+    tagged_auth = GatewayAuthorization(
+        id="auth-tagged",
+        workspace_id="ws-eff",
+        key_hash="key-eff",
+        model_id="openai/gpt-5.4-nano",
+        provider="openai",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=123,
+        created_at="2026-07-11T12:00:00Z",
+        tags={"team": "legal"},
+    )
+    api_key = ApiKey(
+        hash="key-eff",
+        salt="salt",
+        secret_hash="digest",  # noqa: S106 - placeholder test digest.
+        lookup_hash="lookup",
+        name="test key",
+        label="sk-tr...eff",
+        workspace_id="ws-eff",
+        creator_user_id=None,
+        created_at="2026-07-11T12:00:00Z",
+    )
+    credit = CreditAccount(workspace_id="ws-eff")
+
+    for obj in (untagged, tagged, empty_auth, tagged_auth, api_key, credit):
+        body = json_body(obj)
+        assert type(obj)(**json.loads(body)) == obj
+
+    old_body = json.dumps(asdict(untagged), separators=(",", ":"), sort_keys=True)
+    new_payload = json.loads(json_body(untagged))
+    assert len(json_body(untagged)) < len(old_body)
+    for key in ("user", "session_id", "http_referer", "app_categories", "tags"):
+        assert key not in new_payload
+
+    assert "created_at" in new_payload
+    assert json.loads(json_body(tagged))["tags"] == {"team": "legal", "request": "r1"}
+    assert "tags" not in json.loads(json_body(empty_auth))
+    assert json.loads(json_body(tagged_auth))["tags"] == {"team": "legal"}
+
+
+class _FakeCell:
+    def __init__(self, value: Generation) -> None:
+        self.value = json_body(value).encode("utf-8")
+
+
+class _FakeReadRow:
+    def __init__(self, value: Generation) -> None:
+        self.cells = {"m": {b"body": [_FakeCell(value)]}}
+
+
+class _LazyBigtable:
+    def __init__(self, rows: list[Generation]) -> None:
+        self.rows = [_FakeReadRow(row) for row in rows]
+        self.read_count = 0
+        self.yielded = 0
+        self.reads: list[tuple[bytes, bytes, int]] = []
+
+    def read_rows(self, *, start_key: bytes, end_key: bytes, limit: int) -> Any:
+        self.read_count += 1
+        self.reads.append((start_key, end_key, limit))
+
+        def _rows() -> Any:
+            for row in self.rows[:limit]:
+                self.yielded += 1
+                yield row
+
+        return _rows()
+
+
+def _spanner_generations(rows: list[Generation]) -> tuple[SpannerGenerations, _LazyBigtable]:
+    table = _LazyBigtable(rows)
+    store = object.__new__(SpannerGenerations)
+    store._bt_table = table
+    store._family = "m"
+    return store, table
+
+
+def test_tag_filtered_activity_events_exit_after_limit_plus_one_matches() -> None:
+    rows = [_generation(index, tags={"team": "legal"}) for index in range(60)]
+    store, table = _spanner_generations(rows)
+
+    result = store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+
+    assert len(result.data) == 5
+    assert result.truncated is True
+    assert result.scanned < 60
+    assert table.yielded < 60
+
+
+def test_tag_filtered_activity_events_sparse_matches_scan_available_rows() -> None:
+    rows = [
+        _generation(index, tags={"team": "legal"} if index in {0, 20, 40} else {})
+        for index in range(60)
+    ]
+    store, _table = _spanner_generations(rows)
+
+    result = store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+
+    assert len(result.data) == 3
+    assert result.truncated is False
+    assert result.scanned == 60
+
+
+def test_tag_filtered_activity_cache_is_ttl_lru_and_tag_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = [100.0]
+    cache = storage_activity.ActivityTagCache(clock=lambda: now[0])
+    monkeypatch.setattr(storage_activity, "ACTIVITY_TAG_CACHE", cache)
+    rows = [
+        _generation(index, tags={"team": "legal" if index % 2 == 0 else "platform"})
+        for index in range(20)
+    ]
+    store, table = _spanner_generations(rows)
+
+    first = store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+    second = store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+    # Cache hits hand back an equal COPY, never the same object: callers mutate
+    # returned event dicts in place, and a shared cached list would leak one
+    # caller's mutations into the next.
+    assert second is not first
+    assert second == first
+    assert table.read_count == 1
+    second.data[0]["cost_display"] = "mutated"
+    third = store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+    assert "cost_display" not in third.data[0]
+    assert table.read_count == 1
+
+    store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="platform")
+    assert table.read_count == 2
+
+    before_untagged = table.read_count
+    store.activity_events_result("ws-eff", limit=5)
+    store.activity_events_result("ws-eff", limit=5)
+    assert table.read_count == before_untagged + 2
+
+    before_grouped = table.read_count
+    grouped = store.activity_result("ws-eff", tag_key="team", tag_value="legal", group_by_tag="team")
+    grouped_again = store.activity_result(
+        "ws-eff",
+        tag_key="team",
+        tag_value="legal",
+        group_by_tag="team",
+    )
+    assert grouped_again is not grouped
+    assert grouped_again == grouped
+    assert table.read_count == before_grouped + 1
+
+    now[0] += storage_activity.ACTIVITY_TAG_CACHE_TTL_SECONDS + 0.1
+    store.activity_events_result("ws-eff", limit=5, tag_key="team", tag_value="legal")
+    assert table.read_count == before_grouped + 2
+
+
+@pytest.mark.parametrize(
+    ("query", "method_name"),
+    [
+        ("?group_by=none", "activity_events_result"),
+        ("", "activity_result"),
+    ],
+)
+def test_activity_handler_runs_storage_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    method_name: str,
+) -> None:
+    app = create_app(
+        Settings(environment="test", internal_gateway_token=None),
+        init_observability=False,
+    )
+    seen: dict[str, int] = {}
+    original = getattr(InMemoryStore, method_name)
+
+    def spy(self: Any, *args: Any, **kwargs: Any) -> Any:
+        seen["tid"] = threading.get_ident()
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(InMemoryStore, method_name, spy)
+
+    async def scenario() -> int:
+        loop_tid = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            response = await ac.get(
+                f"/v1/activity{query}",
+                headers={"x-trustedrouter-user": "activity-loop@example.com"},
+            )
+            assert response.status_code == 200, response.text
+        return loop_tid
+
+    loop_tid = asyncio.run(scenario())
+    assert seen["tid"] != loop_tid
+
+
+def test_date_scoped_tag_filter_returns_newest_matches_not_oldest() -> None:
+    """Regression: the date-scoped ws# prefix streams OLDEST-first, so the
+    early-exit must not apply there — it would return the day's oldest matches
+    instead of the newest (and cache them). The date path scans the full
+    bounded window and sorts newest-first downstream, exactly the pre-change
+    behavior; only the newest-first ws_recent (date=None) path early-exits."""
+    rows = [_generation(index, tags={"team": "legal"}) for index in range(60)]
+    store, table = _spanner_generations(rows)
+
+    result = store.activity_events_result(
+        "ws-eff", date="2026-07-11", limit=5, tag_key="team", tag_value="legal"
+    )
+
+    assert [event["id"] for event in result.data] == [
+        "gen-59", "gen-58", "gen-57", "gen-56", "gen-55",
+    ]
+    assert result.scanned == 60  # full window scanned: no early exit on the date path


### PR DESCRIPTION
Four fixes from a measured cost audit of the tagging feature (all confirmed by adversarial re-measurement). No billing DML or money math touched.

## Changes

1. **`json_body` default-elision** — drops dataclass keys only when round-trip-safe (value `None` with field default `None`; empty `list`/`dict` with the bare builtin `default_factory`). An untagged generation stops persisting ~80B of `null`/empty attribution scaffolding × its 4 stored copies (**−320B durable per untagged request**). Every raw-dict reader in the tree (incl. the counter-reconcile money tooling) was enumerated: all use `.get()` or index only required keys.
2. **Early-exit tag-filtered scans** — the events listing stops reading at `limit+1` matches instead of materializing 5,000 rows (**~50× fewer rows** in the common case). Applies **only** to the newest-first `ws_recent` path; date-scoped prefixes stream oldest-first and keep the full bounded scan + sort. Group-by never early-exits.
3. **15s TTL+LRU cache** for repeated tag-filtered dashboard polls (tag-filtered only; untagged paths untouched; hits return defensive copies).
4. **`run_in_threadpool`** on `/v1/activity` so a tag-filtered scan can't stall the event loop of the concurrency=2 instance that also settles money.

## Verification

codex authored to spec; Fable reviewed; **two adversarial verifiers** ran (serialization round-trip lens — property-checked all 24 persisted dataclasses through the exact reader path, incl. the scariest `default_factory` sentinel cases; scan/meta/cache-semantics lens — differential-tested old vs new results on a key-ordered Bigtable fake). They caught **two real bugs in the first draft**: date-scoped tag queries would have returned the day's *oldest* matches instead of newest (ascending prefix + early-exit; then cached), and a test helper raw-indexing a now-elided key. Both fixed with dedicated regression tests (incl. the date-path differential and a cache-mutation-isolation test).

Local gates: ruff + mypy clean; 199 tests across tagging/serialization/billing/reconcile/sharding suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)