### PR TITLE
Automate Cohere and Voyage embedding prices

### DIFF
--- a/scripts/pricing/manifest.py
+++ b/scripts/pricing/manifest.py
@@ -1,0 +1,68 @@
+"""Shared writers for committed provider-pricing manifests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts.pricing.base import ProviderPricingResult
+
+
+def write_embedding_provider_manifest(
+    result: ProviderPricingResult,
+    *,
+    manifest_path: Path,
+    required_model_ids: frozenset[str],
+) -> list[str]:
+    """Update input-only embedding prices in a provider manifest.
+
+    Provider parsers use the normal ``ModelPrice`` contract, where embeddings
+    carry a zero completion price. Keeping this writer shared prevents each
+    embedding provider from inventing a subtly different manifest format.
+    """
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError(f"{result.slug} manifest has no models list")
+
+    updated: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("model_type") != "embedding":
+            continue
+        model_id = row.get("id")
+        if not isinstance(model_id, str):
+            continue
+        price = result.prices.get(model_id)
+        if price is None:
+            continue
+        if len(price.tiers) != 1 or price.completion_micro_per_m != 0:
+            raise RuntimeError(
+                f"{result.slug} embedding price for {model_id} must be "
+                "single-tier and input-only"
+            )
+        row["input_token_price_per_m"] = price.prompt_micro_per_m
+        row["output_token_price_per_m"] = 0
+        row["pricing_source"] = result.fetched_url
+        updated.append(model_id)
+
+    missing = sorted(required_model_ids - set(updated))
+    if missing:
+        raise RuntimeError(
+            f"{result.slug} manifest did not update required model(s): {missing}"
+        )
+
+    if result.fetched_url:
+        raw["pricing_source"] = result.fetched_url
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(rows)
+    manifest_path.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return [
+        f"{result.slug}: refreshed provider_models/{manifest_path.name} "
+        f"({len(updated)} priced rows)"
+    ]

--- a/scripts/pricing/parsers/cohere.py
+++ b/scripts/pricing/parsers/cohere.py
@@ -1,0 +1,38 @@
+"""Parse Cohere's embedded first-party pricing data."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+
+def _microdollars_per_million(value: str) -> int:
+    return int((Decimal(value) * Decimal(1_000_000)).to_integral_value())
+
+
+def parse(html: str) -> dict[str, dict[str, int]]:
+    # Next.js serializes the Sanity pricing payload into script text with
+    # escaped quotes. Normalize only that representation, then scope the
+    # price lookup to the Embed 4 record so Model Vault instance rates and
+    # image prices cannot be mistaken for text-token pricing.
+    text = html.replace(r'\"', '"')
+    record = re.search(
+        r'"modelName":"Embed 4","per":"1M tokens"'
+        r'.{0,8000}?"pricings":\[(.*?)\]',
+        text,
+        re.DOTALL,
+    )
+    if record is None:
+        return {}
+    price = re.search(
+        r'"inputLabel":"Cost","inputPrice":([0-9]+(?:\.[0-9]+)?)',
+        record.group(1),
+    )
+    if price is None:
+        return {}
+    return {
+        "cohere/embed-v4.0": {
+            "prompt_micro_per_m": _microdollars_per_million(price.group(1)),
+            "completion_micro_per_m": 0,
+        }
+    }

--- a/scripts/pricing/parsers/voyage.py
+++ b/scripts/pricing/parsers/voyage.py
@@ -1,0 +1,46 @@
+"""Parse Voyage AI's official Markdown pricing tables."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+
+def _microdollars_per_million(value: str) -> int:
+    return int((Decimal(value) * Decimal(1_000_000)).to_integral_value())
+
+
+def _embedding_sections(markdown: str) -> list[str]:
+    sections: list[str] = []
+    for start, end in (
+        (r"^# Text Embeddings\s*$", r"^# Multimodal Embeddings\s*$"),
+        (r"^## Older models\s*$", r"^# Fine-tuned models\s*$"),
+    ):
+        match = re.search(start + r"(.*?)" + end, markdown, re.MULTILINE | re.DOTALL)
+        if match is not None:
+            sections.append(match.group(1))
+    return sections
+
+
+def parse(markdown: str) -> dict[str, dict[str, int]]:
+    prices: dict[str, dict[str, int]] = {}
+    for section in _embedding_sections(markdown):
+        for line in section.splitlines():
+            if not line.lstrip().startswith("|"):
+                continue
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if len(cells) < 3:
+                continue
+            million_price = re.fullmatch(r"\$([0-9]+(?:\.[0-9]+)?)", cells[2])
+            if million_price is None:
+                continue
+            for native_id in re.findall(r"`([^`]+)`", cells[0]):
+                if not native_id.startswith("voyage-"):
+                    continue
+                prices[f"voyage/{native_id}"] = {
+                    "prompt_micro_per_m": _microdollars_per_million(
+                        million_price.group(1)
+                    ),
+                    "completion_micro_per_m": 0,
+                }
+    return prices

--- a/scripts/pricing/providers/cohere.py
+++ b/scripts/pricing/providers/cohere.py
@@ -1,0 +1,32 @@
+"""Cohere first-party embedding pricing refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from scripts.pricing.manifest import write_embedding_provider_manifest
+
+SLUG = "cohere"
+URL = "https://cohere.com/pricing"
+EXPECTED_MODELS = ["cohere/embed-v4.0"]
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "cohere.json"
+)
+
+
+def fetch() -> ProviderPricingResult:
+    return fetch_provider(slug=SLUG, url=URL, expected_models=EXPECTED_MODELS)
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_embedding_provider_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        required_model_ids=frozenset(EXPECTED_MODELS),
+    )

--- a/scripts/pricing/providers/voyage.py
+++ b/scripts/pricing/providers/voyage.py
@@ -1,0 +1,42 @@
+"""Voyage AI first-party embedding pricing refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from scripts.pricing.manifest import write_embedding_provider_manifest
+
+SLUG = "voyage"
+URL = "https://docs.voyageai.com/docs/pricing.md"
+EXPECTED_MODELS = [
+    "voyage/voyage-4-large",
+    "voyage/voyage-4",
+    "voyage/voyage-4-lite",
+    "voyage/voyage-context-3",
+    "voyage/voyage-code-3",
+    "voyage/voyage-finance-2",
+    "voyage/voyage-law-2",
+    "voyage/voyage-code-2",
+    "voyage/voyage-3-large",
+]
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "voyage.json"
+)
+
+
+def fetch() -> ProviderPricingResult:
+    return fetch_provider(slug=SLUG, url=URL, expected_models=EXPECTED_MODELS)
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_embedding_provider_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        required_model_ids=frozenset({"voyage/voyage-3-large"}),
+    )

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -98,6 +98,10 @@ PROVIDER_SLUGS = [
     "xiaomi",
     "alibaba",
     "makora",
+    # First-party embedding providers. Their parsers feed committed provider
+    # manifests that the runtime embedding catalog reads directly.
+    "cohere",
+    "voyage",
 ]
 
 # >N providers failing entirely (network down, blocked, etc.) fails

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -1230,7 +1230,7 @@ _EMBEDDING_SPECS: tuple[_EmbeddingSpec, ...] = (
         "provider": "voyage",
         "upstream_id": "voyage-3-large",
         "context_length": 32_000,
-        "cost_dollars_per_million": "0.06",
+        "cost_dollars_per_million": "0.18",
     },
     # Qwen3-Embedding-8B — open model, served serverlessly by DeepInfra
     # (api.deepinfra.com/v1/openai/embeddings, OpenAI-shaped). Tops MTEB; 4096

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -23,6 +23,7 @@ from trusted_router.catalog_data import (
     PROVIDERS,
     Model,
     ModelEndpoint,
+    _EmbeddingSpec,
 )
 from trusted_router.pricing import (
     PriceTier,
@@ -483,12 +484,25 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
 
 
 def _embedding_models() -> dict[str, Model]:
-    """Seed the embedding-model catalog (input-only pricing)."""
+    """Seed the embedding-model catalog (input-only pricing).
+
+    Provider manifests override the checked-in fallback price when an hourly
+    first-party parser has produced a current embedding row. Static specs
+    remain the last-known-good fallback for providers that do not publish a
+    parseable price source.
+    """
     models: dict[str, Model] = {}
     for spec in _EMBEDDING_SPECS:
         if spec["provider"] not in PROVIDERS:
             continue
-        prompt_price, published_price, _cost = _priced(spec["cost_dollars_per_million"])
+        manifest_cost = _embedding_manifest_cost(spec)
+        if manifest_cost is None:
+            prompt_price, published_price, _cost = _priced(
+                spec["cost_dollars_per_million"]
+            )
+        else:
+            prompt_price = _customer_price(manifest_cost)
+            published_price = prompt_price
         models[spec["id"]] = Model(
             id=spec["id"],
             name=spec["name"],
@@ -508,6 +522,34 @@ def _embedding_models() -> dict[str, Model]:
             published_price_tiers=_flat_tier(published_price, 0, None),
         )
     return models
+
+
+def _embedding_manifest_cost(spec: _EmbeddingSpec) -> int | None:
+    """Return a provider-manifest input cost in microdollars/M, if valid."""
+    path = _PROVIDER_MODELS_DIR / f"{spec['provider']}.json"
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        return None
+    price_scale = _provider_manifest_price_scale(raw)
+    for row in rows:
+        if not isinstance(row, dict) or row.get("id") != spec["id"]:
+            continue
+        if row.get("model_type") != "embedding":
+            return None
+        if "embeddings" not in {str(item) for item in (row.get("endpoints") or [])}:
+            return None
+        cost = _provider_manifest_price_cost(
+            row.get("input_token_price_per_m"),
+            price_scale=price_scale,
+        )
+        return cost if cost > 0 else None
+    return None
 
 
 def _filter_unserved_provider_endpoints(

--- a/src/trusted_router/data/provider_models/cohere.json
+++ b/src/trusted_router/data/provider_models/cohere.json
@@ -1,0 +1,50 @@
+{
+  "_about": "Cohere-hosted embedding models. Embed 4 pricing refreshes hourly from Cohere's public pricing page. Cohere's current public page does not publish legacy Embed v3 token prices, so those rows remain explicitly pinned until Cohere publishes a current first-party rate.",
+  "provider": "cohere",
+  "source": "https://docs.cohere.com/docs/cohere-embed",
+  "pricing_source": "https://cohere.com/pricing",
+  "generated_at": "2026-07-15T22:07:54Z",
+  "price_scale": "microdollars_per_million",
+  "model_count": 3,
+  "models": [
+    {
+      "id": "cohere/embed-v4.0",
+      "upstream_id": "embed-v4.0",
+      "display_name": "Cohere Embed v4.0",
+      "context_length": 128000,
+      "model_type": "embedding",
+      "endpoints": [
+        "embeddings"
+      ],
+      "input_token_price_per_m": 120000,
+      "output_token_price_per_m": 0,
+      "pricing_source": "https://cohere.com/pricing"
+    },
+    {
+      "id": "cohere/embed-english-v3.0",
+      "upstream_id": "embed-english-v3.0",
+      "display_name": "Cohere Embed English v3.0",
+      "context_length": 512,
+      "model_type": "embedding",
+      "endpoints": [
+        "embeddings"
+      ],
+      "input_token_price_per_m": 100000,
+      "output_token_price_per_m": 0,
+      "pricing_source": "legacy-pinned"
+    },
+    {
+      "id": "cohere/embed-multilingual-v3.0",
+      "upstream_id": "embed-multilingual-v3.0",
+      "display_name": "Cohere Embed Multilingual v3.0",
+      "context_length": 512,
+      "model_type": "embedding",
+      "endpoints": [
+        "embeddings"
+      ],
+      "input_token_price_per_m": 100000,
+      "output_token_price_per_m": 0,
+      "pricing_source": "legacy-pinned"
+    }
+  ]
+}

--- a/src/trusted_router/data/provider_models/voyage.json
+++ b/src/trusted_router/data/provider_models/voyage.json
@@ -1,0 +1,24 @@
+{
+  "_about": "Voyage-hosted embedding models with first-party prices refreshed hourly from Voyage's official Markdown pricing page.",
+  "provider": "voyage",
+  "source": "https://docs.voyageai.com/docs/embeddings",
+  "pricing_source": "https://docs.voyageai.com/docs/pricing.md",
+  "generated_at": "2026-07-15T22:07:54Z",
+  "price_scale": "microdollars_per_million",
+  "model_count": 1,
+  "models": [
+    {
+      "id": "voyage/voyage-3-large",
+      "upstream_id": "voyage-3-large",
+      "display_name": "Voyage 3 Large",
+      "context_length": 32000,
+      "model_type": "embedding",
+      "endpoints": [
+        "embeddings"
+      ],
+      "input_token_price_per_m": 180000,
+      "output_token_price_per_m": 0,
+      "pricing_source": "https://docs.voyageai.com/docs/pricing.md"
+    }
+  ]
+}

--- a/tests/fixtures/pricing/cohere.html
+++ b/tests/fixtures/pricing/cohere.html
@@ -1,0 +1,3 @@
+<script>
+self.__next_f.push([1,"{\"pricingGroups\":[{\"models\":[{\"modelName\":\"Embed 4\",\"per\":\"1M tokens\",\"portableBody\":[{\"text\":\"128K context window\"}],\"pricings\":[{\"inputLabel\":\"Cost\",\"inputPrice\":0.12,\"outputLabel\":\"Image cost\",\"outputPrice\":0.47}],\"primaryCta\":{}}]}]}"])
+</script>

--- a/tests/fixtures/pricing/voyage.html
+++ b/tests/fixtures/pricing/voyage.html
@@ -1,0 +1,27 @@
+# Pricing
+
+# Text Embeddings
+
+| Model                                                       | Price per thousand tokens | Price per million tokens | Number of free tokens |
+| ----------------------------------------------------------- | ------------------------- | ------------------------ | --------------------- |
+| `voyage-4-large`                                            | $0.00012                  | $0.12                    | 200 million           |
+| `voyage-4`                                                  | $0.00006                  | $0.06                    | 200 million           |
+| `voyage-4-lite`                                             | $0.00002                  | $0.02                    | 200 million           |
+| `voyage-context-3`                                          | $0.00018                  | $0.18                    | 200 million           |
+| `voyage-code-3`                                             | $0.00018                  | $0.18                    | 200 million           |
+| `voyage-finance-2`<br />`voyage-law-2`<br />`voyage-code-2` | $0.00012                  | $0.12                    | 50 million            |
+
+# Multimodal Embeddings
+
+| Model | Price per million tokens | Price per billion pixels |
+| `voyage-multimodal-3.5` | $0.12 | $0.60 |
+
+## Older models
+
+| Model                    | Price per thousand tokens | Price per million tokens |
+| :----------------------- | :------------------------ | :----------------------- |
+| `voyage-3-large`         | $0.00018                  | $0.18                    |
+| `voyage-3.5`             | $0.00006                  | $0.06                    |
+| `rerank-2`               | $0.00005                  | $0.05                    |
+
+# Fine-tuned models

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -38,13 +38,13 @@ def _known_provider_model_payload(url: str, _env_names: tuple[str, ...]) -> dict
     return {"data": []}
 
 
-def test_audit_flags_uncovered_provider_and_reports_covered() -> None:
-    # Real repo state: Cohere is a prepaid provider with no scraper + no
-    # manifest (hand-coded embedding prices) -> must be flagged as a gap.
-    # If a Cohere scraper/manifest is ever added, update this expectation.
+def test_audit_reports_embedding_provider_scrapers_as_covered() -> None:
     now = dt.datetime(2026, 6, 7, tzinfo=dt.UTC)
     warnings, info = audit(max_age_days=14, now=now, check_model_discovery=False)
-    assert any("cohere" in w for w in warnings), warnings
+    assert not any("cohere" in warning for warning in warnings), warnings
+    assert not any("voyage" in warning for warning in warnings), warnings
+    assert "cohere: live scraper ✓" in info
+    assert "voyage: live scraper ✓" in info
     # Live-scraped providers are reported as covered.
     assert any("openai" in i for i in info), info
 

--- a/tests/test_embedding_pricing_refresh.py
+++ b/tests/test_embedding_pricing_refresh.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult, ast_whitelist_check
+from scripts.pricing.parsers import cohere as cohere_parser
+from scripts.pricing.parsers import voyage as voyage_parser
+from scripts.pricing.providers import cohere, voyage
+from trusted_router import catalog_ingest
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pricing"
+
+
+def test_cohere_parser_reads_embed4_token_cost_not_image_or_instance_cost() -> None:
+    prices = cohere_parser.parse(
+        (FIXTURE_DIR / "cohere.html").read_text(encoding="utf-8")
+    )
+
+    assert prices == {
+        "cohere/embed-v4.0": {
+            "prompt_micro_per_m": 120_000,
+            "completion_micro_per_m": 0,
+        }
+    }
+
+
+def test_voyage_parser_reads_current_and_older_text_embedding_tables() -> None:
+    prices = voyage_parser.parse(
+        (FIXTURE_DIR / "voyage.html").read_text(encoding="utf-8")
+    )
+
+    assert prices["voyage/voyage-4-large"]["prompt_micro_per_m"] == 120_000
+    assert prices["voyage/voyage-finance-2"]["prompt_micro_per_m"] == 120_000
+    assert prices["voyage/voyage-law-2"]["prompt_micro_per_m"] == 120_000
+    assert prices["voyage/voyage-code-2"]["prompt_micro_per_m"] == 120_000
+    assert prices["voyage/voyage-3-large"] == {
+        "prompt_micro_per_m": 180_000,
+        "completion_micro_per_m": 0,
+    }
+    assert "voyage/voyage-multimodal-3.5" not in prices
+    assert "voyage/rerank-2" not in prices
+
+
+@pytest.mark.parametrize("slug", ["cohere", "voyage"])
+def test_embedding_parser_passes_self_heal_ast_policy(slug: str) -> None:
+    source = (Path("scripts/pricing/parsers") / f"{slug}.py").read_text(
+        encoding="utf-8"
+    )
+    assert ast_whitelist_check(source) == []
+
+
+@pytest.mark.parametrize(
+    ("provider", "model_id", "cost"),
+    [
+        (cohere, "cohere/embed-v4.0", 120_000),
+        (voyage, "voyage/voyage-3-large", 180_000),
+    ],
+)
+def test_embedding_provider_writer_updates_runtime_manifest(
+    provider, model_id: str, cost: int, tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / f"{provider.SLUG}.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": provider.SLUG,
+                "source": "model-docs",
+                "generated_at": "2026-01-01T00:00:00Z",
+                "price_scale": "microdollars_per_million",
+                "models": [
+                    {
+                        "id": model_id,
+                        "model_type": "embedding",
+                        "endpoints": ["embeddings"],
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(provider, "MANIFEST_PATH", manifest_path)
+    result = ProviderPricingResult(
+        slug=provider.SLUG,
+        prices={model_id: ModelPrice(cost, 0)},
+        source="deterministic",
+        fetched_url=provider.URL,
+    )
+
+    notes = provider.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert raw["models"][0]["input_token_price_per_m"] == cost
+    assert raw["models"][0]["output_token_price_per_m"] == 0
+    assert raw["models"][0]["pricing_source"] == provider.URL
+    assert notes == [
+        f"{provider.SLUG}: refreshed provider_models/{provider.SLUG}.json "
+        "(1 priced rows)"
+    ]
+
+
+def test_embedding_catalog_uses_manifest_cost_with_customer_markup(
+    tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    (tmp_path / "voyage.json").write_text(
+        json.dumps(
+            {
+                "provider": "voyage",
+                "price_scale": "microdollars_per_million",
+                "models": [
+                    {
+                        "id": "voyage/voyage-3-large",
+                        "model_type": "embedding",
+                        "endpoints": ["embeddings"],
+                        "input_token_price_per_m": 200_000,
+                        "output_token_price_per_m": 0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(catalog_ingest, "_PROVIDER_MODELS_DIR", tmp_path)
+
+    model = catalog_ingest._embedding_models()["voyage/voyage-3-large"]
+
+    assert model.prompt_price_microdollars_per_million_tokens == 220_000
+    assert model.completion_price_microdollars_per_million_tokens == 0
+
+
+def test_embedding_providers_run_in_hourly_refresh() -> None:
+    assert {"cohere", "voyage"} <= set(refresh.PROVIDER_SLUGS)
+
+
+def test_checked_in_voyage_fallback_matches_first_party_rate(
+    tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    monkeypatch.setattr(catalog_ingest, "_PROVIDER_MODELS_DIR", tmp_path)
+    model = catalog_ingest._embedding_models()["voyage/voyage-3-large"]
+    assert model.prompt_price_microdollars_per_million_tokens == 198_000


### PR DESCRIPTION
## Summary
- add first-party hourly pricing parsers for Cohere and Voyage embeddings
- persist parsed costs in provider manifests consumed by the runtime catalog
- correct Voyage 3 Large upstream cost from $0.06/M to the current $0.18/M
- keep Cohere v3 legacy rates explicitly pinned because Cohere's current public page only publishes Embed 4 pricing

## Sources
- Cohere: https://cohere.com/pricing
- Voyage: https://docs.voyageai.com/docs/pricing.md

## Verification
- live parser smoke against both first-party pages
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1551 passed, 33 skipped)
- price-source coverage reports all prepaid providers covered