### PR TITLE
Update Liberty orchestration graphs

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -1175,16 +1175,16 @@ ADVISOR_CATALOG_MODEL_ORDERS: dict[str, tuple[str, ...]] = {
         "moonshotai/kimi-k2.6",
     ),
     LIBERTY_2_0_MODEL_ID: (
-        "google/gemma-4-31b-it",
-        "openai/gpt-oss-120b",
-        LIBERTY_1_0_1M_MODEL_ID,
-    ),
-    LIBERTY_3_0_MODEL_ID: (
-        "thinkingmachines/inkling",
-        "openai/gpt-oss-120b",
-        "google/gemma-4-31b-it",
         "nvidia/nemotron-3-ultra-550b-a55b",
         LIBERTY_1_0_1M_MODEL_ID,
+        LIBERTY_1_0_MODEL_ID,
+    ),
+    LIBERTY_3_0_MODEL_ID: (
+        "nvidia/nemotron-3-ultra-550b-a55b",
+        "google/gemma-4-31b-it",
+        "openai/gpt-oss-120b",
+        LIBERTY_1_0_1M_MODEL_ID,
+        "thinkingmachines/inkling",
     ),
 }
 

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -795,20 +795,20 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
             "advisor_orchestration",
             262_144,
             [
-                "google/gemma-4-31b-it",
-                "openai/gpt-oss-120b",
+                "nvidia/nemotron-3-ultra-550b-a55b",
                 LIBERTY_1_0_1M_MODEL_ID,
+                LIBERTY_1_0_MODEL_ID,
             ],
         ),
         LIBERTY_3_0_MODEL_ID: (
             "advisor_orchestration",
             1_048_576,
             [
-                "thinkingmachines/inkling",
-                "openai/gpt-oss-120b",
-                "google/gemma-4-31b-it",
                 "nvidia/nemotron-3-ultra-550b-a55b",
+                "google/gemma-4-31b-it",
+                "openai/gpt-oss-120b",
                 LIBERTY_1_0_1M_MODEL_ID,
+                "thinkingmachines/inkling",
             ],
         ),
     }

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -911,17 +911,17 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     ]
     assert liberty_2["context_length"] == 262_144
     assert liberty_2["trustedrouter"]["auto_candidates"] == [
-        "google/gemma-4-31b-it",
-        "openai/gpt-oss-120b",
+        "nvidia/nemotron-3-ultra-550b-a55b",
         "trustedrouter/liberty-1.0-1m",
+        "trustedrouter/liberty-1.0",
     ]
     assert liberty_3["context_length"] == 1_048_576
     assert liberty_3["trustedrouter"]["auto_candidates"] == [
-        "thinkingmachines/inkling",
-        "openai/gpt-oss-120b",
-        "google/gemma-4-31b-it",
         "nvidia/nemotron-3-ultra-550b-a55b",
+        "google/gemma-4-31b-it",
+        "openai/gpt-oss-120b",
         "trustedrouter/liberty-1.0-1m",
+        "thinkingmachines/inkling",
     ]
     # Probe one model from each TR-keyed provider that actually appears
     # in the ingest snapshot. Vertex is intentionally absent — TR doesn't


### PR DESCRIPTION
## Summary
- make Nemotron 3 Ultra the Liberty 2 worker
- use Liberty 1.0 1M and Liberty 1.0 as Liberty 2 advisors
- make Nemotron 3 Ultra the Liberty 3 worker with Gemma 4, GPT OSS 120B, Liberty 1.0 1M, and Inkling advisors
- align public model composition metadata with the enclave graph

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1556 passed, 33 skipped)
