### PR TITLE
Leaderboard: give Claude 5 thinking models the reasoning probe budget

### DIFF
--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -979,11 +979,17 @@ def _rotation_max_tokens(provider: str, model: str) -> int:
         or "glm-4.7" in model_l
         or "glm-5" in model_l
         or "nemotron" in model_l
+        or "claude-fable-5" in model_l
+        or "claude-sonnet-5" in model_l
         or "reasoning" in model_l
         or "thinking" in model_l
     ):
-        # Crusoe nemotron-3 reasons by default without streaming reasoning
-        # deltas, so 16 tokens can finish=length with zero visible content.
+        # Reasoning models that think before emitting visible content: at 16
+        # tokens they finish=length with zero streamed content and register as
+        # probe_config_error. Crusoe nemotron-3 reasons by default without
+        # streaming reasoning deltas; Claude Fable 5 (adaptive thinking always
+        # on) and Sonnet 5 do the same, so they need the larger budget to emit
+        # a visible token.
         return 512
     if "kimi-k2" in model_l or "grok" in model_l or "claude-opus" in model_l:
         return 128

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1930,6 +1930,12 @@ def test_rotation_probe_uses_reasoning_safe_request_budget() -> None:
     assert _rotation_max_tokens("openai", "openai/o3") == 512
     assert _rotation_max_tokens("openai", "openai/gpt-5.5") == 512
     assert _rotation_max_tokens("baseten", "nvidia/nemotron-120b-a12b") == 512
+    # Claude 5 thinking models emit no visible token within 16 (adaptive
+    # thinking burns the budget), so they get the reasoning-safe budget too.
+    assert _rotation_max_tokens("anthropic", "anthropic/claude-fable-5") == 512
+    assert _rotation_max_tokens("anthropic", "anthropic/claude-sonnet-5") == 512
+    # Non-thinking Claude models keep the small budget.
+    assert _rotation_max_tokens("anthropic", "anthropic/claude-haiku-4.5") == 16
     assert _rotation_omits_temperature("openai", "openai/o3")
     assert _rotation_omits_temperature("openai", "openai/gpt-5.5")
     # Canary contract: probes mirror customer payloads. The enclave strips


### PR DESCRIPTION
Follow-up to #201/#32. Post-deploy, claude-fable-5 stopped 502ing (enclave temperature fix landed) but flipped to `probe_config_error` — Fable 5's always-on adaptive thinking burns a 16-token budget before emitting any visible token, the same class as the nemotron fix. Give claude-fable-5 + claude-sonnet-5 the existing 512-token reasoning budget so the probe records real TTFT instead of a config error. One-line quirk + test; targeted suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)