### PR TITLE
Keep hourly pricing refresh canonical for Nemotron

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -88,7 +88,7 @@ _BASETEN_MODEL_IDS = {
     "zai-org/GLM-5.1": "z-ai/glm-5.1",
     "moonshotai/Kimi-K2.6": "moonshotai/kimi-k2.6",
     "deepseek-ai/DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro",
-    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": ("nvidia/nvidia-nemotron-3-ultra-550b-a55b"),
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
     "moonshotai/Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
 }

--- a/scripts/pricing/providers/baseten.py
+++ b/scripts/pricing/providers/baseten.py
@@ -43,7 +43,7 @@ _NATIVE_TO_OR_ID = {
     "zai-org/GLM-5.1": "z-ai/glm-5.1",
     "moonshotai/Kimi-K2.6": "moonshotai/kimi-k2.6",
     "deepseek-ai/DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro",
-    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": ("nvidia/nvidia-nemotron-3-ultra-550b-a55b"),
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
     "moonshotai/Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
     "thinkingmachines/inkling": "thinkingmachines/inkling-1m",

--- a/scripts/pricing/providers/nebius.py
+++ b/scripts/pricing/providers/nebius.py
@@ -38,6 +38,14 @@ EXPECTED_MODELS = [
 
 _DISCOVERED_ROWS: dict[str, dict[str, Any]] = {}
 
+_NATIVE_TO_CANONICAL = {
+    # Nebius added this spelling after the same model was already published
+    # under TrustedRouter's canonical cross-provider ID. Keep the native ID
+    # only for upstream requests so refreshes cannot create a duplicate model.
+    "nvidia/Nemotron-3-Ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
+}
+
 
 def _dollars_per_token_to_micro_per_m(value: object) -> int | None:
     try:
@@ -59,15 +67,20 @@ def _positive_int(value: object) -> int | None:
     return parsed if parsed > 0 else None
 
 
-def _manifest_row(row: dict[str, Any], price: ModelPrice) -> dict[str, Any]:
-    model_id = str(row["id"])
+def _manifest_row(
+    row: dict[str, Any],
+    price: ModelPrice,
+    *,
+    model_id: str,
+    upstream_id: str,
+) -> dict[str, Any]:
     architecture = row.get("architecture")
     architecture = architecture if isinstance(architecture, dict) else {}
     modality = str(architecture.get("modality") or "")
     input_modalities = ["text", "image"] if modality.startswith("text+image") else ["text"]
     out: dict[str, Any] = {
         "id": model_id,
-        "upstream_id": model_id,
+        "upstream_id": upstream_id,
         "display_name": str(row.get("name") or model_id.rsplit("/", 1)[-1]),
         "title": model_id,
         "created": _positive_int(row.get("created")) or int(
@@ -119,9 +132,10 @@ def fetch() -> ProviderPricingResult:
     for row in rows:
         if not isinstance(row, dict):
             continue
-        model_id = row.get("id")
-        if not isinstance(model_id, str):
+        upstream_id = row.get("id")
+        if not isinstance(upstream_id, str):
             continue
+        model_id = _NATIVE_TO_CANONICAL.get(upstream_id, upstream_id)
         architecture = row.get("architecture")
         architecture = architecture if isinstance(architecture, dict) else {}
         modality = str(architecture.get("modality") or "")
@@ -136,7 +150,12 @@ def fetch() -> ProviderPricingResult:
             continue
         price = ModelPrice(prompt_micro_per_m=prompt, completion_micro_per_m=completion)
         prices[model_id] = price
-        discovered[model_id] = _manifest_row(row, price)
+        discovered[model_id] = _manifest_row(
+            row,
+            price,
+            model_id=model_id,
+            upstream_id=upstream_id,
+        )
 
     _DISCOVERED_ROWS = discovered
     missing = sorted(set(EXPECTED_MODELS) - set(prices))

--- a/scripts/pricing/providers/parasail.py
+++ b/scripts/pricing/providers/parasail.py
@@ -249,7 +249,7 @@ _DISPLAY_TO_OR_ID = {
     "Mistral Small 3.2 24B": "mistralai/mistral-small-3.2-24b-instruct",
     "Llama 4 Maverick (FP8)": "meta-llama/llama-4-maverick",
     "Llama 3.3 70B (FP8)": "meta-llama/llama-3.3-70b-instruct",
-    "Nemotron 3 Ultra 550B (NVFP4)": "nvidia/nvidia-nemotron-3-ultra-550b-a55b",
+    "Nemotron 3 Ultra 550B (NVFP4)": "nvidia/nemotron-3-ultra-550b-a55b",
     "Trinity Large (Thinking)": "arcee-ai/trinity-large-thinking",
     "Gemma 4 26B-A4B": "google/gemma-4-26b-a4b-it",
     "Gemma 4 31B": "google/gemma-4-31b-it",

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from scripts.pricing.parsers import minimax as minimax_parser
 from scripts.pricing.parsers import xiaomi as xiaomi_parser
 from scripts.pricing.providers import nebius
@@ -104,7 +106,9 @@ class _FakeResponse:
         return self._payload
 
 
-def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(monkeypatch) -> None:  # noqa: ANN001
+def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
+    tmp_path, monkeypatch  # noqa: ANN001
+) -> None:
     payload = {
         "data": [
             {
@@ -130,6 +134,14 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(monkeypatch) -> 
                 "context_length": 202752,
                 "architecture": {"modality": "text->text"},
                 "pricing": {"prompt": "0.0000014", "completion": "0.0000044"},
+            },
+            {
+                "id": "nvidia/Nemotron-3-Ultra-550b-a55b",
+                "name": "NVIDIA Nemotron 3 Ultra 550B A55B",
+                "created": 1,
+                "context_length": 262144,
+                "architecture": {"modality": "text->text"},
+                "pricing": {"prompt": "0.0000006", "completion": "0.0000024"},
             },
             {
                 "id": "Qwen/Qwen3-Embedding-8B",
@@ -161,4 +173,23 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(monkeypatch) -> 
 
     assert result.prices["openai/gpt-oss-120b"].prompt_micro_per_m == 150_000
     assert result.prices["deepseek-ai/DeepSeek-V4-Pro"].completion_micro_per_m == 3_500_000
+    canonical = "nvidia/nemotron-3-ultra-550b-a55b"
+    assert result.prices[canonical].prompt_micro_per_m == 600_000
+    assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in result.prices
+    assert nebius._DISCOVERED_ROWS[canonical]["id"] == canonical
+    assert (
+        nebius._DISCOVERED_ROWS[canonical]["upstream_id"]
+        == "nvidia/Nemotron-3-Ultra-550b-a55b"
+    )
     assert "Qwen/Qwen3-Embedding-8B" not in result.prices
+
+    manifest = tmp_path / "nebius.json"
+    manifest.write_text('{"models": []}\n', encoding="utf-8")
+    monkeypatch.setattr(nebius, "MANIFEST_PATH", manifest)
+
+    nebius.write_provider_manifest(result)
+
+    rows = json.loads(manifest.read_text(encoding="utf-8"))["models"]
+    ids = {row["id"] for row in rows}
+    assert canonical in ids
+    assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in ids

--- a/tests/test_parasail_pricing.py
+++ b/tests/test_parasail_pricing.py
@@ -108,7 +108,7 @@ def test_fetch_prices_only_models_on_both_page_and_api(monkeypatch) -> None:  # 
     assert kimi.prompt_cached_micro_per_m == 160_000
 
     joined = "\n".join(result.notes)
-    assert "nvidia/nvidia-nemotron-3-ultra-550b-a55b" in joined  # page-only
+    assert "nvidia/nemotron-3-ultra-550b-a55b" in joined  # page-only
     assert "Brand New Model 9000" in joined  # unmapped page row
     assert "z-ai/glm-5.2" in joined  # api-only, page missing
 


### PR DESCRIPTION
Canonicalizes Nebius' new mixed-case Nemotron ID while preserving the exact upstream request ID; corrects the same stale alias in Baseten, Parasail, and the coverage audit; and adds refresh and manifest regression coverage. Focused pytest and Ruff checks pass. This fixes the fail-closed hourly refresh gate observed in run 29543774635; that failed run committed nothing.