### PR TITLE
Add Kimi K3 first-party routing

### DIFF
--- a/scripts/pricing/providers/kimi.py
+++ b/scripts/pricing/providers/kimi.py
@@ -33,6 +33,7 @@ SLUG = "kimi"
 DOC_INDEX_URL = "https://platform.kimi.ai/docs/llms.txt"
 MODELS_URL = "https://api.moonshot.ai/v1/models"
 FALLBACK_SUBPAGES = (
+    "https://platform.kimi.ai/docs/pricing/chat-k3.md",
     "https://platform.kimi.ai/docs/pricing/chat-k27-code.md",
     "https://platform.kimi.ai/docs/pricing/chat-k26.md",
     "https://platform.kimi.ai/docs/pricing/chat-k25.md",
@@ -50,6 +51,7 @@ MANIFEST_PATH = (
 )
 
 EXPECTED_MODELS = [
+    "moonshotai/kimi-k3",
     "moonshotai/kimi-k2.6",
     "moonshotai/kimi-k2.7-code",
     "moonshotai/kimi-k2.7-code-highspeed",

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -70,6 +70,23 @@
       "cached_input_token_price_per_m": 380000
     },
     {
+      "id": "moonshotai/kimi-k3",
+      "upstream_id": "kimi-k3",
+      "display_name": "Kimi K3",
+      "title": "kimi-k3",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "context_length": 1048576,
+      "supports_image_in": true,
+      "supports_video_in": true,
+      "supports_reasoning": true,
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000
+    },
+    {
       "id": "moonshotai/moonshot-v1-128k",
       "upstream_id": "moonshot-v1-128k",
       "display_name": "Moonshot V1 128K",
@@ -169,6 +186,6 @@
   "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
   "source": "https://api.moonshot.ai/v1/models",
   "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
-  "generated_at": "2026-07-15T21:03:07Z",
-  "model_count": 10
+  "generated_at": "2026-07-16T15:49:39Z",
+  "model_count": 11
 }

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -73,6 +73,7 @@ from trusted_router.routing import chat_route_candidates, chat_route_endpoint_ca
 def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert len(PROVIDERS) >= 8
     assert "kimi" in PROVIDERS
+    assert "moonshotai/kimi-k3" in MODELS
     assert "moonshotai/kimi-k2.6" in MODELS
     assert "moonshotai/kimi-k2.7-code" in MODELS
     assert "moonshotai/kimi-k2.7-code-highspeed" in MODELS
@@ -82,6 +83,14 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert "moonshotai/kimi-k2.7-code@kimi/byok" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k2.7-code-highspeed@kimi/byok" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@kimi/prepaid" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@kimi/byok" in MODEL_ENDPOINTS
+    kimi_k3 = MODELS["moonshotai/kimi-k3"]
+    assert kimi_k3.context_length == 1_048_576
+    assert kimi_k3.prompt_price_microdollars_per_million_tokens == 3_300_000
+    assert kimi_k3.completion_price_microdollars_per_million_tokens == 16_500_000
+    assert kimi_k3.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 330_000
+    assert MODEL_ENDPOINTS["moonshotai/kimi-k3@kimi/prepaid"].upstream_id == "kimi-k3"
     assert (
         MODEL_ENDPOINTS["moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid"].upstream_id
         == "kimi-k2.7-code-highspeed"
@@ -1118,6 +1127,7 @@ def test_route_candidates_honor_models_provider_order_sort_and_dedupe() -> None:
 @pytest.mark.parametrize(
     ("model_id", "provider"),
     [
+        ("moonshotai/kimi-k3", "kimi"),
         ("moonshotai/kimi-k2.6", "kimi"),
         ("openai/gpt-4.1-mini", "openai"),
         ("mistralai/mistral-small-2603", "mistral"),

--- a/tests/test_kimi_pricing.py
+++ b/tests/test_kimi_pricing.py
@@ -22,8 +22,8 @@ def _pricing_doc(*, include_k3: bool = True, include_ghost: bool = False) -> str
     ]
     if include_k3:
         rows.append(
-            '["kimi-k3", "1M tokens", <>{"$"}0.20</>, <>{"$"}1.00</>, '
-            '<>{"$"}5.00</>, "1,048,576 tokens"]'
+            '["kimi-k3", "1M tokens", <>{"$"}0.30</>, <>{"$"}3.00</>, '
+            '<>{"$"}15.00</>, "1,048,576 tokens"]'
         )
     if include_ghost:
         rows.append(
@@ -80,9 +80,9 @@ def test_parser_accepts_future_kimi_family_without_code_change() -> None:
     parsed = kimi_parser.parse(_pricing_doc(include_k3=True))
 
     assert parsed["moonshotai/kimi-k3"] == {
-        "prompt_micro_per_m": 1_000_000,
-        "completion_micro_per_m": 5_000_000,
-        "prompt_cached_micro_per_m": 200_000,
+        "prompt_micro_per_m": 3_000_000,
+        "completion_micro_per_m": 15_000_000,
+        "prompt_cached_micro_per_m": 300_000,
     }
 
 
@@ -117,8 +117,9 @@ def test_fetch_intersects_live_models_and_writes_manifest(
     assert "moonshotai/kimi-ghost" not in result.prices
     assert by_id["moonshotai/kimi-k3"]["upstream_id"] == "kimi-k3"
     assert by_id["moonshotai/kimi-k3"]["context_length"] == 1_048_576
-    assert by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 1_000_000
-    assert by_id["moonshotai/kimi-k3"]["output_token_price_per_m"] == 5_000_000
+    assert by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 3_000_000
+    assert by_id["moonshotai/kimi-k3"]["output_token_price_per_m"] == 15_000_000
+    assert by_id["moonshotai/kimi-k3"]["cached_input_token_price_per_m"] == 300_000
     assert notes == ["kimi: refreshed provider_models/kimi.json (4 priced rows, appended 4)"]
 
 
@@ -139,9 +140,8 @@ def test_live_model_without_first_party_price_is_not_published(
         lambda _url, **_kwargs: _live_payload(include_k3=True),
     )
 
-    result = kimi.fetch()
-
-    assert "moonshotai/kimi-k3" not in result.prices
+    with pytest.raises(RuntimeError, match="expected models missing.*moonshotai/kimi-k3"):
+        kimi.fetch()
 
 
 def test_manifest_removes_models_no_longer_live_or_priced(


### PR DESCRIPTION
## Summary

- add `moonshotai/kimi-k3` from Moonshot's authenticated model catalog
- publish the official 1,048,576-token context and $3/$15/$0.30 cached-input upstream prices as integer microdollars
- expose Kimi prepaid and BYOK endpoints and require K3 in future pricing refreshes

## Verification

- direct Moonshot text, streaming reasoning, strict JSON schema, and forced tool-call smokes
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1559 passed, 33 skipped)
