### PR TITLE
Fix Mistral API pricing refresh

### DIFF
--- a/scripts/pricing/parsers/mistral.py
+++ b/scripts/pricing/parsers/mistral.py
@@ -9,9 +9,13 @@
 #              {"value": "Output (/M tokens)", "price_dollar": "<p>$2</p>"}]}
 # We extract input + output from the price array and pair them.
 """Mistral pricing-page parser."""
+
 from __future__ import annotations
 
 import re
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+
+from bs4 import BeautifulSoup, Tag
 
 # Display name on mistral.ai → OR-canonical id. Extended over time.
 _NAME_TO_OR_ID = {
@@ -46,12 +50,13 @@ def _to_micro_per_m(text: str | None) -> int | None:
     if not match:
         return None
     try:
-        return int(round(float(match.group(1)) * 1_000_000))
-    except (TypeError, ValueError):
+        value = Decimal(match.group(1)) * Decimal(1_000_000)
+        return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    except (InvalidOperation, TypeError, ValueError):
         return None
 
 
-def parse(html: str) -> dict:
+def _parse_embedded_json(html: str) -> dict:
     out: dict = {}
     # Mistral embeds the model JSON inside a Next.js __next_f payload as
     # a string literal, so the JSON quote characters are escaped:
@@ -97,4 +102,66 @@ def parse(html: str) -> dict:
             "prompt_micro_per_m": prompt,
             "completion_micro_per_m": completion,
         }
+    return out
+
+
+def _rendered_price(card: Tag, label_prefix: str) -> int | None:
+    for label in card.find_all("p"):
+        if not isinstance(label, Tag):
+            continue
+        if not label.get_text(" ", strip=True).startswith(label_prefix):
+            continue
+        row = label.parent
+        if not isinstance(row, Tag):
+            continue
+        price = row.find("mistral-atom-text-price")
+        if isinstance(price, Tag):
+            return _to_micro_per_m(price.get_text(" ", strip=True))
+    return None
+
+
+def _parse_rendered_cards(html: str) -> dict:
+    """Parse the server-rendered cards on Mistral's dedicated API page."""
+    out: dict = {}
+    soup = BeautifulSoup(html, "html.parser")
+    for name_node in soup.find_all("p"):
+        if not isinstance(name_node, Tag):
+            continue
+        name = name_node.get_text(" ", strip=True)
+        or_id = _NAME_TO_OR_ID.get(name)
+        if or_id is None or or_id in out:
+            continue
+
+        # Find the smallest enclosing card that contains both token-price
+        # rows. The model name also appears in navigation and featured-model
+        # links, so anchoring to those rows avoids crossing into another card.
+        card = name_node.parent
+        while isinstance(card, Tag):
+            recognized_names = {
+                node.get_text(" ", strip=True)
+                for node in card.find_all("p")
+                if isinstance(node, Tag) and node.get_text(" ", strip=True) in _NAME_TO_OR_ID
+            }
+            if len(recognized_names) > 1:
+                # Navigation/page-root containers span multiple models. Any
+                # larger ancestor will too, so this name is not a price-card
+                # anchor and must not inherit a neighboring model's prices.
+                break
+            prompt = _rendered_price(card, "Input (/M tokens)")
+            completion = _rendered_price(card, "Output (/M tokens)")
+            if prompt is not None and completion is not None:
+                out[or_id] = {
+                    "prompt_micro_per_m": prompt,
+                    "completion_micro_per_m": completion,
+                }
+                break
+            card = card.parent
+    return out
+
+
+def parse(html: str) -> dict:
+    # Support both the older embedded Next.js payload and the current
+    # server-rendered API cards. Current visible cards win if both exist.
+    out = _parse_embedded_json(html)
+    out.update(_parse_rendered_cards(html))
     return out

--- a/scripts/pricing/providers/mistral.py
+++ b/scripts/pricing/providers/mistral.py
@@ -1,10 +1,11 @@
 """Mistral — human-only provider config."""
+
 from __future__ import annotations
 
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "mistral"
-URL = "https://mistral.ai/pricing"
+URL = "https://mistral.ai/pricing/api/"
 EXPECTED_MODELS = [
     "mistralai/mistral-small-2603",
 ]

--- a/tests/test_mistral_pricing.py
+++ b/tests/test_mistral_pricing.py
@@ -1,0 +1,55 @@
+"""Mistral provider-pricing source contracts."""
+
+from __future__ import annotations
+
+from scripts.pricing.parsers.mistral import parse
+from scripts.pricing.providers import mistral
+
+
+def test_mistral_uses_dedicated_api_pricing_page() -> None:
+    """The general plans page does not contain the API model-price records."""
+    assert mistral.URL == "https://mistral.ai/pricing/api/"
+
+
+def test_mistral_parser_reads_server_rendered_api_price_cards() -> None:
+    html = """
+    <nav>
+      <p>Mistral Medium 3.5</p>
+      <p>Mistral Small 4</p>
+    </nav>
+    <article>
+      <p class="text-h5 font-mistral">Mistral Medium 3.5</p>
+      <div>
+        <p>Input (/M tokens)</p>
+        <mistral-atom-text-price><span>$1.5</span></mistral-atom-text-price>
+      </div>
+      <div>
+        <p>Output (/M tokens)</p>
+        <mistral-atom-text-price><span>$7.5</span></mistral-atom-text-price>
+      </div>
+      <code>mistral-medium-latest</code>
+    </article>
+    <article>
+      <p class="text-h5 font-mistral">Mistral Small 4</p>
+      <div>
+        <p>Input (/M tokens)</p>
+        <mistral-atom-text-price><span>$0.15</span></mistral-atom-text-price>
+      </div>
+      <div>
+        <p>Output (/M tokens)</p>
+        <mistral-atom-text-price><span>$0.6</span></mistral-atom-text-price>
+      </div>
+      <code>mistral-small-latest</code>
+    </article>
+    """
+
+    assert parse(html) == {
+        "mistralai/mistral-medium-3-5": {
+            "prompt_micro_per_m": 1_500_000,
+            "completion_micro_per_m": 7_500_000,
+        },
+        "mistralai/mistral-small-2603": {
+            "prompt_micro_per_m": 150_000,
+            "completion_micro_per_m": 600_000,
+        },
+    }


### PR DESCRIPTION
Summary:
- switch Mistral pricing discovery to the official API pricing page
- parse the current server-rendered pricing cards while preserving the legacy embedded-data parser
- prevent navigation duplicates from inheriting prices from adjacent model cards
- add regression coverage for the live page structure and exact source URL

Verification:
- uv run pytest -q: 1541 passed, 33 skipped
- uv run ruff check .: passed
- uv run mypy: passed
- live deterministic parse: 13 official Mistral model price rows