### PR TITLE
Mark billable MCP inference as irreversible

### DIFF
--- a/src/trusted_router/routes/mcp.py
+++ b/src/trusted_router/routes/mcp.py
@@ -323,7 +323,7 @@ def _tool_schema(
         "annotations": {
             "readOnlyHint": read_only,
             "openWorldHint": False,
-            "destructiveHint": False,
+            "destructiveHint": not read_only,
         },
     }
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -52,7 +52,7 @@ def test_mcp_initialize_and_tool_list(client: TestClient) -> None:
         annotations = tool["annotations"]
         assert annotations["readOnlyHint"] is (name != "chat-send")
         assert annotations["openWorldHint"] is False
-        assert annotations["destructiveHint"] is False
+        assert annotations["destructiveHint"] is (name == "chat-send")
 
 
 def test_mcp_models_list_includes_sonnet_5_and_subagent(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- classify the billable `chat-send` MCP tool as having an irreversible side effect
- preserve read-only and non-destructive metadata for all catalog and documentation tools

This matches the OpenAI plugin-review definition for tools that incur an irreversible action.

## Verification
- `uv run pytest -q tests/test_mcp.py`
- `uv run ruff check .`
- `uv run mypy`
- `git diff --check`