### PR TITLE
Accept reviewed Qwen route price and stabilize headlines

### DIFF
--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -574,7 +574,14 @@ def _merge_snapshot(
             # Model-level headline pricing = the cheapest *positively-priced*
             # provider-direct tier (matches OR's convention and what
             # /v1/models top-level pricing should show).
-            cheapest = min(priced_by_slug.values(), key=lambda p: p.tiers[0].prompt_micro_per_m)
+            _cheapest_slug, cheapest = min(
+                priced_by_slug.items(),
+                key=lambda item: (
+                    item[1].tiers[0].prompt_micro_per_m,
+                    item[1].tiers[0].completion_micro_per_m,
+                    item[0],
+                ),
+            )
             new_pricing.update(_price_to_pricing_block(cheapest))
             new_model["pricing"] = new_pricing
             # Tag pricing_source as self-healed if ANY of the slugs that

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -6096,8 +6096,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000007"
+        "prompt": "0.0000008",
+        "completion": "0.000001",
+        "input_cache_read": "0.0000004"
       },
       "top_provider": {
         "context_length": 32000,
@@ -6143,22 +6144,6 @@
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen2.5-vl-72b-instruct",
-          "model_id": "qwen/qwen2.5-vl-72b-instruct",
-          "model_name": "Qwen: Qwen2.5 VL 72B Instruct",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"

--- a/tests/test_pricing_zero_guard.py
+++ b/tests/test_pricing_zero_guard.py
@@ -108,6 +108,28 @@ def test_positive_price_path_unchanged() -> None:
     assert model["pricing_source"] == "provider_direct"
 
 
+def test_equal_prompt_prices_choose_lower_completion_deterministically() -> None:
+    """Provider iteration order must not create a false completion spike."""
+    mid = "google/gemma-3-27b-it"
+    or_snap = _or_snapshot(
+        mid,
+        ["parasail", "deepinfra"],
+        {"prompt": "0.00000008", "completion": "0.00000016"},
+    )
+    provider_index = {
+        mid: {
+            "parasail": _mp(80_000, 450_000),
+            "deepinfra": _mp(80_000, 160_000),
+        }
+    }
+
+    merged = R._merge_snapshot(or_snap, provider_index, set())
+    model = next(m for m in merged["models"] if m["id"] == mid)
+
+    assert model["pricing"]["prompt"] == "0.00000008"
+    assert model["pricing"]["completion"] == "0.00000016"
+
+
 def test_is_unpriced_helper() -> None:
     assert R._is_unpriced(_mp(0, 0))
     assert not R._is_unpriced(_mp(1, 0))


### PR DESCRIPTION
## Summary
- choose model headline pricing deterministically by input, output, then provider slug
- prevent equal-input provider ordering from producing false completion-price spikes
- remove the retired Phala Qwen 2.5 VL 72B route and accept Parasail current $0.80/$1.00 per million pricing

## Live verification
- authenticated Phala `/v1/models` no longer lists `qwen/qwen2.5-vl-72b-instruct`
- fresh authenticated full refresh leaves no spike-gate failures after this baseline
- the Gemma equal-input regression stays at DeepInfra $0.08/$0.16 rather than arbitrarily selecting Parasail $0.08/$0.45

## Tests
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1530 passed, 33 skipped)
- next-refresh `check_price_spike.py` simulation exits 0