### PR TITLE
Center homepage hero links

### DIFF
--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -634,6 +634,7 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 .home-hero h1 { font-size:52px; line-height:1.08; letter-spacing:-0.02em; color:var(--inkstrong); margin:0 0 20px; font-weight:750; }
 .home-hero .lead { color:var(--muted); font-size:19px; line-height:1.55; max-width:640px; margin:0 auto 28px; }
 .home-hero .hero-actions, .hero-actions.center { display:flex; gap:12px; justify-content:center; flex-wrap:wrap; }
+.home-hero .hero-links { justify-content:center; }
 .hero-sublink { display:inline-block; margin-top:18px; color:var(--muted); font-size:14px; text-decoration:none; }
 .hero-sublink:hover { color:var(--blue); }
 .br-wide { display:none; }

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -79,7 +79,7 @@
           <button class="btn primary" type="button" data-action="open-signin">Get API key</button>
           <a class="btn" href="https://trust.trustedrouter.com">🛡 Verify trust</a>
         </div>
-        <div class="mini-links">
+        <div class="mini-links hero-links">
           <a href="/docs/migrate-from-openrouter">Migrate from OpenRouter</a>
           <a href="/openai-compatible-llm-api">OpenAI-compatible API</a>
           <a href="/llm-provider-latency-benchmarks">Latency benchmarks</a>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -5,6 +5,7 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
 
   await expect(page.getByRole("heading", { name: "Own your alpha." })).toBeVisible();
   await expect(page.getByText("ATTESTED GATEWAY", { exact: true })).toBeVisible();
+  await expect(page.locator(".home-hero .hero-links")).toHaveCSS("justify-content", "center");
 
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.locator("#signinModal")).toBeVisible();


### PR DESCRIPTION
Summary:
- center the homepage hero link row beneath the CTA buttons
- scope the alignment to the homepage hero so other mini-link groups are unchanged
- add a browser regression assertion for computed flex alignment

Verification:
- Playwright desktop and mobile tests passed
- Desktop and 390px mobile screenshots inspected
- Stylelint, ESLint, and focused pytest checks passed