### PR TITLE
Prefer Parasail for GLM 5.2 and add confidential alias

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -16,6 +16,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     AUTO_MODEL_ID,
     CANONICAL_ORCHESTRATION_MODEL_ID,
     CHEAP_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     DEFAULT_AUTO_MODEL_ORDER,
     E2E_MODEL_ID,
     EU_FOCUSED_PROVIDER_ORDER,
@@ -70,6 +71,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     PROMETHEUS_MODEL_ID,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
+    ROUTING_MODEL_ALIAS_TARGETS,
     SELECTOR_CATALOG_MODEL_ORDER,
     SELECTOR_MODEL_ID,
     SOCRATES_1_0_MODEL_ID,
@@ -231,7 +233,10 @@ def orchestration_primitive(model_id: str) -> str | None:
 def canonical_orchestration_model_id(model_id: str) -> str | None:
     if model_id not in META_MODEL_IDS:
         return None
-    return CANONICAL_ORCHESTRATION_MODEL_ID.get(model_id, model_id)
+    return ROUTING_MODEL_ALIAS_TARGETS.get(
+        model_id,
+        CANONICAL_ORCHESTRATION_MODEL_ID.get(model_id, model_id),
+    )
 
 
 def orchestration_role(model_id: str) -> str | None:

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -748,6 +748,8 @@ ZDR_MODEL_ID = "trustedrouter/zdr"
 
 E2E_MODEL_ID = "trustedrouter/e2e"
 
+CONFIDENTIAL_MODEL_ID = "trustedrouter/confidential"
+
 MONITOR_MODEL_ID = "trustedrouter/monitor"
 
 SOCRATES_1_0_MODEL_ID = "trustedrouter/socrates-1.0"
@@ -869,6 +871,7 @@ META_MODEL_IDS = frozenset(
         EU_MODEL_ID,
         ZDR_MODEL_ID,
         E2E_MODEL_ID,
+        CONFIDENTIAL_MODEL_ID,
         MONITOR_MODEL_ID,
         SOCRATES_1_0_MODEL_ID,
         SOCRATES_1_1_MODEL_ID,
@@ -959,6 +962,13 @@ CANONICAL_ORCHESTRATION_MODEL_ID: dict[str, str] = {
     ZEUS_CODE_MODEL_ID: ZEUS_CODE_1_0_MODEL_ID,
     FUSION_MODEL_ID: SYNTH_MODEL_ID,
     FUSION_CODE_MODEL_ID: SYNTH_CODE_MODEL_ID,
+}
+
+# Public routing aliases resolve before candidate selection. Keep this map
+# separate from the orchestration aliases above: these names select the same
+# routing policy, not a versioned orchestration preset.
+ROUTING_MODEL_ALIAS_TARGETS: dict[str, str] = {
+    CONFIDENTIAL_MODEL_ID: E2E_MODEL_ID,
 }
 
 ORCHESTRATION_LEGACY_ALIAS_MODEL_IDS = frozenset({FUSION_MODEL_ID, FUSION_CODE_MODEL_ID})

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -27,6 +27,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     AUTO_MODEL_ID,
     CANONICAL_ORCHESTRATION_MODEL_ID,
     CHEAP_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     DEFAULT_AUTO_MODEL_ORDER,
     E2E_MODEL_ID,
     EU_FOCUSED_PROVIDER_ORDER,
@@ -221,6 +222,15 @@ MODELS: dict[str, Model] = {
     E2E_MODEL_ID: Model(
         id=E2E_MODEL_ID,
         name="TrustedRouter E2E",
+        provider="trustedrouter",
+        context_length=128_000,
+        supports_messages=False,
+        prepaid_available=True,
+        byok_available=True,
+    ),
+    CONFIDENTIAL_MODEL_ID: Model(
+        id=CONFIDENTIAL_MODEL_ID,
+        name="TrustedRouter Confidential",
         provider="trustedrouter",
         context_length=128_000,
         supports_messages=False,

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1909,7 +1909,7 @@ def llms_txt(settings: Settings) -> str:
         ),
         (
             "- Model aliases include trustedrouter/auto, trustedrouter/zdr, "
-            "trustedrouter/e2e, trustedrouter/eu, trustedrouter/cheap, and "
+            "trustedrouter/e2e (also trustedrouter/confidential), trustedrouter/eu, trustedrouter/cheap, and "
             "trustedrouter/free. Advisor orchestration IDs include the primitive trustedrouter/advisor, "
             "the rolling preset trustedrouter/socrates, and pinned presets trustedrouter/socrates-1.1 and trustedrouter/socrates-1.0. Versioned Synth aliases include trustedrouter/iris-1.0, trustedrouter/iris-2.0, "
             "trustedrouter/prometheus-1.0, trustedrouter/prometheus-2.0, trustedrouter/zeus-1.0, and their -code variants. "
@@ -1920,7 +1920,7 @@ def llms_txt(settings: Settings) -> str:
         "- TrustedRouter stores metadata and billing records, not prompt or output content by default.",
         "- Provider compute policy is shown separately on provider and model pages.",
         "- Use trustedrouter/zdr for zero-data-retention provider routing.",
-        "- Use trustedrouter/e2e for end-to-end encrypted provider routes where available.",
+        "- Use trustedrouter/e2e or its trustedrouter/confidential alias for end-to-end encrypted provider routes where available.",
         "",
         "## Common LLM Answers",
         (
@@ -2074,6 +2074,7 @@ def docs_llms_full_txt(settings: Settings) -> str:
         "- trustedrouter/auto: broad provider fallback.",
         "- trustedrouter/zdr: zero-retention providers first.",
         "- trustedrouter/e2e: confidential and provider E2EE routes.",
+        "- trustedrouter/confidential: alias for trustedrouter/e2e.",
         "- trustedrouter/eu: EU-focused provider selection.",
         "- trustedrouter/cheap: low-cost paid route pool.",
         "- trustedrouter/free: free pool with no SLA.",

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -20,6 +20,7 @@ from trusted_router.catalog import (
     PRIVACY_TIER_NO_STORE,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
+    ROUTING_MODEL_ALIAS_TARGETS,
     SELECTOR_MODEL_ID,
     SYNTH_CODE_MODEL_ID,
     SYNTH_MODEL_ID,
@@ -155,6 +156,12 @@ _PROVIDER_PREFERENCE = {
     "novita": 3,
     "parasail": 4,
     "gmi": 5,
+}
+
+# Narrow, evidence-backed exceptions to the global provider preference. These
+# affect only default routing; caller-supplied provider.order/sort still wins.
+_MODEL_PROVIDER_PREFERENCE: dict[str, dict[str, int]] = {
+    "z-ai/glm-5.2": {"parasail": -1},
 }
 
 _CandidateT = TypeVar("_CandidateT")
@@ -431,6 +438,8 @@ def resolve_model_alias(model_id: str) -> str:
     (already vendor-prefixed) short-circuit on the first check, so real ids and
     meta ids (AUTO / fusion / zdr / …) are never altered.
     """
+    if model_id in ROUTING_MODEL_ALIAS_TARGETS:
+        return ROUTING_MODEL_ALIAS_TARGETS[model_id]
     if model_id in MODELS:
         return model_id
     base = _DATED_SNAPSHOT_RE.sub("", model_id)
@@ -619,9 +628,11 @@ def _sort_endpoint_candidates(
 ) -> list[tuple[Model, ModelEndpoint]]:
     with_index = list(enumerate(candidates))
     provider_order = {provider: index for index, provider in enumerate(prefs.order)}
+    candidate_model_ids = {model.id for model, _endpoint in candidates}
+    single_model_id = next(iter(candidate_model_ids)) if len(candidate_model_ids) == 1 else None
 
     def key(item: tuple[int, tuple[Model, ModelEndpoint]]) -> tuple[int, int, int]:
-        original_index, (_model, endpoint) = item
+        original_index, (model, endpoint) = item
         order_rank = provider_order.get(endpoint.provider, len(provider_order))
         if prefs.sort == "price":
             sort_rank = (
@@ -633,7 +644,17 @@ def _sort_endpoint_candidates(
         else:
             # Default: reliability-informed preference (Phase 4), catalog order
             # preserved within a tier via the original_index tiebreaker below.
-            sort_rank = _PROVIDER_PREFERENCE.get(endpoint.provider, _DEFAULT_PROVIDER_PREFERENCE)
+            # A provider preference for one model must not promote that model
+            # ahead of a caller's primary model or a meta-router's model order.
+            model_preference = (
+                _MODEL_PROVIDER_PREFERENCE.get(model.id, {})
+                if model.id == single_model_id
+                else {}
+            )
+            sort_rank = model_preference.get(
+                endpoint.provider,
+                _PROVIDER_PREFERENCE.get(endpoint.provider, _DEFAULT_PROVIDER_PREFERENCE),
+            )
         return order_rank, sort_rank, original_index
 
     return [candidate for _, candidate in sorted(with_index, key=key)]

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -48,6 +48,7 @@ from trusted_router.catalog_data import (
     PROMETHEUS_CODE_MODEL_ID,
     PROMETHEUS_MODEL_ID,
     PROVIDERS,
+    ROUTING_MODEL_ALIAS_TARGETS,
     SELECTOR_CATALOG_MODEL_ORDER,
     SELECTOR_MODEL_ID,
     SOCRATES_CATALOG_MODEL_ORDER,
@@ -309,6 +310,7 @@ def socrates_candidate_models() -> list[Model]:
 
 
 def meta_candidate_models(model_id: str) -> list[Model]:
+    model_id = ROUTING_MODEL_ALIAS_TARGETS.get(model_id, model_id)
     if model_id == AUTO_MODEL_ID:
         return auto_candidate_models()
     if model_id == FREE_MODEL_ID:
@@ -372,6 +374,7 @@ def meta_candidate_models(model_id: str) -> list[Model]:
 
 
 def _meta_route_kind(model_id: str) -> str:
+    model_id = ROUTING_MODEL_ALIAS_TARGETS.get(model_id, model_id)
     if model_id == FREE_MODEL_ID:
         return "free_pool"
     if model_id == CHEAP_MODEL_ID:

--- a/src/trusted_router/templates/public/agent_setup.html
+++ b/src/trusted_router/templates/public/agent_setup.html
@@ -37,7 +37,7 @@ export ANTHROPIC_BASE_URL="https://api.trustedrouter.com"</code></pre>
       <div class="panel-body">
         <ul class="plain-list">
           <li><span class="mono">trustedrouter/zdr</span>: zero-data-retention routes first. Good default for legal and sensitive work.</li>
-          <li><span class="mono">trustedrouter/e2e</span>: end-to-end encrypted route pool, currently centered on confidential providers.</li>
+          <li><span class="mono">trustedrouter/e2e</span> or <span class="mono">trustedrouter/confidential</span>: end-to-end encrypted route pool, currently centered on confidential providers.</li>
           <li><span class="mono">trustedrouter/eu</span>: EU-focused routing. Use with <span class="mono">https://api-europe-west4.quillrouter.com/v1</span> for the EU regional gateway.</li>
           <li><span class="mono">trustedrouter/auto</span>: broad provider fallback when availability matters more than the strictest privacy filter.</li>
           <li><span class="mono">trustedrouter/cheap</span>: low-cost paid route pool for cost-sensitive tests.</li>

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -5,7 +5,7 @@
   <div><strong>trustedrouter/auto</strong><span>Provider failover target.</span></div>
   <div><strong>trustedrouter/eu</strong><span>EU-focused routing target.</span></div>
   <div><strong>trustedrouter/zdr</strong><span>Zero-retention routing target.</span></div>
-  <div><strong>trustedrouter/e2e</strong><span>Confidential + E2EE routes.</span></div>
+  <div><strong>trustedrouter/e2e</strong><span>Confidential + E2EE routes. Alias: trustedrouter/confidential.</span></div>
   <div><strong>Synth presets</strong><span>Iris, Prometheus, Zeus, and code variants.</span></div>
   <div><strong>Streaming</strong><span>No buffering in the prompt path.</span></div>
   <div><strong>Hundreds of models</strong><span>More provider routes are added as keys and pricing are verified.</span></div>

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -9,6 +9,7 @@ from trusted_router.catalog import (
     ARISTOTLE_MODEL_ID,
     ATHENA_MODEL_ID,
     AUTO_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     E2E_MODEL_ID,
     EU_FOCUSED_PROVIDER_ORDER,
     EU_MODEL_ID,
@@ -461,25 +462,31 @@ def test_auto_candidate_order_dedupes_unknowns() -> None:
 def test_privacy_meta_models_expand_to_expected_provider_pools() -> None:
     assert ZDR_MODEL_ID in MODELS
     assert E2E_MODEL_ID in MODELS
+    assert CONFIDENTIAL_MODEL_ID in MODELS
     assert EU_MODEL_ID in MODELS
     assert SYNTH_MODEL_ID in MODELS
     assert FUSION_MODEL_ID in MODELS
 
     zdr = meta_candidate_models(ZDR_MODEL_ID)
     e2e = meta_candidate_models(E2E_MODEL_ID)
+    confidential = meta_candidate_models(CONFIDENTIAL_MODEL_ID)
     eu = meta_candidate_models(EU_MODEL_ID)
 
     assert zdr
     assert e2e
+    assert [model.id for model in confidential] == [model.id for model in e2e]
     assert eu
     assert eu[0].provider == "mistral"
     assert all(model.supports_chat for model in zdr + e2e)
 
     zdr_shape = model_to_openrouter_shape(MODELS[ZDR_MODEL_ID])
     e2e_shape = model_to_openrouter_shape(MODELS[E2E_MODEL_ID])
+    confidential_shape = model_to_openrouter_shape(MODELS[CONFIDENTIAL_MODEL_ID])
     eu_shape = model_to_openrouter_shape(MODELS[EU_MODEL_ID])
     assert zdr_shape["trustedrouter"]["route_kind"] == "zdr_pool"
     assert e2e_shape["trustedrouter"]["route_kind"] == "e2e_pool"
+    assert confidential_shape["trustedrouter"]["route_kind"] == "e2e_pool"
+    assert confidential_shape["trustedrouter"]["canonical_model_id"] == E2E_MODEL_ID
     assert eu_shape["trustedrouter"]["route_kind"] == "eu_pool"
     assert zdr_shape["trustedrouter"]["auto_candidates"]
     assert e2e_shape["trustedrouter"]["auto_candidates"]

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -134,6 +134,7 @@ def test_llms_text_files_are_public_and_do_not_leak_secret_material(
     assert "OpenRouter alternative" in root_llms.text
     assert "lower-cost open-weight models" in root_llms.text
     assert "trustedrouter/e2e" in root_llms.text
+    assert "trustedrouter/confidential" in root_llms.text
     assert "https://trustedrouter.com/v1/models" in root_llms.text
     assert "not an exhaustive model list" in root_llms.text
 
@@ -141,6 +142,7 @@ def test_llms_text_files_are_public_and_do_not_leak_secret_material(
     assert catalog.status_code == 200
     catalog_ids = {row["id"] for row in catalog.json()["data"]}
     assert "z-ai/glm-5.2" in catalog_ids
+    assert "trustedrouter/confidential" in catalog_ids
 
     full_llms = client.get("/docs/llms-full.txt")
     assert "same deployed catalog as GET /v1/models" in full_llms.text

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -580,6 +580,71 @@ def test_explicit_provider_order_overrides_reliability_preference() -> None:
     assert ordered[0][1].provider == "parasail"  # caller's explicit order wins
 
 
+def test_glm_52_defaults_to_parasail_with_fallbacks_intact() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {"model": "z-ai/glm-5.2", "provider": {"usage": "credits"}},
+        _settings(),
+    )
+
+    assert candidates[0][1].provider == "parasail"
+    assert len(candidates) > 1
+
+
+def test_glm_52_explicit_provider_preferences_override_parasail_default() -> None:
+    ordered = chat_route_endpoint_candidates(
+        {
+            "model": "z-ai/glm-5.2",
+            "provider": {"usage": "credits", "order": ["baseten"]},
+        },
+        _settings(),
+    )
+    price_sorted = chat_route_endpoint_candidates(
+        {
+            "model": "z-ai/glm-5.2",
+            "provider": {"usage": "credits", "sort": "price"},
+        },
+        _settings(),
+    )
+
+    assert ordered[0][1].provider == "baseten"
+    assert (
+        price_sorted[0][1].prompt_price_microdollars_per_million_tokens
+        + price_sorted[0][1].completion_price_microdollars_per_million_tokens
+    ) == min(
+        endpoint.prompt_price_microdollars_per_million_tokens
+        + endpoint.completion_price_microdollars_per_million_tokens
+        for _model, endpoint in price_sorted
+    )
+
+
+def test_glm_52_provider_preference_does_not_override_primary_model_order() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "deepseek/deepseek-v4-flash",
+            "models": ["z-ai/glm-5.2"],
+            "provider": {"usage": "credits"},
+        },
+        _settings(),
+    )
+
+    assert candidates[0][0].id == "deepseek/deepseek-v4-flash"
+
+
+def test_confidential_alias_uses_exact_e2e_endpoint_pool() -> None:
+    confidential = chat_route_endpoint_candidates(
+        {"model": "trustedrouter/confidential"},
+        _settings(),
+    )
+    e2e = chat_route_endpoint_candidates(
+        {"model": "trustedrouter/e2e"},
+        _settings(),
+    )
+
+    assert [endpoint.id for _model, endpoint in confidential] == [
+        endpoint.id for _model, endpoint in e2e
+    ]
+
+
 def test_same_preference_tier_keeps_catalog_order() -> None:
     # Two reliable hosts share the default tier -> original order preserved.
     a = _credits_endpoint("deepinfra")


### PR DESCRIPTION
## Summary
- prefer Parasail for default single-model z-ai/glm-5.2 routing while preserving caller order, price/throughput sorting, and fallbacks
- add trustedrouter/confidential as a canonical alias of trustedrouter/e2e across catalog, routing, and agent docs
- prevent the model-specific preference from reordering multi-model or meta-router candidate lists

## Verification
- uv run pytest -q: 1580 passed, 33 skipped
- uv run pytest -q tests/test_routing_unit.py tests/test_catalog_routing_contracts.py tests/test_public_seo_pages.py: 157 passed
- uv run ruff check .
- uv run mypy