### PR TITLE
Make Own your alpha the homepage tagline

### DIFF
--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -73,7 +73,7 @@
     <section class="home-hero">
       <div class="home-hero-copy">
         <span class="hero-badge">End-to-End Encrypted AI gateway</span>
-        <h1>Private, reliable LLM routing<br class="br-wide"> for production AI apps.</h1>
+        <h1>Own your alpha.</h1>
         <p class="lead">Route the open-weight leaders — <strong>Qwen, GLM, DeepSeek, Gemma, Kimi, MiniMax</strong> — plus every frontier model, through one OpenAI-compatible API. TrustedRouter keeps prompt traffic on an attested gateway, avoids prompt/output logs, and gives teams a verifiable trust path instead of another black-box router.</p>
         <div class="hero-actions">
           <button class="btn primary" type="button" data-action="open-signin">Get API key</button>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -3,7 +3,7 @@ const { expect, test } = require("@playwright/test");
 test("homepage opens sign-in modal and handles missing MetaMask", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /Private, reliable LLM routing/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Own your alpha." })).toBeVisible();
   await expect(page.getByText("ATTESTED GATEWAY", { exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Sign in" }).click();
@@ -95,7 +95,7 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /Private, reliable LLM routing/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Own your alpha." })).toBeVisible();
   const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
   expect(overflow).toBeLessThanOrEqual(2);
 });

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -304,7 +304,7 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     # Redesigned homepage (2026-06): a static routing-diagram hero replaces the
     # animated orbital scene, on the friend-provided modern layout. Assert the
     # new conversion surface rather than the old orbital-scene markup.
-    assert "Private, reliable LLM routing" in response.text  # new H1
+    assert "Own your alpha." in response.text  # homepage tagline
     assert "ATTESTED GATEWAY" in response.text  # routing diagram
     assert "Get API key" in response.text  # primary CTA
     assert "Provider failover" in response.text  # hero proof row


### PR DESCRIPTION
## Summary
- replace the TrustedRouter homepage H1 with "Own your alpha."
- update server and browser regression assertions

## Verification
- focused homepage Python tests: 2 passed
- Playwright homepage suite: 8 passed
- desktop and 390px mobile visual QA