### PR TITLE
Prepare TrustedRouter plugin marketplace submission

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -88,6 +88,9 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/eu",
     "/trustedos",
     "/legal",
+    "/privacy",
+    "/terms",
+    "/support",
     "/legal/dpa",
     "/legal/baa",
     "/legal/soc2-readiness",
@@ -1035,6 +1038,62 @@ def public_legal_html(settings: Settings) -> str:
             packet=packet,
             entity=legal_entity(settings),
             subprocessors=subprocessor_packet(),
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
+def public_privacy_html(settings: Settings) -> str:
+    return (
+        _env()
+        .get_template("public/privacy.html")
+        .render(
+            api_base_url=settings.api_base_url,
+            site_url=f"https://{settings.trusted_domain}/privacy",
+            title="Privacy Policy | TrustedRouter",
+            heading="Privacy policy",
+            description=(
+                "How Lore Hex Corp collects, uses, shares, and protects information when you use TrustedRouter."
+            ),
+            entity=legal_entity(settings),
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
+def public_terms_html(settings: Settings) -> str:
+    return (
+        _env()
+        .get_template("public/terms.html")
+        .render(
+            api_base_url=settings.api_base_url,
+            site_url=f"https://{settings.trusted_domain}/terms",
+            title="Terms of Service | TrustedRouter",
+            heading="Terms of service",
+            description="Terms governing access to and use of TrustedRouter services.",
+            entity=legal_entity(settings),
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
+def public_support_html(settings: Settings) -> str:
+    return (
+        _env()
+        .get_template("public/support.html")
+        .render(
+            api_base_url=settings.api_base_url,
+            site_url=f"https://{settings.trusted_domain}/support",
+            title="Support | TrustedRouter",
+            heading="TrustedRouter support",
+            description="Get product, account, billing, plugin, and security support.",
+            entity=legal_entity(settings),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
             static_version=_static_version(settings),

--- a/src/trusted_router/routes/mcp.py
+++ b/src/trusted_router/routes/mcp.py
@@ -293,11 +293,18 @@ def _mcp_tools() -> list[dict[str, Any]]:
                     "optional": True,
                 },
             },
+            read_only=False,
         ),
     ]
 
 
-def _tool_schema(name: str, description: str, properties: dict[str, Any]) -> dict[str, Any]:
+def _tool_schema(
+    name: str,
+    description: str,
+    properties: dict[str, Any],
+    *,
+    read_only: bool = True,
+) -> dict[str, Any]:
     clean_properties = {
         key: {inner_key: inner_value for inner_key, inner_value in value.items() if inner_key != "optional"}
         for key, value in properties.items()
@@ -312,6 +319,11 @@ def _tool_schema(name: str, description: str, properties: dict[str, Any]) -> dic
             "required": [
                 key for key, value in properties.items() if not value.get("optional", False)
             ],
+        },
+        "annotations": {
+            "readOnlyHint": read_only,
+            "openWorldHint": False,
+            "destructiveHint": False,
         },
     }
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -58,12 +58,15 @@ from trusted_router.dashboard import (
     public_model_section_html,
     public_models_html,
     public_page_html,
+    public_privacy_html,
     public_provider_detail_html,
     public_provider_performance_html,
     public_providers_html,
     public_rankings_html,
     public_soc2_readiness_html,
     public_subprocessors_html,
+    public_support_html,
+    public_terms_html,
     robots_txt,
     sitemap_comparisons_xml,
     sitemap_core_xml,
@@ -470,6 +473,18 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/legal")
     async def legal() -> str:
         return public_legal_html(settings)
+
+    @public_html_route("/privacy")
+    async def privacy() -> str:
+        return public_privacy_html(settings)
+
+    @public_html_route("/terms")
+    async def terms() -> str:
+        return public_terms_html(settings)
+
+    @public_html_route("/support")
+    async def support() -> str:
+        return public_support_html(settings)
 
     @public_html_route("/legal/dpa")
     async def legal_dpa() -> str:

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -146,7 +146,9 @@
         <a href="/security">Security</a>
         <a href="/status">Status</a>
         <a href="https://trust.trustedrouter.com">Attestation</a>
-        <a href="/legal">Privacy &amp; terms</a>
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+        <a href="/support">Support</a>
         <a href="/legal/dpa">DPA</a>
         <a href="/legal/baa">BAA</a>
       </div>
@@ -176,7 +178,7 @@
         <a href="https://jperla.com/blog/trustedrouter-founding-engineer">About</a>
       </div>
     </div>
-    <div class="site-footer-base">© 2026 TrustedRouter · <a href="/legal">Legal</a> · <a href="/legal">Privacy</a></div>
+    <div class="site-footer-base">© 2026 TrustedRouter · <a href="/legal">Legal</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a></div>
   </footer>
   <dialog id="signinModal" class="signin-modal" aria-labelledby="signinTitle">
     <form method="dialog">

--- a/src/trusted_router/templates/public/privacy.html
+++ b/src/trusted_router/templates/public/privacy.html
@@ -1,0 +1,53 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="public-proof-strip">
+  <div><strong>Effective</strong><span>July 13, 2026</span></div>
+  <div><strong>Controller</strong><span>{{ entity.name }}</span></div>
+  <div><strong>Prompt storage</strong><span>Off by default</span></div>
+  <div><strong>Contact</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
+</section>
+
+<section class="model-catalog legal-copy">
+  <div class="model-catalog-head"><div><span class="eyebrow">Scope</span><h2>What this policy covers</h2></div></div>
+  <p>This Privacy Policy explains how {{ entity.name }}, a {{ entity.type }}, collects, uses, discloses, and protects information when you use TrustedRouter websites, dashboards, APIs, SDKs, plugins, and related services.</p>
+
+  <h2>Information we collect</h2>
+  <h3>Account and contact information</h3>
+  <p>We may collect your email address, authentication identifiers, wallet address when you use wallet sign-in, workspace and organization membership, support communications, and preferences.</p>
+  <h3>Billing information</h3>
+  <p>Payment processors handle payment-card, PayPal, and supported stablecoin payment details. TrustedRouter receives transaction identifiers, payment status, amounts, and limited payment-method metadata needed for billing, fraud prevention, refunds, and accounting.</p>
+  <h3>API and service metadata</h3>
+  <p>We collect operational metadata such as request and generation identifiers, selected model and provider, token counts, latency, status, cost, region, API-key hash and display hint, rate-limit state, and security events. Raw API keys are shown once and stored only as protected hashes. BYOK provider credentials are encrypted.</p>
+  <h3>Prompts and outputs</h3>
+  <p>TrustedRouter does not store prompt or output content by default. Prompt traffic is designed to terminate inside the attested gateway. If a workspace explicitly enables a content-bearing Broadcast destination or another content feature, the selected content is sent to that destination under the workspace's configuration and the destination's terms. Downstream model providers process content according to the selected route and provider terms.</p>
+  <h3>Website information</h3>
+  <p>We may collect IP address, browser and device information, referring page, coarse location derived from IP, cookie or session identifiers, and page interaction data needed to operate, secure, and improve the service.</p>
+
+  <h2>How we use information</h2>
+  <p>We use information to provide and secure the service, authenticate users, route requests, meter usage, process payments, prevent abuse, respond to support, maintain reliability, comply with law, and improve product performance. We do not use customer prompts or outputs to train our own models.</p>
+
+  <h2>How we disclose information</h2>
+  <p>We disclose information to infrastructure, authentication, payment, communications, monitoring, and model-provider subprocessors as needed to provide the service. The current platform and downstream model-provider list is published at <a href="/legal/subprocessors">/legal/subprocessors</a>. We may also disclose information when required by law, to protect rights and safety, during a corporate transaction, or with your direction or consent.</p>
+
+  <h2>Retention</h2>
+  <p>We retain account, billing, security, and service metadata only as reasonably necessary for the purposes described above, including legal, tax, accounting, fraud-prevention, dispute, and security obligations. Retention periods vary by record type and contractual requirements. Prompt and output content is not retained by TrustedRouter by default. Deleting an account does not require us to delete records that law, security, fraud prevention, or financial controls require us to preserve.</p>
+
+  <h2>Security</h2>
+  <p>We use access controls, encryption, secret isolation, security monitoring, and an attested prompt gateway. No system is perfectly secure. Review current architecture and attestation evidence at <a href="/security">/security</a> and <a href="https://trust.trustedrouter.com">trust.trustedrouter.com</a>.</p>
+
+  <h2>Your choices and rights</h2>
+  <p>You may request access, correction, deletion, or export of personal information, or object to or restrict certain processing, where applicable. You may disable optional content exports and revoke API keys in the console. Contact <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. We may verify identity before completing a request.</p>
+
+  <h2>International processing</h2>
+  <p>TrustedRouter and its providers may process information in the United States and other countries. Available regions and provider routes have different locations and legal terms. Customers requiring a specific region or provider must use the corresponding route controls and contractual terms.</p>
+
+  <h2>Children</h2>
+  <p>The service is not directed to children under 13, and we do not knowingly collect their personal information. Users must be able to form a binding contract for the service in their jurisdiction.</p>
+
+  <h2>Changes</h2>
+  <p>We may update this policy as the service changes. We will post the updated policy here and change the effective date. Material changes may also be communicated through the service or account email.</p>
+
+  <h2>Contact</h2>
+  <p>{{ entity.name }}<br>{{ entity.address }}<br>{{ entity.phone }}<br><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></p>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/support.html
+++ b/src/trusted_router/templates/public/support.html
@@ -1,0 +1,36 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="public-proof-strip">
+  <div><strong>Product and plugin</strong><span><a href="https://github.com/Lore-Hex/LLM-advisor/issues">Open an issue</a></span></div>
+  <div><strong>Security</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
+  <div><strong>Status</strong><span><a href="https://status.trustedrouter.com">Live status</a></span></div>
+  <div><strong>Docs</strong><span><a href="/docs">Developer docs</a></span></div>
+</section>
+
+<section class="marketing-grid three">
+  <div class="marketing-card">
+    <span class="card-label">Product support</span>
+    <h3>Account, billing, routing, and API help</h3>
+    <p>Email <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. Include the request or generation ID, approximate time, route, and region. Never send an API key, BYOK credential, prompt, output, payment number, or other secret.</p>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Open source and plugins</span>
+    <h3>Reproducible bug reports</h3>
+    <p>Use the relevant public GitHub repository for source-code and plugin issues. Remove customer data and credentials before posting.</p>
+    <a class="btn" href="https://github.com/Lore-Hex/LLM-advisor/issues">LLM Advisor issues</a>
+  </div>
+  <div class="marketing-card">
+    <span class="card-label">Security</span>
+    <h3>Report vulnerabilities privately</h3>
+    <p>Send security reports privately to <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. Do not publish an unpatched vulnerability or include live credentials in a public issue.</p>
+    <a class="btn" href="/security">Security details</a>
+  </div>
+</section>
+
+<section class="limitation-band">
+  <span class="pill">Response details</span>
+  <div>
+    <p>Support is provided on a commercially reasonable basis unless a signed agreement states a specific response time or service level. Current incidents and historical availability are published at <a href="https://status.trustedrouter.com">status.trustedrouter.com</a>.</p>
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/terms.html
+++ b/src/trusted_router/templates/public/terms.html
@@ -1,0 +1,62 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="public-proof-strip">
+  <div><strong>Effective</strong><span>July 13, 2026</span></div>
+  <div><strong>Provider</strong><span>{{ entity.name }}</span></div>
+  <div><strong>Service</strong><span>Usage based</span></div>
+  <div><strong>Contact</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
+</section>
+
+<section class="model-catalog legal-copy">
+  <div class="model-catalog-head"><div><span class="eyebrow">Agreement</span><h2>Terms governing TrustedRouter</h2></div></div>
+  <p>These Terms of Service are a binding agreement between you and {{ entity.name }}, a {{ entity.type }}. By accessing or using TrustedRouter websites, dashboards, APIs, SDKs, plugins, or related services, you agree to these terms. If you use the service for an organization, you represent that you can bind that organization.</p>
+
+  <h2>Eligibility and accounts</h2>
+  <p>You must be legally able to enter this agreement and provide accurate account information. You are responsible for activity under your account, workspace, API keys, wallet, and provider credentials. Keep credentials confidential and promptly revoke or report compromised credentials.</p>
+
+  <h2>The service</h2>
+  <p>TrustedRouter provides routing, billing, compatibility, model-selection, and related infrastructure for third-party and TrustedRouter-composed AI models. Features, routes, providers, prices, context limits, and availability may change. Unless a separate signed agreement says otherwise, no service-level agreement or guaranteed model availability applies.</p>
+
+  <h2>Charges, credits, and taxes</h2>
+  <p>Paid usage is charged against prepaid credits or another displayed payment method. Usage and prices are measured in integer microdollars even when the interface displays smaller dollar amounts. You authorize applicable charges, taxes, and automatic refills that you explicitly enable. Except where law requires otherwise, purchased credits and completed usage are non-refundable. We may correct billing errors and suspend service for unpaid or disputed amounts.</p>
+
+  <h2>Your content and credentials</h2>
+  <p>You retain rights in content you submit. You grant us and selected subprocessors the limited rights needed to transmit, process, secure, and return that content according to your request. You represent that you have the rights and permissions needed to submit it. BYOK credentials remain yours and are used only to provide the configured service.</p>
+
+  <h2>Privacy and provider terms</h2>
+  <p>Our <a href="/privacy">Privacy Policy</a> describes our data practices. Downstream model providers process content under their own terms and the route configuration you select. Privacy classes, including ZDR and end-to-end encrypted routes, apply only as described in current provider metadata and any signed agreement. You are responsible for choosing routes appropriate for your legal, regulatory, and contractual requirements.</p>
+
+  <h2>Acceptable use</h2>
+  <p>You may not use the service to violate law; infringe rights; distribute malware; compromise accounts or systems without authorization; evade provider safety, sanctions, export, or access controls; interfere with service operation; conduct abusive automated traffic; misrepresent output as human or authoritative where disclosure is required; or resell access in violation of an applicable provider agreement. You must follow applicable model-provider policies.</p>
+
+  <h2>High-risk use</h2>
+  <p>AI output may be inaccurate, incomplete, or unsuitable. You are responsible for human review and appropriate safeguards, especially for legal, medical, financial, employment, safety-critical, or other high-impact decisions. TrustedRouter does not provide legal, medical, or financial advice.</p>
+
+  <h2>Open source and feedback</h2>
+  <p>Open-source components are governed by their repository licenses. If you provide feedback, you permit us to use it without restriction or compensation.</p>
+
+  <h2>Suspension and termination</h2>
+  <p>You may stop using the service at any time. We may limit, suspend, or terminate access for security risk, legal requirements, nonpayment, abuse, material breach, or conduct that threatens the service or others. Provisions that by their nature should survive termination will survive.</p>
+
+  <h2>Disclaimers</h2>
+  <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SERVICE AND ALL MODEL OUTPUTS ARE PROVIDED "AS IS" AND "AS AVAILABLE." WE DISCLAIM IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, AND WARRANTIES ARISING FROM COURSE OF DEALING. WE DO NOT WARRANT THAT THE SERVICE OR ANY PROVIDER WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, OR ACCURATE.</p>
+
+  <h2>Limitation of liability</h2>
+  <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, NEITHER PARTY WILL BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR LOST PROFITS, REVENUE, DATA, OR GOODWILL. OUR TOTAL LIABILITY ARISING FROM THE SERVICE WILL NOT EXCEED THE GREATER OF $100 OR THE AMOUNT YOU PAID US FOR THE SERVICE DURING THE 12 MONTHS BEFORE THE EVENT GIVING RISE TO LIABILITY. THESE LIMITS DO NOT APPLY WHERE LAW PROHIBITS THEM.</p>
+
+  <h2>Indemnity</h2>
+  <p>You will defend and indemnify {{ entity.name }} and its personnel against third-party claims arising from your content, your unlawful or prohibited use, or your breach of these terms, to the extent permitted by law.</p>
+
+  <h2>Changes</h2>
+  <p>We may update these terms as the service changes. We will post updated terms here and change the effective date. Continued use after updated terms take effect constitutes acceptance, except where law requires another form of consent.</p>
+
+  <h2>Governing law</h2>
+  <p>Delaware law governs these terms without regard to conflict-of-law rules. The state and federal courts located in Delaware have exclusive jurisdiction, and each party consents to those courts, except where applicable law requires otherwise.</p>
+
+  <h2>General</h2>
+  <p>These terms, the Privacy Policy, and any signed order or addendum form the agreement for the service. A signed agreement controls if it expressly conflicts with these online terms. You may not assign this agreement without our consent; we may assign it in connection with a reorganization, financing, or sale. If a provision is unenforceable, the remainder continues. Failure to enforce a provision is not a waiver.</p>
+
+  <h2>Contact</h2>
+  <p>{{ entity.name }}<br>{{ entity.address }}<br>{{ entity.phone }}<br><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></p>
+</section>
+{% endblock %}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -48,6 +48,11 @@ def test_mcp_initialize_and_tool_list(client: TestClient) -> None:
     tools = {tool["name"]: tool for tool in listed.json()["result"]["tools"]}
     assert {"models-list", "chat-send", "credits-get", "docs-search"} <= set(tools)
     assert tools["chat-send"]["inputSchema"]["required"] == ["model", "message"]
+    for name, tool in tools.items():
+        annotations = tool["annotations"]
+        assert annotations["readOnlyHint"] is (name != "chat-send")
+        assert annotations["openWorldHint"] is False
+        assert annotations["destructiveHint"] is False
 
 
 def test_mcp_models_list_includes_sonnet_5_and_subagent(client: TestClient) -> None:

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -368,6 +368,40 @@ def test_public_legal_packet_exposes_procurement_checkpoint(client: TestClient) 
     assert "not_obtained" in page.text
     assert "trust.trustedrouter.com" in page.text
 
+
+def test_public_privacy_terms_and_support_pages_are_distinct(client: TestClient) -> None:
+    privacy = client.get("/privacy")
+    assert privacy.status_code == 200
+    assert "Privacy Policy | TrustedRouter" in privacy.text
+    assert "Lore Hex Corp" in privacy.text
+    assert "does not store prompt or output content by default" in privacy.text
+    assert "We do not use customer prompts or outputs to train our own models" in privacy.text
+    assert "/legal/subprocessors" in privacy.text
+    assert "security@trustedrouter.com" in privacy.text
+
+    terms = client.get("/terms")
+    assert terms.status_code == 200
+    assert "Terms of Service | TrustedRouter" in terms.text
+    assert "Charges, credits, and taxes" in terms.text
+    assert "Acceptable use" in terms.text
+    assert "Delaware law" in terms.text
+    assert "AS IS" in terms.text
+
+    support = client.get("/support")
+    assert support.status_code == 200
+    assert "TrustedRouter support" in support.text
+    assert "github.com/Lore-Hex/LLM-advisor/issues" in support.text
+    assert "Never send an API key" in support.text
+    assert "status.trustedrouter.com" in support.text
+
+
+def test_privacy_terms_and_support_are_in_core_sitemap(client: TestClient) -> None:
+    sitemap = client.get("/sitemap-core.xml")
+    assert sitemap.status_code == 200
+    assert "https://trustedrouter.com/privacy" in sitemap.text
+    assert "https://trustedrouter.com/terms" in sitemap.text
+    assert "https://trustedrouter.com/support" in sitemap.text
+
     packet = client.get("/legal/procurement.json")
     assert packet.status_code == 200
     assert packet.headers["content-type"].startswith("application/json")


### PR DESCRIPTION
## Summary
- publish dedicated Privacy, Terms, and Support pages required by official plugin review
- add OpenAI MCP safety annotations to every TrustedRouter tool
- expose the legal pages in navigation and the core sitemap

## Verification
- `uv run pytest -q` (1548 passed, 33 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `git diff --check`