### PR TITLE
Ingest and bill Tinfoil cached input pricing

### DIFF
--- a/scripts/pricing/providers/tinfoil.py
+++ b/scripts/pricing/providers/tinfoil.py
@@ -78,9 +78,21 @@ def fetch() -> ProviderPricingResult:
             output_usd = float(pricing.get("outputTokenPricePer1M"))
         except (TypeError, ValueError):
             continue
+        cached_input_usd: float | None = None
+        try:
+            cached_raw = pricing.get("cachedInputTokenPricePer1M")
+            if cached_raw is not None:
+                cached_input_usd = float(cached_raw)
+        except (TypeError, ValueError):
+            notes.append(f"invalid cached-input price for {native_id}: {cached_raw!r}")
         prices[or_id] = ModelPrice(
             prompt_micro_per_m=int(round(input_usd * 1_000_000)),
             completion_micro_per_m=int(round(output_usd * 1_000_000)),
+            prompt_cached_micro_per_m=(
+                int(round(cached_input_usd * 1_000_000))
+                if cached_input_usd is not None
+                else None
+            ),
         )
 
     errors = validate(prices, EXPECTED_MODELS)

--- a/src/trusted_router/data/provider_models/tinfoil.json
+++ b/src/trusted_router/data/provider_models/tinfoil.json
@@ -1,8 +1,8 @@
 {
-  "_about": "Provider-native supplement for Tinfoil models whose live API is ahead of the snapshot. Tinfoil announced GLM 5.2 as native glm-5-2 and the GLM 5.1 / Qwen3-VL-30B deprecations for 2026-06-22; this manifest publishes the current replacement routes while deprecated Tinfoil routes are filtered in catalog.py.",
+  "_about": "Provider-native supplement for Tinfoil models whose live API is ahead of the snapshot. Tinfoil announced GLM 5.2 prompt caching on 2026-07-14 at a 75% cached-input discount. Deprecated Tinfoil routes are filtered in catalog.py.",
   "provider": "tinfoil",
   "source": "https://inference.tinfoil.sh/v1/models",
-  "generated_at": "2026-06-18T00:00:00Z",
+  "generated_at": "2026-07-16T00:00:00Z",
   "model_count": 2,
   "models": [
     {
@@ -13,6 +13,7 @@
       "context_length": 384000,
       "max_output_tokens": 131072,
       "input_token_price_per_m": 1500000,
+      "cached_input_token_price_per_m": 375000,
       "output_token_price_per_m": 5250000,
       "model_type": "chat",
       "features": ["reasoning", "function-calling"],

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1237,9 +1237,13 @@ def _endpoint_cost_microdollars(
         and rates.completion_price_microdollars_per_million_tokens > 0
     )
     if cache_read_tokens or cache_creation_tokens:
-        # Endpoint path prices cache via provider multipliers; the tier cached rate is the model-level path's policy.
-        read_price, write_price = cache_token_prices_microdollars(
+        default_read_price, write_price = cache_token_prices_microdollars(
             endpoint.provider, prompt_price
+        )
+        read_price = (
+            rates.prompt_cached_price_microdollars_per_million_tokens
+            if rates.prompt_cached_price_microdollars_per_million_tokens is not None
+            else default_read_price
         )
         cost += token_cost_microdollars(cache_read_tokens, read_price)
         cost += token_cost_microdollars(cache_creation_tokens, write_price)

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -116,6 +116,10 @@ def test_tinfoil_june_2026_deprecations_and_replacements_are_routable() -> None:
     glm_52 = MODEL_ENDPOINTS["z-ai/glm-5.2@tinfoil/prepaid"]
     gemma4 = MODEL_ENDPOINTS["google/gemma-4-31b-it@tinfoil/prepaid"]
     assert glm_52.upstream_id == "glm-5-2"
+    assert (
+        glm_52.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens
+        == 412_500
+    )
     assert gemma4.upstream_id == "gemma4-31b"
 
     assert "z-ai/glm-5.1@tinfoil/prepaid" not in MODEL_ENDPOINTS

--- a/tests/test_gateway_cache_billing.py
+++ b/tests/test_gateway_cache_billing.py
@@ -32,15 +32,24 @@ def _client_and_key() -> tuple[TestClient, dict]:
     return client, created.json()["data"]
 
 
-def _authorize(client: TestClient, key: dict, model: str) -> dict:
+def _authorize(
+    client: TestClient,
+    key: dict,
+    model: str,
+    *,
+    provider: dict | None = None,
+) -> dict:
+    body = {
+        "api_key_hash": key["hash"],
+        "model": model,
+        "estimated_input_tokens": 8_000,
+        "max_output_tokens": 1_000,
+    }
+    if provider is not None:
+        body["provider"] = provider
     authorize = client.post(
         "/v1/internal/gateway/authorize",
-        json={
-            "api_key_hash": key["hash"],
-            "model": model,
-            "estimated_input_tokens": 8_000,
-            "max_output_tokens": 1_000,
-        },
+        json=body,
     )
     assert authorize.status_code == 200, authorize.text
     return authorize.json()["data"]
@@ -128,6 +137,48 @@ def test_openai_compatible_cached_subset_is_normalized() -> None:
     generation = STORE.get_generation(data["generation_id"])
     assert generation is not None
     assert generation.tokens_prompt == 1_000
+
+
+def test_tinfoil_glm_52_uses_published_cached_input_rate() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(
+        client,
+        key,
+        "z-ai/glm-5.2",
+        provider={"only": ["tinfoil"]},
+    )
+    endpoint = endpoint_for_id(auth["endpoint_id"])
+    assert endpoint is not None and endpoint.provider == "tinfoil"
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 50,
+            "cache_read_input_tokens": 900,
+            "request_id": "gw-cache-tinfoil",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+
+    tier = endpoint.price_tiers[0]
+    cached_price = tier.prompt_cached_price_microdollars_per_million_tokens
+    assert cached_price == 412_500
+    expected = (
+        token_cost_microdollars(
+            100, tier.prompt_price_microdollars_per_million_tokens
+        )
+        + token_cost_microdollars(
+            900,
+            cached_price,
+        )
+        + token_cost_microdollars(
+            50, tier.completion_price_microdollars_per_million_tokens
+        )
+    )
+    assert settle.json()["data"]["cost_microdollars"] == expected
 
 
 def test_settle_without_cache_fields_is_unchanged() -> None:

--- a/tests/test_tinfoil_pricing.py
+++ b/tests/test_tinfoil_pricing.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from scripts.pricing.providers import tinfoil
+
+
+def test_tinfoil_fetch_ingests_glm_52_cached_input_price(monkeypatch) -> None:  # noqa: ANN001
+    payload = {
+        "data": [
+            {
+                "id": "glm-5-2",
+                "pricing": {
+                    "inputTokenPricePer1M": 1.5,
+                    "cachedInputTokenPricePer1M": 0.375,
+                    "outputTokenPricePer1M": 5.25,
+                },
+            },
+            {
+                "id": "gemma4-31b",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.4,
+                    "outputTokenPricePer1M": 1.0,
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(tinfoil, "fetch_json", lambda _url: payload)
+
+    result = tinfoil.fetch()
+    glm = result.prices["z-ai/glm-5.2"]
+    gemma = result.prices["google/gemma-4-31b-it"]
+
+    assert glm.prompt_micro_per_m == 1_500_000
+    assert glm.completion_micro_per_m == 5_250_000
+    assert glm.tiers[0].prompt_cached_micro_per_m == 375_000
+    assert gemma.tiers[0].prompt_cached_micro_per_m is None


### PR DESCRIPTION
## Summary
- ingest cachedInputTokenPricePer1M from Tinfoil's live model catalog
- publish GLM 5.2 cached input at the normal TrustedRouter customer markup
- use endpoint-specific cached-input rates during gateway settlement

Tinfoil publishes GLM 5.2 at 1.50 USD/M uncached and 0.375 USD/M cached. TrustedRouter therefore publishes 1.65 USD/M and 0.4125 USD/M while preserving the 75% discount.

## Tests
- 1583 passed, 33 skipped
- uv run ruff check .
- uv run mypy