### PR TITLE
Tagging cleanup: fix documented user/session_id limits, slim merge_tags

### DIFF
--- a/docs/design/request-tagging.md
+++ b/docs/design/request-tagging.md
@@ -58,8 +58,8 @@ panel and advisor calls made by combination models.
 
 ### 2.2 Limits
 
-- `user`: 128 Unicode characters.
-- `session_id`: 128 Unicode characters.
+- `user`: 256 Unicode characters.
+- `session_id`: 256 Unicode characters.
 - `trace`: JSON object, at most 8 KiB after compact UTF-8 encoding, depth at
   most 8, and at most 256 total object keys and array elements.
 - App title: 120 Unicode characters.

--- a/src/trusted_router/request_tags.py
+++ b/src/trusted_router/request_tags.py
@@ -63,9 +63,15 @@ def validate_tags(value: Any, *, field_name: str = "tags") -> dict[str, str]:
 
 
 def merge_tags(defaults: Any, request_tags: Any) -> dict[str, str]:
-    """Overlay request tags on API-key defaults and validate the result."""
-    merged = validate_tags(defaults, field_name="API key tags")
+    """Overlay request tags on API-key defaults and validate the result.
+
+    API-key defaults are validated when written; the effective map is still
+    validated after merging to enforce aggregate limits and catch corruption.
+    """
     supplied = validate_tags(request_tags)
+    # Non-dict stored defaults can only mean row corruption (writes validate);
+    # treat them as absent rather than 500ing the authorize path.
+    merged = dict(defaults) if isinstance(defaults, dict) else {}
     merged.update(supplied)
     try:
         return validate_tags(merged, field_name="effective tags")

--- a/tests/test_request_tagging.py
+++ b/tests/test_request_tagging.py
@@ -209,6 +209,18 @@ def test_merge_tags_overlays_request_values_without_mutating_defaults() -> None:
     assert defaults == {"environment": "production", "team": "platform"}
 
 
+def test_merge_tags_rejects_effective_map_over_entry_limit() -> None:
+    defaults = {f"default-{index:02d}": "value" for index in range(50)}
+    with pytest.raises(
+        InvalidTags,
+        match=(
+            r"effective tags are invalid after merging key defaults \(50\) "
+            r"and request tags \(1\): effective tags may contain at most 50 entries"
+        ),
+    ):
+        merge_tags(defaults, {"request": "value"})
+
+
 def test_api_key_default_tags_round_trip_and_patch(
     client: TestClient, user_headers: dict[str, str]
 ) -> None:


### PR DESCRIPTION
Two small items from the post-ship tagging audit.

1. **Doc drift**: design doc §2.2 said `user`/`session_id` cap at 128 chars; both implementations enforce **256**. Doc now matches code. Tag-*key* limits (genuinely 128) untouched, including the public tagging page's key-limit text.
2. **`merge_tags` micro-opt**: stop per-entry re-validation of API-key default tags on every authorize (~370–390µs pure CPU at the 50-tag cap; defaults are validated at key create/patch — `routes/keys.py:60/:100`). The merged effective map is still fully validated (aggregate caps + corruption safety net), and non-dict stored defaults are treated as absent instead of erroring on the authorize path. Test pins the over-50-entries effective-map rejection.

codex authored; Fable reviewed (added the non-dict defaults guard). ruff/mypy clean; tagging + efficiency + authorize suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)