### PR TITLE
C2b: make CreditAccount metadata-only; re-home in-memory credit money

### DIFF
--- a/docs/design/retire-json-credit-ledger.md
+++ b/docs/design/retire-json-credit-ledger.md
@@ -162,25 +162,26 @@ Legend: [J] = Joseph's explicit go required · [C] = Claude runs autonomously (S
   (inspect balance, `audit_typed_invariants`, `repair_typed_reserved`, grant),
   and the authorize-deadlock-burst section corrected for the 20s retry budget,
   `Aborted`→503 mapping, and now-operable shard spreading.
-- [ ] C2b (cosmetic cleanup, gated on a design call): delete `CreditAccount`'s
-  now-stale money fields (`total_credits_microdollars` / `total_usage_microdollars`
-  / `reserved_microdollars`; keep `shard_count` + auto-refill/Stripe metadata) and
-  update the InMemory twin. NOTE this is an interface refactor, not a dead-field
-  drop: those fields are still the CARRIER the typed book is presented through
-  (`typed_balance.py` populates a `CreditAccount` from the typed rows; `auto_refill`
-  reads `available = total − usage − reserved` off it to decide card charges;
-  `serialization`/`mcp` display them). Deleting them requires choosing a new
-  money-read carrier (e.g. everyone reads the `live_credit_summary` dict) AND
-  reworking the InMemory single-book store — money-adjacent, zero prod-correctness
-  benefit (values are already typed-sourced and correct). The ledger is FULLY
-  RETIRED on the production path after C1+C2a; C2b is pure model hygiene.
+- [x] C2b (2026-07-14): `CreditAccount` is now metadata-only — `total_credits_microdollars`
+  / `total_usage_microdollars` / `reserved_microdollars` deleted (kept `shard_count`
+  + auto-refill/Stripe metadata). The chosen money-read carrier is the existing
+  `live_credit_summary` dict (no new type): `typed_aware_credit_account` was removed,
+  `auto_refill` reads the unclamped `available` off the summary (byte-identical to the
+  old inline `total − usage − reserved`) and metadata off `get_credit_account`, and the
+  InMemory twin's single book moved to a `CreditMoney` sibling holder shared by
+  reference with the reservation engine. `SpannerBigtableStore.credit_money_snapshot`
+  reads the raw `credit` JSON entity so `live_credit_summary` keeps its pre-C2b
+  fallback when the typed snapshot is unavailable (mirror off / row not yet seeded);
+  `scripts/typed_flip.py` + the operator grant scripts read legacy money from the raw
+  entity dict. Clean break — passing a retired money kwarg now raises. Two adversarial
+  verification passes; production write path (typed-DML) unchanged.
 
 ## Status: the JSON credit ledger is retired (C1 + C2a + C3 shipped 2026-07-14)
 Production money is single-book (typed Spanner). The dual-book machinery — mirror,
 backsync, backfill, drift-compare, warm-keep, rollback-to-legacy — is deleted, and
 the surviving tripwires (`audit_typed_invariants` daily, `repair_typed_reserved`
-on demand) are typed-internal. Only C2b (the `CreditAccount` field/twin cleanup
-above) remains, and it is optional hygiene.
+on demand) are typed-internal. C2b (the `CreditAccount` field/twin cleanup above)
+is now shipped, so the model is metadata-only too.
 
 ### Rollback
 Rollback-to-legacy is retired. Emergency rollback is the previous deploy revision.

--- a/scripts/credit_grant_bradleat.py
+++ b/scripts/credit_grant_bradleat.py
@@ -63,15 +63,12 @@ def main() -> int:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
     typed_before = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited before:  ${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited before: ${(typed_before or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
 
     granted = STORE.credit_workspace_once(workspace.id, AMOUNT_MICRODOLLARS, EVENT_ID)
     print("  credit applied" if granted else f"  no-op: event {EVENT_ID!r} already applied")
 
-    after = STORE.get_credit_account(workspace.id)
     typed_after = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited after:  ${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited after: ${(typed_after or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
     expected = (typed_before or 0) + (AMOUNT_MICRODOLLARS if granted else 0)
     if typed_after != expected:

--- a/scripts/credit_grant_david.py
+++ b/scripts/credit_grant_david.py
@@ -62,15 +62,12 @@ def main() -> int:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
     typed_before = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited before:  ${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited before: ${(typed_before or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
 
     granted = STORE.credit_workspace_once(workspace.id, AMOUNT_MICRODOLLARS, EVENT_ID)
     print("  credit applied" if granted else f"  no-op: event {EVENT_ID!r} already applied")
 
-    after = STORE.get_credit_account(workspace.id)
     typed_after = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited after:  ${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited after: ${(typed_after or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
     expected = (typed_before or 0) + (AMOUNT_MICRODOLLARS if granted else 0)
     if typed_after != expected:

--- a/scripts/credit_grant_jay.py
+++ b/scripts/credit_grant_jay.py
@@ -62,15 +62,12 @@ def main() -> int:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
     typed_before = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited before:  ${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited before: ${(typed_before or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
 
     granted = STORE.credit_workspace_once(workspace.id, AMOUNT_MICRODOLLARS, EVENT_ID)
     print("  credit applied" if granted else f"  no-op: event {EVENT_ID!r} already applied")
 
-    after = STORE.get_credit_account(workspace.id)
     typed_after = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited after:  ${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited after: ${(typed_after or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
     expected = (typed_before or 0) + (AMOUNT_MICRODOLLARS if granted else 0)
     if typed_after != expected:

--- a/scripts/credit_grant_joseph.py
+++ b/scripts/credit_grant_joseph.py
@@ -66,17 +66,11 @@ def main() -> int:
     workspace = workspaces[0]
     print(f"granting ${AMOUNT_DOLLARS} ({AMOUNT_MICRODOLLARS} μ$) to workspace {workspace.id}")
 
-    def _avail(acct) -> float:
-        # Available credit = total deposited - total burned - currently reserved
-        net = acct.total_credits_microdollars - acct.total_usage_microdollars - acct.reserved_microdollars
-        return net / MICRODOLLARS_PER_DOLLAR
-
     before = STORE.get_credit_account(workspace.id)
     if before is None:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
     typed_before = _typed_total_credits(workspace.id)
-    print(f"  available before: ${_avail(before):.4f}  (deposited=${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}, used=${before.total_usage_microdollars / MICRODOLLARS_PER_DOLLAR:.4f})")
     print(f"  typed deposited before: ${(typed_before or 0) / MICRODOLLARS_PER_DOLLAR:.4f}")
 
     granted = STORE.credit_workspace_once(
@@ -87,9 +81,7 @@ def main() -> int:
     else:
         print("  credit applied")
 
-    after = STORE.get_credit_account(workspace.id)
     typed_after = _typed_total_credits(workspace.id)
-    print(f"  available after:  ${_avail(after):.4f}  (deposited=${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.4f}, used=${after.total_usage_microdollars / MICRODOLLARS_PER_DOLLAR:.4f})")
     print(f"  typed deposited after:  ${(typed_after or 0) / MICRODOLLARS_PER_DOLLAR:.4f}")
     expected = (typed_before or 0) + (AMOUNT_MICRODOLLARS if granted else 0)
     if typed_after != expected:

--- a/scripts/credit_grant_posix4e.py
+++ b/scripts/credit_grant_posix4e.py
@@ -65,15 +65,12 @@ def main() -> int:
         print(f"ERROR: credit account for workspace {workspace.id} not found")
         return 1
     typed_before = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited before:  ${before.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited before: ${(typed_before or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
 
     granted = STORE.credit_workspace_once(workspace.id, AMOUNT_MICRODOLLARS, EVENT_ID)
     print("  credit applied" if granted else f"  no-op: event {EVENT_ID!r} already applied")
 
-    after = STORE.get_credit_account(workspace.id)
     typed_after = _typed_total_credits(workspace.id)
-    print(f"  JSON deposited after:  ${after.total_credits_microdollars / MICRODOLLARS_PER_DOLLAR:.2f}")
     print(f"  typed deposited after: ${(typed_after or 0) / MICRODOLLARS_PER_DOLLAR:.2f}")
     expected = (typed_before or 0) + (AMOUNT_MICRODOLLARS if granted else 0)
     if typed_after != expected:

--- a/scripts/credit_makeup.py
+++ b/scripts/credit_makeup.py
@@ -64,7 +64,6 @@ def main() -> int:
         )
         return 1
     typed_before = _typed_total_credits(WORKSPACE_ID)
-    print(f"before: total_credits_microdollars = {before.total_credits_microdollars}")
     print(f"before: typed total_credits = {typed_before or 0}")
 
     granted = STORE.credit_workspace_typed_direct(

--- a/scripts/stress_credit_shards.py
+++ b/scripts/stress_credit_shards.py
@@ -115,7 +115,6 @@ def _seed(
         workspace_id,
         CreditAccount(
             workspace_id=workspace_id,
-            total_credits_microdollars=total_credits,
             shard_count=shard_count,
         ),
     )

--- a/scripts/typed_flip.py
+++ b/scripts/typed_flip.py
@@ -19,7 +19,7 @@ from trusted_router.storage_gcp_counter_reconcile import (
     audit_typed_invariants,
     reconcile_for_flip,
 )
-from trusted_router.storage_models import ApiKey, CreditAccount, Reservation, Workspace
+from trusted_router.storage_models import ApiKey, Reservation, Workspace
 
 _DEFAULT_ENV = {
     "TR_STORAGE_BACKEND": "spanner-bigtable",
@@ -42,7 +42,10 @@ class TypedCreditRow:
 class Readiness:
     workspace_id: str
     workspace: Workspace | None
-    credit: CreditAccount | None
+    # Raw legacy-JSON 'credit' entity (dict) or None. Post-C2b CreditAccount is
+    # metadata-only, so the pre-flip legacy money (total_credits/total_usage/
+    # reserved) is read straight from the stored entity dict.
+    credit: dict | None
     keys: list[ApiKey] = field(default_factory=list)
     legacy_open_reservations: int = 0
     typed_reservation_rows: int = 0
@@ -69,8 +72,8 @@ class Readiness:
     @property
     def drain_reasons(self) -> list[str]:
         reasons: list[str] = []
-        if self.credit is not None and int(self.credit.reserved_microdollars) != 0:
-            reasons.append(f"JSON credit reserved={self.credit.reserved_microdollars}")
+        if self.credit is not None and int(self.credit.get("reserved_microdollars", 0)) != 0:
+            reasons.append(f"JSON credit reserved={self.credit.get('reserved_microdollars', 0)}")
         if self.legacy_open_reservations != 0:
             reasons.append(f"{self.legacy_open_reservations} open legacy reservations")
         if self.key_reserved_total != 0:
@@ -179,7 +182,7 @@ def _legacy_open_reservation_count(store: Any, workspace_id: str) -> int:
 
 def assess_readiness(store: Any, workspace_id: str) -> Readiness:
     workspace = store.get_workspace(workspace_id)
-    credit = store.get_credit_account(workspace_id)
+    credit = store._read_entity("credit", workspace_id, dict)
     keys = store.list_keys(workspace_id) if workspace is not None else []
     legacy_open = _legacy_open_reservation_count(store, workspace_id)
     typed_rows, typed_open = _typed_reservation_counts(store, workspace_id)
@@ -221,9 +224,9 @@ def _print_readiness(readiness: Readiness) -> None:
     else:
         print(
             "  JSON credit: "
-            f"total_credits={readiness.credit.total_credits_microdollars} "
-            f"total_usage={readiness.credit.total_usage_microdollars} "
-            f"reserved={readiness.credit.reserved_microdollars}"
+            f"total_credits={readiness.credit.get('total_credits_microdollars', 0)} "
+            f"total_usage={readiness.credit.get('total_usage_microdollars', 0)} "
+            f"reserved={readiness.credit.get('reserved_microdollars', 0)}"
         )
     print(
         "  holds: "
@@ -304,15 +307,15 @@ def _unpause_workspace(store: Any, workspace_id: str) -> bool:
 
 
 def _verify_seeded_credit(store: Any, workspace_id: str) -> tuple[bool, str]:
-    credit = store.get_credit_account(workspace_id)
+    credit = store._read_entity("credit", workspace_id, dict)
     typed = _typed_credit_row(store, workspace_id)
     if credit is None:
         return False, "JSON credit account missing"
     if typed is None:
         return False, "typed tr_credit_balance row missing"
     expected = (
-        int(credit.total_credits_microdollars),
-        int(credit.total_usage_microdollars),
+        int(credit.get("total_credits_microdollars", 0)),
+        int(credit.get("total_usage_microdollars", 0)),
         0,
     )
     actual = (typed.total_credits, typed.total_usage, typed.reserved)

--- a/src/trusted_router/services/auto_refill.py
+++ b/src/trusted_router/services/auto_refill.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from trusted_router.config import Settings
 from trusted_router.storage import STORE
 from trusted_router.storage_models import CreditAccount
-from trusted_router.typed_balance import typed_aware_credit_account
+from trusted_router.typed_balance import live_credit_summary
 
 log = logging.getLogger(__name__)
 
@@ -61,18 +61,21 @@ def maybe_charge_after_settle(
     # Typed-aware: for a typed workspace the authoritative usage/reserved live in
     # the typed table; reading stale JSON here would overstate available and the
     # threshold would never trip → the card never charges (underbill).
-    account = typed_aware_credit_account(STORE, workspace_id, settings=settings)
+    account = STORE.get_credit_account(workspace_id)
     if account is None:
         return AutoRefillOutcome(fired=False, reason="no_account")
     if not account.auto_refill_enabled:
         return AutoRefillOutcome(fired=False, reason="disabled")
     if account.auto_refill_amount_microdollars <= 0:
         return AutoRefillOutcome(fired=False, reason="disabled")
-    available = (
-        account.total_credits_microdollars
-        - account.total_usage_microdollars
-        - account.reserved_microdollars
-    )
+    summary = live_credit_summary(workspace_id, store=STORE)
+    if summary is None:
+        return AutoRefillOutcome(fired=False, reason="no_account")
+    # Unclamped available (may be negative for an overdrawn balance) so the
+    # threshold comparison is byte-identical to the pre-C2b inline computation.
+    # summary["available"] is floored at 0 for display and must NOT be used here:
+    # at threshold 0 it would suppress a refill the overdraw was meant to cover.
+    available = summary["total_credits"] - summary["total_usage"] - summary["reserved"]
     # The product promise is "when balance drops below the threshold".
     # Equal-to-threshold is still not below, so do not charge yet.
     if available >= account.auto_refill_threshold_microdollars:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -19,6 +19,7 @@ from trusted_router.storage_models import (
     BroadcastDestination,
     ByokProviderConfig,
     CreditAccount,
+    CreditMoney,
     CustomModel,
     EmailSendBlock,
     EncryptedSecretEnvelope,
@@ -62,6 +63,7 @@ class InMemoryStore:
         self.workspaces: dict[str, Workspace] = {}
         self.members: dict[tuple[str, str], Member] = {}
         self.credits: dict[str, CreditAccount] = {}
+        self.credit_money: dict[str, CreditMoney] = {}
         self.stripe_events: set[str] = set()
         # Composed feature stores. Each owns its own state and is importable
         # on its own. Keeps storage.py focused on identity + credit ledger;
@@ -69,6 +71,7 @@ class InMemoryStore:
         # rate limits / wallet / SES all live in their own modules.
         self.api_keys = InMemoryApiKeys(
             credits_by_workspace=self.credits,
+            credit_money_by_workspace=self.credit_money,
             lock=self._lock,
         )
         self.generation_store = InMemoryGenerations(
@@ -94,6 +97,7 @@ class InMemoryStore:
             self.workspaces.clear()
             self.members.clear()
             self.credits.clear()
+            self.credit_money.clear()
             self.stripe_events.clear()
             self.api_keys.reset()
             self.generation_store.reset()
@@ -142,7 +146,7 @@ class InMemoryStore:
                 creator_user_id=user.id,
                 management=True,
             )
-            trial = self.credits[workspace.id].total_credits_microdollars
+            trial = self.credit_money[workspace.id].total_credits_microdollars
         return SignupResult(
             user=user,
             workspace=workspace,
@@ -202,11 +206,10 @@ class InMemoryStore:
             # webhook in routes/internal/webhook.py). Stops free-credit
             # farming with throwaway emails. Wallet sign-in already passed
             # 0 explicitly, so its behavior is unchanged.
-            self.credits[workspace.id] = CreditAccount(
-                workspace_id=workspace.id,
-                total_credits_microdollars=(
-                    0 if trial_credit_microdollars is None else trial_credit_microdollars
-                ),
+            initial_total = 0 if trial_credit_microdollars is None else trial_credit_microdollars
+            self.credits[workspace.id] = CreditAccount(workspace_id=workspace.id)
+            self.credit_money[workspace.id] = CreditMoney(
+                total_credits_microdollars=initial_total
             )
             return workspace
 
@@ -248,6 +251,16 @@ class InMemoryStore:
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         with self._lock:
             return self.credits.get(workspace_id)
+
+    def credit_money_snapshot(self, workspace_id: str) -> tuple[int, int, int] | None:
+        money = self.credit_money.get(workspace_id)
+        if money is None:
+            return None
+        return (
+            money.total_credits_microdollars,
+            money.total_usage_microdollars,
+            money.reserved_microdollars,
+        )
 
     def add_members(self, workspace_id: str, emails: list[str], role: str = "member") -> list[Member]:
         with self._lock:
@@ -613,8 +626,7 @@ class InMemoryStore:
             if event_id in self.stripe_events:
                 return False
             self.stripe_events.add(event_id)
-            account = self.credits[workspace_id]
-            account.total_credits_microdollars += amount_microdollars
+            self.credit_money[workspace_id].total_credits_microdollars += amount_microdollars
             return True
 
     def credit_workspace_typed_direct(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -264,16 +264,13 @@ class SpannerBigtableStore:
             # New accounts start at $0; trial credit is granted on first
             # valid-card attach via the Stripe webhook. See
             # routes/internal/webhook.py + the create_workspace doc above.
-            credit = CreditAccount(
-                workspace_id=workspace.id,
-                total_credits_microdollars=0,
-            )
+            credit = CreditAccount(workspace_id=workspace.id)
             self._write_entity_tx(transaction, "user", new_user.id, new_user)
             self._write_entity_tx(transaction, "email_user", normalized_email, {"user_id": new_user.id})
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
             self._write_entity_tx(transaction, "member", _member_id(workspace.id, new_user.id), member)
             self._write_entity_tx(transaction, "credit", workspace.id, credit)
-            self._seed_credit_balance_on_create(transaction, workspace.id, credit)
+            self._seed_credit_balance_on_create(transaction, workspace.id, 0)
             return new_user
 
         return self._run_in_transaction(txn)
@@ -312,7 +309,7 @@ class SpannerBigtableStore:
         self,
         writer: Any,
         workspace_id: str,
-        credit: CreditAccount,
+        initial_total_micro: int,
     ) -> None:
         writer.insert_or_update(
             table=CREDIT_BALANCE_TABLE,
@@ -320,7 +317,7 @@ class SpannerBigtableStore:
             values=[
                 credit_balance_mirror_row(
                     workspace_id,
-                    credit,
+                    initial_total_micro,
                     self._spanner.COMMIT_TIMESTAMP,
                 )
             ],
@@ -373,17 +370,13 @@ class SpannerBigtableStore:
         # webhook in routes/internal/webhook.py). Stops free-credit
         # farming with throwaway emails. Wallet sign-in already passed
         # 0 explicitly, so its behavior is unchanged.
-        credit = CreditAccount(
-            workspace_id=workspace.id,
-            total_credits_microdollars=(
-                0 if trial_credit_microdollars is None else trial_credit_microdollars
-            ),
-        )
+        initial_total = 0 if trial_credit_microdollars is None else trial_credit_microdollars
+        credit = CreditAccount(workspace_id=workspace.id)
         with self._database.batch() as batch:
             self._write_entity_batch(batch, "workspace", workspace.id, workspace)
             self._write_entity_batch(batch, "member", _member_id(workspace.id, owner_user_id), member)
             self._write_entity_batch(batch, "credit", workspace.id, credit)
-            self._seed_credit_balance_on_create(batch, workspace.id, credit)
+            self._seed_credit_balance_on_create(batch, workspace.id, initial_total)
         return workspace
 
     def list_workspaces_for_user(self, user_id: str) -> list[Workspace]:
@@ -431,6 +424,24 @@ class SpannerBigtableStore:
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
+
+    def credit_money_snapshot(self, workspace_id: str) -> tuple[int, int, int] | None:
+        # Fallback money read for live_credit_summary when the typed snapshot is
+        # unavailable (mirror flag off, or the typed row not yet seeded). The
+        # stored 'credit' JSON still carries the legacy money on pre-C2b rows
+        # (they are only dropped when constructing the metadata-only
+        # CreditAccount, never from storage), so read the raw entity — matching
+        # the pre-C2b behavior where live_credit_summary fell back to the JSON
+        # CreditAccount. A tr_credit_balance point-read is deliberately NOT used:
+        # that table may not exist in a deploy-before-DDL state.
+        raw = self._read_entity("credit", workspace_id, dict)
+        if raw is None:
+            return None
+        return (
+            int(raw.get("total_credits_microdollars", 0)),
+            int(raw.get("total_usage_microdollars", 0)),
+            int(raw.get("reserved_microdollars", 0)),
+        )
 
     def _credit_shard_count_loader(self, workspace_id: str) -> Callable[[], int]:
         def load() -> int:
@@ -550,16 +561,13 @@ class SpannerBigtableStore:
                 owner_user_id=new_user.id,
             )
             member = Member(workspace_id=workspace.id, user_id=new_user.id, role="owner")
-            credit = CreditAccount(
-                workspace_id=workspace.id,
-                total_credits_microdollars=0,
-            )
+            credit = CreditAccount(workspace_id=workspace.id)
             self._write_entity_tx(transaction, "user", new_user.id, new_user)
             self._write_entity_tx(transaction, "wallet_user", normalized, {"user_id": new_user.id})
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
             self._write_entity_tx(transaction, "member", _member_id(workspace.id, new_user.id), member)
             self._write_entity_tx(transaction, "credit", workspace.id, credit)
-            self._seed_credit_balance_on_create(transaction, workspace.id, credit)
+            self._seed_credit_balance_on_create(transaction, workspace.id, 0)
             return new_user
 
         return self._run_in_transaction(txn)
@@ -890,8 +898,12 @@ class SpannerBigtableStore:
                     raise RuntimeError(
                         f"missing tr_credit_balance shard {shard} for sharded workspace"
                     )
-                # Seed path for legacy/missing typed rows; JSON credit money is stale.
-                new_total = int(account.total_credits_microdollars) + amount
+                # Seed path for legacy/missing typed rows; preserve any old JSON
+                # money if this is the first typed grant for a pre-C2b row.
+                raw_credit = (
+                    self._read_entity_tx(transaction, "credit", workspace_id, dict) or {}
+                )
+                new_total = int(raw_credit.get("total_credits_microdollars", 0)) + amount
                 transaction.execute_update(
                     "INSERT INTO tr_credit_balance "
                     "(workspace_id, shard, total_credits, source_updated_at, updated_at) "

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -112,12 +112,13 @@ def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
     return tuple(values)
 
 
-def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> tuple:
-    """Mirror the JSON-owned `total_credits` of a `credit` row into
-    tr_credit_balance. reserved + total_usage are typed-DML-owned and are
-    deliberately NOT mirrored (see CREDIT_BALANCE_COLUMNS).
+def credit_balance_mirror_row(workspace_id: str, total_micro: int, commit_ts: Any) -> tuple:
+    """Seed the one-shard `total_credits` value into tr_credit_balance.
 
-    This generic absolute-value mirror is intentionally one-shard only. Once a
+    reserved + total_usage are typed-DML-owned and are deliberately NOT mirrored
+    (see CREDIT_BALANCE_COLUMNS).
+
+    This absolute-value seed is intentionally one-shard only. Once a
     workspace is explicitly sharded, credit deltas are distributed by
     credit_workspace_typed_direct; replaying the global JSON total into shard 0
     would multiply its budget.
@@ -125,7 +126,7 @@ def credit_balance_mirror_row(workspace_id: str, value: Any, commit_ts: Any) -> 
     return (
         workspace_id,
         UNSHARDED,
-        int(_field(value, "total_credits_microdollars", 0)),
+        int(total_micro),
         commit_ts,  # source_updated_at — the JSON row's updated_at, same commit
         commit_ts,  # this mirror's updated_at
     )

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -124,14 +124,6 @@ def inspect_credit_reshard(
         result.reasons.append(
             f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
         )
-    if int(account.reserved_microdollars) != 0:
-        result.reasons.append(
-            f"JSON credit has reserved={account.reserved_microdollars}; wait for drain"
-        )
-    if total_credits != int(account.total_credits_microdollars):
-        result.reasons.append(
-            "typed/JSON deposited-credit totals differ; reconcile before reshard"
-        )
     return result
 
 
@@ -191,8 +183,6 @@ def reshard_credit_account(
         if (
             open_typed != 0
             or reserved != 0
-            or int(account.reserved_microdollars) != 0
-            or total_credits != int(account.total_credits_microdollars)
             or any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows)
             or any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows)
         ):
@@ -231,9 +221,6 @@ def reshard_credit_account(
             )
 
         account.shard_count = target_count
-        account.total_credits_microdollars = total_credits
-        account.total_usage_microdollars = total_usage
-        account.reserved_microdollars = 0
         # Deliberately bypass _write_entity_tx: this admin transaction already
         # owns the exact typed-row mutations above.
         transaction.insert_or_update(

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -9,8 +9,8 @@ The "spend control" half of the in-memory store. Owns four dicts:
     the authorize call).
 
 Three of those dicts are owned outright; reservations need read+write access
-to the workspace credit ledger (CreditAccount.reserved/total_usage), so the
-class accepts the credits dict by reference at construction time. The
+to the workspace credit ledger (CreditMoney.reserved/total_usage), so the
+class accepts the money dict by reference at construction time. The
 parent InMemoryStore's lock is shared so reserve→credit-debit happens
 atomically.
 
@@ -44,6 +44,7 @@ from trusted_router.spend_windows import (
 from trusted_router.storage_models import (
     ApiKey,
     CreditAccount,
+    CreditMoney,
     GatewayAuthorization,
     Reservation,
     _is_byok,
@@ -57,10 +58,12 @@ class InMemoryApiKeys:
         self,
         *,
         credits_by_workspace: dict[str, CreditAccount],
+        credit_money_by_workspace: dict[str, CreditMoney],
         lock: threading.RLock,
     ) -> None:
         self._lock = lock
         self._credits = credits_by_workspace
+        self._credit_money = credit_money_by_workspace
         self.keys: dict[str, ApiKey] = {}
         self.key_ids_by_lookup_hash: dict[str, str] = {}
         self.reservations: dict[str, Reservation] = {}
@@ -330,7 +333,7 @@ class InMemoryApiKeys:
                 existing_id = self.reservation_id_by_idempotency_key.get(idempotency_key)
                 if existing_id is not None:
                     return self.reservations[existing_id]
-            account = self._credits[workspace_id]
+            account = self._credit_money[workspace_id]
             available = (
                 account.total_credits_microdollars
                 - account.total_usage_microdollars
@@ -356,9 +359,9 @@ class InMemoryApiKeys:
             reservation = self.reservations[reservation_id]
             if reservation.settled:
                 return
-            account = self._credits[reservation.workspace_id]
-            account.reserved_microdollars -= reservation.amount_microdollars
-            account.total_usage_microdollars += actual_microdollars
+            m = self._credit_money[reservation.workspace_id]
+            m.reserved_microdollars -= reservation.amount_microdollars
+            m.total_usage_microdollars += actual_microdollars
             reservation.settled = True
 
     def refund(self, reservation_id: str) -> None:
@@ -366,8 +369,8 @@ class InMemoryApiKeys:
             reservation = self.reservations[reservation_id]
             if reservation.settled:
                 return
-            account = self._credits[reservation.workspace_id]
-            account.reserved_microdollars -= reservation.amount_microdollars
+            m = self._credit_money[reservation.workspace_id]
+            m.reserved_microdollars -= reservation.amount_microdollars
             reservation.settled = True
 
     # ── Gateway authorizations ──────────────────────────────────────────

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -250,9 +250,6 @@ class SettleOutboxRow:
 @dataclass
 class CreditAccount:
     workspace_id: str
-    total_credits_microdollars: int = 0
-    total_usage_microdollars: int = 0
-    reserved_microdollars: int = 0
     # Number of independent tr_credit_balance sub-ledgers owned by this
     # workspace. The default preserves the original one-row behavior; only the
     # pause/drain operator path may activate more shards for a hot workspace.
@@ -269,6 +266,17 @@ class CreditAccount:
     # and surface a helpful error if the saved card declines.
     last_auto_refill_at: str | None = None
     last_auto_refill_status: str | None = None  # "succeeded" | "failed:<code>" | "pending"
+
+
+@dataclass
+class CreditMoney:
+    """In-memory single-book credit money for one workspace. The Spanner
+    store keeps this in the typed tr_credit_balance table; the InMemory twin
+    keeps it here so CreditAccount stays metadata-only."""
+
+    total_credits_microdollars: int = 0
+    total_usage_microdollars: int = 0
+    reserved_microdollars: int = 0
 
 
 @dataclass

--- a/src/trusted_router/typed_balance.py
+++ b/src/trusted_router/typed_balance.py
@@ -18,11 +18,9 @@ single-book test twin.
 
 from __future__ import annotations
 
-import dataclasses
 from typing import Any, TypedDict
 
 from trusted_router.storage import STORE, typed_billing_store
-from trusted_router.storage_models import CreditAccount
 
 
 class LiveCreditSummary(TypedDict):
@@ -32,34 +30,6 @@ class LiveCreditSummary(TypedDict):
     available: int
 
 
-def typed_aware_credit_account(
-    store: Any, workspace_id: str, *, settings: Any
-) -> CreditAccount | None:
-    """Return the workspace's CreditAccount with total_credits/total_usage/
-    reserved overlaid from the typed table when the workspace is typed. JSON
-    metadata (auto-refill config, stripe ids) is preserved. No-op for legacy
-    workspaces, stores without the typed capability, or a not-yet-seeded typed
-    row.
-
-    The typed read goes through the TypedBillingStore capability (a point-read
-    method on the store) instead of reaching into the store's private Spanner
-    handles — the reason isinstance(store, TypedBillingStore) replaced the old
-    hasattr(_database) probe (#39)."""
-    account = store.get_credit_account(workspace_id)
-    typed_store = typed_billing_store(store)
-    if account is None or typed_store is None:
-        return account
-    typed = typed_store.typed_credit_snapshot(workspace_id)
-    if typed is None:
-        return account  # typed-capable store, but no row yet — JSON is the best estimate
-    return dataclasses.replace(
-        account,
-        total_credits_microdollars=int(typed[0]),
-        total_usage_microdollars=int(typed[1]),
-        reserved_microdollars=int(typed[2]),
-    )
-
-
 def live_credit_summary(
     workspace_id: str,
     *,
@@ -67,9 +37,9 @@ def live_credit_summary(
 ) -> LiveCreditSummary | None:
     """Return the live money counters for display/API reads.
 
-    A typed counter row wins whenever it exists. Workspaces without a typed row
-    yet, plus the in-memory single-book store, fall back to the JSON
-    CreditAccount. Non-money JSON metadata remains the caller's responsibility.
+    A typed counter row wins whenever it exists. The in-memory single-book store
+    falls back to its CreditMoney snapshot. Non-money JSON metadata remains the
+    caller's responsibility.
     """
     active_store = STORE if store is None else store
     typed_store = typed_billing_store(active_store)
@@ -78,14 +48,13 @@ def live_credit_summary(
         if typed is not None:
             return _summary(int(typed[0]), int(typed[1]), int(typed[2]))
 
-    account = active_store.get_credit_account(workspace_id)
-    if account is None:
-        return None
-    return _summary(
-        account.total_credits_microdollars,
-        account.total_usage_microdollars,
-        account.reserved_microdollars,
-    )
+    snapshot_fn = getattr(active_store, "credit_money_snapshot", None)
+    if snapshot_fn is not None:
+        money = snapshot_fn(workspace_id)
+        if money is None:
+            return None
+        return _summary(int(money[0]), int(money[1]), int(money[2]))
+    return None
 
 
 def _summary(total_credits: int, total_usage: int, reserved: int) -> LiveCreditSummary:

--- a/tests/test_auto_refill.py
+++ b/tests/test_auto_refill.py
@@ -20,6 +20,13 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.services.auto_refill import AutoRefillOutcome, maybe_charge_after_settle
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
+
+
+def _credit_summary(workspace_id: str) -> dict[str, int]:
+    summary = live_credit_summary(workspace_id)
+    assert summary is not None
+    return summary
 
 
 @pytest.fixture
@@ -223,9 +230,7 @@ def test_payment_intent_succeeded_webhook_credits_workspace(
                 }
             },
         }
-        before = STORE.get_credit_account(configured_workspace)
-        assert before is not None
-        before_credits = before.total_credits_microdollars
+        before_credits = _credit_summary(configured_workspace)["total_credits"]
         resp = client.post("/internal/stripe/webhook", json=event)
         next(client_iter)  # silence unused-iter warning.
     assert resp.status_code == 200
@@ -234,7 +239,7 @@ def test_payment_intent_succeeded_webhook_credits_workspace(
 
     after = STORE.get_credit_account(configured_workspace)
     assert after is not None
-    assert after.total_credits_microdollars == before_credits + 20_000_000
+    assert _credit_summary(configured_workspace)["total_credits"] == before_credits + 20_000_000
     assert after.last_auto_refill_status == "succeeded"
 
 
@@ -346,11 +351,7 @@ def test_auto_refill_exits_band_after_successful_credit(
 
     account = STORE.get_credit_account(configured_workspace)
     assert account is not None
-    available = (
-        account.total_credits_microdollars
-        - account.total_usage_microdollars
-        - account.reserved_microdollars
-    )
+    available = _credit_summary(configured_workspace)["available"]
     # $1 + $20 refill = $21, well above $5 threshold.
     assert available > account.auto_refill_threshold_microdollars
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -9,19 +9,26 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.security import lookup_hash_api_key
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
+
+
+def _credit_summary(workspace_id: str) -> dict[str, int]:
+    summary = live_credit_summary(workspace_id)
+    assert summary is not None
+    return summary
 
 
 def test_stripe_event_idempotency(user_headers: dict[str, str], client) -> None:
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    before = STORE.credits[workspace_id].total_credits_microdollars
+    before = STORE.credit_money[workspace_id].total_credits_microdollars
     assert STORE.credit_workspace_once(workspace_id, 5_000_000, "evt_1") is True
     assert STORE.credit_workspace_once(workspace_id, 5_000_000, "evt_1") is False
-    assert STORE.credits[workspace_id].total_credits_microdollars == before + 5_000_000
+    assert STORE.credit_money[workspace_id].total_credits_microdollars == before + 5_000_000
 
 
 def test_stripe_webhook_route_is_idempotent(user_headers: dict[str, str], client) -> None:
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    before = STORE.credits[workspace_id].total_credits_microdollars
+    before = STORE.credit_money[workspace_id].total_credits_microdollars
     event = {
         "id": "evt_checkout_1",
         "type": "checkout.session.completed",
@@ -38,7 +45,7 @@ def test_stripe_webhook_route_is_idempotent(user_headers: dict[str, str], client
     assert second.status_code == 200
     assert first.json()["data"]["credited"] is True
     assert second.json()["data"]["credited"] is False
-    assert STORE.credits[workspace_id].total_credits_microdollars == before + 12_000_000
+    assert STORE.credit_money[workspace_id].total_credits_microdollars == before + 12_000_000
 
 
 def test_billing_checkout_and_portal_mock_without_stripe_secret(user_headers: dict[str, str], client) -> None:
@@ -142,7 +149,7 @@ def test_setup_checkout_completed_marks_customer_pending_without_granting_trial(
     # in the dedup ledger so the webhook's idempotent credit_workspace_once
     # actually fires (otherwise it'd see the conftest fixture's grant as a
     # prior trial-grant and no-op).
-    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 0
     STORE.stripe_events.discard(f"trial:{workspace_id}")
     event = {
         "id": "evt_checkout_setup_1",
@@ -165,7 +172,7 @@ def test_setup_checkout_completed_marks_customer_pending_without_granting_trial(
     assert body["trial_credit_granted_microdollars"] == 0
     account = STORE.get_credit_account(workspace_id)
     assert account is not None
-    assert account.total_credits_microdollars == 0
+    assert _credit_summary(workspace_id)["total_credits"] == 0
     assert account.stripe_customer_id == "cus_checkout_setup"
     assert account.stripe_payment_method_id is None
 
@@ -174,7 +181,7 @@ def test_setup_intent_without_customer_does_not_grant_trial_or_save_method(
     user_headers: dict[str, str], client
 ) -> None:
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 0
     STORE.credits[workspace_id].stripe_customer_id = None
     STORE.credits[workspace_id].stripe_payment_method_id = None
     STORE.stripe_events.discard(f"trial:{workspace_id}")
@@ -196,7 +203,7 @@ def test_setup_intent_without_customer_does_not_grant_trial_or_save_method(
     assert resp.json()["data"]["ignored"] is True
     account = STORE.get_credit_account(workspace_id)
     assert account is not None
-    assert account.total_credits_microdollars == 0
+    assert _credit_summary(workspace_id)["total_credits"] == 0
     assert account.stripe_customer_id is None
     assert account.stripe_payment_method_id is None
 
@@ -208,7 +215,7 @@ def test_setup_intent_grants_no_trial_credit_by_default(
     but grants NO free credit — signup_trial_credit_microdollars defaults to 0."""
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
     # Undo the conftest auto-credit so a grant *would* fire if it were enabled.
-    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 0
     STORE.stripe_events.discard(f"trial:{workspace_id}")
     event = {
         "id": "evt_setup_intent_no_trial",
@@ -230,7 +237,7 @@ def test_setup_intent_grants_no_trial_credit_by_default(
     assert body["trial_credit_granted_microdollars"] == 0
     account = STORE.get_credit_account(workspace_id)
     assert account is not None
-    assert account.total_credits_microdollars == 0
+    assert _credit_summary(workspace_id)["total_credits"] == 0
     assert account.stripe_payment_method_id == "pm_no_trial"
 
 
@@ -242,7 +249,7 @@ def test_setup_intent_grants_configured_trial_credit_when_enabled(
         client.app.state.settings, "signup_trial_credit_microdollars", 5_000_000
     )
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 0
     STORE.stripe_events.discard(f"trial:{workspace_id}")
     event = {
         "id": "evt_setup_intent_enabled_trial",
@@ -263,7 +270,7 @@ def test_setup_intent_grants_configured_trial_credit_when_enabled(
     assert body["trial_credit_granted_microdollars"] == 5_000_000
     account = STORE.get_credit_account(workspace_id)
     assert account is not None
-    assert account.total_credits_microdollars == 5_000_000
+    assert _credit_summary(workspace_id)["total_credits"] == 5_000_000
 
 
 def test_payment_intent_succeeded_from_checkout_saves_payment_method_without_crediting(
@@ -272,7 +279,7 @@ def test_payment_intent_succeeded_from_checkout_saves_payment_method_without_cre
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
     before = STORE.get_credit_account(workspace_id)
     assert before is not None
-    before_total = before.total_credits_microdollars
+    before_total = _credit_summary(workspace_id)["total_credits"]
     event = {
         "id": "evt_payment_intent_checkout_pm",
         "type": "payment_intent.succeeded",
@@ -291,7 +298,7 @@ def test_payment_intent_succeeded_from_checkout_saves_payment_method_without_cre
     assert resp.json()["data"]["payment_method_saved"] is True
     account = STORE.get_credit_account(workspace_id)
     assert account is not None
-    assert account.total_credits_microdollars == before_total
+    assert _credit_summary(workspace_id)["total_credits"] == before_total
     assert account.stripe_customer_id == "cus_checkout_pm"
     assert account.stripe_payment_method_id == "pm_checkout_saved"
 
@@ -364,9 +371,9 @@ def test_billing_checkout_validates_amount_and_workspace(user_headers: dict[str,
 def test_concurrent_reservations_do_not_overspend(user_headers: dict[str, str], client) -> None:
     key = client.post("/v1/keys", headers=user_headers, json={"name": "reserve"}).json()["data"]
     workspace_id = key["workspace_id"]
-    STORE.credits[workspace_id].total_credits_microdollars = 1_000_000
-    STORE.credits[workspace_id].total_usage_microdollars = 0
-    STORE.credits[workspace_id].reserved_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 1_000_000
+    STORE.credit_money[workspace_id].total_usage_microdollars = 0
+    STORE.credit_money[workspace_id].reserved_microdollars = 0
 
     def reserve_once() -> bool:
         try:
@@ -378,7 +385,7 @@ def test_concurrent_reservations_do_not_overspend(user_headers: dict[str, str], 
     with ThreadPoolExecutor(max_workers=4) as pool:
         results = list(pool.map(lambda _: reserve_once(), range(4)))
     assert results.count(True) == 1
-    assert STORE.credits[workspace_id].reserved_microdollars == 600_000
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 600_000
 
 
 def test_internal_gateway_authorize_and_settle_records_metadata(
@@ -403,7 +410,7 @@ def test_internal_gateway_authorize_and_settle_records_metadata(
     assert auth_data["usage_type"] == "Credits"
     assert auth_data["credit_reservation_id"]
     assert auth_data["content_storage_enabled"] is False
-    assert STORE.credits[workspace_id].reserved_microdollars > 0
+    assert STORE.credit_money[workspace_id].reserved_microdollars > 0
 
     settle = client.post(
         "/v1/internal/gateway/settle",
@@ -423,8 +430,8 @@ def test_internal_gateway_authorize_and_settle_records_metadata(
     generation = STORE.generation_store.generations[generation_id]
     assert generation.request_id == "gw-req-1"
     assert generation.app == "attested-gateway-test"
-    assert STORE.credits[workspace_id].reserved_microdollars == 0
-    assert STORE.credits[workspace_id].total_usage_microdollars == generation.total_cost_microdollars
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 0
+    assert STORE.credit_money[workspace_id].total_usage_microdollars == generation.total_cost_microdollars
 
     repeat = client.post(
         "/v1/internal/gateway/settle",
@@ -455,7 +462,7 @@ def test_internal_gateway_authorize_replays_same_idempotency_key_once(
     )
     assert first.status_code == 200, first.text
     first_data = first.json()["data"]
-    first_reserved = STORE.credits[workspace_id].reserved_microdollars
+    first_reserved = STORE.credit_money[workspace_id].reserved_microdollars
 
     repeat = client.post(
         "/v1/internal/gateway/authorize",
@@ -467,7 +474,7 @@ def test_internal_gateway_authorize_replays_same_idempotency_key_once(
     assert repeat_data["authorization_id"] == first_data["authorization_id"]
     assert repeat_data["credit_reservation_id"] == first_data["credit_reservation_id"]
     assert repeat_data["idempotent_replay"] is True
-    assert STORE.credits[workspace_id].reserved_microdollars == first_reserved
+    assert STORE.credit_money[workspace_id].reserved_microdollars == first_reserved
 
 
 def test_internal_gateway_authorize_rejects_idempotency_key_body_mismatch(
@@ -717,7 +724,7 @@ def test_stripe_webhook_handles_stripe_object_from_construct_event(
     from trusted_router.routes.internal import webhook as webhook_module
 
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    before = STORE.credits[workspace_id].total_credits_microdollars
+    before = STORE.credit_money[workspace_id].total_credits_microdollars
 
     # Build a real stripe.Event so we exercise the actual StripeObject code
     # path that bit us in prod (rather than a fake "dict-without-.get"
@@ -783,7 +790,7 @@ def test_stripe_webhook_handles_stripe_object_from_construct_event(
     assert body["event_id"] == "evt_stripeobj_regression_1"
     # Verify the credit actually landed — the whole point of fixing this is
     # that real Stripe payments grant credit again.
-    after = STORE.credits[workspace_id].total_credits_microdollars
+    after = STORE.credit_money[workspace_id].total_credits_microdollars
     assert after - before == 100 * 10000, f"expected +$1.00 in microdollars, got {after-before}"
 
 

--- a/tests/test_billing_flip_reconcile.py
+++ b/tests/test_billing_flip_reconcile.py
@@ -11,7 +11,7 @@ See docs/design/billing-typed-counters.md.
 from __future__ import annotations
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount, Workspace
+from trusted_router.storage import Workspace
 from trusted_router.storage_gcp_counter_reconcile import reconcile_for_flip
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 
@@ -35,11 +35,11 @@ def _seed_drained_workspace(store, ws: str, *, total_credits: int, total_usage: 
     )
     store._write_entity(
         "credit", ws,
-        CreditAccount(
-            workspace_id=ws,
-            total_credits_microdollars=total_credits,
-            total_usage_microdollars=total_usage,
-        ),
+        {
+            "workspace_id": ws,
+            "total_credits_microdollars": total_credits,
+            "total_usage_microdollars": total_usage,
+        },
     )
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
         "workspace_id": ws,
@@ -89,11 +89,11 @@ def test_reconcile_refuses_open_credit_hold() -> None:
     store._write_entity(
         "credit",
         ws,
-        CreditAccount(
-            workspace_id=ws,
-            total_credits_microdollars=1_000_000,
-            reserved_microdollars=250_000,
-        ),
+        {
+            "workspace_id": ws,
+            "total_credits_microdollars": 1_000_000,
+            "reserved_microdollars": 250_000,
+        },
     )
 
     result = reconcile_for_flip(store, ws, apply=True)

--- a/tests/test_billing_key_window_limits.py
+++ b/tests/test_billing_key_window_limits.py
@@ -307,7 +307,7 @@ def test_window_check_passes_through_idempotent_replay() -> None:
 def test_flip_seed_carries_window_limit_config() -> None:
     """codex #93 round 2: reconcile_for_flip's seed must include the window
     config columns."""
-    from trusted_router.storage import CreditAccount, Workspace
+    from trusted_router.storage import Workspace
     from trusted_router.storage_gcp_counter_reconcile import reconcile_for_flip
     from trusted_router.storage_gcp_counters import KEY_LIMIT_TABLE as KLT
 
@@ -318,7 +318,7 @@ def test_flip_seed_carries_window_limit_config() -> None:
     )
     store._write_entity(
         "credit", ws,
-        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000),
+        {"workspace_id": ws, "total_credits_microdollars": 1_000_000},
     )
     _raw, key = store.api_keys.create(
         workspace_id=ws, name="k", creator_user_id=None,

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -28,12 +28,10 @@ def test_create_workspace_seeds_tr_credit_balance_row() -> None:
         trial_credit_microdollars=7_000_000,
     )
 
-    account = store.get_credit_account(workspace.id)
     row = _typed_credit(db, workspace.id)
-    assert account is not None
     assert row["workspace_id"] == workspace.id
     assert row["shard"] == 0
-    assert row["total_credits"] == account.total_credits_microdollars == 7_000_000
+    assert row["total_credits"] == 7_000_000
     assert row["total_usage"] == 0
     assert row["reserved"] == 0
 
@@ -74,7 +72,7 @@ def test_metadata_writes_never_reseed_or_clobber_typed_topups() -> None:
 
     assert store.credit_workspace_once(workspace.id, 50_000_000, "evt-topup")
     assert _typed_credit(db, workspace.id)["total_credits"] == 150_000_000
-    assert _json_credit(db, workspace.id)["total_credits_microdollars"] == 100_000_000
+    assert "total_credits_microdollars" not in _json_credit(db, workspace.id)
     typed_version = db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, 0))]
 
     assert store.record_auto_refill_outcome(workspace.id, status="succeeded") is not None

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -13,8 +13,17 @@ def _seed_credit(store, workspace_id: str, total: int) -> None:
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(workspace_id=workspace_id, total_credits_microdollars=total),
+        CreditAccount(workspace_id=workspace_id),
     )
+    store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
+        "workspace_id": workspace_id,
+        "shard": 0,
+        "total_credits": total,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
 
 
 def _json_credit(db, workspace_id: str) -> dict:
@@ -33,21 +42,25 @@ def test_credit_workspace_typed_direct_applies_once_in_one_transaction() -> None
 
     assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is True
 
-    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_000_000
+    assert "total_credits_microdollars" not in _json_credit(db, ws)
     assert _typed_credit(db, ws)["total_credits"] == 1_500_000
     assert ("stripe_event", event_id) in db.rows
     commit_version = db.rows[("stripe_event", event_id)].version
     assert db.typed_versions[(CREDIT_BALANCE_TABLE, (ws, 0))] == commit_version
 
     assert store.credit_workspace_typed_direct(ws, 500_000, event_id) is False
-    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_000_000
+    assert "total_credits_microdollars" not in _json_credit(db, ws)
     assert _typed_credit(db, ws)["total_credits"] == 1_500_000
 
 
 def test_credit_workspace_typed_direct_creates_missing_typed_row_from_json() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_b2_missing_typed"
-    _seed_credit(store, ws, 2_000_000)
+    store._write_entity(
+        "credit",
+        ws,
+        {"workspace_id": ws, "total_credits_microdollars": 2_000_000},
+    )
     assert (ws, 0) not in db.typed.get(CREDIT_BALANCE_TABLE, {})
 
     assert store.credit_workspace_typed_direct(ws, 750_000, "evt_b2_seed") is True
@@ -67,13 +80,13 @@ def test_credit_workspace_once_wrapper_cross_path_idempotency() -> None:
 
     assert store.credit_workspace_typed_direct(ws, 400_000, "evt_new_path") is True
     assert store.credit_workspace_once(ws, 400_000, "evt_new_path") is False
-    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_000_000
+    assert "total_credits_microdollars" not in _json_credit(db, ws)
     assert _typed_credit(db, ws)["total_credits"] == 1_400_000
 
     store._write_entity("stripe_event", "evt_old_marker", {"created_at": "2026-07-10T00:00:00Z"})
     assert store.credit_workspace_once(ws, 900_000, "evt_old_marker") is False
     assert store.credit_workspace_typed_direct(ws, 900_000, "evt_old_marker") is False
-    assert _json_credit(db, ws)["total_credits_microdollars"] == 1_000_000
+    assert "total_credits_microdollars" not in _json_credit(db, ws)
     assert _typed_credit(db, ws)["total_credits"] == 1_400_000
 
 
@@ -96,7 +109,7 @@ def test_gcp_signup_reports_typed_trial_credit(monkeypatch) -> None:
 
     assert result is not None
     assert result.trial_credit_microdollars == grant_amount
-    assert _json_credit(db, result.workspace.id)["total_credits_microdollars"] == 0
+    assert "total_credits_microdollars" not in _json_credit(db, result.workspace.id)
     assert _typed_credit(db, result.workspace.id)["total_credits"] == grant_amount
 
 

--- a/tests/test_billing_typed_enforcement.py
+++ b/tests/test_billing_typed_enforcement.py
@@ -33,9 +33,7 @@ def _floors() -> dict:
 
 
 def _seed_credit(store, ws: str, total: int) -> None:
-    store._write_entity(
-        "credit", ws, CreditAccount(workspace_id=ws, total_credits_microdollars=total)
-    )
+    store._write_entity("credit", ws, CreditAccount(workspace_id=ws))
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
         "workspace_id": ws,
         "shard": 0,
@@ -178,8 +176,12 @@ def test_dml_after_mutation_is_rejected() -> None:
     pt = store._param_types
 
     def mix(transaction) -> None:
-        store._write_entity_tx(transaction, "credit", ws, CreditAccount(
-            workspace_id=ws, total_credits_microdollars=1_000_000))  # mutation
+        store._write_entity_tx(
+            transaction,
+            "credit",
+            ws,
+            CreditAccount(workspace_id=ws),
+        )  # mutation
         reserve_credit(transaction, pt, ws, 100_000)  # DML -> must raise
 
     with pytest.raises(RuntimeError, match="DML.*mutation"):

--- a/tests/test_contract_regressions.py
+++ b/tests/test_contract_regressions.py
@@ -6,6 +6,7 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.openrouter_coverage import ROUTE_COVERAGE
 from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
 
 TEST_BYOK_KMS_KEY_NAME = (
     "projects/test/locations/us-central1/keyRings/trusted-router/cryptoKeys/byok-envelope"
@@ -100,7 +101,7 @@ def test_gateway_settle_repeat_cannot_charge_or_log_twice(
         },
     )
     assert first.status_code == 200, first.text
-    usage_after_first = STORE.credits[workspace_id].total_usage_microdollars
+    usage_after_first = STORE.credit_money[workspace_id].total_usage_microdollars
     generation_count_after_first = len(STORE.generation_store.generations)
 
     repeat = client.post(
@@ -115,7 +116,7 @@ def test_gateway_settle_repeat_cannot_charge_or_log_twice(
     )
     assert repeat.status_code == 200, repeat.text
     assert repeat.json()["data"]["already_settled"] is True
-    assert STORE.credits[workspace_id].total_usage_microdollars == usage_after_first
+    assert STORE.credit_money[workspace_id].total_usage_microdollars == usage_after_first
     assert len(STORE.generation_store.generations) == generation_count_after_first
     assert all(gen.request_id != "gw-double-charge-attempt" for gen in STORE.generation_store.generations.values())
 
@@ -149,7 +150,7 @@ def test_gateway_refund_repeat_cannot_restore_credit_twice(
     assert repeat.status_code == 200, repeat.text
     assert repeat.json()["data"]["already_settled"] is True
     assert _available_microdollars(workspace_id) == starting_available
-    assert STORE.credits[workspace_id].reserved_microdollars == 0
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 0
 
 
 def test_production_prompt_routes_are_absent_and_gateway_requires_internal_token() -> None:
@@ -219,12 +220,9 @@ def _production_app():
 
 
 def _available_microdollars(workspace_id: str) -> int:
-    account = STORE.credits[workspace_id]
-    return (
-        account.total_credits_microdollars
-        - account.total_usage_microdollars
-        - account.reserved_microdollars
-    )
+    summary = live_credit_summary(workspace_id)
+    assert summary is not None
+    return summary["available"]
 
 
 def _per_token_decimal(microdollars_per_million: int) -> str:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -393,9 +393,9 @@ def test_provider_errors_do_not_echo_prompt_or_create_generation(
     assert prompt not in resp.text
     assert STORE.generation_store.generations == {}
     key = next(iter(STORE.api_keys.keys.values()))
-    account = STORE.credits[key.workspace_id]
-    assert account.total_usage_microdollars == 0
-    assert account.reserved_microdollars == 0
+    money = STORE.credit_money[key.workspace_id]
+    assert money.total_usage_microdollars == 0
+    assert money.reserved_microdollars == 0
     assert key.reserved_microdollars == 0
 
 
@@ -622,7 +622,7 @@ def test_prepaid_insufficient_credits_blocks_before_provider_call(
     from trusted_router.storage import STORE
 
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    STORE.credits[workspace_id].total_credits_microdollars = 0
+    STORE.credit_money[workspace_id].total_credits_microdollars = 0
     resp = client.post(
         "/v1/chat/completions",
         headers=inference_headers,

--- a/tests/test_credit_ledger_idempotency.py
+++ b/tests/test_credit_ledger_idempotency.py
@@ -30,7 +30,7 @@ def _seed_credited_workspace(initial_credits_microdollars: int = 100_000_000) ->
     credit balance. Returns (workspace_id, key_hash)."""
     user = STORE.ensure_user("idempotency-test@example.com")
     workspace = STORE.list_workspaces_for_user(user.id)[0]
-    STORE.credits[workspace.id].total_credits_microdollars = initial_credits_microdollars
+    STORE.credit_money[workspace.id].total_credits_microdollars = initial_credits_microdollars
     _, api_key = STORE.create_api_key(
         workspace_id=workspace.id,
         name="idempotency-test",
@@ -55,9 +55,7 @@ def test_reserve_with_same_idempotency_key_returns_same_reservation() -> None:
     # Credit was only locked once. With $10M initial credit and one $3M
     # reservation, $7M should remain available (not $4M as it would be
     # if both reserve calls had debited).
-    account = STORE.get_credit_account(workspace_id)
-    assert account is not None
-    assert account.reserved_microdollars == 3_000_000
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 3_000_000
 
 
 def test_reserve_without_idempotency_key_still_creates_distinct_reservations() -> None:
@@ -69,9 +67,7 @@ def test_reserve_without_idempotency_key_still_creates_distinct_reservations() -
     assert first.id != second.id
     assert first.idempotency_key is None
     assert second.idempotency_key is None
-    account = STORE.get_credit_account(workspace_id)
-    assert account is not None
-    assert account.reserved_microdollars == 6_000_000
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 6_000_000
 
 
 def test_reserve_with_different_idempotency_keys_creates_distinct_reservations() -> None:
@@ -83,9 +79,7 @@ def test_reserve_with_different_idempotency_keys_creates_distinct_reservations()
     assert first.id != second.id
     assert first.idempotency_key == "req-1"
     assert second.idempotency_key == "req-2"
-    account = STORE.get_credit_account(workspace_id)
-    assert account is not None
-    assert account.reserved_microdollars == 4_000_000
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 4_000_000
 
 
 def test_reserve_idempotency_returns_existing_even_when_amounts_differ() -> None:
@@ -110,6 +104,4 @@ def test_reserve_idempotency_returns_existing_even_when_amounts_differ() -> None
     assert first.id == second.id
     assert first.amount_microdollars == 1_000_000
     assert second.amount_microdollars == 1_000_000
-    account = STORE.get_credit_account(workspace_id)
-    assert account is not None
-    assert account.reserved_microdollars == 1_000_000
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 1_000_000

--- a/tests/test_credit_ledger_idempotency_audit.py
+++ b/tests/test_credit_ledger_idempotency_audit.py
@@ -37,6 +37,7 @@ from trusted_router.config import Settings
 from trusted_router.storage import (
     STORE,
     CreditAccount,
+    CreditMoney,
 )
 from trusted_router.types import UsageType
 
@@ -45,10 +46,8 @@ def _fresh_workspace(name: str = "ws_idem_audit") -> str:
     """Set up a workspace with $5 of credit so we have headroom to
     reserve+settle without going negative. Returns the workspace_id."""
     workspace_id = f"{name}_{len(STORE.credits)}"
-    STORE.credits[workspace_id] = CreditAccount(
-        workspace_id=workspace_id,
-        total_credits_microdollars=5_000_000,
-    )
+    STORE.credits[workspace_id] = CreditAccount(workspace_id=workspace_id)
+    STORE.credit_money[workspace_id] = CreditMoney(total_credits_microdollars=5_000_000)
     return workspace_id
 
 
@@ -62,7 +61,7 @@ def test_credit_workspace_once_is_idempotent_on_repeat_event_id() -> None:
     after the 2026-05-24 deploy that fixed the StripeObject crash)
     cannot grant twice."""
     workspace_id = _fresh_workspace()
-    before = STORE.credits[workspace_id].total_credits_microdollars
+    before = STORE.credit_money[workspace_id].total_credits_microdollars
 
     first = STORE.credit_workspace_once(workspace_id, 1_000_000, "evt_audit_credit_1")
     second = STORE.credit_workspace_once(workspace_id, 1_000_000, "evt_audit_credit_1")
@@ -71,7 +70,7 @@ def test_credit_workspace_once_is_idempotent_on_repeat_event_id() -> None:
     assert first is True
     assert second is False
     assert third is False
-    after = STORE.credits[workspace_id].total_credits_microdollars
+    after = STORE.credit_money[workspace_id].total_credits_microdollars
     assert after - before == 1_000_000, (
         f"credit_workspace_once double-applied on event_id retry; "
         f"expected +1_000_000, got +{after - before}"
@@ -82,12 +81,12 @@ def test_credit_workspace_once_different_event_ids_grant_independently() -> None
     """Sanity: idempotency keys are PER-event_id, not blanket per-
     workspace. Two DIFFERENT Stripe events must both credit."""
     workspace_id = _fresh_workspace()
-    before = STORE.credits[workspace_id].total_credits_microdollars
+    before = STORE.credit_money[workspace_id].total_credits_microdollars
 
     assert STORE.credit_workspace_once(workspace_id, 1_000_000, "evt_distinct_a") is True
     assert STORE.credit_workspace_once(workspace_id, 2_000_000, "evt_distinct_b") is True
 
-    after = STORE.credits[workspace_id].total_credits_microdollars
+    after = STORE.credit_money[workspace_id].total_credits_microdollars
     assert after - before == 3_000_000
 
 
@@ -109,10 +108,10 @@ def test_reserve_with_same_idempotency_key_returns_same_reservation() -> None:
 
     assert r1.id == r2.id == r3.id
     # Reserved amount should reflect ONE reservation, not three.
-    account = STORE.credits[workspace_id]
-    assert account.reserved_microdollars == 250_000, (
+    money = STORE.credit_money[workspace_id]
+    assert money.reserved_microdollars == 250_000, (
         f"reserve with same idempotency_key double-counted; "
-        f"reserved_microdollars={account.reserved_microdollars}"
+        f"reserved_microdollars={money.reserved_microdollars}"
     )
 
 
@@ -145,10 +144,10 @@ def test_settle_is_naturally_idempotent_via_reservation_settled_flag() -> None:
     STORE.settle(reservation.id, actual_microdollars=300_000)  # retry
     STORE.settle(reservation.id, actual_microdollars=300_000)  # retry again
 
-    account = STORE.credits[workspace_id]
-    assert account.reserved_microdollars == 0  # released once
-    assert account.total_usage_microdollars == 300_000, (
-        f"settle double-applied; total_usage_microdollars={account.total_usage_microdollars}"
+    money = STORE.credit_money[workspace_id]
+    assert money.reserved_microdollars == 0  # released once
+    assert money.total_usage_microdollars == 300_000, (
+        f"settle double-applied; total_usage_microdollars={money.total_usage_microdollars}"
     )
 
 
@@ -167,9 +166,9 @@ def test_refund_is_naturally_idempotent_via_reservation_settled_flag() -> None:
     STORE.refund(reservation.id)  # retry — must be a no-op
     STORE.refund(reservation.id)  # retry again
 
-    account = STORE.credits[workspace_id]
-    assert account.reserved_microdollars == 0  # released exactly once
-    assert account.total_usage_microdollars == 0  # refund never charges
+    money = STORE.credit_money[workspace_id]
+    assert money.reserved_microdollars == 0  # released exactly once
+    assert money.total_usage_microdollars == 0  # refund never charges
 
 
 def test_settle_then_refund_does_not_undo_settled_charge() -> None:
@@ -184,9 +183,9 @@ def test_settle_then_refund_does_not_undo_settled_charge() -> None:
     STORE.settle(reservation.id, actual_microdollars=150_000)
     STORE.refund(reservation.id)  # must be a no-op since reservation.settled is True
 
-    account = STORE.credits[workspace_id]
-    assert account.total_usage_microdollars == 150_000  # not undone
-    assert account.reserved_microdollars == 0
+    money = STORE.credit_money[workspace_id]
+    assert money.total_usage_microdollars == 150_000  # not undone
+    assert money.reserved_microdollars == 0
 
 
 # ── 5. mark_gateway_authorization_settled (idempotency at the gateway layer) ─
@@ -291,8 +290,8 @@ def test_finalize_gateway_authorization_returns_false_on_replay() -> None:
     assert first is True
     assert second is False
     assert third is False
-    account = STORE.credits[workspace_id]
-    assert account.total_usage_microdollars == 150_000  # not 450_000
+    money = STORE.credit_money[workspace_id]
+    assert money.total_usage_microdollars == 150_000  # not 450_000
 
 
 # ── 8. End-to-end Stage 5a dual-write contract ──────────────────────────────

--- a/tests/test_credit_rebalance_contention.py
+++ b/tests/test_credit_rebalance_contention.py
@@ -35,13 +35,7 @@ def _seed(
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=sum(totals),
-            total_usage_microdollars=sum(usage),
-            reserved_microdollars=sum(reserved),
-            shard_count=len(totals),
-        ),
+        CreditAccount(workspace_id=workspace_id, shard_count=len(totals)),
     )
     _set_credit_rows(database, totals, usage=usage, reserved=reserved, workspace_id=workspace_id)
     _raw, key = store.api_keys.create(
@@ -346,13 +340,7 @@ def test_unshard_behind_refresh_dedupe_returns_402_not_500(
     store._write_entity(
         "credit",
         WORKSPACE_ID,
-        CreditAccount(
-            workspace_id=WORKSPACE_ID,
-            total_credits_microdollars=40,
-            total_usage_microdollars=0,
-            reserved_microdollars=0,
-            shard_count=1,
-        ),
+        CreditAccount(workspace_id=WORKSPACE_ID, shard_count=1),
     )
 
     outcome, authorization = _typed_authorize(store, key, estimate=60)

--- a/tests/test_credit_row_sharding_increment1.py
+++ b/tests/test_credit_row_sharding_increment1.py
@@ -47,11 +47,7 @@ def _seed_sharded_credit(
     workspace_id: str,
     totals: list[int],
 ) -> None:
-    account = CreditAccount(
-        workspace_id=workspace_id,
-        total_credits_microdollars=sum(totals),
-        shard_count=len(totals),
-    )
+    account = CreditAccount(workspace_id=workspace_id, shard_count=len(totals))
     store._write_entity("credit", workspace_id, account)  # type: ignore[attr-defined]
     table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})  # type: ignore[attr-defined]
     for shard, total in enumerate(totals):
@@ -226,7 +222,7 @@ def test_typed_direct_grant_distributes_delta_and_is_idempotent() -> None:
     rows = database.typed[CREDIT_BALANCE_TABLE]
     assert [rows[(workspace_id, shard)]["total_credits"] for shard in range(3)] == [44, 33, 33]
     assert live_credit_summary(workspace_id, store=store)["total_credits"] == 110
-    assert store.get_credit_account(workspace_id).total_credits_microdollars == 100
+    assert store.get_credit_account(workspace_id).shard_count == 3
 
 
 def test_typed_direct_grant_rolls_back_when_active_shard_is_missing() -> None:
@@ -239,7 +235,7 @@ def test_typed_direct_grant_rolls_back_when_active_shard_is_missing() -> None:
         store.credit_workspace_typed_direct(workspace_id, 10, "evt-missing")
 
     assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_credits"] == 50
-    assert store.get_credit_account(workspace_id).total_credits_microdollars == 100
+    assert store.get_credit_account(workspace_id).shard_count == 2
     assert ("stripe_event", "evt-missing") not in database.rows
 
 
@@ -271,11 +267,7 @@ def test_typed_credit_snapshot_fails_closed_on_missing_configured_shard() -> Non
 def test_generic_credit_metadata_write_does_not_overwrite_sharded_sub_budgets() -> None:
     store, database, _ = make_fake_store()
     workspace_id = "ws-mirror-shards"
-    account = CreditAccount(
-        workspace_id=workspace_id,
-        total_credits_microdollars=100,
-        shard_count=2,
-    )
+    account = CreditAccount(workspace_id=workspace_id, shard_count=2)
 
     store._write_entity("credit", workspace_id, account)
 

--- a/tests/test_credit_row_sharding_increment2.py
+++ b/tests/test_credit_row_sharding_increment2.py
@@ -45,11 +45,7 @@ def _seed(
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=sum(totals),
-            shard_count=len(totals),
-        ),
+        CreditAccount(workspace_id=workspace_id, shard_count=len(totals)),
     )
     table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
     for shard, total in enumerate(totals):

--- a/tests/test_credit_row_sharding_increment3.py
+++ b/tests/test_credit_row_sharding_increment3.py
@@ -34,13 +34,7 @@ def _seed(
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=sum(totals),
-            total_usage_microdollars=sum(usage),
-            reserved_microdollars=sum(reserved),
-            shard_count=len(totals),
-        ),
+        CreditAccount(workspace_id=workspace_id, shard_count=len(totals)),
     )
     table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
     for shard, total in enumerate(totals):

--- a/tests/test_credit_row_sharding_increment4.py
+++ b/tests/test_credit_row_sharding_increment4.py
@@ -37,13 +37,7 @@ def _seed(
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=sum(shard_credits),
-            total_usage_microdollars=sum(shard_usage),
-            reserved_microdollars=sum(shard_reserved),
-            shard_count=len(shard_credits),
-        ),
+        CreditAccount(workspace_id=workspace_id, shard_count=len(shard_credits)),
     )
     table = database.typed.setdefault(CREDIT_BALANCE_TABLE, {})
     for shard, credits in enumerate(shard_credits):
@@ -98,8 +92,6 @@ def test_split_is_atomic_even_partitioned_and_invalidates_cached_count() -> None
     assert sum(row["total_usage"] for row in rows) == 37
     account = store.get_credit_account("ws-reshard")
     assert account.shard_count == 4
-    assert account.total_credits_microdollars == 101
-    assert account.total_usage_microdollars == 37
     assert store._credit_shard_count("ws-reshard") == 4
 
 
@@ -125,8 +117,6 @@ def test_split_then_unshard_round_trip_preserves_every_global_counter() -> None:
     ]
     account = store.get_credit_account("ws-reshard")
     assert account.shard_count == 1
-    assert account.total_credits_microdollars == 101
-    assert account.total_usage_microdollars == 37
 
 
 def test_same_target_is_verified_idempotent_noop() -> None:
@@ -189,7 +179,7 @@ def test_reshard_refuses_any_undrained_hold(
     assert store.get_credit_account("ws-reshard").shard_count == 1
 
 
-def test_reshard_refuses_incomplete_rows_and_deposited_credit_mismatch() -> None:
+def test_reshard_refuses_incomplete_rows_and_uses_typed_totals() -> None:
     store, database = _seed(
         shard_credits=[50, 50],
         shard_usage=[10, 10],
@@ -209,26 +199,19 @@ def test_reshard_refuses_incomplete_rows_and_deposited_credit_mismatch() -> None
         "source_updated_at": None,
         "updated_at": None,
     }
-    drift = reshard_credit_account(store, "ws-reshard", 4, apply=True)
-    assert not drift.ready
-    assert any(
-        reason.startswith("typed/JSON deposited-credit totals differ")
-        for reason in drift.reasons
-    )
-    assert store.get_credit_account("ws-reshard").shard_count == 2
+    changed = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+    assert changed.ready and changed.applied
+    assert sum(row["total_credits"] for row in _rows(database)) == 90
+    assert store.get_credit_account("ws-reshard").shard_count == 4
 
 
-def test_reshard_refreshes_stale_json_usage_from_authoritative_typed_sum() -> None:
+def test_reshard_persists_shard_count_without_json_money() -> None:
     store, _database = _seed(shard_credits=[100], shard_usage=[60])
-    account = store.get_credit_account("ws-reshard")
-    account.total_usage_microdollars = 1
-    store._write_entity("credit", "ws-reshard", account)
 
     result = reshard_credit_account(store, "ws-reshard", 2, apply=True)
 
     assert result.ready and result.applied
     refreshed = store.get_credit_account("ws-reshard")
-    assert refreshed.total_usage_microdollars == 60
     assert refreshed.shard_count == 2
 
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -31,7 +31,7 @@ def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() 
     store._write_entity(
         "credit",
         ws,
-        CreditAccount(workspace_id=ws, total_credits_microdollars=10_000_000),
+        CreditAccount(workspace_id=ws),
     )
     db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
         "workspace_id": ws,
@@ -76,7 +76,7 @@ def test_gateway_settle_ancient_legacy_reservation_missing_typed_row_is_clean() 
     store._write_entity(
         "credit",
         ws,
-        CreditAccount(workspace_id=ws, total_credits_microdollars=10_000_000),
+        CreditAccount(workspace_id=ws),
     )
     _raw, api_key = store.create_api_key(
         workspace_id=ws,
@@ -186,12 +186,11 @@ def test_gateway_settle_can_bill_authorized_fallback_model() -> None:
     assert generation.usage_type == "BYOK"
     assert generation.total_cost_microdollars == expected_cost
 
-    credit = STORE.get_credit_account(key["workspace_id"])
+    money = STORE.credit_money[key["workspace_id"]]
     refreshed_key = STORE.get_key_by_hash(key["hash"])
-    assert credit is not None
     assert refreshed_key is not None
-    assert credit.reserved_microdollars == 0
-    assert credit.total_usage_microdollars == 0
+    assert money.reserved_microdollars == 0
+    assert money.total_usage_microdollars == 0
     assert refreshed_key.reserved_microdollars == 0
     assert refreshed_key.usage_microdollars == 0
     assert refreshed_key.byok_usage_microdollars == expected_cost
@@ -262,12 +261,11 @@ def test_gateway_validate_checks_key_without_reserving_or_recording_usage() -> N
         "route_type": "responses.input_tokens",
     }
     refreshed_key = STORE.get_key_by_hash(key["hash"])
-    credit = STORE.get_credit_account(key["workspace_id"])
+    money = STORE.credit_money[key["workspace_id"]]
     assert refreshed_key is not None
-    assert credit is not None
     assert refreshed_key.reserved_microdollars == 0
     assert refreshed_key.usage_microdollars == 0
-    assert credit.reserved_microdollars == 0
+    assert money.reserved_microdollars == 0
     assert not STORE.generation_store.generations
 
 
@@ -297,10 +295,10 @@ def test_gateway_settle_rejects_unlisted_fallback_without_charge_or_generation()
     assert rejected.status_code == 400
     assert rejected.json()["error"]["type"] == "bad_request"
     assert not STORE.generation_store.generations
-    credit = STORE.get_credit_account(key["workspace_id"])
+    money = STORE.credit_money[key["workspace_id"]]
     refreshed_key = STORE.get_key_by_hash(key["hash"])
-    assert credit is not None and credit.total_usage_microdollars == 0
     assert refreshed_key is not None
+    assert money.total_usage_microdollars == 0
     assert refreshed_key.usage_microdollars == 0
     assert refreshed_key.byok_usage_microdollars == 0
 
@@ -408,12 +406,11 @@ def test_gateway_missing_byok_primary_uses_prepaid_endpoint() -> None:
     assert data["usage_type"] == "Credits"
     assert data["cost_microdollars"] == expected_cost
 
-    credit = STORE.get_credit_account(key["workspace_id"])
+    money = STORE.credit_money[key["workspace_id"]]
     refreshed_key = STORE.get_key_by_hash(key["hash"])
-    assert credit is not None
     assert refreshed_key is not None
-    assert credit.reserved_microdollars == 0
-    assert credit.total_usage_microdollars == expected_cost
+    assert money.reserved_microdollars == 0
+    assert money.total_usage_microdollars == expected_cost
     assert refreshed_key.usage_microdollars == expected_cost
     assert refreshed_key.byok_usage_microdollars == 0
 

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -44,10 +44,7 @@ def _seed(*, key_shards: int = 4) -> tuple[Any, Any, Any]:
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=1_000_000,
-        ),
+        CreditAccount(workspace_id=workspace_id),
     )
     database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
         "workspace_id": workspace_id,

--- a/tests/test_live_credit_summary.py
+++ b/tests/test_live_credit_summary.py
@@ -12,7 +12,7 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.storage import InMemoryStore, configure_store
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
-from trusted_router.storage_models import CreditAccount
+from trusted_router.storage_models import CreditAccount, CreditMoney
 from trusted_router.typed_balance import live_credit_summary
 
 
@@ -38,12 +38,7 @@ def test_live_credit_summary_typed_row_wins() -> None:
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=10_000_000,
-            total_usage_microdollars=1_000_000,
-            reserved_microdollars=500_000,
-        ),
+        CreditAccount(workspace_id=workspace_id),
     )
     db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
         "workspace_id": workspace_id,
@@ -69,17 +64,22 @@ def test_live_credit_summary_typed_row_wins() -> None:
 
 
 def test_live_credit_summary_typed_row_absent_falls_back_to_json() -> None:
+    # No typed snapshot available (row not yet seeded, or the mirror flag is
+    # off) but the 'credit' entity still carries legacy JSON money. Must fall
+    # back to that money — matching pre-C2b behavior. Returning None here would
+    # 404 the billing/mcp reads and stop auto-refill for a workspace that has
+    # real credit.
     store, _db, _ = make_fake_store()
     workspace_id = "ws_json_summary"
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=5_000_000,
-            total_usage_microdollars=1_500_000,
-            reserved_microdollars=500_000,
-        ),
+        {
+            "workspace_id": workspace_id,
+            "total_credits_microdollars": 5_000_000,
+            "total_usage_microdollars": 1_500_000,
+            "reserved_microdollars": 500_000,
+        },
     )
 
     assert live_credit_summary(workspace_id, store=store) == {
@@ -90,11 +90,17 @@ def test_live_credit_summary_typed_row_absent_falls_back_to_json() -> None:
     }
 
 
+def test_live_credit_summary_no_credit_entity_returns_none() -> None:
+    # A workspace with no 'credit' entity at all has no money to report.
+    store, _db, _ = make_fake_store()
+    assert live_credit_summary("ws_missing_entirely", store=store) is None
+
+
 def test_live_credit_summary_memory_store_uses_single_book() -> None:
     store = InMemoryStore()
     workspace_id = "ws_memory_summary"
-    store.credits[workspace_id] = CreditAccount(
-        workspace_id=workspace_id,
+    store.credits[workspace_id] = CreditAccount(workspace_id=workspace_id)
+    store.credit_money[workspace_id] = CreditMoney(
         total_credits_microdollars=2_000_000,
         total_usage_microdollars=1_500_000,
         reserved_microdollars=750_000,
@@ -157,12 +163,7 @@ def _seed_stale_json_live_typed(store: Any, db: Any, workspace_id: str) -> None:
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=10_000_000,
-            total_usage_microdollars=1_000_000,
-            reserved_microdollars=500_000,
-        ),
+        CreditAccount(workspace_id=workspace_id),
     )
     db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)].update({
         "total_credits": 10_000_000,

--- a/tests/test_request_tagging.py
+++ b/tests/test_request_tagging.py
@@ -196,7 +196,7 @@ def test_gateway_authorize_rejects_oversized_trace_before_reservation(
     )
     assert response.status_code == 400
     assert response.json()["error"]["type"] == "invalid_request_metadata"
-    assert STORE.credits[created["data"]["workspace_id"]].reserved_microdollars == 0
+    assert STORE.credit_money[created["data"]["workspace_id"]].reserved_microdollars == 0
 
 
 def test_merge_tags_overlays_request_values_without_mutating_defaults() -> None:

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -44,7 +44,7 @@ def _seed_credit(store: Any, workspace_id: str, total: int = TOTAL_CREDIT) -> No
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(workspace_id=workspace_id, total_credits_microdollars=total),
+        CreditAccount(workspace_id=workspace_id),
     )
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
         "workspace_id": workspace_id,
@@ -112,9 +112,9 @@ def _legacy_authorization(
     estimate: int = ESTIMATE,
 ) -> GatewayAuthorization:
     reservation_id = f"legacy-res-{workspace_id}"
-    credit = store.get_credit_account(workspace_id)
+    credit = store._read_entity("credit", workspace_id, dict)
     if credit is not None:
-        credit.reserved_microdollars += estimate
+        credit["reserved_microdollars"] = int(credit.get("reserved_microdollars", 0)) + estimate
         store._write_entity("credit", workspace_id, credit)
     store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(
@@ -393,9 +393,9 @@ def test_transient_pre_read_parks_typed_and_errors_legacy(
 
     monkeypatch.setattr(store, "get_gateway_authorization", original_get_gateway_authorization)
     assert store.get_gateway_authorization(legacy_auth.id).settled is False
-    legacy_credit = store.get_credit_account(legacy_ws)
-    assert legacy_credit.total_usage_microdollars == 0
-    assert legacy_credit.reserved_microdollars == ESTIMATE
+    legacy_credit = store._read_entity("credit", legacy_ws, dict)
+    assert legacy_credit.get("total_usage_microdollars", 0) == 0
+    assert legacy_credit.get("reserved_microdollars", 0) == ESTIMATE
 
 
 def test_transient_outage_errors_legacy_row(
@@ -415,9 +415,9 @@ def test_transient_outage_errors_legacy_row(
 
     assert apply_frozen_settle(_row(auth, origin="legacy")) == ApplyOutcome.ERROR
     assert store.get_gateway_authorization(auth.id).settled is False
-    credit = store.get_credit_account(ws)
-    assert credit.total_usage_microdollars == 0
-    assert credit.reserved_microdollars == ESTIMATE
+    credit = store._read_entity("credit", ws, dict)
+    assert credit.get("total_usage_microdollars", 0) == 0
+    assert credit.get("reserved_microdollars", 0) == ESTIMATE
 
 
 def test_transient_disambiguation_read_parks_typed_row(

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -63,7 +63,7 @@ def _seed_credit(store: Any, workspace_id: str, total: int = TOTAL_CREDIT) -> No
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(workspace_id=workspace_id, total_credits_microdollars=total),
+        CreditAccount(workspace_id=workspace_id),
     )
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
         "workspace_id": workspace_id,
@@ -152,9 +152,9 @@ def _legacy_authorization(
     estimate: int = ESTIMATE,
 ) -> GatewayAuthorization:
     reservation_id = f"legacy-res-{workspace_id}-{key_hash}"
-    credit = store.get_credit_account(workspace_id)
+    credit = store._read_entity("credit", workspace_id, dict)
     if credit is not None:
-        credit.reserved_microdollars += estimate
+        credit["reserved_microdollars"] = int(credit.get("reserved_microdollars", 0)) + estimate
         store._write_entity("credit", workspace_id, credit)
     store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(

--- a/tests/test_storage_gcp_auth_contracts.py
+++ b/tests/test_storage_gcp_auth_contracts.py
@@ -59,7 +59,7 @@ def test_gcp_wallet_user_email_and_membership_are_uuid_keyed() -> None:
     workspace = store.list_workspaces_for_user(wallet_user.id)[0]
     credit = store.get_credit_account(workspace.id)
     assert credit is not None
-    assert credit.total_credits_microdollars == 0
+    assert store.typed_credit_snapshot(workspace.id)[0] == 0
     invited = store.add_members(workspace.id, ["friend@example.com"], role="member")[0]
     store.remove_members(workspace.id, ["friend@example.com"])
     assert not store.user_is_member(invited.user_id, workspace.id)

--- a/tests/test_storage_gcp_concurrency.py
+++ b/tests/test_storage_gcp_concurrency.py
@@ -21,10 +21,7 @@ def _seed_credit(store, workspace_id: str, total_microdollars: int) -> None:
     store._write_entity(
         "credit",
         workspace_id,
-        CreditAccount(
-            workspace_id=workspace_id,
-            total_credits_microdollars=total_microdollars,
-        ),
+        CreditAccount(workspace_id=workspace_id),
     )
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
         "workspace_id": workspace_id,
@@ -77,7 +74,7 @@ def test_concurrent_stripe_credit_is_idempotent_under_retries() -> None:
     assert results.count(False) == n - 1, results
 
     account = _credit_account(db, workspace_id)
-    assert account["total_credits_microdollars"] == 0
+    assert "total_credits_microdollars" not in account
     assert db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]["total_credits"] == 5_000_000
     assert ("stripe_event", "evt_dup") in db.rows
     assert db.aborts >= n - 1, f"expected >= {n - 1} aborts, got {db.aborts}"

--- a/tests/test_streaming_failure_contracts.py
+++ b/tests/test_streaming_failure_contracts.py
@@ -198,8 +198,8 @@ def test_route_stream_failure_refunds_reserved_quota(
 
     monkeypatch.setattr(ProviderClient, "stream_chat", broken_stream)
     key = next(iter(STORE.api_keys.keys.values()))
-    account = STORE.credits[key.workspace_id]
-    before_credits = account.total_credits_microdollars
+    money = STORE.credit_money[key.workspace_id]
+    before_credits = money.total_credits_microdollars
 
     with pytest.raises(RuntimeError, match="provider stream broke"):
         with client.stream(
@@ -214,9 +214,9 @@ def test_route_stream_failure_refunds_reserved_quota(
         ) as response:
             _ = b"".join(response.iter_bytes())
 
-    assert account.total_credits_microdollars == before_credits
-    assert account.total_usage_microdollars == 0
-    assert account.reserved_microdollars == 0
+    assert money.total_credits_microdollars == before_credits
+    assert money.total_usage_microdollars == 0
+    assert money.reserved_microdollars == 0
     assert key.reserved_microdollars == 0
     assert STORE.generation_store.generations == {}
 
@@ -248,7 +248,7 @@ def test_empty_first_provider_stream_rolls_over_without_charge_or_generation(
 
     monkeypatch.setattr(ProviderClient, "stream_chat", route_stream)
     key = next(iter(STORE.api_keys.keys.values()))
-    account = STORE.credits[key.workspace_id]
+    money = STORE.credit_money[key.workspace_id]
 
     with client.stream(
         "POST",
@@ -269,7 +269,7 @@ def test_empty_first_provider_stream_rolls_over_without_charge_or_generation(
     assert len(generations) == 1
     assert generations[0].model == "meta-llama/llama-3.1-8b-instruct"
     assert generations[0].request_id == "second-provider-stream"
-    assert account.reserved_microdollars == 0
+    assert money.reserved_microdollars == 0
     assert key.reserved_microdollars == 0
     samples = STORE.provider_benchmark_samples(provider="openai")
     assert len(samples) == 1

--- a/tests/test_typed_balance.py
+++ b/tests/test_typed_balance.py
@@ -1,54 +1,42 @@
-"""Typed-aware balance reads: typed-capable stores read authoritative typed
-counters when a typed row exists; the in-memory store and unseeded typed rows
-fall back to the single JSON book.
-"""
-
 from __future__ import annotations
 
-from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount
-from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
-from trusted_router.typed_balance import typed_aware_credit_account
+from trusted_router.storage import InMemoryStore
+from trusted_router.typed_balance import live_credit_summary
 
 
-def test_credit_overlay_uses_typed_row_when_store_has_capability() -> None:
-    store, db, _ = make_fake_store()
-    ws = "ws_typed"
-    store._write_entity(
-        "credit", ws,
-        CreditAccount(workspace_id=ws, total_credits_microdollars=1_000_000, total_usage_microdollars=0),
+def test_live_credit_summary_memory_store_uses_credit_money_book() -> None:
+    store = InMemoryStore()
+    workspace = store.create_workspace(
+        owner_user_id="typed-balance-user",
+        name="Balance",
+        trial_credit_microdollars=0,
     )
-    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
-        "workspace_id": ws,
-        "shard": 0,
-        "total_credits": 1_000_000,
+    _raw_key, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="balance",
+        creator_user_id="typed-balance-user",
+    )
+
+    assert store.credit_workspace_once(workspace.id, 2_000_000, "evt_balance") is True
+    reservation = store.reserve(workspace.id, api_key.hash, 750_000)
+
+    assert live_credit_summary(workspace.id, store=store) == {
+        "total_credits": 2_000_000,
         "total_usage": 0,
-        "reserved": 0,
-        "source_updated_at": None,
-        "updated_at": None,
+        "reserved": 750_000,
+        "available": 1_250_000,
     }
-    # Simulate the typed DML having booked usage + a hold ahead of stale JSON.
-    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update({"total_usage": 300_000, "reserved": 150_000})
 
-    typed = typed_aware_credit_account(store, ws, settings=object())
-    assert typed.total_credits_microdollars == 1_000_000  # JSON-owned, unchanged
-    assert typed.total_usage_microdollars == 300_000
-    assert typed.reserved_microdollars == 150_000
-    assert typed.workspace_id == ws  # JSON metadata preserved
+    store.settle(reservation.id, 500_000)
 
-
-def test_credit_typed_but_unseeded_falls_back_to_json() -> None:
-    store, _db, _ = make_fake_store()
-    ws = "ws_unseeded"
-    store._write_entity(
-        "credit", ws,
-        CreditAccount(workspace_id=ws, total_credits_microdollars=2_000_000, total_usage_microdollars=50_000),
-    )
-    acct = typed_aware_credit_account(store, ws, settings=object())
-    assert acct is not None
-    assert acct.total_usage_microdollars == 50_000  # JSON, since no typed row
+    assert live_credit_summary(workspace.id, store=store) == {
+        "total_credits": 2_000_000,
+        "total_usage": 500_000,
+        "reserved": 0,
+        "available": 1_500_000,
+    }
 
 
-def test_credit_missing_account_returns_none() -> None:
-    store, _db, _ = make_fake_store()
-    assert typed_aware_credit_account(store, "nope", settings=object()) is None
+def test_live_credit_summary_memory_store_missing_account_returns_none() -> None:
+    store = InMemoryStore()
+    assert live_credit_summary("missing", store=store) is None

--- a/tests/test_typed_flip_tool.py
+++ b/tests/test_typed_flip_tool.py
@@ -7,7 +7,7 @@ import pytest
 
 from scripts import typed_flip
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount, Reservation, Workspace
+from trusted_router.storage import Reservation, Workspace
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 
 
@@ -33,12 +33,12 @@ def _seed_workspace(
     store._write_entity(
         "credit",
         ws,
-        CreditAccount(
-            workspace_id=ws,
-            total_credits_microdollars=total_credits,
-            total_usage_microdollars=total_usage,
-            reserved_microdollars=reserved,
-        ),
+        {
+            "workspace_id": ws,
+            "total_credits_microdollars": total_credits,
+            "total_usage_microdollars": total_usage,
+            "reserved_microdollars": reserved,
+        },
     )
     store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
         "workspace_id": ws,
@@ -52,9 +52,9 @@ def _seed_workspace(
 
 
 def _add_legacy_hold(store: Any, ws: str, amount: int = 100_000) -> None:
-    credit = store.get_credit_account(ws)
+    credit = store._read_entity("credit", ws, dict)
     assert credit is not None
-    credit.reserved_microdollars += amount
+    credit["reserved_microdollars"] = int(credit.get("reserved_microdollars", 0)) + amount
     store._write_entity("credit", ws, credit)
     store._write_entity(
         "reservation",

--- a/tests/test_x402_billing.py
+++ b/tests/test_x402_billing.py
@@ -10,7 +10,13 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
+
+
+def _credit_summary(workspace_id: str) -> dict[str, int]:
+    summary = live_credit_summary(workspace_id)
+    assert summary is not None
+    return summary
 
 
 def _x402_client(**settings: Any) -> TestClient:
@@ -101,9 +107,7 @@ def test_x402_config_refuses_mock_or_missing_stripe_outside_local_test() -> None
 def test_x402_enabled_without_stripe_secret_does_not_mock_credit() -> None:
     with _x402_client(stripe_secret_key=None) as client:
         headers, workspace_id = _api_headers(client)
-        before = STORE.get_credit_account(workspace_id)
-        assert before is not None
-        before_total = before.total_credits_microdollars
+        before_total = _credit_summary(workspace_id)["total_credits"]
         fund = client.post(
             "/v1/billing/x402/fund",
             headers=headers,
@@ -114,12 +118,10 @@ def test_x402_enabled_without_stripe_secret_does_not_mock_credit() -> None:
             headers=headers,
             json={"payment_intent_id": f"pi_x402_mock_{workspace_id}_attacker"},
         )
-        after = STORE.get_credit_account(workspace_id)
 
     assert fund.status_code == 503
     assert settle.status_code == 503
-    assert after is not None
-    assert after.total_credits_microdollars == before_total
+    assert _credit_summary(workspace_id)["total_credits"] == before_total
 
 
 def test_x402_fund_creates_stripe_crypto_payment_intent_and_returns_payment_required(
@@ -260,9 +262,7 @@ def test_x402_fund_enforces_amount_cap_and_rate_limit(monkeypatch) -> None:
 def test_x402_settle_credits_succeeded_payment_once(monkeypatch) -> None:
     with _x402_client() as client:
         headers, workspace_id = _api_headers(client)
-        before = STORE.get_credit_account(workspace_id)
-        assert before is not None
-        before_total = before.total_credits_microdollars
+        before_total = _credit_summary(workspace_id)["total_credits"]
 
         def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
             return _payment_intent(workspace_id=workspace_id)
@@ -281,14 +281,12 @@ def test_x402_settle_credits_succeeded_payment_once(monkeypatch) -> None:
             headers=headers,
             json={"payment_intent_id": "pi_x402_good"},
         )
-        account = STORE.get_credit_account(workspace_id)
 
     assert first.status_code == 200, first.text
     assert first.json()["data"]["credited"] is True
     assert second.status_code == 200, second.text
     assert second.json()["data"]["credited"] is False
-    assert account is not None
-    assert account.total_credits_microdollars == before_total + 10_000_000
+    assert _credit_summary(workspace_id)["total_credits"] == before_total + 10_000_000
 
 
 def test_x402_settle_pending_wrong_workspace_and_invalid_payment_intents(monkeypatch) -> None:
@@ -379,9 +377,7 @@ def test_x402_settle_rejects_malformed_payment_intent_before_stripe(monkeypatch)
 def test_x402_settle_caps_credit_to_requested_amount(monkeypatch) -> None:
     with _x402_client() as client:
         headers, workspace_id = _api_headers(client)
-        before = STORE.get_credit_account(workspace_id)
-        assert before is not None
-        before_total = before.total_credits_microdollars
+        before_total = _credit_summary(workspace_id)["total_credits"]
 
         def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
             return _payment_intent(
@@ -400,20 +396,16 @@ def test_x402_settle_caps_credit_to_requested_amount(monkeypatch) -> None:
             headers=headers,
             json={"payment_intent_id": "pi_x402_good"},
         )
-        account = STORE.get_credit_account(workspace_id)
 
     assert response.status_code == 200
     assert response.json()["data"]["amount_microdollars"] == 5_000_000
-    assert account is not None
-    assert account.total_credits_microdollars == before_total + 5_000_000
+    assert _credit_summary(workspace_id)["total_credits"] == before_total + 5_000_000
 
 
 def test_x402_webhook_and_settle_are_idempotent_in_both_orders(monkeypatch) -> None:
     with _x402_client() as client:
         headers, workspace_id = _api_headers(client)
-        before = STORE.get_credit_account(workspace_id)
-        assert before is not None
-        before_total = before.total_credits_microdollars
+        before_total = _credit_summary(workspace_id)["total_credits"]
         payment = _payment_intent(workspace_id=workspace_id)
 
         first_webhook = client.post(
@@ -445,7 +437,6 @@ def test_x402_webhook_and_settle_are_idempotent_in_both_orders(monkeypatch) -> N
             headers=headers,
             json={"payment_intent_id": "pi_x402_good"},
         )
-        account = STORE.get_credit_account(workspace_id)
 
     assert first_webhook.status_code == 200
     assert first_webhook.json()["data"]["credited"] is True
@@ -453,16 +444,13 @@ def test_x402_webhook_and_settle_are_idempotent_in_both_orders(monkeypatch) -> N
     assert retry_webhook.json()["data"]["credited"] is False
     assert settle.status_code == 200
     assert settle.json()["data"]["credited"] is False
-    assert account is not None
-    assert account.total_credits_microdollars == before_total + 10_000_000
+    assert _credit_summary(workspace_id)["total_credits"] == before_total + 10_000_000
 
 
 def test_x402_concurrent_settle_credits_once(monkeypatch) -> None:
     with _x402_client(x402_settle_rate_limit_per_window=100) as client:
         headers, workspace_id = _api_headers(client)
-        before = STORE.get_credit_account(workspace_id)
-        assert before is not None
-        before_total = before.total_credits_microdollars
+        before_total = _credit_summary(workspace_id)["total_credits"]
 
         def retrieve(_payment_intent_id: str, **_kwargs: Any) -> dict[str, Any]:
             return _payment_intent(workspace_id=workspace_id)
@@ -483,11 +471,9 @@ def test_x402_concurrent_settle_credits_once(monkeypatch) -> None:
 
         with ThreadPoolExecutor(max_workers=4) as pool:
             results = list(pool.map(lambda _: settle_once(), range(4)))
-        account = STORE.get_credit_account(workspace_id)
 
     assert results.count(True) == 1
-    assert account is not None
-    assert account.total_credits_microdollars == before_total + 10_000_000
+    assert _credit_summary(workspace_id)["total_credits"] == before_total + 10_000_000
 
 
 def test_x402_refund_webhook_is_operator_visible_not_silent(client: TestClient) -> None:


### PR DESCRIPTION
## What

Final step of the JSON credit-ledger retirement: make `CreditAccount`
metadata-only. Production money already lives in the typed `tr_credit_balance`
table; the `CreditAccount` money fields (`total_credits_microdollars` /
`total_usage_microdollars` / `reserved_microdollars`) were read-only overlays.

- Delete those three fields; `CreditAccount` now carries only `shard_count` +
  auto-refill/Stripe metadata. Clean break — passing a retired money kwarg now
  raises `TypeError` (no silent-ignore shim).
- Add `CreditMoney` and move the in-memory single-book money into it, shared by
  reference with the reservation engine (`reserve`/`settle`/`refund` and
  `credit_workspace_once` mutate it under the existing shared lock).
- All money reads go through the existing `live_credit_summary` dict carrier
  (no new type). `typed_aware_credit_account` is removed.

## Money-safety

**The production write path (typed-DML) is unchanged.** Behavior is preserved
byte-for-byte:

- `auto_refill` reads the **unclamped** `available` (`total − usage − reserved`)
  off the summary — identical to the old inline computation — and reads
  auto-refill/Stripe metadata off `get_credit_account`. A missing summary
  suppresses the charge (never charges on a read failure).
- `live_credit_summary` keeps its pre-refactor fallback for the non-typed path:
  `SpannerBigtableStore.credit_money_snapshot` reads the raw `credit` JSON entity
  so a workspace still resolves when the typed snapshot is unavailable (counter
  mirror off, or the typed row not yet seeded).
- Workspace-create seeds the typed shard-0 row from an explicit initial total;
  the legacy grant path reads the raw JSON total.
- `reshard` drops only the now-vacuous JSON-vs-typed drift gates; the typed-side
  safety gates remain.
- `scripts/typed_flip.py` + the operator grant/makeup scripts read legacy money
  from the raw `credit` entity dict instead of the deleted fields.

## Verification

- Two independent adversarial verification passes over the money paths
  (auto-refill fire/suppress decisions, in-memory reserve/settle/refund math,
  Spanner seed/legacy paths, and display parity). The first pass caught two real
  issues that the test suite missed — a `live_credit_summary` fallback gap and a
  flip-tool field read — both fixed here; the re-verification is clean.
- Full suite: **1522 passed, 33 skipped**. `ruff check` clean.
