### PR TITLE
Auto-discover Moonshot model releases

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -134,6 +134,7 @@ jobs:
                       DEEPINFRA_API_KEY:trustedrouter-deepinfra-api-key \
                       PHALA_CONFIDENTIAL_API_KEY:trustedrouter-phala-confidential-api-key \
                       CEREBRAS_API_KEY:trustedrouter-cerebras-api-key \
+                      KIMI_API_KEY:trustedrouter-kimi-api-key \
                       FIREWORKS_API_KEY:trustedrouter-fireworks-api-key \
                       GEMINI_API_KEY:trustedrouter-gemini-api-key \
                       NOVITA_API_KEY:trustedrouter-novita-api-key \

--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -190,9 +190,22 @@ def _alibaba_model_id(native_id: str) -> str | None:
     return None
 
 
+def _kimi_model_id(native_id: str) -> str | None:
+    value = native_id.strip().casefold()
+    if value.startswith(("kimi-", "moonshot-v1-")):
+        return f"moonshotai/{value}"
+    return None
+
+
 _DISCOVERABLE_MANIFEST_PROVIDERS: tuple[
     tuple[str, str, tuple[str, ...], Callable[[str], str | None]], ...
 ] = (
+    (
+        "kimi",
+        "https://api.moonshot.ai/v1/models",
+        ("KIMI_API_KEY", "MOONSHOT_API_KEY"),
+        _kimi_model_id,
+    ),
     (
         "cerebras",
         "https://api.cerebras.ai/v1/models",
@@ -623,6 +636,7 @@ def _run_audit(
             warning
             for warning in discovery_warnings
             if warning.startswith("zai:")
+            or warning.startswith("kimi:")
             or "live GLM current model API lists unpublished" in warning
         )
         info.extend(discovery_info)

--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -312,12 +312,15 @@ def fetch_html(url: str, *, extra_headers: dict[str, str] | None = None) -> str:
         return response.text
 
 
-def fetch_json(url: str) -> Any:
+def fetch_json(url: str, *, extra_headers: dict[str, str] | None = None) -> Any:
     """Fetch a provider JSON API (e.g., Together's /v1/models). The
     only providers that bypass the parser tier are those with a real
     JSON pricing API; this helper lives here so its network IO is also
-    accounted for in the human-only tier."""
+    accounted for in the human-only tier. ``extra_headers`` supports
+    provider-specific authentication."""
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
     with _provider_client() as client:
         response = _get_with_retries(client, url, headers)
         response.raise_for_status()

--- a/scripts/pricing/parsers/kimi.py
+++ b/scripts/pricing/parsers/kimi.py
@@ -1,10 +1,9 @@
 # LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
 #
-# Parses the concatenation of all Kimi pricing sub-pages
-# (chat-k26.md / chat-k25.md / chat-k2.md / chat-v1.md). The
-# providers/kimi.py orchestrator fetches each .md and joins them
-# before calling parse(); we just need to handle the JSX-shaped
-# table rows.
+# Parses the concatenation of all Kimi chat-pricing pages discovered from
+# Moonshot's official llms.txt index. The providers/kimi.py orchestrator
+# allowlists each URL and joins the pages before calling parse(); we just need
+# to handle the JSX-shaped table rows.
 #
 # Row format (5- and 4-cell variants):
 #
@@ -19,9 +18,11 @@
 # fresh request pays). Cache hit is irrelevant for our billing —
 # we don't track cache state per-request.
 """Kimi/Moonshot pricing parser (multi-subpage markdown)."""
+
 from __future__ import annotations
 
 import re
+from decimal import ROUND_HALF_UP, Decimal
 
 # Native model id → OR-canonical id.
 _NAME_TO_OR_ID = {
@@ -52,15 +53,15 @@ def _or_id(native_id: str) -> str | None:
 # OR  : ["model-id", "1M tokens", <>{"$"}X.X</>, <>{"$"}Y.Y</>, "context"]
 _ROW_RE = re.compile(
     r'\["([^"]+)"\s*,\s*"1M tokens"\s*,'
-    r'\s*<>\{"\$"\}([\d.]+)</>\s*,'      # column A (cache hit OR input)
-    r'\s*<>\{"\$"\}([\d.]+)</>\s*,'      # column B (cache miss OR output)
-    r'(?:\s*<>\{"\$"\}([\d.]+)</>\s*,)?' # column C (output, only K2 family)
-    r'\s*"([^"]+)"\s*\]'                  # context window
+    r'\s*<>\{"\$"\}([\d.]+)</>\s*,'  # column A (cache hit OR input)
+    r'\s*<>\{"\$"\}([\d.]+)</>\s*,'  # column B (cache miss OR output)
+    r'(?:\s*<>\{"\$"\}([\d.]+)</>\s*,)?'  # column C (output, only K2 family)
+    r'\s*"([^"]+)"\s*\]'  # context window
 )
 
 
 def _to_micro_per_m(usd: str) -> int:
-    return int(round(float(usd) * 1_000_000))
+    return int((Decimal(usd) * Decimal(1_000_000)).quantize(Decimal("1"), ROUND_HALF_UP))
 
 
 def parse(text: str) -> dict:

--- a/scripts/pricing/providers/kimi.py
+++ b/scripts/pricing/providers/kimi.py
@@ -1,64 +1,89 @@
-"""Moonshot/Kimi — human-only provider config.
+"""Moonshot/Kimi first-party pricing and live-model discovery.
 
-Kimi's pricing is published as raw .md files at predictable URLs:
+Moonshot publishes a documentation index at ``/docs/llms.txt``. Pricing
+pages linked from that index contain JSX-shaped tables, while the authenticated
+``/v1/models`` endpoint is authoritative for what the operator account can
+actually invoke. A model becomes routable only when both sources agree: it
+must be live and have a non-zero first-party price.
 
-    https://platform.kimi.ai/docs/pricing/chat-k26.md  → K2.6 family
-    https://platform.kimi.ai/docs/pricing/chat-k25.md  → K2.5 family
-    https://platform.kimi.ai/docs/pricing/chat-k2.md   → K2 family (5 SKUs)
-    https://platform.kimi.ai/docs/pricing/chat-v1.md   → Moonshot V1 family
-
-Each .md returns a JSX-shaped table embedded in markdown:
-
-    ["kimi-k2.6", "1M tokens", <>{"$"}0.16</>, <>{"$"}0.95</>, <>{"$"}4.00</>, "262,144 tokens"]
-
-Columns are: model_id | unit | cache_hit | cache_miss_input | output | context
-
-The cache_miss_input is the headline (non-cached) input rate; we use
-that for billing.
-
-Different from the other providers because we fetch FOUR separate
-URLs, concatenate, then parse. The parser layer's contract stays
-`parse(combined_text)`; concatenation is how we present the union of
-the family pages as a single input.
+The provider module is human-maintained. The parser remains a pure
+``parse(text)`` function in ``parsers/kimi.py`` and cannot perform network IO.
 """
+
 from __future__ import annotations
 
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from scripts.pricing.base import (
     ProviderPricingResult,
     _coerce_to_model_prices,
     fetch_html,
+    fetch_json,
     log,
     parser_path,
     validate,
 )
 
 SLUG = "kimi"
-
-# Sub-pages of platform.kimi.ai/docs/pricing/chat. Fetched directly
-# (no Jina proxy needed — these .md URLs serve plain text). Listed in
-# order; the K2 page is the canonical "headline" and goes first so
-# its URL ends up logged.
-SUBPAGES = [
+DOC_INDEX_URL = "https://platform.kimi.ai/docs/llms.txt"
+MODELS_URL = "https://api.moonshot.ai/v1/models"
+FALLBACK_SUBPAGES = (
+    "https://platform.kimi.ai/docs/pricing/chat-k27-code.md",
     "https://platform.kimi.ai/docs/pricing/chat-k26.md",
     "https://platform.kimi.ai/docs/pricing/chat-k25.md",
     "https://platform.kimi.ai/docs/pricing/chat-k2.md",
     "https://platform.kimi.ai/docs/pricing/chat-v1.md",
-]
-URL = SUBPAGES[0]  # for log/diagnostic purposes only
+)
+URL = DOC_INDEX_URL
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "kimi.json"
+)
 
 EXPECTED_MODELS = [
     "moonshotai/kimi-k2.6",
+    "moonshotai/kimi-k2.7-code",
+    "moonshotai/kimi-k2.7-code-highspeed",
 ]
+
+_PRICING_LINK_RE = re.compile(
+    r"https://platform\.kimi\.ai/docs/pricing/chat(?:-[a-z0-9]+)*\.md",
+    re.IGNORECASE,
+)
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _pricing_subpages(index_text: str) -> list[str]:
+    """Return deduplicated, allowlisted Kimi chat-pricing pages.
+
+    The origin and path are part of the regex, so a compromised documentation
+    index cannot turn the pricing worker into an arbitrary URL fetcher.
+    Fallback pages preserve known families during a transient index failure.
+    """
+
+    discovered = [match.group(0) for match in _PRICING_LINK_RE.finditer(index_text)]
+    ordered = [*discovered, *FALLBACK_SUBPAGES]
+    return list(dict.fromkeys(ordered))
 
 
 def _combined_html() -> str:
-    """Fetch all 4 sub-pages and concatenate so the parser sees the
-    union as a single document. Failure of one sub-page is non-fatal —
-    we keep what we got."""
+    try:
+        index_text = fetch_html(DOC_INDEX_URL)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("kimi.doc_index_fetch_failed err=%s", exc)
+        index_text = ""
+
     chunks: list[str] = []
-    for url in SUBPAGES:
+    for url in _pricing_subpages(index_text):
         try:
             chunks.append(fetch_html(url))
         except Exception as exc:  # noqa: BLE001
@@ -66,16 +91,84 @@ def _combined_html() -> str:
     return "\n\n--- PAGE BREAK ---\n\n".join(chunks)
 
 
+def _canonical_model_id(native_id: str) -> str | None:
+    lowered = native_id.strip().casefold()
+    if lowered.startswith(("kimi-", "moonshot-v1-")):
+        return f"moonshotai/{lowered}"
+    return None
+
+
+def _display_name(native_id: str) -> str:
+    words = native_id.replace("-", " ").split()
+    rendered: list[str] = []
+    for word in words:
+        lowered = word.casefold()
+        if lowered == "kimi":
+            rendered.append("Kimi")
+        elif lowered == "moonshot":
+            rendered.append("Moonshot")
+        elif lowered == "highspeed":
+            rendered.append("HighSpeed")
+        elif lowered.startswith(("k2", "v1")):
+            rendered.append(word.upper())
+        else:
+            rendered.append(word.title())
+    return " ".join(rendered)
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    token = os.environ.get("KIMI_API_KEY") or os.environ.get("MOONSHOT_API_KEY")
+    if not token:
+        raise RuntimeError("kimi: KIMI_API_KEY or MOONSHOT_API_KEY is required")
+
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {token}"},
+    )
+    raw_rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(raw_rows, list):
+        raise RuntimeError("kimi: /v1/models response has no data list")
+
+    rows: dict[str, dict[str, Any]] = {}
+    for raw in raw_rows:
+        if not isinstance(raw, dict):
+            continue
+        native_id = raw.get("id")
+        if not isinstance(native_id, str):
+            continue
+        model_id = _canonical_model_id(native_id)
+        if model_id is None:
+            continue
+        context_length = raw.get("context_length")
+        if not isinstance(context_length, int) or context_length <= 0:
+            context_length = 0
+        rows[model_id] = {
+            "id": model_id,
+            "upstream_id": native_id,
+            "display_name": _display_name(native_id),
+            "title": native_id,
+            "model_type": "chat",
+            "endpoints": ["chat/completions"],
+            "context_length": context_length,
+            "supports_image_in": bool(raw.get("supports_image_in")),
+            "supports_video_in": bool(raw.get("supports_video_in")),
+            "supports_reasoning": bool(raw.get("supports_reasoning")),
+        }
+    if not rows:
+        raise RuntimeError("kimi: /v1/models returned no supported model ids")
+    return rows
+
+
 def fetch() -> ProviderPricingResult:
-    """Custom fetch path: fetches multiple sub-pages, parses the
-    combined text via parsers/kimi.py. Self-heal still works — if the
-    parser breaks, the LLM rewrites parsers/kimi.py and we retry on
-    the same combined text."""
+    """Fetch first-party prices and intersect them with live account models."""
+
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+    _DISCOVERED_MANIFEST_ROWS = {}
+
     html = _combined_html()
     if not html:
-        raise RuntimeError("kimi: all sub-pages failed to fetch")
+        raise RuntimeError("kimi: all pricing pages failed to fetch")
 
-    # Run parsers/kimi.py against the combined text.
     src = parser_path(SLUG).read_text(encoding="utf-8")
     namespace: dict[str, Any] = {}
     exec(compile(src, str(parser_path(SLUG)), "exec"), namespace)  # noqa: S102
@@ -89,15 +182,80 @@ def fetch() -> ProviderPricingResult:
         raise RuntimeError(f"{SLUG}: parser schema errors: {schema_errors}")
     if prices is None:
         raise RuntimeError(f"{SLUG}: parser returned None unexpectedly")
+
+    live_rows = _live_model_rows()
+    prices = {model_id: price for model_id, price in prices.items() if model_id in live_rows}
+    _DISCOVERED_MANIFEST_ROWS = live_rows
+
     errors = validate(prices, EXPECTED_MODELS)
     if errors:
-        # No self-heal path here — Kimi's structure is too custom for
-        # the standard fetch_provider flow. If validation fails, we
-        # fail loudly and a human updates parsers/kimi.py.
         raise RuntimeError(f"{SLUG}: validation failed: {errors}")
     return ProviderPricingResult(
         slug=SLUG,
         prices=prices,
-        source="multi_page_md",
+        source="multi_page_md+api",
         fetched_url=URL,
     )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Refresh the provider-native Kimi manifest from live, priced models."""
+
+    if MANIFEST_PATH.exists():
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    else:
+        raw = {"provider": SLUG, "models": []}
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("kimi manifest has no models list")
+
+    existing_by_id: dict[str, dict[str, Any]] = {
+        row["id"]: row for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    active_rows: list[dict[str, Any]] = []
+    updated: list[str] = []
+    appended: list[str] = []
+    for model_id, price in sorted(result.prices.items()):
+        discovered = _DISCOVERED_MANIFEST_ROWS.get(model_id)
+        if discovered is None:
+            continue
+        existing = existing_by_id.get(model_id)
+        row = dict(existing) if existing is not None else {}
+        row.update(discovered)
+        if existing is None:
+            appended.append(model_id)
+
+        tier = price.tiers[0]
+        row["input_token_price_per_m"] = tier.prompt_micro_per_m
+        row["output_token_price_per_m"] = tier.completion_micro_per_m
+        if tier.prompt_cached_micro_per_m is not None:
+            row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+        else:
+            row.pop("cached_input_token_price_per_m", None)
+        active_rows.append(row)
+        updated.append(model_id)
+
+    missing = sorted(set(EXPECTED_MODELS) - set(updated))
+    if missing:
+        raise RuntimeError(f"kimi manifest did not update expected model(s): {missing}")
+
+    active_rows.sort(key=lambda row: str(row.get("id") or ""))
+    raw["models"] = active_rows
+    raw["_about"] = (
+        "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models "
+        "present in both the official pricing docs and authenticated /v1/models feed."
+    )
+    raw["source"] = MODELS_URL
+    raw["pricing_source"] = DOC_INDEX_URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(active_rows)
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    suffix = f", appended {len(appended)}" if appended else ""
+    return [f"kimi: refreshed provider_models/kimi.json ({len(updated)} priced rows{suffix})"]

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -1267,14 +1267,6 @@ _UNSERVED_CREDITS_MODELS: frozenset[str] = frozenset(
 )
 
 _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
-    "kimi": frozenset(
-        {
-            # 2026-06-24: first-party Moonshot returns
-            # "Not found the model ... or Permission denied" for K2.7 Code on
-            # the operator key. Keep Novita/BYOK K2.7 routes visible.
-            "moonshotai/kimi-k2.7-code",
-        }
-    ),
     "gmi": frozenset(
         {
             "anthropic/claude-opus-4.7",

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -336,7 +336,8 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
     control plane can authorize routes the attested gateway can actually
     call and bill.
 
-    Novita, Nebius, MiniMax, Crusoe, Cerebras, Gemini, Fireworks, DeepInfra, and Z.AI currently use this path because their
+    Novita, Nebius, MiniMax, Crusoe, Cerebras, Gemini, Fireworks, DeepInfra,
+    Moonshot/Kimi, and Z.AI currently use this path because their
     live `/models` feeds expose working provider-direct routes before
     OpenRouter's public endpoint catalog catches up. Anthropic uses it for
     Claude Opus 4.8, which shipped after the snapshot — the attested gateway
@@ -366,6 +367,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "wafer",
         "crusoe",
         "makora",
+        "kimi",
         "zai",
         "tinfoil",
         "xiaomi",

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -1,0 +1,174 @@
+{
+  "provider": "kimi",
+  "models": [
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "upstream_id": "kimi-k2.5",
+      "display_name": "Kimi K2.5",
+      "title": "kimi-k2.5",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 262144,
+      "supports_image_in": true,
+      "supports_video_in": true,
+      "supports_reasoning": true,
+      "input_token_price_per_m": 600000,
+      "output_token_price_per_m": 3000000,
+      "cached_input_token_price_per_m": 100000
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "upstream_id": "kimi-k2.6",
+      "display_name": "Kimi K2.6",
+      "title": "kimi-k2.6",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 262144,
+      "supports_image_in": true,
+      "supports_video_in": true,
+      "supports_reasoning": true,
+      "input_token_price_per_m": 950000,
+      "output_token_price_per_m": 4000000,
+      "cached_input_token_price_per_m": 160000
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "upstream_id": "kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "title": "kimi-k2.7-code",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 262144,
+      "supports_image_in": true,
+      "supports_video_in": true,
+      "supports_reasoning": true,
+      "input_token_price_per_m": 950000,
+      "output_token_price_per_m": 4000000,
+      "cached_input_token_price_per_m": 190000
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code-highspeed",
+      "upstream_id": "kimi-k2.7-code-highspeed",
+      "display_name": "Kimi K2.7 Code HighSpeed",
+      "title": "kimi-k2.7-code-highspeed",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 262144,
+      "supports_image_in": true,
+      "supports_video_in": true,
+      "supports_reasoning": true,
+      "input_token_price_per_m": 1900000,
+      "output_token_price_per_m": 8000000,
+      "cached_input_token_price_per_m": 380000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-128k",
+      "upstream_id": "moonshot-v1-128k",
+      "display_name": "Moonshot V1 128K",
+      "title": "moonshot-v1-128k",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 131072,
+      "supports_image_in": false,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 2000000,
+      "output_token_price_per_m": 5000000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-128k-vision-preview",
+      "upstream_id": "moonshot-v1-128k-vision-preview",
+      "display_name": "Moonshot V1 128K Vision Preview",
+      "title": "moonshot-v1-128k-vision-preview",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 131072,
+      "supports_image_in": true,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 2000000,
+      "output_token_price_per_m": 5000000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-32k",
+      "upstream_id": "moonshot-v1-32k",
+      "display_name": "Moonshot V1 32K",
+      "title": "moonshot-v1-32k",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 32768,
+      "supports_image_in": false,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 3000000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-32k-vision-preview",
+      "upstream_id": "moonshot-v1-32k-vision-preview",
+      "display_name": "Moonshot V1 32K Vision Preview",
+      "title": "moonshot-v1-32k-vision-preview",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 32768,
+      "supports_image_in": true,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 3000000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-8k",
+      "upstream_id": "moonshot-v1-8k",
+      "display_name": "Moonshot V1 8K",
+      "title": "moonshot-v1-8k",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 8192,
+      "supports_image_in": false,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 200000,
+      "output_token_price_per_m": 2000000
+    },
+    {
+      "id": "moonshotai/moonshot-v1-8k-vision-preview",
+      "upstream_id": "moonshot-v1-8k-vision-preview",
+      "display_name": "Moonshot V1 8K Vision Preview",
+      "title": "moonshot-v1-8k-vision-preview",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 8192,
+      "supports_image_in": true,
+      "supports_video_in": false,
+      "supports_reasoning": false,
+      "input_token_price_per_m": 200000,
+      "output_token_price_per_m": 2000000
+    }
+  ],
+  "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
+  "source": "https://api.moonshot.ai/v1/models",
+  "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
+  "generated_at": "2026-07-14T20:08:46Z",
+  "model_count": 10
+}

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -71,10 +71,17 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert "kimi" in PROVIDERS
     assert "moonshotai/kimi-k2.6" in MODELS
     assert "moonshotai/kimi-k2.7-code" in MODELS
+    assert "moonshotai/kimi-k2.7-code-highspeed" in MODELS
     assert "moonshotai/kimi-k2.6@kimi/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.6@kimi/byok" in MODEL_ENDPOINTS
-    assert "moonshotai/kimi-k2.7-code@kimi/prepaid" not in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k2.7-code@kimi/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.7-code@kimi/byok" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k2.7-code-highspeed@kimi/byok" in MODEL_ENDPOINTS
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid"].upstream_id
+        == "kimi-k2.7-code-highspeed"
+    )
     assert "moonshotai/kimi-k2.7-code@novita/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.7-code@novita/byok" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.6" in [model.id for model in auto_candidate_models()]
@@ -314,7 +321,6 @@ def test_minimax_empty_operator_routes_are_not_prepaid() -> None:
             "gmi",
             ("google/gemma-4-26b-a4b-it", "google/gemma-4-31b-it"),
         ),
-        ("kimi", ("moonshotai/kimi-k2.7-code",)),
         (
             "parasail",
             (

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -9,6 +9,8 @@ from scripts.check_price_coverage import audit
 
 
 def _known_provider_model_payload(url: str, _env_names: tuple[str, ...]) -> dict:
+    if "api.moonshot.ai" in url:
+        return {"data": [{"id": "kimi-k2.7-code"}]}
     if "cerebras.ai" in url:
         return {"data": [{"id": "gpt-oss-120b"}]}
     if "generativelanguage.googleapis.com" in url:

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -500,7 +500,7 @@ def test_gateway_can_prefer_byok_endpoint_for_dual_mode_model() -> None:
         {
             "endpoint_id": data["endpoint_id"],
             "model": "moonshotai/kimi-k2.6",
-            "upstream_model": "moonshotai/kimi-k2.6",
+            "upstream_model": "kimi-k2.6",
             "provider": "kimi",
             "provider_name": "Kimi",
             "usage_type": "BYOK",

--- a/tests/test_kimi_pricing.py
+++ b/tests/test_kimi_pricing.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import check_price_coverage
+from scripts.pricing.parsers import kimi as kimi_parser
+from scripts.pricing.providers import kimi
+
+
+def _pricing_doc(*, include_k3: bool = True, include_ghost: bool = False) -> str:
+    rows = [
+        '["kimi-k2.6", "1M tokens", <>{"$"}0.16</>, <>{"$"}0.95</>, '
+        '<>{"$"}4.00</>, "262,144 tokens"]',
+        '["kimi-k2.7-code", "1M tokens", <>{"$"}0.19</>, <>{"$"}0.95</>, '
+        '<>{"$"}4.00</>, "262,144 tokens"]',
+        '["kimi-k2.7-code-highspeed", "1M tokens", <>{"$"}0.38</>, '
+        '<>{"$"}1.90</>, <>{"$"}8.00</>, "262,144 tokens"]',
+    ]
+    if include_k3:
+        rows.append(
+            '["kimi-k3", "1M tokens", <>{"$"}0.20</>, <>{"$"}1.00</>, '
+            '<>{"$"}5.00</>, "1,048,576 tokens"]'
+        )
+    if include_ghost:
+        rows.append(
+            '["kimi-ghost", "1M tokens", <>{"$"}0.01</>, <>{"$"}0.01</>, '
+            '<>{"$"}0.01</>, "1,024 tokens"]'
+        )
+    return "\n".join(rows)
+
+
+def _live_payload(*, include_k3: bool = True) -> dict[str, Any]:
+    ids = ["kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed"]
+    if include_k3:
+        ids.append("kimi-k3")
+    return {
+        "data": [
+            {
+                "id": model_id,
+                "context_length": 1_048_576 if model_id == "kimi-k3" else 262_144,
+                "supports_image_in": True,
+                "supports_video_in": model_id != "kimi-k3",
+                "supports_reasoning": True,
+            }
+            for model_id in ids
+        ]
+    }
+
+
+def _fake_docs(url: str, *, extra_headers: dict[str, str] | None = None) -> str:
+    del extra_headers
+    if url == kimi.DOC_INDEX_URL:
+        return "\n".join(
+            [
+                f"- [K3]({kimi.DOC_INDEX_URL.removesuffix('llms.txt')}pricing/chat-k3.md)",
+                "- [Ignore](https://attacker.example/pricing/chat-k4.md)",
+            ]
+        )
+    return _pricing_doc(include_k3=True, include_ghost=True)
+
+
+def test_pricing_subpages_only_accepts_moonshot_docs_origin() -> None:
+    k3_url = "https://platform.kimi.ai/docs/pricing/chat-k3.md"
+    urls = kimi._pricing_subpages(  # noqa: SLF001
+        f"[K3]({k3_url}) [duplicate]({k3_url}) "
+        "[bad](https://attacker.example/docs/pricing/chat-k4.md)"
+    )
+
+    assert urls[0] == k3_url
+    assert urls.count(k3_url) == 1
+    assert all("attacker.example" not in url for url in urls)
+    assert "https://platform.kimi.ai/docs/pricing/chat-k27-code.md" in urls
+
+
+def test_parser_accepts_future_kimi_family_without_code_change() -> None:
+    parsed = kimi_parser.parse(_pricing_doc(include_k3=True))
+
+    assert parsed["moonshotai/kimi-k3"] == {
+        "prompt_micro_per_m": 1_000_000,
+        "completion_micro_per_m": 5_000_000,
+        "prompt_cached_micro_per_m": 200_000,
+    }
+
+
+def test_fetch_intersects_live_models_and_writes_manifest(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "kimi.json"
+    seen_headers: list[dict[str, str] | None] = []
+
+    def fake_fetch_json(
+        url: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        assert url == kimi.MODELS_URL
+        seen_headers.append(extra_headers)
+        return _live_payload(include_k3=True)
+
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+    monkeypatch.setattr(kimi, "fetch_html", _fake_docs)
+    monkeypatch.setattr(kimi, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(kimi, "MANIFEST_PATH", manifest_path)
+
+    result = kimi.fetch()
+    notes = kimi.write_provider_manifest(result)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in manifest["models"]}
+
+    assert seen_headers == [{"Authorization": "Bearer test-kimi-key"}]
+    assert "moonshotai/kimi-k3" in result.prices
+    assert "moonshotai/kimi-ghost" not in result.prices
+    assert by_id["moonshotai/kimi-k3"]["upstream_id"] == "kimi-k3"
+    assert by_id["moonshotai/kimi-k3"]["context_length"] == 1_048_576
+    assert by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 1_000_000
+    assert by_id["moonshotai/kimi-k3"]["output_token_price_per_m"] == 5_000_000
+    assert notes == ["kimi: refreshed provider_models/kimi.json (4 priced rows, appended 4)"]
+
+
+def test_live_model_without_first_party_price_is_not_published(
+    monkeypatch: Any,
+) -> None:
+    def docs_without_k3(url: str, *, extra_headers: dict[str, str] | None = None) -> str:
+        del extra_headers
+        if url == kimi.DOC_INDEX_URL:
+            return ""
+        return _pricing_doc(include_k3=False)
+
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+    monkeypatch.setattr(kimi, "fetch_html", docs_without_k3)
+    monkeypatch.setattr(
+        kimi,
+        "fetch_json",
+        lambda _url, **_kwargs: _live_payload(include_k3=True),
+    )
+
+    result = kimi.fetch()
+
+    assert "moonshotai/kimi-k3" not in result.prices
+
+
+def test_manifest_removes_models_no_longer_live_or_priced(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "kimi.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "kimi",
+                "models": [
+                    {
+                        "id": "moonshotai/kimi-retired",
+                        "upstream_id": "kimi-retired",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+    monkeypatch.setattr(kimi, "fetch_html", _fake_docs)
+    monkeypatch.setattr(
+        kimi,
+        "fetch_json",
+        lambda _url, **_kwargs: _live_payload(include_k3=True),
+    )
+    monkeypatch.setattr(kimi, "MANIFEST_PATH", manifest_path)
+
+    result = kimi.fetch()
+    kimi.write_provider_manifest(result)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert "moonshotai/kimi-retired" not in {row["id"] for row in manifest["models"]}
+
+
+def test_missing_key_fails_closed_before_publishing_provider_routes(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+    monkeypatch.setattr(kimi, "fetch_html", _fake_docs)
+    monkeypatch.setattr(
+        kimi,
+        "fetch_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected API call")),
+    )
+
+    with pytest.raises(RuntimeError, match="KIMI_API_KEY or MOONSHOT_API_KEY is required"):
+        kimi.fetch()
+
+
+def test_coverage_normalizes_kimi_native_ids() -> None:
+    assert check_price_coverage._kimi_model_id("kimi-k3") == "moonshotai/kimi-k3"  # noqa: SLF001
+    assert check_price_coverage._kimi_model_id(" KIMI-K2.7-CODE ") == (  # noqa: SLF001
+        "moonshotai/kimi-k2.7-code"
+    )
+    assert check_price_coverage._kimi_model_id("unrelated-model") is None  # noqa: SLF001

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1823,7 +1823,8 @@ def test_rotation_candidates_cover_credits_endpoints() -> None:
     assert "novita" in pool
     assert "google/gemma-4-26b-a4b-it" not in pool.get("gmi", [])
     assert "google/gemma-4-31b-it" not in pool.get("gmi", [])
-    assert "moonshotai/kimi-k2.7-code" not in pool.get("kimi", [])
+    assert "moonshotai/kimi-k2.7-code" in pool.get("kimi", [])
+    assert "moonshotai/kimi-k2.7-code-highspeed" in pool.get("kimi", [])
     assert "minimax/minimax-m2.1" not in pool.get("minimax", [])
     assert "minimax/minimax-m2.5" not in pool.get("minimax", [])
     assert "deepseek/deepseek-v3.2" not in pool.get("parasail", [])


### PR DESCRIPTION
## Summary
- ingest Moonshot's authenticated live model catalog and first-party pricing pages hourly
- publish only models that are both callable by the operator account and officially priced
- add verified Kimi K2.7 Code and K2.7 Code HighSpeed provider-direct routes
- fail the release coverage gate when a future Kimi model appears before catalog ingestion
- remove retired Kimi routes automatically

Kimi K3 is intentionally not hard-coded: as of 2026-07-14, Moonshot's authenticated model list omits it and direct invocation returns 404. The hourly path will add it after the official model and pricing feeds both expose it.

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1522 passed, 33 skipped)
- authenticated live Moonshot pricing/catalog check (10 live priced models; K2.7 HighSpeed present; K3 absent)
