### PR TITLE
Repair hourly provider pricing discovery

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -63,6 +63,7 @@ def _gemini_model_id(native_id: str) -> str | None:
 _FIREWORKS_MODEL_IDS = {
     "accounts/fireworks/models/kimi-k2p6": "moonshotai/kimi-k2.6",
     "accounts/fireworks/models/kimi-k2p5": "moonshotai/kimi-k2.5",
+    "accounts/fireworks/models/kimi-k2p7-code": "moonshotai/kimi-k2.7-code",
     "accounts/fireworks/models/deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "accounts/fireworks/models/glm-5p2": "z-ai/glm-5.2",
     "accounts/fireworks/routers/glm-5p2-fast": "z-ai/glm-5.2-fast",
@@ -104,6 +105,7 @@ _WAFER_MODEL_IDS = {
     "GLM-5.1": "z-ai/glm-5.1",
     "GLM-5.2": "z-ai/glm-5.2",
     "GLM-5.2-Fast": "z-ai/glm-5.2-fast",
+    "glm5.2-fast": "z-ai/glm-5.2-fast",
     "Kimi-K2.6": "moonshotai/kimi-k2.6",
     "Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
     "Qwen3.5-397B-A17B": "qwen/qwen3.5-397b-a17b",
@@ -192,6 +194,11 @@ def _alibaba_model_id(native_id: str) -> str | None:
 
 def _kimi_model_id(native_id: str) -> str | None:
     value = native_id.strip().casefold()
+    # Moonshot exposes this dynamic alias without a separately published
+    # price. Publishing it as a billable route would require guessing which
+    # concrete model/rate it selects, so the strict discovery gate ignores it.
+    if value == "moonshot-v1-auto":
+        return None
     if value.startswith(("kimi-", "moonshot-v1-")):
         return f"moonshotai/{value}"
     return None
@@ -470,6 +477,11 @@ def _normalize_glm_model_id(native_id: str) -> str | None:
     if not match:
         return None
     slug = match.group(0).removesuffix("[1m]")
+    # FP8 is a deployment quantization used by providers such as GMI and
+    # Parasail, not a distinct public/billable model in their manifests.
+    # Preserve semantic variants (for example -fast and -nvfp4), which can
+    # have different routing and prices.
+    slug = re.sub(r"-fp8(?:-block)?$", "", slug)
     return f"z-ai/{slug}"
 
 

--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -633,13 +633,15 @@ def ast_whitelist_check(source: str) -> list[str]:
 
 _SANDBOX_RUNNER_TEMPLATE = textwrap.dedent(
     '''
-    import sys, json
     {parser_source}
 
+    import json as _sandbox_json
+    import sys as _sandbox_sys
+
     if __name__ == "__main__":
-        html = sys.stdin.read()
+        html = _sandbox_sys.stdin.read()
         result = parse(html)
-        sys.stdout.write(json.dumps(result))
+        _sandbox_sys.stdout.write(_sandbox_json.dumps(result))
     '''
 ).strip()
 

--- a/scripts/pricing/parsers/xiaomi.py
+++ b/scripts/pricing/parsers/xiaomi.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import re
+from decimal import Decimal
 
 
 def _money_to_micro_per_m(value: str) -> int:
-    return int(round(float(value) * 1_000_000))
+    return int((Decimal(value) * Decimal(1_000_000)).to_integral_value())
 
 
 def _section(text: str, title: str) -> str:
@@ -15,9 +16,46 @@ def _section(text: str, title: str) -> str:
     return match.group(1) if match else ""
 
 
-def parse(html: str) -> dict[str, dict[str, int]]:
-    text = re.sub(r"\s+", " ", html)
+def _overseas_payg_prices(html: str) -> dict[str, dict[str, int]]:
+    """Parse the authoritative USD table from Xiaomi's PAYG page."""
+    section_match = re.search(
+        r"###\s*Overseas Pricing of the Model\s+(.*?)(?=###\s|$)",
+        html,
+        flags=re.I | re.S,
+    )
+    if not section_match:
+        return {}
+
+    mapping = {
+        "mimo-v2.5-pro": "xiaomi/mimo-v2.5-pro",
+        "mimo-v2.5": "xiaomi/mimo-v2.5",
+    }
     prices: dict[str, dict[str, int]] = {}
+    row_pattern = re.compile(
+        r"\|\s*`?(mimo-v2\.5(?:-pro)?)`?\s*"
+        r"\|\s*\$([0-9.]+)\s*"
+        r"\|\s*\$([0-9.]+)\s*"
+        r"\|\s*\$([0-9.]+)\s*\|",
+        flags=re.I,
+    )
+    for model, cache, prompt, completion in row_pattern.findall(section_match.group(1)):
+        model_id = mapping.get(model.casefold())
+        if model_id is None:
+            continue
+        prices[model_id] = {
+            "prompt_micro_per_m": _money_to_micro_per_m(prompt),
+            "completion_micro_per_m": _money_to_micro_per_m(completion),
+            "prompt_cached_micro_per_m": _money_to_micro_per_m(cache),
+        }
+    return prices
+
+
+def parse(html: str) -> dict[str, dict[str, int]]:
+    # The current official page publishes a Markdown table. Keep the
+    # card parser below as a compatibility fallback for older captures and
+    # for UltraSpeed if Xiaomi republishes its standalone PAYG card.
+    prices = _overseas_payg_prices(html)
+    text = re.sub(r"\s+", " ", html)
     mapping = {
         "MiMo-V2.5-Pro": "xiaomi/mimo-v2.5-pro",
         "MiMo-V2.5-Pro-UltraSpeed": "xiaomi/mimo-v2.5-pro-ultraspeed",
@@ -38,5 +76,5 @@ def parse(html: str) -> dict[str, dict[str, int]]:
         }
         if cache:
             row["prompt_cached_micro_per_m"] = _money_to_micro_per_m(cache.group(1))
-        prices[model_id] = row
+        prices.setdefault(model_id, row)
     return prices

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -2,30 +2,165 @@
 
 Fireworks publishes a first-party serverless pricing table for its headline
 models. We fetch that docs page and parse the standard serving-path prices.
-The live model list is handled separately by provider_models/fireworks.json.
+Prices become routable only when the authenticated operator model list also
+contains the model. The supplemental manifest is pruned from that intersection.
 """
+
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    fetch_json,
+    fetch_provider,
+    validate,
+)
 
 SLUG = "fireworks"
 URL = "https://r.jina.ai/https://docs.fireworks.ai/serverless/pricing"
+MODELS_URL = "https://api.fireworks.ai/inference/v1/models"
 JINA_HEADERS = {"X-Return-Format": "markdown"}
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "fireworks.json"
+)
 
 EXPECTED_MODELS = [
     "moonshotai/kimi-k2.6",
-    "moonshotai/kimi-k2.5",
     "deepseek/deepseek-v4-pro",
     "z-ai/glm-5.2",
     "z-ai/glm-5.1",
     "openai/gpt-oss-120b",
 ]
 
+_NATIVE_TO_CANONICAL = {
+    "accounts/fireworks/models/kimi-k2p6": "moonshotai/kimi-k2.6",
+    "accounts/fireworks/models/kimi-k2p7-code": "moonshotai/kimi-k2.7-code",
+    "accounts/fireworks/models/deepseek-v4-pro": "deepseek/deepseek-v4-pro",
+    "accounts/fireworks/models/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+    "accounts/fireworks/models/glm-5p2": "z-ai/glm-5.2",
+    "accounts/fireworks/models/glm-5p1": "z-ai/glm-5.1",
+    "accounts/fireworks/models/gpt-oss-120b": "openai/gpt-oss-120b",
+    "accounts/fireworks/models/gpt-oss-20b": "openai/gpt-oss-20b",
+    "accounts/fireworks/models/minimax-m3": "minimax/minimax-m3",
+    "accounts/fireworks/models/minimax-m2p7": "minimax/minimax-m2.7",
+}
+UPSTREAM_ID_MAP = {canonical: native for native, canonical in _NATIVE_TO_CANONICAL.items()}
+# Fast is an account router rather than a row in /v1/models. It remains an
+# explicit, separately smoke-tested route and is not subject to model pruning.
+UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] = "accounts/fireworks/routers/glm-5p2-fast"
+_DISCOVERED_LIVE_MODEL_IDS: set[str] = set()
+
+
+def _live_model_ids() -> set[str]:
+    api_key = os.environ.get("FIREWORKS_API_KEY") or os.environ.get("FIREWORKS_AI_API_KEY")
+    if not api_key:
+        raise RuntimeError("fireworks: FIREWORKS_API_KEY is required")
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {api_key}"},
+    )
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError("fireworks: /v1/models response has no data list")
+    discovered: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        native_id = row.get("id")
+        if not isinstance(native_id, str):
+            continue
+        canonical = _NATIVE_TO_CANONICAL.get(native_id)
+        if canonical is not None:
+            discovered.add(canonical)
+    return discovered
+
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    global _DISCOVERED_LIVE_MODEL_IDS
+
+    result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
         extra_headers=JINA_HEADERS,
     )
+    live_model_ids = _live_model_ids()
+    _DISCOVERED_LIVE_MODEL_IDS = live_model_ids
+    docs_only = sorted(set(result.prices) - live_model_ids)
+    result.prices = {
+        model_id: price for model_id, price in result.prices.items() if model_id in live_model_ids
+    }
+    errors = validate(result.prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    if docs_only:
+        result.notes.append(
+            "official pricing rows not enabled for this Fireworks account: " + ", ".join(docs_only)
+        )
+    return result
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Refresh prices and remove retired Fireworks model routes.
+
+    Account routers are preserved because Fireworks does not expose them in
+    the model-list API. Ordinary model routes must be present in the
+    authenticated operator catalog and on the official pricing page.
+    """
+
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("fireworks manifest has no models list")
+
+    retained: list[dict[str, Any]] = []
+    updated = 0
+    removed: list[str] = []
+    for candidate in rows:
+        if not isinstance(candidate, dict):
+            continue
+        model_id = candidate.get("id")
+        upstream_id = candidate.get("upstream_id")
+        if not isinstance(model_id, str) or not isinstance(upstream_id, str):
+            continue
+        is_model_route = upstream_id.startswith("accounts/fireworks/models/")
+        if is_model_route and model_id not in _DISCOVERED_LIVE_MODEL_IDS:
+            removed.append(model_id)
+            continue
+
+        price = result.prices.get(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            candidate["input_token_price_per_m"] = tier.prompt_micro_per_m
+            candidate["output_token_price_per_m"] = tier.completion_micro_per_m
+            if tier.prompt_cached_micro_per_m is not None:
+                candidate["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+            else:
+                candidate.pop("cached_input_token_price_per_m", None)
+            updated += 1
+        retained.append(candidate)
+
+    if not retained:
+        raise RuntimeError("fireworks manifest pruning removed every route")
+    rows[:] = retained
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(rows)
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    suffix = f", removed {len(removed)} unavailable" if removed else ""
+    return [f"fireworks: refreshed provider_models/fireworks.json ({updated} priced rows{suffix})"]

--- a/scripts/pricing/providers/wafer.py
+++ b/scripts/pricing/providers/wafer.py
@@ -39,8 +39,10 @@ MANIFEST_PATH = (
 )
 
 EXPECTED_MODELS = [
+    "z-ai/glm-5.1",
     "z-ai/glm-5.2",
-    "moonshotai/kimi-k2.7-code",
+    "z-ai/glm-5.2-fast",
+    "moonshotai/kimi-k2.6",
     "minimax/minimax-m3",
 ]
 
@@ -48,6 +50,7 @@ _NATIVE_TO_OR_ID = {
     "GLM-5.1": "z-ai/glm-5.1",
     "GLM-5.2": "z-ai/glm-5.2",
     "GLM-5.2-Fast": "z-ai/glm-5.2-fast",
+    "glm5.2-fast": "z-ai/glm-5.2-fast",
     "Kimi-K2.6": "moonshotai/kimi-k2.6",
     "Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
     "Qwen3.5-397B-A17B": "qwen/qwen3.5-397b-a17b",
@@ -111,9 +114,17 @@ def _manifest_row(
     capabilities = _wafer_capabilities(source_row)
     chat_capabilities = capabilities.get("chat_completions")
     chat_capabilities = chat_capabilities if isinstance(chat_capabilities, dict) else {}
+    message_capabilities = capabilities.get("messages")
+    message_capabilities = (
+        message_capabilities if isinstance(message_capabilities, dict) else {}
+    )
     zdr_capabilities = capabilities.get("zdr")
     zdr_capabilities = zdr_capabilities if isinstance(zdr_capabilities, dict) else {}
-    supports_vision = bool(chat_capabilities.get("vision"))
+    supports_vision = bool(
+        capabilities.get("vision")
+        or chat_capabilities.get("vision")
+        or message_capabilities.get("vision")
+    )
 
     row: dict[str, Any] = {
         "id": model_id,
@@ -220,26 +231,16 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not isinstance(rows, list):
         raise RuntimeError("wafer manifest has no models list")
 
-    existing_by_id: dict[str, dict[str, Any]] = {
-        row["id"]: row
-        for row in rows
-        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    previous_ids = {
+        row["id"] for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
     }
     updated: list[str] = []
-    appended: list[str] = []
+    refreshed_rows: list[dict[str, Any]] = []
     for model_id, price in sorted(result.prices.items()):
         discovered = _DISCOVERED_MANIFEST_ROWS.get(model_id)
-        row = existing_by_id.get(model_id)
-        if row is None:
-            if discovered is None:
-                continue
-            row = dict(discovered)
-            rows.append(row)
-            existing_by_id[model_id] = row
-            appended.append(model_id)
-        elif discovered is not None:
-            for key, value in discovered.items():
-                row[key] = value
+        if discovered is None:
+            continue
+        row = dict(discovered)
 
         tier = price.tiers[0]
         row["input_token_price_per_m"] = tier.prompt_micro_per_m
@@ -248,6 +249,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
             row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
         else:
             row.pop("cached_input_token_price_per_m", None)
+        refreshed_rows.append(row)
         updated.append(model_id)
 
     missing = sorted(set(EXPECTED_MODELS) - set(updated))
@@ -256,13 +258,21 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not updated:
         raise RuntimeError("wafer manifest update touched no rows")
 
+    # Wafer's authenticated /v1/models feed is both the availability and
+    # pricing source. Rebuild the provider supplement from that feed so
+    # retired models cannot remain routable with stale prices.
+    rows[:] = refreshed_rows
+    current_ids = set(updated)
+    appended = sorted(current_ids - previous_ids)
+    removed = sorted(previous_ids - current_ids)
+
     raw["_about"] = (
         "Provider-native supplement for Wafer serverless API. Refreshed "
         "hourly from Wafer's OpenAI-compatible /v1/models feed."
     )
     raw["source"] = URL
-    raw["generated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
     raw["model_count"] = len(rows)
     MANIFEST_PATH.write_text(
@@ -270,5 +280,10 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         encoding="utf-8",
     )
 
-    suffix = f", appended {len(appended)}" if appended else ""
+    changes: list[str] = []
+    if appended:
+        changes.append(f"appended {len(appended)}")
+    if removed:
+        changes.append(f"removed {len(removed)} unavailable")
+    suffix = f", {', '.join(changes)}" if changes else ""
     return [f"wafer: refreshed provider_models/wafer.json ({len(updated)} priced rows{suffix})"]

--- a/scripts/pricing/providers/xiaomi.py
+++ b/scripts/pricing/providers/xiaomi.py
@@ -23,7 +23,6 @@ MANIFEST_PATH = (
 EXPECTED_MODELS = [
     "xiaomi/mimo-v2.5",
     "xiaomi/mimo-v2.5-pro",
-    "xiaomi/mimo-v2.5-pro-ultraspeed",
 ]
 
 
@@ -66,8 +65,16 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         raise RuntimeError(f"xiaomi manifest did not update expected model(s): {missing}")
 
     raw["source"] = "https://mimo.mi.com/docs/en-US/pricing"
-    raw["generated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
+    raw["_note"] = (
+        "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and "
+        "V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD "
+        "table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated "
+        "/v1/models feed but has no public PAYG row, so its last verified "
+        "price is retained until Xiaomi republishes one. Legacy V2 rows are "
+        "kept only as historical fallback metadata."
+    )
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
     raw["model_count"] = len(rows)
     MANIFEST_PATH.write_text(

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -714,6 +714,11 @@ def _write_provider_manifests(results: dict[str, ProviderPricingResult]) -> list
 
     notes: list[str] = []
     for slug, result in sorted(results.items()):
+        # A stale fallback represents the last known good catalog state. Do not
+        # let provider-specific hooks rewrite that state without fresh discovery
+        # data; destructive hooks may otherwise prune every currently live row.
+        if result.source == "stale_snapshot":
+            continue
         module = _import_provider(slug)
         hook = getattr(module, "write_provider_manifest", None)
         if not callable(hook):

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -3,8 +3,8 @@
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-01T00:00:00Z",
-  "model_count": 7,
+  "generated_at": "2026-07-15T00:38:52Z",
+  "model_count": 6,
   "models": [
     {
       "id": "moonshotai/kimi-k2.6",
@@ -16,34 +16,6 @@
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
       "cached_input_token_price_per_m": 160000,
-      "model_type": "chat",
-      "features": [
-        "function-calling",
-        "serverless",
-        "vision"
-      ],
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "endpoints": [
-        "chat/completions"
-      ],
-      "status": 1
-    },
-    {
-      "id": "moonshotai/kimi-k2.5",
-      "upstream_id": "accounts/fireworks/models/kimi-k2p5",
-      "display_name": "Kimi K2.5 on Fireworks",
-      "title": "accounts/fireworks/models/kimi-k2p5",
-      "context_length": 262144,
-      "max_output_tokens": 65536,
-      "input_token_price_per_m": 600000,
-      "output_token_price_per_m": 3000000,
-      "cached_input_token_price_per_m": 100000,
       "model_type": "chat",
       "features": [
         "function-calling",
@@ -97,7 +69,7 @@
       "max_output_tokens": 65536,
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,
-      "cached_input_token_price_per_m": 260000,
+      "cached_input_token_price_per_m": 140000,
       "model_type": "chat",
       "features": [
         "reasoning",

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -2,65 +2,42 @@
   "_about": "Provider-native supplement for Wafer serverless API. Refreshed hourly from Wafer's OpenAI-compatible /v1/models feed.",
   "provider": "wafer",
   "source": "https://pass.wafer.ai/v1/models",
-  "generated_at": "2026-07-03T22:19:16Z",
+  "generated_at": "2026-07-15T00:41:39Z",
   "price_scale": "microdollars_per_million",
   "zdr_header": "Wafer-ZDR: required",
-  "model_count": 10,
+  "model_count": 5,
   "models": [
     {
-      "id": "z-ai/glm-5.1",
-      "upstream_id": "GLM-5.1",
-      "display_name": "GLM-5.1",
-      "context_length": 202752,
+      "id": "minimax/minimax-m3",
+      "upstream_id": "MiniMax-M3",
+      "display_name": "MiniMax-M3",
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 1000000,
-      "output_token_price_per_m": 3200000,
-      "cached_input_token_price_per_m": 100000,
-      "zdr_supported": true
-    },
-    {
-      "id": "z-ai/glm-5.2",
-      "upstream_id": "GLM-5.2",
-      "display_name": "GLM-5.2",
+      "input_token_price_per_m": 330000,
+      "output_token_price_per_m": 1320000,
+      "zdr_supported": false,
       "context_length": 1048576,
-      "endpoints": [
-        "chat/completions"
+      "input_modalities": [
+        "text",
+        "image"
       ],
-      "input_token_price_per_m": 1200000,
-      "output_token_price_per_m": 4100000,
-      "cached_input_token_price_per_m": 200000,
-      "zdr_supported": true
+      "output_modalities": [
+        "text"
+      ],
+      "cached_input_token_price_per_m": 70000
     },
     {
       "id": "moonshotai/kimi-k2.6",
       "upstream_id": "Kimi-K2.6",
       "display_name": "Kimi-K2.6",
-      "context_length": 262144,
       "endpoints": [
         "chat/completions"
-      ],
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
       ],
       "input_token_price_per_m": 1140000,
       "output_token_price_per_m": 4800000,
-      "cached_input_token_price_per_m": 190000,
-      "zdr_supported": false
-    },
-    {
-      "id": "qwen/qwen3.5-397b-a17b",
-      "upstream_id": "Qwen3.5-397B-A17B",
-      "display_name": "Qwen3.5 397B A17B",
+      "zdr_supported": false,
       "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
       "input_modalities": [
         "text",
         "image"
@@ -68,109 +45,46 @@
       "output_modalities": [
         "text"
       ],
-      "input_token_price_per_m": 430000,
-      "output_token_price_per_m": 2600000,
-      "cached_input_token_price_per_m": 40000,
-      "zdr_supported": false
+      "cached_input_token_price_per_m": 190000
     },
     {
-      "id": "qwen/qwen3.6-35b-a3b",
-      "upstream_id": "Qwen3.6-35B-A3B",
-      "display_name": "Qwen3.6-35B-A3B",
-      "context_length": 256000,
+      "id": "z-ai/glm-5.1",
+      "upstream_id": "GLM-5.1",
+      "display_name": "GLM-5.1",
       "endpoints": [
         "chat/completions"
       ],
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "input_token_price_per_m": 150000,
-      "output_token_price_per_m": 1000000,
-      "cached_input_token_price_per_m": 20000,
-      "zdr_supported": false
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 3200000,
+      "zdr_supported": true,
+      "context_length": 202752,
+      "cached_input_token_price_per_m": 100000
     },
     {
-      "id": "deepseek/deepseek-v4-flash",
-      "upstream_id": "deepseek-v4-flash",
-      "display_name": "DeepSeek V4 Flash",
-      "context_length": 1000000,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 90000,
-      "output_token_price_per_m": 180000,
-      "cached_input_token_price_per_m": 20000,
-      "zdr_supported": true
-    },
-    {
-      "id": "minimax/minimax-m3",
-      "upstream_id": "MiniMax-M3",
-      "display_name": "MiniMax-M3",
-      "context_length": 1048576,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "input_token_price_per_m": 330000,
-      "output_token_price_per_m": 1320000,
-      "cached_input_token_price_per_m": 70000,
-      "zdr_supported": false
-    },
-    {
-      "id": "moonshotai/kimi-k2.7-code",
-      "upstream_id": "Kimi-K2.7-Code",
-      "display_name": "Kimi-K2.7-Code",
-      "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "input_token_price_per_m": 950000,
-      "output_token_price_per_m": 4000000,
-      "cached_input_token_price_per_m": 190000,
-      "zdr_supported": false
-    },
-    {
-      "id": "qwen/qwen3.7-max",
-      "upstream_id": "qwen3.7-max",
-      "display_name": "Qwen3.7-Max",
-      "context_length": 256000,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 1500000,
-      "output_token_price_per_m": 4500000,
-      "cached_input_token_price_per_m": 300000,
-      "zdr_supported": false
-    },
-    {
-      "id": "deepseek/deepseek-v4-pro",
-      "upstream_id": "deepseek-v4-pro",
-      "display_name": "DeepSeek V4 Pro",
-      "context_length": 1000000,
+      "id": "z-ai/glm-5.2",
+      "upstream_id": "GLM-5.2",
+      "display_name": "GLM-5.2",
       "endpoints": [
         "chat/completions"
       ],
       "input_token_price_per_m": 1200000,
-      "output_token_price_per_m": 2400000,
-      "cached_input_token_price_per_m": 100000,
-      "zdr_supported": true
+      "output_token_price_per_m": 4100000,
+      "zdr_supported": true,
+      "context_length": 1048576,
+      "cached_input_token_price_per_m": 200000
+    },
+    {
+      "id": "z-ai/glm-5.2-fast",
+      "upstream_id": "glm5.2-fast",
+      "display_name": "GLM5.2-Fast",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 10250000,
+      "zdr_supported": true,
+      "context_length": 1048576,
+      "cached_input_token_price_per_m": 500000
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -1,9 +1,9 @@
 {
   "provider": "xiaomi",
   "source": "https://mimo.mi.com/docs/en-US/pricing",
-  "generated_at": "2026-07-03T22:35:56Z",
+  "generated_at": "2026-07-15T00:38:52Z",
   "model_count": 5,
-  "_note": "Xiaomi MiMo. OpenAI-compatible chat at api.xiaomimimo.com/v1 (Bearer auth). Model ids verified live against /v1/models 2026-06-09; /v1/models does not expose context/price, so context and pricing are hand-maintained from Xiaomi MiMo docs/pages. MiMo-V2.5-Pro context/pricing updated from https://mimo.mi.com/models/en-US/mimo-v2.5-pro and https://mimo.mi.com/docs/en-US/price/pay-as-you-go on 2026-06-30. MiMo-V2 legacy rows remain at 256K. mimo-v2.5-pro-ultraspeed: 1T-param speed-serving tier with up to ~1000 tok/s; pricing from Xiaomi page.",
+  "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated /v1/models feed but has no public PAYG row, so its last verified price is retained until Xiaomi republishes one. Legacy V2 rows are kept only as historical fallback metadata.",
   "models": [
     {
       "id": "xiaomi/mimo-v2-flash",

--- a/tests/test_baseten_wafer_pricing.py
+++ b/tests/test_baseten_wafer_pricing.py
@@ -70,6 +70,16 @@ def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # no
     payload = {
         "data": [
             {
+                "id": "GLM-5.1",
+                "wafer": {
+                    "pricing": {
+                        "input_cents_per_million": 100,
+                        "output_cents_per_million": 320,
+                        "cache_read_cents_per_million": 10,
+                    }
+                },
+            },
+            {
                 "id": "GLM-5.2",
                 "wafer": {
                     "display_name": "GLM-5.2",
@@ -82,11 +92,11 @@ def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # no
                         "input_cents_per_million": 120,
                         "output_cents_per_million": 410,
                         "cache_read_cents_per_million": 20,
-                    }
+                    },
                 },
             },
             {
-                "id": "GLM-5.2-Fast",
+                "id": "glm5.2-fast",
                 "wafer": {
                     "display_name": "GLM-5.2-Fast",
                     "context_length": 1048576,
@@ -102,11 +112,16 @@ def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # no
                 },
             },
             {
-                "id": "Kimi-K2.7-Code",
+                "id": "Kimi-K2.6",
                 "wafer": {
+                    "capabilities": {
+                        "vision": True,
+                        "zdr": {"supported": False},
+                        "chat_completions": {"supported": True},
+                    },
                     "pricing": {
-                        "input_cents_per_million": 95,
-                        "output_cents_per_million": 400,
+                        "input_cents_per_million": 114,
+                        "output_cents_per_million": 480,
                         "cache_read_cents_per_million": 19,
                     }
                 },
@@ -142,7 +157,7 @@ def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # no
     result = wafer.fetch()
     glm = result.prices["z-ai/glm-5.2"]
     fast = result.prices["z-ai/glm-5.2-fast"]
-    kimi = result.prices["moonshotai/kimi-k2.7-code"]
+    kimi = result.prices["moonshotai/kimi-k2.6"]
     minimax = result.prices["minimax/minimax-m3"]
 
     assert glm.prompt_micro_per_m == 1_200_000
@@ -151,16 +166,14 @@ def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # no
     assert fast.prompt_micro_per_m == 3_000_000
     assert fast.completion_micro_per_m == 10_250_000
     assert fast.tiers[0].prompt_cached_micro_per_m == 500_000
-    assert kimi.prompt_micro_per_m == 950_000
+    assert kimi.prompt_micro_per_m == 1_140_000
     assert minimax.completion_micro_per_m == 1_320_000
     assert wafer.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "GLM-5.2"
-    assert wafer.UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] == "GLM-5.2-Fast"
-    assert wafer.UPSTREAM_ID_MAP["moonshotai/kimi-k2.7-code"] == "Kimi-K2.7-Code"
+    assert wafer.UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] == "glm5.2-fast"
+    assert wafer.UPSTREAM_ID_MAP["moonshotai/kimi-k2.6"] == "Kimi-K2.6"
 
 
-def test_wafer_provider_appends_new_priced_models_to_manifest(
-    tmp_path: Path, monkeypatch
-) -> None:  # noqa: ANN001
+def test_wafer_provider_appends_new_priced_models_to_manifest(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
     manifest_path = tmp_path / "wafer.json"
     manifest_path.write_text(
         json.dumps(
@@ -208,6 +221,16 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(
     payload = {
         "data": [
             {
+                "id": "GLM-5.1",
+                "wafer": {
+                    "pricing": {
+                        "input_cents_per_million": 100,
+                        "output_cents_per_million": 320,
+                        "cache_read_cents_per_million": 10,
+                    }
+                },
+            },
+            {
                 "id": "GLM-5.2",
                 "wafer": {
                     "display_name": "GLM-5.2",
@@ -224,7 +247,7 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(
                 },
             },
             {
-                "id": "GLM-5.2-Fast",
+                "id": "glm5.2-fast",
                 "wafer": {
                     "display_name": "GLM-5.2-Fast",
                     "context_length": 1048576,
@@ -240,11 +263,16 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(
                 },
             },
             {
-                "id": "Kimi-K2.7-Code",
+                "id": "Kimi-K2.6",
                 "wafer": {
+                    "capabilities": {
+                        "vision": True,
+                        "zdr": {"supported": False},
+                        "chat_completions": {"supported": True},
+                    },
                     "pricing": {
-                        "input_cents_per_million": 95,
-                        "output_cents_per_million": 400,
+                        "input_cents_per_million": 114,
+                        "output_cents_per_million": 480,
                         "cache_read_cents_per_million": 19,
                     }
                 },
@@ -281,14 +309,17 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(
     notes = wafer.write_provider_manifest(result)
 
     assert notes == [
-        "wafer: refreshed provider_models/wafer.json (4 priced rows, appended 1)"
+        "wafer: refreshed provider_models/wafer.json "
+        "(5 priced rows, appended 3, removed 1 unavailable)"
     ]
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
     by_id = {row["id"]: row for row in raw["models"]}
-    assert raw["model_count"] == 4
+    assert raw["model_count"] == 5
+    assert "moonshotai/kimi-k2.7-code" not in by_id
     assert by_id["z-ai/glm-5.2"]["input_token_price_per_m"] == 1_200_000
-    assert by_id["z-ai/glm-5.2-fast"]["upstream_id"] == "GLM-5.2-Fast"
+    assert by_id["z-ai/glm-5.2-fast"]["upstream_id"] == "glm5.2-fast"
     assert by_id["z-ai/glm-5.2-fast"]["input_token_price_per_m"] == 3_000_000
     assert by_id["z-ai/glm-5.2-fast"]["output_token_price_per_m"] == 10_250_000
     assert by_id["z-ai/glm-5.2-fast"]["cached_input_token_price_per_m"] == 500_000
     assert by_id["z-ai/glm-5.2-fast"]["zdr_supported"] is True
+    assert by_id["moonshotai/kimi-k2.6"]["input_modalities"] == ["text", "image"]

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -67,6 +67,7 @@ def test_provider_glm_model_discovery_normalizes_native_ids() -> None:
     payload = {
         "data": [
             {"id": "zai-org/GLM-5.2"},
+            {"id": "zai-org/GLM-5.2-FP8"},
             {"id": "accounts/fireworks/models/glm-5p2"},
             {"id": "zai-org/glm-5.1"},
             {"id": "not-a-glm-model"},
@@ -77,6 +78,11 @@ def test_provider_glm_model_discovery_normalizes_native_ids() -> None:
         "z-ai/glm-5.1",
         "z-ai/glm-5.2",
     }
+
+
+def test_kimi_discovery_ignores_unpriced_auto_alias() -> None:
+    assert check_price_coverage._kimi_model_id("moonshot-v1-auto") is None
+    assert check_price_coverage._kimi_model_id("kimi-k2.7-code") == "moonshotai/kimi-k2.7-code"
 
 
 def test_provider_glm_required_gate_targets_current_flagships() -> None:

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import fireworks
+
+
+def _price() -> ModelPrice:
+    return ModelPrice(
+        prompt_micro_per_m=1_000_000,
+        completion_micro_per_m=2_000_000,
+        prompt_cached_micro_per_m=100_000,
+    )
+
+
+def test_fireworks_fetch_intersects_prices_with_operator_catalog(
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    priced_ids = {*fireworks.EXPECTED_MODELS, "moonshotai/kimi-k2.7-code"}
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="fireworks",
+            prices={model_id: _price() for model_id in priced_ids},
+            source="deterministic",
+        ),
+    )
+    live_rows = [
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]} for model_id in fireworks.EXPECTED_MODELS
+    ]
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_json",
+        lambda *_args, **_kwargs: {"data": live_rows},
+    )
+
+    result = fireworks.fetch()
+
+    assert set(result.prices) == set(fireworks.EXPECTED_MODELS)
+    assert any("kimi-k2.7-code" in note for note in result.notes)
+
+
+def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "fireworks.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "fireworks",
+                "models": [
+                    {
+                        "id": "moonshotai/kimi-k2.6",
+                        "upstream_id": "accounts/fireworks/models/kimi-k2p6",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
+                    {
+                        "id": "moonshotai/kimi-k2.5",
+                        "upstream_id": "accounts/fireworks/models/kimi-k2p5",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
+                    {
+                        "id": "z-ai/glm-5.2-fast",
+                        "upstream_id": "accounts/fireworks/routers/glm-5p2-fast",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(fireworks, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        fireworks,
+        "_DISCOVERED_LIVE_MODEL_IDS",
+        {"moonshotai/kimi-k2.6"},
+    )
+    result = ProviderPricingResult(
+        slug="fireworks",
+        prices={"moonshotai/kimi-k2.6": _price()},
+        source="deterministic",
+    )
+
+    notes = fireworks.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert set(by_id) == {"moonshotai/kimi-k2.6", "z-ai/glm-5.2-fast"}
+    assert by_id["moonshotai/kimi-k2.6"]["input_token_price_per_m"] == 1_000_000
+    assert notes == [
+        "fireworks: refreshed provider_models/fireworks.json (1 priced rows, removed 1 unavailable)"
+    ]

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -67,6 +67,32 @@ def test_xiaomi_parser_reads_official_mimo_payg_prices() -> None:
     }
 
 
+def test_xiaomi_parser_reads_current_overseas_markdown_table() -> None:
+    html = """
+    ### Domestic Pricing of the Model
+    | `mimo-v2.5-pro` | ¥0.025 | ¥3.00 | ¥6.00 |
+    ### Overseas Pricing of the Model
+    |  | **Input (Cache Hit)** | **Input (Cache Miss)** | **Output** |
+    | --- | --- | --- | --- |
+    | `mimo-v2.5-pro` | $0.0036 | $0.435 | $0.87 |
+    | `mimo-v2.5` | $0.0028 | $0.14 | $0.28 |
+    ### Pricing for Web Search Plugins
+    """
+
+    assert xiaomi_parser.parse(html) == {
+        "xiaomi/mimo-v2.5-pro": {
+            "prompt_micro_per_m": 435_000,
+            "completion_micro_per_m": 870_000,
+            "prompt_cached_micro_per_m": 3_600,
+        },
+        "xiaomi/mimo-v2.5": {
+            "prompt_micro_per_m": 140_000,
+            "completion_micro_per_m": 280_000,
+            "prompt_cached_micro_per_m": 2_800,
+        },
+    }
+
+
 class _FakeResponse:
     def __init__(self, payload: dict) -> None:
         self._payload = payload

--- a/tests/test_pricing_base.py
+++ b/tests/test_pricing_base.py
@@ -261,6 +261,20 @@ def parse(html: str) -> dict:
     assert prices["x/y"].completion_micro_per_m == 5678
 
 
+def test_sandbox_runs_parser_with_future_import() -> None:
+    """The wrapper must not precede compile-time future imports."""
+    src = """from __future__ import annotations
+
+def parse(markdown: str) -> dict:
+    return {"x/y": {"prompt_micro_per_m": 1234, "completion_micro_per_m": 5678}}
+"""
+    prices, errors = sandbox_run_parser(src, "<html></html>")
+
+    assert errors == []
+    assert prices is not None
+    assert prices["x/y"].prompt_micro_per_m == 1234
+
+
 def test_sandbox_rejects_non_dict_return() -> None:
     src = """
 def parse(html: str) -> dict:

--- a/tests/test_pricing_self_heal.py
+++ b/tests/test_pricing_self_heal.py
@@ -400,3 +400,27 @@ def test_failed_provider_without_snapshot_price_still_counts_unrecovered() -> No
     assert unrecovered == [("new-provider", "temporary 502")]
     assert results["provider-with-snapshot"].source == "stale_snapshot"
     assert "new-provider" not in results
+
+
+def test_stale_snapshot_never_rewrites_provider_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[pricing_base.ProviderPricingResult] = []
+
+    class FakeProvider:
+        @staticmethod
+        def write_provider_manifest(
+            result: pricing_base.ProviderPricingResult,
+        ) -> list[str]:
+            calls.append(result)
+            return ["manifest rewritten"]
+
+    monkeypatch.setattr(refresh, "_import_provider", lambda _slug: FakeProvider)
+    stale = pricing_base.ProviderPricingResult(
+        slug="fireworks",
+        prices={"provider/model": pricing_base.ModelPrice(1, 1)},
+        source="stale_snapshot",
+    )
+
+    assert refresh._write_provider_manifests({"fireworks": stale}) == []
+    assert calls == []


### PR DESCRIPTION
## Summary
- repair sandbox execution for generated parsers that use future imports
- intersect Fireworks and Wafer manifests with authenticated live availability and current provider pricing
- parse Xiaomi current overseas PAYG table without float math
- normalize provider deployment suffixes and ignore unpriced Kimi auto alias in strict discovery
- prevent stale snapshot fallbacks from ever rewriting last-known-good manifests

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1529 passed, 33 skipped)
- authenticated `uv run python scripts/check_price_coverage.py --strict-model-discovery`
- authenticated full pricing refresh (target providers succeeded)