### PR TITLE
Remove misleading content storage labels

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -2169,7 +2169,6 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         or model.prepaid_available,
         "byok": model.byok_available,
         "attested": provider.attested_gateway,
-        "stores_content": provider.stores_content,
         "provider_zero_data_retention": provider.provider_zero_data_retention,
         "provider_confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
@@ -2295,7 +2294,6 @@ def _model_detail_view(
                 "prompt_microdollars_per_million_tokens": endpoint.prompt_price_microdollars_per_million_tokens,
                 "completion_microdollars_per_million_tokens": endpoint.completion_price_microdollars_per_million_tokens,
                 "attested_gateway": ep_provider.attested_gateway if ep_provider else False,
-                "stores_content": ep_provider.stores_content if ep_provider else False,
                 "provider_zero_data_retention": (
                     ep_provider.provider_zero_data_retention if ep_provider else None
                 ),

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -126,7 +126,6 @@
           <th>Prompt</th>
           <th>Completion</th>
           <th>Attested</th>
-          <th>TR stores content</th>
           <th>Provider policy</th>
         </tr>
       </thead>
@@ -138,7 +137,6 @@
           <td>{{ endpoint.prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
           <td>{% if endpoint.attested_gateway %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
-          <td>{% if endpoint.stores_content %}<span class="pill warn">yes</span>{% else %}<span class="pill good">no</span>{% endif %}</td>
           <td>
             {% if endpoint.provider_e2ee %}<span class="pill good">provider E2EE</span>{% endif %}
             {% if endpoint.provider_confidential_compute %}<span class="pill good">confidential</span>{% endif %}

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -89,7 +89,6 @@
             {% if model.prepaid %}<span class="pill good">prepaid</span>{% endif %}
             {% if model.byok %}<span class="pill">BYOK</span>{% endif %}
             {% if model.attested %}<span class="pill good">attested</span>{% endif %}
-            {% if model.stores_content %}<span class="pill warn">stores content</span>{% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -237,6 +237,18 @@ def test_public_model_detail_lists_distinct_serving_providers(client: TestClient
         assert f'title="{provider}"' in response.text
 
 
+def test_public_model_pages_never_claim_tr_stores_content(client: TestClient) -> None:
+    catalog = client.get("/models")
+    detail = client.get("/models/moonshotai/kimi-k2.6")
+
+    assert catalog.status_code == 200
+    assert detail.status_code == 200
+    assert "stores content" not in catalog.text.lower()
+    assert "tr stores content" not in detail.text.lower()
+    assert "Provider policy" in detail.text
+    assert "upstream varies" in detail.text
+
+
 def test_public_meta_model_detail_renders_orchestration_components(client: TestClient) -> None:
     response = client.get("/models/trustedrouter/socrates-1.1")
 


### PR DESCRIPTION
## Summary
- remove the mislabeled TR content-storage column from every public model endpoint table
- remove the provider-scoped stores-content badge from the public model catalog
- keep provider ZDR, confidential-compute, E2EE, and upstream-policy labels visible
- add a regression test proving model pages never claim TrustedRouter stores content

## Validation
- uv run pytest -q tests/test_public_revenue_pages.py::test_public_model_pages_never_claim_tr_stores_content tests/test_public_revenue_pages.py::test_public_model_detail_lists_distinct_serving_providers
- uv run ruff check src/trusted_router/dashboard.py tests/test_public_revenue_pages.py
- uv run mypy