### PR TITLE
Schedule Phala July 29 retirements and price change

### DIFF
--- a/scripts/pricing/providers/phala.py
+++ b/scripts/pricing/providers/phala.py
@@ -28,6 +28,7 @@ to `_NATIVE_TO_OR_ID`. Refresh.py overlays the price automatically.
 from __future__ import annotations
 
 import os
+from datetime import datetime
 
 import httpx
 
@@ -40,6 +41,10 @@ from scripts.pricing.base import (
     validate,
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from trusted_router.provider_lifecycle import (
+    provider_model_retired,
+    provider_price_microdollars,
+)
 
 SLUG = "phala"
 URL = "https://api.redpill.ai/v1/models"
@@ -82,6 +87,33 @@ _NATIVE_TO_OR_ID = {
     "phala/minimax-m2.5": "minimax/minimax-m2.5",
 }
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+
+
+def _apply_lifecycle_policy(
+    prices: dict[str, ModelPrice],
+    *,
+    at: datetime | str | None = None,
+) -> dict[str, ModelPrice]:
+    effective = {
+        model_id: price
+        for model_id, price in prices.items()
+        if not provider_model_retired(
+            SLUG,
+            model_id,
+            UPSTREAM_ID_MAP.get(model_id),
+            at=at,
+        )
+    }
+    for model_id, existing in tuple(effective.items()):
+        announced = provider_price_microdollars(SLUG, model_id, at=at)
+        if announced is None:
+            continue
+        effective[model_id] = ModelPrice(
+            announced.prompt_microdollars_per_million_tokens,
+            announced.completion_microdollars_per_million_tokens,
+            prompt_cached_micro_per_m=existing.tiers[0].prompt_cached_micro_per_m,
+        )
+    return effective
 
 
 def _extract_rates(pricing: object) -> tuple[float, float, float | None] | None:
@@ -149,6 +181,7 @@ def fetch() -> ProviderPricingResult:
             ),
         )
 
+    prices = _apply_lifecycle_policy(prices)
     notes: list[str] = []
     errors = validate(prices, EXPECTED_MODELS)
     if errors:

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from datetime import datetime
+
 from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-compat
     _EMBEDDING_SPECS,
     _MODEL_PROVIDER_PRIVACY_OVERRIDES,
@@ -164,6 +167,10 @@ from trusted_router.pricing import (  # noqa: F401 - re-exported for back-compat
     cache_token_prices_microdollars,
     select_price_tier,
 )
+from trusted_router.provider_lifecycle import (
+    provider_model_retired,
+    provider_price_microdollars,
+)
 from trusted_router.routing_candidates import (  # noqa: F401 - re-exported for back-compat
     InvalidAutoModelOrder,
     _is_regular_chat_model,
@@ -271,8 +278,50 @@ def orchestration_role(model_id: str) -> str | None:
 # mid-tier model. (gpt-5.5 works too but is the pricey flagship.)
 
 
+def effective_endpoint(
+    endpoint: ModelEndpoint,
+    *,
+    at: datetime | str | None = None,
+) -> ModelEndpoint:
+    """Return an endpoint with any effective-dated announced price applied."""
+    provider_price = provider_price_microdollars(
+        endpoint.provider,
+        endpoint.model_id,
+        at=at,
+    )
+    if provider_price is None:
+        return endpoint
+    prompt_price = _customer_price(
+        provider_price.prompt_microdollars_per_million_tokens
+    )
+    completion_price = _customer_price(
+        provider_price.completion_microdollars_per_million_tokens
+    )
+    tiers = _flat_tier(prompt_price, completion_price)
+    return replace(
+        endpoint,
+        prompt_price_microdollars_per_million_tokens=prompt_price,
+        completion_price_microdollars_per_million_tokens=completion_price,
+        published_prompt_price_microdollars_per_million_tokens=prompt_price,
+        published_completion_price_microdollars_per_million_tokens=completion_price,
+        price_tiers=tiers,
+        published_price_tiers=tiers,
+    )
+
+
 def endpoints_for_model(model_id: str) -> list[ModelEndpoint]:
-    return [endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.model_id == model_id]
+    endpoints: list[ModelEndpoint] = []
+    for endpoint in MODEL_ENDPOINTS.values():
+        if endpoint.model_id != model_id:
+            continue
+        if provider_model_retired(
+            endpoint.provider,
+            endpoint.model_id,
+            endpoint.upstream_id,
+        ):
+            continue
+        endpoints.append(effective_endpoint(endpoint))
+    return endpoints
 
 
 def endpoint_for_id(endpoint_id: str | None) -> ModelEndpoint | None:
@@ -429,15 +478,14 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     is_meta = model.id in META_MODEL_IDS
     endpoints = endpoints_for_model(model.id)
     prepaid_available = (
-        any(endpoint.usage_type == "Credits" for endpoint in endpoints) or model.prepaid_available
+        model.prepaid_available
+        if is_meta
+        else any(endpoint.usage_type == "Credits" for endpoint in endpoints)
     )
     byok_available = (
         False
         if is_meta
-        else (
-            any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
-            or (model.byok_available and PROVIDERS[model.provider].supports_byok)
-        )
+        else any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
     )
 
     # For meta routers, derive prompt/completion price from the candidate range
@@ -456,7 +504,28 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     pub_prompt_max = pub_prompt_min
     pub_completion_min = model.published_completion_price_microdollars_per_million_tokens
     pub_completion_max = pub_completion_min
-    if is_meta:
+    if not is_meta and endpoints:
+        prompt_min = min(
+            endpoint.prompt_price_microdollars_per_million_tokens
+            for endpoint in endpoints
+        )
+        completion_min = min(
+            endpoint.completion_price_microdollars_per_million_tokens
+            for endpoint in endpoints
+        )
+        prompt_max = prompt_min
+        completion_max = completion_min
+        pub_prompt_min = min(
+            endpoint.published_prompt_price_microdollars_per_million_tokens
+            for endpoint in endpoints
+        )
+        pub_completion_min = min(
+            endpoint.published_completion_price_microdollars_per_million_tokens
+            for endpoint in endpoints
+        )
+        pub_prompt_max = pub_prompt_min
+        pub_completion_max = pub_completion_min
+    elif is_meta:
         prompt_min, prompt_max = _meta_price_range(
             model.id, "prompt_price_microdollars_per_million_tokens"
         )

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -37,6 +37,7 @@ from trusted_router.pricing import (
     _provider_manifest_price_tiers,
     _read_pricing_tiers,
 )
+from trusted_router.provider_lifecycle import provider_model_retired
 
 
 def _endpoint(
@@ -220,6 +221,8 @@ def _is_provider_deprecated_model(
     model_id: str,
     upstream_id: str | None,
 ) -> bool:
+    if provider_model_retired(provider_slug, model_id, upstream_id):
+        return True
     deprecated = _PROVIDER_DEPRECATED_UPSTREAM_MODELS.get(provider_slug)
     if not deprecated:
         return False

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -1,0 +1,99 @@
+"""Effective-dated provider model retirements and announced price changes.
+
+Live provider catalog refreshes remain the normal source of truth. This module
+handles provider announcements with a precise future cutover so routing and
+billing do not depend on an hourly refresh landing at exactly the right second.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class ProviderPrice:
+    prompt_microdollars_per_million_tokens: int
+    completion_microdollars_per_million_tokens: int
+
+
+@dataclass(frozen=True)
+class _Retirement:
+    provider: str
+    model_ids: frozenset[str]
+    upstream_ids: frozenset[str]
+    effective_at: datetime
+
+
+_RETIREMENTS = (
+    _Retirement(
+        provider="phala",
+        model_ids=frozenset(
+            {
+                "z-ai/glm-4.7",
+                "qwen/qwen3-30b-a3b-instruct-2507",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "phala/glm-4.7",
+                "phala/qwen3-30b-a3b-instruct-2507",
+            }
+        ),
+        effective_at=PHALA_JULY_2026_EFFECTIVE_AT,
+    ),
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _effective_time(at: datetime | str | None) -> datetime:
+    if at is None:
+        return _utc_now()
+    if isinstance(at, str):
+        parsed = datetime.fromisoformat(at.replace("Z", "+00:00"))
+    else:
+        parsed = at
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def provider_model_retired(
+    provider_slug: str,
+    model_id: str,
+    upstream_id: str | None = None,
+    *,
+    at: datetime | str | None = None,
+) -> bool:
+    effective_at = _effective_time(at)
+    for retirement in _RETIREMENTS:
+        if retirement.provider != provider_slug or effective_at < retirement.effective_at:
+            continue
+        if model_id in retirement.model_ids:
+            return True
+        if upstream_id is not None and upstream_id in retirement.upstream_ids:
+            return True
+    return False
+
+
+def provider_price_microdollars(
+    provider_slug: str,
+    model_id: str,
+    *,
+    at: datetime | str | None = None,
+) -> ProviderPrice | None:
+    """Return an announced provider cost override, before or after cutover.
+
+    Pinning both sides prevents a provider API from publishing the new price
+    early and makes the exact advertised transition deterministic.
+    """
+    if provider_slug != "phala" or model_id != "qwen/qwen-2.5-7b-instruct":
+        return None
+    if _effective_time(at) < PHALA_JULY_2026_EFFECTIVE_AT:
+        return ProviderPrice(40_000, 100_000)
+    return ProviderPrice(100_000, 200_000)

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import uuid
+from datetime import datetime
 from time import perf_counter
 from typing import Any
 
@@ -30,6 +31,7 @@ from trusted_router.catalog import (
     ModelEndpoint,
     cache_token_prices_microdollars,
     default_endpoint_for_model,
+    effective_endpoint,
     endpoint_for_id,
 )
 from trusted_router.config import Settings
@@ -877,6 +879,7 @@ def _settle_gateway_authorization(
         output_tokens,
         cache_read_tokens=cache_read,
         cache_creation_tokens=cache_creation,
+        effective_at=authorization.created_at,
     )
     input_tokens = total_input
     selected_usage_type = UsageType.for_endpoint(selected_endpoint)
@@ -1215,10 +1218,12 @@ def _endpoint_cost_microdollars(
     *,
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
+    effective_at: datetime | str | None = None,
 ) -> int:
     """input_tokens must be the UNCACHED prompt tokens when cache counts
     are passed — cached reads/writes bill at the provider-specific
     multiple of the prompt price (see catalog.cache_token_prices_microdollars)."""
+    endpoint = effective_endpoint(endpoint, at=effective_at)
     total_prompt = input_tokens + cache_read_tokens + cache_creation_tokens
     rates = resolve_request_rates(
         getattr(endpoint, "price_tiers", ()) or (),

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.pricing.base import ModelPrice
+from scripts.pricing.providers import phala
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import (
+    MODELS,
+    effective_endpoint,
+    endpoint_for_id,
+    endpoints_for_model,
+    model_to_openrouter_shape,
+)
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes.internal.gateway import _endpoint_cost_microdollars
+from trusted_router.storage import STORE
+
+_CUTOFF = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
+
+
+def test_phala_retirements_switch_at_announced_instant() -> None:
+    before = _CUTOFF - timedelta(microseconds=1)
+
+    for model_id, upstream_id in (
+        ("z-ai/glm-4.7", "phala/glm-4.7"),
+        (
+            "qwen/qwen3-30b-a3b-instruct-2507",
+            "phala/qwen3-30b-a3b-instruct-2507",
+        ),
+    ):
+        assert not provider_lifecycle.provider_model_retired(
+            "phala", model_id, upstream_id, at=before
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "phala", model_id, upstream_id, at=_CUTOFF
+        )
+
+
+def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    glm_providers = {
+        endpoint.provider for endpoint in endpoints_for_model("z-ai/glm-4.7")
+    }
+    qwen_providers = {
+        endpoint.provider
+        for endpoint in endpoints_for_model("qwen/qwen3-30b-a3b-instruct-2507")
+    }
+
+    assert "phala" not in glm_providers
+    assert glm_providers
+    assert "phala" not in qwen_providers
+    # Phala is currently the only live route for this exact Qwen revision.
+    assert not qwen_providers
+
+
+def test_phala_qwen_price_switches_exactly_at_cutoff() -> None:
+    endpoint = endpoint_for_id("qwen/qwen-2.5-7b-instruct@phala/prepaid")
+    assert endpoint is not None
+
+    before = effective_endpoint(endpoint, at=_CUTOFF - timedelta(microseconds=1))
+    after = effective_endpoint(endpoint, at=_CUTOFF)
+
+    assert before.prompt_price_microdollars_per_million_tokens == 44_000
+    assert before.completion_price_microdollars_per_million_tokens == 110_000
+    assert after.prompt_price_microdollars_per_million_tokens == 110_000
+    assert after.completion_price_microdollars_per_million_tokens == 220_000
+
+    assert (
+        _endpoint_cost_microdollars(
+            endpoint,
+            1_000_000,
+            1_000_000,
+            effective_at=_CUTOFF - timedelta(microseconds=1),
+        )
+        == 154_000
+    )
+    assert (
+        _endpoint_cost_microdollars(
+            endpoint,
+            1_000_000,
+            1_000_000,
+            effective_at=_CUTOFF,
+        )
+        == 330_000
+    )
+
+
+def test_public_catalog_uses_effective_price_and_active_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    qwen_price = model_to_openrouter_shape(MODELS["qwen/qwen-2.5-7b-instruct"])
+    assert qwen_price["trustedrouter"][
+        "prompt_price_microdollars_per_million_tokens"
+    ] == 110_000
+    assert qwen_price["trustedrouter"][
+        "completion_price_microdollars_per_million_tokens"
+    ] == 220_000
+
+    retired_qwen = model_to_openrouter_shape(
+        MODELS["qwen/qwen3-30b-a3b-instruct-2507"]
+    )
+    assert retired_qwen["trustedrouter"]["prepaid_available"] is False
+    assert retired_qwen["trustedrouter"]["byok_available"] is False
+    assert retired_qwen["trustedrouter"]["endpoints"] == []
+
+
+def test_phala_hourly_parser_applies_announced_policy() -> None:
+    prices = {
+        "z-ai/glm-4.7": ModelPrice(1, 2),
+        "qwen/qwen3-30b-a3b-instruct-2507": ModelPrice(3, 4),
+        "qwen/qwen-2.5-7b-instruct": ModelPrice(40_000, 100_000),
+        "z-ai/glm-5.2": ModelPrice(300_000, 2_000_000),
+    }
+
+    before = phala._apply_lifecycle_policy(
+        prices, at=_CUTOFF - timedelta(microseconds=1)
+    )
+    after = phala._apply_lifecycle_policy(prices, at=_CUTOFF)
+
+    assert set(before) == set(prices)
+    assert before["qwen/qwen-2.5-7b-instruct"] == ModelPrice(40_000, 100_000)
+    assert "z-ai/glm-4.7" not in after
+    assert "qwen/qwen3-30b-a3b-instruct-2507" not in after
+    assert after["qwen/qwen-2.5-7b-instruct"] == ModelPrice(100_000, 200_000)
+    assert after["z-ai/glm-5.2"] == prices["z-ai/glm-5.2"]
+
+
+def test_settlement_keeps_authorization_time_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(seconds=1),
+    )
+    client = TestClient(create_app(Settings(environment="test"), init_observability=False))
+    created = client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "phala-cutover@example.com"},
+        json={"name": "phala cutover"},
+    )
+    assert created.status_code == 201, created.text
+    key = created.json()["data"]
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "qwen/qwen-2.5-7b-instruct",
+            "provider": {"only": ["phala"]},
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 1_000,
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    authorization_id = authorize.json()["data"]["authorization_id"]
+    authorization = STORE.get_gateway_authorization(authorization_id)
+    assert authorization is not None
+    authorization.created_at = (_CUTOFF - timedelta(seconds=1)).isoformat()
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF + timedelta(seconds=1),
+    )
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": authorization_id,
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 1_000,
+            "request_id": "gw-phala-price-cutover",
+            "elapsed_seconds": 1.0,
+        },
+    )
+
+    assert settle.status_code == 200, settle.text
+    assert settle.json()["data"]["cost_microdollars"] == 154


### PR DESCRIPTION
## Summary
- retire Phala routes for z-ai/glm-4.7 and qwen/qwen3-30b-a3b-instruct-2507 exactly at 2026-07-29 18:00 UTC
- switch Phala qwen/qwen-2.5-7b-instruct upstream pricing from $0.04/$0.10 to $0.10/$0.20 per million at the same instant
- apply one effective-dated policy across routing, catalog display, hourly provider refresh, authorization, and settlement
- preserve authorization-time pricing for requests that cross the cutoff

## Verification
- live Phala API currently returns both retiring routes and the announced old Qwen price
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 1590 passed, 33 skipped
