### PR TITLE
Make provider credential source precedence deterministic

### DIFF
--- a/src/trusted_router/providers.py
+++ b/src/trusted_router/providers.py
@@ -435,8 +435,16 @@ class ProviderClient:
         return self.key_file.get(name) or os.environ.get(name)
 
     def _secret_any(self, names: tuple[str, ...] | None) -> str | None:
+        # Treat the explicitly supplied key file as one source. Check every
+        # accepted alias there before consulting ambient process variables;
+        # otherwise KIMI_API_KEY in the environment can unexpectedly override
+        # MOONSHOT_API_KEY in the caller's key file (and likewise for Makora).
         for name in names or ():
-            value = self._secret(name)
+            value = self.key_file.get(name)
+            if value:
+                return value
+        for name in names or ():
+            value = os.environ.get(name)
             if value:
                 return value
         return None

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -9,6 +9,7 @@ import pytest
 
 from trusted_router.catalog import MODELS, Model, endpoints_for_model
 from trusted_router.providers import (
+    OPENAI_COMPATIBLE_PROVIDERS,
     ProviderClient,
     ProviderError,
     estimate_tokens_from_messages,
@@ -460,6 +461,10 @@ async def test_new_openai_compatible_provider_platforms_use_native_keys_and_urls
 ) -> None:
     key_file = tmp_path / "keys.private"
     key_file.write_text(f"{env_key}={env_value}\n", encoding="utf-8")
+    model = MODELS[provider_model] if isinstance(provider_model, str) else provider_model
+    provider_env_keys = OPENAI_COMPATIBLE_PROVIDERS[model.provider][0]
+    if env_key != provider_env_keys[0]:
+        monkeypatch.setenv(provider_env_keys[0], "ambient-key-must-not-win")
     calls: list[dict[str, Any]] = []
 
     class FakeAsyncClient:
@@ -489,7 +494,7 @@ async def test_new_openai_compatible_provider_platforms_use_native_keys_and_urls
     client = ProviderClient(LocalKeyFile(key_file), live=True)
 
     result = await client.chat(
-        MODELS[provider_model] if isinstance(provider_model, str) else provider_model,
+        model,
         {"messages": [{"role": "user", "content": "hello"}], "max_tokens": 5},
     )
 


### PR DESCRIPTION
## Summary
- reproduce the live refresh workflow collision for Kimi and Makora aliases
- treat the explicitly supplied local key file as one authoritative source across every accepted provider-key alias
- consult ambient environment variables only after no key-file alias is present
- keep canonical alias ordering within each source

## Validation
- Kimi and Makora regressions failed on previous code before the fix
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 1539 passed, 33 skipped
- git diff --check