### PR TITLE
Persist narrow Kimi pricing secret access

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -73,10 +73,9 @@ jobs:
       - name: Authenticate to GCP via WIF
         # Same WIF setup as deploy.yml — short-lived OIDC token from
         # GitHub exchanged for an impersonation token on tr-deploy@.
-        # tr-deploy@ has been granted accessor on ONLY the
-        # trustedrouter-tr-api-key-for-self-heal secret (per-secret IAM
-        # binding in scripts/deploy/secrets.sh), so this workflow
-        # cannot read any other TR secret.
+        # tr-deploy@ receives only per-secret IAM grants for the provider
+        # credentials this workflow reads. It has no project-wide Secret
+        # Manager accessor role.
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -149,25 +149,27 @@ ensure_secret_from_prompt_file "trustedrouter-athena-worker-prompt-v1" "$ATHENA_
 ensure_secret_from_env_file "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key" "SYNTHETIC_MONITOR_API_KEY"
 ensure_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
 
-# Self-heal LLM key for the hourly pricing refresh GHA workflow.
-# Read from the local key file like every other TR secret; pushed to
-# Secret Manager and granted to tr-deploy@ (the GHA WIF SA) so the
-# workflow can pull it via `gcloud secrets versions access`.
+# Credentials used by the hourly pricing refresh GHA workflow. Values are
+# pushed to Secret Manager like every other TR secret. The GHA WIF service
+# account receives access only to the individual secrets it needs.
 ensure_secret_from_env_file "TR_API_KEY_FOR_SELF_HEAL" "trustedrouter-tr-api-key-for-self-heal"
-# Bind tr-deploy@ here, right next to the secret creation, so that a
-# downstream `set -e` on a later step (e.g. an etag-conflict on a
-# project-role call) cannot strand this secret without an accessor.
-# `|| log` so add-iam-policy-binding's harmless "already exists" or
-# transient etag conflicts do not abort the rest of the script.
 TR_DEPLOY_SA="${TR_DEPLOY_SA:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
-if gc secrets describe trustedrouter-tr-api-key-for-self-heal >/dev/null 2>&1; then
-  log "granting ${TR_DEPLOY_SA} accessor on trustedrouter-tr-api-key-for-self-heal"
-  gc secrets add-iam-policy-binding trustedrouter-tr-api-key-for-self-heal \
+
+grant_tr_deploy_secret_access() {
+  local secret_name="$1"
+  if ! gc secrets describe "$secret_name" >/dev/null 2>&1; then
+    return
+  fi
+  log "granting ${TR_DEPLOY_SA} accessor on ${secret_name}"
+  gc secrets add-iam-policy-binding "$secret_name" \
     --member="serviceAccount:${TR_DEPLOY_SA}" \
     --role="roles/secretmanager.secretAccessor" \
     --quiet >/dev/null \
-    || log "WARN: per-secret binding returned non-zero (may already be present)"
-fi
+    || log "WARN: per-secret binding for ${secret_name} returned non-zero"
+}
+
+grant_tr_deploy_secret_access "trustedrouter-tr-api-key-for-self-heal"
+grant_tr_deploy_secret_access "trustedrouter-kimi-api-key"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -33,3 +33,12 @@ def test_deploy_wires_athena_worker_prompt_secret() -> None:
     assert (
         'add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-prompt-v1"'
     ) in rollout
+
+
+def test_hourly_kimi_discovery_has_narrow_secret_access_wiring() -> None:
+    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
+    workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text()
+
+    assert 'grant_tr_deploy_secret_access "trustedrouter-kimi-api-key"' in secrets
+    assert "KIMI_API_KEY:trustedrouter-kimi-api-key" in workflow
+    assert "no project-wide Secret" in workflow


### PR DESCRIPTION
## Summary
- codify the approved per-secret `tr-deploy` grant for the Kimi API key
- keep the existing self-heal grant on the same reusable helper
- clarify that the pricing workflow has no project-wide Secret Manager role
- add regression coverage for Kimi workflow and IAM wiring

## Verification
- `bash -n scripts/deploy/secrets.sh`
- `uv run ruff check tests/test_deploy_secret_wiring.py`
- `uv run pytest -q tests/test_deploy_secret_wiring.py tests/test_kimi_pricing.py` (`10 passed`)
- manual GitHub WIF refresh proved `KIMI_API_KEY` can be read and Kimi returned `10 models via multi_page_md+api`