### PR TITLE
Clarify router attestation boundary

### DIFF
--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -118,6 +118,11 @@
       (or append <code>:nitro</code> to the model id) to route to the
       fastest provider instead.
     </p>
+    <p style="color:var(--muted);font-size:14px">
+      <strong>Trust boundary:</strong> TR router attestation verifies the
+      TrustedRouter gateway only. Provider policy separately describes the
+      upstream model host's retention, confidential compute, and E2EE posture.
+    </p>
     <table data-sortable="true">
       <thead>
         <tr>
@@ -125,7 +130,7 @@
           <th>Usage</th>
           <th>Prompt</th>
           <th>Completion</th>
-          <th>Attested</th>
+          <th>TR router attested</th>
           <th>Provider policy</th>
         </tr>
       </thead>

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -88,7 +88,7 @@
           <td>
             {% if model.prepaid %}<span class="pill good">prepaid</span>{% endif %}
             {% if model.byok %}<span class="pill">BYOK</span>{% endif %}
-            {% if model.attested %}<span class="pill good">attested</span>{% endif %}
+            {% if model.attested %}<span class="pill good">TR router attested</span>{% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -249,6 +249,23 @@ def test_public_model_pages_never_claim_tr_stores_content(client: TestClient) ->
     assert "upstream varies" in detail.text
 
 
+def test_public_kimi_k3_page_separates_router_attestation_from_provider_e2ee(
+    client: TestClient,
+) -> None:
+    catalog = client.get("/models")
+    detail = client.get("/models/moonshotai/kimi-k3")
+
+    assert catalog.status_code == 200
+    assert detail.status_code == 200
+    assert "TR router attested" in catalog.text
+    assert "TR router attestation verifies the\n      TrustedRouter gateway only" in detail.text
+    assert "<th>TR router attested</th>" in detail.text
+    assert "<th>Attested</th>" not in detail.text
+    assert "Provider policy" in detail.text
+    assert "upstream varies" in detail.text
+    assert "provider E2EE" not in detail.text
+
+
 def test_public_meta_model_detail_renders_orchestration_components(client: TestClient) -> None:
     response = client.get("/models/trustedrouter/socrates-1.1")
 


### PR DESCRIPTION
Summary:
- label model routes as TR router attested instead of bare attested
- explain that attestation covers the TrustedRouter gateway while provider policy describes upstream compute
- add Kimi K3 regression coverage preventing a provider E2EE implication

Verification:
- public revenue and SEO tests: 40 passed
- mypy passed
- ruff passed