### PR TITLE
Route Liberty Nemotron through verified providers

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -1322,6 +1322,9 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
         {
             "anthropic/claude-opus-4.7",
             "openai/gpt-5.5",
+            # 2026-07-15: the snapshot route returns 404 when pinned to GMI.
+            # Keep the directly verified Baseten route.
+            "nvidia/nemotron-3-ultra-550b-a55b",
             # 2026-06-24: GMI returns HTTP 200 with an empty assistant message
             # for these Gemma 4 routes when pinned through the live gateway.
             # Treat as unserved for prepaid routing until GMI returns usable
@@ -1338,6 +1341,9 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
         {
             "meta-llama/llama-3.1-8b-instruct",
             "meta-llama/llama-3.1-70b-instruct",
+            # 2026-07-15: the snapshot route returns 404 when pinned to
+            # Together. Keep the directly verified Baseten route.
+            "nvidia/nemotron-3-ultra-550b-a55b",
             "qwen/qwen-2.5-72b-instruct",
         }
     ),

--- a/src/trusted_router/data/provider_models/baseten.json
+++ b/src/trusted_router/data/provider_models/baseten.json
@@ -87,7 +87,7 @@
       "cached_input_token_price_per_m": 145000
     },
     {
-      "id": "nvidia/nvidia-nemotron-3-ultra-550b-a55b",
+      "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "upstream_id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
       "display_name": "NVIDIA Nemotron 3 Ultra 550B A55B",
       "context_length": 202800,

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -865,32 +865,6 @@
       "status": 1
     },
     {
-      "id": "nvidia/Nemotron-3-Ultra-550b-a55b",
-      "upstream_id": "nvidia/Nemotron-3-Ultra-550b-a55b",
-      "display_name": "Nemotron-3-Ultra-550b-a55b",
-      "title": "nvidia/Nemotron-3-Ultra-550b-a55b",
-      "created": 1783118261,
-      "context_length": 8000,
-      "max_output_tokens": 65536,
-      "input_token_price_per_m": 1000000,
-      "output_token_price_per_m": 3000000,
-      "model_type": "chat",
-      "features": [
-        "serverless",
-        "function-calling"
-      ],
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "endpoints": [
-        "chat/completions"
-      ],
-      "status": 1
-    },
-    {
       "id": "openbmb/MiniCPM-V-4_5",
       "upstream_id": "openbmb/MiniCPM-V-4_5",
       "display_name": "openbmb/MiniCPM-V-4_5",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -841,6 +841,23 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
     } == {("baseten", "thinkingmachines/inkling")}
 
 
+def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() -> None:
+    model_id = "nvidia/nemotron-3-ultra-550b-a55b"
+    assert model_id in MODELS
+    assert "nvidia/nvidia-nemotron-3-ultra-550b-a55b" not in MODELS
+    assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in MODELS
+
+    prepaid = {
+        endpoint.provider: endpoint.upstream_id
+        for endpoint in endpoints_for_model(model_id)
+        if endpoint.usage_type == "Credits"
+    }
+    assert prepaid["baseten"] == "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
+    assert "nebius" not in prepaid
+    assert "together" not in prepaid
+    assert "gmi" not in prepaid
+
+
 def test_athena_catalog_hides_orchestration_configuration() -> None:
     from trusted_router.catalog import ATHENA_MODEL_ID
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -69,6 +69,38 @@ def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() 
     assert ("reservation", data["credit_reservation_id"]) not in db.rows
 
 
+def test_gateway_authorizes_every_liberty_alias_to_working_nemotron_hosts() -> None:
+    client, key = _client_and_key()
+
+    for model_id in (
+        "trustedrouter/liberty-1.0",
+        "trustedrouter/liberty-1.0-1m",
+        "trustedrouter/liberty-2.0",
+        "trustedrouter/liberty-3.0",
+    ):
+        authorize = client.post(
+            "/v1/internal/gateway/authorize",
+            json={
+                "api_key_hash": key["hash"],
+                "model": model_id,
+                "estimated_input_tokens": 1,
+                "max_output_tokens": 1,
+            },
+        )
+
+        assert authorize.status_code == 200, (model_id, authorize.text)
+        routes = authorize.json()["data"]["route_candidates"]
+        assert routes, model_id
+        nemotron_hosts = {
+            route["provider"]
+            for route in routes
+            if route["model"] == "nvidia/nemotron-3-ultra-550b-a55b"
+            and route["usage_type"] == "Credits"
+        }
+        assert "baseten" in nemotron_hosts, (model_id, routes)
+        assert not {"together", "gmi", "nebius"} & nemotron_hosts, (model_id, routes)
+
+
 def test_gateway_settle_ancient_legacy_reservation_missing_typed_row_is_clean() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_gcp_ancient_legacy_settle"


### PR DESCRIPTION
## Summary
- attach Baseten's verified native Nemotron 3 Ultra endpoint to the canonical model ID
- remove the stale Nebius registration after authenticated direct and model-list checks proved it unavailable
- suppress known-404 Together and GMI prepaid snapshot routes while preserving BYOK behavior
- add catalog and gateway authorization regressions for every Liberty alias

## Direct provider verification
- Baseten canonical route: HTTP 200, exact PONG
- Nebius route: HTTP 404 and absent from authenticated /v1/models

## Local verification
- 1558 passed, 33 skipped
- focused catalog and Liberty authorization tests: 72 passed
- ruff clean
- mypy clean
- git diff --check clean

Deployment order: merge/deploy quill-cloud-proxy#27 first, then this PR.