### PR TITLE
Leaderboard: fix monitor triggers, dead routes, probe quirks, error detail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -316,7 +316,9 @@ jobs:
             if [ -z "$changed" ]; then
               changed="$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)"
             fi
-            if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/synthetic/|scripts/deploy/synthetic\.sh|\.github/workflows/deploy\.yml)$'; then
+            # Any app source change can affect the synthetic monitor image; it
+            # imports the same trusted_router package as the API service.
+            if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/|scripts/deploy/synthetic\.sh$|\.github/workflows/deploy\.yml$)'; then
               deploy_synthetic_monitor="true"
             fi
           fi

--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -275,7 +275,8 @@ jobs:
           # snapshot for hours because deploy.yml never auto-fired.
           gh workflow run ci.yml --ref main --repo "${GITHUB_REPOSITORY}"
           echo "  dispatched ci.yml for new snapshot"
-          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}"
+          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}" \
+            -f deploy_synthetic_monitor=true
           echo "  dispatched deploy.yml for new snapshot"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/pricing/providers/wafer.py
+++ b/scripts/pricing/providers/wafer.py
@@ -42,7 +42,9 @@ EXPECTED_MODELS = [
     "z-ai/glm-5.1",
     "z-ai/glm-5.2",
     "z-ai/glm-5.2-fast",
-    "moonshotai/kimi-k2.6",
+    # Pinning a model Wafer might delist deadlocks manifest rebuilds
+    # (validate raises -> stale fallback -> prune skipped); kimi-k2.6 already
+    # flipped non-ZDR once.
     "minimax/minimax-m3",
 ]
 

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -98,6 +98,19 @@ _MODEL_PROVIDER_PRIVACY_OVERRIDES: dict[tuple[str, str], ModelProviderPrivacyOve
         ),
         provider_policy_url="https://platform.claude.com/docs/en/api/data-retention",
     ),
+    (
+        "moonshotai/kimi-k2.6",
+        "wafer",
+    ): ModelProviderPrivacyOverride(
+        privacy_tier=PRIVACY_TIER_STANDARD,
+        provider_zero_data_retention=False,
+        provider_policy=(
+            "Wafer withdrew ZDR support for Kimi-K2.6 on 2026-06-26 "
+            "(capabilities.zdr.supported=false in their /v1/models). The "
+            "route is served at standard tier and excluded from "
+            "trustedrouter/zdr and provider.min_privacy=zdr routing."
+        ),
+    ),
 }
 
 
@@ -479,10 +492,10 @@ PROVIDERS: dict[str, Provider] = {
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
     # Wafer — OpenAI-compatible serverless API at pass.wafer.ai/v1. Wafer
-    # supports request-scoped ZDR with `Wafer-ZDR: required` on models whose
-    # /v1/models rows advertise `zdr_supported=true`; the gateway sends that
-    # header on Wafer routes. The provider itself is not marked globally ZDR
-    # because several Wafer models explicitly report zdr_supported=false.
+    # supports request-scoped ZDR with `Wafer-ZDR: required`; providers.py's
+    # live-provider allowlist sends that header on Wafer routes. The provider
+    # itself is not marked globally ZDR because several Wafer models explicitly
+    # report zdr_supported=false.
     "wafer": Provider(
         slug="wafer",
         name="Wafer",
@@ -1356,6 +1369,15 @@ _UNSERVED_CREDITS_MODELS: frozenset[str] = frozenset(
 )
 
 _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
+    "anthropic": frozenset(
+        {
+            # Undated alias stopped serving on TR's operator key ~2026-06-21.
+            # Credits-only drop keeps BYOK visible for customers whose own keys
+            # may still serve it; PROMOTE to _PROVIDER_DEPRECATED_UPSTREAM_MODELS
+            # after Anthropic's formal retirement on 2026-08-05.
+            "anthropic/claude-opus-4.1",
+        }
+    ),
     "gmi": frozenset(
         {
             "anthropic/claude-opus-4.7",

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -110,6 +110,17 @@ _AUTHOR_TO_PROVIDER_SLUG: dict[str, str] = {
 }
 
 _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
+    # Xiaomi retired the MiMo V2 family upstream on 2026-06-29; these manifest
+    # rows are historical fallback metadata and have shown 100% probe failure
+    # since 2026-06-29. Keep provider-scoped: V2.5 Xiaomi routes remain alive.
+    "xiaomi": frozenset(
+        {
+            "xiaomi/mimo-v2-flash",
+            "mimo-v2-flash",
+            "xiaomi/mimo-v2-pro",
+            "mimo-v2-pro",
+        }
+    ),
     # Nebius notified customers that these Token Factory model APIs / UI
     # entries will be disabled on 2026-06-22. This is provider-scoped:
     # equivalent model families on MiniMax, Kimi, Z.AI, Cerebras, etc. remain
@@ -164,13 +175,43 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "qwen/qwen3-vl-32b-thinking",
             "qwen/qwen3-vl-8b-instruct",
             "qwen/qwen3-vl-8b-thinking",
+            # 100% MODEL_NOT_AVAILABLE-class probe failures since 2026-06-05.
+            "baidu/ernie-4.5-vl-28b-a3b",
+            # 100% MODEL_NOT_AVAILABLE-class probe failures since 2026-06-23.
+            "meta-llama/llama-3-70b-instruct",
         }
     ),
     # Friendli notified customers that GLM-5 serverless Model APIs stop being
     # supported at 2026-07-03 00:00 UTC. Dedicated endpoints are unaffected, but
     # TrustedRouter's Friendli route is the serverless API, so remove only this
-    # provider/model pair from routable candidates.
-    "friendli": frozenset({"z-ai/glm-5", "zai-org/GLM-5"}),
+    # provider/model pair from routable candidates. Friendli also dropped
+    # Llama 3.3 70B from serverless /models around 2026-06-26; it has shown
+    # 100% probe failure since 2026-06-26.
+    "friendli": frozenset(
+        {
+            "z-ai/glm-5",
+            "zai-org/GLM-5",
+            "meta-llama/llama-3.3-70b-instruct",
+            "meta-llama-3.3-70b-instruct",
+        }
+    ),
+    # Google retired the Gemini 3.1 Flash Lite preview id on 2026-07-09; the
+    # direct Gemini preview route has shown 100% probe failure since then. GA
+    # flash-lite routes on reseller providers are unaffected.
+    "gemini": frozenset(
+        {
+            "google/gemini-3.1-flash-lite-preview",
+            "gemini-3.1-flash-lite-preview",
+        }
+    ),
+    # Makora's AMD Llama 3.3 70B FP8 KV row was added on 2026-07-03 but never
+    # served a request; probes hang or 502, giving 100% failure since 2026-07-03.
+    "makora": frozenset(
+        {
+            "amd/llama-3.3-70b-instruct-fp8-kv",
+            "amd/Llama-3.3-70B-Instruct-FP8-KV",
+        }
+    ),
 }
 
 

--- a/src/trusted_router/providers.py
+++ b/src/trusted_router/providers.py
@@ -82,7 +82,9 @@ WAFER_ZDR_NATIVE_MODELS = frozenset(
     {
         "GLM-5.1",
         "GLM-5.2",
-        "Kimi-K2.6",
+        # Wafer withdrew ZDR support for Kimi-K2.6 on 2026-06-26
+        # (capabilities.zdr.supported=false in their /v1/models). Keep it out
+        # of the static live-provider ZDR-header allowlist.
         "Qwen3.6-35B-A3B",
         "deepseek-v4-flash",
         "deepseek-v4-pro",

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -11,6 +11,7 @@ from trusted_router.errors import api_error
 from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
 from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProbeSample
+from trusted_router.storage_models import scrub_provider_error_message
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
     gateway_fallback_probe,
@@ -165,6 +166,12 @@ def _benchmark_from_body(body: Any) -> ProviderBenchmarkSample:
         "finish_reason": _optional_str(body.get("finish_reason")),
         "error_type": _optional_str(body.get("error_type")),
         "error_status": _optional_int(body.get("error_status")),
+        # Scrub server-side too: the probe already redacts, but the ingest
+        # boundary must not trust any internal caller with key-shaped material.
+        "error_message": scrub_provider_error_message(
+            _optional_str(body.get("error_message")) or ""
+        )[:300]
+        or None,
         "region": _optional_str(body.get("region")),
         # This ingest is the synthetic rotation path; default provenance is
         # synthetic (the probe also sets it explicitly).

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -143,7 +143,6 @@ def fast_candidate_models(limit: int = 8) -> list[Model]:
     preferred_ids = [
         "cerebras/gpt-oss-120b",
         "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "xiaomi/mimo-v2-flash",
         "cerebras/zai-glm-4.7",
     ]
     candidates: list[Model] = []

--- a/src/trusted_router/storage_gcp_benchmark_index.py
+++ b/src/trusted_router/storage_gcp_benchmark_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 from typing import Any
 
@@ -78,10 +79,15 @@ def _benchmark_prefix(
 
 
 def _samples_from_rows(rows: Any, family: str) -> list[ProviderBenchmarkSample]:
+    field_names = {field.name for field in dataclasses.fields(ProviderBenchmarkSample)}
     samples: list[ProviderBenchmarkSample] = []
     for row in rows:
         cells = row.cells.get(family, {}).get(b"body", [])
         if not cells:
             continue
-        samples.append(ProviderBenchmarkSample(**json.loads(cells[0].value.decode("utf-8"))))
+        decoded = json.loads(cells[0].value.decode("utf-8"))
+        # Forward-compat: rollback readers predating a new stored field must
+        # not crash on rows that already carry it.
+        filtered = {key: value for key, value in decoded.items() if key in field_names}
+        samples.append(ProviderBenchmarkSample(**filtered))
     return samples

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
@@ -566,6 +567,18 @@ class Generation:
         }
 
 
+# Redaction for provider error strings persisted on benchmark samples. Shared
+# by the probe (client-side) and the internal ingest route (server-side) so a
+# buggy or future caller cannot persist key-shaped or bearer material.
+_KEY_SHAPED_RE = re.compile(r"(?i)\b(sk|rk)-[A-Za-z0-9_\-*]{4,}")
+_BEARER_TOKEN_RE = re.compile(r"(?i)bearer\s+\S+")
+
+
+def scrub_provider_error_message(value: str) -> str:
+    scrubbed = _KEY_SHAPED_RE.sub("sk-***", value)
+    return _BEARER_TOKEN_RE.sub("Bearer ***", scrubbed)
+
+
 @dataclass
 class ProviderBenchmarkSample:
     """Privacy-safe provider performance sample for future public rankings.
@@ -591,6 +604,10 @@ class ProviderBenchmarkSample:
     finish_reason: str | None = None
     error_type: str | None = None
     error_status: int | None = None
+    # Truncated upstream/provider error detail from synthetic probes. Organic
+    # samples leave it None; privacy-safe because this is a provider error
+    # string, never tenant content.
+    error_message: str | None = None
     region: str | None = None
     # Internal-only provenance: "organic" (real production traffic) or
     # "synthetic" (rotation-probe sample). Lets internal queries separate the

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -16,7 +16,11 @@ import httpx
 from trusted_router.config import Settings
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.security import lookup_hash_api_key
-from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
+from trusted_router.storage_models import (
+    ProviderBenchmarkSample,
+    SyntheticProbeSample,
+    scrub_provider_error_message,
+)
 from trusted_router.types import UsageType
 
 
@@ -877,7 +881,7 @@ async def provider_rotation_probe(
             served_model = response.headers.get("x-trustedrouter-served-model") or model
             if response.status_code != 200:
                 await response.aread()
-                error_type, error_status, _message = _response_error(response)
+                error_type, error_status, message = _response_error(response)
                 return _rotation_error_sample(
                     served_provider,
                     served_model,
@@ -885,6 +889,7 @@ async def provider_rotation_probe(
                     elapsed_ms=_elapsed_ms(started),
                     error_status=error_status,
                     error_type=error_type,
+                    error_message=message,
                 )
             tail = ""
             finish_reason: str | None = None
@@ -911,7 +916,7 @@ async def provider_rotation_probe(
                     break
             elapsed_ms = _elapsed_ms(started)
             if stream_error is not None:
-                error_type, status, _message = stream_error
+                error_type, status, message = stream_error
                 return _rotation_error_sample(
                     served_provider,
                     served_model,
@@ -919,6 +924,7 @@ async def provider_rotation_probe(
                     elapsed_ms=elapsed_ms,
                     error_status=status or 502,
                     error_type=error_type,
+                    error_message=message,
                 )
     except (httpx.HTTPError, ValueError) as exc:
         return _rotation_error_sample(
@@ -928,6 +934,7 @@ async def provider_rotation_probe(
             elapsed_ms=_elapsed_ms(started),
             error_status=None,
             error_type=exc.__class__.__name__,
+            error_message=str(exc),
         )
     if ttft_ms is None:
         error_type = "probe_config_error" if finish_reason == "length" else "empty_stream"
@@ -971,9 +978,12 @@ def _rotation_max_tokens(provider: str, model: str) -> int:
         or "glm-4.6" in model_l
         or "glm-4.7" in model_l
         or "glm-5" in model_l
+        or "nemotron" in model_l
         or "reasoning" in model_l
         or "thinking" in model_l
     ):
+        # Crusoe nemotron-3 reasons by default without streaming reasoning
+        # deltas, so 16 tokens can finish=length with zero visible content.
         return 512
     if "kimi-k2" in model_l or "grok" in model_l or "claude-opus" in model_l:
         return 128
@@ -1009,8 +1019,12 @@ def _rotation_error_sample(
     elapsed_ms: int,
     error_status: int | None,
     error_type: str,
+    error_message: str | None = None,
 ) -> ProviderBenchmarkSample:
     status = "unsupported" if _rotation_error_excluded_from_uptime(error_type) else "error"
+    truncated_error_message = None
+    if error_message is not None:
+        truncated_error_message = scrub_provider_error_message(str(error_message))[:300]
     return ProviderBenchmarkSample(
         id=f"bench-{uuid.uuid4().hex}",
         model=model,
@@ -1025,6 +1039,7 @@ def _rotation_error_sample(
         finish_reason=status,
         error_type=error_type,
         error_status=error_status,
+        error_message=truncated_error_message,
         region=region,
         source="synthetic",
     )

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -372,10 +372,9 @@ def test_gateway_authorize_expands_fast_router_pool() -> None:
     assert data["model"] == "cerebras/gpt-oss-120b"
     assert data["provider"] == "cerebras"
     route_candidates = data["route_candidates"]
-    assert [item["model"] for item in route_candidates[:4]] == [
+    assert [item["model"] for item in route_candidates] == [
         "cerebras/gpt-oss-120b",
         "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "xiaomi/mimo-v2-flash",
         "cerebras/zai-glm-4.7",
     ]
     assert {item["provider"] for item in route_candidates} == {"cerebras", "xiaomi"}

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -180,9 +180,6 @@ def test_friendli_july_2026_glm_5_deprecation_does_not_remove_glm_52() -> None:
 
 def test_gemini_native_supplement_publishes_missing_text_models() -> None:
     gemini_35 = MODEL_ENDPOINTS["google/gemini-3.5-flash@gemini/prepaid"]
-    gemini_lite_preview = MODEL_ENDPOINTS[
-        "google/gemini-3.1-flash-lite-preview@gemini/prepaid"
-    ]
     image_preview = MODEL_ENDPOINTS[
         "google/gemini-3.1-flash-image-preview@gemini/prepaid"
     ]
@@ -191,7 +188,6 @@ def test_gemini_native_supplement_publishes_missing_text_models() -> None:
     assert gemini_35.upstream_id == "gemini-3.5-flash"
     assert gemini_35.prompt_price_microdollars_per_million_tokens == 1_650_000
     assert gemini_35.completion_price_microdollars_per_million_tokens == 9_900_000
-    assert gemini_lite_preview.upstream_id == "gemini-3.1-flash-lite-preview"
     image_model = MODELS["google/gemini-3.1-flash-image-preview"]
     assert image_model.context_length == 65_536
     assert image_model.supports_chat

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -240,10 +240,10 @@ def test_model_storage_flag_is_gateway_scoped_endpoint_flag_is_provider_scoped()
         ),
         (
             "gemini",
-            6,
+            5,
             [
                 "google/gemini-3.5-flash",
-                "google/gemini-3.1-flash-lite-preview",
+                "google/gemini-3.1-flash-image-preview",
             ],
         ),
         (
@@ -508,6 +508,36 @@ def test_reverification_required_providers_are_not_marked_zdr() -> None:
     for provider in sorted(configured):
         assert PROVIDERS[provider].provider_zero_data_retention is not True
         assert provider_privacy_tier(PROVIDERS[provider]) < PRIVACY_TIER_ZERO_RETENTION
+
+
+def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
+    quarantined_routes = [
+        ("xiaomi", "xiaomi/mimo-v2-flash"),
+        ("xiaomi", "xiaomi/mimo-v2-pro"),
+        ("friendli", "meta-llama/llama-3.3-70b-instruct"),
+        ("gemini", "google/gemini-3.1-flash-lite-preview"),
+        ("novita", "baidu/ernie-4.5-vl-28b-a3b"),
+        ("novita", "meta-llama/llama-3-70b-instruct"),
+        ("makora", "amd/llama-3.3-70b-instruct-fp8-kv"),
+    ]
+
+    for provider, model_id in quarantined_routes:
+        assert not [
+            endpoint
+            for endpoint in MODEL_ENDPOINTS.values()
+            if endpoint.provider == provider and endpoint.model_id == model_id
+        ], f"{provider}/{model_id} should be quarantined"
+
+
+def test_anthropic_opus_41_drops_prepaid_but_keeps_byok_until_retirement() -> None:
+    endpoints = [
+        endpoint
+        for endpoint in endpoints_for_model("anthropic/claude-opus-4.1")
+        if endpoint.provider == "anthropic"
+    ]
+
+    assert not [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+    assert [endpoint for endpoint in endpoints if endpoint.usage_type == "BYOK"]
 
 
 def test_synth_alias_is_cataloged_but_not_silent_auto_route() -> None:
@@ -1303,7 +1333,7 @@ def test_route_candidate_validation_errors_are_specific(body: dict, message: str
 
 
 def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
-    """Xiaomi MiMo onboarding: the 5 chat models load from the static manifest,
+    """Xiaomi MiMo onboarding: the live chat models load from the static manifest,
     map to the right upstream ids, and have a prepaid (Credits) xiaomi endpoint
     the attested gateway can dispatch."""
     from trusted_router.catalog import PROVIDERS, endpoints_for_model
@@ -1311,8 +1341,6 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
     assert "xiaomi" in PROVIDERS
     assert "xiaomi" in GATEWAY_PREPAID_PROVIDER_SLUGS
     expected = {
-        "xiaomi/mimo-v2-flash": "mimo-v2-flash",
-        "xiaomi/mimo-v2-pro": "mimo-v2-pro",
         "xiaomi/mimo-v2.5": "mimo-v2.5",
         "xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
         "xiaomi/mimo-v2.5-pro-ultraspeed": "mimo-v2.5-pro-ultraspeed",
@@ -1403,14 +1431,13 @@ def test_makora_provider_models_present_and_routable() -> None:
         "moonshotai/kimi-k2.7-code": "moonshotai/Kimi-K2.7-Code",
         "qwen/qwen3.6-27b": "unsloth/Qwen3.6-27B-NVFP4",
         "qwen/qwen3.6-35b-a3b": "unsloth/Qwen3.6-35B-A3B-NVFP4",
-        "amd/llama-3.3-70b-instruct-fp8-kv": "amd/Llama-3.3-70B-Instruct-FP8-KV",
     }
     makora_model_ids = {
         endpoint.model_id
         for endpoint in MODEL_ENDPOINTS.values()
         if endpoint.provider == "makora" and str(endpoint.usage_type) == "Credits"
     }
-    assert len(makora_model_ids) >= 10
+    assert len(makora_model_ids) >= 9
     for model_id, upstream in expected.items():
         model = MODELS.get(model_id)
         assert model is not None, f"{model_id} missing from catalog"
@@ -1484,6 +1511,48 @@ def test_anthropic_claude_fable_5_is_available_but_not_zdr_routable() -> None:
                 "model": "anthropic/claude-fable-5",
                 "messages": [{"role": "user", "content": "pong"}],
                 "provider": {"min_privacy": "zdr"},
+            },
+            Settings(environment="test"),
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "No route candidates match" in str(exc.value)
+
+
+def test_wafer_kimi_k26_is_available_but_standard_tier_only() -> None:
+    model = MODELS["moonshotai/kimi-k2.6"]
+    wafer_endpoints = [
+        endpoint for endpoint in endpoints_for_model(model.id) if endpoint.provider == "wafer"
+    ]
+    if not wafer_endpoints:
+        pytest.skip("wafer no longer lists kimi-k2.6 — delisted upstream")
+    assert all(
+        endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD
+        for endpoint in wafer_endpoints
+    )
+
+    shape = model_to_openrouter_shape(model)
+    wafer_meta = [
+        endpoint for endpoint in shape["trustedrouter"]["endpoints"] if endpoint["provider"] == "wafer"
+    ]
+    assert wafer_meta
+    assert all(endpoint["provider_zero_data_retention"] is False for endpoint in wafer_meta)
+    assert "withdrew ZDR support" in str(wafer_meta[0]["provider_policy"])
+
+    zdr_endpoints = chat_route_endpoint_candidates(
+        {"model": ZDR_MODEL_ID},
+        Settings(environment="test"),
+    )
+    assert not [
+        endpoint
+        for _model, endpoint in zdr_endpoints
+        if endpoint.provider == "wafer" and endpoint.model_id == "moonshotai/kimi-k2.6"
+    ]
+    with pytest.raises(Exception) as exc:
+        chat_route_endpoint_candidates(
+            {
+                "model": "moonshotai/kimi-k2.6",
+                "messages": [{"role": "user", "content": "pong"}],
+                "provider": {"only": ["wafer"], "min_privacy": "zdr"},
             },
             Settings(environment="test"),
         )

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -795,10 +795,9 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     models_by_id = {model["id"]: model for model in models}
     fast_meta = models_by_id["trustedrouter/fast"]["trustedrouter"]
     assert fast_meta["route_kind"] == "fast_pool"
-    assert fast_meta["auto_candidates"][:4] == [
+    assert fast_meta["auto_candidates"] == [
         "cerebras/gpt-oss-120b",
         "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "xiaomi/mimo-v2-flash",
         "cerebras/zai-glm-4.7",
     ]
     plato_meta = models_by_id["trustedrouter/plato"]["trustedrouter"]

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 from typing import Any
 
 from tests.fakes.spanner import make_fake_store
@@ -328,7 +328,8 @@ def test_gcp_rate_limit_counts_in_same_window_and_resets_later() -> None:
 
 class _FakeCell:
     def __init__(self, value: Any) -> None:
-        self.value = json.dumps(asdict(value), separators=(",", ":"), sort_keys=True).encode()
+        body = asdict(value) if is_dataclass(value) else value
+        self.value = json.dumps(body, separators=(",", ":"), sort_keys=True).encode()
 
 
 class _FakeReadRow:
@@ -514,6 +515,28 @@ def test_gcp_provider_benchmark_round_trips_ttfb_and_source() -> None:
     assert rows[0].ttfb_milliseconds == 120
     assert rows[0].first_token_milliseconds == 180
     assert rows[0].source == "synthetic"
+
+
+def test_gcp_provider_benchmark_read_ignores_unknown_future_fields() -> None:
+    body = {
+        "id": "bench_future",
+        "model": "openai/gpt-5.4-nano",
+        "provider": "openai",
+        "provider_name": "OpenAI",
+        "status": "success",
+        "usage_type": "Credits",
+        "streamed": True,
+        "created_at": "2026-05-02T12:00:00Z",
+        "future_field": "reader does not know this yet",
+    }
+    table = _FakeBigtable([_FakeReadRow(body)])
+
+    rows = _bt_provider_benchmark_samples(
+        table, "m", date="2026-05-02", provider="openai", model="openai/gpt-5.4-nano", limit=10
+    )
+
+    assert [row.id for row in rows] == ["bench_future"]
+    assert not hasattr(rows[0], "future_field")
 
 
 def test_provider_benchmark_from_generation_carries_ttfb_default_organic() -> None:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1929,8 +1929,16 @@ def test_rotation_probe_uses_reasoning_safe_request_budget() -> None:
     assert _rotation_max_tokens("zai", "z-ai/glm-4.6") == 512
     assert _rotation_max_tokens("openai", "openai/o3") == 512
     assert _rotation_max_tokens("openai", "openai/gpt-5.5") == 512
+    assert _rotation_max_tokens("baseten", "nvidia/nemotron-120b-a12b") == 512
     assert _rotation_omits_temperature("openai", "openai/o3")
     assert _rotation_omits_temperature("openai", "openai/gpt-5.5")
+    # Canary contract: probes mirror customer payloads. The enclave strips
+    # temperature for known deprecated Anthropic generations, so future missing
+    # enclave updates surface here as direct probe 400s instead of being hidden.
+    assert not _rotation_omits_temperature("anthropic", "anthropic/claude-fable-5")
+    assert not _rotation_omits_temperature("anthropic", "anthropic/claude-sonnet-5")
+    assert _rotation_omits_temperature("anthropic", "anthropic/claude-opus-4.7")
+    assert _rotation_omits_temperature("anthropic", "anthropic/claude-opus-4.8")
     assert not _rotation_omits_temperature("openai", "openai/gpt-4.1-mini")
 
 
@@ -2043,6 +2051,7 @@ async def test_provider_rotation_probe_records_sse_error_frame() -> None:
     assert sample.model == "moonshotai/kimi-k2.6"
     assert sample.error_type == "provider_error"
     assert sample.error_status == 502
+    assert sample.error_message == "provider error"
     assert sample.first_token_milliseconds is None
 
 
@@ -2137,8 +2146,17 @@ async def test_provider_rotation_probe_uses_provider_safe_request_shape() -> Non
 
 @pytest.mark.asyncio
 async def test_provider_rotation_probe_records_http_error() -> None:
+    upstream_message = (
+        "provider quota exhausted Bearer live-secret sk-live1234 rk-route5678 "
+        + ("x" * 400)
+    )
+    scrubbed_message = "provider quota exhausted Bearer *** sk-*** sk-*** " + ("x" * 400)
+
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(500, json={"error": "boom"})
+        return httpx.Response(
+            500,
+            json={"error": {"type": "provider_error", "message": upstream_message}},
+        )
 
     target = SyntheticTarget("rotation", "https://api.trustedrouter.com/v1", "us-central1")
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
@@ -2152,8 +2170,35 @@ async def test_provider_rotation_probe_records_http_error() -> None:
         )
 
     assert sample.status == "error"
-    assert sample.error_type == "http_500"
+    assert sample.error_type == "provider_error"
     assert sample.error_status == 500
+    assert sample.error_message == scrubbed_message[:300]
+    assert "live-secret" not in str(sample.error_message)
+    assert "sk-live1234" not in str(sample.error_message)
+    assert "rk-route5678" not in str(sample.error_message)
+    assert sample.first_token_milliseconds is None
+    assert sample.source == "synthetic"
+
+
+@pytest.mark.asyncio
+async def test_provider_rotation_probe_records_httpx_error_message() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("gateway connection failed", request=request)
+
+    target = SyntheticTarget("rotation", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_rotation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="openai",
+            model="openai/gpt-5.4-nano",
+        )
+
+    assert sample.status == "error"
+    assert sample.error_type == "ConnectError"
+    assert sample.error_message == "gateway connection failed"
     assert sample.first_token_milliseconds is None
     assert sample.source == "synthetic"
 
@@ -2201,6 +2246,9 @@ def _benchmark_ingest_settings() -> Settings:
 
 def test_internal_benchmark_ingest_records_sample() -> None:
     client = TestClient(create_app(_benchmark_ingest_settings(), init_observability=False))
+    # Key-shaped + bearer material up front proves the ingest boundary scrubs
+    # server-side (not just the probe); the x-padding proves [:300] truncation.
+    error_message = "denied for Bearer SK-LIVE-abcd1234 upstream said no " + ("x" * 400)
     payload = {
         "samples": [
             {
@@ -2214,6 +2262,7 @@ def test_internal_benchmark_ingest_records_sample() -> None:
                 "elapsed_milliseconds": 300,
                 "first_token_milliseconds": 150,
                 "ttfb_milliseconds": 90,
+                "error_message": error_message,
                 "source": "synthetic",
                 "created_at": "2026-06-04T00:00:00Z",
             }
@@ -2232,6 +2281,11 @@ def test_internal_benchmark_ingest_records_sample() -> None:
     matched = [row for row in rows if row.id == "bench-ingest-test-1"]
     assert matched, "ingested benchmark sample not found in store"
     assert matched[0].ttfb_milliseconds == 90
+    stored_message = str(matched[0].error_message)
+    assert len(stored_message) <= 300
+    assert "SK-LIVE-abcd1234" not in stored_message
+    assert "Bearer ***" in stored_message
+    assert stored_message.endswith("x" * 50)
     assert matched[0].source == "synthetic"
 
 


### PR DESCRIPTION
## What

Fixes the failure clusters shown on trustedrouter.com/leaderboard, root-caused
from probe history and two rounds of adversarial review.

**Monitor pipeline**
- The synthetic-monitor redeploy trigger regex was `$`-anchored, so no real
  file under `synthetic/` could ever match — monitors ran frozen images for
  weeks, and newly cataloged routes went unprobed until an unrelated deploy
  rebuilt them (their leaderboard "failure onset" was really first-probe
  time). Now prefix-matches all of `src/trusted_router/` with the exact-file
  alternatives re-anchored.
- Dispatched deploys (the hourly snapshot refresh path) skip the push-path
  file gate, so refresh-prices now passes an explicit
  `deploy_synthetic_monitor=true` input.

**Probes**
- nemotron-family models get the 512-token reasoning budget (they reason by
  default without streaming reasoning deltas; 16 tokens finishes at `length`
  with zero visible content and skews the provider error rate through
  denominator exclusion).
- Rotation probes deliberately keep sending `temperature` to anthropic-direct
  routes: the enclave strips it for the deprecated generations, so a future
  Anthropic temperature deprecation missing from the enclave list surfaces as
  a probe failure instead of silently breaking only customer traffic.

**Catalog**
- Quarantine routes their providers no longer serve (xiaomi MiMo V2 family,
  friendli Llama 3.3 70B serverless, the retired Gemini 3.1 Flash Lite
  preview id, two novita ids, makora's never-served AMD Llama row) via the
  provider-scoped deprecation map. Anthropic's deprecated Opus 4.1 undated
  alias is dropped from Credits only — BYOK stays visible until the
  2026-08-05 formal retirement. Stale mimo-v2 fast-pool entry removed.

**Benchmarks**
- Persist a truncated, secret-scrubbed provider error message end-to-end
  (probe → internal ingest → store); redaction is single-sourced and applied
  on both sides of the boundary. The Bigtable sample reader now tolerates
  unknown stored fields so rollbacks survive rows written by newer code.

**Wafer**
- Kimi-K2.6 served at standard tier (Wafer withdrew ZDR support for it on
  2026-06-26 per their /v1/models capabilities); removed from the router-side
  ZDR-header allowlist and unpinned from EXPECTED_MODELS so a future upstream
  delisting prunes instead of freezing the manifest rebuild.

## Deploy note

Old replicas reading benchmark rows written by new replicas during the
rolling window may transiently 500 on benchmark reads (new optional stored
field). Self-heals as the rollout completes; if a rollback is ever needed
after this lands, roll back to this version or later (the tolerant reader
ships here).

## Verification

- Full suite 1574 passed / 33 skipped; lint clean.
- Two adversarial review rounds; all findings applied and re-verified
  (including an ingest-boundary gap that would have silently dropped the new
  error detail, and a dispatch-path gap that would have left monitor rebuilds
  dead on the snapshot-refresh path).
- Companion enclave PR (temperature strip for the Claude 5 generation + wafer
  ZDR header) merges immediately after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
