### PR TITLE
Add Meta Muse Spark catalog route

### DIFF
--- a/scripts/ingest_openrouter_catalog.py
+++ b/scripts/ingest_openrouter_catalog.py
@@ -10,13 +10,11 @@ Usage:
     python scripts/ingest_openrouter_catalog.py            # refresh snapshot
     python scripts/ingest_openrouter_catalog.py --check    # CI guard: exits 1 if the file would change
 
-The filter keeps models whose endpoints[].provider_name resolves to one
-of TR's 8 keyed providers (anthropic, openai, gemini, cerebras, deepseek,
-mistral, kimi, zai). Within each kept model we keep only those endpoints
-— secondary inference providers (DeepInfra, Together, etc.) are dropped
-because TR has no key for them. Vertex is intentionally excluded until
-TR's GCP project gets the Anthropic-on-Vertex / Gemini-on-Vertex quota
-approvals.
+The filter keeps endpoints that resolve to a configured TrustedRouter
+downstream. Most use provider-direct keys. The deliberately labelled Meta via
+OpenRouter route uses TrustedRouter's OpenRouter inference key because Muse
+Spark is not currently available through a direct Meta endpoint. Vertex rows
+remain excluded until the required project quota is available.
 """
 
 from __future__ import annotations
@@ -40,6 +38,10 @@ MAX_WORKERS = 8
 # OpenRouter's per-endpoint `provider_name` → TR provider slug. Anything
 # not in this table gets filtered out (TR has no key/gateway client for it).
 PROVIDER_NAME_TO_SLUG: dict[str, str] = {
+    # Muse Spark is currently available from Meta only through OpenRouter's
+    # standard inference surface. Keep this provider distinct from Meta Llama
+    # weights hosted by Cerebras/Novita/etc. so downstream custody is explicit.
+    "Meta": "meta",
     "Anthropic": "anthropic",
     "OpenAI": "openai",
     "Google": "gemini",

--- a/scripts/pricing/providers/meta.py
+++ b/scripts/pricing/providers/meta.py
@@ -1,0 +1,100 @@
+"""Meta Muse pricing through OpenRouter's provider endpoint.
+
+Muse Spark is not exposed by a direct Meta Model API credential in this
+deployment. OpenRouter is therefore the actual downstream API and billing
+source, and its endpoint feed is authoritative for this explicitly labelled
+route.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult, fetch_json, validate
+
+SLUG = "meta"
+MODEL_ID = "meta/muse-spark-1.1"
+URL = f"https://openrouter.ai/api/v1/models/{MODEL_ID}/endpoints"
+EXPECTED_MODELS = [MODEL_ID]
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "meta.json"
+)
+
+
+def _microdollars_per_million(raw: Any) -> int:
+    try:
+        return int((Decimal(str(raw)) * Decimal(1_000_000_000_000)).to_integral_value())
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise RuntimeError(f"meta: invalid per-token price {raw!r}") from exc
+
+
+def _meta_endpoint(payload: Any) -> dict[str, Any]:
+    data = payload.get("data") if isinstance(payload, dict) else None
+    endpoints = data.get("endpoints") if isinstance(data, dict) else None
+    if not isinstance(endpoints, list):
+        raise RuntimeError("meta: endpoint API returned an unexpected shape")
+    for row in endpoints:
+        if isinstance(row, dict) and row.get("provider_name") == "Meta":
+            return row
+    raise RuntimeError("meta: Muse endpoint API did not contain the Meta route")
+
+
+def fetch() -> ProviderPricingResult:
+    row = _meta_endpoint(fetch_json(URL))
+    pricing = row.get("pricing")
+    if not isinstance(pricing, dict):
+        raise RuntimeError("meta: Muse endpoint has no pricing object")
+    cached = pricing.get("input_cache_read")
+    price = ModelPrice(
+        prompt_micro_per_m=_microdollars_per_million(pricing.get("prompt")),
+        completion_micro_per_m=_microdollars_per_million(pricing.get("completion")),
+        prompt_cached_micro_per_m=(
+            _microdollars_per_million(cached) if cached not in (None, "") else None
+        ),
+    )
+    prices = {MODEL_ID: price}
+    errors = validate(prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError(f"meta: invalid Muse pricing: {errors}")
+    return ProviderPricingResult(
+        slug=SLUG,
+        prices=prices,
+        source="api",
+        fetched_url=URL,
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list) or len(rows) != 1 or not isinstance(rows[0], dict):
+        raise RuntimeError("meta: provider manifest must contain exactly one model")
+    price = result.prices.get(MODEL_ID)
+    if price is None:
+        raise RuntimeError("meta: refreshed pricing did not include Muse")
+    row = rows[0]
+    tier = price.tiers[0]
+    row["input_token_price_per_m"] = tier.prompt_micro_per_m
+    row["output_token_price_per_m"] = tier.completion_micro_per_m
+    if tier.prompt_cached_micro_per_m is not None:
+        row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+    else:
+        row.pop("cached_input_token_price_per_m", None)
+    raw["source"] = URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return ["meta: refreshed Muse Spark pricing from OpenRouter's Meta endpoint"]

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -59,10 +59,14 @@ from ingest_openrouter_catalog import build_snapshot as build_openrouter_snapsho
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SNAPSHOT_PATH = REPO_ROOT / "src" / "trusted_router" / "data" / "openrouter_snapshot.json"
 
-# Provider modules in order of execution. Together first because it's
-# the JSON-API path that doesn't touch the LLM-rewriteable parser tier.
+# Provider modules in order of execution. Together stays first because existing
+# refresh contracts depend on it; Meta is another JSON API path that does not
+# touch the LLM-rewriteable parser tier.
 PROVIDER_SLUGS = [
     "together",
+    # Meta Muse is served through OpenRouter, so OpenRouter is the provider API
+    # and billing source for this one explicitly labelled downstream route.
+    "meta",
     "anthropic",
     "openai",
     "gemini",
@@ -122,6 +126,19 @@ MAX_TOLERATED_FAILURES = int(os.environ.get("TR_PRICING_MAX_FAILURES", "2"))
 # Threshold for cross-check disagreements between provider-direct and
 # OR. Above this, we log a note. Provider-direct still wins.
 CROSS_CHECK_DISAGREE_THRESHOLD = 0.02  # 2%
+
+# OpenRouter is the actual serving and billing API for this deliberately
+# labelled downstream provider. Keep its provenance distinct from both direct
+# provider prices and emergency OpenRouter fallback prices.
+_OPENROUTER_BACKED_PROVIDER_SLUGS = frozenset({"meta"})
+
+
+def _endpoint_pricing_source(slug: str, healed_slugs: set[str]) -> str:
+    if slug in healed_slugs:
+        return "self_healed_provider"
+    if slug in _OPENROUTER_BACKED_PROVIDER_SLUGS:
+        return "openrouter_provider"
+    return "provider_direct"
 
 
 def _import_provider(slug: str):
@@ -531,11 +548,11 @@ def _merge_snapshot(
 ) -> dict[str, Any]:
     """Build the final snapshot.
 
-    Policy: only models we have provider-direct prices for are in the
-    snapshot. OR is a cross-check signal, never a billing source — TR
-    routes directly to each provider (Anthropic, OpenAI, Gemini, etc.)
-    using TR's own keys, so prices MUST come from provider-direct
-    parsers. Anything OR-only falls out of the catalog by design.
+    Policy: only models with an authoritative price from the API we actually
+    pay are in the snapshot. Almost every route is provider-direct, with OR
+    used only as a cross-check. The explicitly labelled Meta via OpenRouter
+    route is the narrow exception: its OpenRouter endpoint is both the serving
+    API and billing source. Unconfigured OR-only models still fall out.
 
     A single model can have multiple provider-direct endpoints (e.g.
     meta-llama/llama-3.1-8b on both Cerebras and Novita;
@@ -579,7 +596,7 @@ def _merge_snapshot(
             # Model-level headline pricing = the cheapest *positively-priced*
             # provider-direct tier (matches OR's convention and what
             # /v1/models top-level pricing should show).
-            _cheapest_slug, cheapest = min(
+            cheapest_slug, cheapest = min(
                 priced_by_slug.items(),
                 key=lambda item: (
                     item[1].tiers[0].prompt_micro_per_m,
@@ -591,10 +608,9 @@ def _merge_snapshot(
             new_model["pricing"] = new_pricing
             # Tag pricing_source as self-healed if ANY of the slugs that
             # priced this model went through the LLM rewrite.
-            if any(slug in healed_slugs for slug in priced_by_slug):
-                new_model["pricing_source"] = "self_healed_provider"
-            else:
-                new_model["pricing_source"] = "provider_direct"
+            new_model["pricing_source"] = _endpoint_pricing_source(
+                cheapest_slug, healed_slugs
+            )
         else:
             # Every keyed provider returned $0 for a model that OR prices
             # above $0 — a feed glitch across all of them at once. Fall
@@ -641,9 +657,7 @@ def _merge_snapshot(
             new_ep_pricing = dict(new_ep.get("pricing") or {})
             new_ep_pricing.update(_price_to_pricing_block(ep_price))
             new_ep["pricing"] = new_ep_pricing
-            new_ep["pricing_source"] = (
-                "self_healed_provider" if ep_slug in healed_slugs else "provider_direct"
-            )
+            new_ep["pricing_source"] = _endpoint_pricing_source(ep_slug, healed_slugs)
             # If this provider's config module exports an
             # UPSTREAM_ID_MAP, override the endpoint's model_id with
             # the provider-native id so the enclave sends what the
@@ -675,9 +689,7 @@ def _merge_snapshot(
                 "tr_provider_slug": missing_slug,
                 "context_length": int(new_model.get("context_length") or 0),
                 "pricing": _price_to_pricing_block(missing_price),
-                "pricing_source": (
-                    "self_healed_provider" if missing_slug in healed_slugs else "provider_direct"
-                ),
+                "pricing_source": _endpoint_pricing_source(missing_slug, healed_slugs),
                 "supported_parameters": list(new_model.get("supported_parameters") or []),
                 "quantization": "unknown",
             }
@@ -692,13 +704,12 @@ def _merge_snapshot(
     merged_models.sort(key=lambda m: str(m.get("id") or ""))
     return {
         "source": (
-            "provider-direct (anthropic.com, openai.com, ai.google.dev, ...) "
-            "with openrouter.ai used only for cross-check sanity"
+            "authoritative downstream APIs; provider-direct except explicitly "
+            "labelled proxy-backed routes such as Meta via OpenRouter"
         ),
         "filter": (
-            "kept ONLY models with provider-direct prices; OR-only models are "
-            "dropped (TR never routes via OR — every model in this snapshot is "
-            "billable at the price set by the provider's own pricing page)"
+            "kept only models with a configured, billable downstream route; "
+            "unconfigured OpenRouter-only models are dropped"
         ),
         "tr_keyed_providers": or_snapshot.get("tr_keyed_providers", []),
         "model_count": len(merged_models),

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -267,9 +267,9 @@ def orchestration_role(model_id: str) -> str | None:
 # provider allowlist in their agreement and request body.
 # IDs follow snapshot naming exactly. The picks span the 8 keyed
 # providers so `trustedrouter/auto` rolls over across providers if any
-# one is down. Each entry must have a provider-direct price in the
-# snapshot — OR-only models can no longer reach the catalog (see
-# scripts/pricing/refresh.py:_merge_snapshot).
+# one is down. Each entry must have an authoritative price for the API that the
+# gateway actually calls. Unconfigured OR-only models cannot reach the catalog;
+# explicitly labelled proxy-backed routes are never auto candidates.
 #
 # 2026-06 update: OpenAI's GPT-5.4 line (incl. gpt-5.4-nano) and the "-pro"
 # tiers 502 on our key — verified via the gateway probe; see

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -182,6 +182,24 @@ PROVIDERS: dict[str, Provider] = {
         provider_policy_url="https://trust.trustedrouter.com",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
+    "meta": Provider(
+        slug="meta",
+        name="Meta via OpenRouter",
+        supports_prepaid=True,
+        supports_byok=False,
+        stores_content=True,
+        provider_zero_data_retention=False,
+        provider_confidential_compute=False,
+        provider_e2ee=False,
+        provider_policy=(
+            "TrustedRouter sends requests through its attested gateway to "
+            "OpenRouter, which routes them to Meta. This downstream route is "
+            "not marked zero-retention, confidential-compute, or end-to-end "
+            "encrypted."
+        ),
+        provider_policy_url="https://openrouter.ai/docs/features/privacy-and-logging",
+        provider_headquarters_country=PROVIDER_JURISDICTION_US,
+    ),
     "anthropic": Provider(
         slug="anthropic",
         name="Anthropic",
@@ -731,6 +749,10 @@ GATEWAY_PREPAID_PROVIDER_SLUGS = frozenset(
         "voyage",
         # Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1).
         "xiaomi",
+        # Meta-hosted Muse is currently exposed through OpenRouter's standard
+        # inference API. The public provider label says "Meta via OpenRouter"
+        # and the privacy posture remains standard/non-ZDR.
+        "meta",
     }
 )
 

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -378,9 +378,10 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
 ]:
     """Read provider-native model manifests for providers whose live API
     lists more routes than OpenRouter's endpoint feed. These manifests
-    preserve exact upstream model IDs and provider-direct prices, so the
-    control plane can authorize routes the attested gateway can actually
-    call and bill.
+    preserve exact upstream model IDs and authoritative downstream prices, so
+    the control plane can authorize routes the attested gateway can actually
+    call and bill. Most are provider-direct; Meta Muse is explicitly labelled
+    as Meta via OpenRouter.
 
     Novita, Nebius, MiniMax, Crusoe, Cerebras, Gemini, Fireworks, DeepInfra,
     Moonshot/Kimi, and Z.AI currently use this path because their
@@ -418,6 +419,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "zai",
         "tinfoil",
         "xiaomi",
+        "meta",
     ):
         path = _PROVIDER_MODELS_DIR / f"{provider_slug}.json"
         if not path.exists() or provider_slug not in PROVIDERS:

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "source": "provider-direct (anthropic.com, openai.com, ai.google.dev, ...) with openrouter.ai used only for cross-check sanity",
-  "filter": "kept ONLY models with provider-direct prices; OR-only models are dropped (TR never routes via OR — every model in this snapshot is billable at the price set by the provider's own pricing page)",
+  "source": "authoritative downstream APIs; provider-direct except explicitly labelled proxy-backed routes such as Meta via OpenRouter",
+  "filter": "kept only models with a configured, billable downstream route; unconfigured OpenRouter-only models are dropped",
   "tr_keyed_providers": [
     "anthropic",
     "baseten",

--- a/src/trusted_router/data/provider_models/meta.json
+++ b/src/trusted_router/data/provider_models/meta.json
@@ -1,0 +1,22 @@
+{
+  "_about": "Meta Muse Spark served through OpenRouter. This is not a direct Meta, ZDR, confidential-compute, or downstream-attested route.",
+  "provider": "meta",
+  "source": "https://openrouter.ai/api/v1/models/meta/muse-spark-1.1/endpoints",
+  "generated_at": "2026-07-16T00:00:00Z",
+  "price_scale": "microdollars_per_million",
+  "model_count": 1,
+  "models": [
+    {
+      "id": "meta/muse-spark-1.1",
+      "upstream_id": "meta/muse-spark-1.1",
+      "display_name": "Meta Muse Spark 1.1 via OpenRouter",
+      "context_length": 1048576,
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_token_price_per_m": 1250000,
+      "output_token_price_per_m": 4250000,
+      "cached_input_token_price_per_m": 150000
+    }
+  ]
+}

--- a/src/trusted_router/providers.py
+++ b/src/trusted_router/providers.py
@@ -39,6 +39,7 @@ from trusted_router.provider_types import (
 from trusted_router.secrets import LocalKeyFile
 
 OPENAI_COMPATIBLE_PROVIDERS: dict[str, tuple[tuple[str, ...], str]] = {
+    "meta": (("OPENROUTER_API_KEY",), "https://openrouter.ai/api/v1"),
     "openai": (("OPENAI_API_KEY",), "https://api.openai.com/v1"),
     "cerebras": (("CEREBRAS_API_KEY",), "https://api.cerebras.ai/v1"),
     "deepseek": (("DEEPSEEK_API_KEY",), "https://api.deepseek.com"),

--- a/tests/test_meta_muse_spark.py
+++ b/tests/test_meta_muse_spark.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from scripts.ingest_openrouter_catalog import PROVIDER_NAME_TO_SLUG
+from scripts.pricing import refresh
+from trusted_router.catalog import (
+    GATEWAY_PREPAID_PROVIDER_SLUGS,
+    MODEL_ENDPOINTS,
+    MODELS,
+    PROVIDERS,
+)
+from trusted_router.providers import OPENAI_COMPATIBLE_PROVIDERS
+
+MODEL_ID = "meta/muse-spark-1.1"
+ENDPOINT_ID = f"{MODEL_ID}@meta/prepaid"
+
+
+def test_muse_spark_is_a_prepaid_openrouter_backed_route() -> None:
+    provider = PROVIDERS["meta"]
+    assert provider.name == "Meta via OpenRouter"
+    assert provider.supports_prepaid is True
+    assert provider.supports_byok is False
+    assert provider.stores_content is True
+    assert provider.provider_zero_data_retention is False
+    assert provider.provider_confidential_compute is False
+    assert provider.provider_e2ee is False
+    assert "OpenRouter" in provider.provider_policy
+    assert provider.provider_policy_url
+
+    assert "meta" in GATEWAY_PREPAID_PROVIDER_SLUGS
+    model = MODELS[MODEL_ID]
+    assert model.context_length == 1_048_576
+    assert model.prepaid_available is False
+    assert model.byok_available is False
+
+    endpoint = MODEL_ENDPOINTS[ENDPOINT_ID]
+    assert endpoint.provider == "meta"
+    assert endpoint.usage_type == "Credits"
+    assert endpoint.upstream_id == MODEL_ID
+    assert endpoint.prompt_price_microdollars_per_million_tokens == 1_375_000
+    assert endpoint.completion_price_microdollars_per_million_tokens == 4_675_000
+    assert endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 165_000
+    assert f"{MODEL_ID}@meta/byok" not in MODEL_ENDPOINTS
+
+
+def test_meta_openrouter_route_stays_in_automated_catalog_refresh() -> None:
+    assert PROVIDER_NAME_TO_SLUG["Meta"] == "meta"
+    assert "meta" in refresh.PROVIDER_SLUGS
+    assert OPENAI_COMPATIBLE_PROVIDERS["meta"] == (
+        ("OPENROUTER_API_KEY",),
+        "https://openrouter.ai/api/v1",
+    )

--- a/tests/test_meta_pricing.py
+++ b/tests/test_meta_pricing.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice
+from scripts.pricing.providers import meta
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "data": {
+            "endpoints": [
+                {
+                    "provider_name": "Meta",
+                    "context_length": 1_048_576,
+                    "pricing": {
+                        "prompt": "0.00000125",
+                        "completion": "0.00000425",
+                        "input_cache_read": "0.00000015",
+                    },
+                }
+            ]
+        }
+    }
+
+
+def test_meta_pricing_reads_exact_openrouter_endpoint_rates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(meta, "fetch_json", lambda _url: _payload())
+
+    result = meta.fetch()
+
+    price = result.prices[meta.MODEL_ID]
+    assert result.source == "api"
+    assert price.prompt_micro_per_m == 1_250_000
+    assert price.completion_micro_per_m == 4_250_000
+    assert price.tiers[0].prompt_cached_micro_per_m == 150_000
+
+
+def test_meta_pricing_rejects_missing_meta_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(meta, "fetch_json", lambda _url: {"data": {"endpoints": []}})
+
+    with pytest.raises(RuntimeError, match="did not contain the Meta route"):
+        meta.fetch()
+
+
+def test_meta_pricing_refresh_updates_manifest_without_changing_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "meta.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "provider": "meta",
+                "models": [
+                    {
+                        "id": meta.MODEL_ID,
+                        "upstream_id": meta.MODEL_ID,
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(meta, "MANIFEST_PATH", manifest)
+    monkeypatch.setattr(meta, "fetch_json", lambda _url: _payload())
+
+    notes = meta.write_provider_manifest(meta.fetch())
+    refreshed = json.loads(manifest.read_text(encoding="utf-8"))
+
+    assert notes
+    assert refreshed["models"][0]["id"] == meta.MODEL_ID
+    assert refreshed["models"][0]["upstream_id"] == meta.MODEL_ID
+    assert refreshed["models"][0]["input_token_price_per_m"] == 1_250_000
+    assert refreshed["models"][0]["output_token_price_per_m"] == 4_250_000
+    assert refreshed["models"][0]["cached_input_token_price_per_m"] == 150_000
+
+
+def test_snapshot_merge_marks_meta_as_openrouter_backed() -> None:
+    endpoint = {
+        "provider_name": "Meta",
+        "tr_provider_slug": "meta",
+        "model_id": meta.MODEL_ID,
+        "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00000425",
+        },
+    }
+    openrouter_snapshot = {
+        "tr_keyed_providers": ["meta"],
+        "models": [
+            {
+                "id": meta.MODEL_ID,
+                "name": "Meta: Muse Spark 1.1",
+                "context_length": 1_048_576,
+                "pricing": endpoint["pricing"],
+                "endpoints": [endpoint],
+            }
+        ],
+    }
+    price = ModelPrice(
+        prompt_micro_per_m=1_250_000,
+        completion_micro_per_m=4_250_000,
+        prompt_cached_micro_per_m=150_000,
+    )
+
+    merged = refresh._merge_snapshot(
+        openrouter_snapshot,
+        {meta.MODEL_ID: {"meta": price}},
+        set(),
+    )
+
+    assert merged["models"][0]["pricing_source"] == "openrouter_provider"
+    assert merged["models"][0]["endpoints"][0]["pricing_source"] == (
+        "openrouter_provider"
+    )


### PR DESCRIPTION
## Summary
- publish meta/muse-spark-1.1 as Meta via OpenRouter with explicit downstream privacy labels
- add hourly authoritative OpenRouter endpoint pricing for this narrow proxy-backed provider
- keep the route prepaid-only and out of BYOK
- expose 1M context and exact cache/input/output pricing with provenance

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 1596 passed, 33 skipped
- live endpoint pricing fetch and streaming PONG verified