### PR TITLE
Fix pricing bot CI deploy handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Bot-authored pricing commits use GITHUB_TOKEN, so GitHub suppresses
+  # their normal push-triggered workflows. refresh-prices.yml dispatches
+  # CI explicitly for the generated commit before dispatching deploy.yml.
+  workflow_dispatch: {}
 
 jobs:
   test:

--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -34,7 +34,7 @@ concurrency:
 permissions:
   id-token: write   # for Workload Identity Federation
   contents: write   # auto-commit + push the snapshot diff to main
-  actions: write    # dispatch deploy.yml when we land a new snapshot
+  actions: write    # dispatch ci.yml + deploy.yml for a new snapshot
                     # (GITHUB_TOKEN-pushed commits don't auto-trigger
                     # downstream workflows, so we explicitly fan out
                     # via workflow_dispatch — the one exception to
@@ -253,14 +253,17 @@ jobs:
           # Bot-pushed commits don't auto-trigger downstream workflows
           # (GHA loop prevention applies to the `push` event when the
           # token is GITHUB_TOKEN). `workflow_dispatch` is the only
-          # exception — explicitly fan out so the catalog snapshot we
-          # just landed actually rolls to prod within ~20 min instead
-          # of waiting for the next manual operator dispatch.
+          # exception. Dispatch CI first, then deploy; deploy.yml's
+          # same-SHA gate waits for that CI run to pass before rollout.
+          # Failing either dispatch is a release failure, not a warning:
+          # otherwise a generated catalog can land on main but never
+          # become deployable.
           # Discovered live on 2026-05-13: hourly bot was committing
           # but TR's deployed catalog was stuck on a 3-phala-endpoint
           # snapshot for hours because deploy.yml never auto-fired.
-          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}" \
-            && echo "  dispatched deploy.yml for new snapshot" \
-            || echo "  WARN: failed to dispatch deploy.yml; operator can dispatch manually"
+          gh workflow run ci.yml --ref main --repo "${GITHUB_REPOSITORY}"
+          echo "  dispatched ci.yml for new snapshot"
+          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}"
+          echo "  dispatched deploy.yml for new snapshot"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -194,6 +194,18 @@ jobs:
           uv run python scripts/check_price_coverage.py --strict-model-discovery \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: Validate generated catalog before commit
+        # The refresh can change parsers, provider manifests, model ownership,
+        # routing, pricing, and SEO output in one pass. GitHub suppresses
+        # push-triggered CI for commits created with GITHUB_TOKEN, so these
+        # checks must run before the bot is allowed to move main. This keeps
+        # the last known-good snapshot live when a provider page changes in a
+        # way the self-healer or catalog merger does not understand yet.
+        run: |
+          uv run ruff check .
+          uv run mypy
+          uv run pytest -q
+
       - name: Commit and push if changed
         run: |
           set -euo pipefail

--- a/scripts/pricing/parsers/makora.py
+++ b/scripts/pricing/parsers/makora.py
@@ -1,4 +1,4 @@
-"""Parse Makora's homepage model lineup pricing."""
+"""Parse Makora's public homepage model lineup pricing."""
 
 from __future__ import annotations
 
@@ -9,15 +9,13 @@ MODEL_LABELS: dict[str, tuple[str, ...]] = {
     "GLM-5.2": ("z-ai/glm-5.2", "z-ai/glm-5.2-nvfp4"),
     "Kimi-K2.7-Code": ("moonshotai/kimi-k2.7-code",),
     "DeepSeek-V4-Pro": ("deepseek/deepseek-v4-pro",),
-    "DeepSeek V4 Flash": ("deepseek/deepseek-v4-flash",),
     "Qwen3.6-27B-NVFP4": ("qwen/qwen3.6-27b",),
     "Llama-3.3-70B-Instruct": (
         "meta-llama/llama-3.3-70b-instruct",
         "amd/llama-3.3-70b-instruct-fp8-kv",
     ),
-    "GPT - OSS-120B": ("openai/gpt-oss-120b",),
+    "DeepSeek V4 Flash": ("deepseek/deepseek-v4-flash",),
     "Qwen3.6-35B-A3B": ("qwen/qwen3.6-35b-a3b",),
-    "Gemma-4-26B-A4B": ("google/gemma-4-26b-a4b",),
 }
 
 
@@ -26,13 +24,13 @@ def _money_to_micro(raw: str) -> int:
 
 
 def _section_for_label(text: str, label: str) -> str:
-    match = re.search(
-        rf"(?<![A-Za-z0-9._-]){re.escape(label)}(?![A-Za-z0-9._-])",
-        text,
-    )
+    match = re.search(rf"(?<![A-Za-z0-9._-]){re.escape(label)}(?![A-Za-z0-9._-])", text)
     if not match:
         return ""
-    tail = text[match.end():]
+    tail = text[match.start() :]
+    # Makora's Jina-rendered markdown repeats "[Try Now]" at the end
+    # of each model card; bounding by it avoids accidentally reading
+    # prices from the following card if a field disappears.
     end = tail.find("[Try Now]")
     if end != -1:
         return tail[:end]
@@ -40,9 +38,11 @@ def _section_for_label(text: str, label: str) -> str:
 
 
 def _field(section: str, label: str) -> str | None:
-    # Format: "Input|$1.00/M tokens" (with possible spaces around |)
-    pattern = rf"{label}\s*\|?\s*\$([0-9]+(?:\.[0-9]+)?)\s*/\s*M\s+tokens"
-    match = re.search(pattern, section, flags=re.I)
+    match = re.search(
+        rf"{label}\s+\$([0-9]+(?:\.[0-9]+)?)\s*/\s*M\s+tokens",
+        section,
+        flags=re.I,
+    )
     return match.group(1) if match else None
 
 
@@ -55,12 +55,10 @@ def parse(html: str) -> dict:
             continue
         prompt = _field(section, "Input")
         completion = _field(section, "Output")
-        cache = _field(section, r"Cached(?:\s+Read)?")
-        if cache is None:
-            cache = _field(section, r"Cache(?:\s+Read)?")
+        cache = _field(section, r"Cache(?:\s+Read)?")
         if prompt is None or completion is None:
             continue
-        row: dict[str, int] = {
+        row = {
             "prompt_micro_per_m": _money_to_micro(prompt),
             "completion_micro_per_m": _money_to_micro(completion),
         }

--- a/scripts/pricing/parsers/novita.py
+++ b/scripts/pricing/parsers/novita.py
@@ -1,177 +1,83 @@
-"""Novita pricing parser (plain-text tabular render)."""
+# LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
+#
+# Parses novita.ai/pricing (Jina-rendered markdown). Each row looks like:
+#
+#   | [deepseek/deepseek-v4-flash](...) | 1,048,576 | $0.14 /Mt· Cache Read $0.028 /Mt | $0.28 /Mt | [More](...) |
+#
+# Columns: model_id (in link text) | context | input | output | (more link).
+# We extract the bracketed model id, input $-amount, output $-amount.
+"""Novita pricing parser (Jina-rendered markdown)."""
 from __future__ import annotations
 
 import re
 
-# Display name (as shown in the Model Name column) → OR-canonical id.
-_DISPLAY_TO_OR_ID: dict[str, str] = {
-    # Deepseek
-    "Deepseek V4 Pro": "deepseek/deepseek-v4-pro",
-    "Deepseek V4 Flash": "deepseek/deepseek-v4-flash",
-    "Deepseek V3.2": "deepseek/deepseek-v3.2",
-    "DeepSeek-OCR 2": "deepseek/deepseek-ocr-2",
-    "Deepseek V3.2 Exp": "deepseek/deepseek-v3.2-exp",
-    "Deepseek V3.1 Terminus": "deepseek/deepseek-v3.1-terminus",
-    "DeepSeek V3.1": "deepseek/deepseek-v3.1",
-    "DeepSeek V3 0324": "deepseek/deepseek-chat-v3-0324",
-    "DeepSeek R1 0528": "deepseek/deepseek-r1-0528",
-    "DeepSeek R1 Distill LLama 70B": "deepseek/deepseek-r1-distill-llama-70b",
-    "DeepSeek V3 (Turbo)": "deepseek/deepseek-chat-v3-turbo",
-    "DeepSeek R1 (Turbo)": "deepseek/deepseek-r1-turbo",
-    # Qwen
-    "Qwen3.7-Max": "qwen/qwen3.7-max",
-    "Qwen3.6-27B": "qwen/qwen3.6-27b",
-    "Qwen3.5-27B": "qwen/qwen3.5-27b",
-    "Qwen3.5-122B-A10B": "qwen/qwen3.5-122b-a10b",
-    "Qwen3.5-35B-A3B": "qwen/qwen3.5-35b-a3b",
-    "Qwen3.5-397B-A17B": "qwen/qwen3.5-397b-a17b",
-    "Qwen3 Coder Next": "qwen/qwen3-coder-next",
-    "Qwen3 VL 235B A22B Thinking": "qwen/qwen3-vl-235b-a22b-thinking",
-    "Qwen3.6-35B-A3B": "qwen/qwen3.6-35b-a3b",
-    "Qwen3 Next 80B A3B Instruct": "qwen/qwen3-next-80b-a3b-instruct",
-    "Qwen3 VL 235B A22B Instruct": "qwen/qwen3-vl-235b-a22b-instruct",
-    "Qwen3 Coder 480B A35B Instruct": "qwen/qwen3-coder",
-    "Qwen3 Coder 30b A3B Instruct": "qwen/qwen3-coder-30b-a3b-instruct",
-    "Qwen3 235B A22b Thinking 2507": "qwen/qwen3-235b-a22b-thinking-2507",
-    "Qwen3 235B A22B Instruct 2507": "qwen/qwen3-235b-a22b-2507",
-    "Qwen 2.5 72B Instruct": "qwen/qwen-2.5-72b-instruct",
-    "Qwen3 235B A22B": "qwen/qwen3-235b-a22b",
-    "qwen/qwen3-vl-30b-a3b-instruct": "qwen/qwen3-vl-30b-a3b-instruct",
-    "Qwen MT Plus": "qwen/qwen-mt-plus",
-    # Baidu
-    "CoBuddy": "baidu/cobuddy",
-    "ERNIE 4.5 VL 424B A47B": "baidu/ernie-4.5-vl-424b-a47b",
-    "ERNIE 4.5 21B A3B": "baidu/ernie-4.5-21b-a3b",
-    # Zai-org / GLM
-    "GLM 5.2": "z-ai/glm-5.2",
-    "GLM-5.1": "z-ai/glm-5.1",
-    "GLM-5": "z-ai/glm-5",
-    "GLM-4.7-Flash": "z-ai/glm-4.7-flash",
-    "GLM-4.7": "z-ai/glm-4.7",
-    "AutoGLM-Phone-9B-Multilingual": "z-ai/autoglm-phone-9b-multilingual",
-    "GLM 4.6V": "z-ai/glm-4.6v",
-    "GLM 4.6": "z-ai/glm-4.6",
-    "GLM 4.5V": "z-ai/glm-4.5v",
-    "zai-org/glm-4.5-air": "z-ai/glm-4.5-air",
-    # Sao10k
-    "Sao10k L3 8B Lunaris": "sao10k/l3-lunaris-8b",
-    "L3 8B Stheno V3.2": "sao10k/l3-stheno-8b",
-    "L31 70B Euryale V2.2": "sao10k/l3.1-euryale-70b",
-    # Hunyuan
+# Native model id (as shown in the link text) → OR-canonical id.
+# Novita already uses OR-canonical-style ids ("deepseek/deepseek-v3.2"),
+# so most ids pass through unchanged.
+_NAME_TO_OR_ID: dict[str, str] = {}  # populated by _normalize
+
+# Some newly launched rows render as plain display-name tables instead of
+# markdown links. Keep these explicit so pricing does not invent model IDs.
+_DISPLAY_NAME_TO_OR_ID: dict[str, str] = {
     "Hy3": "tencent/hy3",
-    # MoonshotAI
-    "Kimi K2.7 Code": "moonshotai/kimi-k2.7-code",
-    "Kimi K2.6": "moonshotai/kimi-k2.6",
-    "Kimi K2.5": "moonshotai/kimi-k2.5",
-    "Kimi K2 Thinking": "moonshotai/kimi-k2-thinking",
-    "Kimi K2 0905": "moonshotai/kimi-k2-0905",
-    "Kimi K2 Instruct": "moonshotai/kimi-k2",
-    # MiniMax
-    "MiniMax M2.7": "minimax/minimax-m2.7",
-    "MiniMax M2.5-highspeed": "minimax/minimax-m2.5-highspeed",
-    "MiniMax M2.5": "minimax/minimax-m2.5",
-    "Minimax M2.1": "minimax/minimax-m2.1",
-    "MiniMax-M2": "minimax/minimax-m2",
-    "MiniMax M1": "minimax/minimax-m1",
-    # StepFun
-    "Step 3.7 Flash": "stepfun/step-3.7-flash",
-    # Nvidia
-    "Nemotron 3 Nano 30B A3B": "nvidia/nemotron-3-nano-30b-a3b",
-    # Gemma
-    "Gemma 4 26B A4B": "google/gemma-4-26b-a4b",
-    "Gemma 4 31B": "google/gemma-4-31b",
-    "Gemma 3 27B": "google/gemma-3-27b-it",
-    # KwaiKAT
-    "Kat Coder Pro": "kwaikat/kat-coder-pro",
-    # OpenAI
-    "OpenAI GPT OSS 120B": "openai/gpt-oss-120b",
-    "OpenAI: GPT OSS 20B": "openai/gpt-oss-20b",
-    # Llama
-    "Llama 3.1 8B Instruct": "meta-llama/llama-3.1-8b-instruct",
-    "Llama 3.3 70B Instruct": "meta-llama/llama-3.3-70b-instruct",
-    "Llama 4 Maverick Instruct": "meta-llama/llama-4-maverick",
-    "Llama 4 Scout Instruct": "meta-llama/llama-4-scout",
-    # Mistral
-    "Mistral Nemo": "mistralai/mistral-nemo",
-    # Others
-    "XiaomiMiMo/MiMo-V2.5": "xiaomi/mimo-v2.5",
-    "XiaomiMiMo/MiMo-V2.5-Pro": "xiaomi/mimo-v2.5-pro",
-    "Wizardlm 2 8x22B": "microsoft/wizardlm-2-8x22b",
-    "Ring-2.6-1T": "inclusionai/ring-2.6-1t",
-    "Ling-2.6-flash": "inclusionai/ling-2.6-flash",
-    "Ling-2.6-1T": "inclusionai/ling-2.6-1t",
 }
 
 
-# Match a model row. Because rows may span multiple lines (due to
-# cache-read info), we use a somewhat loose pattern.
-#
-# Pattern: name, then TAB, then digits with commas (context),
-# then everything up to /Mt (input price with optional cache-read),
-# then output price /Mt.
-_ROW_RE = re.compile(
-    r"(?m)^(?P<name>[^\t\n][^\t\n]*?)\t"
-    r"(?P<ctx>[\d,]+)\s*(?:\t|\n)"
-    r"(?P<pricing>.*?)"
-    r"(?=\n[^\t\n]*?\t[\d,]+\s*(?:\t|\n)|\nEmbeddings|\nImage\n|\Z)",
-    re.DOTALL,
+def _normalize(native_id: str) -> str:
+    """Novita's ids match OR's convention closely (`vendor/model-name`),
+    so we pass them through unchanged unless an explicit override is
+    specified in _NAME_TO_OR_ID."""
+    return _NAME_TO_OR_ID.get(native_id, native_id)
+
+
+_LINK_PRICE_RE = re.compile(
+    r"\| \[([\w./:_\-]+)\][^|]*"           # model id link
+    r"\|\s*[\d,]+\s*"                       # context
+    r"\|\s*\$([\d.]+)\s*/Mt"                # headline input price
+    r"(?:[^|]*?Cache Read \$([\d.]+)\s*/Mt)?"  # optional cache-read in same cell
+    r"[^|]*"
+    r"\|\s*\$([\d.]+)\s*/Mt"                # output price
+    r"[^|]*"
+    r"\|"
 )
 
-_INPUT_PRICE_RE = re.compile(r"\$([\d.]+)\s*/Mt")
-_CACHE_PRICE_RE = re.compile(r"Cache Read\s*\$([\d.]+)\s*/Mt")
-_FREE_RE = re.compile(r"\bFree\b")
+_FREE_TEXT_ROW_RE = re.compile(
+    r"(?m)^\s*(?P<name>[^\t\n]+)\t[\d,]+\s*\n"
+    r"\s*Free\s*\n\s*\n?\s*Free\s*\n",
+)
 
 
-def parse(html: str) -> dict:
+def parse(md: str) -> dict:
     out: dict = {}
-    for match in _ROW_RE.finditer(html):
-        name = match.group("name").strip()
-        if not name or name not in _DISPLAY_TO_OR_ID:
-            continue
-        or_id = _DISPLAY_TO_OR_ID[name]
+    for match in _LINK_PRICE_RE.finditer(md):
+        native, input_usd, cached_usd, output_usd = match.groups()
+        or_id = _normalize(native)
         if or_id in out:
             continue
-        pricing = match.group("pricing")
-
-        cache_match = _CACHE_PRICE_RE.search(pricing)
-        cache_usd = None
-        if cache_match:
-            cache_usd = cache_match.group(1)
-            # Remove the cache read segment so it doesn't confuse
-            # the input/output extraction.
-            pricing_stripped = _CACHE_PRICE_RE.sub("", pricing)
-        else:
-            pricing_stripped = pricing
-
-        prices = _INPUT_PRICE_RE.findall(pricing_stripped)
-        free_hits = _FREE_RE.findall(pricing_stripped)
-
-        input_micro = None
-        output_micro = None
-
-        if len(prices) >= 2:
-            try:
-                input_micro = int(round(float(prices[0]) * 1_000_000))
-                output_micro = int(round(float(prices[-1]) * 1_000_000))
-            except ValueError:
-                continue
-        elif len(free_hits) >= 2:
-            input_micro = 0
-            output_micro = 0
-        else:
-            # skip rows without clear numeric input+output
+        try:
+            input_micro = int(round(float(input_usd) * 1_000_000))
+            output_micro = int(round(float(output_usd) * 1_000_000))
+        except ValueError:
             continue
-
-        row: dict = {
+        row_out: dict = {
             "prompt_micro_per_m": input_micro,
             "completion_micro_per_m": output_micro,
         }
-        if cache_usd is not None:
+        if cached_usd:
             try:
-                row["prompt_cached_micro_per_m"] = int(
-                    round(float(cache_usd) * 1_000_000)
+                row_out["prompt_cached_micro_per_m"] = int(
+                    round(float(cached_usd) * 1_000_000)
                 )
             except ValueError:
                 pass
-        out[or_id] = row
+        out[or_id] = row_out
+    for match in _FREE_TEXT_ROW_RE.finditer(md):
+        name = match.group("name").strip()
+        or_id = _DISPLAY_NAME_TO_OR_ID.get(name)
+        if not or_id or or_id in out:
+            continue
+        out[or_id] = {
+            "prompt_micro_per_m": 0,
+            "completion_micro_per_m": 0,
+        }
     return out

--- a/scripts/pricing/parsers/openai.py
+++ b/scripts/pricing/parsers/openai.py
@@ -3,24 +3,23 @@
 # Parses platform.openai.com/docs/pricing as rendered by r.jina.ai.
 # Captured fixture lives at tests/fixtures/pricing/openai.html.
 #
-# The page format changed in mid-2026: the flagship Standard table now has
-# 8 data columns instead of 6 (a "Cache writes" column was added for both
-# Short context and Long context). The header now looks like:
+# Page format: Jina returns clean markdown tables. The Standard tier
+# tables look like:
 #
-#   | Model | Input | Cached input | Cache writes | Output |
-#          Input | Cached input | Cache writes | Output |
+#   |  | Short context | Long context |
+#   | --- | --- | --- |
+#   | Model | Input | Cached input | Output | Input | Cached input | Output |
+#   | gpt-5.5 | $5.00 | $0.50 | $30.00 | $10.00 | $1.00 | $45.00 |
+#   | gpt-5.4 | $2.50 | $0.25 | $15.00 | $5.00 | $0.50 | $22.50 |
+#   ...
 #
-# So a data row like gpt-5.5 has 9 pipe-delimited cells:
-#   [name, short_in, short_cached, short_cache_writes, short_out,
-#          long_in,  long_cached,  long_cache_writes,  long_out]
+# Columns 1+3 are Short context (≤ some threshold) input/output;
+# columns 4+6 are Long context input/output. We pull the Standard
+# tier (the headline rate) and ignore Batch/Flex/Priority for now.
 #
-# Short-context-only rows (gpt-5.4-mini/nano) have "-" in the long columns.
-# Some rows (gpt-5.5-pro, gpt-5.4-pro) don't support caching and put "-" in
-# cached / cache-writes columns.
-#
-# We only extract the Standard tier (first flagship table on the page);
-# Batch/Flex/Priority variants come later in the doc and are skipped via
-# the `_live_seen` guard.
+# OpenAI doesn't explicitly state the Short/Long threshold on the page,
+# but their docs convention is 200k for the GPT-5 family. We emit a
+# tiered ModelPrice when both columns are populated; otherwise flat.
 """OpenAI pricing parser (Jina-rendered markdown)."""
 from __future__ import annotations
 
@@ -28,9 +27,6 @@ import re
 
 # Display name on platform.openai.com/docs/pricing → OR-canonical id.
 _NAME_TO_OR_ID = {
-    "gpt-5.6-sol": "openai/gpt-5.6-sol",
-    "gpt-5.6-terra": "openai/gpt-5.6-terra",
-    "gpt-5.6-luna": "openai/gpt-5.6-luna",
     "gpt-5.5": "openai/gpt-5.5",
     "gpt-5.5-pro": "openai/gpt-5.5-pro",
     "gpt-5.4": "openai/gpt-5.4",
@@ -38,11 +34,17 @@ _NAME_TO_OR_ID = {
     "gpt-5.4-nano": "openai/gpt-5.4-nano",
     "gpt-5.4-pro": "openai/gpt-5.4-pro",
     "gpt-5.3-codex": "openai/gpt-5.3-codex",
-    "chat-latest": "openai/chat-latest",
 }
 
-# Legacy OpenAI models still served by the API but no longer on the
-# current pricing page.
+# Legacy OpenAI models that the API still serves but that no longer
+# appear on the current pricing page (5.5/5.4 family is what's
+# advertised). We keep them so back-compat callers can still route
+# to model ids that have been around for years.
+#
+# Prices captured manually from openai.com/api/pricing/ via Wayback
+# Machine on 2026-05-08; OpenAI hasn't published updated rates for
+# these since the GPT-5 launch. The cross-check vs OR will surface
+# any drift the LLM self-heal didn't catch.
 _LEGACY_PRICES: dict[str, tuple[float, float]] = {
     "openai/gpt-4o-mini": (0.15, 0.60),
     "openai/gpt-4o": (2.50, 10.00),
@@ -56,9 +58,12 @@ _LEGACY_PRICES: dict[str, tuple[float, float]] = {
     "openai/o4-mini": (1.10, 4.40),
 }
 
-# Threshold for Short vs Long context tiers, in tokens. See gpt-5.5
-# model card ("prompts with >272K input tokens are priced at 2x input
-# and 1.5x output"). The gpt-5.6 family follows the same convention.
+# Threshold for OpenAI's Short context vs Long context tiers, in tokens.
+# Verified from platform.openai.com/docs/models/gpt-5.5:
+# "For GPT-5.5, prompts with >272K input tokens are priced at 2x input
+# and 1.5x output for the full session for standard, batch, and flex."
+# Same rule applies to gpt-5.4 / gpt-5.4-pro / gpt-5.5-pro (the table
+# values verify: 10/5=2x input, 45/30=1.5x output).
 _SHORT_CONTEXT_THRESHOLD = 272_000
 
 
@@ -66,12 +71,9 @@ _DOLLAR_RE = re.compile(r"\$([\d.]+)")
 
 
 def _to_micro_per_m(text: str | None) -> int | None:
-    if text is None:
+    if not text or text.strip() in {"-", ""}:
         return None
-    stripped = text.strip()
-    if stripped in {"-", "", "—"}:
-        return None
-    match = _DOLLAR_RE.search(stripped)
+    match = _DOLLAR_RE.search(text)
     if not match:
         return None
     try:
@@ -80,40 +82,15 @@ def _to_micro_per_m(text: str | None) -> int | None:
         return None
 
 
-def _flat_row(prompt: int, completion: int,
-              cached: int | None) -> dict:
-    row: dict = {
-        "prompt_micro_per_m": prompt,
-        "completion_micro_per_m": completion,
-    }
-    if cached is not None:
-        row["prompt_cached_micro_per_m"] = cached
-    return row
-
-
-def _tiered_row(short_in: int, short_out: int, short_cached: int | None,
-                long_in: int, long_out: int, long_cached: int | None) -> dict:
-    tier_low: dict = {
-        "max_prompt_tokens": _SHORT_CONTEXT_THRESHOLD,
-        "prompt_micro_per_m": short_in,
-        "completion_micro_per_m": short_out,
-    }
-    if short_cached is not None:
-        tier_low["prompt_cached_micro_per_m"] = short_cached
-    tier_high: dict = {
-        "max_prompt_tokens": None,
-        "prompt_micro_per_m": long_in,
-        "completion_micro_per_m": long_out,
-    }
-    if long_cached is not None:
-        tier_high["prompt_cached_micro_per_m"] = long_cached
-    return {"tiers": [tier_low, tier_high]}
-
-
 def parse(md: str) -> dict:
     out: dict = {}
+    # Track which ids have been populated by the live page in this run.
+    # Live values override the legacy seed on collision; later
+    # Batch/Flex/Priority sections of the live page do NOT override
+    # the Standard tier (first table in the page is the canonical rate).
     _live_seen: set[str] = set()
-
+    # Walk every markdown table row that starts with "| " — Jina renders
+    # OpenAI's HTML tables as pipe-delimited markdown.
     for line in md.splitlines():
         if not line.startswith("|"):
             continue
@@ -124,95 +101,72 @@ def parse(md: str) -> dict:
         or_id = _NAME_TO_OR_ID.get(name)
         if or_id is None:
             continue
+        # The legacy seed populated `out` with flat back-compat prices
+        # for some ids; we DO want live-page data to overwrite legacy
+        # since live is fresher. But we don't want a Batch/Flex/Priority
+        # section to overwrite the Standard rate from earlier in the
+        # same page. Track which ids we've already populated from the
+        # live data via a separate set.
         if or_id in _live_seen:
-            # Ignore Batch/Flex/Priority tables that appear later in the
-            # page — Standard tier is canonical.
             continue
-
-        # New 8-column flagship layout (Short+Long context, each with
-        # Input / Cached / Cache-writes / Output). Data row has 9 cells:
-        # [name] + 8 numeric columns.
-        if len(cells) >= 9:
-            short_in = _to_micro_per_m(cells[1])
-            short_cached = _to_micro_per_m(cells[2])
-            # cells[3] = short cache writes  (ignored)
-            short_out = _to_micro_per_m(cells[4])
-            long_in = _to_micro_per_m(cells[5])
-            long_cached = _to_micro_per_m(cells[6])
-            # cells[7] = long cache writes   (ignored)
-            long_out = _to_micro_per_m(cells[8])
-            if short_in is None or short_out is None:
-                continue
-            if long_in is not None and long_out is not None:
-                out[or_id] = _tiered_row(
-                    short_in, short_out, short_cached,
-                    long_in, long_out, long_cached,
-                )
-            else:
-                out[or_id] = _flat_row(short_in, short_out, short_cached)
-            _live_seen.add(or_id)
-            continue
-
-        # Older 6-column layout (Short+Long, no cache-writes). 7 cells.
+        # 6-column table (Standard / chat models): Input | Cached |
+        # Output | Long Input | Long Cached | Long Output. The cached
+        # columns are real prices (not "-") for the chat models that
+        # support cache reads (gpt-5.5, gpt-5.4 family).
         if len(cells) >= 7:
-            short_in = _to_micro_per_m(cells[1])
+            short_input = _to_micro_per_m(cells[1])
             short_cached = _to_micro_per_m(cells[2])
-            short_out = _to_micro_per_m(cells[3])
-            long_in = _to_micro_per_m(cells[4])
+            short_output = _to_micro_per_m(cells[3])
+            long_input = _to_micro_per_m(cells[4])
             long_cached = _to_micro_per_m(cells[5])
-            long_out = _to_micro_per_m(cells[6])
-            if short_in is None or short_out is None:
+            long_output = _to_micro_per_m(cells[6])
+            if short_input is None or short_output is None:
                 continue
-            if long_in is not None and long_out is not None:
-                out[or_id] = _tiered_row(
-                    short_in, short_out, short_cached,
-                    long_in, long_out, long_cached,
-                )
+            if long_input is not None and long_output is not None:
+                tier_low: dict = {
+                    "max_prompt_tokens": _SHORT_CONTEXT_THRESHOLD,
+                    "prompt_micro_per_m": short_input,
+                    "completion_micro_per_m": short_output,
+                }
+                if short_cached is not None:
+                    tier_low["prompt_cached_micro_per_m"] = short_cached
+                tier_high: dict = {
+                    "max_prompt_tokens": None,
+                    "prompt_micro_per_m": long_input,
+                    "completion_micro_per_m": long_output,
+                }
+                if long_cached is not None:
+                    tier_high["prompt_cached_micro_per_m"] = long_cached
+                out[or_id] = {"tiers": [tier_low, tier_high]}
             else:
-                out[or_id] = _flat_row(short_in, short_out, short_cached)
+                row_out: dict = {
+                    "prompt_micro_per_m": short_input,
+                    "completion_micro_per_m": short_output,
+                }
+                if short_cached is not None:
+                    row_out["prompt_cached_micro_per_m"] = short_cached
+                out[or_id] = row_out
             _live_seen.add(or_id)
             continue
-
-        # 4-column single-context layout (Codex / specialized / chat-latest
-        # in the specialized-models table): Input | Cached | Output.
+        # 4-column table (single-context models like Codex /
+        # transcription): Input | Cached | Output. Skip if shape
+        # doesn't match what we expect.
         if len(cells) >= 4:
-            single_in = _to_micro_per_m(cells[1])
+            single_input = _to_micro_per_m(cells[1])
             single_cached = _to_micro_per_m(cells[2])
-            single_out = _to_micro_per_m(cells[3])
-            if single_in is not None and single_out is not None:
-                out[or_id] = _flat_row(single_in, single_out, single_cached)
+            single_output = _to_micro_per_m(cells[3])
+            if single_input is not None and single_output is not None:
+                row_out = {
+                    "prompt_micro_per_m": single_input,
+                    "completion_micro_per_m": single_output,
+                }
+                if single_cached is not None:
+                    row_out["prompt_cached_micro_per_m"] = single_cached
+                out[or_id] = row_out
                 _live_seen.add(or_id)
-                continue
-
-        # Specialized-models table has an extra leading "Category" column,
-        # so a data row is 5 cells: [category, model, input, cached, output].
-        # In that case cells[0] is the category, not the model name — this
-        # branch is only reached when name matched, meaning the table has
-        # already dropped the category prefix (e.g. rows without a rowspan
-        # continuation). Handled by the 4-column branch above via the
-        # secondary lookup below.
-
-    # Also handle the specialized-models table where the row is prefixed
-    # with a category column: | Codex | gpt-5.3-codex | $1.75 | $0.175 | $14.00 |
-    # That yields 5 cells with cells[1] as the model name.
-    for line in md.splitlines():
-        if not line.startswith("|"):
-            continue
-        cells = [c.strip() for c in line.strip("|").split("|")]
-        if len(cells) < 5:
-            continue
-        name = cells[1]
-        or_id = _NAME_TO_OR_ID.get(name)
-        if or_id is None or or_id in _live_seen:
-            continue
-        single_in = _to_micro_per_m(cells[2])
-        single_cached = _to_micro_per_m(cells[3])
-        single_out = _to_micro_per_m(cells[4])
-        if single_in is not None and single_out is not None:
-            out[or_id] = _flat_row(single_in, single_out, single_cached)
-            _live_seen.add(or_id)
-
-    # Fall-back legacy prices for ids the live page no longer lists.
+    # Add legacy back-compat entries for ids the live page didn't list.
+    # See _LEGACY_PRICES docstring for why these stay even though
+    # they're not on platform.openai.com/docs/pricing anymore.
     for or_id, (prompt_usd, completion_usd) in _LEGACY_PRICES.items():
         if or_id in out:
             continue

--- a/scripts/pricing/parsers/venice.py
+++ b/scripts/pricing/parsers/venice.py
@@ -1,9 +1,22 @@
-"""Venice pricing parser (Jina-rendered markdown table)."""
+# LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
+#
+# Parses docs.venice.ai/overview/pricing via Jina. The page emits a
+# repeating block per model:
+#
+#   GLM 4.6`zai-org-glm-4.6`
+#
+#   Input Price$0.85 Output Price$2.75 Cache Read$0.30 Context 198K
+#
+# Other rows have no Cache Read field. We pull the backtick-quoted
+# native id and the Input/Output dollar amounts.
+"""Venice pricing parser (Jina-rendered markdown)."""
 from __future__ import annotations
 
 import re
 
 # Native Venice id (in backticks on the page) → OR-canonical id.
+# Venice uses dash-separated forms ("zai-org-glm-4.6") that don't quite
+# match OR's canonical ("z-ai/glm-4.6"). Map the families we route to.
 _NAME_TO_OR_ID = {
     "zai-org-glm-5-2": "z-ai/glm-5.2",
     "zai-org-glm-5-1": "z-ai/glm-5.1",
@@ -24,24 +37,18 @@ _NAME_TO_OR_ID = {
 }
 
 
-# Match a chat-completions table row:
-#   | Display | `native-id` | $X.XX | $Y.YY | $Z.ZZ | ... |
-# Cache-read column may be "-" or "$N.NN".
-_ROW_RE = re.compile(
-    r"\|[^|\n]*\|\s*`([\w.\-]+)`\s*\|"      # native id
-    r"\s*\$([\d.]+)\s*\|"                     # input
-    r"\s*\$([\d.]+)\s*\|"                     # output
-    r"\s*(?:\$([\d.]+)|-)\s*\|"               # optional cache read (or "-")
+_BLOCK_RE = re.compile(
+    r"`([\w.\-]+)`"                                          # native id in backticks
+    r"[\s\S]{0,300}?"                                         # short window (next price block)
+    r"Input Price\$([\d.]+)"
+    r"\s*Output Price\$([\d.]+)"
+    r"(?:\s*Cache Read\$([\d.]+))?",                         # optional cached rate
 )
-
-
-def _to_micro(value_usd: str) -> int:
-    return int(round(float(value_usd) * 1_000_000))
 
 
 def parse(md: str) -> dict:
     out: dict = {}
-    for match in _ROW_RE.finditer(md):
+    for match in _BLOCK_RE.finditer(md):
         native, input_usd, output_usd, cached_usd = match.groups()
         or_id = _NAME_TO_OR_ID.get(native)
         if or_id is None:
@@ -49,15 +56,19 @@ def parse(md: str) -> dict:
         if or_id in out:
             continue
         try:
-            row_out: dict = {
-                "prompt_micro_per_m": _to_micro(input_usd),
-                "completion_micro_per_m": _to_micro(output_usd),
-            }
+            input_micro = int(round(float(input_usd) * 1_000_000))
+            output_micro = int(round(float(output_usd) * 1_000_000))
         except ValueError:
             continue
+        row_out: dict = {
+            "prompt_micro_per_m": input_micro,
+            "completion_micro_per_m": output_micro,
+        }
         if cached_usd:
             try:
-                row_out["prompt_cached_micro_per_m"] = _to_micro(cached_usd)
+                row_out["prompt_cached_micro_per_m"] = int(
+                    round(float(cached_usd) * 1_000_000)
+                )
             except ValueError:
                 pass
         out[or_id] = row_out

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -3,13 +3,9 @@
   "filter": "kept ONLY models with provider-direct prices; OR-only models are dropped (TR never routes via OR — every model in this snapshot is billable at the price set by the provider's own pricing page)",
   "tr_keyed_providers": [
     "anthropic",
-    "baseten",
     "cerebras",
-    "crusoe",
     "deepinfra",
     "deepseek",
-    "fireworks",
-    "friendli",
     "gemini",
     "gmi",
     "grok",
@@ -26,96 +22,10 @@
     "tinfoil",
     "together",
     "venice",
-    "wafer",
     "zai"
   ],
-  "model_count": 159,
+  "model_count": 98,
   "models": [
-    {
-      "id": "anthropic/claude-fable-5",
-      "name": "Anthropic: Claude Fable 5",
-      "created": 1781007515,
-      "description": "Claude Fable 5 is a Mythos-class model from Anthropic, built for autonomous knowledge work and coding. It supports text, image, and file inputs with text output, with reasoning support and...",
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Claude",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00001",
-        "completion": "0.00005",
-        "web_search": "0.01",
-        "input_cache_read": "0.000001",
-        "input_cache_write": "0.0000125"
-      },
-      "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 128000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "lightning | anthropic/claude-fable-5",
-          "model_id": "anthropic/claude-fable-5",
-          "model_name": "Anthropic: Claude Fable 5",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-fable-5",
-          "model_id": "anthropic/claude-fable-5",
-          "model_name": "Anthropic: Claude Fable 5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00005",
-            "input_cache_read": "0.000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | anthropic/claude-fable-5",
-          "model_id": "anthropic/claude-fable-5",
-          "model_name": "Anthropic: Claude Fable 5",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
     {
       "id": "anthropic/claude-haiku-4.5",
       "name": "Anthropic: Claude Haiku 4.5",
@@ -140,13 +50,12 @@
         "completion": "0.000005",
         "web_search": "0.01",
         "input_cache_read": "0.0000001",
-        "input_cache_write": "0.00000125",
-        "input_cache_write_1h": "0.000002"
+        "input_cache_write": "0.00000125"
       },
       "top_provider": {
         "context_length": 200000,
         "max_completion_tokens": 64000,
-        "is_moderated": false
+        "is_moderated": true
       },
       "per_request_limits": null,
       "endpoints": [
@@ -163,7 +72,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000001",
             "input_cache_write": "0.00000125",
-            "input_cache_write_1h": "0.000002",
             "discount": 0
           },
           "quantization": "unknown",
@@ -183,45 +91,84 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.963530269876,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.78078954820188,
+          "uptime_last_1d": 99.87700685381654,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "anthropic/claude-opus-4",
+      "name": "Anthropic: Claude Opus 4",
+      "created": 1747931245,
+      "description": "Claude Opus 4 is benchmarked as the world’s best coding model, at time of release, bringing sustained performance on complex, long-running tasks and agent workflows. It sets new benchmarks in...",
+      "context_length": 200000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "image",
+          "text",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Claude",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000015",
+        "completion": "0.000075",
+        "web_search": "0.01",
+        "input_cache_read": "0.0000015",
+        "input_cache_write": "0.00001875"
+      },
+      "top_provider": {
+        "context_length": 200000,
+        "max_completion_tokens": 32000,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
         {
-          "name": "phala | anthropic/claude-haiku-4.5",
-          "model_id": "anthropic/claude-haiku-4.5",
-          "model_name": "Anthropic: Claude Haiku 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "name": "Anthropic | anthropic/claude-4-opus-20250522",
+          "model_id": "anthropic/claude-opus-4",
+          "model_name": "Anthropic: Claude Opus 4",
+          "provider_name": "Anthropic",
+          "tag": "anthropic",
           "context_length": 200000,
           "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000005"
+            "prompt": "0.000015",
+            "completion": "0.000075",
+            "web_search": "0.01",
+            "input_cache_read": "0.0000015",
+            "input_cache_write": "0.00001875",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-haiku-4.5",
-          "model_id": "anthropic/claude-haiku-4.5",
-          "model_name": "Anthropic: Claude Haiku 4.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000005",
-            "input_cache_read": "0.0000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "unknown",
+          "max_completion_tokens": 32000,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "max_tokens",
+            "top_p",
+            "temperature",
+            "stop",
+            "reasoning",
+            "include_reasoning",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 100,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "anthropic",
+          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
@@ -250,13 +197,12 @@
         "completion": "0.000075",
         "web_search": "0.01",
         "input_cache_read": "0.0000015",
-        "input_cache_write": "0.00001875",
-        "input_cache_write_1h": "0.00003"
+        "input_cache_write": "0.00001875"
       },
       "top_provider": {
         "context_length": 200000,
         "max_completion_tokens": 32000,
-        "is_moderated": true
+        "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
@@ -273,7 +219,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000015",
             "input_cache_write": "0.00001875",
-            "input_cache_write_1h": "0.00003",
             "discount": 0
           },
           "quantization": "unknown",
@@ -293,43 +238,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.95224450811844,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.1",
-          "model_id": "anthropic/claude-opus-4.1",
-          "model_name": "Anthropic: Claude Opus 4.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000015",
-            "completion": "0.000075"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-opus-4.1",
-          "model_id": "anthropic/claude-opus-4.1",
-          "model_name": "Anthropic: Claude Opus 4.1",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000015",
-            "completion": "0.000075",
-            "input_cache_read": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -358,8 +270,7 @@
         "completion": "0.000025",
         "web_search": "0.01",
         "input_cache_read": "0.0000005",
-        "input_cache_write": "0.00000625",
-        "input_cache_write_1h": "0.00001"
+        "input_cache_write": "0.00000625"
       },
       "top_provider": {
         "context_length": 200000,
@@ -381,7 +292,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -400,9 +310,9 @@
             "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.55223880597015,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.98731849597362,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -420,7 +330,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -441,43 +350,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.53768844221105,
+          "uptime_last_1d": 98.53958493466564,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.5",
-          "model_id": "anthropic/claude-opus-4.5",
-          "model_name": "Anthropic: Claude Opus 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-opus-4.5",
-          "model_id": "anthropic/claude-opus-4.5",
-          "model_name": "Anthropic: Claude Opus 4.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025",
-            "input_cache_read": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -506,13 +382,12 @@
         "completion": "0.000025",
         "web_search": "0.01",
         "input_cache_read": "0.0000005",
-        "input_cache_write": "0.00000625",
-        "input_cache_write_1h": "0.00001"
+        "input_cache_write": "0.00000625"
       },
       "top_provider": {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
-        "is_moderated": true
+        "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
@@ -529,7 +404,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -546,13 +420,12 @@
             "tools",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98840041758497,
-          "uptime_last_5m": 99.88412514484357,
-          "uptime_last_1d": 99.8604027587732,
+          "uptime_last_30m": 99.94888570844408,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9000733914755,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -570,7 +443,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -587,49 +459,15 @@
             "tools",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 49.65034965034965,
+          "uptime_last_1d": 97.43336623889437,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.6",
-          "model_id": "anthropic/claude-opus-4.6",
-          "model_name": "Anthropic: Claude Opus 4.6",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.0000375"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-opus-4.6",
-          "model_id": "anthropic/claude-opus-4.6",
-          "model_name": "Anthropic: Claude Opus 4.6",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025",
-            "input_cache_read": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -658,13 +496,12 @@
         "completion": "0.000025",
         "web_search": "0.01",
         "input_cache_read": "0.0000005",
-        "input_cache_write": "0.00000625",
-        "input_cache_write_1h": "0.00001"
+        "input_cache_write": "0.00000625"
       },
       "top_provider": {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
-        "is_moderated": true
+        "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
@@ -681,7 +518,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -696,13 +532,12 @@
             "tools",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97075901249008,
+          "uptime_last_30m": 99.98659427575575,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90665978365114,
+          "uptime_last_1d": 99.88199512045016,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -720,7 +555,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "input_cache_write": "0.00000625",
-            "input_cache_write_1h": "0.00001",
             "discount": 0
           },
           "quantization": "unknown",
@@ -735,32 +569,15 @@
             "tools",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.81109643328931,
+          "uptime_last_1d": 99.88697372139022,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.7",
-          "model_id": "anthropic/claude-opus-4.7",
-          "model_name": "Anthropic: Claude Opus 4.7",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-opus-4.7",
@@ -783,16 +600,16 @@
       "pricing_source": "provider_direct"
     },
     {
-      "id": "anthropic/claude-opus-4.8",
-      "name": "Anthropic: Claude Opus 4.8",
-      "created": 1779905091,
-      "description": "Claude Opus 4.8 is Anthropic's most capable generally available model in the Opus family. It supports text, image, and file inputs with text output, with reasoning support and a 1M-token...",
+      "id": "anthropic/claude-sonnet-4",
+      "name": "Anthropic: Claude Sonnet 4",
+      "created": 1747930371,
+      "description": "Claude Sonnet 4 significantly enhances the capabilities of its predecessor, Sonnet 3.7, excelling in both coding and reasoning tasks with improved precision and controllability. Achieving state-of-the-art performance on SWE-bench (72.7%),...",
       "context_length": 1000000,
       "architecture": {
         "modality": "text+image+file->text",
         "input_modalities": [
-          "text",
           "image",
+          "text",
           "file"
         ],
         "output_modalities": [
@@ -802,52 +619,54 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000005",
-        "completion": "0.000025",
+        "prompt": "0.000003",
+        "completion": "0.000015",
         "web_search": "0.01",
-        "input_cache_read": "0.0000005",
-        "input_cache_write": "0.00000625",
-        "input_cache_write_1h": "0.00001"
+        "input_cache_read": "0.0000003",
+        "input_cache_write": "0.00000375"
       },
       "top_provider": {
         "context_length": 1000000,
-        "max_completion_tokens": 128000,
+        "max_completion_tokens": 64000,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | anthropic/claude-opus-4.8",
-          "model_id": "anthropic/claude-opus-4.8",
-          "model_name": "Anthropic: Claude Opus 4.8",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "name": "Anthropic | anthropic/claude-4-sonnet-20250522",
+          "model_id": "anthropic/claude-sonnet-4",
+          "model_name": "Anthropic: Claude Sonnet 4",
+          "provider_name": "Anthropic",
+          "tag": "anthropic",
           "context_length": 1000000,
           "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "web_search": "0.01",
+            "input_cache_read": "0.0000003",
+            "input_cache_write": "0.00000375",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-opus-4.8",
-          "model_id": "anthropic/claude-opus-4.8",
-          "model_name": "Anthropic: Claude Opus 4.8",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025",
-            "input_cache_read": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "unknown",
+          "max_completion_tokens": 64000,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "max_tokens",
+            "top_p",
+            "temperature",
+            "stop",
+            "reasoning",
+            "include_reasoning",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 100,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "anthropic",
+          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
@@ -876,18 +695,7 @@
         "completion": "0.000015",
         "web_search": "0.01",
         "input_cache_read": "0.0000003",
-        "input_cache_write": "0.00000375",
-        "input_cache_write_1h": "0.000006",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.000006",
-            "completion": "0.0000225",
-            "input_cache_read": "0.0000006",
-            "input_cache_write": "0.0000075",
-            "input_cache_write_1h": "0.000012"
-          }
-        ]
+        "input_cache_write": "0.00000375"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -909,18 +717,7 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000003",
             "input_cache_write": "0.00000375",
-            "input_cache_write_1h": "0.000006",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000006",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000006",
-                "input_cache_write": "0.0000075",
-                "input_cache_write_1h": "0.000012"
-              }
-            ]
+            "discount": 0
           },
           "quantization": "unknown",
           "max_completion_tokens": 64000,
@@ -939,9 +736,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.76470588235294,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.59201374945789,
+          "uptime_last_30m": 99.73421926910298,
+          "uptime_last_5m": 99.00990099009901,
+          "uptime_last_1d": 99.65392129500418,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -959,18 +756,7 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000003",
             "input_cache_write": "0.00000375",
-            "input_cache_write_1h": "0.000006",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000006",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000006",
-                "input_cache_write": "0.0000075",
-                "input_cache_write_1h": "0.000012"
-              }
-            ]
+            "discount": 0
           },
           "quantization": "unknown",
           "max_completion_tokens": 64000,
@@ -991,43 +777,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 77.21518987341773,
+          "uptime_last_1d": null,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-sonnet-4.5",
-          "model_id": "anthropic/claude-sonnet-4.5",
-          "model_name": "Anthropic: Claude Sonnet 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-sonnet-4.5",
-          "model_id": "anthropic/claude-sonnet-4.5",
-          "model_name": "Anthropic: Claude Sonnet 4.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015",
-            "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -1056,8 +809,7 @@
         "completion": "0.000015",
         "web_search": "0.01",
         "input_cache_read": "0.0000003",
-        "input_cache_write": "0.00000375",
-        "input_cache_write_1h": "0.000006"
+        "input_cache_write": "0.00000375"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -1079,7 +831,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000003",
             "input_cache_write": "0.00000375",
-            "input_cache_write_1h": "0.000006",
             "discount": 0
           },
           "quantization": "unknown",
@@ -1096,13 +847,12 @@
             "tool_choice",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": 99.73313565604151,
-          "uptime_last_5m": 99.9651385741677,
-          "uptime_last_1d": 99.80763076043489,
+          "uptime_last_30m": 99.93299546805711,
+          "uptime_last_5m": 99.9364406779661,
+          "uptime_last_1d": 99.8910167772611,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1120,7 +870,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000003",
             "input_cache_write": "0.00000375",
-            "input_cache_write_1h": "0.000006",
             "discount": 0
           },
           "quantization": "unknown",
@@ -1137,149 +886,28 @@
             "tool_choice",
             "structured_outputs",
             "response_format",
-            "verbosity",
-            "reasoning_effort"
+            "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 90.55865921787709,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.01612138454243,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-sonnet-4.6",
-          "model_id": "anthropic/claude-sonnet-4.6",
-          "model_name": "Anthropic: Claude Sonnet 4.6",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-sonnet-4.6",
-          "model_id": "anthropic/claude-sonnet-4.6",
-          "model_name": "Anthropic: Claude Sonnet 4.6",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015",
-            "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
     },
     {
-      "id": "anthropic/claude-sonnet-5",
-      "name": "Anthropic: Claude Sonnet 5",
-      "created": 1782843083,
-      "description": "Sonnet 5 is Anthropic's most capable Sonnet-class model, with frontier performance across coding, agents, and professional work. It supports adaptive thinking with selectable reasoning effort levels (low, medium, high, max,...",
-      "context_length": 1000000,
+      "id": "arcee-ai/trinity-large-thinking",
+      "name": "Arcee AI: Trinity Large Thinking",
+      "created": 1775058318,
+      "description": "Trinity Large Thinking is a powerful open source reasoning model from the team at Arcee AI. It shows strong performance in PinchBench, agentic workloads, and reasoning tasks. Launch video: https://youtu.be/Gc82AXLa0Rg?si=4RLn6WBz33qT--B7...",
+      "context_length": 262144,
       "architecture": {
-        "modality": "text+image+file->text",
+        "modality": "text->text",
         "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Claude",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000002",
-        "completion": "0.00001",
-        "web_search": "0.01",
-        "input_cache_read": "0.0000002",
-        "input_cache_write": "0.0000025",
-        "input_cache_write_1h": "0.000004"
-      },
-      "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 128000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | anthropic/claude-sonnet-5",
-          "model_id": "anthropic/claude-sonnet-5",
-          "model_name": "Anthropic: Claude Sonnet 5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | anthropic/claude-sonnet-5",
-          "model_id": "anthropic/claude-sonnet-5",
-          "model_name": "Anthropic: Claude Sonnet 5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.00001",
-            "input_cache_read": "0.0000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | anthropic/claude-sonnet-5",
-          "model_id": "anthropic/claude-sonnet-5",
-          "model_name": "Anthropic: Claude Sonnet 5",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "baidu/ernie-4.5-vl-424b-a47b",
-      "name": "Baidu: ERNIE 4.5 VL 424B A47B ",
-      "created": 1751300903,
-      "description": "ERNIE-4.5-VL-424B-A47B is a multimodal Mixture-of-Experts (MoE) model from Baidu’s ERNIE 4.5 series, featuring 424B total parameters with 47B active per token. It is trained jointly on text and image data...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "image",
           "text"
         ],
         "output_modalities": [
@@ -1289,30 +917,32 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000042",
-        "completion": "0.00000125"
+        "prompt": "0.00000022",
+        "completion": "0.00000085",
+        "input_cache_read": "0.00000006"
       },
       "top_provider": {
-        "context_length": 123000,
-        "max_completion_tokens": 16000,
+        "context_length": 262144,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | baidu/ernie-4.5-vl-424b-a47b",
-          "model_id": "baidu/ernie-4.5-vl-424b-a47b",
-          "model_name": "Baidu: ERNIE 4.5 VL 424B A47B ",
-          "provider_name": "Novita",
-          "tag": "novita/fp16",
-          "context_length": 123000,
+          "name": "Parasail | arcee-ai/trinity-large-thinking",
+          "model_id": "arcee-ai/trinity-large-thinking",
+          "model_name": "Arcee AI: Trinity Large Thinking",
+          "provider_name": "Parasail",
+          "tag": "parasail/fp4",
+          "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000042",
-            "completion": "0.00000125",
+            "prompt": "0.00000022",
+            "completion": "0.00000085",
+            "input_cache_read": "0.00000006",
             "discount": 0
           },
-          "quantization": "fp16",
-          "max_completion_tokens": 16000,
+          "quantization": "fp4",
+          "max_completion_tokens": 262144,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -1320,23 +950,28 @@
             "max_tokens",
             "temperature",
             "top_p",
-            "stop",
             "frequency_penalty",
             "presence_penalty",
+            "repetition_penalty",
             "seed",
+            "stop",
             "top_k",
-            "repetition_penalty"
+            "logit_bias",
+            "structured_outputs",
+            "response_format",
+            "tools",
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.58396618899822,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
+          "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "bytedance/ui-tars-1.5-7b",
@@ -1370,7 +1005,7 @@
       "endpoints": [
         {
           "name": "Parasail | bytedance/ui-tars-1.5-7b",
-          "model_id": "ByteDance-Seed/UI-TARS-1.5-7B",
+          "model_id": "bytedance/ui-tars-1.5-7b",
           "model_name": "ByteDance: UI-TARS 7B ",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
@@ -1394,14 +1029,11 @@
             "seed",
             "stop",
             "top_k",
-            "logit_bias",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "logit_bias"
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
@@ -1409,75 +1041,6 @@
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "deepseek/deepseek-chat-v3-0324",
-      "name": "DeepSeek: DeepSeek V3 0324",
-      "created": 1742824755,
-      "description": "DeepSeek V3, a 685B-parameter, mixture-of-experts model, is the latest iteration of the flagship chat model family from the DeepSeek team. It succeeds the [DeepSeek V3](/deepseek/deepseek-chat-v3) model and performs really well...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000112",
-        "input_cache_read": "0.000000135"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | deepseek/deepseek-chat-v3-0324",
-          "model_id": "deepseek/deepseek-chat-v3-0324",
-          "model_name": "DeepSeek: DeepSeek V3 0324",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000112",
-            "input_cache_read": "0.000000135",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.64313995524186,
-          "uptime_last_5m": 97.19626168224299,
-          "uptime_last_1d": 94.54739694113634,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "deepseek/deepseek-chat-v3.1",
@@ -1510,7 +1073,7 @@
       "endpoints": [
         {
           "name": "phala | deepseek/deepseek-chat-v3.1",
-          "model_id": "phala/deepseek-chat-v3.1",
+          "model_id": "deepseek/deepseek-chat-v3.1",
           "model_name": "DeepSeek: DeepSeek V3.1",
           "provider_name": "phala",
           "tag": "phala",
@@ -1526,352 +1089,6 @@
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "deepseek/deepseek-r1-0528",
-      "name": "DeepSeek: R1 0528",
-      "created": 1748455170,
-      "description": "May 28th update to the [original DeepSeek R1](/deepseek/deepseek-r1) Performance on par with [OpenAI o1](/openai/o1), but open-sourced and with fully open reasoning tokens. It's 671B parameters in size, with 37B active...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": "deepseek-r1"
-      },
-      "pricing": {
-        "prompt": "0.0000005",
-        "completion": "0.00000215",
-        "input_cache_read": "0.00000035"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | deepseek/deepseek-r1-0528",
-          "model_id": "deepseek-ai/DeepSeek-R1-0528",
-          "model_name": "DeepSeek: R1 0528",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.00000215",
-            "input_cache_read": "0.00000035",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.92951090177985,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | deepseek/deepseek-r1-0528",
-          "model_id": "deepseek/deepseek-r1-0528",
-          "model_name": "DeepSeek: R1 0528",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000025",
-            "input_cache_read": "0.00000035",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.79253112033194,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "together | deepseek/deepseek-r1-0528",
-          "model_id": "deepseek-ai/DeepSeek-R1-0528",
-          "model_name": "DeepSeek: R1 0528",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | deepseek/deepseek-r1-0528",
-          "model_id": "deepseek-ai/DeepSeek-R1-0528",
-          "model_name": "DeepSeek: R1 0528",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000057",
-            "completion": "0.00000229",
-            "input_cache_read": "0.00000023"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "deepseek/deepseek-r1-distill-llama-70b",
-      "name": "DeepSeek: R1 Distill Llama 70B",
-      "created": 1737663169,
-      "description": "DeepSeek R1 Distill Llama 70B is a distilled large language model based on [Llama-3.3-70B-Instruct](/meta-llama/llama-3.3-70b-instruct), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). The model combines advanced distillation techniques to achieve high performance across...",
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "deepseek-r1"
-      },
-      "pricing": {
-        "prompt": "0.0000008",
-        "completion": "0.0000008"
-      },
-      "top_provider": {
-        "context_length": 8192,
-        "max_completion_tokens": 8192,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | deepseek/deepseek-r1-distill-llama-70b",
-          "model_id": "deepseek/deepseek-r1-distill-llama-70b",
-          "model_name": "DeepSeek: R1 Distill Llama 70B",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 8192,
-          "pricing": {
-            "prompt": "0.0000008",
-            "completion": "0.0000008",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "together | deepseek/deepseek-r1-distill-llama-70b",
-          "model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-          "model_name": "DeepSeek: R1 Distill Llama 70B",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "deepseek/deepseek-v3.1-terminus",
-      "name": "DeepSeek: DeepSeek V3.1 Terminus",
-      "created": 1758548275,
-      "description": "DeepSeek-V3.1 Terminus is an update to [DeepSeek V3.1](/deepseek/deepseek-chat-v3.1) that maintains the model's original capabilities while addressing issues reported by users, including language consistency and agent capabilities, further optimizing the model's...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": "deepseek-v3.1"
-      },
-      "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000095",
-        "input_cache_read": "0.00000013"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | deepseek/deepseek-v3.1-terminus",
-          "model_id": "deepseek-ai/DeepSeek-V3.1-Terminus",
-          "model_name": "DeepSeek: DeepSeek V3.1 Terminus",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000095",
-            "input_cache_read": "0.00000013",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95249461219382,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | deepseek/deepseek-v3.1-terminus",
-          "model_id": "deepseek/deepseek-v3.1-terminus",
-          "model_name": "DeepSeek: DeepSeek V3.1 Terminus",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.000001",
-            "input_cache_read": "0.000000135",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.99792134364347,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99980916431144,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "deepseek/deepseek-v3.2",
@@ -1891,9 +1108,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000026",
-        "completion": "0.00000038",
-        "input_cache_read": "0.00000002145"
+        "prompt": "0.00000028",
+        "completion": "0.00000045",
+        "input_cache_read": "0.00000013"
       },
       "top_provider": {
         "context_length": 128000,
@@ -1903,20 +1120,20 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | deepseek/deepseek-v3.2-20251201",
-          "model_id": "deepseek-ai/DeepSeek-V3.2",
+          "name": "Parasail | deepseek/deepseek-v3.2-20251201",
+          "model_id": "deepseek/deepseek-v3.2",
           "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
+          "provider_name": "Parasail",
+          "tag": "parasail/fp8",
           "context_length": 163840,
           "pricing": {
-            "prompt": "0.00000026",
-            "completion": "0.00000038",
+            "prompt": "0.00000028",
+            "completion": "0.00000045",
             "input_cache_read": "0.00000013",
             "discount": 0
           },
-          "quantization": "fp4",
-          "max_completion_tokens": 16384,
+          "quantization": "fp8",
+          "max_completion_tokens": 65536,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -1924,259 +1141,42 @@
             "max_tokens",
             "temperature",
             "top_p",
-            "stop",
             "frequency_penalty",
             "presence_penalty",
             "repetition_penalty",
-            "top_k",
             "seed",
-            "min_p",
-            "response_format",
-            "tool_choice",
-            "tools",
+            "stop",
+            "top_k",
             "logit_bias",
+            "response_format",
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69426152398871,
-          "uptime_last_5m": 99.40476190476191,
-          "uptime_last_1d": 99.37792698753033,
+          "uptime_last_30m": 99.34725848563968,
+          "uptime_last_5m": 99.3368700265252,
+          "uptime_last_1d": 98.73938436872781,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
+          "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Friendli | deepseek/deepseek-v3.2-20251201",
-          "model_id": "deepseek-ai/DeepSeek-V3.2",
-          "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "Friendli",
-          "tag": "friendli",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.0000015",
-            "input_cache_read": "0.00000025",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 163840,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.83167007334376,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.74554244345978,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | deepseek/deepseek-v3.2-20251201",
-          "model_id": "deepseek-ai/DeepSeek-V3.2",
-          "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000029",
-            "completion": "0.00000043",
-            "input_cache_read": "0.00000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85486211901306,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 87.19191417091255,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | deepseek/deepseek-v3.2-20251201",
+          "name": "phala | deepseek/deepseek-v3.2",
           "model_id": "deepseek/deepseek-v3.2",
           "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.000000269",
-            "completion": "0.0000004",
-            "input_cache_read": "0.0000001345",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.9745213656548,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93844132430138,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Phala | deepseek/deepseek-v3.2-20251201",
-          "model_id": "phala/deepseek-v3.2",
-          "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "Phala",
+          "provider_name": "phala",
           "tag": "phala",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000001",
-            "input_cache_read": "0.0000005",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 64000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.80657640232108,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.92687206830223,
-          "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "deepseek/deepseek-v3.2-exp",
-      "name": "DeepSeek: DeepSeek V3.2 Exp",
-      "created": 1759150481,
-      "description": "DeepSeek-V3.2-Exp is an experimental large language model released by DeepSeek as an intermediate step between V3.1 and future architectures. It introduces DeepSeek Sparse Attention (DSA), a fine-grained sparse attention mechanism...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": "deepseek-v3.1"
-      },
-      "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000041"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | deepseek/deepseek-v3.2-exp",
-          "model_id": "deepseek/deepseek-v3.2-exp",
-          "model_name": "DeepSeek: DeepSeek V3.2 Exp",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 163840,
+          "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000041",
-            "discount": 0
+            "prompt": "0.00000032",
+            "completion": "0.00000048"
           },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.49518127581459,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.11388042374111,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -2196,61 +1196,17 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000009",
-        "completion": "0.00000018",
-        "input_cache_read": "0.000000018"
+        "prompt": "0.00000013",
+        "completion": "0.00000028",
+        "input_cache_read": "0.0000000197"
       },
       "top_provider": {
         "context_length": 1048576,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 131072,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | deepseek/deepseek-v4-flash-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.00000018",
-            "input_cache_read": "0.000000018",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "logit_bias",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.711160439678,
-          "uptime_last_5m": 99.76939671204345,
-          "uptime_last_1d": 99.77472219041951,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "DeepSeek | deepseek/deepseek-v4-flash-20260423",
           "model_id": "deepseek/deepseek-v4-flash",
@@ -2280,97 +1236,19 @@
             "top_logprobs",
             "tools",
             "tool_choice",
-            "response_format",
-            "reasoning_effort"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9718915469525,
-          "uptime_last_5m": 99.98852421390865,
-          "uptime_last_1d": 99.70800742711552,
+          "uptime_last_30m": 99.97514018175289,
+          "uptime_last_5m": 99.98988059097348,
+          "uptime_last_1d": 99.99037115494292,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "GMICloud | deepseek/deepseek-v4-flash-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 1048575,
-          "pricing": {
-            "prompt": "0.000000098",
-            "completion": "0.000000196",
-            "input_cache_read": "0.00000002",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.37390653711998,
-          "uptime_last_5m": 99.57968776805627,
-          "uptime_last_1d": 95.79723341775191,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | deepseek/deepseek-v4-flash-20260423",
-          "model_id": "deepseek/deepseek-v4-flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
-            "input_cache_read": "0.000000028",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 393216,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tool_choice",
-            "tools",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.81202690343852,
-          "uptime_last_5m": 99.87970441656641,
-          "uptime_last_1d": 99.86172221006866,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | deepseek/deepseek-v4-flash-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Flash",
+          "model_id": "deepseek/deepseek-v4-flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -2400,15 +1278,12 @@
             "tools",
             "tool_choice",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
+            "response_format"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.5978164579692,
-          "uptime_last_5m": 93.4857934857935,
-          "uptime_last_1d": 98.94125507529424,
+          "status": 0,
+          "uptime_last_30m": 98.75292936056243,
+          "uptime_last_5m": 99.38461538461539,
+          "uptime_last_1d": 99.03497613995768,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -2439,86 +1314,18 @@
             "max_tokens",
             "tools",
             "tool_choice",
-            "response_format",
-            "reasoning_effort"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.1868083222665,
-          "uptime_last_5m": 98.97172236503856,
-          "uptime_last_1d": 94.58004575305846,
+          "uptime_last_30m": 96.86273221530527,
+          "uptime_last_5m": 98.24055379290454,
+          "uptime_last_1d": 97.29590798299385,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek/deepseek-v4-flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek-ai/Deepseek-V4-Flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek-v4-flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek/deepseek-v4-flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.0000002",
-            "input_cache_read": "0.00000002"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -2550,50 +1357,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000013",
-            "completion": "0.0000026",
-            "input_cache_read": "0.0000001",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.75579975579976,
-          "uptime_last_5m": 99.85549132947978,
-          "uptime_last_1d": 99.16752972639914,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "DeepSeek | deepseek/deepseek-v4-pro-20260423",
           "model_id": "deepseek/deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
@@ -2622,143 +1385,19 @@
             "top_logprobs",
             "tools",
             "tool_choice",
-            "response_format",
-            "reasoning_effort"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69447893875781,
-          "uptime_last_5m": 99.89669421487604,
-          "uptime_last_1d": 99.92608286949923,
+          "uptime_last_30m": 99.99907519582727,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.98963591347906,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Fireworks | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "accounts/fireworks/models/deepseek-v4-pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "Fireworks",
-          "tag": "fireworks",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.000000145",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.70766129032258,
-          "uptime_last_5m": 99.49748743718592,
-          "uptime_last_1d": 91.10585387700124,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "fireworks",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000001131",
-            "completion": "0.000002262",
-            "input_cache_read": "0.000000094",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.21052631578948,
-          "uptime_last_5m": 95.66666666666667,
-          "uptime_last_1d": 95.82477589581269,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek/deepseek-v4-pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000016",
-            "completion": "0.0000032",
-            "input_cache_read": "0.000000135",
-            "discount": 0.27
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 393216,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": -5,
-          "uptime_last_30m": 72.60661829764643,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.77715891118773,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+          "model_id": "deepseek/deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -2766,7 +1405,7 @@
           "pricing": {
             "prompt": "0.00000174",
             "completion": "0.00000348",
-            "input_cache_read": "0.0000001",
+            "input_cache_read": "0.00000087",
             "discount": 0
           },
           "quantization": "fp8",
@@ -2788,15 +1427,12 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.9501312335958,
-          "uptime_last_5m": 97.72727272727273,
-          "uptime_last_1d": 97.12852122601619,
+          "uptime_last_30m": 99.08501715592833,
+          "uptime_last_5m": 98.51403412217941,
+          "uptime_last_1d": 99.27489771232541,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -2810,8 +1446,8 @@
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000016",
-            "completion": "0.000003135",
-            "input_cache_read": "0.000000135",
+            "completion": "0.00000348",
+            "input_cache_read": "0.000000145",
             "discount": 0
           },
           "quantization": "fp8",
@@ -2827,67 +1463,23 @@
             "max_tokens",
             "tools",
             "tool_choice",
-            "response_format",
-            "reasoning_effort"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.73651027354825,
+          "uptime_last_30m": 98.74558996471971,
+          "uptime_last_5m": 97.54098360655738,
+          "uptime_last_1d": 98.10549182349658,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Together | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 512000,
-          "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.1187143597719,
-          "uptime_last_5m": 99.56140350877193,
-          "uptime_last_1d": 97.53562120222027,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | deepseek/deepseek-v4-pro",
+          "name": "tinfoil | deepseek/deepseek-v4-pro",
           "model_id": "deepseek/deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "tinfoil",
+          "tag": "tinfoil",
+          "tr_provider_slug": "tinfoil",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000015",
@@ -2898,75 +1490,24 @@
           "quantization": "unknown"
         },
         {
-          "name": "baseten | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.000000145"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek-v4-pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000024",
-            "completion": "0.0000048",
-            "input_cache_read": "0.00000024"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | deepseek/deepseek-v4-pro",
+          "name": "gmi | deepseek/deepseek-v4-pro",
           "model_id": "deepseek/deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000112",
-            "completion": "0.00000224",
-            "input_cache_read": "0.00000011"
+            "prompt": "0.000001392",
+            "completion": "0.000002784",
+            "input_cache_read": "0.000000116"
           },
-          "pricing_source": "self_healed_provider",
+          "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "google/gemini-2.5-flash",
@@ -2994,7 +1535,6 @@
         "completion": "0.0000025",
         "image": "0.0000003",
         "audio": "0.000001",
-        "input_audio_cache": "0.0000001",
         "web_search": "0.014",
         "internal_reasoning": "0.0000025",
         "input_cache_read": "0.00000003",
@@ -3043,146 +1583,12 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99406704242064,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94266055045871,
+          "uptime_last_30m": 99.90287220757597,
+          "uptime_last_5m": 99.6078431372549,
+          "uptime_last_1d": 99.94835900980974,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025",
-            "image": "0.00000015",
-            "audio": "0.0000005",
-            "input_audio_cache": "0.00000005",
-            "web_search": "0.014",
-            "internal_reasoning": "0.00000125",
-            "input_cache_read": "0.000000015",
-            "input_cache_write": "0.00000004166666666666667",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.99406704242064,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94266055045871,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025",
-            "image": "0.00000054",
-            "audio": "0.0000018",
-            "input_audio_cache": "0.00000018",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000045",
-            "input_cache_read": "0.000000054",
-            "input_cache_write": "0.000000150000000000000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.99406704242064,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94266055045871,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -3213,7 +1619,6 @@
         "completion": "0.0000004",
         "image": "0.0000001",
         "audio": "0.0000003",
-        "input_audio_cache": "0.00000003",
         "web_search": "0.014",
         "internal_reasoning": "0.0000004",
         "input_cache_read": "0.00000001",
@@ -3262,114 +1667,12 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.71320159660966,
-          "uptime_last_5m": 99.64936886395512,
-          "uptime_last_1d": 99.66808119733425,
+          "uptime_last_30m": 99.9277425321907,
+          "uptime_last_5m": 99.96732560039209,
+          "uptime_last_1d": 99.95818657858834,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-flash-lite",
-          "model_id": "google/gemini-2.5-flash-lite",
-          "model_name": "Google: Gemini 2.5 Flash Lite",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000004",
-            "image": "0.00000005",
-            "audio": "0.00000015",
-            "input_audio_cache": "0.000000015",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000002",
-            "input_cache_read": "0.000000005",
-            "input_cache_write": "0.00000004166666666666667",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.71320159660966,
-          "uptime_last_5m": 99.64936886395512,
-          "uptime_last_1d": 99.66808119733425,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-flash-lite",
-          "model_id": "google/gemini-2.5-flash-lite",
-          "model_name": "Google: Gemini 2.5 Flash Lite",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000004",
-            "image": "0.00000018",
-            "audio": "0.00000054",
-            "input_audio_cache": "0.000000054",
-            "web_search": "0.014",
-            "internal_reasoning": "0.00000072",
-            "input_cache_read": "0.000000018",
-            "input_cache_write": "0.000000150000000000000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.71320159660966,
-          "uptime_last_5m": 99.64936886395512,
-          "uptime_last_1d": 99.66808119733425,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | google/gemini-2.5-flash-lite",
-          "model_id": "google/gemini-2.5-flash-lite",
-          "model_name": "Google: Gemini 2.5 Flash Lite",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -3400,19 +1703,28 @@
         "completion": "0.00001",
         "image": "0.00000125",
         "audio": "0.00000125",
-        "input_audio_cache": "0.000000125",
         "web_search": "0.014",
         "internal_reasoning": "0.00001",
         "input_cache_read": "0.000000125",
         "input_cache_write": "0.000000375",
-        "overrides": [
+        "prompt_tiers": [
           {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "audio": "0.0000025",
-            "input_audio_cache": "0.00000025",
-            "input_cache_read": "0.00000025"
+            "max_prompt_tokens": 200000,
+            "prompt": "0.00000125"
+          },
+          {
+            "max_prompt_tokens": null,
+            "prompt": "0.0000025"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 200000,
+            "completion": "0.00001"
+          },
+          {
+            "max_prompt_tokens": null,
+            "completion": "0.000015"
           }
         ]
       },
@@ -3441,16 +1753,6 @@
             "input_cache_read": "0.000000125",
             "input_cache_write": "0.000000375",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000015",
-                "audio": "0.0000025",
-                "input_audio_cache": "0.00000025",
-                "input_cache_read": "0.00000025"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 200000,
@@ -3485,207 +1787,16 @@
             "top_p",
             "seed",
             "tools",
-            "tool_choice"
+            "tool_choice",
+            "stop"
           ],
-          "status": -2,
-          "uptime_last_30m": 86.95652173913044,
+          "status": 0,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.58532699225067,
+          "uptime_last_1d": 85.98390230363586,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "image": "0.000000625",
-            "audio": "0.000000625",
-            "input_audio_cache": "0.0000000625",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000005",
-            "input_cache_read": "0.0000000625",
-            "input_cache_write": "0.0000001875",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.00000125",
-                "completion": "0.0000075",
-                "audio": "0.00000125",
-                "input_audio_cache": "0.000000125",
-                "input_cache_read": "0.000000125"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.00000125"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.0000025"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.00001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000015"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice"
-          ],
-          "status": -2,
-          "uptime_last_30m": 86.95652173913044,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 98.58532699225067,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "image": "0.00000225",
-            "audio": "0.00000225",
-            "input_audio_cache": "0.000000225",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000018",
-            "input_cache_read": "0.000000225",
-            "input_cache_write": "0.000000675",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000045",
-                "completion": "0.000027",
-                "audio": "0.0000045",
-                "input_audio_cache": "0.00000045",
-                "input_cache_read": "0.00000045"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.00000125"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.0000025"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.00001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000015"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice"
-          ],
-          "status": -2,
-          "uptime_last_30m": 86.95652173913044,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 98.58532699225067,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -3716,7 +1827,6 @@
         "completion": "0.000003",
         "image": "0.0000005",
         "audio": "0.000001",
-        "input_audio_cache": "0.0000001",
         "web_search": "0.014",
         "internal_reasoning": "0.000003",
         "input_cache_read": "0.00000005",
@@ -3724,7 +1834,7 @@
       },
       "top_provider": {
         "context_length": 1048576,
-        "max_completion_tokens": 65535,
+        "max_completion_tokens": 65536,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -3761,221 +1871,19 @@
             "response_format",
             "tools",
             "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
+            "stop",
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.55355522485573,
-          "uptime_last_5m": 99.7060984570169,
-          "uptime_last_1d": 99.6518007474178,
+          "uptime_last_30m": 99.02469091040935,
+          "uptime_last_5m": 99.39167056621432,
+          "uptime_last_1d": 99.4701165508978,
           "supports_implicit_caching": true,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3-flash-preview-20251217",
-          "model_id": "google/gemini-3-flash-preview",
-          "model_name": "Google: Gemini 3 Flash Preview",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000003",
-            "image": "0.00000025",
-            "audio": "0.0000005",
-            "input_audio_cache": "0.00000005",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000015",
-            "input_cache_read": "0.000000025",
-            "input_cache_write": "0.00000004166666666666667",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.55355522485573,
-          "uptime_last_5m": 99.7060984570169,
-          "uptime_last_1d": 99.6518007474178,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3-flash-preview-20251217",
-          "model_id": "google/gemini-3-flash-preview",
-          "model_name": "Google: Gemini 3 Flash Preview",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000003",
-            "image": "0.0000009",
-            "audio": "0.0000018",
-            "input_audio_cache": "0.00000018",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000054",
-            "input_cache_read": "0.00000009",
-            "input_cache_write": "0.000000150000000000000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.55355522485573,
-          "uptime_last_5m": 99.7060984570169,
-          "uptime_last_1d": 99.6518007474178,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "lightning | google/gemini-3-flash-preview",
-          "model_id": "google/gemini-3-flash-preview",
-          "model_name": "Google: Gemini 3 Flash Preview",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | google/gemini-3-flash-preview",
-          "model_id": "google/gemini-3-flash-preview",
-          "model_name": "Google: Gemini 3 Flash Preview",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "google/gemini-3-pro-image",
-      "name": "Google: Nano Banana Pro (Gemini 3 Pro Image)",
-      "created": 1781754054,
-      "description": "Nano Banana Pro is Google’s most advanced image-generation and editing model, built on Gemini 3 Pro. It extends the original Nano Banana with significantly improved multimodal reasoning, real-world grounding, and...",
-      "context_length": 65536,
-      "architecture": {
-        "modality": "text+image->text+image",
-        "input_modalities": [
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "image",
-          "text"
-        ],
-        "tokenizer": "Gemini",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000002",
-        "completion": "0.000012",
-        "image": "0.000002",
-        "image_output": "0.00012",
-        "audio": "0.000002",
-        "input_audio_cache": "0.0000002",
-        "web_search": "0.014",
-        "internal_reasoning": "0.000012",
-        "input_cache_read": "0.0000002",
-        "input_cache_write": "0.000000375"
-      },
-      "top_provider": {
-        "context_length": 65536,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Google AI Studio | google/gemini-3-pro-image-20260528",
-          "model_id": "google/gemini-3-pro-image",
-          "model_name": "Google: Nano Banana Pro (Gemini 3 Pro Image)",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/global",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.000002",
-            "image_output": "0.00012",
-            "audio": "0.000002",
-            "input_audio_cache": "0.0000002",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000012",
-            "input_cache_read": "0.0000002",
-            "input_cache_write": "0.000000375",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.21372897579653,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "openrouter_fallback"
-        }
-      ],
-      "pricing_source": "openrouter_fallback"
     },
     {
       "id": "google/gemini-3.1-flash-lite",
@@ -4003,7 +1911,6 @@
         "completion": "0.0000015",
         "image": "0.00000025",
         "audio": "0.0000005",
-        "input_audio_cache": "0.00000005",
         "web_search": "0.014",
         "internal_reasoning": "0.0000015",
         "input_cache_read": "0.000000025",
@@ -4046,195 +1953,18 @@
             "top_p",
             "seed",
             "response_format",
+            "stop",
             "structured_outputs",
             "tool_choice",
-            "tools",
-            "reasoning_effort"
+            "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.5834124322386,
-          "uptime_last_5m": 99.62670798704043,
-          "uptime_last_1d": 99.69470676746388,
+          "uptime_last_30m": 99.25367778973808,
+          "uptime_last_5m": 99.69955417716612,
+          "uptime_last_1d": 99.20585793625474,
           "supports_implicit_caching": true,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.1-flash-lite-20260507",
-          "model_id": "google/gemini-3.1-flash-lite",
-          "model_name": "Google: Gemini 3.1 Flash Lite",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015",
-            "image": "0.000000125",
-            "audio": "0.00000025",
-            "input_audio_cache": "0.000000025",
-            "web_search": "0.014",
-            "internal_reasoning": "0.00000075",
-            "input_cache_read": "0.0000000125",
-            "input_cache_write": "0.00000004166666666666667",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.5834124322386,
-          "uptime_last_5m": 99.62670798704043,
-          "uptime_last_1d": 99.69470676746388,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.1-flash-lite-20260507",
-          "model_id": "google/gemini-3.1-flash-lite",
-          "model_name": "Google: Gemini 3.1 Flash Lite",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015",
-            "image": "0.00000045",
-            "audio": "0.0000009",
-            "input_audio_cache": "0.00000009",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000027",
-            "input_cache_read": "0.000000045",
-            "input_cache_write": "0.000000150000000000000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.5834124322386,
-          "uptime_last_5m": 99.62670798704043,
-          "uptime_last_1d": 99.69470676746388,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "deepinfra | google/gemini-3.1-flash-lite",
-          "model_id": "google/gemini-3.1-flash-lite",
-          "model_name": "Google: Gemini 3.1 Flash Lite",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "google/gemini-3.1-flash-lite-preview",
-      "name": "Google: Gemini 3.1 Flash Lite Preview",
-      "created": 1772512673,
-      "description": "Gemini 3.1 Flash Lite Preview is Google's high-efficiency model optimized for high-volume use cases. It outperforms Gemini 2.5 Flash Lite on overall quality and approaches Gemini 2.5 Flash performance across...",
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text+image+file+audio+video->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "video",
-          "file",
-          "audio"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.0000015",
-        "image": "0.00000025",
-        "audio": "0.0000005",
-        "input_audio_cache": "0.00000005",
-        "web_search": "0.014",
-        "internal_reasoning": "0.0000015",
-        "input_cache_read": "0.000000025",
-        "input_cache_write": "0.00000008333333333333334"
-      },
-      "top_provider": {
-        "context_length": 1048576,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "lightning | google/gemini-3.1-flash-lite-preview",
-          "model_id": "google/gemini-3.1-flash-lite-preview",
-          "model_name": "Google: Gemini 3.1 Flash Lite Preview",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | google/gemini-3.1-flash-lite-preview",
-          "model_id": "google/gemini-3.1-flash-lite-preview",
-          "model_name": "Google: Gemini 3.1 Flash Lite Preview",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015",
-            "input_cache_read": "0.000000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -4265,21 +1995,10 @@
         "completion": "0.000012",
         "image": "0.000002",
         "audio": "0.000002",
-        "input_audio_cache": "0.0000002",
         "web_search": "0.014",
         "internal_reasoning": "0.000012",
         "input_cache_read": "0.0000002",
         "input_cache_write": "0.000000375",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.000004",
-            "completion": "0.000018",
-            "audio": "0.000004",
-            "input_audio_cache": "0.0000004",
-            "input_cache_read": "0.0000004"
-          }
-        ],
         "prompt_tiers": [
           {
             "max_prompt_tokens": 200000,
@@ -4326,16 +2045,6 @@
             "input_cache_read": "0.0000002",
             "input_cache_write": "0.000000375",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000004",
-                "completion": "0.000018",
-                "audio": "0.000004",
-                "input_audio_cache": "0.0000004",
-                "input_cache_read": "0.0000004"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 200000,
@@ -4370,194 +2079,16 @@
             "response_format",
             "tools",
             "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
+            "stop",
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.32533733133432,
-          "uptime_last_5m": 99.00709219858156,
-          "uptime_last_1d": 98.9863666845729,
+          "uptime_last_30m": 98.19535303406272,
+          "uptime_last_5m": 98.76543209876543,
+          "uptime_last_1d": 98.68530009571231,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.1-pro-preview-20260219",
-          "model_id": "google/gemini-3.1-pro-preview",
-          "model_name": "Google: Gemini 3.1 Pro Preview",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.000001",
-            "audio": "0.000001",
-            "input_audio_cache": "0.0000001",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000006",
-            "input_cache_read": "0.0000001",
-            "input_cache_write": "0.0000001875",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000002",
-                "completion": "0.000009",
-                "audio": "0.000002",
-                "input_audio_cache": "0.0000002",
-                "input_cache_read": "0.0000002"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.000002"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000004"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.000012"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000018"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.32533733133432,
-          "uptime_last_5m": 99.00709219858156,
-          "uptime_last_1d": 98.9863666845729,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.1-pro-preview-20260219",
-          "model_id": "google/gemini-3.1-pro-preview",
-          "model_name": "Google: Gemini 3.1 Pro Preview",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.0000036",
-            "audio": "0.0000036",
-            "input_audio_cache": "0.00000036",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000216",
-            "input_cache_read": "0.00000036",
-            "input_cache_write": "0.000000675",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000072",
-                "completion": "0.0000324",
-                "audio": "0.0000072",
-                "input_audio_cache": "0.00000072",
-                "input_cache_read": "0.00000072"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.000002"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000004"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.000012"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000018"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.32533733133432,
-          "uptime_last_5m": 99.00709219858156,
-          "uptime_last_1d": 98.9863666845729,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "lightning | google/gemini-3.1-pro-preview",
-          "model_id": "google/gemini-3.1-pro-preview",
-          "model_name": "Google: Gemini 3.1 Pro Preview",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | google/gemini-3.1-pro-preview",
-          "model_id": "google/gemini-3.1-pro-preview",
-          "model_name": "Google: Gemini 3.1 Pro Preview",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -4588,7 +2119,6 @@
         "completion": "0.000009",
         "image": "0.0000015",
         "audio": "0.000003",
-        "input_audio_cache": "0.0000003",
         "web_search": "0.014",
         "internal_reasoning": "0.000009",
         "input_cache_read": "0.00000015",
@@ -4631,153 +2161,18 @@
             "top_p",
             "seed",
             "response_format",
+            "stop",
             "structured_outputs",
             "tool_choice",
-            "tools",
-            "reasoning_effort"
+            "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.81940765711533,
-          "uptime_last_5m": 99.92625368731564,
-          "uptime_last_1d": 99.77604569269089,
+          "uptime_last_30m": 99.86970684039088,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9108011676938,
           "supports_implicit_caching": true,
           "tr_provider_slug": "gemini",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.5-flash-20260519",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/flex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009",
-            "image": "0.00000075",
-            "audio": "0.0000015",
-            "input_audio_cache": "0.00000015",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000045",
-            "input_cache_read": "0.000000075",
-            "input_cache_write": "0.00000004166666666666667",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.81940765711533,
-          "uptime_last_5m": 99.92625368731564,
-          "uptime_last_1d": 99.77604569269089,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3.5-flash-20260519",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio/priority",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009",
-            "image": "0.0000027",
-            "audio": "0.0000054",
-            "input_audio_cache": "0.00000054",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000162",
-            "input_cache_read": "0.00000027",
-            "input_cache_write": "0.000000150000000000000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.81940765711533,
-          "uptime_last_5m": 99.92625368731564,
-          "uptime_last_1d": 99.77604569269089,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "gemini",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "lightning | google/gemini-3.5-flash",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | google/gemini-3.5-flash",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009",
-            "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | google/gemini-3.5-flash",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -4844,9 +2239,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99354755452316,
+          "uptime_last_30m": 99.77109221713538,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90148440923484,
+          "uptime_last_1d": 99.93076848410102,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4916,83 +2311,12 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.84082769598089,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.79408252324245,
+          "uptime_last_30m": 98.83720930232558,
+          "uptime_last_5m": 98.78869448183042,
+          "uptime_last_1d": 98.11781353568873,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Nebius | google/gemma-3-27b-it",
-          "model_id": "google/gemma-3-27b-it",
-          "model_name": "Google: Gemma 3 27B",
-          "provider_name": "Nebius",
-          "tag": "nebius/fp8",
-          "context_length": 110000,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "logit_bias",
-            "structured_outputs",
-            "response_format",
-            "repetition_penalty"
-          ],
-          "status": -2,
-          "uptime_last_30m": 82.7491921451653,
-          "uptime_last_5m": 98.2376453488372,
-          "uptime_last_1d": 85.76685491826615,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "nebius",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | google/gemma-3-27b-it",
-          "model_id": "google/gemma-3-27b-it",
-          "model_name": "Google: Gemma 3 27B",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 98304,
-          "pricing": {
-            "prompt": "0.000000119",
-            "completion": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": -5,
-          "uptime_last_30m": 71.17339667458432,
-          "uptime_last_5m": 67.61658031088082,
-          "uptime_last_1d": 83.4895548897815,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
         },
         {
           "name": "Parasail | google/gemma-3-27b-it",
@@ -5022,33 +2346,30 @@
             "top_k",
             "logit_bias",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97294006223785,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93384626447113,
+          "uptime_last_30m": 99.92579767499382,
+          "uptime_last_5m": 99.67532467532467,
+          "uptime_last_1d": 99.83606111412581,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | google/gemma-3-27b-it",
-          "model_id": "phala/gemma-3-27b-it",
+          "model_id": "google/gemma-3-27b-it",
           "model_name": "Google: Gemma 3 27B",
           "provider_name": "Phala",
           "tag": "phala",
-          "context_length": 262144,
+          "context_length": 53920,
           "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000046",
-            "input_cache_read": "0.000000075",
+            "prompt": "0.00000011",
+            "completion": "0.0000004",
             "discount": 0
           },
           "quantization": "unknown",
-          "max_completion_tokens": 262144,
+          "max_completion_tokens": 53920,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "structured_outputs",
@@ -5064,16 +2385,16 @@
             "min_p",
             "repetition_penalty"
           ],
-          "status": -5,
-          "uptime_last_30m": 75.72173913043478,
-          "uptime_last_5m": 82.11382113821138,
-          "uptime_last_1d": 57.40676193795748,
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.86793315385788,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "google/gemma-3-4b-it",
@@ -5135,79 +2456,11 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.6716526815031,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94029952098147,
+          "uptime_last_1d": 99.98427012134127,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "google/gemma-3n-e4b-it",
-      "name": "Google: Gemma 3n 4B",
-      "created": 1747776824,
-      "description": "Gemma 3n E4B-it is optimized for efficient execution on mobile and low-resource devices, such as phones, laptops, and tablets. It supports multimodal inputs—including text, visual data, and audio—enabling diverse tasks...",
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000006",
-        "completion": "0.00000012"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Together | google/gemma-3n-e4b-it",
-          "model_id": "google/gemma-3n-E4B-it",
-          "model_name": "Google: Gemma 3n 4B",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 32768,
-          "pricing": {
-            "prompt": "0.00000006",
-            "completion": "0.00000012",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.90300678952472,
-          "uptime_last_5m": 99.2248062015504,
-          "uptime_last_1d": 99.99606155231102,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
         }
       ],
@@ -5245,7 +2498,7 @@
       "endpoints": [
         {
           "name": "DeepInfra | google/gemma-4-26b-a4b-it-20260403",
-          "model_id": "google/gemma-4-26B-A4B-it",
+          "model_id": "google/gemma-4-26b-a4b-it",
           "model_name": "Google: Gemma 4 26B A4B ",
           "provider_name": "DeepInfra",
           "tag": "deepinfra/fp8",
@@ -5278,16 +2531,16 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99107182715056,
-          "uptime_last_5m": 99.97091332169866,
-          "uptime_last_1d": 99.88557902496271,
+          "uptime_last_30m": 99.52198516748093,
+          "uptime_last_5m": 99.48364888123923,
+          "uptime_last_1d": 99.8317870261673,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Parasail | google/gemma-4-26b-a4b-it-20260403",
-          "model_id": "google/gemma-4-26B-A4B",
+          "model_id": "google/gemma-4-26b-a4b-it",
           "model_name": "Google: Gemma 4 26B A4B ",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
@@ -5315,14 +2568,12 @@
             "top_k",
             "logit_bias",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.43968358602505,
-          "uptime_last_5m": 99.8792270531401,
-          "uptime_last_1d": 99.82479684920261,
+          "uptime_last_30m": 98.81634780019355,
+          "uptime_last_5m": 98.90788224121557,
+          "uptime_last_1d": 99.4806968641115,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -5371,15 +2622,15 @@
         "input_cache_read": "0.00000009"
       },
       "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "context_length": 256000,
+        "max_completion_tokens": 8192,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
           "name": "DeepInfra | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31B-it",
+          "model_id": "google/gemma-4-31b-it",
           "model_name": "Google: Gemma 4 31B",
           "provider_name": "DeepInfra",
           "tag": "deepinfra/turbo",
@@ -5406,20 +2657,19 @@
             "seed",
             "min_p",
             "response_format",
-            "logit_bias",
-            "structured_outputs"
+            "logit_bias"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.81570788839132,
-          "uptime_last_5m": 97.43396226415094,
-          "uptime_last_1d": 93.18875812814926,
+          "status": 0,
+          "uptime_last_30m": 98.72682599955327,
+          "uptime_last_5m": 98.58956276445699,
+          "uptime_last_1d": 98.4074137171635,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
           "name": "DeepInfra | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31B-it",
+          "model_id": "google/gemma-4-31b-it",
           "model_name": "Google: Gemma 4 31B",
           "provider_name": "DeepInfra",
           "tag": "deepinfra/fp8",
@@ -5451,25 +2701,25 @@
             "structured_outputs",
             "logit_bias"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.30458109781263,
-          "uptime_last_5m": 87.68115942028986,
-          "uptime_last_1d": 96.26523137679544,
+          "status": 0,
+          "uptime_last_30m": 98.56881692347872,
+          "uptime_last_5m": 98.77232142857143,
+          "uptime_last_1d": 97.8295490278762,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Parasail | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31B",
+          "model_id": "google/gemma-4-31b-it",
           "model_name": "Google: Gemma 4 31B",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000015",
+            "prompt": "0.00000014",
             "completion": "0.0000004",
-            "input_cache_read": "0.00000006",
+            "input_cache_read": "0.0000001",
             "discount": 0
           },
           "quantization": "fp8",
@@ -5491,156 +2741,19 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 97.26477024070022,
-          "uptime_last_5m": 95.947265625,
-          "uptime_last_1d": 94.13316719037816,
+          "uptime_last_30m": 97.0950344058025,
+          "uptime_last_5m": 98.46553352219075,
+          "uptime_last_1d": 98.16275512024548,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Phala | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31b-it",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000046",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": -2,
-          "uptime_last_30m": 85.82296699907475,
-          "uptime_last_5m": 96.89497716894977,
-          "uptime_last_1d": 23.805545767160407,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31B-it",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000039",
-            "completion": "0.00000097",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "response_format"
-          ],
-          "status": -2,
-          "uptime_last_30m": 87.57549611734254,
-          "uptime_last_5m": 77.08333333333334,
-          "uptime_last_1d": 79.08934146656436,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31B-it",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000039",
-            "completion": "0.00000097",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "structured_outputs",
-            "response_format",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.88080207946528,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 92.95959803043546,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "tinfoil | google/gemma-4-31b-it",
-          "model_id": "gemma4-31b",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "tinfoil",
-          "tag": "tinfoil",
-          "tr_provider_slug": "tinfoil",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "lightning | google/gemma-4-31b-it",
-          "model_id": "lightning-ai/gemma-4-31B-it",
+          "model_id": "google/gemma-4-31b-it",
           "model_name": "Google: Gemma 4 31B",
           "provider_name": "lightning",
           "tag": "lightning",
@@ -5669,313 +2782,9 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | google/gemma-4-31b-it",
-          "model_id": "google/gemma-4-31b-it",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000014"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "gryphe/mythomax-l2-13b",
-      "name": "MythoMax 13B",
-      "created": 1688256000,
-      "description": "One of the highest performing and most popular fine-tunes of Llama 2 13B, with rich descriptions and roleplay. #merge",
-      "context_length": 4096,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama2",
-        "instruct_type": "alpaca"
-      },
-      "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000004"
-      },
-      "top_provider": {
-        "context_length": 4096,
-        "max_completion_tokens": 4096,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | gryphe/mythomax-l2-13b",
-          "model_id": "Gryphe/MythoMax-L2-13b",
-          "model_name": "MythoMax 13B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp16",
-          "context_length": 4096,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.0000004",
-            "discount": 0
-          },
-          "quantization": "fp16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97849076895501,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "inclusionai/ling-2.6-1t",
-      "name": "inclusionAI: Ling-2.6-1T",
-      "created": 1776948238,
-      "description": "Ling-2.6-1T is an instant (instruct) model from inclusionAI and the company’s trillion-parameter flagship, designed for real-world agents that require fast execution and high efficiency at scale. It uses a “fast...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000025",
-        "input_cache_read": "0.00000006"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | inclusionai/ling-2.6-1t-20260423",
-          "model_id": "inclusionai/ling-2.6-1t",
-          "model_name": "inclusionAI: Ling-2.6-1T",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025",
-            "input_cache_read": "0.00000006",
-            "discount": 0.75
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "inclusionai/ling-2.6-flash",
-      "name": "inclusionAI: Ling-2.6-flash",
-      "created": 1776795886,
-      "description": "Ling-2.6-flash is an instant (instruct) model from inclusionAI with 104B total parameters and 7.4B active parameters, designed for real-world agents that require fast responses, strong execution, and high token efficiency....",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000001",
-        "completion": "0.0000003",
-        "input_cache_read": "0.00000002"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | inclusionai/ling-2.6-flash-20260421",
-          "model_id": "inclusionai/ling-2.6-flash",
-          "model_name": "inclusionAI: Ling-2.6-flash",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000003",
-            "input_cache_read": "0.00000002",
-            "discount": 0.9
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.99873528184244,
-          "uptime_last_5m": 99.99174304351416,
-          "uptime_last_1d": 99.99994755522107,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "inclusionai/ring-2.6-1t",
-      "name": "inclusionAI: Ring-2.6-1T",
-      "created": 1778247440,
-      "description": "Ring-2.6-1T is a 1T-parameter-scale thinking model with 63B active parameters, built for real-world agent workflows that require both strong capability and operational efficiency. It is optimized for coding agents, tool...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000025",
-        "input_cache_read": "0.00000006"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | inclusionai/ring-2.6-1t-20260508",
-          "model_id": "inclusionai/ring-2.6-1t",
-          "model_name": "inclusionAI: Ring-2.6-1T",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025",
-            "input_cache_read": "0.00000006",
-            "discount": 0.75
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "meta-llama/llama-3.1-70b-instruct",
@@ -6007,7 +2816,7 @@
       "endpoints": [
         {
           "name": "DeepInfra | meta-llama/llama-3.1-70b-instruct",
-          "model_id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+          "model_id": "meta-llama/llama-3.1-70b-instruct",
           "model_name": "Meta: Llama 3.1 70B Instruct",
           "provider_name": "DeepInfra",
           "tag": "deepinfra/turbo",
@@ -6038,9 +2847,49 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.76556776556777,
-          "uptime_last_5m": 99.64141640519945,
-          "uptime_last_1d": 98.29435822343845,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.83690430974777,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "DeepInfra | meta-llama/llama-3.1-70b-instruct",
+          "model_id": "meta-llama/llama-3.1-70b-instruct",
+          "model_name": "Meta: Llama 3.1 70B Instruct",
+          "provider_name": "DeepInfra",
+          "tag": "deepinfra/base",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000004",
+            "completion": "0.0000004",
+            "discount": 0
+          },
+          "quantization": "bf16",
+          "max_completion_tokens": 16384,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "top_k",
+            "seed",
+            "min_p",
+            "tools",
+            "tool_choice",
+            "logit_bias",
+            "structured_outputs"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.96016994158258,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.9102396721026,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6082,8 +2931,8 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.00000002",
-        "completion": "0.00000005"
+        "prompt": "0.00000018",
+        "completion": "0.00000018"
       },
       "top_provider": {
         "context_length": 131072,
@@ -6092,43 +2941,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | meta-llama/llama-3.1-8b-instruct",
-          "model_id": "meta-llama/llama-3.1-8b-instruct",
-          "model_name": "Meta: Llama 3.1 8B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 16384,
-          "pricing": {
-            "prompt": "0.00000002",
-            "completion": "0.00000005",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.25092724913638,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "together | meta-llama/llama-3.1-8b-instruct",
           "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
@@ -6140,53 +2952,6 @@
           "pricing": {
             "prompt": "0.00000018",
             "completion": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "meta-llama/llama-3.2-3b-instruct",
-      "name": "Meta: Llama 3.2 3B Instruct",
-      "created": 1727222400,
-      "description": "Llama 3.2 3B is a 3-billion-parameter multilingual large language model, optimized for advanced natural language processing tasks like dialogue generation, reasoning, and summarization. Designed with the latest transformer architecture, it...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "llama3"
-      },
-      "pricing": {
-        "prompt": "0.00000006",
-        "completion": "0.00000006"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 131072,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "together | meta-llama/llama-3.2-3b-instruct",
-          "model_id": "meta-llama/Llama-3.2-3B-Instruct",
-          "model_name": "Meta: Llama 3.2 3B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000006",
-            "completion": "0.00000006"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -6213,9 +2978,9 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.00000012",
-        "completion": "0.00000038",
-        "input_cache_read": "0.00000008"
+        "prompt": "0.00000022",
+        "completion": "0.0000005",
+        "input_cache_read": "0.00000011"
       },
       "top_provider": {
         "context_length": 131072,
@@ -6225,50 +2990,11 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | meta-llama/llama-3.3-70b-instruct",
+          "name": "Parasail | meta-llama/llama-3.3-70b-instruct",
           "model_id": "meta-llama/llama-3.3-70b-instruct",
           "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 6000,
-          "pricing": {
-            "prompt": "0.000000135",
-            "completion": "0.0000004",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 120000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.65275966970883,
-          "uptime_last_5m": 98.08917197452229,
-          "uptime_last_1d": 96.83725932388462,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Parasail | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/Llama-3.3-70B-Instruct",
-          "model_name": "Meta: Llama 3.3 70B Instruct",
           "provider_name": "Parasail",
-          "tag": "parasail/fp8",
+          "tag": "parasail/int8",
           "context_length": 131072,
           "pricing": {
             "prompt": "0.00000022",
@@ -6276,7 +3002,7 @@
             "input_cache_read": "0.00000011",
             "discount": 0
           },
-          "quantization": "fp8",
+          "quantization": "int8",
           "max_completion_tokens": 16384,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -6291,37 +3017,58 @@
             "top_k",
             "logit_bias",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "response_format"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.08531222515391,
-          "uptime_last_5m": 96.72364672364672,
-          "uptime_last_1d": 99.34426079266086,
+          "status": 0,
+          "uptime_last_30m": 99.20310853530032,
+          "uptime_last_5m": 98.91826923076923,
+          "uptime_last_1d": 99.26573274550213,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/llama-3.3-70b-instruct",
+          "name": "Together | meta-llama/llama-3.3-70b-instruct",
+          "model_id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
           "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "Together",
+          "tag": "together/fp8",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000002"
+            "prompt": "0.00000104",
+            "completion": "0.00000104",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "fp8",
+          "max_completion_tokens": 2048,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "top_k",
+            "repetition_penalty",
+            "logit_bias",
+            "min_p",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.68575451771885,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "together",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "tinfoil | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "llama3-3-70b",
+          "model_id": "meta-llama/llama-3.3-70b-instruct",
           "model_name": "Meta: Llama 3.3 70B Instruct",
           "provider_name": "tinfoil",
           "tag": "tinfoil",
@@ -6334,43 +3081,9 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/Llama-3.3-70B-Instruct",
-          "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.00000075",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/llama-3.3-70b-instruct",
-          "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000012",
-            "completion": "0.00000038",
-            "input_cache_read": "0.00000008"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "meta-llama/llama-4-maverick",
@@ -6391,8 +3104,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000085"
+        "prompt": "0.00000035",
+        "completion": "0.000001",
+        "input_cache_read": "0.00000017"
       },
       "top_provider": {
         "context_length": 1048576,
@@ -6402,44 +3116,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | meta-llama/llama-4-maverick-17b-128e-instruct",
-          "model_id": "meta-llama/llama-4-maverick",
-          "model_name": "Meta: Llama 4 Maverick",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000085",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.97333570349302,
-          "uptime_last_5m": 99.94764397905759,
-          "uptime_last_1d": 99.8834716706878,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | meta-llama/llama-4-maverick-17b-128e-instruct",
-          "model_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+          "model_id": "meta-llama/llama-4-maverick",
           "model_name": "Meta: Llama 4 Maverick",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -6465,540 +3143,18 @@
             "seed",
             "stop",
             "top_k",
-            "logit_bias",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.7340425531915,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84063120493259,
+          "uptime_last_1d": 99.99626657551961,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "meta-llama/llama-4-scout",
-      "name": "Meta: Llama 4 Scout",
-      "created": 1743881519,
-      "description": "Llama 4 Scout 17B Instruct (16E) is a mixture-of-experts (MoE) language model developed by Meta, activating 17 billion parameters out of a total of 109B. It supports native multimodal input...",
-      "context_length": 10000000,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama4",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000018",
-        "completion": "0.00000059"
-      },
-      "top_provider": {
-        "context_length": 327680,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | meta-llama/llama-4-scout-17b-16e-instruct",
-          "model_id": "meta-llama/llama-4-scout",
-          "model_name": "Meta: Llama 4 Scout",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000059",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.91019938542705,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "meta-llama/llama-guard-4-12b",
-      "name": "Meta: Llama Guard 4 12B",
-      "created": 1745975193,
-      "description": "Llama Guard 4 is a Llama 4 Scout-derived multimodal pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000018",
-        "completion": "0.00000018"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | meta-llama/llama-guard-4-12b",
-          "model_id": "meta-llama/Llama-Guard-4-12B",
-          "model_name": "Meta: Llama Guard 4 12B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000018",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.45910290237467,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.78913412788123,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | meta-llama/llama-guard-4-12b",
-          "model_id": "meta-llama/Llama-Guard-4-12B",
-          "model_name": "Meta: Llama Guard 4 12B",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.79473782422093,
-          "uptime_last_5m": 99.40688018979834,
-          "uptime_last_1d": 99.94200297995738,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        }
-      ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "microsoft/phi-4",
-      "name": "Microsoft: Phi 4",
-      "created": 1736489872,
-      "description": "[Microsoft Research](/microsoft) Phi-4 is designed to perform well in complex reasoning tasks and can operate efficiently in situations with limited memory or where quick responses are needed. At 14 billion...",
-      "context_length": 16384,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000007",
-        "completion": "0.00000014"
-      },
-      "top_provider": {
-        "context_length": 16384,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | microsoft/phi-4",
-          "model_id": "microsoft/phi-4",
-          "model_name": "Microsoft: Phi 4",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 16384,
-          "pricing": {
-            "prompt": "0.00000007",
-            "completion": "0.00000014",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": 4096,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "microsoft/wizardlm-2-8x22b",
-      "name": "WizardLM-2 8x22B",
-      "created": 1713225600,
-      "description": "WizardLM-2 8x22B is Microsoft AI's most advanced Wizard model. It demonstrates highly competitive performance compared to leading proprietary models, and it consistently outperforms all existing state-of-the-art opensource models. It is...",
-      "context_length": 65536,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral",
-        "instruct_type": "vicuna"
-      },
-      "pricing": {
-        "prompt": "0.00000062",
-        "completion": "0.00000062"
-      },
-      "top_provider": {
-        "context_length": 65535,
-        "max_completion_tokens": 8000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | microsoft/wizardlm-2-8x22b",
-          "model_id": "microsoft/wizardlm-2-8x22b",
-          "model_name": "WizardLM-2 8x22B",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 65535,
-          "pricing": {
-            "prompt": "0.00000062",
-            "completion": "0.00000062",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 8000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99492153775836,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "minimax/minimax-m1",
-      "name": "MiniMax: MiniMax M1",
-      "created": 1750200414,
-      "description": "MiniMax-M1 is a large-scale, open-weight reasoning model designed for extended context and high-efficiency inference. It leverages a hybrid Mixture-of-Experts (MoE) architecture paired with a custom \"lightning attention\" mechanism, allowing it...",
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000055",
-        "completion": "0.0000022"
-      },
-      "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 40000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | minimax/minimax-m1",
-          "model_id": "minimax/minimax-m1",
-          "model_name": "MiniMax: MiniMax M1",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000055",
-            "completion": "0.0000022",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 40000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "minimax/minimax-m2",
-      "name": "MiniMax: MiniMax M2",
-      "created": 1761252093,
-      "description": "MiniMax-M2 is a compact, high-efficiency large language model optimized for end-to-end coding and agentic workflows. With 10 billion activated parameters (230 billion total), it delivers near-frontier intelligence across general reasoning,...",
-      "context_length": 204800,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000003"
-      },
-      "top_provider": {
-        "context_length": 204800,
-        "max_completion_tokens": 131072,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | minimax/minimax-m2",
-          "model_id": "minimax/minimax-m2",
-          "model_name": "MiniMax: MiniMax M2",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.3571715548413,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "minimax/minimax-m2.1",
-      "name": "MiniMax: MiniMax M2.1",
-      "created": 1766454997,
-      "description": "MiniMax-M2.1 is a lightweight, state-of-the-art large language model optimized for coding, agentic workflows, and modern application development. With only 10 billion activated parameters, it delivers a major jump in real-world...",
-      "context_length": 204800,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000003"
-      },
-      "top_provider": {
-        "context_length": 204800,
-        "max_completion_tokens": 131072,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | minimax/minimax-m2.1",
-          "model_id": "minimax/minimax-m2.1",
-          "model_name": "MiniMax: MiniMax M2.1",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.1543756145526,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "minimax/minimax-m2.5",
@@ -7019,8 +3175,7 @@
       },
       "pricing": {
         "prompt": "0.0000002",
-        "completion": "0.00000138",
-        "input_cache_read": "0.00000005"
+        "completion": "0.00000138"
       },
       "top_provider": {
         "context_length": 196608,
@@ -7030,90 +3185,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Friendli | minimax/minimax-m2.5-20260211",
-          "model_id": "MiniMaxAI/MiniMax-M2.5",
-          "model_name": "MiniMax: MiniMax M2.5",
-          "provider_name": "Friendli",
-          "tag": "friendli",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 196608,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.95204066951226,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | minimax/minimax-m2.5-20260211",
-          "model_id": "minimax/minimax-m2.5",
-          "model_name": "MiniMax: MiniMax M2.5",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131100,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.74379503602883,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | minimax/minimax-m2.5-20260211",
-          "model_id": "MiniMaxAI/MiniMax-M2.5",
+          "model_id": "minimax/minimax-m2.5",
           "model_name": "MiniMax: MiniMax M2.5",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -7143,21 +3216,19 @@
             "tools",
             "tool_choice",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.90371885906848,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94084590357882,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | minimax/minimax-m2.5-20260211",
-          "model_id": "phala/minimax-m2.5",
+          "model_id": "minimax/minimax-m2.5",
           "model_name": "MiniMax: MiniMax M2.5",
           "provider_name": "Phala",
           "tag": "phala",
@@ -7165,7 +3236,6 @@
           "pricing": {
             "prompt": "0.0000002",
             "completion": "0.00000138",
-            "input_cache_read": "0.000000075",
             "discount": 0
           },
           "quantization": "unknown",
@@ -7190,331 +3260,15 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.91568505889646,
+          "uptime_last_30m": 98.60383944153578,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 90.38110947130828,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | minimax/minimax-m2.5",
-          "model_id": "MiniMaxAI/MiniMax-M2.5",
-          "model_name": "MiniMax: MiniMax M2.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "minimax/minimax-m2.7",
-      "name": "MiniMax: MiniMax M2.7",
-      "created": 1773836697,
-      "description": "MiniMax-M2.7 is a next-generation large language model designed for autonomous, real-world productivity and continuous improvement. Built to actively participate in its own evolution, M2.7 integrates advanced agentic capabilities through multi-agent...",
-      "context_length": 204800,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.000001"
-      },
-      "top_provider": {
-        "context_length": 196608,
-        "max_completion_tokens": 196608,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | minimax/minimax-m2.7-20260318",
-          "model_id": "MiniMaxAI/MiniMax-M2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000001",
-            "input_cache_read": "0.00000005",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.92372394100508,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "DeepInfra | minimax/minimax-m2.7-20260318",
-          "model_id": "MiniMaxAI/MiniMax-M2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/turbo",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000001",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.59276632514505,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | minimax/minimax-m2.7-20260318",
-          "model_id": "MiniMaxAI/MiniMax-M2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.64581736419848,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Minimax | minimax/minimax-m2.7-20260318",
-          "model_id": "minimax/minimax-m2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "Minimax",
-          "tag": "minimax/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "response_format",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.15966386554622,
-          "uptime_last_5m": 98.87640449438202,
-          "uptime_last_1d": 98.56350806451613,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "minimax",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Minimax | minimax/minimax-m2.7-20260318",
-          "model_id": "minimax/minimax-m2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "Minimax",
-          "tag": "minimax/highspeed",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "response_format",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.31740614334471,
-          "uptime_last_5m": 98.67549668874173,
-          "uptime_last_1d": 98.55195911413969,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "minimax",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | minimax/minimax-m2.7-20260318",
-          "model_id": "minimax/minimax-m2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0.1
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85119047619048,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.21157570924007,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Together | minimax/minimax-m2.7-20260318",
-          "model_id": "MiniMaxAI/MiniMax-M2.7",
-          "model_name": "MiniMax: MiniMax M2.7",
-          "provider_name": "Together",
-          "tag": "together/fp4",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.60518113181409,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "minimax/minimax-m3",
@@ -7541,228 +3295,12 @@
         "input_cache_read": "0.00000006"
       },
       "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 131072,
+        "context_length": 524288,
+        "max_completion_tokens": 512000,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | minimax/minimax-m3-20260531",
-          "model_id": "MiniMaxAI/MiniMax-M3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 524288,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 512000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "logit_bias",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.90636704119851,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.01192454161827,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | minimax/minimax-m3-20260531",
-          "model_id": "MiniMaxAI/MiniMax-M3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.54967367657723,
-          "uptime_last_5m": 98.55595667870037,
-          "uptime_last_1d": 98.67162799369218,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Minimax | minimax/minimax-m3-20260531",
-          "model_id": "minimax/minimax-m3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "Minimax",
-          "tag": "minimax/fp8",
-          "context_length": 524288,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 512000,
-                "prompt": "0.0000003",
-                "input_cache_read": "0.00000006"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.0000006",
-                "input_cache_read": "0.00000012"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 512000,
-                "completion": "0.0000012"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000024"
-              }
-            ]
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 512000,
-          "max_prompt_tokens": 524288,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "response_format",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.90960588164397,
-          "uptime_last_5m": 99.91971095945404,
-          "uptime_last_1d": 99.76366528505632,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "minimax",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Parasail | minimax/minimax-m3-20260531",
-          "model_id": "MiniMaxAI/Minimax-M3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "Parasail",
-          "tag": "parasail/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 1048576,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "seed",
-            "stop",
-            "top_k",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.0392156862745,
-          "uptime_last_5m": 98.72611464968153,
-          "uptime_last_1d": 90.38138677997831,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | minimax/minimax-m3-20260531",
-          "model_id": "MiniMaxAI/MiniMax-M3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 524288,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000012",
-            "input_cache_read": "0.00000006",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.44388270980788,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.01134952362823,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "siliconflow | minimax/minimax-m3",
           "model_id": "minimax/minimax-m3",
@@ -7774,23 +3312,6 @@
           "pricing": {
             "prompt": "0.0000003",
             "completion": "0.0000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "wafer | minimax/minimax-m3",
-          "model_id": "MiniMax-M3",
-          "model_name": "MiniMax: MiniMax M3",
-          "provider_name": "wafer",
-          "tag": "wafer",
-          "tr_provider_slug": "wafer",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000033",
-            "completion": "0.00000132",
-            "input_cache_read": "0.00000007"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7859,9 +3380,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59503923057453,
-          "uptime_last_5m": 98.10218978102189,
-          "uptime_last_1d": 99.58405972593172,
+          "uptime_last_30m": 99.64036500268384,
+          "uptime_last_5m": 99.14529914529915,
+          "uptime_last_1d": 99.43788016306863,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7929,9 +3450,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97155858930603,
-          "uptime_last_5m": 99.85569985569985,
-          "uptime_last_1d": 99.4868964565673,
+          "uptime_last_30m": 99.98766650222002,
+          "uptime_last_5m": 99.96868149076104,
+          "uptime_last_1d": 99.9618404846828,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7999,9 +3520,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.4844095261478,
-          "uptime_last_5m": 99.4772218073189,
-          "uptime_last_1d": 98.99369430915087,
+          "uptime_last_30m": 99.98560752836978,
+          "uptime_last_5m": 99.96343425479012,
+          "uptime_last_1d": 99.94300713910573,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8070,8 +3591,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.88145639288739,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.98868138087154,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8139,13 +3660,12 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9422940340909,
+          "uptime_last_1d": 99.99420289855072,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8171,8 +3691,9 @@
         "instruct_type": "mistral"
       },
       "pricing": {
-        "prompt": "0.00000004",
-        "completion": "0.00000017"
+        "prompt": "0.00000015",
+        "completion": "0.00000015",
+        "input_cache_read": "0.000000015"
       },
       "top_provider": {
         "context_length": 131072,
@@ -8211,135 +3732,12 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.5416832298439,
+          "uptime_last_30m": 99.46433354164806,
+          "uptime_last_5m": 99.95226730310263,
+          "uptime_last_1d": 99.83095697785676,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | mistralai/mistral-nemo",
-          "model_id": "mistralai/mistral-nemo",
-          "model_name": "Mistral: Mistral Nemo",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 60288,
-          "pricing": {
-            "prompt": "0.00000004",
-            "completion": "0.00000017",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.38521677327647,
-          "uptime_last_5m": 96.58886894075404,
-          "uptime_last_1d": 81.98002885837144,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "mistralai/mistral-small-24b-instruct-2501",
-      "name": "Mistral: Mistral Small 3",
-      "created": 1738255409,
-      "description": "Mistral Small 3 is a 24B-parameter language model optimized for low-latency performance across common AI tasks. Released under the Apache 2.0 license, it features both pre-trained and instruction-tuned versions designed...",
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000008"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | mistralai/mistral-small-24b-instruct-2501",
-          "model_id": "mistralai/Mistral-Small-24B-Instruct-2501",
-          "model_name": "Mistral: Mistral Small 3",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 32768,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000008",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99847652012822,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | mistralai/mistral-small-24b-instruct-2501",
-          "model_id": "mistralai/Mistral-Small-24B-Instruct-2501",
-          "model_name": "Mistral: Mistral Small 3",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 32768,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -8403,13 +3801,12 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.93379675604105,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99523590980624,
+          "uptime_last_1d": 99.98697829918417,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8437,7 +3834,7 @@
       },
       "pricing": {
         "prompt": "0.00000009",
-        "completion": "0.0000003",
+        "completion": "0.0000006",
         "input_cache_read": "0.00000005"
       },
       "top_provider": {
@@ -8477,23 +3874,23 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94376271913322,
+          "uptime_last_30m": 99.88753213367609,
+          "uptime_last_5m": 99.4199535962877,
+          "uptime_last_1d": 99.88472303556524,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Parasail | mistralai/mistral-small-3.2-24b-instruct-2506",
-          "model_id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+          "model_id": "mistralai/mistral-small-3.2-24b-instruct",
           "model_name": "Mistral: Mistral Small 3.2 24B",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
           "context_length": 131072,
           "pricing": {
             "prompt": "0.00000009",
-            "completion": "0.0000003",
+            "completion": "0.0000006",
             "input_cache_read": "0.00000005",
             "discount": 0
           },
@@ -8512,245 +3909,18 @@
             "top_k",
             "logit_bias",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.2725619458968,
-          "uptime_last_5m": 99.8792270531401,
-          "uptime_last_1d": 99.46303467219333,
+          "uptime_last_30m": 99.35768030831346,
+          "uptime_last_5m": 98.90260631001372,
+          "uptime_last_1d": 99.68393815768502,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "moonshotai/kimi-k2",
-      "name": "MoonshotAI: Kimi K2 0711",
-      "created": 1752263252,
-      "description": "Kimi K2 Instruct is a large-scale Mixture-of-Experts (MoE) language model developed by Moonshot AI, featuring 1 trillion total parameters with 32 billion active per forward pass. It is optimized for...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000057",
-        "completion": "0.0000023"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 100352,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | moonshotai/kimi-k2",
-          "model_id": "moonshotai/kimi-k2",
-          "model_name": "MoonshotAI: Kimi K2 0711",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000057",
-            "completion": "0.0000023",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 100352,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.5712243925679,
-          "uptime_last_5m": 99.09502262443439,
-          "uptime_last_1d": 99.44841954268345,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "moonshotai/kimi-k2-0905",
-      "name": "MoonshotAI: Kimi K2 0905",
-      "created": 1757021147,
-      "description": "Kimi K2 0905 is the September update of [Kimi K2 0711](moonshotai/kimi-k2). It is a large-scale Mixture-of-Experts (MoE) language model developed by Moonshot AI, featuring 1 trillion total parameters with 32...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000006",
-        "completion": "0.0000025"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 100352,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | moonshotai/kimi-k2-0905",
-          "model_id": "moonshotai/kimi-k2-0905",
-          "model_name": "MoonshotAI: Kimi K2 0905",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000025",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 100352,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.89877809624377,
-          "uptime_last_5m": 97.50499001996008,
-          "uptime_last_1d": 98.20315242281913,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "moonshotai/kimi-k2-thinking",
-      "name": "MoonshotAI: Kimi K2 Thinking",
-      "created": 1762440622,
-      "description": "Kimi K2 Thinking is Moonshot AI’s most advanced open reasoning model to date, extending the K2 series into agentic, long-horizon reasoning. Built on the trillion-parameter Mixture-of-Experts (MoE) architecture introduced in...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000006",
-        "completion": "0.0000025",
-        "input_cache_read": "0.00000015"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 100352,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | moonshotai/kimi-k2-thinking-20251106",
-          "model_id": "moonshotai/kimi-k2-thinking",
-          "model_name": "MoonshotAI: Kimi K2 Thinking",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000025",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 100352,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.14903537914553,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "gmi | moonshotai/kimi-k2-thinking",
-          "model_id": "moonshotai/Kimi-K2-Thinking",
-          "model_name": "MoonshotAI: Kimi K2 Thinking",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000008",
-            "completion": "0.0000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -8771,59 +3941,17 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000045",
-        "completion": "0.00000225",
-        "input_cache_read": "0.000000203"
+        "prompt": "0.0000006",
+        "completion": "0.000003",
+        "input_cache_read": "0.00000009"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": null,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | moonshotai/kimi-k2.5-0127",
-          "model_id": "moonshotai/Kimi-K2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.00000225",
-            "input_cache_read": "0.00000007",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 64000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.88580129425199,
-          "uptime_last_5m": 99.40828402366864,
-          "uptime_last_1d": 99.81484246677617,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Moonshot AI | moonshotai/kimi-k2.5-0127",
           "model_id": "moonshotai/kimi-k2.5",
@@ -8855,25 +3983,25 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99259495123776,
+          "uptime_last_1d": 99.9163197422648,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Novita | moonshotai/kimi-k2.5-0127",
+          "name": "Parasail | moonshotai/kimi-k2.5-0127",
           "model_id": "moonshotai/kimi-k2.5",
           "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "Novita",
-          "tag": "novita",
+          "provider_name": "Parasail",
+          "tag": "parasail/int4",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.0000006",
-            "completion": "0.000003",
-            "input_cache_read": "0.0000001",
-            "discount": 0.05
+            "completion": "0.0000028",
+            "input_cache_read": "0.0000002",
+            "discount": 0
           },
-          "quantization": "unknown",
+          "quantization": "int4",
           "max_completion_tokens": 262144,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -8882,30 +4010,29 @@
             "max_tokens",
             "temperature",
             "top_p",
-            "stop",
             "frequency_penalty",
             "presence_penalty",
-            "seed",
-            "top_k",
             "repetition_penalty",
-            "tools",
-            "tool_choice",
+            "seed",
+            "stop",
+            "top_k",
+            "logit_bias",
             "response_format",
             "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "tools",
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.97715666067138,
+          "uptime_last_30m": 98.43260188087774,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.64051596532036,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
+          "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | moonshotai/kimi-k2.5-0127",
-          "model_id": "phala/kimi-k2.5",
+          "model_id": "moonshotai/kimi-k2.5",
           "model_name": "MoonshotAI: Kimi K2.5",
           "provider_name": "Phala",
           "tag": "phala",
@@ -8913,7 +4040,6 @@
           "pricing": {
             "prompt": "0.0000006",
             "completion": "0.000003",
-            "input_cache_read": "0.00000022",
             "discount": 0
           },
           "quantization": "unknown",
@@ -8938,65 +4064,15 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 97.87234042553192,
           "uptime_last_5m": null,
-          "uptime_last_1d": 96.796975317449,
+          "uptime_last_1d": 97.81016949152543,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | moonshotai/kimi-k2.5",
-          "model_id": "moonshotai/Kimi-K2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | moonshotai/kimi-k2.5",
-          "model_id": "moonshotai/Kimi-K2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.000003",
-            "input_cache_read": "0.00000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | moonshotai/kimi-k2.5",
-          "model_id": "kimi-k2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000574",
-            "completion": "0.000003011",
-            "input_cache_read": "0.000000115"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -9017,9 +4093,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000007",
+        "prompt": "0.0000008",
         "completion": "0.0000035",
-        "input_cache_read": "0.00000035"
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
         "context_length": 262144,
@@ -9028,92 +4104,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | moonshotai/kimi-k2.6-20260420",
-          "model_id": "moonshotai/Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000035",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tool_choice",
-            "tools",
-            "structured_outputs",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89520958083831,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Fireworks | moonshotai/kimi-k2.6-20260420",
-          "model_id": "accounts/fireworks/models/kimi-k2p6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "Fireworks",
-          "tag": "fireworks",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000016",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 0,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "fireworks",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Moonshot AI | moonshotai/kimi-k2.6-20260420",
           "model_id": "moonshotai/kimi-k2.6",
@@ -9143,65 +4133,24 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.73045822102425,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89305485656769,
+          "uptime_last_1d": 99.98373635440467,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Novita | moonshotai/kimi-k2.6-20260420",
-          "model_id": "moonshotai/kimi-k2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000008",
-            "completion": "0.0000034",
-            "input_cache_read": "0.00000016",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.79144942648593,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.43266788520427,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | moonshotai/kimi-k2.6-20260420",
-          "model_id": "moonshotai/Kimi-K2.6",
+          "model_id": "moonshotai/kimi-k2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
           "provider_name": "Parasail",
           "tag": "parasail/int4",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000075",
+            "prompt": "0.0000008",
             "completion": "0.0000035",
-            "input_cache_read": "0.00000016",
+            "input_cache_read": "0.0000002",
             "discount": 0
           },
           "quantization": "int4",
@@ -9223,21 +4172,19 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.6299722479186,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.49748743718592,
+          "uptime_last_1d": 99.33608514024269,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | moonshotai/kimi-k2.6-20260420",
-          "model_id": "phala/kimi-k2.6",
+          "model_id": "moonshotai/kimi-k2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
           "provider_name": "Phala",
           "tag": "phala",
@@ -9245,7 +4192,6 @@
           "pricing": {
             "prompt": "0.00000109",
             "completion": "0.0000046",
-            "input_cache_read": "0.00000037",
             "discount": 0
           },
           "quantization": "unknown",
@@ -9266,13 +4212,14 @@
             "repetition_penalty",
             "structured_outputs",
             "response_format",
+            "reasoning_effort",
             "tool_choice",
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.25653798256539,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 93.25330132052821,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -9312,16 +4259,16 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.63636363636364,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.73922977482488,
+          "uptime_last_1d": 97.87949233475747,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
         },
         {
           "name": "tinfoil | moonshotai/kimi-k2.6",
-          "model_id": "kimi-k2-6",
+          "model_id": "moonshotai/kimi-k2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
           "provider_name": "tinfoil",
           "tag": "tinfoil",
@@ -9334,89 +4281,22 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
-        },
-        {
-          "name": "gmi | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000855",
-            "completion": "0.0000036",
-            "input_cache_read": "0.000000144"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000016"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "wafer | moonshotai/kimi-k2.6",
-          "model_id": "Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "wafer",
-          "tag": "wafer",
-          "tr_provider_slug": "wafer",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000114",
-            "completion": "0.0000048",
-            "input_cache_read": "0.00000019"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000035",
-            "input_cache_read": "0.00000035"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "moonshotai/kimi-k2.7-code",
       "name": "MoonshotAI: Kimi K2.7 Code",
       "created": 1781266361,
-      "description": "MoonshotAI: Kimi K2.7 Code is a coding-focused model in Moonshot AI's Kimi K2 family, built to complete end-to-end programming tasks reliably over long contexts. It uses a native multimodal mixture-of-experts...",
+      "description": "MoonshotAI: Kimi K2.7 Code is a coding-focused model in Moonshot AI's Kimi K2 family, built to complete end-to-end programming tasks reliably over long contexts. It uses a native multimodal mixture-of-experts architecture.",
       "context_length": 262144,
       "architecture": {
-        "modality": "text+image->text",
+        "modality": "text+image+video->text",
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "video"
         ],
         "output_modalities": [
           "text"
@@ -9425,9 +4305,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000074",
-        "completion": "0.0000035",
-        "input_cache_read": "0.000000149"
+        "prompt": "0.00000095",
+        "completion": "0.000004",
+        "input_cache_read": "0.00000019"
       },
       "top_provider": {
         "context_length": 262144,
@@ -9436,48 +4316,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | moonshotai/kimi-k2.7-code-20260612",
-          "model_id": "moonshotai/Kimi-K2.7-Code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000074",
-            "completion": "0.0000035",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.52606635071089,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.60278053624627,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Moonshot AI | moonshotai/kimi-k2.7-code-20260612",
           "model_id": "moonshotai/kimi-k2.7-code",
@@ -9507,45 +4345,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.95719178082192,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97131265112085,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "kimi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Moonshot AI | moonshotai/kimi-k2.7-code-20260612",
-          "model_id": "moonshotai/kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "Moonshot AI",
-          "tag": "moonshotai/highspeed",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000019",
-            "discount": 0
-          },
-          "quantization": "int4",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "response_format",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.96928746928747,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.689662955161,
+          "uptime_last_1d": 99.96265870052278,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9555,15 +4357,15 @@
           "model_id": "moonshotai/kimi-k2.7-code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
           "provider_name": "Novita",
-          "tag": "novita/int4",
+          "tag": "novita",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000095",
             "completion": "0.000004",
             "input_cache_read": "0.00000019",
-            "discount": 0.04
+            "discount": 0
           },
-          "quantization": "int4",
+          "quantization": "unknown",
           "max_completion_tokens": 262144,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -9581,856 +4383,15 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.84472049689441,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.96310416922888,
+          "uptime_last_1d": 97.45519713261649,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Parasail | moonshotai/kimi-k2.7-code-20260612",
-          "model_id": "moonshotai/Kimi-K2.7-Code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "Parasail",
-          "tag": "parasail/int4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000035",
-            "input_cache_read": "0.00000016",
-            "discount": 0
-          },
-          "quantization": "int4",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "seed",
-            "stop",
-            "top_k",
-            "logit_bias",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.83393501805054,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.6631263743976,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | moonshotai/kimi-k2.7-code-20260612",
-          "model_id": "moonshotai/Kimi-K2.7-Code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000019",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.16083916083916,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 98.25969841814772,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000019"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/Kimi-K2.7-Code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000016"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | moonshotai/kimi-k2.7-code",
-          "model_id": "kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000894",
-            "completion": "0.000003713",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000082",
-            "completion": "0.00000338",
-            "input_cache_read": "0.00000016"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "nousresearch/hermes-3-llama-3.1-405b",
-      "name": "Nous: Hermes 3 405B Instruct",
-      "created": 1723766400,
-      "description": "Hermes 3 is a generalist language model with many improvements over Hermes 2, including advanced agentic capabilities, much better roleplaying, reasoning, multi-turn conversation, long context coherence, and improvements across the...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "chatml"
-      },
-      "pricing": {
-        "prompt": "0.000001",
-        "completion": "0.000001"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | nousresearch/hermes-3-llama-3.1-405b",
-          "model_id": "NousResearch/Hermes-3-Llama-3.1-405B",
-          "model_name": "Nous: Hermes 3 405B Instruct",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000001",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98746971848634,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | nousresearch/hermes-3-llama-3.1-405b",
-          "model_id": "nousresearch/hermes-3-llama-3.1-405b",
-          "model_name": "Nous: Hermes 3 405B Instruct",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "nousresearch/hermes-3-llama-3.1-70b",
-      "name": "Nous: Hermes 3 70B Instruct",
-      "created": 1723939200,
-      "description": "Hermes 3 is a generalist language model with many improvements over [Hermes 2](/models/nousresearch/nous-hermes-2-mistral-7b-dpo), including advanced agentic capabilities, much better roleplaying, reasoning, multi-turn conversation, long context coherence, and improvements across the...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "chatml"
-      },
-      "pricing": {
-        "prompt": "0.0000007",
-        "completion": "0.0000007"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | nousresearch/hermes-3-llama-3.1-70b",
-          "model_id": "NousResearch/Hermes-3-Llama-3.1-70B",
-          "model_name": "Nous: Hermes 3 70B Instruct",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000007",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "nvidia/nemotron-3-nano-30b-a3b",
-      "name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-      "created": 1765731275,
-      "description": "NVIDIA Nemotron 3 Nano 30B A3B is a small language MoE model with highest compute efficiency and accuracy for developers to build specialized agentic AI systems. The model is fully...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.0000002",
-        "input_cache_read": "0.00000003"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 228000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | nvidia/nemotron-3-nano-30b-a3b",
-          "model_id": "nvidia/Nemotron-3-Nano-30B-A3B",
-          "model_name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 228000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tool_choice",
-            "tools",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.57712305025996,
-          "uptime_last_5m": 99.95796553173602,
-          "uptime_last_1d": 99.02847039295636,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | nvidia/nemotron-3-nano-30b-a3b",
-          "model_id": "nvidia/nemotron-3-nano-30b-a3b",
-          "model_name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-          "provider_name": "Novita",
-          "tag": "novita/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.79123173277662,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 85.8350831394359,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "crusoe | nvidia/nemotron-3-nano-30b-a3b",
-          "model_id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
-          "model_name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000002",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "nvidia/nemotron-3-super-120b-a12b",
-      "name": "NVIDIA: Nemotron 3 Super",
-      "created": 1773245239,
-      "description": "NVIDIA Nemotron 3 Super is a 120B-parameter open hybrid MoE model, activating just 12B parameters for maximum compute efficiency and accuracy in complex multi-agent applications. Built on a hybrid Mamba-Transformer...",
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000009"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Nebius | nvidia/nemotron-3-super-120b-a12b-20230311",
-          "model_id": "nvidia/nemotron-3-super-120b-a12b",
-          "model_name": "NVIDIA: Nemotron 3 Super",
-          "provider_name": "Nebius",
-          "tag": "nebius/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000009",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "logit_bias",
-            "response_format",
-            "repetition_penalty",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": null,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "nebius",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "crusoe | nvidia/nemotron-3-super-120b-a12b",
-          "model_id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
-          "model_name": "NVIDIA: Nemotron 3 Super",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "nvidia/nemotron-3-ultra-550b-a55b",
-      "name": "NVIDIA: Nemotron 3 Ultra",
-      "created": 1780551208,
-      "description": "NVIDIA Nemotron 3 Ultra is an open frontier-reasoning and orchestration model from NVIDIA, with 55B active parameters out of 550B total (MoE). Built on a hybrid Transformer-Mamba mixture-of-experts architecture, it...",
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000006",
-        "completion": "0.0000036",
-        "input_cache_read": "0.0000001"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Together | nvidia/nemotron-3-ultra-550b-a55b-20260604",
-          "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
-          "model_name": "NVIDIA: Nemotron 3 Ultra",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 512288,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tool_choice",
-            "tools",
-            "structured_outputs",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.7124842370744,
-          "uptime_last_5m": 99.71910112359551,
-          "uptime_last_1d": 98.40855486216894,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | nvidia/nemotron-3-ultra-550b-a55b",
-          "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
-          "model_name": "NVIDIA: Nemotron 3 Ultra",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.0000008",
-            "completion": "0.0000026",
-            "input_cache_read": "0.0000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-3.5-turbo",
-      "name": "OpenAI: GPT-3.5 Turbo",
-      "created": 1685232000,
-      "description": "GPT-3.5 Turbo is OpenAI's fastest model. It can understand and generate natural language or code, and is optimized for chat and traditional completion tasks.\n\nTraining data up to Sep 2021.",
-      "context_length": 16385,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000005",
-        "completion": "0.0000015"
-      },
-      "top_provider": {
-        "context_length": 16385,
-        "max_completion_tokens": 4096,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-3.5-turbo",
-          "model_id": "openai/gpt-3.5-turbo",
-          "model_name": "OpenAI: GPT-3.5 Turbo",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 16385,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-3.5-turbo",
-          "model_id": "openai/gpt-3.5-turbo",
-          "model_name": "OpenAI: GPT-3.5 Turbo",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 16385,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-4",
-      "name": "OpenAI: GPT-4",
-      "created": 1685232000,
-      "description": "OpenAI's flagship model, GPT-4 is a large-scale multimodal language model capable of solving difficult problems with greater accuracy than previous models due to its broader general knowledge and advanced reasoning...",
-      "context_length": 8191,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00003",
-        "completion": "0.00006"
-      },
-      "top_provider": {
-        "context_length": 8191,
-        "max_completion_tokens": 4096,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-4",
-          "model_id": "openai/gpt-4",
-          "model_name": "OpenAI: GPT-4",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 8191,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-4",
-          "model_id": "openai/gpt-4",
-          "model_name": "OpenAI: GPT-4",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 8191,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-4-turbo",
-      "name": "OpenAI: GPT-4 Turbo",
-      "created": 1712620800,
-      "description": "The latest GPT-4 Turbo model with vision capabilities. Vision requests can now use JSON mode and function calling.\n\nTraining data: up to December 2023.",
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00001",
-        "completion": "0.00003"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 4096,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "lightning | openai/gpt-4-turbo",
-          "model_id": "openai/gpt-4-turbo",
-          "model_name": "OpenAI: GPT-4 Turbo",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-4-turbo-preview",
-      "name": "OpenAI: GPT-4 Turbo Preview",
-      "created": 1706140800,
-      "description": "The preview GPT-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Training data: up to Dec 2023. **Note:** heavily rate limited by OpenAI while...",
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00001",
-        "completion": "0.00003"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 4096,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "lightning | openai/gpt-4-turbo-preview",
-          "model_id": "openai/gpt-4-turbo-preview",
-          "model_name": "OpenAI: GPT-4 Turbo Preview",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -10495,47 +4456,15 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 98.64377338321752,
-          "uptime_last_5m": 98.49759615384616,
-          "uptime_last_1d": 99.30658891424406,
+          "uptime_last_30m": 99.30334060768843,
+          "uptime_last_5m": 99.57537154989384,
+          "uptime_last_1d": 99.39749530386626,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-4.1",
-          "model_id": "openai/gpt-4.1",
-          "model_name": "OpenAI: GPT-4.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1047576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-4.1",
-          "model_id": "openai/gpt-4.1",
-          "model_name": "OpenAI: GPT-4.1",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1047576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-4.1-mini",
@@ -10597,31 +4526,15 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8403299846983,
-          "uptime_last_5m": 99.81751824817519,
-          "uptime_last_1d": 98.20710226563295,
+          "uptime_last_30m": 99.44142588737115,
+          "uptime_last_5m": 98.62525458248473,
+          "uptime_last_1d": 99.41617756468546,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-4.1-mini",
-          "model_id": "openai/gpt-4.1-mini",
-          "model_name": "OpenAI: GPT-4.1 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1047576,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.0000016"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-4.1-nano",
@@ -10683,31 +4596,15 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.66349793892488,
-          "uptime_last_5m": 99.77740678909294,
-          "uptime_last_1d": 98.72810188171228,
+          "uptime_last_30m": 99.17916016552472,
+          "uptime_last_5m": 99.28477112676056,
+          "uptime_last_1d": 99.32174956499355,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-4.1-nano",
-          "model_id": "openai/gpt-4.1-nano",
-          "model_name": "OpenAI: GPT-4.1 Nano",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1047576,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-4o",
@@ -10730,8 +4627,7 @@
       },
       "pricing": {
         "prompt": "0.0000025",
-        "completion": "0.00001",
-        "input_cache_read": "0.00000125"
+        "completion": "0.00001"
       },
       "top_provider": {
         "context_length": 128000,
@@ -10774,64 +4670,15 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98298451590948,
+          "uptime_last_30m": 99.79002183772889,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94547028384687,
+          "uptime_last_1d": 99.92298366968552,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-4o",
-          "model_id": "openai/gpt-4o",
-          "model_name": "OpenAI: GPT-4o",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-4o",
-          "model_id": "openai/gpt-4o",
-          "model_name": "OpenAI: GPT-4o",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-4o",
-          "model_id": "openai/gpt-4o",
-          "model_name": "OpenAI: GPT-4o",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.00001",
-            "input_cache_read": "0.00000125"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-4o-mini",
@@ -10855,7 +4702,7 @@
       "pricing": {
         "prompt": "0.00000015",
         "completion": "0.0000006",
-        "input_cache_read": "0.00000008"
+        "input_cache_read": "0.000000075"
       },
       "top_provider": {
         "context_length": 128000,
@@ -10898,681 +4745,15 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98959898301167,
-          "uptime_last_5m": 99.99288829888108,
-          "uptime_last_1d": 99.95631942389728,
+          "uptime_last_30m": 99.89858012170384,
+          "uptime_last_5m": 99.88192850114793,
+          "uptime_last_1d": 99.94312506704986,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-4o-mini",
-          "model_id": "openai/gpt-4o-mini",
-          "model_name": "OpenAI: GPT-4o-mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-4o-mini",
-          "model_id": "openai/gpt-4o-mini",
-          "model_name": "OpenAI: GPT-4o-mini",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "input_cache_read": "0.00000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "openai/gpt-5",
-      "name": "OpenAI: GPT-5",
-      "created": 1754587413,
-      "description": "GPT-5 is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy...",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000013"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-5",
-          "model_id": "openai/gpt-5",
-          "model_name": "OpenAI: GPT-5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-5",
-          "model_id": "openai/gpt-5",
-          "model_name": "OpenAI: GPT-5",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5",
-          "model_id": "openai/gpt-5",
-          "model_name": "OpenAI: GPT-5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5-mini",
-      "name": "OpenAI: GPT-5 Mini",
-      "created": 1754587407,
-      "description": "GPT-5 Mini is a compact version of GPT-5, designed to handle lighter-weight reasoning tasks. It provides the same instruction-following and safety-tuning benefits as GPT-5, but with reduced latency and cost....",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.000002",
-        "web_search": "0.01",
-        "input_cache_read": "0.000000025"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-5-mini",
-          "model_id": "openai/gpt-5-mini",
-          "model_name": "OpenAI: GPT-5 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-5-mini",
-          "model_id": "openai/gpt-5-mini",
-          "model_name": "OpenAI: GPT-5 Mini",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5-nano",
-      "name": "OpenAI: GPT-5 Nano",
-      "created": 1754587402,
-      "description": "GPT-5-Nano is the smallest and fastest variant in the GPT-5 system, optimized for developer tools, rapid interactions, and ultra-low latency environments. While limited in reasoning depth compared to its larger...",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.0000004",
-        "web_search": "0.01",
-        "input_cache_read": "0.000000005"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-5-nano",
-          "model_id": "openai/gpt-5-nano",
-          "model_name": "OpenAI: GPT-5 Nano",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/gpt-5-nano",
-          "model_id": "openai/gpt-5-nano",
-          "model_name": "OpenAI: GPT-5 Nano",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.1",
-      "name": "OpenAI: GPT-5.1",
-      "created": 1763060305,
-      "description": "GPT-5.1 is the latest frontier-grade model in the GPT-5 series, offering stronger general-purpose reasoning, improved instruction adherence, and a more natural conversational style compared to GPT-5. It uses adaptive reasoning...",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "image",
-          "text",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000013"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-5.1",
-          "model_id": "openai/gpt-5.1",
-          "model_name": "OpenAI: GPT-5.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.1",
-          "model_id": "openai/gpt-5.1",
-          "model_name": "OpenAI: GPT-5.1",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.1-chat",
-      "name": "OpenAI: GPT-5.1 Chat",
-      "created": 1763060302,
-      "description": "GPT-5.1 Chat (AKA Instant is the fast, lightweight member of the 5.1 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively “think” on...",
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000125",
-        "completion": "0.00001",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000013"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 32000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "gmi | openai/gpt-5.1-chat",
-          "model_id": "openai/gpt-5.1-chat",
-          "model_name": "OpenAI: GPT-5.1 Chat",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.2",
-      "name": "OpenAI: GPT-5.2",
-      "created": 1765389775,
-      "description": "GPT-5.2 is the latest frontier-grade model in the GPT-5 series, offering stronger agentic and long context perfomance compared to GPT-5.1. It uses adaptive reasoning to allocate computation dynamically, responding quickly...",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000175",
-        "completion": "0.000014",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000018"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | openai/gpt-5.2",
-          "model_id": "openai/gpt-5.2",
-          "model_name": "OpenAI: GPT-5.2",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.2",
-          "model_id": "openai/gpt-5.2",
-          "model_name": "OpenAI: GPT-5.2",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.2-chat",
-      "name": "OpenAI: GPT-5.2 Chat",
-      "created": 1765389783,
-      "description": "GPT-5.2 Chat (AKA Instant) is the fast, lightweight member of the 5.2 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively “think” on...",
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000175",
-        "completion": "0.000014",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000018"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 16384,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "gmi | openai/gpt-5.2-chat",
-          "model_id": "openai/gpt-5.2-chat",
-          "model_name": "OpenAI: GPT-5.2 Chat",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.2-codex",
-      "name": "OpenAI: GPT-5.2-Codex",
-      "created": 1768409315,
-      "description": "GPT-5.2-Codex is an upgraded version of GPT-5.1-Codex optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks....",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000175",
-        "completion": "0.000014",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000018"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "gmi | openai/gpt-5.2-codex",
-          "model_id": "openai/gpt-5.2-codex",
-          "model_name": "OpenAI: GPT-5.2-Codex",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "openai/gpt-5.3-codex",
-      "name": "OpenAI: GPT-5.3-Codex",
-      "created": 1771959164,
-      "description": "GPT-5.3-Codex is OpenAI’s most advanced agentic coding model, combining the frontier software engineering performance of GPT-5.2-Codex with the broader reasoning and professional knowledge capabilities of GPT-5.2. It achieves state-of-the-art results...",
-      "context_length": 400000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000175",
-        "completion": "0.000014",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000018"
-      },
-      "top_provider": {
-        "context_length": 400000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "OpenAI | openai/gpt-5.3-codex-20260224",
-          "model_id": "openai/gpt-5.3-codex",
-          "model_name": "OpenAI: GPT-5.3-Codex",
-          "provider_name": "OpenAI",
-          "tag": "openai",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "web_search": "0.01",
-            "input_cache_read": "0.000000175",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 272000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.6067864271457,
-          "uptime_last_5m": 98.82352941176471,
-          "uptime_last_1d": 98.24023387119888,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.3-codex-20260224",
-          "model_id": "openai/gpt-5.3-codex",
-          "model_name": "OpenAI: GPT-5.3-Codex",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "web_search": "0.01",
-            "input_cache_read": "0.000000175",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 272000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.6067864271457,
-          "uptime_last_5m": 98.82352941176471,
-          "uptime_last_1d": 98.24023387119888,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "gmi | openai/gpt-5.3-codex",
-          "model_id": "openai/gpt-5.3-codex",
-          "model_name": "OpenAI: GPT-5.3-Codex",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "openai/gpt-5.4",
@@ -11598,12 +4779,26 @@
         "completion": "0.000015",
         "web_search": "0.01",
         "input_cache_read": "0.00000025",
-        "overrides": [
+        "prompt_tiers": [
           {
-            "min_prompt_tokens": 272000,
+            "max_prompt_tokens": 272000,
+            "prompt": "0.0000025",
+            "input_cache_read": "0.00000025"
+          },
+          {
+            "max_prompt_tokens": null,
             "prompt": "0.000005",
-            "completion": "0.0000225",
             "input_cache_read": "0.0000005"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 272000,
+            "completion": "0.000015"
+          },
+          {
+            "max_prompt_tokens": null,
+            "completion": "0.0000225"
           }
         ]
       },
@@ -11627,14 +4822,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.00000025",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000005"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 272000,
@@ -11669,176 +4856,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8133032302883,
-          "uptime_last_5m": 99.94285714285715,
-          "uptime_last_1d": 98.6584858292194,
+          "uptime_last_30m": 98.50557535348891,
+          "uptime_last_5m": 98.4577637574483,
+          "uptime_last_1d": 89.75360820265324,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-20260305",
-          "model_id": "openai/gpt-5.4",
-          "model_name": "OpenAI: GPT-5.4",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000025",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "completion": "0.00001125",
-                "input_cache_read": "0.00000025"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "input_cache_read": "0.00000025"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000015"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000225"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.8133032302883,
-          "uptime_last_5m": 99.94285714285715,
-          "uptime_last_1d": 98.6584858292194,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-20260305",
-          "model_id": "openai/gpt-5.4",
-          "model_name": "OpenAI: GPT-5.4",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000025",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "input_cache_read": "0.00000025"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000015"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000225"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.8133032302883,
-          "uptime_last_5m": 99.94285714285715,
-          "uptime_last_1d": 98.6584858292194,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-5.4",
-          "model_id": "openai/gpt-5.4",
-          "model_name": "OpenAI: GPT-5.4",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.4",
-          "model_id": "openai/gpt-5.4",
-          "model_name": "OpenAI: GPT-5.4",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "input_cache_read": "0.00000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-5.4-mini",
@@ -11897,124 +4926,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.55955428399338,
-          "uptime_last_5m": 99.66595084705321,
-          "uptime_last_1d": 90.57239232507054,
+          "status": -5,
+          "uptime_last_30m": 54.1741692584711,
+          "uptime_last_5m": 97.988552739166,
+          "uptime_last_1d": 80.53313160301649,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-mini-20260317",
-          "model_id": "openai/gpt-5.4-mini",
-          "model_name": "OpenAI: GPT-5.4 Mini",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000045",
-            "web_search": "0.01",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.55955428399338,
-          "uptime_last_5m": 99.66595084705321,
-          "uptime_last_1d": 90.57239232507054,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-mini-20260317",
-          "model_id": "openai/gpt-5.4-mini",
-          "model_name": "OpenAI: GPT-5.4 Mini",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000045",
-            "web_search": "0.01",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.55955428399338,
-          "uptime_last_5m": 99.66595084705321,
-          "uptime_last_1d": 90.57239232507054,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-5.4-mini",
-          "model_id": "openai/gpt-5.4-mini",
-          "model_name": "OpenAI: GPT-5.4 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000045"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.4-mini",
-          "model_id": "openai/gpt-5.4-mini",
-          "model_name": "OpenAI: GPT-5.4 Mini",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000045",
-            "input_cache_read": "0.000000075"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-5.4-nano",
@@ -12073,52 +4996,15 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 96.09454826184691,
-          "uptime_last_5m": 97.92207792207792,
-          "uptime_last_1d": 94.68482540343115,
+          "uptime_last_30m": 97.07233173940162,
+          "uptime_last_5m": 96.76947814646981,
+          "uptime_last_1d": 97.35171812164552,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-nano-20260317",
-          "model_id": "openai/gpt-5.4-nano",
-          "model_name": "OpenAI: GPT-5.4 Nano",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000125",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000002",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.09454826184691,
-          "uptime_last_5m": 97.92207792207792,
-          "uptime_last_1d": 94.68482540343115,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         },
         {
           "name": "gmi | openai/gpt-5.4-nano",
@@ -12138,7 +5024,7 @@
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-5.4-pro",
@@ -12163,10 +5049,23 @@
         "prompt": "0.00003",
         "completion": "0.00018",
         "web_search": "0.01",
-        "overrides": [
+        "prompt_tiers": [
           {
-            "min_prompt_tokens": 272000,
-            "prompt": "0.00006",
+            "max_prompt_tokens": 272000,
+            "prompt": "0.00003"
+          },
+          {
+            "max_prompt_tokens": null,
+            "prompt": "0.00006"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 272000,
+            "completion": "0.00018"
+          },
+          {
+            "max_prompt_tokens": null,
             "completion": "0.00027"
           }
         ]
@@ -12190,13 +5089,6 @@
             "completion": "0.00018",
             "web_search": "0.01",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00006",
-                "completion": "0.00027"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 272000,
@@ -12229,97 +5121,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 53.27313769751692,
+          "uptime_last_1d": 99.4608195542775,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.4-pro-20260305",
-          "model_id": "openai/gpt-5.4-pro",
-          "model_name": "OpenAI: GPT-5.4 Pro",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00018",
-            "web_search": "0.01",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00003",
-                "completion": "0.000135"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00006"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00018"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.00027"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 53.27313769751692,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "gmi | openai/gpt-5.4-pro",
-          "model_id": "openai/gpt-5.4-pro",
-          "model_name": "OpenAI: GPT-5.4 Pro",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-5.5",
@@ -12345,12 +5158,26 @@
         "completion": "0.00003",
         "web_search": "0.01",
         "input_cache_read": "0.0000005",
-        "overrides": [
+        "prompt_tiers": [
           {
-            "min_prompt_tokens": 272000,
+            "max_prompt_tokens": 272000,
+            "prompt": "0.000005",
+            "input_cache_read": "0.0000005"
+          },
+          {
+            "max_prompt_tokens": null,
             "prompt": "0.00001",
-            "completion": "0.000045",
             "input_cache_read": "0.000001"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 272000,
+            "completion": "0.00003"
+          },
+          {
+            "max_prompt_tokens": null,
+            "completion": "0.000045"
           }
         ]
       },
@@ -12374,14 +5201,6 @@
             "web_search": "0.01",
             "input_cache_read": "0.0000005",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00001",
-                "completion": "0.000045",
-                "input_cache_read": "0.000001"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 272000,
@@ -12416,156 +5235,15 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 97.0873786407767,
-          "uptime_last_5m": 98.65459249676584,
-          "uptime_last_1d": 94.77685835000202,
+          "status": -2,
+          "uptime_last_30m": 91.82545454545455,
+          "uptime_last_5m": 94.89990467111534,
+          "uptime_last_1d": 85.54778790436859,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.5-20260423",
-          "model_id": "openai/gpt-5.5",
-          "model_name": "OpenAI: GPT-5.5",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000005",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00001",
-                "input_cache_read": "0.000001"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000045"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.0873786407767,
-          "uptime_last_5m": 98.65459249676584,
-          "uptime_last_1d": 94.77685835000202,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.5-20260423",
-          "model_id": "openai/gpt-5.5",
-          "model_name": "OpenAI: GPT-5.5",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000005",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00001",
-                "input_cache_read": "0.000001"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000045"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.0873786407767,
-          "uptime_last_5m": 98.65459249676584,
-          "uptime_last_1d": 94.77685835000202,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/gpt-5.5",
-          "model_id": "openai/gpt-5.5",
-          "model_name": "OpenAI: GPT-5.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         },
         {
           "name": "gmi | openai/gpt-5.5",
@@ -12585,7 +5263,7 @@
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-5.5-pro",
@@ -12610,13 +5288,6 @@
         "prompt": "0.00003",
         "completion": "0.00018",
         "web_search": "0.01",
-        "overrides": [
-          {
-            "min_prompt_tokens": 272000,
-            "prompt": "0.00006",
-            "completion": "0.00027"
-          }
-        ],
         "prompt_tiers": [
           {
             "max_prompt_tokens": 272000,
@@ -12657,13 +5328,6 @@
             "completion": "0.00018",
             "web_search": "0.01",
             "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00006",
-                "completion": "0.00027"
-              }
-            ],
             "prompt_tiers": [
               {
                 "max_prompt_tokens": 272000,
@@ -12696,900 +5360,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.5-pro-20260423",
-          "model_id": "openai/gpt-5.5-pro",
-          "model_name": "OpenAI: GPT-5.5 Pro",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00018",
-            "web_search": "0.01",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00003",
-                "completion": "0.000135"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00006"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00018"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.00027"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "openai/gpt-5.6-luna",
-      "name": "OpenAI: GPT-5.6 Luna",
-      "created": 1783590864,
-      "description": "GPT-5.6 Luna is a fast, cost-efficient model in OpenAI's GPT-5.6 series. It is suited for high-volume, latency-sensitive tasks such as chat, classification, and lightweight agentic workflows, providing capable reasoning for...",
-      "context_length": 1050000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000001",
-        "completion": "0.000006",
-        "web_search": "0.01",
-        "input_cache_read": "0.0000001",
-        "input_cache_write": "0.00000125",
-        "overrides": [
-          {
-            "min_prompt_tokens": 272000,
-            "prompt": "0.000002",
-            "completion": "0.000009",
-            "input_cache_read": "0.0000002",
-            "input_cache_write": "0.0000025"
-          }
-        ]
-      },
-      "top_provider": {
-        "context_length": 1050000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "OpenAI | openai/gpt-5.6-luna-20260709",
-          "model_id": "openai/gpt-5.6-luna",
-          "model_name": "OpenAI: GPT-5.6 Luna",
-          "provider_name": "OpenAI",
-          "tag": "openai",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000006",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000001",
-            "input_cache_write": "0.00000125",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000002",
-                "completion": "0.000009",
-                "input_cache_read": "0.0000002",
-                "input_cache_write": "0.0000025"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000001",
-                "input_cache_read": "0.0000001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000002",
-                "input_cache_read": "0.0000002"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000006"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000009"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.96106677048861,
-          "uptime_last_5m": 99.9645390070922,
-          "uptime_last_1d": 99.53669560567049,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-luna-20260709",
-          "model_id": "openai/gpt-5.6-luna",
-          "model_name": "OpenAI: GPT-5.6 Luna",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000006",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000001",
-            "input_cache_write": "0.000000625",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000001",
-                "completion": "0.0000045",
-                "input_cache_read": "0.0000001",
-                "input_cache_write": "0.00000125"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000001",
-                "input_cache_read": "0.0000001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000002",
-                "input_cache_read": "0.0000002"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000006"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000009"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.96106677048861,
-          "uptime_last_5m": 99.9645390070922,
-          "uptime_last_1d": 99.53669560567049,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-luna-20260709",
-          "model_id": "openai/gpt-5.6-luna",
-          "model_name": "OpenAI: GPT-5.6 Luna",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000006",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000001",
-            "input_cache_write": "0.0000025",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000001",
-                "input_cache_read": "0.0000001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000002",
-                "input_cache_read": "0.0000002"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000006"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000009"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.96106677048861,
-          "uptime_last_5m": 99.9645390070922,
-          "uptime_last_1d": 99.53669560567049,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "lightning | openai/gpt-5.6-luna",
-          "model_id": "openai/gpt-5.6-luna",
-          "model_name": "OpenAI: GPT-5.6 Luna",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.6-luna",
-          "model_id": "openai/gpt-5.6-luna",
-          "model_name": "OpenAI: GPT-5.6 Luna",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000006",
-            "input_cache_read": "0.0000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "openai/gpt-5.6-sol",
-      "name": "OpenAI: GPT-5.6 Sol",
-      "created": 1783590850,
-      "description": "GPT-5.6 Sol is the flagship model in OpenAI's GPT-5.6 series. It is suited for complex reasoning, coding, and agentic workflows, and is particularly strong at command-line and multi-step coding tasks...",
-      "context_length": 1050000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000005",
-        "completion": "0.00003",
-        "web_search": "0.01",
-        "input_cache_read": "0.0000005",
-        "input_cache_write": "0.00000625",
-        "overrides": [
-          {
-            "min_prompt_tokens": 272000,
-            "prompt": "0.00001",
-            "completion": "0.000045",
-            "input_cache_read": "0.000001",
-            "input_cache_write": "0.0000125"
-          }
-        ]
-      },
-      "top_provider": {
-        "context_length": 1050000,
-        "max_completion_tokens": 128000,
-        "is_moderated": true
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "OpenAI | openai/gpt-5.6-sol-20260709",
-          "model_id": "openai/gpt-5.6-sol",
-          "model_name": "OpenAI: GPT-5.6 Sol",
-          "provider_name": "OpenAI",
-          "tag": "openai",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000005",
-            "input_cache_write": "0.00000625",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.00001",
-                "completion": "0.000045",
-                "input_cache_read": "0.000001",
-                "input_cache_write": "0.0000125"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00001",
-                "input_cache_read": "0.000001"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000045"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.7417615338526,
-          "uptime_last_5m": 98.71244635193133,
-          "uptime_last_1d": 96.42916342332475,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-sol-20260709",
-          "model_id": "openai/gpt-5.6-sol",
-          "model_name": "OpenAI: GPT-5.6 Sol",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000005",
-            "input_cache_write": "0.000003125",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000005",
-                "input_cache_write": "0.00000625"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00001",
-                "input_cache_read": "0.000001"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000045"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.7417615338526,
-          "uptime_last_5m": 98.71244635193133,
-          "uptime_last_1d": 96.42916342332475,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-sol-20260709",
-          "model_id": "openai/gpt-5.6-sol",
-          "model_name": "OpenAI: GPT-5.6 Sol",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "web_search": "0.01",
-            "input_cache_read": "0.0000005",
-            "input_cache_write": "0.0000125",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.00001",
-                "input_cache_read": "0.000001"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.00003"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000045"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.7417615338526,
-          "uptime_last_5m": 98.71244635193133,
-          "uptime_last_1d": 96.42916342332475,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "lightning | openai/gpt-5.6-sol",
-          "model_id": "openai/gpt-5.6-sol",
-          "model_name": "OpenAI: GPT-5.6 Sol",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.6-sol",
-          "model_id": "openai/gpt-5.6-sol",
-          "model_name": "OpenAI: GPT-5.6 Sol",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003",
-            "input_cache_read": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "openai/gpt-5.6-terra",
-      "name": "OpenAI: GPT-5.6 Terra",
-      "created": 1783590857,
-      "description": "GPT-5.6 Terra is a balanced model in OpenAI's GPT-5.6 series, positioned between the flagship Sol tier and the cost-efficient Luna tier. It is suited for everyday coding, reasoning, and agentic...",
-      "context_length": 1050000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "file",
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000025",
-        "completion": "0.000015",
-        "web_search": "0.01",
-        "input_cache_read": "0.00000025",
-        "input_cache_write": "0.000003125",
-        "overrides": [
-          {
-            "min_prompt_tokens": 272000,
-            "prompt": "0.000005",
-            "completion": "0.0000225",
-            "input_cache_read": "0.0000005",
-            "input_cache_write": "0.00000625"
-          }
-        ]
-      },
-      "top_provider": {
-        "context_length": 1050000,
-        "max_completion_tokens": 128000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "OpenAI | openai/gpt-5.6-terra-20260709",
-          "model_id": "openai/gpt-5.6-terra",
-          "model_name": "OpenAI: GPT-5.6 Terra",
-          "provider_name": "OpenAI",
-          "tag": "openai",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000025",
-            "input_cache_write": "0.000003125",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.000005",
-                "completion": "0.0000225",
-                "input_cache_read": "0.0000005",
-                "input_cache_write": "0.00000625"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "input_cache_read": "0.00000025"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000015"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000225"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.3984266543267,
-          "uptime_last_5m": 99.29203539823008,
-          "uptime_last_1d": 99.61227194094894,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-terra-20260709",
-          "model_id": "openai/gpt-5.6-terra",
-          "model_name": "OpenAI: GPT-5.6 Terra",
-          "provider_name": "OpenAI",
-          "tag": "openai/flex",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000025",
-            "input_cache_write": "0.0000015625",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "completion": "0.00001125",
-                "input_cache_read": "0.00000025",
-                "input_cache_write": "0.000003125"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "input_cache_read": "0.00000025"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000015"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000225"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.3984266543267,
-          "uptime_last_5m": 99.29203539823008,
-          "uptime_last_1d": 99.61227194094894,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "OpenAI | openai/gpt-5.6-terra-20260709",
-          "model_id": "openai/gpt-5.6-terra",
-          "model_name": "OpenAI: GPT-5.6 Terra",
-          "provider_name": "OpenAI",
-          "tag": "openai/priority",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "web_search": "0.01",
-            "input_cache_read": "0.00000025",
-            "input_cache_write": "0.00000625",
-            "discount": 0,
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "prompt": "0.0000025",
-                "input_cache_read": "0.00000025"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000005",
-                "input_cache_read": "0.0000005"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 272000,
-                "completion": "0.000015"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.0000225"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": 922000,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "seed",
-            "max_tokens",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.3984266543267,
-          "uptime_last_5m": 99.29203539823008,
-          "uptime_last_1d": 99.61227194094894,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "lightning | openai/gpt-5.6-terra",
-          "model_id": "openai/gpt-5.6-terra",
-          "model_name": "OpenAI: GPT-5.6 Terra",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | openai/gpt-5.6-terra",
-          "model_id": "openai/gpt-5.6-terra",
-          "model_name": "OpenAI: GPT-5.6 Terra",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015",
-            "input_cache_read": "0.00000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -13609,12 +5391,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000037",
-        "completion": "0.00000017"
+        "prompt": "0.0000001",
+        "completion": "0.00000075",
+        "input_cache_read": "0.000000055"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -13651,187 +5434,15 @@
             "structured_outputs",
             "frequency_penalty",
             "presence_penalty",
-            "logit_bias",
-            "reasoning_effort"
+            "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99552532665116,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96313412594962,
+          "uptime_last_1d": 99.95375266775083,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "DeepInfra | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000000037",
-            "completion": "0.00000017",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.97605937275557,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 84.7746811176634,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "DeepInfra | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/turbo",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000000037",
-            "completion": "0.00000017",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85174203113417,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95674791389598,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Nebius | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "Nebius",
-          "tag": "nebius/fp4",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "repetition_penalty",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.43490005402485,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.73803229375791,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "nebius",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "Novita",
-          "tag": "novita/fp4",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000025",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 91.96320503510046,
-          "uptime_last_5m": 95.45454545454545,
-          "uptime_last_1d": 87.06271637052197,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
         },
         {
           "name": "Parasail | openai/gpt-oss-120b",
@@ -13863,24 +5474,19 @@
             "stop",
             "top_k",
             "logit_bias",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 95.9832134292566,
-          "uptime_last_5m": 97.1252566735113,
-          "uptime_last_1d": 86.07125080545899,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9696340455936,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | openai/gpt-oss-120b",
-          "model_id": "phala/gpt-oss-120b",
+          "model_id": "openai/gpt-oss-120b",
           "model_name": "OpenAI: gpt-oss-120b",
           "provider_name": "Phala",
           "tag": "phala",
@@ -13907,149 +5513,34 @@
             "min_p",
             "repetition_penalty",
             "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.91839864269633,
+          "uptime_last_1d": 95.3918848621467,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Together | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.83812221772563,
-          "uptime_last_5m": 99.9107939339875,
-          "uptime_last_1d": 98.5679916586765,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "fireworks | openai/gpt-oss-120b",
-          "model_id": "accounts/fireworks/models/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "fireworks",
-          "tag": "fireworks",
-          "tr_provider_slug": "fireworks",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "input_cache_read": "0.000000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "tinfoil | openai/gpt-oss-120b",
-          "model_id": "gpt-oss-120b",
+          "model_id": "openai/gpt-oss-120b",
           "model_name": "OpenAI: gpt-oss-120b",
           "provider_name": "tinfoil",
           "tag": "tinfoil",
           "tr_provider_slug": "tinfoil",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006"
+            "prompt": "0.00000075",
+            "completion": "0.00000125"
           },
           "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000005",
-            "input_cache_read": "0.0000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000025",
-            "input_cache_read": "0.00000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000013",
-            "completion": "0.00000045",
-            "input_cache_read": "0.0000001"
-          },
-          "pricing_source": "self_healed_provider",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/gpt-oss-20b",
@@ -14069,8 +5560,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000003",
-        "completion": "0.00000014"
+        "prompt": "0.00000004",
+        "completion": "0.00000015"
       },
       "top_provider": {
         "context_length": 131072,
@@ -14079,90 +5570,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | openai/gpt-oss-20b",
-          "model_id": "openai/gpt-oss-20b",
-          "model_name": "OpenAI: gpt-oss-20b",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000003",
-            "completion": "0.00000014",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.99530064146244,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.91533574685445,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | openai/gpt-oss-20b",
-          "model_id": "openai/gpt-oss-20b",
-          "model_name": "OpenAI: gpt-oss-20b",
-          "provider_name": "Novita",
-          "tag": "novita/fp4",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000004",
-            "completion": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.85601540490036,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "Parasail | openai/gpt-oss-20b",
           "model_id": "openai/gpt-oss-20b",
@@ -14193,24 +5600,19 @@
             "top_k",
             "logit_bias",
             "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.02174300481198,
-          "uptime_last_5m": 98.04353816478368,
-          "uptime_last_1d": 94.03623150234,
+          "uptime_last_30m": 99.29560359485062,
+          "uptime_last_5m": 98.74326750448833,
+          "uptime_last_1d": 99.4761515068853,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | openai/gpt-oss-20b",
-          "model_id": "phala/gpt-oss-20b",
+          "model_id": "openai/gpt-oss-20b",
           "model_name": "OpenAI: gpt-oss-20b",
           "provider_name": "Phala",
           "tag": "phala",
@@ -14235,59 +5637,18 @@
             "seed",
             "top_k",
             "min_p",
-            "repetition_penalty",
-            "reasoning_effort"
+            "repetition_penalty"
           ],
           "status": 0,
-          "uptime_last_30m": 99.09228441754917,
-          "uptime_last_5m": 96.67590027700831,
-          "uptime_last_1d": 99.35331830682308,
+          "uptime_last_30m": 95.9319526627219,
+          "uptime_last_5m": 95.81151832460732,
+          "uptime_last_1d": 97.41001064962727,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | openai/gpt-oss-20b",
-          "model_id": "openai/gpt-oss-20b",
-          "model_name": "OpenAI: gpt-oss-20b",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 98.93238434163702,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/o1",
@@ -14354,10 +5715,10 @@
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/o3",
@@ -14421,45 +5782,13 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96049215487075,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/o3",
-          "model_id": "openai/o3",
-          "model_name": "OpenAI: o3",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "lightning | openai/o3",
-          "model_id": "openai/o3",
-          "model_name": "OpenAI: o3",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/o3-mini",
@@ -14525,26 +5854,10 @@
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "lightning | openai/o3-mini",
-          "model_id": "openai/o3-mini",
-          "model_name": "OpenAI: o3 Mini",
-          "provider_name": "lightning",
-          "tag": "lightning",
-          "tr_provider_slug": "lightning",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.0000011",
-            "completion": "0.0000044"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "openai/o4-mini",
@@ -14608,29 +5921,13 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99333860861701,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | openai/o4-mini",
-          "model_id": "openai/o4-mini",
-          "model_name": "OpenAI: o4 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.0000011",
-            "completion": "0.0000044"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen-2.5-72b-instruct",
@@ -14650,8 +5947,8 @@
         "instruct_type": "chatml"
       },
       "pricing": {
-        "prompt": "0.00000038",
-        "completion": "0.0000004"
+        "prompt": "0.0000012",
+        "completion": "0.0000012"
       },
       "top_provider": {
         "context_length": 32768,
@@ -14660,43 +5957,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | qwen/qwen-2.5-72b-instruct",
-          "model_id": "qwen/qwen-2.5-72b-instruct",
-          "model_name": "Qwen2.5 72B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 32000,
-          "pricing": {
-            "prompt": "0.00000038",
-            "completion": "0.0000004",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 45.728406683925634,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "together | qwen/qwen-2.5-72b-instruct",
           "model_id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
@@ -14714,7 +5974,7 @@
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen-2.5-7b-instruct",
@@ -14746,7 +6006,7 @@
       "endpoints": [
         {
           "name": "Phala | qwen/qwen-2.5-7b-instruct",
-          "model_id": "phala/qwen-2.5-7b-instruct",
+          "model_id": "qwen/qwen-2.5-7b-instruct",
           "model_name": "Qwen: Qwen2.5 7B Instruct",
           "provider_name": "Phala",
           "tag": "phala",
@@ -14769,18 +6029,12 @@
             "seed",
             "top_k",
             "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "repetition_penalty"
           ],
-          "status": 0,
-          "uptime_last_30m": 97.39397321428571,
-          "uptime_last_5m": 96.97910602238179,
-          "uptime_last_1d": 99.5303212834421,
+          "status": -5,
+          "uptime_last_30m": 78.3955132894416,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 82.56999892937841,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -14810,14 +6064,12 @@
             "top_k",
             "repetition_penalty",
             "logit_bias",
-            "min_p",
-            "response_format",
-            "structured_outputs"
+            "min_p"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9594709111676,
+          "uptime_last_30m": 99.98080429983683,
+          "uptime_last_5m": 99.93351063829788,
+          "uptime_last_1d": 99.88584586264427,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -14857,7 +6109,7 @@
       "endpoints": [
         {
           "name": "Parasail | qwen/qwen2.5-vl-72b-instruct",
-          "model_id": "Qwen/Qwen2.5-VL-72B-Instruct",
+          "model_id": "qwen/qwen2.5-vl-72b-instruct",
           "model_name": "Qwen: Qwen2.5 VL 72B Instruct",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -14883,105 +6135,14 @@
             "top_k",
             "logit_bias",
             "structured_outputs",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.10714285714286,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.55210957634726,
+          "uptime_last_1d": 99.33055417180113,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen2.5-vl-72b-instruct",
-          "model_id": "Qwen/Qwen2.5-VL-72B-Instruct",
-          "model_name": "Qwen: Qwen2.5 VL 72B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000195",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "qwen/qwen3-14b",
-      "name": "Qwen: Qwen3 14B",
-      "created": 1745876478,
-      "description": "Qwen3-14B is a dense 14.8B parameter causal language model from the Qwen3 series, designed for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for...",
-      "context_length": 131702,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": "qwen3"
-      },
-      "pricing": {
-        "prompt": "0.00000012",
-        "completion": "0.00000024"
-      },
-      "top_provider": {
-        "context_length": 40960,
-        "max_completion_tokens": 40960,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3-14b-04-28",
-          "model_id": "Qwen/Qwen3-14B",
-          "model_name": "Qwen: Qwen3 14B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 40960,
-          "pricing": {
-            "prompt": "0.00000012",
-            "completion": "0.00000024",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.8221695317131,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.57947457947458,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         }
       ],
@@ -15005,8 +6166,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000009",
-        "completion": "0.00000058"
+        "prompt": "0.0000001",
+        "completion": "0.0000006",
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 262144,
@@ -15016,93 +6178,15 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Friendli | qwen/qwen3-235b-a22b-07-25",
-          "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
-          "provider_name": "Friendli",
-          "tag": "friendli",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000008",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.87730061349693,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.49731255558562,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-235b-a22b-07-25",
-          "model_id": "qwen/qwen3-235b-a22b-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.00000058",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.54275262917238,
-          "uptime_last_5m": 99.66914805624482,
-          "uptime_last_1d": 99.20350926553529,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | qwen/qwen3-235b-a22b-07-25",
-          "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+          "model_id": "qwen/qwen3-235b-a22b-2507",
           "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.0000008",
+            "prompt": "0.0000001",
+            "completion": "0.0000006",
             "input_cache_read": "0.00000005",
             "discount": 0
           },
@@ -15123,37 +6207,18 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94132603168394,
-          "uptime_last_5m": 99.89071038251366,
-          "uptime_last_1d": 99.8921940939699,
+          "uptime_last_30m": 99.44984412250137,
+          "uptime_last_5m": 99.57983193277312,
+          "uptime_last_1d": 99.7895814376706,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "crusoe | qwen/qwen3-235b-a22b-2507",
-          "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000022",
-            "completion": "0.0000008",
-            "input_cache_read": "0.00000011"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -15173,234 +6238,29 @@
         "instruct_type": "qwen3"
       },
       "pricing": {
-        "prompt": "0.00000023",
-        "completion": "0.0000023",
-        "input_cache_read": "0.000000023"
+        "prompt": "0.00000045",
+        "completion": "0.0000035",
+        "input_cache_read": "0"
       },
       "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": null,
+        "context_length": 262144,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3-235b-a22b-thinking-2507",
-          "model_id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000023",
-            "completion": "0.0000023",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.96578076879206,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-235b-a22b-thinking-2507",
-          "model_id": "qwen/qwen3-235b-a22b-thinking-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.000003",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 74.51798847147685,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Venice | qwen/qwen3-235b-a22b-thinking-2507",
+          "name": "venice | qwen/qwen3-235b-a22b-thinking-2507",
           "model_id": "qwen3-235b-a22b-thinking-2507",
           "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
-          "provider_name": "Venice",
-          "tag": "venice/fp8",
-          "context_length": 128000,
+          "provider_name": "venice",
+          "tag": "venice",
+          "tr_provider_slug": "venice",
+          "context_length": 262144,
           "pricing": {
             "prompt": "0.00000045",
             "completion": "0.0000035",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 88.27433628318585,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-235b-a22b-thinking-2507",
-          "model_id": "qwen3-235b-a22b-thinking-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000023",
-            "completion": "0.0000023",
-            "input_cache_read": "0.000000023"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "qwen/qwen3-30b-a3b",
-      "name": "Qwen: Qwen3 30B A3B",
-      "created": 1745878604,
-      "description": "Qwen3, the latest generation in the Qwen large language model series, features both dense and mixture-of-experts (MoE) architectures to excel in reasoning, multilingual support, and advanced agent tasks. Its unique...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": "qwen3"
-      },
-      "pricing": {
-        "prompt": "0.00000012",
-        "completion": "0.0000005"
-      },
-      "top_provider": {
-        "context_length": 40960,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3-30b-a3b-04-28",
-          "model_id": "Qwen/Qwen3-30B-A3B",
-          "model_name": "Qwen: Qwen3 30B A3B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 40960,
-          "pricing": {
-            "prompt": "0.00000012",
-            "completion": "0.0000005",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93622729471787,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-30b-a3b",
-          "model_id": "qwen3-30b-a3b",
-          "model_name": "Qwen: Qwen3 30B A3B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000002"
+            "input_cache_read": "0"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15438,163 +6298,16 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Phala | qwen/qwen3-30b-a3b-instruct-2507",
-          "model_id": "phala/qwen3-30b-a3b-instruct-2507",
+          "name": "phala | qwen/qwen3-30b-a3b-instruct-2507",
+          "model_id": "qwen/qwen3-30b-a3b-instruct-2507",
           "model_name": "Qwen: Qwen3 30B A3B Instruct 2507",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000055",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "structured_outputs",
-            "tools",
-            "logprobs",
-            "top_logprobs",
-            "tool_choice"
-          ],
-          "status": -5,
-          "uptime_last_30m": 53.6986301369863,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 62.471752121729516,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-30b-a3b-instruct-2507",
-          "model_id": "qwen3-30b-a3b-instruct-2507",
-          "model_name": "Qwen: Qwen3 30B A3B Instruct 2507",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000008",
-            "input_cache_read": "0.00000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "qwen/qwen3-32b",
-      "name": "Qwen: Qwen3 32B",
-      "created": 1745875945,
-      "description": "Qwen3-32B is a dense 32.8B parameter causal language model from the Qwen3 series, optimized for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": "qwen3"
-      },
-      "pricing": {
-        "prompt": "0.00000008",
-        "completion": "0.00000028"
-      },
-      "top_provider": {
-        "context_length": 40960,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3-32b-04-28",
-          "model_id": "Qwen/Qwen3-32B",
-          "model_name": "Qwen: Qwen3 32B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 40960,
-          "pricing": {
-            "prompt": "0.00000008",
-            "completion": "0.00000028",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.93441189331001,
-          "uptime_last_5m": 99.85013113525665,
-          "uptime_last_1d": 99.92233239794682,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen3-32b",
-          "model_id": "qwen/qwen3-32b",
-          "model_name": "Qwen: Qwen3 32B",
           "provider_name": "phala",
           "tag": "phala",
           "tr_provider_slug": "phala",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000012",
-            "completion": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-32b",
-          "model_id": "qwen3-32b",
-          "model_name": "Qwen: Qwen3 32B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000016",
-            "completion": "0.00000064",
-            "input_cache_read": "0.000000016"
+            "prompt": "0.00000015",
+            "completion": "0.00000055"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15602,161 +6315,6 @@
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "qwen/qwen3-coder",
-      "name": "Qwen: Qwen3 Coder 480B A35B",
-      "created": 1753230546,
-      "description": "Qwen3-Coder-480B-A35B-Instruct is a Mixture-of-Experts (MoE) code generation model developed by the Qwen team. It is optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning over...",
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000038",
-        "completion": "0.00000155"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | qwen/qwen3-coder-480b-a35b-07-25",
-          "model_id": "qwen/qwen3-coder",
-          "model_name": "Qwen: Qwen3 Coder 480B A35B",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000038",
-            "completion": "0.00000155",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.5981468184771,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "qwen/qwen3-coder-30b-a3b-instruct",
-      "name": "Qwen: Qwen3 Coder 30B A3B Instruct",
-      "created": 1753972379,
-      "description": "Qwen3-Coder-30B-A3B-Instruct is a 30.5B parameter Mixture-of-Experts (MoE) model with 128 experts (8 active per forward pass), designed for advanced code generation, repository-scale understanding, and agentic tool use. Built on the...",
-      "context_length": 160000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000007",
-        "completion": "0.00000027"
-      },
-      "top_provider": {
-        "context_length": 160000,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | qwen/qwen3-coder-30b-a3b-instruct",
-          "model_id": "qwen/qwen3-coder-30b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 Coder 30B A3B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 160000,
-          "pricing": {
-            "prompt": "0.00000007",
-            "completion": "0.00000027",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": -5,
-          "uptime_last_30m": 70.38383838383838,
-          "uptime_last_5m": 88.23529411764706,
-          "uptime_last_1d": 76.74804481082224,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-coder-30b-a3b-instruct",
-          "model_id": "qwen3-coder-30b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 Coder 30B A3B Instruct",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 160000,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.00000225",
-            "input_cache_read": "0.000000045"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
     },
     {
       "id": "qwen/qwen3-coder-next",
@@ -15788,45 +6346,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | qwen/qwen3-coder-next-2025-02-03",
-          "model_id": "qwen/qwen3-coder-next",
-          "model_name": "Qwen: Qwen3 Coder Next",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000015",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.82512705612329,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | qwen/qwen3-coder-next-2025-02-03",
-          "model_id": "Qwen/Qwen3-Coder-Next",
+          "model_id": "qwen/qwen3-coder-next",
           "model_name": "Qwen: Qwen3 Coder Next",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
@@ -15854,37 +6375,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99705449189985,
+          "uptime_last_30m": 98.29931972789116,
+          "uptime_last_5m": 97.22222222222221,
+          "uptime_last_1d": 99.7080291970803,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-coder-next",
-          "model_id": "qwen3-coder-next",
-          "model_name": "Qwen: Qwen3 Coder Next",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000015",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3-next-80b-a3b-instruct",
@@ -15904,8 +6406,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000009",
-        "completion": "0.0000011"
+        "prompt": "0.0000001",
+        "completion": "0.0000011",
+        "input_cache_read": "0.00000007"
       },
       "top_provider": {
         "context_length": 262144,
@@ -15915,87 +6418,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3-next-80b-a3b-instruct-2509",
-          "model_id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.0000011",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.68527918781726,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.10044356345557,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-next-80b-a3b-instruct-2509",
-          "model_id": "qwen/qwen3-next-80b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000015",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 83.95648114318192,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | qwen/qwen3-next-80b-a3b-instruct-2509",
-          "model_id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+          "model_id": "qwen/qwen3-next-80b-a3b-instruct",
           "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -16023,69 +6447,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.92050874403816,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84952996737333,
+          "uptime_last_1d": 99.99448001766395,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen3-next-80b-a3b-instruct",
-          "model_id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | qwen/qwen3-next-80b-a3b-instruct",
-          "model_id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-next-80b-a3b-instruct",
-          "model_id": "qwen3-next-80b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000012",
-            "input_cache_read": "0.000000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3-vl-235b-a22b-instruct",
@@ -16106,9 +6479,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.00000088",
-        "input_cache_read": "0.00000011"
+        "prompt": "0.00000021",
+        "completion": "0.0000019",
+        "input_cache_read": "0.0000001"
       },
       "top_provider": {
         "context_length": 262144,
@@ -16118,89 +6491,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3-vl-235b-a22b-instruct",
-          "model_id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-          "model_name": "Qwen: Qwen3 VL 235B A22B Instruct",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000088",
-            "input_cache_read": "0.00000011",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.2743105950653,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 95.64220183486239,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-vl-235b-a22b-instruct",
-          "model_id": "qwen/qwen3-vl-235b-a22b-instruct",
-          "model_name": "Qwen: Qwen3 VL 235B A22B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000015",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": -2,
-          "uptime_last_30m": 93.25513196480938,
-          "uptime_last_5m": 87.5,
-          "uptime_last_1d": 97.0148044487,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | qwen/qwen3-vl-235b-a22b-instruct",
-          "model_id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+          "model_id": "qwen/qwen3-vl-235b-a22b-instruct",
           "model_name": "Qwen: Qwen3 VL 235B A22B Instruct",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -16228,127 +6520,18 @@
             "top_k",
             "logit_bias",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.32785660941,
-          "uptime_last_5m": 98.17708333333334,
-          "uptime_last_1d": 99.3639545894645,
+          "uptime_last_30m": 98.8255033557047,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.29114987731504,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-vl-235b-a22b-instruct",
-          "model_id": "qwen3-vl-235b-a22b-instruct",
-          "model_name": "Qwen: Qwen3 VL 235B A22B Instruct",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000084",
-            "input_cache_read": "0.00000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "qwen/qwen3-vl-235b-a22b-thinking",
-      "name": "Qwen: Qwen3 VL 235B A22B Thinking",
-      "created": 1758668690,
-      "description": "Qwen3-VL-235B-A22B Thinking is a multimodal model that unifies strong text generation with visual understanding across images and video. The Thinking model is optimized for multimodal reasoning in STEM and math....",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000007",
-        "completion": "0.0000084",
-        "input_cache_read": "0.00000007"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | qwen/qwen3-vl-235b-a22b-thinking",
-          "model_id": "qwen/qwen3-vl-235b-a22b-thinking",
-          "model_name": "Qwen: Qwen3 VL 235B A22B Thinking",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000098",
-            "completion": "0.00000395",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 95.4995499549955,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-vl-235b-a22b-thinking",
-          "model_id": "qwen3-vl-235b-a22b-thinking",
-          "model_name": "Qwen: Qwen3 VL 235B A22B Thinking",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000084",
-            "input_cache_read": "0.00000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3-vl-30b-a3b-instruct",
@@ -16369,8 +6552,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.0000006"
+        "prompt": "0.0000002",
+        "completion": "0.0000007"
       },
       "top_provider": {
         "context_length": 131072,
@@ -16380,88 +6563,8 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3-vl-30b-a3b-instruct",
-          "model_id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
-          "model_name": "Qwen: Qwen3 VL 30B A3B Instruct",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.96113486202876,
-          "uptime_last_5m": 99.81785063752277,
-          "uptime_last_1d": 99.76306799397568,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-vl-30b-a3b-instruct",
-          "model_id": "qwen/qwen3-vl-30b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 VL 30B A3B Instruct",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000007",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.86524822695036,
-          "uptime_last_5m": 99.01960784313727,
-          "uptime_last_1d": 97.17175887696119,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Phala | qwen/qwen3-vl-30b-a3b-instruct",
-          "model_id": "phala/qwen3-vl-30b-a3b-instruct",
+          "model_id": "qwen/qwen3-vl-30b-a3b-instruct",
           "model_name": "Qwen: Qwen3 VL 30B A3B Instruct",
           "provider_name": "Phala",
           "tag": "phala",
@@ -16472,7 +6575,7 @@
             "discount": 0
           },
           "quantization": "unknown",
-          "max_completion_tokens": 32768,
+          "max_completion_tokens": 128000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "max_tokens",
@@ -16491,79 +6594,12 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.74572405929305,
-          "uptime_last_5m": 98.14814814814815,
-          "uptime_last_1d": 98.33153928955866,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.83169983169982,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-vl-30b-a3b-instruct",
-          "model_id": "qwen3-vl-30b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 VL 30B A3B Instruct",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "qwen/qwen3-vl-30b-a3b-thinking",
-      "name": "Qwen: Qwen3 VL 30B A3B Thinking",
-      "created": 1759794479,
-      "description": "Qwen3-VL-30B-A3B-Thinking is a multimodal model that unifies strong text generation with visual understanding for images and videos. Its Thinking variant enhances reasoning in STEM, math, and complex tasks. It excels...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000024",
-        "input_cache_read": "0.00000002"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "alibaba | qwen/qwen3-vl-30b-a3b-thinking",
-          "model_id": "qwen3-vl-30b-a3b-thinking",
-          "model_name": "Qwen: Qwen3 VL 30B A3B Thinking",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -16587,9 +6623,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.0000004",
-        "input_cache_read": "0.000000005"
+        "prompt": "0.00000025",
+        "completion": "0.00000075",
+        "input_cache_read": "0.00000012"
       },
       "top_provider": {
         "context_length": 131072,
@@ -16600,7 +6636,7 @@
       "endpoints": [
         {
           "name": "Parasail | qwen/qwen3-vl-8b-instruct",
-          "model_id": "Qwen/Qwen3-VL-8B-Instruct",
+          "model_id": "qwen/qwen3-vl-8b-instruct",
           "model_name": "Qwen: Qwen3 VL 8B Instruct",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
@@ -16628,216 +6664,18 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.81246552675124,
-          "uptime_last_5m": 99.70523212969786,
-          "uptime_last_1d": 99.64050621523144,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen3-vl-8b-instruct",
-          "model_id": "Qwen/Qwen3-VL-8B-Instruct",
-          "model_name": "Qwen: Qwen3 VL 8B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 256000,
-          "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000068"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3-vl-8b-instruct",
-          "model_id": "qwen3-vl-8b-instruct",
-          "model_name": "Qwen: Qwen3 VL 8B Instruct",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 256000,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000004",
-            "input_cache_read": "0.000000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "qwen/qwen3.5-122b-a10b",
-      "name": "Qwen: Qwen3.5-122B-A10B",
-      "created": 1772053789,
-      "description": "The Qwen3.5 122B-A10B native vision-language model is built on a hybrid architecture that integrates a linear attention mechanism with a sparse mixture-of-experts model, achieving higher inference efficiency. In terms of...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text+image+video->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "video"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000029",
-        "completion": "0.0000024"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 262144,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3.5-122b-a10b-20260224",
-          "model_id": "Qwen/Qwen3.5-122B-A10B",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000029",
-            "completion": "0.0000024",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 81920,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "logit_bias",
-            "tools",
-            "tool_choice"
-          ],
-          "status": -2,
-          "uptime_last_30m": 87.71929824561403,
-          "uptime_last_5m": 60.29411764705882,
-          "uptime_last_1d": 87.71222731623759,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3.5-122b-a10b-20260224",
-          "model_id": "qwen/qwen3.5-122b-a10b",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.0000032",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.70983342289091,
+          "uptime_last_1d": 99.81774849292023,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "phala | qwen/qwen3.5-122b-a10b",
-          "model_id": "qwen/qwen3.5-122b-a10b",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000046",
-            "completion": "0.00000368"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | qwen/qwen3.5-122b-a10b",
-          "model_id": "Qwen/Qwen3.5-122B-A10B",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.0000032"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3.5-122b-a10b",
-          "model_id": "qwen3.5-122b-a10b",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.0000032",
-            "input_cache_read": "0.00000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.5-27b",
@@ -16871,7 +6709,7 @@
       "endpoints": [
         {
           "name": "DeepInfra | qwen/qwen3.5-27b-20260224",
-          "model_id": "Qwen/Qwen3.5-27B",
+          "model_id": "qwen/qwen3.5-27b",
           "model_name": "Qwen: Qwen3.5-27B",
           "provider_name": "DeepInfra",
           "tag": "deepinfra/fp8",
@@ -16906,55 +6744,14 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.94866867965962,
+          "uptime_last_1d": 99.57472051869057,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Novita | qwen/qwen3.5-27b-20260224",
-          "model_id": "qwen/qwen3.5-27b",
-          "model_name": "Qwen: Qwen3.5-27B",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.70193740685544,
-          "uptime_last_5m": 99.07407407407408,
-          "uptime_last_1d": 99.45533451781085,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Phala | qwen/qwen3.5-27b-20260224",
-          "model_id": "phala/qwen3.5-27b",
+          "model_id": "qwen/qwen3.5-27b",
           "model_name": "Qwen: Qwen3.5-27B",
           "provider_name": "Phala",
           "tag": "phala",
@@ -16962,11 +6759,10 @@
           "pricing": {
             "prompt": "0.0000003",
             "completion": "0.0000024",
-            "input_cache_read": "0.00000015",
             "discount": 0
           },
           "quantization": "unknown",
-          "max_completion_tokens": 65536,
+          "max_completion_tokens": 262144,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -16980,55 +6776,18 @@
             "seed",
             "top_k",
             "min_p",
-            "repetition_penalty",
-            "response_format",
-            "logprobs",
-            "top_logprobs",
-            "structured_outputs"
+            "repetition_penalty"
           ],
           "status": 0,
-          "uptime_last_30m": 98.45559845559846,
-          "uptime_last_5m": 98.4375,
-          "uptime_last_1d": 92.62242526248296,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.9515503875969,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | qwen/qwen3.5-27b",
-          "model_id": "Qwen/Qwen3.5-27B",
-          "model_name": "Qwen: Qwen3.5-27B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3.5-27b",
-          "model_id": "qwen3.5-27b",
-          "model_name": "Qwen: Qwen3.5-27B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.5-35b-a3b",
@@ -17050,61 +6809,20 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000014",
+        "prompt": "0.00000015",
         "completion": "0.000001",
         "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 81920,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3.5-35b-a3b-20260224",
-          "model_id": "Qwen/Qwen3.5-35B-A3B",
-          "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.000001",
-            "input_cache_read": "0.00000005",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 81920,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85865724381625,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.42810298050085,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Parasail | qwen/qwen3.5-35b-a3b-20260224",
-          "model_id": "Qwen/Qwen3.5-35B-A3B-FP8",
+          "model_id": "qwen/qwen3.5-35b-a3b",
           "model_name": "Qwen: Qwen3.5-35B-A3B",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -17134,76 +6852,25 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.7314180156531,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.99506915509973,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | qwen/qwen3.5-35b-a3b",
-          "model_id": "Qwen/Qwen3.5-35B-A3B",
-          "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3.5-35b-a3b",
-          "model_id": "qwen3.5-35b-a3b",
-          "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002",
-            "input_cache_read": "0.000000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "novita | qwen/qwen3.5-35b-a3b",
-          "model_id": "qwen/qwen3.5-35b-a3b",
-          "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.5-397b-a17b",
       "name": "Qwen: Qwen3.5 397B A17B",
       "created": 1771223018,
       "description": "The Qwen3.5 series 397B-A17B native vision-language model is built on a hybrid architecture that integrates a linear attention mechanism with a sparse mixture-of-experts model, achieving higher inference efficiency. It delivers...",
-      "context_length": 256000,
+      "context_length": 262144,
       "architecture": {
         "modality": "text+image+video->text",
         "input_modalities": [
@@ -17218,138 +6885,20 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000045",
-        "completion": "0.000003",
-        "input_cache_read": "0.000000111"
+        "prompt": "0.0000005",
+        "completion": "0.0000036",
+        "input_cache_read": "0.0000003"
       },
       "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": null,
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "Qwen/Qwen3.5-397B-A17B",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.000003",
-            "input_cache_read": "0.00000022",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 81920,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.0246913580247,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.0300610230577,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "Qwen/Qwen3.5-397B-A17B",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.24242424242425,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 97.29219991917014,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "qwen/qwen3.5-397b-a17b",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.58156028368793,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.3412237606074,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "Qwen/Qwen3.5-397B-A17B",
+          "model_id": "qwen/qwen3.5-397b-a17b",
           "model_name": "Qwen: Qwen3.5 397B A17B",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -17379,21 +6928,19 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.5846313603323,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.82027318475917,
+          "uptime_last_1d": 96.89803909572026,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "phala/qwen3.5-397b-a17b",
+          "model_id": "qwen/qwen3.5-397b-a17b",
           "model_name": "Qwen: Qwen3.5 397B A17B",
           "provider_name": "Phala",
           "tag": "phala",
@@ -17401,7 +6948,6 @@
           "pricing": {
             "prompt": "0.00000055",
             "completion": "0.0000035",
-            "input_cache_read": "0.000000225",
             "discount": 0
           },
           "quantization": "unknown",
@@ -17421,13 +6967,12 @@
             "min_p",
             "repetition_penalty",
             "tools",
-            "tool_choice",
-            "structured_outputs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.96907216494846,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.50135434622014,
+          "uptime_last_30m": 99.73821989528795,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 90.71642910727682,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -17442,7 +6987,8 @@
           "pricing": {
             "prompt": "0.00000075",
             "completion": "0.0000045",
-            "discount": 0
+            "discount": 0,
+            "input_cache_read": "0"
           },
           "quantization": "unknown",
           "max_completion_tokens": 32768,
@@ -17460,53 +7006,18 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.02483900643975,
+          "uptime_last_1d": 85.55435175153485,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "together | qwen/qwen3.5-397b-a17b",
-          "model_id": "Qwen/Qwen3.5-397B-A17B",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 256000,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3.5-397b-a17b",
-          "model_id": "qwen3.5-397b-a17b",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 256000,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036",
-            "input_cache_read": "0.00000006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.5-9b",
@@ -17529,7 +7040,8 @@
       },
       "pricing": {
         "prompt": "0.0000001",
-        "completion": "0.00000015"
+        "completion": "0.00000015",
+        "input_cache_read": "0"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17538,89 +7050,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3.5-9b-20260310",
-          "model_id": "Qwen/Qwen3.5-9B",
-          "model_name": "Qwen: Qwen3.5-9B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 81920,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.68111343250759,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | qwen/qwen3.5-9b-20260310",
-          "model_id": "Qwen/Qwen3.5-9B",
-          "model_name": "Qwen: Qwen3.5-9B",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000017",
-            "completion": "0.00000025",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.98021733073278,
-          "uptime_last_5m": 99.86741796486575,
-          "uptime_last_1d": 97.59837533799586,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Venice | qwen/qwen3.5-9b-20260310",
           "model_id": "qwen3-5-9b",
@@ -17631,7 +7060,8 @@
           "pricing": {
             "prompt": "0.0000001",
             "completion": "0.00000015",
-            "discount": 0
+            "discount": 0,
+            "input_cache_read": "0"
           },
           "quantization": "fp8",
           "max_completion_tokens": 32768,
@@ -17654,15 +7084,15 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.65568125922283,
-          "uptime_last_5m": 99.84848484848486,
-          "uptime_last_1d": 99.77308366386865,
+          "uptime_last_30m": 99.94059405940594,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.82388386398803,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.6-27b",
@@ -17684,9 +7114,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000282",
-        "input_cache_read": "0.0000003"
+        "prompt": "0.00000033",
+        "completion": "0.00000325",
+        "input_cache_read": "0"
       },
       "top_provider": {
         "context_length": 131072,
@@ -17695,89 +7125,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | qwen/qwen3.6-27b-20260422",
-          "model_id": "Qwen/Qwen3.6-27B",
-          "model_name": "Qwen: Qwen3.6 27B",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000032",
-            "completion": "0.0000032",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 81920,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.59116925592805,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 97.77349715396363,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | qwen/qwen3.6-27b-20260422",
-          "model_id": "qwen/qwen3.6-27b",
-          "model_name": "Qwen: Qwen3.6 27B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000032",
-            "completion": "0.0000027",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262140,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.42765273311898,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.89017760057992,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Venice | qwen/qwen3.6-27b-20260422",
           "model_id": "qwen3-6-27b",
@@ -17788,7 +7135,8 @@
           "pricing": {
             "prompt": "0.00000033",
             "completion": "0.00000325",
-            "discount": 0
+            "discount": 0,
+            "input_cache_read": "0"
           },
           "quantization": "fp8",
           "max_completion_tokens": 65536,
@@ -17809,48 +7157,15 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 97.17223650385604,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.69321145084105,
+          "uptime_last_1d": 91.52038887388603,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "novita | qwen/qwen3.6-27b",
-          "model_id": "qwen/qwen3.6-27b",
-          "model_name": "Qwen: Qwen3.6 27B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | qwen/qwen3.6-27b",
-          "model_id": "qwen/qwen3.6-27b",
-          "model_name": "Qwen: Qwen3.6 27B",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000282",
-            "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
@@ -17872,20 +7187,20 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000014",
-        "completion": "0.00000085",
-        "input_cache_read": "0.00000011"
+        "prompt": "0.00000015",
+        "completion": "0.000001",
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "context_length": 262140,
+        "max_completion_tokens": 262140,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
           "name": "Parasail | qwen/qwen3.6-35b-a3b-20260415",
-          "model_id": "Qwen/Qwen3.6-35B-A3B",
+          "model_id": "qwen/qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -17915,266 +7230,29 @@
             "structured_outputs",
             "response_format",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.0971797485559,
-          "uptime_last_5m": 98.71559633027523,
-          "uptime_last_1d": 99.62451197223665,
+          "uptime_last_30m": 99.85001874765655,
+          "uptime_last_5m": 99.68253968253968,
+          "uptime_last_1d": 97.9989193778704,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen/qwen3.6-35b-a3b",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000127"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | qwen/qwen3.6-35b-a3b",
-          "model_id": "Qwen/Qwen3.6-35B-A3B",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000248",
-            "completion": "0.000001485"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | qwen/qwen3.6-35b-a3b",
-          "model_id": "Qwen/Qwen3.6-35B-A3B",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000095"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen3.6-35b-a3b",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000375",
-            "completion": "0.00000225",
-            "input_cache_read": "0.0000000375"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "novita | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen/qwen3.6-35b-a3b",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000248",
-            "completion": "0.000001485"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen/qwen3.6-35b-a3b",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000085",
-            "input_cache_read": "0.00000011"
-          },
-          "pricing_source": "self_healed_provider",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
-      "id": "sao10k/l3-lunaris-8b",
-      "name": "Sao10K: Llama 3 8B Lunaris",
-      "created": 1723507200,
-      "description": "Lunaris 8B is a versatile generalist and roleplaying model based on Llama 3. It's a strategic merge of multiple models, designed to balance creativity with improved logic and general knowledge....",
-      "context_length": 8192,
+      "id": "stepfun/step-3.5-flash",
+      "name": "StepFun: Step 3.5 Flash",
+      "created": 1769728337,
+      "description": "Step 3.5 Flash is StepFun's most capable open-source foundation model. Built on a sparse Mixture of Experts (MoE) architecture, it selectively activates only 11B of its 196B parameters per token....",
+      "context_length": 262144,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
           "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "llama3"
-      },
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000005"
-      },
-      "top_provider": {
-        "context_length": 8192,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | sao10k/l3-lunaris-8b",
-          "model_id": "sao10k/l3-lunaris-8b",
-          "model_name": "Sao10K: Llama 3 8B Lunaris",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 8192,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000005",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97170945611428,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "sao10k/l3.1-euryale-70b",
-      "name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
-      "created": 1724803200,
-      "description": "Euryale L3.1 70B v2.2 is a model focused on creative roleplay from [Sao10k](https://ko-fi.com/sao10k). It is the successor of [Euryale L3 70B v2.1](/models/sao10k/l3-euryale-70b).",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "llama3"
-      },
-      "pricing": {
-        "prompt": "0.00000148",
-        "completion": "0.00000148"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | sao10k/l3.1-euryale-70b",
-          "model_id": "sao10k/l3.1-euryale-70b",
-          "model_name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 8192,
-          "pricing": {
-            "prompt": "0.00000148",
-            "completion": "0.00000148",
-            "discount": 0.02
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.88642816581488,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "stepfun/step-3.7-flash",
-      "name": "StepFun: Step 3.7 Flash",
-      "created": 1779985069,
-      "description": "Step 3.7 Flash is StepFun's latest high-efficiency multimodal Mixture-of-Experts model. It pairs a 196B-parameter language backbone with a vision encoder for native image and video understanding, activating roughly 11B parameters...",
-      "context_length": 256000,
-      "architecture": {
-        "modality": "text+image+video->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "video"
         ],
         "output_modalities": [
           "text"
@@ -18183,62 +7261,36 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.00000115",
-        "input_cache_read": "0.00000004"
+        "prompt": "0.0000001",
+        "completion": "0.0000003",
+        "input_cache_read": "0.00000003"
       },
       "top_provider": {
-        "context_length": 256000,
-        "max_completion_tokens": 256000,
+        "context_length": 262144,
+        "max_completion_tokens": 16384,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | stepfun/step-3.7-flash-20260528",
-          "model_id": "stepfun/step-3.7-flash",
-          "model_name": "StepFun: Step 3.7 Flash",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
+          "name": "parasail | stepfun/step-3.5-flash",
+          "model_id": "stepfun/step-3.5-flash",
+          "model_name": "StepFun: Step 3.5 Flash",
+          "provider_name": "parasail",
+          "tag": "parasail",
+          "tr_provider_slug": "parasail",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000115",
-            "input_cache_read": "0.00000004",
-            "discount": 0
+            "prompt": "0.0000001",
+            "completion": "0.0000003",
+            "input_cache_read": "0.00000003"
           },
-          "quantization": "fp8",
-          "max_completion_tokens": 256000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.61832061068702,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.34791059280855,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "tencent/hunyuan-a13b-instruct",
@@ -18306,115 +7358,6 @@
       "pricing_source": "provider_direct"
     },
     {
-      "id": "tencent/hy3",
-      "name": "Tencent: Hy3",
-      "created": 1783344048,
-      "description": "Hy3 is a 295B-parameter Mixture-of-Experts model from Tencent (21B active, 192 experts with top-8 routing) built for reasoning, agentic workflows, and real-world production use. It supports a configurable reasoning effort:...",
-      "context_length": 262144,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000014",
-        "completion": "0.00000058",
-        "input_cache_read": "0.000000035"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | tencent/hy3-20260706",
-          "model_id": "tencent/Hy3",
-          "model_name": "Tencent: Hy3",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp8",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000058",
-            "input_cache_read": "0.000000035",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85272459499264,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.48546794604367,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | tencent/hy3-20260706",
-          "model_id": "tencent/Hy3",
-          "model_name": "Tencent: Hy3",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000058",
-            "input_cache_read": "0.000000035",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.8193315266486,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.77274687365244,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
       "id": "tencent/hy3-preview",
       "name": "Tencent: Hy3 preview",
       "created": 1776878150,
@@ -18432,8 +7375,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000063",
-        "completion": "0.00000021",
+        "prompt": "0.000000066",
+        "completion": "0.00000026",
         "input_cache_read": "0.000000021"
       },
       "top_provider": {
@@ -18443,41 +7386,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "GMICloud | tencent/hy3-preview-20260421",
-          "model_id": "tencent/hy3-preview",
-          "model_name": "Tencent: Hy3 preview",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/bf16",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000063",
-            "completion": "0.00000021",
-            "input_cache_read": "0.000000021",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.58769425943545,
-          "uptime_last_5m": 99.81684981684981,
-          "uptime_last_1d": 98.2025962498613,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "SiliconFlow | tencent/hy3-preview-20260421",
           "model_id": "tencent/hy3-preview",
@@ -18505,13 +7413,12 @@
             "tool_choice",
             "stop",
             "presence_penalty",
-            "max_tokens",
-            "reasoning_effort"
+            "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70184853905785,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8257099755408,
+          "uptime_last_30m": 96.03118355776046,
+          "uptime_last_5m": 94.68390804597702,
+          "uptime_last_1d": 96.91597996002956,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -18550,7 +7457,7 @@
       "endpoints": [
         {
           "name": "Parasail | thedrummer/cydonia-24b-v4.1",
-          "model_id": "TheDrummer/Cydonia-24B-v4.1",
+          "model_id": "thedrummer/cydonia-24b-v4.1",
           "model_name": "TheDrummer: Cydonia 24B V4.1",
           "provider_name": "Parasail",
           "tag": "parasail/bf16",
@@ -18574,16 +7481,12 @@
             "seed",
             "stop",
             "top_k",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "logit_bias"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97929520891134,
+          "uptime_last_1d": 99.9984978895348,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -18622,7 +7525,7 @@
       "endpoints": [
         {
           "name": "Parasail | thedrummer/skyfall-36b-v2",
-          "model_id": "TheDrummer/Skyfall-36B-v2",
+          "model_id": "thedrummer/skyfall-36b-v2",
           "model_name": "TheDrummer: Skyfall 36B V2",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -18646,14 +7549,10 @@
             "seed",
             "stop",
             "top_k",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -18686,15 +7585,7 @@
         "prompt": "0.00000125",
         "completion": "0.0000025",
         "web_search": "0.005",
-        "input_cache_read": "0.0000002",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.0000025",
-            "completion": "0.000005",
-            "input_cache_read": "0.0000004"
-          }
-        ]
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
         "context_length": 2000000,
@@ -18715,15 +7606,7 @@
             "completion": "0.0000025",
             "web_search": "0.005",
             "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
+            "discount": 0
           },
           "quantization": "unknown",
           "max_completion_tokens": null,
@@ -18743,150 +7626,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85211475894705,
-          "uptime_last_5m": 99.68193384223919,
-          "uptime_last_1d": 99.81527973757994,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-20260309",
-          "model_id": "x-ai/grok-4.20",
-          "model_name": "xAI: Grok 4.20",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.85211475894705,
-          "uptime_last_5m": 99.68193384223919,
-          "uptime_last_1d": 99.81527973757994,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-20260309",
-          "model_id": "x-ai/grok-4.20",
-          "model_name": "xAI: Grok 4.20",
-          "provider_name": "xAI",
-          "tag": "xai/zdr",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.84217568819406,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-20260309",
-          "model_id": "x-ai/grok-4.20",
-          "model_name": "xAI: Grok 4.20",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.84217568819406,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.99966643984575,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18917,15 +7659,7 @@
         "prompt": "0.00000125",
         "completion": "0.0000025",
         "web_search": "0.005",
-        "input_cache_read": "0.0000002",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.0000025",
-            "completion": "0.000005",
-            "input_cache_read": "0.0000004"
-          }
-        ]
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
         "context_length": 2000000,
@@ -18946,15 +7680,7 @@
             "completion": "0.0000025",
             "web_search": "0.005",
             "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
+            "discount": 0
           },
           "quantization": "unknown",
           "max_completion_tokens": null,
@@ -18969,151 +7695,12 @@
             "logprobs",
             "top_logprobs",
             "response_format",
-            "structured_outputs",
-            "reasoning_effort"
+            "structured_outputs"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 70.86519114688129,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
-          "model_id": "x-ai/grok-4.20-multi-agent",
-          "model_name": "xAI: Grok 4.20 Multi-Agent",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 70.86519114688129,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
-          "model_id": "x-ai/grok-4.20-multi-agent",
-          "model_name": "xAI: Grok 4.20 Multi-Agent",
-          "provider_name": "xAI",
-          "tag": "xai/zdr",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 95.35655058043118,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
-          "model_id": "x-ai/grok-4.20-multi-agent",
-          "model_name": "xAI: Grok 4.20 Multi-Agent",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 95.35655058043118,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19128,11 +7715,10 @@
       "description": "Grok 4.3 is a reasoning model from xAI. It accepts text and image inputs with text output, and is suited for agentic workflows, instruction-following tasks, and applications requiring high factual...",
       "context_length": 1000000,
       "architecture": {
-        "modality": "text+image+file->text",
+        "modality": "text+image->text",
         "input_modalities": [
           "text",
-          "image",
-          "file"
+          "image"
         ],
         "output_modalities": [
           "text"
@@ -19144,15 +7730,7 @@
         "prompt": "0.00000125",
         "completion": "0.0000025",
         "web_search": "0.005",
-        "input_cache_read": "0.0000002",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.0000025",
-            "completion": "0.000005",
-            "input_cache_read": "0.0000004"
-          }
-        ]
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -19173,563 +7751,45 @@
             "completion": "0.0000025",
             "web_search": "0.005",
             "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94206916096735,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.3-20260430",
-          "model_id": "x-ai/grok-4.3",
-          "model_name": "xAI: Grok 4.3",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94206916096735,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.3-20260430",
-          "model_id": "x-ai/grok-4.3",
-          "model_name": "xAI: Grok 4.3",
-          "provider_name": "xAI",
-          "tag": "xai/zdr",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000002",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000005",
-                "input_cache_read": "0.0000004"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93489150431103,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.3-20260430",
-          "model_id": "x-ai/grok-4.3",
-          "model_name": "xAI: Grok 4.3",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93489150431103,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "x-ai/grok-4.5",
-      "name": "xAI: Grok 4.5",
-      "created": 1783523154,
-      "description": "Grok 4.5 is SpaceXAI's smartest model with frontier performance on coding, knowledge work, and STEM.",
-      "context_length": 500000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Grok",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000018",
-        "completion": "0.0000054",
-        "web_search": "0.005",
-        "input_cache_read": "0.00000045",
-        "overrides": [
-          {
-            "min_prompt_tokens": 200000,
-            "prompt": "0.000004",
-            "completion": "0.000012",
-            "input_cache_read": "0.000001"
-          }
-        ]
-      },
-      "top_provider": {
-        "context_length": 500000,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000005",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000004",
-                "completion": "0.000012",
-                "input_cache_read": "0.000001"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.94544462629568,
-          "uptime_last_5m": 99.96765847347994,
-          "uptime_last_1d": 99.72150637452913,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.000001",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000008",
-                "completion": "0.000024",
-                "input_cache_read": "0.000002"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.94544462629568,
-          "uptime_last_5m": 99.96765847347994,
-          "uptime_last_1d": 99.72150637452913,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai/zdr",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000005",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000004",
-                "completion": "0.000012",
-                "input_cache_read": "0.000001"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.87490524886415,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.000001",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000008",
-                "completion": "0.000024",
-                "input_cache_read": "0.000002"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.87490524886415,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "gmi | x-ai/grok-4.5",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.0000018",
-            "completion": "0.0000054",
-            "input_cache_read": "0.00000045"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "xiaomi/mimo-v2.5",
-      "name": "Xiaomi: MiMo-V2.5",
-      "created": 1776874269,
-      "description": "MiMo-V2.5 is a native omnimodal model by Xiaomi. It delivers Pro-level agentic performance at roughly half the inference cost, while surpassing MiMo-V2-Omni in multimodal perception across image and video understanding...",
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text+image+audio+video->text",
-        "input_modalities": [
-          "text",
-          "audio",
-          "image",
-          "video"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000014",
-        "completion": "0.00000028",
-        "input_cache_read": "0.0000000028"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | xiaomi/mimo-v2.5-20260422",
-          "model_id": "xiaomi/mimo-v2.5",
-          "model_name": "Xiaomi: MiMo-V2.5",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000000168",
-            "completion": "0.000000336",
-            "input_cache_read": "0.0000000034",
             "discount": 0
           },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
+          "quantization": "unknown",
+          "max_completion_tokens": null,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
             "include_reasoning",
+            "structured_outputs",
+            "response_format",
             "max_tokens",
             "temperature",
             "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
             "stop",
             "frequency_penalty",
             "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
             "tools",
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97932175351531,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.87350159628939,
+          "uptime_last_1d": 99.99981799749929,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "xiaomi | xiaomi/mimo-v2.5",
-          "model_id": "xiaomi/mimo-v2.5",
-          "model_name": "Xiaomi: MiMo-V2.5",
-          "provider_name": "xiaomi",
-          "tag": "xiaomi",
-          "tr_provider_slug": "xiaomi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
-            "input_cache_read": "0.0000000028"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
-      "id": "xiaomi/mimo-v2.5-pro",
-      "name": "Xiaomi: MiMo-V2.5-Pro",
-      "created": 1776874273,
-      "description": "MiMo-V2.5-Pro is Xiaomi’s flagship model, delivering strong performance in general agentic capabilities, complex software engineering, and long-horizon tasks, with top rankings on benchmarks such as ClawEval, GDPVal, and SWE-bench Pro....",
-      "context_length": 1048576,
+      "id": "z-ai/glm-4-32b",
+      "name": "Z.ai: GLM 4 32B ",
+      "created": 1753376617,
+      "description": "GLM 4 32B is a cost-effective foundation language model. It can efficiently perform complex tasks and has significantly enhanced capabilities in tool use, online search, and code-related intelligent tasks. It...",
+      "context_length": 128000,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -19742,76 +7802,48 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000435",
-        "completion": "0.00000087",
-        "input_cache_read": "0.0000000036"
+        "prompt": "0.0000001",
+        "completion": "0.0000001"
       },
       "top_provider": {
-        "context_length": 1048576,
-        "max_completion_tokens": 131072,
+        "context_length": 128000,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | xiaomi/mimo-v2.5-pro-20260422",
-          "model_id": "xiaomi/mimo-v2.5-pro",
-          "model_name": "Xiaomi: MiMo-V2.5-Pro",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 1048576,
+          "name": "Z.AI | z-ai/glm-4-32b-0414",
+          "model_id": "z-ai/glm-4-32b",
+          "model_name": "Z.ai: GLM 4 32B ",
+          "provider_name": "Z.AI",
+          "tag": "z-ai",
+          "context_length": 128000,
           "pricing": {
-            "prompt": "0.000000522",
-            "completion": "0.000001044",
-            "input_cache_read": "0.0000000043",
-            "discount": 0.08
+            "prompt": "0.0000001",
+            "completion": "0.0000001",
+            "discount": 0
           },
           "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
+          "max_completion_tokens": null,
+          "max_prompt_tokens": 4095,
           "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
             "max_tokens",
             "temperature",
             "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
             "tools",
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49664429530202,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.62644160005962,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "xiaomi | xiaomi/mimo-v2.5-pro",
-          "model_id": "xiaomi/mimo-v2.5-pro",
-          "model_name": "Xiaomi: MiMo-V2.5-Pro",
-          "provider_name": "xiaomi",
-          "tag": "xiaomi",
-          "tr_provider_slug": "xiaomi",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000000435",
-            "completion": "0.00000087",
-            "input_cache_read": "0.0000000036"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "tr_provider_slug": "zai",
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.5",
@@ -19856,7 +7888,7 @@
             "discount": 0
           },
           "quantization": "fp8",
-          "max_completion_tokens": 98304,
+          "max_completion_tokens": 96000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -19866,13 +7898,12 @@
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
-            "top_k"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90880904614262,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.38998211091234,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -19898,56 +7929,17 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000013",
-        "completion": "0.00000085",
-        "input_cache_read": "0.000000025"
+        "prompt": "0.0000002",
+        "completion": "0.0000011",
+        "input_cache_read": "0.00000003"
       },
       "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 98304,
+        "context_length": 131070,
+        "max_completion_tokens": 131070,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | z-ai/glm-4.5-air",
-          "model_id": "z-ai/glm-4.5-air",
-          "model_name": "Z.ai: GLM 4.5 Air",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000013",
-            "completion": "0.00000085",
-            "input_cache_read": "0.000000025",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 98304,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.93430656934306,
-          "uptime_last_5m": 97.6303317535545,
-          "uptime_last_1d": 97.49592963498603,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "Z.AI | z-ai/glm-4.5-air",
           "model_id": "z-ai/glm-4.5-air",
@@ -19962,7 +7954,7 @@
             "discount": 0
           },
           "quantization": "fp8",
-          "max_completion_tokens": 98304,
+          "max_completion_tokens": 96000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -19971,19 +7963,81 @@
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
-            "top_k"
+            "tool_choice"
           ],
-          "status": -2,
-          "uptime_last_30m": 87.32394366197182,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 94.7701624002202,
+          "status": 0,
+          "uptime_last_30m": 99.98861818434747,
+          "uptime_last_5m": 99.98199900994554,
+          "uptime_last_1d": 99.98893722656408,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "z-ai/glm-4.5-air:free",
+      "name": "Z.ai: GLM 4.5 Air (free)",
+      "created": 1753471258,
+      "description": "GLM-4.5-Air is the lightweight variant of our latest flagship model family, also purpose-built for agent-centric applications. Like GLM-4.5, it adopts the Mixture-of-Experts (MoE) architecture but with a more compact parameter...",
+      "context_length": 131072,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0",
+        "completion": "0"
+      },
+      "top_provider": {
+        "context_length": 131072,
+        "max_completion_tokens": 96000,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "Z.AI | z-ai/glm-4.5-air:free",
+          "model_id": "z-ai/glm-4.5-air:free",
+          "model_name": "Z.ai: GLM 4.5 Air",
+          "provider_name": "Z.AI",
+          "tag": "z-ai",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 96000,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.159233806112,
+          "uptime_last_5m": 98.83040935672514,
+          "uptime_last_1d": 98.98440822219229,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "zai",
+          "pricing_source": "provider_direct"
+        }
+      ],
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.5v",
@@ -20016,46 +8070,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | z-ai/glm-4.5v",
-          "model_id": "z-ai/glm-4.5v",
-          "model_name": "Z.ai: GLM 4.5V",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 65536,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000018",
-            "input_cache_read": "0.00000011",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 87.82172002510985,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Z.AI | z-ai/glm-4.5v",
           "model_id": "z-ai/glm-4.5v",
           "model_name": "Z.ai: GLM 4.5V",
@@ -20078,27 +8092,25 @@
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
-            "top_k",
-            "response_format"
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 90.3379343169919,
+          "uptime_last_1d": 85.4881266490765,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.6",
       "name": "Z.ai: GLM 4.6",
       "created": 1759235576,
       "description": "Compared with GLM-4.5, this generation brings several key improvements: Longer context window: The context window has been expanded from 128K to 200K tokens, enabling the model to handle more complex...",
-      "context_length": 200000,
+      "context_length": 202752,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -20111,99 +8123,17 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000043",
-        "completion": "0.00000175",
-        "input_cache_read": "0.00000008"
+        "prompt": "0.0000006",
+        "completion": "0.0000022",
+        "input_cache_read": "0.00000011"
       },
       "top_provider": {
-        "context_length": 198000,
-        "max_completion_tokens": 16384,
+        "context_length": 202752,
+        "max_completion_tokens": 131072,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "DeepInfra | z-ai/glm-4.6",
-          "model_id": "zai-org/GLM-4.6",
-          "model_name": "Z.ai: GLM 4.6",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000002",
-            "input_cache_read": "0.0000001",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94577706628108,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-4.6",
-          "model_id": "z-ai/glm-4.6",
-          "model_name": "Z.ai: GLM 4.6",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000055",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000011",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.36842105263158,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.01695750764073,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "Venice | z-ai/glm-4.6",
           "model_id": "zai-org-glm-4.6",
@@ -20212,9 +8142,9 @@
           "tag": "venice/fp4",
           "context_length": 198000,
           "pricing": {
-            "prompt": "0.00000043",
-            "completion": "0.00000175",
-            "input_cache_read": "0.00000008",
+            "prompt": "0.00000085",
+            "completion": "0.00000275",
+            "input_cache_read": "0.0000003",
             "discount": 0
           },
           "quantization": "fp4",
@@ -20236,28 +8166,28 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70930232558139,
-          "uptime_last_5m": 98.07692307692307,
-          "uptime_last_1d": 99.1103404078863,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.23273657289002,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         },
         {
           "name": "Z.AI | z-ai/glm-4.6",
           "model_id": "z-ai/glm-4.6",
           "model_name": "Z.ai: GLM 4.6",
           "provider_name": "Z.AI",
-          "tag": "z-ai/fp4",
-          "context_length": 202752,
+          "tag": "z-ai",
+          "context_length": 200000,
           "pricing": {
             "prompt": "0.0000006",
             "completion": "0.0000022",
             "input_cache_read": "0.00000011",
             "discount": 0
           },
-          "quantization": "fp4",
-          "max_completion_tokens": 131072,
+          "quantization": "unknown",
+          "max_completion_tokens": 128000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -20266,35 +8196,18 @@
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
-            "top_k"
+            "tool_choice"
           ],
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 83.37764738241496,
+          "uptime_last_1d": 80.87730252887918,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | z-ai/glm-4.6",
-          "model_id": "zai-org/GLM-4.6",
-          "model_name": "Z.ai: GLM 4.6",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000022"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.6v",
@@ -20318,55 +8231,15 @@
       "pricing": {
         "prompt": "0.0000003",
         "completion": "0.0000009",
-        "input_cache_read": "0.000000055"
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 32768,
+        "max_completion_tokens": 24000,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | z-ai/glm-4.6-20251208",
-          "model_id": "z-ai/glm-4.6v",
-          "model_name": "Z.ai: GLM 4.6V",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000009",
-            "input_cache_read": "0.000000055",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.62624254473161,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 92.6137257988352,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
         {
           "name": "Z.AI | z-ai/glm-4.6-20251208",
           "model_id": "z-ai/glm-4.6v",
@@ -20381,7 +8254,7 @@
             "discount": 0
           },
           "quantization": "fp8",
-          "max_completion_tokens": 32768,
+          "max_completion_tokens": 24000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -20390,19 +8263,18 @@
             "temperature",
             "top_p",
             "tool_choice",
-            "tools",
-            "top_k"
+            "tools"
           ],
-          "status": -2,
-          "uptime_last_30m": 83.78378378378379,
+          "status": 0,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 89.96928746928748,
+          "uptime_last_1d": 97.92140305293927,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.7",
@@ -20422,9 +8294,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.00000175",
-        "input_cache_read": "0.00000008"
+        "prompt": "0.00000045",
+        "completion": "0.0000021",
+        "input_cache_read": "0.00000011"
       },
       "top_provider": {
         "context_length": 202752,
@@ -20468,28 +8340,28 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.68253968253968,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94800537875392,
+          "uptime_last_1d": 99.984125304265,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "DeepInfra | z-ai/glm-4.7-20251222",
-          "model_id": "zai-org/GLM-4.7",
+          "name": "Parasail | z-ai/glm-4.7-20251222",
+          "model_id": "z-ai/glm-4.7",
           "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
+          "provider_name": "Parasail",
+          "tag": "parasail/fp8",
           "context_length": 202752,
           "pricing": {
-            "prompt": "0.0000004",
-            "completion": "0.00000175",
-            "input_cache_read": "0.00000008",
+            "prompt": "0.00000045",
+            "completion": "0.0000021",
+            "input_cache_read": "0.00000011",
             "discount": 0
           },
-          "quantization": "fp4",
-          "max_completion_tokens": 131072,
+          "quantization": "fp8",
+          "max_completion_tokens": 202752,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -20497,70 +8369,29 @@
             "max_tokens",
             "temperature",
             "top_p",
-            "stop",
             "frequency_penalty",
             "presence_penalty",
             "repetition_penalty",
-            "top_k",
             "seed",
-            "min_p",
-            "response_format",
+            "stop",
+            "top_k",
+            "logit_bias",
             "tools",
             "tool_choice",
-            "structured_outputs",
-            "logit_bias"
+            "response_format",
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.65609476499809,
-          "uptime_last_5m": 99.40119760479041,
-          "uptime_last_1d": 98.69206593195449,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.46363342118649,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
+          "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Novita | z-ai/glm-4.7-20251222",
-          "model_id": "z-ai/glm-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000011",
-            "discount": 0.1
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.22850412249706,
-          "uptime_last_5m": 96.03174603174604,
-          "uptime_last_1d": 91.17832495526966,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Phala | z-ai/glm-4.7-20251222",
-          "model_id": "phala/glm-4.7",
+          "model_id": "z-ai/glm-4.7",
           "model_name": "Z.ai: GLM 4.7",
           "provider_name": "Phala",
           "tag": "phala",
@@ -20589,14 +8420,12 @@
             "tool_choice",
             "tools",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.47634069400631,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.70556596071651,
+          "uptime_last_30m": 99.1869918699187,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 95.01867995018681,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -20633,27 +8462,27 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.33795013850416,
-          "uptime_last_5m": 95.65217391304348,
-          "uptime_last_1d": 97.03816984488624,
+          "uptime_last_30m": 99.25925925925925,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 96.88502673796792,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         },
         {
           "name": "Z.AI | z-ai/glm-4.7-20251222",
           "model_id": "z-ai/glm-4.7",
           "model_name": "Z.ai: GLM 4.7",
           "provider_name": "Z.AI",
-          "tag": "z-ai/fp4",
-          "context_length": 202752,
+          "tag": "z-ai",
+          "context_length": 200000,
           "pricing": {
             "prompt": "0.0000006",
             "completion": "0.0000022",
             "input_cache_read": "0.00000011",
             "discount": 0
           },
-          "quantization": "fp4",
+          "quantization": "unknown",
           "max_completion_tokens": 131072,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -20664,52 +8493,18 @@
             "top_p",
             "tools",
             "tool_choice",
-            "top_k",
             "response_format"
           ],
           "status": -2,
-          "uptime_last_30m": 93.573264781491,
-          "uptime_last_5m": 91.66666666666666,
-          "uptime_last_1d": 86.53414915427986,
+          "uptime_last_30m": 94.49283506602978,
+          "uptime_last_5m": 93.73493975903614,
+          "uptime_last_1d": 94.65531991534964,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | z-ai/glm-4.7",
-          "model_id": "zai-org/GLM-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | z-ai/glm-4.7",
-          "model_id": "zai-org/GLM-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-4.7-flash",
@@ -20729,8 +8524,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000006",
-        "completion": "0.0000004",
+        "prompt": "0.0000001",
+        "completion": "0.00000043",
         "input_cache_read": "0.00000001"
       },
       "top_provider": {
@@ -20741,63 +8536,19 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | z-ai/glm-4.7-flash-20260119",
-          "model_id": "zai-org/GLM-4.7-Flash",
-          "model_name": "Z.ai: GLM 4.7 Flash",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000006",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000001",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tool_choice",
-            "tools",
-            "structured_outputs",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8586907128929,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-4.7-flash-20260119",
+          "name": "Phala | z-ai/glm-4.7-flash-20260119",
           "model_id": "z-ai/glm-4.7-flash",
           "model_name": "Z.ai: GLM 4.7 Flash",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 200000,
+          "provider_name": "Phala",
+          "tag": "phala",
+          "context_length": 202752,
           "pricing": {
-            "prompt": "0.00000007",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000001",
+            "prompt": "0.0000001",
+            "completion": "0.00000043",
             "discount": 0
           },
-          "quantization": "bf16",
-          "max_completion_tokens": 128000,
+          "quantization": "unknown",
+          "max_completion_tokens": 202752,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -20810,18 +8561,20 @@
             "presence_penalty",
             "seed",
             "top_k",
+            "min_p",
             "repetition_penalty",
             "tools",
             "tool_choice",
+            "structured_outputs",
             "response_format"
           ],
           "status": -2,
-          "uptime_last_30m": 90.75,
-          "uptime_last_5m": 88.88888888888889,
-          "uptime_last_1d": 90.17097664362322,
+          "uptime_last_30m": 90.76923076923077,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 91.37799043062202,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
+          "tr_provider_slug": "phala",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "Venice | z-ai/glm-4.7-flash-20260119",
@@ -20833,7 +8586,8 @@
           "pricing": {
             "prompt": "0.00000013",
             "completion": "0.0000005",
-            "discount": 0
+            "discount": 0,
+            "input_cache_read": "0"
           },
           "quantization": "fp8",
           "max_completion_tokens": 16384,
@@ -20856,13 +8610,13 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.30578512396694,
+          "uptime_last_1d": 98.3147594455015,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-5",
@@ -20887,133 +8641,15 @@
         "input_cache_read": "0.00000012"
       },
       "top_provider": {
-        "context_length": 198000,
-        "max_completion_tokens": 128000,
+        "context_length": 202752,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | z-ai/glm-5-20260211",
-          "model_id": "zai-org/GLM-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.00000208",
-            "input_cache_read": "0.00000012",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "logit_bias"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.9660539616284,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | z-ai/glm-5-20260211",
-          "model_id": "zai-org/GLM-5-FP8",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.00000192",
-            "input_cache_read": "0.00000012",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.59926449127313,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-5-20260211",
-          "model_id": "z-ai/glm-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 202800,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.0000032",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99518891526075,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | z-ai/glm-5-20260211",
-          "model_id": "zai-org/GLM-5-FP8",
+          "model_id": "z-ai/glm-5",
           "model_name": "Z.ai: GLM 5",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -21043,21 +8679,19 @@
             "tools",
             "tool_choice",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.37888198757764,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.90406036651096,
+          "uptime_last_1d": 99.28655363437973,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | z-ai/glm-5-20260211",
-          "model_id": "phala/glm-5",
+          "model_id": "z-ai/glm-5",
           "model_name": "Z.ai: GLM 5",
           "provider_name": "Phala",
           "tag": "phala",
@@ -21065,7 +8699,6 @@
           "pricing": {
             "prompt": "0.0000012",
             "completion": "0.0000035",
-            "input_cache_read": "0.000000475",
             "discount": 0
           },
           "quantization": "unknown",
@@ -21092,7 +8725,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 68.09055118110237,
+          "uptime_last_1d": 89.50827653359299,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -21127,7 +8760,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.88563825400404,
+          "uptime_last_1d": 99.73367766927609,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -21166,17 +8799,17 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.23008849557522,
+          "uptime_last_1d": 99.91438356164383,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
+          "pricing_source": "provider_direct"
         },
         {
           "name": "Z.AI | z-ai/glm-5-20260211",
           "model_id": "z-ai/glm-5",
           "model_name": "Z.ai: GLM 5",
           "provider_name": "Z.AI",
-          "tag": "z-ai/fp8",
+          "tag": "z-ai",
           "context_length": 202752,
           "pricing": {
             "prompt": "0.000001",
@@ -21184,7 +8817,7 @@
             "input_cache_read": "0.0000002",
             "discount": 0
           },
-          "quantization": "fp8",
+          "quantization": "unknown",
           "max_completion_tokens": 131072,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -21195,58 +8828,42 @@
             "top_p",
             "tools",
             "tool_choice",
-            "top_k"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 97.41176470588235,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 97.72104130428374,
+          "uptime_last_30m": 99.66555183946488,
+          "uptime_last_5m": 99.38271604938271,
+          "uptime_last_1d": 99.80478783519983,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "together | z-ai/glm-5",
-          "model_id": "zai-org/GLM-5",
+          "name": "gmi | z-ai/glm-5",
+          "model_id": "z-ai/glm-5",
           "model_name": "Z.ai: GLM 5",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
           "context_length": 202752,
           "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.0000032"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | z-ai/glm-5",
-          "model_id": "zai-org/GLM-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.00000315",
-            "input_cache_read": "0.0000002"
+            "prompt": "0.0000006",
+            "completion": "0.00000192",
+            "input_cache_read": "0.00000012"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-5-turbo",
       "name": "Z.ai: GLM 5 Turbo",
       "created": 1773583573,
       "description": "GLM-5 Turbo is a new model from Z.ai designed for fast inference and strong performance in agent-driven environments such as OpenClaw scenarios. It is deeply optimized for real-world agent workflows...",
-      "context_length": 262144,
+      "context_length": 202752,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -21264,7 +8881,7 @@
         "input_cache_read": "0.00000024"
       },
       "top_provider": {
-        "context_length": 262144,
+        "context_length": 202752,
         "max_completion_tokens": 131072,
         "is_moderated": false
       },
@@ -21294,13 +8911,12 @@
             "top_p",
             "tools",
             "tool_choice",
-            "response_format",
-            "top_k"
+            "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 89.13685592385954,
+          "uptime_last_30m": 98.01829268292683,
+          "uptime_last_5m": 98.48484848484848,
+          "uptime_last_1d": 94.0269464765142,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -21312,18 +8928,18 @@
           "provider_name": "venice",
           "tag": "venice",
           "tr_provider_slug": "venice",
-          "context_length": 262144,
+          "context_length": 202752,
           "pricing": {
             "prompt": "0.0000012",
             "completion": "0.000004",
             "input_cache_read": "0.00000024"
           },
-          "pricing_source": "self_healed_provider",
+          "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-5.1",
@@ -21348,216 +8964,15 @@
         "input_cache_read": "0.000000182"
       },
       "top_provider": {
-        "context_length": 200000,
-        "max_completion_tokens": 128000,
+        "context_length": 202752,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "DeepInfra | z-ai/glm-5.1-20260406",
-          "model_id": "zai-org/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000105",
-            "completion": "0.0000035",
-            "input_cache_read": "0.000000205",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logit_bias",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90933292179483,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Fireworks | z-ai/glm-5.1-20260406",
-          "model_id": "accounts/fireworks/models/glm-5p1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Fireworks",
-          "tag": "fireworks",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 98.78846619820692,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "fireworks",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Friendli | z-ai/glm-5.1-20260406",
-          "model_id": "zai-org/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Friendli",
-          "tag": "friendli",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 202752,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97781639368507,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | z-ai/glm-5.1-20260406",
-          "model_id": "zai-org/GLM-5.1-FP8",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000098",
-            "completion": "0.00000308",
-            "input_cache_read": "0.000000182",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.42028985507247,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.84970191402573,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-5.1-20260406",
-          "model_id": "z-ai/glm-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000138",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.8929889298893,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 97.89068045837136,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
           "name": "Parasail | z-ai/glm-5.1-20260406",
-          "model_id": "zai-org/GLM-5.1-FP8",
+          "model_id": "z-ai/glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
           "provider_name": "Parasail",
           "tag": "parasail/fp8",
@@ -21587,21 +9002,19 @@
             "response_format",
             "structured_outputs",
             "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
+            "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.36873885000686,
+          "uptime_last_30m": 99.65397923875432,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.42572257983088,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "Phala | z-ai/glm-5.1-20260406",
-          "model_id": "phala/glm-5.1",
+          "model_id": "z-ai/glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
           "provider_name": "Phala",
           "tag": "phala",
@@ -21609,11 +9022,10 @@
           "pricing": {
             "prompt": "0.00000121",
             "completion": "0.0000042",
-            "input_cache_read": "0.0000006",
             "discount": 0
           },
           "quantization": "unknown",
-          "max_completion_tokens": 128000,
+          "max_completion_tokens": 202752,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -21631,14 +9043,12 @@
             "tool_choice",
             "tools",
             "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
+            "structured_outputs"
           ],
-          "status": -2,
-          "uptime_last_30m": 85.78199052132702,
-          "uptime_last_5m": 91.42857142857143,
-          "uptime_last_1d": 81.54616668806986,
+          "status": 0,
+          "uptime_last_30m": 96,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 95.39385847797062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
@@ -21651,13 +9061,13 @@
           "tag": "venice/fp8",
           "context_length": 200000,
           "pricing": {
-            "prompt": "0.00000154",
-            "completion": "0.00000484",
-            "input_cache_read": "0.00000029",
+            "prompt": "0.00000175",
+            "completion": "0.0000055",
+            "input_cache_read": "0.00000033",
             "discount": 0
           },
           "quantization": "fp8",
-          "max_completion_tokens": 80000,
+          "max_completion_tokens": 24000,
           "max_prompt_tokens": null,
           "supported_parameters": [
             "reasoning",
@@ -21675,56 +9085,11 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.30027380590204,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 97.79698828778584,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Wafer | z-ai/glm-5.1-20260406",
-          "model_id": "GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Wafer",
-          "tag": "wafer/fp4",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.0000032",
-            "input_cache_read": "0.0000001",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "temperature",
-            "top_p",
-            "top_k",
-            "min_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "stop",
-            "seed",
-            "max_tokens",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "logprobs",
-            "top_logprobs",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.74468085106383,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
         },
         {
@@ -21732,7 +9097,7 @@
           "model_id": "z-ai/glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
           "provider_name": "Z.AI",
-          "tag": "z-ai/fp8",
+          "tag": "z-ai",
           "context_length": 202752,
           "pricing": {
             "prompt": "0.0000014",
@@ -21740,7 +9105,7 @@
             "input_cache_read": "0.00000026",
             "discount": 0
           },
-          "quantization": "fp8",
+          "quantization": "unknown",
           "max_completion_tokens": 131072,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -21751,639 +9116,24 @@
             "top_p",
             "tools",
             "tool_choice",
-            "top_k",
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.25179659783498,
+          "uptime_last_30m": 98.12161731932505,
+          "uptime_last_5m": 99.5249406175772,
+          "uptime_last_1d": 99.02606827682304,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "together | z-ai/glm-5.1",
-          "model_id": "zai-org/GLM-5.1",
+          "name": "tinfoil | z-ai/glm-5.1",
+          "model_id": "z-ai/glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | z-ai/glm-5.1",
-          "model_id": "zai-org/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000013",
-            "completion": "0.0000043",
-            "input_cache_read": "0.00000026"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | z-ai/glm-5.1",
-          "model_id": "zai/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | z-ai/glm-5.1",
-          "model_id": "glm-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "self_healed_provider"
-    },
-    {
-      "id": "z-ai/glm-5.2",
-      "name": "Z.ai: GLM 5.2",
-      "created": 1781631930,
-      "description": "GLM 5.2 is a large-scale reasoning model from Z.ai. It supports text input and output with a 1M-token context window, and is suited for long-horizon agent workflows, project-level software engineering,...",
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000093",
-        "completion": "0.000003",
-        "input_cache_read": "0.00000016848"
-      },
-      "top_provider": {
-        "context_length": 1048576,
-        "max_completion_tokens": 131072,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "DeepInfra | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org/GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "DeepInfra",
-          "tag": "deepinfra/fp4",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000093",
-            "completion": "0.000003",
-            "input_cache_read": "0.00000018",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "top_k",
-            "seed",
-            "min_p",
-            "response_format",
-            "logit_bias",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.86006825938567,
-          "uptime_last_5m": 95.34368070953437,
-          "uptime_last_1d": 98.216489896681,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Fireworks | z-ai/glm-5.2-20260616",
-          "model_id": "accounts/fireworks/models/glm-5p2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Fireworks",
-          "tag": "fireworks",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000014",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.72623195619711,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.72447795823666,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "fireworks",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Fireworks | z-ai/glm-5.2-20260616",
-          "model_id": "accounts/fireworks/models/glm-5p2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Fireworks",
-          "tag": "fireworks/fast",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000014",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.72861824937895,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "fireworks",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Friendli | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org/GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Friendli",
-          "tag": "friendli",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 1048576,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.45317840054683,
-          "uptime_last_5m": 98.73949579831933,
-          "uptime_last_1d": 99.32424770487212,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "GMICloud | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org/GLM-5.2-FP8",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "GMICloud",
-          "tag": "gmicloud/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000098",
-            "completion": "0.00000308",
-            "input_cache_read": "0.000000182",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "structured_outputs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.33628318584071,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 91.55614390022563,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-5.2-20260616",
-          "model_id": "z-ai/glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0.352
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.57453212214075,
-          "uptime_last_5m": 99.58812424918483,
-          "uptime_last_1d": 99.59409865914675,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Parasail | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org/GLM-5.2-FP8",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Parasail",
-          "tag": "parasail/fp4",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "seed",
-            "stop",
-            "top_k",
-            "logit_bias",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.87076537013802,
-          "uptime_last_5m": 96.46017699115043,
-          "uptime_last_1d": 99.34526527257785,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | z-ai/glm-5.2-20260616",
-          "model_id": "phala/glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.0000007",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.76190476190476,
-          "uptime_last_5m": 94.23076923076923,
-          "uptime_last_1d": 93.33913529978554,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Together | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org/GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Together",
-          "tag": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 82.86969253294289,
-          "uptime_last_5m": 78.78787878787878,
-          "uptime_last_1d": 98.38592059661548,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Venice | z-ai/glm-5.2-20260616",
-          "model_id": "zai-org-glm-5-2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Venice",
-          "tag": "venice/fp8",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.47991313789359,
-          "uptime_last_5m": 98.06259314456037,
-          "uptime_last_1d": 98.76898618600555,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "venice",
-          "pricing_source": "self_healed_provider"
-        },
-        {
-          "name": "Wafer | z-ai/glm-5.2-20260616",
-          "model_id": "GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Wafer",
-          "tag": "wafer/fp4",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000041",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "temperature",
-            "top_p",
-            "top_k",
-            "min_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "stop",
-            "seed",
-            "max_tokens",
-            "logit_bias",
-            "structured_outputs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 91.20492524186456,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.53652536632322,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "wafer",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Wafer | z-ai/glm-5.2-20260616",
-          "model_id": "GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Wafer",
-          "tag": "wafer/fast",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000041",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp4",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "temperature",
-            "top_p",
-            "top_k",
-            "min_p",
-            "frequency_penalty",
-            "presence_penalty",
-            "repetition_penalty",
-            "stop",
-            "seed",
-            "max_tokens",
-            "logit_bias",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89317490049169,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "wafer",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "tinfoil | z-ai/glm-5.2",
-          "model_id": "glm-5-2",
-          "model_name": "Z.ai: GLM 5.2",
           "provider_name": "tinfoil",
           "tag": "tinfoil",
           "tr_provider_slug": "tinfoil",
-          "context_length": 1048576,
+          "context_length": 202752,
           "pricing": {
             "prompt": "0.0000015",
             "completion": "0.00000525"
@@ -22393,58 +9143,24 @@
           "quantization": "unknown"
         },
         {
-          "name": "baseten | z-ai/glm-5.2",
-          "model_id": "zai-org/GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 1048576,
+          "name": "gmi | z-ai/glm-5.1",
+          "model_id": "z-ai/glm-5.1",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
+          "context_length": 202752,
           "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
+            "prompt": "0.00000098",
+            "completion": "0.00000308",
+            "input_cache_read": "0.000000182"
           },
           "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | z-ai/glm-5.2",
-          "model_id": "glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "makora | z-ai/glm-5.2",
-          "model_id": "z-ai/glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000003",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "self_healed_provider",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     },
     {
       "id": "z-ai/glm-5v-turbo",
@@ -22501,13 +9217,12 @@
             "top_p",
             "tools",
             "tool_choice",
-            "response_format",
-            "top_k"
+            "response_format"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.99289116371651,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22541,12 +9256,12 @@
             "completion": "0.000005",
             "input_cache_read": "0.0000003"
           },
-          "pricing_source": "self_healed_provider",
+          "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
         }
       ],
-      "pricing_source": "self_healed_provider"
+      "pricing_source": "provider_direct"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -3,7 +3,7 @@
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-15T00:38:52Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -169,6 +169,6 @@
   "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
   "source": "https://api.moonshot.ai/v1/models",
   "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-14T20:08:46Z",
   "model_count": 10
 }

--- a/src/trusted_router/data/provider_models/makora.json
+++ b/src/trusted_router/data/provider_models/makora.json
@@ -1,9 +1,9 @@
 {
-  "_about": "Provider-native supplement for Makora Inference routes. Makora's /v1/models feed publishes native model ids and context windows but not pricing. Prices are refreshed hourly from Makora's public homepage lineup where listed; Gemma keeps the OpenRouter canonical price fallback because Makora does not currently publish a Gemma price on its homepage/pricing page/API feed.",
+  "_about": "Provider-native supplement for Makora Inference routes. Makora's /v1/models feed publishes native model ids and context windows but not pricing. Prices are sourced from Makora's public homepage lineup where listed; Gemma keeps the OpenRouter canonical price fallback because Makora does not currently publish a Gemma price on its homepage/pricing page/API feed.",
   "provider": "makora",
   "source": "https://inference.makora.com/v1/models",
   "pricing_source": "https://www.makora.com/; https://openrouter.ai/api/v1/models for Gemma fallback",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-03T18:30:00Z",
   "price_scale": "microdollars_per_million",
   "model_count": 10,
   "models": [
@@ -12,287 +12,129 @@
       "upstream_id": "deepseek-ai/DeepSeek-V4-Flash",
       "display_name": "DeepSeek V4 Flash",
       "context_length": 1048576,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 90000,
-      "output_token_price_per_m": 200000,
-      "cached_input_token_price_per_m": 20000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 113400,
+      "output_token_price_per_m": 279100,
+      "cached_input_token_price_per_m": 85100,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "deepseek/deepseek-v4-pro",
       "upstream_id": "deepseek-ai/DeepSeek-V4-Pro",
       "display_name": "DeepSeek V4 Pro",
       "context_length": 1048576,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 1120000,
-      "output_token_price_per_m": 2240000,
-      "cached_input_token_price_per_m": 110000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 1318000,
+      "output_token_price_per_m": 2636100,
+      "cached_input_token_price_per_m": 988500,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
       "upstream_id": "google/gemma-4-26B-A4B",
       "display_name": "Gemma 4 26B A4B",
       "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
+      "endpoints": ["chat/completions"],
       "input_token_price_per_m": 60000,
       "output_token_price_per_m": 330000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "z-ai/glm-5.2",
       "upstream_id": "zai-org/GLM-5.2-FP8",
       "display_name": "GLM 5.2 FP8",
       "context_length": 980000,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 1000000,
-      "output_token_price_per_m": 3000000,
-      "cached_input_token_price_per_m": 180000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 1350000,
+      "output_token_price_per_m": 3990000,
+      "cached_input_token_price_per_m": 240000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "moonshotai/kimi-k2.7-code",
       "upstream_id": "moonshotai/Kimi-K2.7-Code",
       "display_name": "Kimi K2.7 Code",
       "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 820000,
-      "output_token_price_per_m": 3380000,
-      "cached_input_token_price_per_m": 160000,
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "chat_template_kwargs",
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 760000,
+      "output_token_price_per_m": 3774900,
+      "cached_input_token_price_per_m": 575700,
+      "input_modalities": ["text", "image"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["chat_template_kwargs", "max_completion_tokens", "max_tokens", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "amd/llama-3.3-70b-instruct-fp8-kv",
       "upstream_id": "amd/Llama-3.3-70B-Instruct-FP8-KV",
       "display_name": "Llama 3.3 70B FP8",
       "context_length": 128000,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 120000,
-      "output_token_price_per_m": 380000,
-      "cached_input_token_price_per_m": 80000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 180000,
+      "output_token_price_per_m": 400000,
+      "cached_input_token_price_per_m": 150000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
       "upstream_id": "meta-llama/Llama-3.3-70B-Instruct",
       "display_name": "Llama 3.3 70B Instruct",
       "context_length": 131072,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 120000,
-      "output_token_price_per_m": 380000,
-      "cached_input_token_price_per_m": 80000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 180000,
+      "output_token_price_per_m": 400000,
+      "cached_input_token_price_per_m": 150000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "qwen/qwen3.6-27b",
       "upstream_id": "unsloth/Qwen3.6-27B-NVFP4",
       "display_name": "Qwen 3.6 27B NVFP4",
       "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 270000,
-      "output_token_price_per_m": 2820000,
-      "cached_input_token_price_per_m": 300000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 467100,
+      "output_token_price_per_m": 3459200,
+      "cached_input_token_price_per_m": 350300,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
       "upstream_id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "display_name": "Qwen 3.6 35B A3B NVFP4",
       "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 140000,
-      "output_token_price_per_m": 850000,
-      "cached_input_token_price_per_m": 110000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 172000,
+      "output_token_price_per_m": 1200200,
+      "cached_input_token_price_per_m": 129000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     },
     {
       "id": "z-ai/glm-5.2-nvfp4",
       "upstream_id": "zai-org/GLM-5.2-NVFP4",
       "display_name": "GLM 5.2 NVFP4",
       "context_length": 1048576,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 1000000,
-      "output_token_price_per_m": 3000000,
-      "cached_input_token_price_per_m": 180000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
+      "endpoints": ["chat/completions"],
+      "input_token_price_per_m": 1350000,
+      "output_token_price_per_m": 3990000,
+      "cached_input_token_price_per_m": 240000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_completion_tokens", "max_tokens", "reasoning_effort", "response_format", "stream_options", "temperature", "tool_choice", "tools", "top_p"]
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/minimax.json
+++ b/src/trusted_router/data/provider_models/minimax.json
@@ -1,7 +1,7 @@
 {
   "provider": "minimax",
   "source": "https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-03T22:35:56Z",
   "model_count": 8,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -1,8 +1,8 @@
 {
   "provider": "nebius",
   "source": "https://api.tokenfactory.nebius.com/v1/models?verbose=true",
-  "generated_at": "2026-07-15T01:37:51Z",
-  "model_count": 38,
+  "generated_at": "2026-07-03T22:37:49Z",
+  "model_count": 37,
   "models": [
     {
       "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
@@ -926,32 +926,6 @@
       "max_output_tokens": 65536,
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,
-      "model_type": "chat",
-      "features": [
-        "serverless",
-        "function-calling"
-      ],
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "endpoints": [
-        "chat/completions"
-      ],
-      "status": 1
-    },
-    {
-      "id": "MiniMaxAI/MiniMax-M3",
-      "upstream_id": "MiniMaxAI/MiniMax-M3",
-      "display_name": "MiniMax-M3",
-      "title": "MiniMaxAI/MiniMax-M3",
-      "created": 1784079445,
-      "context_length": 1048576,
-      "max_output_tokens": 65536,
-      "input_token_price_per_m": 300000,
-      "output_token_price_per_m": 1200000,
       "model_type": "chat",
       "features": [
         "serverless",

--- a/src/trusted_router/data/provider_models/parasail.json
+++ b/src/trusted_router/data/provider_models/parasail.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Parasail models live ahead of the shared snapshot. Prices refreshed hourly from the public pricing page (www.parasail.io/pricing); model liveness gated on api.parasail.io/v1/models.",
   "provider": "parasail",
   "source": "https://www.parasail.io/pricing",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-13T18:24:17Z",
   "model_count": 4,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Wafer serverless API. Refreshed hourly from Wafer's OpenAI-compatible /v1/models feed.",
   "provider": "wafer",
   "source": "https://pass.wafer.ai/v1/models",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-15T00:41:39Z",
   "price_scale": "microdollars_per_million",
   "zdr_header": "Wafer-ZDR: required",
   "model_count": 5,

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -1,7 +1,7 @@
 {
   "provider": "xiaomi",
   "source": "https://mimo.mi.com/docs/en-US/pricing",
-  "generated_at": "2026-07-15T01:37:51Z",
+  "generated_at": "2026-07-15T00:38:52Z",
   "model_count": 5,
   "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated /v1/models feed but has no public PAYG row, so its last verified price is retained until Xiaomi republishes one. Legacy V2 rows are kept only as historical fallback metadata.",
   "models": [

--- a/tests/test_refresh_workflow_dispatch.py
+++ b/tests/test_refresh_workflow_dispatch.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_accepts_explicit_dispatch_for_bot_commits() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch: {}" in workflow
+
+
+def test_price_refresh_dispatches_ci_before_deploy_and_fails_closed() -> None:
+    workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
+        encoding="utf-8"
+    )
+    ci_dispatch = 'gh workflow run ci.yml --ref main --repo "${GITHUB_REPOSITORY}"'
+    deploy_dispatch = (
+        'gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}"'
+    )
+
+    assert ci_dispatch in workflow
+    assert deploy_dispatch in workflow
+    assert workflow.index(ci_dispatch) < workflow.index(deploy_dispatch)
+    assert "WARN: failed to dispatch deploy.yml" not in workflow

--- a/tests/test_refresh_workflow_dispatch.py
+++ b/tests/test_refresh_workflow_dispatch.py
@@ -22,3 +22,20 @@ def test_price_refresh_dispatches_ci_before_deploy_and_fails_closed() -> None:
     assert deploy_dispatch in workflow
     assert workflow.index(ci_dispatch) < workflow.index(deploy_dispatch)
     assert "WARN: failed to dispatch deploy.yml" not in workflow
+
+
+def test_price_refresh_validates_generated_catalog_before_committing() -> None:
+    workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
+        encoding="utf-8"
+    )
+    validation_step = "- name: Validate generated catalog before commit"
+    commit_step = "- name: Commit and push if changed"
+
+    assert validation_step in workflow
+    assert workflow.index(validation_step) < workflow.index(commit_step)
+    validation = workflow[
+        workflow.index(validation_step) : workflow.index(commit_step)
+    ]
+    assert "uv run ruff check ." in validation
+    assert "uv run mypy" in validation
+    assert "uv run pytest -q" in validation


### PR DESCRIPTION
## Summary
- make CI explicitly dispatchable for GITHUB_TOKEN-authored pricing commits
- dispatch same-SHA CI before the control-plane deploy
- fail the price refresh if either downstream dispatch fails
- add regression tests for ordering and fail-closed behavior

## Validation
- .....                                                                    [100%]
5 passed in 0.10s
- All checks passed!
- Success: no issues found in 168 source files
- 

## Production finding
The 2026-07-15 hourly refresh successfully committed its catalog and dispatched deploy, but GitHub correctly suppressed push-triggered CI for the bot commit. The normal deploy therefore had no same-SHA CI run and would wait until its 45-minute timeout. This change closes that release deadlock.