### PR TITLE
Clarify empty observability windows

### DIFF
--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -73,6 +73,12 @@ def register(app: FastAPI) -> None:
         )
         result = dict(result)
         result["range"] = range_
+        latest = STORE.activity_events(
+            ctx.workspace.id,
+            api_key_hash=api_key_hash,
+            limit=1,
+        )
+        result["latest_activity_at"] = latest[0].get("created_at") if latest else None
         # A shared cache (Redis) is deferred; this per-worker TTL covers
         # occasional console reads and protects Bigtable from refresh bursts.
         _USAGE_CACHE[cache_key] = (now + _USAGE_CACHE_TTL_SECONDS, result)

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -345,6 +345,14 @@ body.console {
   color: var(--red);
 }
 
+.usage-empty-state p {
+  margin: 0;
+}
+
+.usage-empty-state .btn {
+  margin-top: 12px;
+}
+
 .usage-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -26,6 +26,14 @@
     "30d": "Last 30 days",
     "90d": "Last 90 days"
   };
+  const rangeDurations = {
+    "1h": 60 * 60 * 1000,
+    "6h": 6 * 60 * 60 * 1000,
+    "24h": 24 * 60 * 60 * 1000,
+    "7d": 7 * 24 * 60 * 60 * 1000,
+    "30d": 30 * 24 * 60 * 60 * 1000,
+    "90d": 90 * 24 * 60 * 60 * 1000
+  };
   const granularityLabels = {
     minute: "minute",
     "5min": "5-minute",
@@ -65,6 +73,8 @@
   let chart = null;
   let breakdown = null;
   let empty = null;
+  let emptyMessage = null;
+  let expandRange = null;
   let layout = null;
   let message = null;
   let status = null;
@@ -126,6 +136,38 @@
       return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", timeZone: "UTC" });
     }
     return date.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
+  }
+
+  function formatActivityTime(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short"
+    });
+  }
+
+  function rangeContaining(value) {
+    const timestamp = new Date(value).getTime();
+    if (Number.isNaN(timestamp)) {
+      return null;
+    }
+    const age = Math.max(0, Date.now() - timestamp);
+    return Object.keys(rangeDurations).find((range) => age <= rangeDurations[range]) || null;
+  }
+
+  function showRange(range) {
+    const input = panel.querySelector(`input[name="usage-range"][value="${range}"]`);
+    if (!input) {
+      return;
+    }
+    input.checked = true;
+    loadUsage();
   }
 
   function renderChart(series, metric, granularity, rangeText) {
@@ -276,7 +318,22 @@
       empty.hidden = false;
       chart.replaceChildren();
       breakdown.replaceChildren();
-      setStatus("empty", "warn");
+      setStatus("0 requests", "");
+      const latestActivityAt = String(data.latest_activity_at || "");
+      const containingRange = rangeContaining(latestActivityAt);
+      if (latestActivityAt) {
+        emptyMessage.textContent = `No usage in ${rangeText.toLowerCase()}. Most recent request: ${formatActivityTime(latestActivityAt)}.`;
+      } else {
+        emptyMessage.textContent = "No activity yet. Make a request with your API key to see it here.";
+      }
+      if (containingRange && containingRange !== state.range) {
+        expandRange.dataset.range = containingRange;
+        expandRange.textContent = `Show ${rangeLabels[containingRange].replace(/^Last /, "").toLowerCase()}`;
+        expandRange.hidden = false;
+      } else {
+        expandRange.hidden = true;
+        delete expandRange.dataset.range;
+      }
       showMessage(data.truncated ? "Showing partial data." : "", "");
       return;
     }
@@ -351,6 +408,8 @@
     chart = panel.querySelector("[data-usage-chart]");
     breakdown = panel.querySelector("[data-usage-breakdown]");
     empty = panel.querySelector("[data-usage-empty]");
+    emptyMessage = panel.querySelector("[data-usage-empty-message]");
+    expandRange = panel.querySelector("[data-usage-expand-range]");
     layout = panel.querySelector("[data-usage-layout]");
     message = panel.querySelector("[data-usage-message]");
     status = panel.querySelector("[data-usage-status]");
@@ -360,6 +419,12 @@
 
     panel.querySelectorAll('input[name="usage-range"], input[name="usage-metric"]').forEach((input) => {
       input.addEventListener("change", loadUsage);
+    });
+    expandRange.addEventListener("click", () => {
+      const range = expandRange.dataset.range;
+      if (range) {
+        showRange(range);
+      }
     });
     if ("ResizeObserver" in window) {
       new ResizeObserver(rerenderOnResize).observe(chart);
@@ -451,7 +516,10 @@
         <div data-usage-breakdown></div>
       </aside>
     </div>
-    <p class="empty" data-usage-empty hidden>No activity yet. Make a request with your API key to see it here.</p>
+    <div class="empty usage-empty-state" data-usage-empty role="status" aria-live="polite" hidden>
+      <p data-usage-empty-message>No activity yet. Make a request with your API key to see it here.</p>
+      <button class="btn" type="button" data-usage-expand-range hidden></button>
+    </div>
   </div>
 </section>
 

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -678,6 +678,10 @@ def test_console_activity_renders_usage_panel(
     assert "/console/activity/usage.json" in resp.text
     assert 'range: state.range' in resp.text
     assert 'by_model: "1"' in resp.text
+    assert 'setStatus("0 requests", "")' in resp.text
+    assert "No usage in ${rangeText.toLowerCase()}" in resp.text
+    assert 'data-usage-empty-message' in resp.text
+    assert 'data-usage-expand-range' in resp.text
     assert 'const truncatedPrefix = data.truncated ? "≥" : "";' in resp.text
     assert (
         "Partial data — some rows were not scanned; narrow the range for an exact total"

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -539,8 +539,72 @@ def test_console_usage_series_endpoint_returns_json_and_uses_cache(
     assert second.status_code == 200
     assert first.json()["granularity"] == "minute"
     assert first.json()["range"] == "1h"
+    assert first.json()["latest_activity_at"] is None
     assert first.json() == second.json()
     assert calls == [(workspace.id, 60, "minute", "key_a", True)]
+
+
+def test_console_usage_series_empty_window_reports_latest_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _USAGE_CACHE.clear()
+    app = create_app(Settings(environment="local"), init_observability=False)
+    client = TestClient(app)
+    user = STORE.ensure_user("usage-latest@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_token, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="usage-latest@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+
+    def empty_usage_series(
+        self: InMemoryStore,
+        workspace_id: str,
+        *,
+        window_minutes: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        _ = (self, workspace_id, window_minutes, api_key_hash, by_model)
+        return {
+            "granularity": granularity,
+            "start_day": "2026-07-15",
+            "end_day": "2026-07-15",
+            "truncated": False,
+            "buckets": [],
+        }
+
+    def latest_activity(
+        self: InMemoryStore,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None = None,
+        date: str | None = None,
+        limit: int = 100,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = (self, date, tag_key, tag_value)
+        assert workspace_id == workspace.id
+        assert api_key_hash == "key-a"
+        assert limit == 1
+        return [{"created_at": "2026-07-14T15:34:16Z"}]
+
+    monkeypatch.setattr(InMemoryStore, "usage_series", empty_usage_series)
+    monkeypatch.setattr(InMemoryStore, "activity_events", latest_activity)
+
+    response = client.get(
+        "/console/activity/usage.json?range=1h&api_key_hash=key-a"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["buckets"] == []
+    assert response.json()["latest_activity_at"] == "2026-07-14T15:34:16Z"
 
 
 def test_console_usage_series_endpoint_rejects_bad_range() -> None:


### PR DESCRIPTION
## Summary
- distinguish an empty selected time window from a workspace with no activity
- return the latest activity timestamp with usage-series data
- offer the smallest longer range containing prior requests
- render empty windows as zero requests instead of a warning

## Production diagnosis
Jay's workspace has 11,054 indexed requests in 30d and 8,895 in 7d. Its latest settled request was 2026-07-14T15:34:16Z, so 1h, 6h, and 24h correctly contain zero requests. The old copy incorrectly said there was no activity at all.

## Verification
- 1542 passed, 33 skipped
- ruff check .
- mypy (168 source files)