### PR TITLE
C1: delete the GCP legacy money path (single-book era begins)

### DIFF
--- a/docs/design/retire-json-credit-ledger.md
+++ b/docs/design/retire-json-credit-ledger.md
@@ -145,11 +145,17 @@ Legend: [J] = Joseph's explicit go required · [C] = Claude runs autonomously (S
   `total_credits` still written in the same txn for rollback safety
 - [x] B3 grant-script verification against the typed snapshot — already satisfied: scripts/credit_grant_*.py have verified the typed counter since inception
 - [x] Daily invariant audit scheduling (.github/workflows/typed-audit.yml, 11:43 UTC; failing run = alert)
+- [x] C1 deletions (2026-07-14): legacy JSON reserve/finalize and the
+  cohort/denylist brake are removed; rollback-to-legacy is retired, so
+  emergency rollback means the previous deploy revision. The shard=0-only
+  backsync was already unusable for sharded workspaces, which is part of why
+  C1 landed.
 - [ ] Stale legacy-hold cleanup for workspace `ea7dd3d8` (JSON reserved=29373,
   3 open legacy reservations; display-only impact, fold into Phase C or a small cleanup)
 - [ ] Phase C deletions after 2 weeks of clean audits from 2026-07-10, the first
   clean-audit day once #148 frees the orphan holds
 
-### Rollback (any point through B)
+### Rollback (any point through B; retired by C1)
 `typed_flip.py rollback --workspace <id> --apply` → allowlist-REMOVAL deploy →
 `typed_flip.py finish --workspace <id> --allowlist-deployed --rollback --apply`.
+After C1, rollback-to-legacy is retired; emergency rollback is the previous deploy revision.

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -118,41 +118,6 @@ ENV_VARS=(
   # typed tables before the enforcement cohort flag. The typed tables already
   # exist (migrate_typed_counters.sh). Remove to revert the dual-write.
   "TR_TYPED_COUNTER_MIRROR=1"
-  # Billing typed-counter migration cutover — ENFORCEMENT. A workspace's gateway
-  # authorize/settle goes through the typed conditional-DML path (the deadlock
-  # fix) when this gate passes. Settle/refund route by reservation ORIGIN, so
-  # straddling requests stay matched. The denylist env
-  # (TR_TYPED_BILLING_WORKSPACE_DENYLIST) ALWAYS wins → per-workspace emergency
-  # kill switch (revert one workspace to legacy without a code change).
-  #
-  # 2026-06-25: REVERTED from the universal "*" default back to the validated
-  # cohort. The "*" flip exposed a latent bug — the one-way JSON->typed exact
-  # mirror copied reserved/total_usage, which the typed DML owns; any JSON write
-  # on a typed workspace clobbered the in-flight hold -> "typed finalize failed:
-  # release row-count != 1". The mirror itself is fixed by the ownership-split PR
-  # (#79: mirror only JSON-owned columns). BUT THE MIRROR FIX ALONE DOES NOT MAKE
-  # "*" SAFE. After the split, backfill() no longer seeds typed reserved/usage,
-  # so flipping a not-yet-typed workspace would leave typed.reserved blind to its
-  # open holds -> SILENT OVERSPEND (no row-count error). Re-enabling "*" requires
-  # the separate ledger-derived flip reconciliation + fail-closed seed
-  # verification (the "Step 6" safe-cutover effort).
-  #
-  # 2026-06-26: Step 6 LANDED + prod-validated — ownership-split mirror (#79),
-  # reconcile_for_flip seed (#80), typed-aware reads (#81), workspace billing-pause
-  # (#82), invariant auditor (#83/#84), reserved-clobber repair (#86). The live
-  # cohort was repaired; the CANARY (cohort + 5 seeded never-typed) deployed,
-  # converged across all regions, and the auditor stayed CLEAN through
-  # pause→flip→unpause with the typed path healthy (synthetic reserving normally,
-  # bounded open holds, zero "release row-count" errors).
-  #
-  # UNIVERSAL FLIP: every remaining workspace was reconcile_for_flip-seeded while
-  # paused (typed total_usage=JSON, reserved=0; auditor CLEAN) before this "*" went
-  # in; they stay paused through the full cross-region rollout, then unpause. The
-  # latent bug that broke the FIRST "*" is fixed at the root (ownership-split mirror
-  # no longer clobbers typed-owned columns) and every workspace is seeded, so
-  # typed.reserved is never blind to its open holds. Denylist still wins for an
-  # emergency per-workspace revert.
-  "TR_TYPED_BILLING_WORKSPACE_IDS=*"
   # Durable settle outbox (docs/design/durable-settle-outbox.md §5.4, §8):
   # every gateway settle/refund durably records its frozen intent BEFORE the
   # inline finalize, and /internal/gateway/settle-outbox/drain recovers any

--- a/scripts/typed_flip.py
+++ b/scripts/typed_flip.py
@@ -372,11 +372,11 @@ def _run_audit(store: Any) -> bool:
 def _print_prepare_next_steps(workspace_id: str) -> None:
     print("NEXT STEPS:")
     print(
-        "add the workspace id to TR_TYPED_BILLING_WORKSPACE_IDS in "
-        "scripts/deploy/rollout.sh, merge (deploy runs),"
+        "deploy the C1 typed-capability route after verifying the prepared "
+        f"workspace {workspace_id} is seeded,"
     )
     print(
-        "verify the SERVING revision env, then run "
+        "verify the SERVING revision, then run "
         f"`typed_flip.py finish --workspace {workspace_id} --allowlist-deployed`."
     )
     print("Workspace REMAINS PAUSED.")
@@ -491,11 +491,11 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
 def _print_rollback_next_steps(workspace_id: str) -> None:
     print("ROLLBACK NEXT STEPS:")
     print(
-        "remove the workspace id from TR_TYPED_BILLING_WORKSPACE_IDS in "
-        "scripts/deploy/rollout.sh, merge (deploy runs),"
+        "roll back the deploy to the previous revision if you need the retired "
+        f"legacy gate for workspace {workspace_id},"
     )
     print(
-        "verify the SERVING revision env, then run "
+        "verify the SERVING revision, then run "
         f"`typed_flip.py finish --workspace {workspace_id} --allowlist-deployed --rollback`."
     )
     print("Workspace REMAINS PAUSED.")

--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -28,6 +28,7 @@ Design choices:
 """
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 import re
@@ -37,13 +38,13 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
-from requests.adapters import HTTPAdapter  # type: ignore[import-untyped]
 from urllib3.util.retry import Retry
 
 from trusted_router.config import Settings
 from trusted_router.sentry_config import _scrub
 
 log = logging.getLogger(__name__)
+HTTPAdapter: Any = importlib.import_module("requests.adapters").HTTPAdapter
 
 # Key-based `_scrub` cannot see positional-arg VALUES; collapsing + regex is
 # the args-safe complement (PR #124 review P2).

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -41,21 +41,6 @@ class Settings(BaseSettings):
     bigtable_instance_id: str | None = None
     bigtable_generation_table: str = "trustedrouter-generations"
 
-    # Typed-column billing enforcement cutover (docs/design/billing-typed-counters).
-    # Per-workspace allowlist (CSV) that authorize uses the typed conditional-DML
-    # path for; settle/refund route by reservation ORIGIN, not this flag. Default
-    # empty = legacy path everywhere (zero behavior change). "*" = all workspaces.
-    # The denylist is an emergency kill switch that always wins; "*" in the
-    # DENYLIST is the FAST GLOBAL kill-switch — it disables typed enforcement for
-    # every workspace on the next request (no deploy). It is a break-glass
-    # AVAILABILITY brake (keeps the app serving via the legacy path), NOT a
-    # billing-clean rollback: already-typed workspaces have stale-low JSON usage
-    # (#79) so the fallback under-bills until re-enabled or reconciled via the
-    # pause->drain->backsync runbook (#32). Flip via
-    # TR_TYPED_BILLING_WORKSPACE_DENYLIST=*, then run the backsync.
-    typed_billing_workspace_ids: str = ""
-    typed_billing_workspace_denylist: str = ""
-
     # Free "trial" credit granted to a new workspace the first time a valid
     # payment card is attached (routes/internal/webhook.py). Default 0 = NO free
     # credit for new users (policy as of 2026-06-25); a card attach saves the

--- a/src/trusted_router/routes/console/welcome.py
+++ b/src/trusted_router/routes/console/welcome.py
@@ -8,7 +8,7 @@ from fastapi.responses import HTMLResponse, Response
 from trusted_router.auth import SettingsDep
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.routes.oauth import PENDING_REVEAL_COOKIE
-from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
 
 
 def register(app: FastAPI) -> None:
@@ -19,8 +19,8 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         first: int | None = None,
     ) -> Response:
-        credit = STORE.get_credit_account(ctx.workspace.id)
-        trial_microdollars = credit.total_credits_microdollars if credit else 0
+        summary = live_credit_summary(ctx.workspace.id)
+        trial_microdollars = summary["total_credits"] if summary else 0
         # `tr_pending_reveal` is the short-lived one-shot cookie set by
         # the OAuth callback right before its 302 here. It carries the
         # raw API key minted during STORE.signup(). We read it ONCE,

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -264,10 +264,10 @@ def _authorize_gateway_sync(
         workspace.id, api_key.hash, request_idempotency_key
     )
     if existing_authorization is None:
-        # Typed authorizations have no JSON idempotency index; look them up
-        # INDEPENDENT of the cohort flag so a retry after a cohort flag-off /
-        # denylist rollback still replays (codex 3e route review #2).
-        _typed_store = typed_billing_store()
+        # Typed authorizations have no JSON idempotency index; whenever the
+        # active store has typed billing, retries must replay from the typed
+        # table because the legacy cohort brake no longer exists after C1.
+        _typed_store = typed_billing_store(STORE)
         if _typed_store is not None:
             existing_authorization = _typed_store.get_typed_authorization_by_idempotency(
                 workspace.id, api_key.hash, request_idempotency_key
@@ -282,22 +282,11 @@ def _authorize_gateway_sync(
         return _replay_response(existing_authorization)
     credit_reservation_id: str | None = None
     idempotent_replay = False
-    # Typed-column billing cutover: when this workspace is in the cohort AND
-    # the store supports it (Spanner), authorize via the atomic conditional-DML
-    # path (the deadlock fix). Default-off -> the legacy path below, unchanged.
-    _typed_store = typed_billing_store()
-    _typed_cohort = False
+    # C1 removed the workspace cohort/denylist brake: GCP now always uses typed
+    # billing when the store exposes that capability. Emergency rollback is the
+    # previous deploy revision; the memory store below remains the test twin.
+    _typed_store = typed_billing_store(STORE)
     if _typed_store is not None:
-        from trusted_router.storage_gcp_authorize import (
-            typed_billing_enabled_for_workspace,
-        )
-
-        _typed_cohort = typed_billing_enabled_for_workspace(
-            workspace.id,
-            allowlist_csv=settings.typed_billing_workspace_ids,
-            denylist_csv=settings.typed_billing_workspace_denylist,
-        )
-    if _typed_store is not None and _typed_cohort:
         import datetime as _dt
 
         from trusted_router.spend_windows import (
@@ -908,17 +897,10 @@ def _settle_gateway_authorization(
         )
         generation_id = generation.id
 
-    # Typed-column billing cutover: settle by reservation ORIGIN, not the cohort
-    # flag, so a request that reserved typed settles typed and a JSON one settles
-    # JSON (codex 3e). Default: no typed reservation (or InMemory store) -> legacy
-    # path unchanged.
-    _typed_store = typed_billing_store()
-    is_typed = (
-        _typed_store is not None
-        and _typed_store.is_typed_reservation(
-            authorization.credit_reservation_id, authorization.id
-        )
-    )
+    # C1 removed the GCP legacy finalize branch; Spanner finalizes through typed
+    # billing unconditionally. The memory store still uses the single-book path.
+    _typed_store = typed_billing_store(STORE)
+    is_typed = _typed_store is not None
     intent_kind = "settle" if success else "refund"
     enqueue_ms = 0.0
     if settings.settle_outbox_enabled:
@@ -926,7 +908,7 @@ def _settle_gateway_authorization(
         try:
             # §5.4 honest scope: durability starts only when this INSERT commits;
             # crashes before it still rely on enclave redelivery. MF4/MF5 freeze
-            # the origin and exact resolved cost used by the inline finalize.
+            # the finalize path and exact resolved cost used by the inline attempt.
             spanner_settle_outbox().enqueue(
                 SettleOutboxRow(
                     authorization_id=authorization.id,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -85,7 +85,6 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 )
 from trusted_router.storage_gcp_verification_tokens import SpannerVerificationTokens
 from trusted_router.storage_gcp_wallet_challenges import SpannerWalletChallenges
-from trusted_router.storage_models import _is_byok
 from trusted_router.types import UsageType
 
 T = TypeVar("T")
@@ -302,13 +301,15 @@ class SpannerBigtableStore:
             creator_user_id=user.id,
             management=True,
         )
-        credit = self.get_credit_account(workspace.id)
+        from trusted_router.typed_balance import live_credit_summary
+
+        summary = live_credit_summary(workspace.id, store=self)
         return SignupResult(
             user=user,
             workspace=workspace,
             raw_key=raw_key,
             api_key=api_key,
-            trial_credit_microdollars=credit.total_credits_microdollars if credit else 0,
+            trial_credit_microdollars=summary["total_credits"] if summary else 0,
         )
 
     # Auth sessions delegate to storage_gcp_auth_sessions.SpannerAuthSessions.
@@ -838,9 +839,10 @@ class SpannerBigtableStore:
         def txn(transaction: Any) -> bool:
             if self._read_entity_tx(transaction, "stripe_event", event_id, dict) is not None:
                 return False
-            account = self._require_credit_tx(transaction, workspace_id)
             amount = int(amount_microdollars)
-            new_total = int(account.total_credits_microdollars) + amount
+            account = self._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+            if account is None:
+                raise ValueError("credit account not found")
             shard_count = credit_shard_count(account)
             shard_deltas = distribute_credit_amount(amount, shard_count)
             now = dt.datetime.now(dt.UTC).replace(microsecond=0)
@@ -872,6 +874,8 @@ class SpannerBigtableStore:
                     raise RuntimeError(
                         f"missing tr_credit_balance shard {shard} for sharded workspace"
                     )
+                # Seed path for pre-mirror rows; JSON credit money dies in C2.
+                new_total = int(account.total_credits_microdollars) + amount
                 transaction.execute_update(
                     "INSERT INTO tr_credit_balance "
                     "(workspace_id, shard, total_credits, source_updated_at, updated_at) "
@@ -890,10 +894,15 @@ class SpannerBigtableStore:
                     },
                 )
 
-            account.total_credits_microdollars = new_total
-            # Post-B2 authoritative top-up path: typed total_credits is updated
-            # explicitly above, and JSON is kept warm directly. Do not call
-            # _write_entity_tx here or the generic mirror would double-apply.
+            # Keep the JSON total_credits WARM until C2 deletes the mirror.
+            # The credit mirror still replays the JSON body's total_credits
+            # into tr_credit_balance shard 0 on every credit-entity metadata
+            # write (auto-refill toggles, stripe customer updates); a stale
+            # JSON total would clobber typed-direct top-ups (verified P0).
+            # Warm-keeping and the mirror must be deleted TOGETHER in C2.
+            account.total_credits_microdollars = (
+                int(account.total_credits_microdollars) + amount
+            )
             if update_entity_body_dml(
                 transaction,
                 pt,
@@ -996,18 +1005,19 @@ class SpannerBigtableStore:
         *,
         idempotency_key: str | None = None,
     ) -> Reservation:
-        return self.api_keys.reserve(
-            workspace_id,
-            key_hash,
-            amount_microdollars,
-            idempotency_key=idempotency_key,
+        raise RuntimeError(
+            "legacy JSON reserve path removed (C1); direct inference requires the memory store"
         )
 
     def settle(self, reservation_id: str, actual_microdollars: int) -> None:
-        self.api_keys.settle(reservation_id, actual_microdollars)
+        raise RuntimeError(
+            "legacy JSON settle path removed (C1); direct inference requires the memory store"
+        )
 
     def refund(self, reservation_id: str) -> None:
-        self.api_keys.refund(reservation_id)
+        raise RuntimeError(
+            "legacy JSON refund path removed (C1); direct inference requires the memory store"
+        )
 
     def create_gateway_authorization(
         self,
@@ -1074,96 +1084,13 @@ class SpannerBigtableStore:
         selected_usage_type: UsageType | str,
         generation: Generation | None = None,
     ) -> bool:
-        actual_usage_type = UsageType.coerce(selected_usage_type)
-
-        def txn(transaction: Any) -> bool:
-            authorization = self._read_entity_tx(
-                transaction, "gateway_authorization", authorization_id, GatewayAuthorization
-            )
-            if authorization is None or authorization.settled:
-                return False
-
-            if authorization.credit_reservation_id is not None:
-                reservation = self._read_entity_tx(
-                    transaction,
-                    "reservation",
-                    authorization.credit_reservation_id,
-                    Reservation,
-                )
-                if reservation is None:
-                    raise ValueError("gateway reservation not found")
-                if not reservation.settled:
-                    account = self._require_credit_tx(
-                        transaction, reservation.workspace_id
-                    )
-                    account.reserved_microdollars -= reservation.amount_microdollars
-                    if success and actual_usage_type == UsageType.CREDITS:
-                        account.total_usage_microdollars += actual_microdollars
-                    reservation.settled = True
-                    self._write_entity_tx(
-                        transaction, "credit", account.workspace_id, account
-                    )
-                    self._write_entity_tx(
-                        transaction, "reservation", reservation.id, reservation
-                    )
-
-            key = self._read_entity_tx(transaction, "api_key", authorization.key_hash, ApiKey)
-            if key is not None:
-                if key.limit_microdollars is not None and not (
-                    _is_byok(authorization.usage_type) and not key.include_byok_in_limit
-                ):
-                    key.reserved_microdollars = max(
-                        0,
-                        key.reserved_microdollars
-                        - authorization.estimated_microdollars,
-                    )
-                if success and generation is not None:
-                    if _is_byok(generation.usage_type):
-                        key.byok_usage_microdollars += generation.total_cost_microdollars
-                    else:
-                        key.usage_microdollars += generation.total_cost_microdollars
-                self._write_entity_tx(transaction, "api_key", key.hash, key)
-
-            if success and generation is not None:
-                self._write_entity_tx(transaction, "generation", generation.id, generation)
-                self._write_entity_tx(
-                    transaction,
-                    "generation_by_workspace",
-                    _generation_workspace_id(generation),
-                    {"generation_id": generation.id},
-                )
-
-            authorization.settled = True
-            self._write_entity_tx(
-                transaction,
-                "gateway_authorization",
-                authorization.id,
-                authorization,
-            )
-            return True
-
-        spanner_start = time.perf_counter()
-        finalized = self._run_in_transaction(txn)
-        spanner_ms = (time.perf_counter() - spanner_start) * 1000
-        index_ms = 0.0
-        if finalized and success and generation is not None:
-            index_start = time.perf_counter()
-            self.generation_store.index_after_commit(generation)
-            index_ms = (time.perf_counter() - index_start) * 1000
-        if finalized:
-            # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
-            # into Spanner-txn vs Bigtable-index time.
-            log.info(
-                "legacy finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f",
-                authorization_id,
-                spanner_ms,
-                index_ms,
-            )
-        return bool(finalized)
+        raise RuntimeError(
+            "legacy JSON finalize path removed (C1); use typed finalize on Spanner"
+        )
 
     # ── Typed-column billing (Step 3): thin wrappers over storage_gcp_authorize.
-    # The atomic conditional-DML authorize/settle engine. Gated by the route on
-    # the cohort flag (authorize) and reservation origin (settle/refund).
+    # The atomic conditional-DML authorize/settle engine. Routes select this by
+    # typed-store capability; the legacy cohort/denylist brake is gone after C1.
     def authorize_gateway_atomic(self, **kwargs: Any) -> dict:
         from trusted_router.storage_gcp_authorize import authorize_atomic
 
@@ -1930,12 +1857,6 @@ class SpannerBigtableStore:
         if email_user:
             return str(email_user["user_id"])
         return None
-
-    def _require_credit_tx(self, transaction: Any, workspace_id: str) -> CreditAccount:
-        account = self._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if account is None:
-            raise ValueError("credit account not found")
-        return account
 
     def _read_entity(self, kind: str, entity_id: str, cls: type[T]) -> T | None:
         with self._database.snapshot() as snapshot:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -628,36 +628,3 @@ def typed_finalize_atomic(
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
 
-
-def typed_billing_enabled_for_workspace(
-    workspace_id: str, *, allowlist_csv: str, denylist_csv: str
-) -> bool:
-    """Cohort gate for the typed AUTHORIZE path. Default-off; the denylist is an
-    emergency kill switch that always wins; "*" in the allowlist = all. Settle/
-    refund route by reservation ORIGIN, not this gate (codex 3e).
-
-    Fast global kill-switch: "*" in the DENYLIST disables typed enforcement for
-    every workspace at once (deny always wins, so it beats an "*" allowlist).
-    Flip it with `gcloud run services update --update-env-vars
-    TR_TYPED_BILLING_WORKSPACE_DENYLIST=*` — takes effect on the next request
-    across the region without a code deploy, and reverting is just clearing the
-    var. Every typed path (authorize + the typed-aware balance reads) funnels
-    through this one predicate, so the kill is comprehensive.
-
-    This is a BREAK-GLASS AVAILABILITY brake, NOT a billing-clean rollback.
-    Reach for it when the typed gate itself misbehaves (deadlocks, elevated
-    errors/latency) and you need requests flowing again NOW; killed workspaces
-    fall back to the legacy JSON authorize path, so the app keeps serving. But
-    it is deliberately NOT revenue-neutral for a workspace that was already
-    running typed: its JSON usage columns are stale-LOW because the typed-owned
-    counters are never mirrored back to JSON (the #79 ownership split), so the
-    JSON fallback under-counts spend and can OVER-admit / UNDER-bill until typed
-    is re-enabled. A *correct* rollback is the pause -> drain -> backsync runbook
-    (storage_gcp_counter_reconcile / #32), which reconciles JSON before cutting
-    over; denylisting alone is knowingly lossy. Use the kill-switch to stop the
-    bleeding, then run the backsync — don't treat it as a clean off-switch."""
-    deny = {w.strip() for w in denylist_csv.split(",") if w.strip()}
-    if "*" in deny or workspace_id in deny:
-        return False
-    allow = {w.strip() for w in allowlist_csv.split(",") if w.strip()}
-    return "*" in allow or workspace_id in allow

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -1,9 +1,9 @@
-"""Spanner-backed API key + reservation + gateway-authorization lifecycle.
+"""Spanner-backed API key + gateway-authorization lifecycle.
 
 Sibling of InMemoryApiKeys (storage_keys.py). Both expose the same public
 surface (create / get_by_hash / get_by_raw / list_for_workspace / delete /
-update / reserve_limit / settle_limit / refund_limit / reserve / settle /
-refund / create_gateway_authorization / get_gateway_authorization /
+update / reserve_limit / settle_limit / refund_limit /
+create_gateway_authorization / get_gateway_authorization /
 mark_gateway_authorization_settled / add_usage); SpannerBigtableStore's
 public methods become thin one-line delegations.
 """
@@ -28,9 +28,7 @@ from trusted_router.storage_gcp_codec import workspace_key_id as _workspace_key_
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
 from trusted_router.storage_models import (
     ApiKey,
-    CreditAccount,
     GatewayAuthorization,
-    Reservation,
     _is_byok,
     iso_now,
 )
@@ -257,100 +255,6 @@ class SpannerApiKeys:
             self._io.write_entity_tx(transaction, "api_key", key.hash, key)
 
         run_in_transaction_with_retry(self._io.database, txn)
-
-    # ── Credit reservations ─────────────────────────────────────────────
-    def reserve(
-        self,
-        workspace_id: str,
-        key_hash: str,
-        amount_microdollars: int,
-        *,
-        idempotency_key: str | None = None,
-    ) -> Reservation:
-        def txn(transaction: Any) -> Reservation:
-            # Idempotency first. We persist the lookup as a separate
-            # entity (kind = "reservation_idemp") with the key as the
-            # primary id. If found, fetch the original reservation and
-            # return it without re-debiting. Both writes (the lookup
-            # row + the reservation + the credit-account update)
-            # commit in the same Spanner transaction below, so a
-            # retry that finds the lookup is guaranteed to find the
-            # reservation too.
-            if idempotency_key is not None:
-                lookup = self._io.read_entity_tx(
-                    transaction,
-                    "reservation_idemp",
-                    idempotency_key,
-                    dict,
-                )
-                if lookup is not None:
-                    existing = self._io.read_entity_tx(
-                        transaction,
-                        "reservation",
-                        lookup["reservation_id"],
-                        Reservation,
-                    )
-                    if existing is not None:
-                        return existing
-            account = self._read_credit_tx(transaction, workspace_id)
-            available = (
-                account.total_credits_microdollars
-                - account.total_usage_microdollars
-                - account.reserved_microdollars
-            )
-            if amount_microdollars > available:
-                raise ValueError("insufficient credits")
-            account.reserved_microdollars += amount_microdollars
-            reservation = Reservation(
-                id=str(uuid.uuid4()),
-                workspace_id=workspace_id,
-                key_hash=key_hash,
-                amount_microdollars=amount_microdollars,
-                idempotency_key=idempotency_key,
-            )
-            self._io.write_entity_tx(transaction, "credit", workspace_id, account)
-            self._io.write_entity_tx(transaction, "reservation", reservation.id, reservation)
-            if idempotency_key is not None:
-                self._io.write_entity_tx(
-                    transaction,
-                    "reservation_idemp",
-                    idempotency_key,
-                    {"reservation_id": reservation.id},
-                )
-            return reservation
-
-        return run_in_transaction_with_retry(self._io.database, txn)
-
-    def settle(self, reservation_id: str, actual_microdollars: int) -> None:
-        self._finish_reservation(reservation_id, actual_microdollars, success=True)
-
-    def refund(self, reservation_id: str) -> None:
-        self._finish_reservation(reservation_id, 0, success=False)
-
-    def _finish_reservation(
-        self, reservation_id: str, actual_microdollars: int, *, success: bool
-    ) -> None:
-        def txn(transaction: Any) -> None:
-            reservation = self._io.read_entity_tx(
-                transaction, "reservation", reservation_id, Reservation
-            )
-            if reservation is None or reservation.settled:
-                return
-            account = self._read_credit_tx(transaction, reservation.workspace_id)
-            account.reserved_microdollars -= reservation.amount_microdollars
-            if success:
-                account.total_usage_microdollars += actual_microdollars
-            reservation.settled = True
-            self._io.write_entity_tx(transaction, "credit", account.workspace_id, account)
-            self._io.write_entity_tx(transaction, "reservation", reservation.id, reservation)
-
-        run_in_transaction_with_retry(self._io.database, txn)
-
-    def _read_credit_tx(self, transaction: Any, workspace_id: str) -> CreditAccount:
-        account = self._io.read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if account is None:
-            raise ValueError("credit account not found")
-        return account
 
     # ── Gateway authorizations ──────────────────────────────────────────
     def create_gateway_authorization(

--- a/src/trusted_router/typed_balance.py
+++ b/src/trusted_router/typed_balance.py
@@ -11,10 +11,9 @@ usage/remaining — would see a stale-LOW usage and an overstated available
 balance (e.g. auto-refill would never fire → the card is never charged →
 underbill). These helpers overlay the authoritative typed counters onto the
 JSON-loaded object for typed workspaces, and are a no-op for legacy workspaces or
-stores without typed tables.
-
-Routing decision = the same cohort gate the authorize path uses
-(typed_billing_enabled_for_workspace), evaluated from the caller's Settings.
+stores without typed tables. After C1, typed-overlay eligibility is capability
+based: a typed store with a typed row wins, and the in-memory store remains the
+single-book test twin.
 """
 
 from __future__ import annotations
@@ -23,7 +22,6 @@ import dataclasses
 from typing import Any, TypedDict
 
 from trusted_router.storage import STORE, typed_billing_store
-from trusted_router.storage_gcp_authorize import typed_billing_enabled_for_workspace
 from trusted_router.storage_models import CreditAccount
 
 
@@ -32,14 +30,6 @@ class LiveCreditSummary(TypedDict):
     total_usage: int
     reserved: int
     available: int
-
-
-def _typed_enabled(workspace_id: str, settings: Any) -> bool:
-    return typed_billing_enabled_for_workspace(
-        workspace_id,
-        allowlist_csv=settings.typed_billing_workspace_ids,
-        denylist_csv=settings.typed_billing_workspace_denylist,
-    )
 
 
 def typed_aware_credit_account(
@@ -59,11 +49,9 @@ def typed_aware_credit_account(
     typed_store = typed_billing_store(store)
     if account is None or typed_store is None:
         return account
-    if not _typed_enabled(workspace_id, settings):
-        return account
     typed = typed_store.typed_credit_snapshot(workspace_id)
     if typed is None:
-        return account  # typed enforcement on but row not seeded yet — JSON is the best estimate
+        return account  # typed-capable store, but no row yet — JSON is the best estimate
     return dataclasses.replace(
         account,
         total_credits_microdollars=int(typed[0]),

--- a/tests/test_billing_flip_reconcile.py
+++ b/tests/test_billing_flip_reconcile.py
@@ -77,7 +77,15 @@ def test_reconcile_refuses_open_credit_hold() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_hold"
     _seed_drained_workspace(store, ws, total_credits=1_000_000, total_usage=0)
-    store.reserve(ws, "key_1", 250_000)  # open legacy credit hold
+    store._write_entity(
+        "credit",
+        ws,
+        CreditAccount(
+            workspace_id=ws,
+            total_credits_microdollars=1_000_000,
+            reserved_microdollars=250_000,
+        ),
+    )
 
     result = reconcile_for_flip(store, ws, apply=True)
     assert not result.ready

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -101,21 +101,6 @@ def test_other_json_credit_writes_still_fire_mirror() -> None:
     assert _typed_credit(db, ws)["reserved"] == 0
 
 
-def test_json_credit_reserve_does_not_propagate_to_typed_reserved() -> None:
-    """A legacy JSON-path reserve updates JSON.reserved, but the mirror does NOT
-    carry it into the typed-DML-owned tr_credit_balance.reserved."""
-    store, db, _ = make_fake_store()
-    ws = "ws_legacy_reserve"
-    store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
-    )
-    store.reserve(ws, "key_1", 250_000)
-    assert _json_credit(db, ws)["reserved_microdollars"] == 250_000
-    # total_credits still mirrored; reserved stays at the typed default (0).
-    assert_credit_total_mirrored(db, ws)
-    assert _typed_credit(db, ws)["reserved"] == 0
-
-
 def test_json_credit_write_does_not_clobber_typed_hold() -> None:
     """THE 2026-06-25 incident reproduction. A typed-DML hold sits in
     tr_credit_balance.reserved; a JSON credit write (top-up) fires the mirror.
@@ -132,7 +117,7 @@ def test_json_credit_write_does_not_clobber_typed_hold() -> None:
     assert store._database.run_in_transaction(lambda t: reserve_credit(t, pt, ws, 300_000))
     assert _typed_credit(db, ws)["reserved"] == 300_000
 
-    # a JSON credit top-up (mirror fires) must NOT clobber the in-flight hold
+    # a typed-direct top-up must NOT clobber the in-flight hold
     store.credit_workspace_once(ws, 500_000, "evt_topup")
     assert _typed_credit(db, ws)["total_credits"] == 1_500_000  # credit applied
     assert _typed_credit(db, ws)["reserved"] == 300_000  # hold preserved
@@ -202,12 +187,9 @@ def test_mirror_disabled_writes_no_typed_rows() -> None:
     store._write_entity(
         "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
     )
-    store.reserve(ws, "key_1", 100_000)
     assert CREDIT_BALANCE_TABLE not in db.typed or (ws, 0) not in db.typed.get(
         CREDIT_BALANCE_TABLE, {}
     )
-    # JSON path unaffected.
-    assert _json_credit(db, ws)["reserved_microdollars"] == 100_000
 
 
 def test_uncapped_key_mirrors_null_limit() -> None:
@@ -264,7 +246,15 @@ def test_compare_clean_after_mirror() -> None:
     _raw, key = store.api_keys.create(
         workspace_id=ws, name="k", creator_user_id=None, limit_microdollars=2_000_000
     )
-    store.reserve(ws, key.hash, 400_000)
+    store._write_entity(
+        "credit",
+        ws,
+        CreditAccount(
+            workspace_id=ws,
+            total_credits_microdollars=3_000_000,
+            reserved_microdollars=400_000,
+        ),
+    )
     store.reserve_key_limit(key.hash, 400_000, usage_type="Credits")
 
     report = compare(store)
@@ -369,3 +359,40 @@ def test_backfill_dry_run_still_compares_and_signals_drift() -> None:
     assert counts["credit"] == 1
     assert CREDIT_BALANCE_TABLE not in db.typed
     assert not compare(store).clean
+
+
+def test_metadata_writes_never_clobber_typed_topups() -> None:
+    """P0 regression (C1 verification): a typed-direct top-up followed by ANY
+    JSON credit metadata write (auto-refill outcome, stripe customer) must not
+    revert typed total_credits. The mirror replays the JSON body's
+    total_credits on every credit write, so the JSON copy must stay WARM until
+    the mirror dies in C2 — a stale JSON total silently destroyed paid credits
+    (and looped Stripe auto-refill charges) when the warm-keep was removed."""
+    store, db, _ = make_fake_store()
+    ws = "ws-warmkeep"
+    store.ensure_user("warmkeep@example.com")
+    store._write_entity(
+        "credit",
+        ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=100_000_000),
+    )
+    db.typed.setdefault("tr_credit_balance", {})[(ws, 0)] = {
+        "workspace_id": ws,
+        "shard": 0,
+        "total_credits": 100_000_000,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+    assert store.credit_workspace_once(ws, 50_000_000, "evt-topup-1")
+    typed_after_topup = db.typed["tr_credit_balance"][(ws, 0)]["total_credits"]
+    assert typed_after_topup == 150_000_000
+
+    # The webhook calls these immediately after crediting — the clobber path.
+    store.record_auto_refill_outcome(ws, status="succeeded")
+    assert db.typed["tr_credit_balance"][(ws, 0)]["total_credits"] == 150_000_000
+
+    store.set_stripe_customer(ws, customer_id="cus_warmkeep")
+    assert db.typed["tr_credit_balance"][(ws, 0)]["total_credits"] == 150_000_000

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -30,14 +30,16 @@ def test_credit_workspace_typed_direct_applies_once_in_one_transaction() -> None
     ws = "ws_b2_apply"
     event_id = "evt_b2_apply"
     _seed_credit(store, ws, 1_000_000)
-
+    
     assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is True
 
     assert _json_credit(db, ws)["total_credits_microdollars"] == 1_500_000
     assert _typed_credit(db, ws)["total_credits"] == 1_500_000
     assert ("stripe_event", event_id) in db.rows
+    commit_version = db.rows[("stripe_event", event_id)].version
     commit_version = db.rows[("credit", ws)].version
     assert db.rows[("stripe_event", event_id)].version == commit_version
+    assert db.typed_versions[(CREDIT_BALANCE_TABLE, (ws, 0))] == commit_version
     assert db.typed_versions[(CREDIT_BALANCE_TABLE, (ws, 0))] == commit_version
 
     assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is False
@@ -60,6 +62,7 @@ def test_credit_workspace_typed_direct_creates_missing_typed_row_from_json() -> 
     assert typed["total_credits"] == 2_750_000
     assert typed["total_usage"] == 0
     assert typed["reserved"] == 0
+    assert ("stripe_event", "evt_b2_seed") in db.rows
 
 
 def test_credit_workspace_once_wrapper_cross_path_idempotency() -> None:
@@ -77,6 +80,29 @@ def test_credit_workspace_once_wrapper_cross_path_idempotency() -> None:
     assert store.credit_workspace_typed_direct(ws, 900_000, "evt_old_marker") is False
     assert _json_credit(db, ws)["total_credits_microdollars"] == 1_400_000
     assert _typed_credit(db, ws)["total_credits"] == 1_400_000
+
+
+def test_gcp_signup_reports_typed_trial_credit(monkeypatch) -> None:
+    store, db, _ = make_fake_store()
+    original_create_api_key = store.create_api_key
+    grant_amount = 3_000_000
+
+    def create_api_key_and_grant(*args, **kwargs):
+        result = original_create_api_key(*args, **kwargs)
+        workspace_id = kwargs["workspace_id"]
+        assert store.credit_workspace_typed_direct(
+            workspace_id, grant_amount, f"trial:{workspace_id}"
+        )
+        return result
+
+    monkeypatch.setattr(store, "create_api_key", create_api_key_and_grant)
+
+    result = store.signup(email="typed-signup@example.com")
+
+    assert result is not None
+    assert result.trial_credit_microdollars == grant_amount
+    assert _json_credit(db, result.workspace.id)["total_credits_microdollars"] == _typed_credit(db, result.workspace.id)["total_credits"]
+    assert _typed_credit(db, result.workspace.id)["total_credits"] == grant_amount
 
 
 def test_stripe_checkout_webhook_routes_topup_through_typed_direct(

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -1024,35 +1024,7 @@ def test_typed_finalize_race_books_once() -> None:
     assert _typed(db, ws)["total_usage"] == 900_000  # charged exactly once
 
 
-# ── 3e-2: cohort gate + store wrappers + origin detection ───────────────────
-
-from trusted_router.storage_gcp_authorize import typed_billing_enabled_for_workspace  # noqa: E402
-
-
-def test_cohort_gate_allowlist_denylist_wildcard() -> None:
-    f = typed_billing_enabled_for_workspace
-    assert f("ws1", allowlist_csv="ws1,ws2", denylist_csv="") is True
-    assert f("ws3", allowlist_csv="ws1,ws2", denylist_csv="") is False
-    assert f("ws9", allowlist_csv="*", denylist_csv="") is True
-    assert f("ws1", allowlist_csv="*", denylist_csv="ws1") is False  # denylist wins
-    assert f("ws1", allowlist_csv="", denylist_csv="") is False  # default off
-
-
-def test_cohort_gate_denylist_wildcard_is_global_kill_switch() -> None:
-    """"*" in the denylist = fast global kill: typed enforcement off for EVERY
-    workspace, beating even an "*" allowlist (deny always wins). This is a
-    break-glass availability brake — for already-typed workspaces the JSON
-    fallback is stale-low (#79), so it under-bills until the backsync runbook
-    (#32) runs; see typed_billing_enabled_for_workspace + test_typed_balance."""
-    f = typed_billing_enabled_for_workspace
-    # Kills a workspace that would otherwise be allowed by an explicit allowlist…
-    assert f("ws1", allowlist_csv="ws1,ws2", denylist_csv="*") is False
-    # …and one allowed by the "*" allowlist (the "everyone on" cutover state).
-    assert f("ws9", allowlist_csv="*", denylist_csv="*") is False
-    # Works alongside specific denies, and any workspace is killed.
-    assert f("anything", allowlist_csv="*", denylist_csv="ws1, *") is False
-    # Sanity: without the wildcard, a specific deny only kills that workspace.
-    assert f("ws2", allowlist_csv="*", denylist_csv="ws1") is True
+# ── 3e-2: store wrappers + origin detection ─────────────────────────────────
 
 
 def test_store_authorize_wrapper_and_origin_detection() -> None:

--- a/tests/test_credit_row_sharding_increment1.py
+++ b/tests/test_credit_row_sharding_increment1.py
@@ -19,6 +19,7 @@ from trusted_router.storage_gcp_counters import (
     distribute_credit_amount,
 )
 from trusted_router.storage_models import CreditAccount
+from trusted_router.typed_balance import live_credit_summary
 
 
 def _credit_row(
@@ -224,6 +225,7 @@ def test_typed_direct_grant_distributes_delta_and_is_idempotent() -> None:
 
     rows = database.typed[CREDIT_BALANCE_TABLE]
     assert [rows[(workspace_id, shard)]["total_credits"] for shard in range(3)] == [44, 33, 33]
+    assert live_credit_summary(workspace_id, store=store)["total_credits"] == 110
     assert store.get_credit_account(workspace_id).total_credits_microdollars == 110
 
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from trusted_router.catalog import MODELS, endpoint_for_id
+from tests.fakes.spanner import make_fake_store
+from trusted_router.catalog import MODELS, default_endpoint_for_model, endpoint_for_id
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.money import token_cost_microdollars
 from trusted_router.routes.helpers import cost_microdollars
-from trusted_router.storage import STORE
+from trusted_router.storage import STORE, CreditAccount, Workspace, configure_store
 
 
 def _client_and_key() -> tuple[TestClient, dict]:
@@ -20,6 +21,99 @@ def _client_and_key() -> tuple[TestClient, dict]:
     )
     assert created.status_code == 201, created.text
     return client, created.json()["data"]
+
+
+def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_gcp_capability_authorize"
+    store._write_entity("workspace", ws, Workspace(id=ws, name="GCP", owner_user_id="u"))
+    store._write_entity(
+        "credit",
+        ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=10_000_000),
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=ws,
+        name="gateway typed",
+        creator_user_id="u",
+    )
+    configure_store(store)
+    settings = Settings(environment="test")
+    client = TestClient(
+        create_app(settings, configure_store_arg=False, init_observability=False)
+    )
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 1_000,
+        },
+    )
+
+    assert authorize.status_code == 200, authorize.text
+    data = authorize.json()["data"]
+    assert data["credit_reservation_id"] in db.reservations
+    assert ("reservation", data["credit_reservation_id"]) not in db.rows
+
+
+def test_gateway_settle_ancient_legacy_reservation_missing_typed_row_is_clean() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_gcp_ancient_legacy_settle"
+    store._write_entity("workspace", ws, Workspace(id=ws, name="GCP", owner_user_id="u"))
+    store._write_entity(
+        "credit",
+        ws,
+        CreditAccount(workspace_id=ws, total_credits_microdollars=10_000_000),
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=ws,
+        name="gateway legacy",
+        creator_user_id="u",
+    )
+    model = MODELS["anthropic/claude-opus-4.7"]
+    endpoint = default_endpoint_for_model(model)
+    assert endpoint is not None
+    auth = store.create_gateway_authorization(
+        workspace_id=ws,
+        key_hash=api_key.hash,
+        model_id=model.id,
+        provider=endpoint.provider,
+        usage_type="Credits",
+        estimated_microdollars=100_000,
+        credit_reservation_id="legacy-reservation-never-in-typed",
+        requested_model_id=model.id,
+        candidate_model_ids=[model.id],
+        region="us-central1",
+        endpoint_id=endpoint.id,
+        candidate_endpoint_ids=[endpoint.id],
+    )
+    assert auth.credit_reservation_id not in db.reservations
+    configure_store(store)
+    client = TestClient(
+        create_app(Settings(environment="test"), configure_store_arg=False, init_observability=False)
+    )
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth.id,
+            "selected_endpoint": endpoint.id,
+            "actual_input_tokens": 1,
+            "actual_output_tokens": 1,
+            "request_id": "ancient-legacy-settle",
+        },
+    )
+
+    assert settle.status_code == 200, settle.text
+    assert settle.json()["data"] == {
+        "authorization_id": auth.id,
+        "settled": False,
+        "already_settled": True,
+    }
+    assert auth.credit_reservation_id not in db.reservations
 
 
 def test_gateway_settle_can_bill_authorized_fallback_model() -> None:

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -24,6 +24,7 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.routes.console.activity import _USAGE_CACHE
 from trusted_router.storage import STORE, Generation, InMemoryStore
+from trusted_router.typed_balance import live_credit_summary
 
 
 @pytest.fixture
@@ -402,7 +403,7 @@ def test_wallet_verify_success_creates_active_wallet_only_session_with_zero_cred
     assert user.email_verified is False
     workspace = STORE.list_workspaces_for_user(user.id)[0]
     assert data["workspace_id"] == workspace.id
-    assert STORE.get_credit_account(workspace.id).total_credits_microdollars == 0
+    assert live_credit_summary(workspace.id)["total_credits"] == 0
     session_cookie = client.cookies.get("tr_session")
     assert session_cookie is not None
     session = STORE.get_auth_session_by_raw(session_cookie)
@@ -458,7 +459,7 @@ def test_wallet_user_created_workspaces_do_not_receive_trial_credits(
 
     assert created.status_code == 201, created.text
     workspace_id = created.json()["data"]["id"]
-    assert STORE.get_credit_account(workspace_id).total_credits_microdollars == 0
+    assert live_credit_summary(workspace_id)["total_credits"] == 0
 
 
 def test_wallet_verify_rejects_wrong_address(client: TestClient) -> None:

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -102,7 +102,11 @@ def _legacy_authorization(
     key_hash: str,
     estimate: int = ESTIMATE,
 ) -> GatewayAuthorization:
-    reservation = store.reserve(workspace_id, key_hash, estimate)
+    reservation_id = f"legacy-res-{workspace_id}"
+    credit = store.get_credit_account(workspace_id)
+    if credit is not None:
+        credit.reserved_microdollars += estimate
+        store._write_entity("credit", workspace_id, credit)
     store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(
         workspace_id=workspace_id,
@@ -111,7 +115,7 @@ def _legacy_authorization(
         provider=PROVIDER,
         usage_type="Credits",
         estimated_microdollars=estimate,
-        credit_reservation_id=reservation.id,
+        credit_reservation_id=reservation_id,
         requested_model_id=MODEL_ID,
         candidate_model_ids=[MODEL_ID],
         region="us",
@@ -429,22 +433,6 @@ def test_transient_disambiguation_read_parks_typed_row(
     assert apply_frozen_settle(row) == ApplyOutcome.PARK_TYPED_UNAVAILABLE
     assert _typed_credit(db, ws)["total_usage"] == 777_777
     assert len(_generation_bodies(db)) == 1
-
-
-def test_legacy_origin_applies_and_replays(fake_store: tuple[Any, Any, Any]) -> None:
-    store, _db, _bt = fake_store
-    ws = "ws_apply_legacy"
-    _seed_credit(store, ws)
-    key = _make_key(store, ws)
-    auth = _legacy_authorization(store, workspace_id=ws, key_hash=key.hash)
-    row = _row(auth, origin="legacy", cost=654_321)
-
-    assert apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
-    credit = store.get_credit_account(ws)
-    assert credit.total_usage_microdollars == 654_321
-    assert credit.reserved_microdollars == 0
-    assert apply_frozen_settle(row) == ApplyOutcome.ALREADY_SETTLED_LEGACY
-    assert store.get_credit_account(ws).total_usage_microdollars == 654_321
 
 
 def test_retired_endpoint_does_not_reprice_or_raise(fake_store: tuple[Any, Any, Any]) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -142,7 +142,11 @@ def _legacy_authorization(
     key_hash: str,
     estimate: int = ESTIMATE,
 ) -> GatewayAuthorization:
-    reservation = store.reserve(workspace_id, key_hash, estimate)
+    reservation_id = f"legacy-res-{workspace_id}-{key_hash}"
+    credit = store.get_credit_account(workspace_id)
+    if credit is not None:
+        credit.reserved_microdollars += estimate
+        store._write_entity("credit", workspace_id, credit)
     store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(
         workspace_id=workspace_id,
@@ -151,7 +155,7 @@ def _legacy_authorization(
         provider=PROVIDER,
         usage_type="Credits",
         estimated_microdollars=estimate,
-        credit_reservation_id=reservation.id,
+        credit_reservation_id=reservation_id,
         requested_model_id=MODEL_ID,
         candidate_model_ids=[MODEL_ID],
         region="us",

--- a/tests/test_storage_gcp_concurrency.py
+++ b/tests/test_storage_gcp_concurrency.py
@@ -1,26 +1,20 @@
 """Concurrency tests for SpannerBigtableStore.
 
 Drives the real store code against an in-process Spanner fake that simulates
-snapshot-isolation conflict-abort. The point is to verify that the credit
-ledger and Stripe idempotency paths actually exercise the transaction-retry
-contract correctly under concurrent writers — which the in-memory store's
-threading.RLock does not test."""
+snapshot-isolation conflict-abort. The point is to verify that the surviving
+ledger and Stripe idempotency paths exercise the transaction-retry contract
+correctly under concurrent writers; the retired JSON credit reservation/finalize
+transactions are no longer part of the GCP backend after C1.
+"""
 
 from __future__ import annotations
 
 import json
 import threading
 
-import pytest
-
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import (
-    ApiKey,
-    CreditAccount,
-    GatewayAuthorization,
-    Generation,
-    Reservation,
-)
+from trusted_router.storage import ApiKey, CreditAccount
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 
 
 def _seed_credit(store, workspace_id: str, total_microdollars: int) -> None:
@@ -50,43 +44,6 @@ def _run_workers(workers: list[threading.Thread], barrier: threading.Barrier) ->
     assert all(not thread.is_alive() for thread in workers), "worker hang"
 
 
-def test_concurrent_reservations_against_spanner_do_not_overspend() -> None:
-    workspace_id = "ws_credit"
-    n = 8
-    amount = 250_000  # 4 of 8 should succeed against a 1_000_000 balance.
-    barrier = threading.Barrier(n + 1)
-    store, db, _ = make_fake_store(ready_barrier=barrier)
-    _seed_credit(store, workspace_id, 1_000_000)
-
-    successes: list[bool] = []
-    successes_lock = threading.Lock()
-
-    def reserve_once() -> None:
-        try:
-            store.reserve(workspace_id, "key_1", amount)
-        except ValueError:
-            with successes_lock:
-                successes.append(False)
-            return
-        with successes_lock:
-            successes.append(True)
-
-    _run_workers(
-        [threading.Thread(target=reserve_once, daemon=True) for _ in range(n)],
-        barrier,
-    )
-
-    assert successes.count(True) == 4, successes
-    assert successes.count(False) == 4, successes
-
-    account = _credit_account(db, workspace_id)
-    assert account["reserved_microdollars"] == 1_000_000
-    assert account["total_usage_microdollars"] == 0
-
-    # The whole point of the test: the retry path was exercised.
-    assert db.aborts >= n - 1, f"expected ≥{n - 1} aborts, got {db.aborts}"
-
-
 def test_concurrent_stripe_credit_is_idempotent_under_retries() -> None:
     workspace_id = "ws_stripe"
     n = 8
@@ -112,49 +69,9 @@ def test_concurrent_stripe_credit_is_idempotent_under_retries() -> None:
 
     account = _credit_account(db, workspace_id)
     assert account["total_credits_microdollars"] == 5_000_000
+    assert db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_credits"] == 5_000_000
     assert ("stripe_event", "evt_dup") in db.rows
-    assert db.aborts >= n - 1, f"expected ≥{n - 1} aborts, got {db.aborts}"
-
-
-def test_concurrent_settle_does_not_double_apply() -> None:
-    workspace_id = "ws_settle"
-    n = 8
-    barrier = threading.Barrier(n + 1)
-    store, db, _ = make_fake_store(ready_barrier=barrier)
-    _seed_credit(store, workspace_id, 1_000_000)
-
-    reservation = Reservation(
-        id="res_1",
-        workspace_id=workspace_id,
-        key_hash="key_1",
-        amount_microdollars=400_000,
-    )
-    store._write_entity("reservation", reservation.id, reservation)
-    # Account state matches an outstanding reservation so the math is meaningful.
-    store._write_entity(
-        "credit",
-        workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=1_000_000,
-            reserved_microdollars=400_000,
-        ),
-    )
-
-    def settle_once() -> None:
-        store.settle("res_1", 350_000)
-
-    _run_workers(
-        [threading.Thread(target=settle_once, daemon=True) for _ in range(n)],
-        barrier,
-    )
-
-    account = _credit_account(db, workspace_id)
-    # Reservation released exactly once; usage charged exactly once.
-    assert account["reserved_microdollars"] == 0
-    assert account["total_usage_microdollars"] == 350_000
-    reservation_row = json.loads(db.rows[("reservation", "res_1")].body)
-    assert reservation_row["settled"] is True
+    assert db.aborts >= n - 1, f"expected >= {n - 1} aborts, got {db.aborts}"
 
 
 def test_concurrent_key_limit_reservations_do_not_overspend() -> None:
@@ -199,216 +116,3 @@ def test_concurrent_key_limit_reservations_do_not_overspend() -> None:
     assert successes.count(False) == 1, successes
     key_row = json.loads(db.rows[("api_key", api_key.hash)].body)
     assert key_row["reserved_microdollars"] == 1_000_000
-
-
-def test_gateway_authorize_then_settle_charges_exactly_once() -> None:
-    """End-to-end: a gateway authorize reserves credits, a parallel batch of
-    settle calls drains the reservation exactly once, and a parallel batch of
-    refund calls is a no-op once settled. Models the real attested-gateway
-    flow under load (settle and refund races are both possible during
-    crash-recovery)."""
-    workspace_id = "ws_gw"
-    barrier_size = 8
-    barrier = threading.Barrier(barrier_size + 1)
-    store, db, _ = make_fake_store(ready_barrier=barrier)
-    _seed_credit(store, workspace_id, 2_000_000)
-
-    reservation = Reservation(
-        id="res_gw",
-        workspace_id=workspace_id,
-        key_hash="key_1",
-        amount_microdollars=500_000,
-    )
-    store._write_entity("reservation", reservation.id, reservation)
-    store._write_entity(
-        "credit",
-        workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=2_000_000,
-            reserved_microdollars=500_000,
-        ),
-    )
-    auth = GatewayAuthorization(
-        id="gwa_1",
-        workspace_id=workspace_id,
-        key_hash="key_1",
-        model_id="openai/gpt-5.4-nano",
-        provider="openai",
-        usage_type="Credits",
-        estimated_microdollars=500_000,
-        credit_reservation_id=reservation.id,
-    )
-    store._write_entity("gateway_authorization", auth.id, auth)
-
-    def race_once(index: int) -> None:
-        # Half settle, half refund — they should converge to a single outcome.
-        if index % 2 == 0:
-            store.settle(reservation.id, 480_000)
-        else:
-            store.refund(reservation.id)
-
-    _run_workers(
-        [
-            threading.Thread(target=race_once, args=(i,), daemon=True)
-            for i in range(barrier_size)
-        ],
-        barrier,
-    )
-
-    account = _credit_account(db, workspace_id)
-    reservation_row = json.loads(db.rows[("reservation", reservation.id)].body)
-    assert reservation_row["settled"] is True
-    assert account["reserved_microdollars"] == 0
-    # First-writer-wins: usage is either the settle amount or zero (refund),
-    # never both. The credit ledger must never go negative or be charged twice.
-    assert account["total_usage_microdollars"] in {0, 480_000}
-    available = (
-        account["total_credits_microdollars"]
-        - account["total_usage_microdollars"]
-        - account["reserved_microdollars"]
-    )
-    assert 0 <= available <= 2_000_000
-
-
-def test_concurrent_gateway_finalize_writes_generation_and_charges_once() -> None:
-    workspace_id = "ws_gw_finalize"
-    n = 8
-    barrier = threading.Barrier(n + 1)
-    store, db, bt = make_fake_store(ready_barrier=barrier)
-    _seed_credit(store, workspace_id, 2_000_000)
-
-    api_key = ApiKey(
-        hash="key_1",
-        salt="salt",
-        secret_hash="digest",  # noqa: S106 - placeholder test digest.
-        lookup_hash="lookup",
-        name="key",
-        label="sk-tr...abcd",
-        workspace_id=workspace_id,
-        creator_user_id=None,
-        limit_microdollars=2_000_000,
-        reserved_microdollars=500_000,
-    )
-    reservation = Reservation(
-        id="res_gw_finalize",
-        workspace_id=workspace_id,
-        key_hash=api_key.hash,
-        amount_microdollars=500_000,
-    )
-    auth = GatewayAuthorization(
-        id="gwa_finalize",
-        workspace_id=workspace_id,
-        key_hash=api_key.hash,
-        model_id="openai/gpt-5.4-nano",
-        provider="openai",
-        usage_type="Credits",
-        estimated_microdollars=500_000,
-        credit_reservation_id=reservation.id,
-    )
-    generation = Generation(
-        id="gen_finalize",
-        request_id="req_finalize",
-        workspace_id=workspace_id,
-        key_hash=api_key.hash,
-        model="openai/gpt-5.4-nano",
-        provider="openai",
-        provider_name="OpenAI",
-        app="gateway",
-        tokens_prompt=100,
-        tokens_completion=50,
-        total_cost_microdollars=480_000,
-        usage_type="Credits",
-        speed_tokens_per_second=50.0,
-        finish_reason="stop",
-        status="success",
-        streamed=False,
-        created_at="2026-05-02T12:00:00Z",
-    )
-    store._write_entity("api_key", api_key.hash, api_key)
-    store._write_entity("reservation", reservation.id, reservation)
-    store._write_entity("gateway_authorization", auth.id, auth)
-    store._write_entity(
-        "credit",
-        workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=2_000_000,
-            reserved_microdollars=500_000,
-        ),
-    )
-
-    results: list[bool] = []
-    lock = threading.Lock()
-
-    def finalize_once() -> None:
-        result = store.finalize_gateway_authorization(
-            auth.id,
-            success=True,
-            actual_microdollars=generation.total_cost_microdollars,
-            selected_usage_type="Credits",
-            generation=generation,
-        )
-        with lock:
-            results.append(result)
-
-    _run_workers([threading.Thread(target=finalize_once, daemon=True) for _ in range(n)], barrier)
-
-    assert results.count(True) == 1, results
-    assert results.count(False) == n - 1, results
-    account = _credit_account(db, workspace_id)
-    key_row = json.loads(db.rows[("api_key", api_key.hash)].body)
-    reservation_row = json.loads(db.rows[("reservation", reservation.id)].body)
-    auth_row = json.loads(db.rows[("gateway_authorization", auth.id)].body)
-
-    assert account["reserved_microdollars"] == 0
-    assert account["total_usage_microdollars"] == generation.total_cost_microdollars
-    assert key_row["reserved_microdollars"] == 0
-    assert key_row["usage_microdollars"] == generation.total_cost_microdollars
-    assert reservation_row["settled"] is True
-    assert auth_row["settled"] is True
-    assert ("generation", generation.id) in db.rows
-    assert ("generation_by_workspace", f"{workspace_id}#2026-05-02#2026-05-02T12:00:00Z#{generation.id}") in db.rows
-    assert sum(key.startswith(b"gen#gen_finalize") for key in bt.committed) == 1
-
-
-def test_no_aborts_when_uncontended() -> None:
-    """Sanity: a single thread reserving credits should not retry, ever.
-    Catches a regression where the fake's conflict detection over-fires on
-    pure read-then-write within one transaction."""
-    workspace_id = "ws_solo"
-    store, db, _ = make_fake_store()
-    _seed_credit(store, workspace_id, 1_000_000)
-    store.reserve(workspace_id, "key_1", 250_000)
-    store.reserve(workspace_id, "key_1", 250_000)
-    assert db.aborts == 0
-
-
-@pytest.mark.parametrize("parallelism", [4, 16])
-def test_parallelism_does_not_change_correctness(parallelism: int) -> None:
-    workspace_id = f"ws_param_{parallelism}"
-    barrier = threading.Barrier(parallelism + 1)
-    store, db, _ = make_fake_store(ready_barrier=barrier)
-    _seed_credit(store, workspace_id, parallelism * 100_000)
-
-    successes: list[bool] = []
-    lock = threading.Lock()
-
-    def reserve_once() -> None:
-        try:
-            store.reserve(workspace_id, "key_1", 100_000)
-        except ValueError:
-            with lock:
-                successes.append(False)
-            return
-        with lock:
-            successes.append(True)
-
-    _run_workers(
-        [threading.Thread(target=reserve_once, daemon=True) for _ in range(parallelism)],
-        barrier,
-    )
-
-    assert successes.count(True) == parallelism
-    account = _credit_account(db, workspace_id)
-    assert account["reserved_microdollars"] == parallelism * 100_000

--- a/tests/test_storage_gcp_features.py
+++ b/tests/test_storage_gcp_features.py
@@ -7,8 +7,7 @@ hit the wallet/verification surfaces; this file pushes the rest:
 * SpannerEmailBlocks (block, is_blocked, get, record_message_once)
 * SpannerByok (upsert idempotency, list-by-workspace, hint preservation)
 * SpannerOAuthCodes (create, consume, replay, expiry sweep)
-* SpannerApiKeys gateway_authorization + finalize lifecycle (the
-  cross-request reservation handle that has zero coverage today)
+* SpannerApiKeys gateway_authorization lifecycle
 * SpannerGenerations.add → key counter rollup invariant + activity index
 * SpannerRateLimits transactional bucket increment
 
@@ -296,7 +295,7 @@ def test_gcp_oauth_code_tampered_secret_rejected() -> None:
     assert store.consume_oauth_authorization_code(raw) is not None
 
 
-# ── Gateway authorizations + finalize ───────────────────────────────────
+# ── Gateway authorizations ──────────────────────────────────────────────
 
 
 def test_gcp_gateway_authorization_create_get_and_mark_settled() -> None:
@@ -335,117 +334,6 @@ def test_gcp_gateway_authorization_create_get_and_mark_settled() -> None:
     store.mark_gateway_authorization_settled("gwa-nonexistent")
     # Sanity: nothing leaked into the rows.
     assert ("gateway_authorization", "gwa-nonexistent") not in db.rows
-
-
-def test_gcp_finalize_gateway_authorization_settles_credits_and_writes_generation() -> None:
-    from trusted_router.storage_models import Generation
-
-    store, db, _ = make_fake_store()
-    workspace_id, key_hash = _seed_workspace_and_key(store)
-
-    reservation = store.reserve(workspace_id, key_hash, 5_000_000)
-    auth = store.create_gateway_authorization(
-        workspace_id=workspace_id,
-        key_hash=key_hash,
-        model_id="anthropic/claude-sonnet-4.6",
-        provider="anthropic",
-        usage_type="Credits",
-        estimated_microdollars=5_000_000,
-        credit_reservation_id=reservation.id,
-    )
-    store.reserve_key_limit(key_hash, 5_000_000, usage_type="Credits")
-
-    generation = Generation(
-        id="gen-finalize-success",
-        request_id="req-finalize-success",
-        workspace_id=workspace_id,
-        key_hash=key_hash,
-        model="anthropic/claude-sonnet-4.6",
-        provider_name="Anthropic",
-        app="finalize-test",
-        tokens_prompt=100,
-        tokens_completion=50,
-        total_cost_microdollars=2_500_000,
-        usage_type="Credits",
-        speed_tokens_per_second=12.5,
-        finish_reason="stop",
-        status="success",
-        streamed=False,
-    )
-
-    settled = store.finalize_gateway_authorization(
-        auth.id,
-        success=True,
-        actual_microdollars=2_500_000,
-        selected_usage_type="Credits",
-        generation=generation,
-    )
-    assert settled is True
-
-    after = store.get_gateway_authorization(auth.id)
-    assert after is not None and after.settled is True
-    credit = store.get_credit_account(workspace_id)
-    assert credit is not None
-    assert credit.total_usage_microdollars == 2_500_000
-    assert credit.reserved_microdollars == 0
-    # Generation row landed under the right Spanner key.
-    assert ("generation", generation.id) in db.rows
-
-
-def test_gcp_finalize_gateway_authorization_refunds_on_failure() -> None:
-    store, db, _ = make_fake_store()
-    workspace_id, key_hash = _seed_workspace_and_key(store)
-
-    reservation = store.reserve(workspace_id, key_hash, 1_000_000)
-    auth = store.create_gateway_authorization(
-        workspace_id=workspace_id,
-        key_hash=key_hash,
-        model_id="openai/gpt-5.4-nano",
-        provider="openai",
-        usage_type="Credits",
-        estimated_microdollars=1_000_000,
-        credit_reservation_id=reservation.id,
-    )
-    store.reserve_key_limit(key_hash, 1_000_000, usage_type="Credits")
-
-    refunded = store.finalize_gateway_authorization(
-        auth.id,
-        success=False,
-        actual_microdollars=0,
-        selected_usage_type="Credits",
-        generation=None,
-    )
-    assert refunded is True
-
-    credit = store.get_credit_account(workspace_id)
-    assert credit is not None
-    assert credit.reserved_microdollars == 0
-    assert credit.total_usage_microdollars == 0
-    # No generation row written on the failure path.
-    assert not any(kind == "generation" for kind, _ in db.rows)
-
-
-def test_gcp_finalize_gateway_authorization_is_one_shot() -> None:
-    store, _db, _ = make_fake_store()
-    workspace_id, key_hash = _seed_workspace_and_key(store)
-    auth = store.create_gateway_authorization(
-        workspace_id=workspace_id,
-        key_hash=key_hash,
-        model_id="openai/gpt-5.4-nano",
-        provider="openai",
-        usage_type="BYOK",
-        estimated_microdollars=0,
-        credit_reservation_id=None,
-    )
-
-    first = store.finalize_gateway_authorization(
-        auth.id, success=True, actual_microdollars=0, selected_usage_type="BYOK", generation=None
-    )
-    second = store.finalize_gateway_authorization(
-        auth.id, success=True, actual_microdollars=0, selected_usage_type="BYOK", generation=None
-    )
-    assert first is True
-    assert second is False
 
 
 # ── Generations: per-key counter rollup ────────────────────────────────

--- a/tests/test_store_protocol_conformance.py
+++ b/tests/test_store_protocol_conformance.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import inspect
 from typing import get_type_hints
 
+import pytest
+
 from trusted_router.storage import InMemoryStore
 from trusted_router.store_protocol import Store
 
@@ -137,6 +139,14 @@ def test_spanner_store_satisfies_typed_billing_store() -> None:
         if not hasattr(SpannerBigtableStore, name)
     ]
     assert not missing, f"SpannerBigtableStore missing TypedBillingStore members: {missing}"
+
+
+def test_spanner_legacy_json_reserve_path_removed() -> None:
+    from trusted_router.storage_gcp import SpannerBigtableStore
+
+    store = SpannerBigtableStore.__new__(SpannerBigtableStore)
+    with pytest.raises(RuntimeError, match="legacy JSON reserve path removed"):
+        store.reserve("ws", "key", 1)
 
 
 def test_in_memory_store_is_not_a_typed_billing_store() -> None:

--- a/tests/test_typed_balance.py
+++ b/tests/test_typed_balance.py
@@ -1,11 +1,9 @@
-"""Typed-aware balance reads: for a typed workspace, display + auto-refill must
-read the authoritative typed counters (usage/reserved booked by the typed DML),
-not the intentionally-stale JSON. For a legacy workspace they read JSON.
+"""Typed-aware balance reads: typed-capable stores read authoritative typed
+counters when a typed row exists; the in-memory store and unseeded typed rows
+fall back to the single JSON book.
 """
 
 from __future__ import annotations
-
-from types import SimpleNamespace
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage import CreditAccount
@@ -13,13 +11,7 @@ from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.typed_balance import typed_aware_credit_account
 
 
-def _settings(allow: str = "", deny: str = "") -> SimpleNamespace:
-    return SimpleNamespace(
-        typed_billing_workspace_ids=allow, typed_billing_workspace_denylist=deny
-    )
-
-
-def test_credit_overlay_only_for_typed_workspace() -> None:
+def test_credit_overlay_uses_typed_row_when_store_has_capability() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_typed"
     store._write_entity(
@@ -29,47 +21,11 @@ def test_credit_overlay_only_for_typed_workspace() -> None:
     # Simulate the typed DML having booked usage + a hold ahead of stale JSON.
     db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 300_000, "reserved": 150_000})
 
-    # Legacy view (not in allowlist) → JSON (usage/reserved still 0).
-    legacy = typed_aware_credit_account(store, ws, settings=_settings(allow=""))
-    assert legacy.total_usage_microdollars == 0
-    assert legacy.reserved_microdollars == 0
-
-    # Typed view (in allowlist) → authoritative typed counters.
-    typed = typed_aware_credit_account(store, ws, settings=_settings(allow=ws))
+    typed = typed_aware_credit_account(store, ws, settings=object())
     assert typed.total_credits_microdollars == 1_000_000  # JSON-owned, unchanged
     assert typed.total_usage_microdollars == 300_000
     assert typed.reserved_microdollars == 150_000
     assert typed.workspace_id == ws  # JSON metadata preserved
-
-
-def test_credit_overlay_denylist_wins() -> None:
-    store, db, _ = make_fake_store()
-    ws = "ws_deny"
-    store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
-    )
-    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 999_999})
-    # "*" allowlist but denied → legacy (JSON, usage 0).
-    acct = typed_aware_credit_account(store, ws, settings=_settings(allow="*", deny=ws))
-    assert acct.total_usage_microdollars == 0
-
-
-def test_credit_overlay_denylist_wildcard_global_kill_reads_stale_json() -> None:
-    """The "*" global kill-switch routes the balance read to JSON for EVERY
-    workspace — and this test pins the documented hazard: a workspace that was
-    running typed has stale-LOW JSON usage, so under the kill it under-reports
-    spend (999_999 booked in typed, but JSON reads 0). That is exactly why the
-    kill-switch is a break-glass availability brake, not a billing-clean
-    rollback (the pause->drain->backsync runbook reconciles JSON first)."""
-    store, db, _ = make_fake_store()
-    ws = "ws_globalkill"
-    store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000)
-    )
-    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 999_999})
-    # "*" allowlist (everyone-on cutover) + "*" denylist (global kill) → JSON.
-    acct = typed_aware_credit_account(store, ws, settings=_settings(allow="*", deny="*"))
-    assert acct.total_usage_microdollars == 0  # stale-low JSON, NOT the typed 999_999
 
 
 def test_credit_typed_but_unseeded_falls_back_to_json() -> None:
@@ -80,11 +36,11 @@ def test_credit_typed_but_unseeded_falls_back_to_json() -> None:
         "credit", ws,
         CreditAccount(workspace_id=ws, total_credits_microdollars=2_000_000, total_usage_microdollars=50_000),
     )
-    acct = typed_aware_credit_account(store, ws, settings=_settings(allow=ws))
+    acct = typed_aware_credit_account(store, ws, settings=object())
     assert acct is not None
     assert acct.total_usage_microdollars == 50_000  # JSON, since no typed row
 
 
 def test_credit_missing_account_returns_none() -> None:
     store, _db, _ = make_fake_store()
-    assert typed_aware_credit_account(store, "nope", settings=_settings(allow="*")) is None
+    assert typed_aware_credit_account(store, "nope", settings=object()) is None

--- a/tests/test_typed_flip_tool.py
+++ b/tests/test_typed_flip_tool.py
@@ -7,7 +7,7 @@ import pytest
 
 from scripts import typed_flip
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount, Workspace
+from trusted_router.storage import CreditAccount, Reservation, Workspace
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 
 
@@ -42,6 +42,23 @@ def _seed_workspace(
     )
 
 
+def _add_legacy_hold(store: Any, ws: str, amount: int = 100_000) -> None:
+    credit = store.get_credit_account(ws)
+    assert credit is not None
+    credit.reserved_microdollars += amount
+    store._write_entity("credit", ws, credit)
+    store._write_entity(
+        "reservation",
+        f"legacy-{ws}",
+        Reservation(
+            id=f"legacy-{ws}",
+            workspace_id=ws,
+            key_hash="key",
+            amount_microdollars=amount,
+        ),
+    )
+
+
 def _typed_credit(db: Any, ws: str) -> dict:
     return db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]
 
@@ -57,7 +74,7 @@ def test_readiness_verdicts_ready_not_ready_and_already_typed() -> None:
     assert typed_flip.assess_readiness(store, "ws_ready").verdict == "READY"
 
     _seed_workspace(store, "ws_reserved", paused=True)
-    store.reserve("ws_reserved", "key", 100_000)
+    _add_legacy_hold(store, "ws_reserved")
     reserved = typed_flip.assess_readiness(store, "ws_reserved")
     assert reserved.verdict == "NOT_READY"
     assert any("reserved" in reason for reason in reserved.reasons)
@@ -112,7 +129,7 @@ def test_prepare_apply_pauses_and_parks_on_existing_legacy_hold(
     store, db, _ = make_fake_store()
     ws = "ws_prepare_hold"
     _seed_workspace(store, ws, paused=False)
-    store.reserve(ws, "key", 100_000)
+    _add_legacy_hold(store, ws)
     typed_before = deepcopy(db.typed)
 
     rc = typed_flip.main(["prepare", "--workspace", ws, "--apply"], store=store)
@@ -162,7 +179,7 @@ def test_prepare_apply_exits_2_when_hold_appears_after_pause(
     def update_workspace_with_racing_hold(*args: Any, **kwargs: Any) -> Any:
         result = original_update(*args, **kwargs)
         if kwargs.get("billing_paused") is True:
-            store.reserve(ws, "key", 100_000)
+            _add_legacy_hold(store, ws)
         return result
 
     monkeypatch.setattr(store, "update_workspace", update_workspace_with_racing_hold)
@@ -181,7 +198,7 @@ def test_prepare_dry_run_with_existing_legacy_hold_would_pause_and_park(
     store, db, _ = make_fake_store()
     ws = "ws_prepare_dry_hold"
     _seed_workspace(store, ws, paused=False)
-    store.reserve(ws, "key", 100_000)
+    _add_legacy_hold(store, ws)
     before = _snapshot_state(db)
 
     rc = typed_flip.main(["prepare", "--workspace", ws], store=store)


### PR DESCRIPTION
Phase C1 of the JSON credit-ledger retirement (regenerated fresh against current main; supersedes stale #154).

## What
- Spanner uses **typed billing unconditionally** — capability-based (`typed_billing_store(STORE)`); the per-workspace cohort/denylist brake is deleted (settings + `TR_TYPED_BILLING_WORKSPACE_IDS` rollout env + `typed_billing_enabled_for_workspace`).
- Settle/refund route typed always (reservation-ORIGIN routing removed). A settle naming an **ancient legacy reservation id** (3 exist, long-expired) degrades cleanly via typed finalize's `not_found` → the `already_settled` response shape — regression-tested at the route level.
- Legacy JSON reserve/finalize bodies and `_require_credit_tx` deleted, with fail-loud `RuntimeError` guards on the now-unreachable store methods. The route fallback branch remains solely as the InMemory test twin. Emergency rollback = previous deploy revision.
- Signup/welcome read the live typed summary; `typed_flip` text updated; design-doc checklist ticked.

## The P0 that verification caught (and why one C1 item was deliberately deferred)
The original C1 plan said to also delete B2's JSON `total_credits` warm-keeping. **Two independent adversarial verifiers proved (by executable repro) that doing so destroys money**: the credit mirror (which lives until C2) replays the JSON body's `total_credits` into shard 0 on every credit metadata write — and the Stripe webhook writes metadata one line after crediting, so every checkout/auto-refill would be silently reverted, with auto-refill **looping real card charges**. The full 1,537-test suite was green with that bug present. Resolution: **warm-keeping stays until C2**, where it and the mirror die together; a regression test now pins "typed top-up → metadata writes → typed total intact."

Also verified: every caller of the raising legacy methods is memory-twin-only or local/test-gated (x402/MCP/console clean); `rollout.sh` uses replace-all env semantics and `Settings` ignores unknown env (no boot risk); idempotency fingerprints unchanged across the deploy; operator tooling (`typed_flip`, reshard workflow, daily audit) still functional.

## Pre-merge operational check
Recommended by verification, before merging: confirm zero pending legacy-origin settle-outbox rows (`settle_origin='legacy'` non-done) — expected zero since traffic has been typed-universal since 2026-06-26.

Gates: full suite **1538 passed, 33 skipped**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)