### PR TITLE
Catalog: stage scoped OpenAI ZDR activation

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -133,6 +133,8 @@ from trusted_router.catalog_ingest import (  # noqa: F401 - used by import-time 
 # keeps working for every existing caller.
 from trusted_router.catalog_privacy import (  # noqa: F401 - re-exported for back-compat
     endpoint_privacy_tier,
+    endpoint_zero_data_retention,
+    endpoint_zero_data_retention_scope,
     model_provider_policy,
     model_provider_policy_url,
     model_provider_privacy_tier,
@@ -291,12 +293,8 @@ def effective_endpoint(
     )
     if provider_price is None:
         return endpoint
-    prompt_price = _customer_price(
-        provider_price.prompt_microdollars_per_million_tokens
-    )
-    completion_price = _customer_price(
-        provider_price.completion_microdollars_per_million_tokens
-    )
+    prompt_price = _customer_price(provider_price.prompt_microdollars_per_million_tokens)
+    completion_price = _customer_price(provider_price.completion_microdollars_per_million_tokens)
     tiers = _flat_tier(prompt_price, completion_price)
     return replace(
         endpoint,
@@ -483,9 +481,7 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         else any(endpoint.usage_type == "Credits" for endpoint in endpoints)
     )
     byok_available = (
-        False
-        if is_meta
-        else any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
+        False if is_meta else any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
     )
 
     # For meta routers, derive prompt/completion price from the candidate range
@@ -506,12 +502,10 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     pub_completion_max = pub_completion_min
     if not is_meta and endpoints:
         prompt_min = min(
-            endpoint.prompt_price_microdollars_per_million_tokens
-            for endpoint in endpoints
+            endpoint.prompt_price_microdollars_per_million_tokens for endpoint in endpoints
         )
         completion_min = min(
-            endpoint.completion_price_microdollars_per_million_tokens
-            for endpoint in endpoints
+            endpoint.completion_price_microdollars_per_million_tokens for endpoint in endpoints
         )
         prompt_max = prompt_min
         completion_max = completion_min
@@ -566,6 +560,9 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         "provider_zero_data_retention": model_provider_zero_data_retention(
             model.id, model.provider
         ),
+        "zero_data_retention_available": any(
+            endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints
+        ),
         "provider_confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
         "provider_policy": model_provider_policy(model.id, model.provider),
@@ -614,9 +611,10 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
                 "upstream_id": endpoint.upstream_id,
                 "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
                 "stores_content": PROVIDERS[endpoint.provider].stores_content,
-                "provider_zero_data_retention": model_provider_zero_data_retention(
-                    endpoint.model_id, endpoint.provider
-                ),
+                "provider_zero_data_retention": endpoint_zero_data_retention(endpoint),
+                "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
+                "privacy_tier": endpoint_privacy_tier(endpoint),
+                "privacy_tier_label": PRIVACY_TIER_LABELS[endpoint_privacy_tier(endpoint)],
                 "provider_confidential_compute": PROVIDERS[
                     endpoint.provider
                 ].provider_confidential_compute,
@@ -678,6 +676,17 @@ def provider_to_openrouter_shape(provider: Provider) -> dict[str, object]:
         "attested_gateway": provider.attested_gateway,
         "stores_content": provider.stores_content,
         "provider_zero_data_retention": provider.provider_zero_data_retention,
+        "prepaid_zero_data_retention": provider.prepaid_zero_data_retention,
+        "prepaid_zero_data_retention_effective_on": (
+            provider.prepaid_zero_data_retention_effective_on
+        ),
+        "zero_data_retention_scope": (
+            "trustedrouter_prepaid"
+            if provider.prepaid_zero_data_retention
+            else "provider"
+            if provider.provider_zero_data_retention is True
+            else None
+        ),
         "provider_confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
         "provider_policy": provider.provider_policy,

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -33,6 +33,11 @@ class Provider:
     # higher tier only with an explicit, cited flag below.
     stores_content: bool = True
     provider_zero_data_retention: bool | None = None
+    # Some upstream privacy agreements apply only to TrustedRouter's managed
+    # provider account. Keep that distinct from provider-wide ZDR so customer
+    # BYOK credentials never inherit contractual controls they may not have.
+    prepaid_zero_data_retention: bool = False
+    prepaid_zero_data_retention_effective_on: str | None = None
     provider_confidential_compute: bool | None = None
     provider_e2ee: bool | None = None
     provider_policy: str = (
@@ -220,10 +225,18 @@ PROVIDERS: dict[str, Provider] = {
         supports_embeddings=True,
         supports_prepaid=True,
         provider_zero_data_retention=False,
+        # Activation gate: flip only after the managed production key passes
+        # the store=true/create then retrieve-must-fail ZDR smoke on/after the
+        # contractual effective date. BYOK remains outside this flag.
+        prepaid_zero_data_retention=False,
+        prepaid_zero_data_retention_effective_on="2026-07-28",
         provider_policy=(
-            "Not currently marked ZDR in TrustedRouter. OpenAI may offer endpoint- "
-            "or account-specific data-retention controls, but this provider is "
-            "excluded from trustedrouter/zdr until that posture is reverified."
+            "Contracted Zero Data Retention is scheduled to begin for "
+            "TrustedRouter's managed OpenAI account on July 28, 2026. OpenAI remains "
+            "outside trustedrouter/zdr until live activation verification passes. "
+            "Once verified, the guarantee will apply only to TrustedRouter-funded "
+            "prepaid routes; customer BYOK credentials use the data controls on the "
+            "customer's own OpenAI organization or project."
         ),
         provider_policy_url="https://platform.openai.com/docs/models/default-usage-policies-by-endpoint",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,

--- a/src/trusted_router/catalog_privacy.py
+++ b/src/trusted_router/catalog_privacy.py
@@ -54,7 +54,37 @@ def model_provider_privacy_tier(model_id: str, provider_slug: str) -> int:
 
 
 def endpoint_privacy_tier(endpoint: ModelEndpoint) -> int:
-    return model_provider_privacy_tier(endpoint.model_id, endpoint.provider)
+    override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)
+    if override is not None:
+        return override.privacy_tier
+    provider = PROVIDERS[endpoint.provider]
+    if endpoint.usage_type == "Credits" and provider.prepaid_zero_data_retention:
+        return max(provider_privacy_tier(provider), PRIVACY_TIER_ZERO_RETENTION)
+    return provider_privacy_tier(provider)
+
+
+def endpoint_zero_data_retention(endpoint: ModelEndpoint) -> bool | None:
+    """Return the ZDR guarantee that applies to this exact credential path."""
+    override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)
+    if override is not None and override.provider_zero_data_retention is not None:
+        return override.provider_zero_data_retention
+    provider = PROVIDERS[endpoint.provider]
+    if endpoint.usage_type == "Credits" and provider.prepaid_zero_data_retention:
+        return True
+    return provider.provider_zero_data_retention
+
+
+def endpoint_zero_data_retention_scope(endpoint: ModelEndpoint) -> str | None:
+    """Describe why an endpoint qualifies without broadening the claim."""
+    if endpoint_zero_data_retention(endpoint) is not True:
+        return None
+    override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)
+    if override is not None and override.provider_zero_data_retention is True:
+        return "model_endpoint"
+    provider = PROVIDERS[endpoint.provider]
+    if endpoint.usage_type == "Credits" and provider.prepaid_zero_data_retention:
+        return "trustedrouter_prepaid"
+    return "provider"
 
 
 def model_provider_zero_data_retention(model_id: str, provider_slug: str) -> bool | None:

--- a/src/trusted_router/content/legal.py
+++ b/src/trusted_router/content/legal.py
@@ -274,6 +274,20 @@ def _provider_subprocessor_row(provider: Provider) -> dict[str, Any]:
         "purpose": "Downstream model inference provider when a workspace selects this provider, this model, or an alias that routes to this provider.",
         "data_access": "Prompt/output content in transit only for requests routed to this provider; request metadata needed for billing, routing, abuse controls, and support.",
         "zdr": provider.provider_zero_data_retention,
+        "prepaid_zdr": provider.prepaid_zero_data_retention,
+        "prepaid_zdr_effective_on": provider.prepaid_zero_data_retention_effective_on,
+        "zdr_label": (
+            "prepaid only"
+            if provider.prepaid_zero_data_retention
+            and provider.provider_zero_data_retention is not True
+            else f"scheduled {provider.prepaid_zero_data_retention_effective_on}"
+            if provider.prepaid_zero_data_retention_effective_on
+            else "yes"
+            if provider.provider_zero_data_retention is True
+            else "no"
+            if provider.provider_zero_data_retention is False
+            else "unknown"
+        ),
         "confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
         "privacy_tier": tier,

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -29,6 +29,7 @@ from trusted_router.catalog import (
     ModelEndpoint,
     Provider,
     canonical_orchestration_model_id,
+    endpoint_zero_data_retention,
     endpoints_for_model,
     meta_candidate_models,
     model_eu_focused_provider_available,
@@ -2170,7 +2171,9 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         or model.prepaid_available,
         "byok": model.byok_available,
         "attested": provider.attested_gateway,
-        "provider_zero_data_retention": provider.provider_zero_data_retention,
+        "provider_zero_data_retention": any(
+            endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints
+        ),
         "provider_confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
         "open_weights": model_open_weights(model),
@@ -2219,9 +2222,20 @@ def _provider_view(provider: Provider) -> dict[str, object]:
         "attested_gateway": provider.attested_gateway,
         "gateway_stores_content": provider.stores_content,
         "zero_data_retention": provider.provider_zero_data_retention,
+        "prepaid_zero_data_retention": provider.prepaid_zero_data_retention,
+        "prepaid_zero_data_retention_effective_on": (
+            provider.prepaid_zero_data_retention_effective_on
+        ),
         "confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
-        "zero_data_retention_label": _policy_label(provider.provider_zero_data_retention),
+        "zero_data_retention_label": (
+            "prepaid only"
+            if provider.prepaid_zero_data_retention
+            and provider.provider_zero_data_retention is not True
+            else f"scheduled {provider.prepaid_zero_data_retention_effective_on}"
+            if provider.prepaid_zero_data_retention_effective_on
+            else _policy_label(provider.provider_zero_data_retention)
+        ),
         "confidential_compute_label": _policy_label(provider.provider_confidential_compute),
         "provider_e2ee_label": _policy_label(provider.provider_e2ee),
         "policy": provider.provider_policy,
@@ -2250,6 +2264,8 @@ def _provider_privacy_tier(provider: Provider) -> str:
         return "Confidential"
     if provider.provider_zero_data_retention:
         return "No logs"
+    if provider.prepaid_zero_data_retention:
+        return "No logs (prepaid)"
     if provider.provider_confidential_compute:
         return "Confidential compute"
     return "No provider claim"
@@ -2296,7 +2312,7 @@ def _model_detail_view(
                 "completion_microdollars_per_million_tokens": endpoint.completion_price_microdollars_per_million_tokens,
                 "attested_gateway": ep_provider.attested_gateway if ep_provider else False,
                 "provider_zero_data_retention": (
-                    ep_provider.provider_zero_data_retention if ep_provider else None
+                    endpoint_zero_data_retention(endpoint) if ep_provider else None
                 ),
                 "provider_confidential_compute": (
                     ep_provider.provider_confidential_compute if ep_provider else None
@@ -2618,7 +2634,7 @@ def _privacy_summary(model: Model) -> str:
         return "has provider E2EE route"
     if any(provider and provider.provider_confidential_compute for provider in providers):
         return "has confidential-compute route"
-    if any(provider and provider.provider_zero_data_retention for provider in providers):
+    if any(endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints):
         return "has ZDR route"
     return "provider posture varies"
 

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -8,11 +8,14 @@ from trusted_router.auth import ManagementPrincipal, SettingsDep
 from trusted_router.catalog import (
     EU_FOCUSED_PROVIDER_ORDER,
     MODELS,
+    PRIVACY_TIER_LABELS,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
+    endpoint_privacy_tier,
+    endpoint_zero_data_retention,
+    endpoint_zero_data_retention_scope,
     model_provider_policy,
     model_provider_policy_url,
-    model_provider_zero_data_retention,
     model_to_openrouter_shape,
     provider_to_openrouter_shape,
     providers_for_display,
@@ -169,10 +172,10 @@ def register_catalog_routes(router: APIRouter) -> None:
                     "trustedrouter": {
                         "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
                         "stores_content": PROVIDERS[endpoint.provider].stores_content,
-                        "provider_zero_data_retention": model_provider_zero_data_retention(
-                            endpoint.model_id,
-                            endpoint.provider,
-                        ),
+                        "provider_zero_data_retention": endpoint_zero_data_retention(endpoint),
+                        "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
+                        "privacy_tier": endpoint_privacy_tier(endpoint),
+                        "privacy_tier_label": PRIVACY_TIER_LABELS[endpoint_privacy_tier(endpoint)],
                         "provider_confidential_compute": PROVIDERS[
                             endpoint.provider
                         ].provider_confidential_compute,
@@ -213,6 +216,17 @@ def register_catalog_routes(router: APIRouter) -> None:
                     "attested_gateway": provider.attested_gateway,
                     "stores_content": provider.stores_content,
                     "provider_zero_data_retention": provider.provider_zero_data_retention,
+                    "prepaid_zero_data_retention": provider.prepaid_zero_data_retention,
+                    "prepaid_zero_data_retention_effective_on": (
+                        provider.prepaid_zero_data_retention_effective_on
+                    ),
+                    "zero_data_retention_scope": (
+                        "trustedrouter_prepaid"
+                        if provider.prepaid_zero_data_retention
+                        else "provider"
+                        if provider.provider_zero_data_retention is True
+                        else None
+                    ),
                     "provider_confidential_compute": provider.provider_confidential_compute,
                     "provider_e2ee": provider.provider_e2ee,
                     "provider_policy": provider.provider_policy,
@@ -220,6 +234,7 @@ def register_catalog_routes(router: APIRouter) -> None:
                 }
                 for provider in providers_for_display()
                 if provider.provider_zero_data_retention is True
+                or provider.prepaid_zero_data_retention
                 or provider.provider_confidential_compute is True
                 or provider.provider_e2ee is True
             ]

--- a/src/trusted_router/templates/public/legal_subprocessors.html
+++ b/src/trusted_router/templates/public/legal_subprocessors.html
@@ -62,7 +62,7 @@
         {% for provider in provider_subprocessors %}
         <tr>
           <td><a href="/providers/{{ provider.id }}"><strong>{{ provider.name }}</strong></a><br><code>{{ provider.id }}</code></td>
-          <td><span class="pill {% if provider.zdr is sameas true %}good{% endif %}">{% if provider.zdr is sameas true %}yes{% elif provider.zdr is sameas false %}no{% else %}unknown{% endif %}</span></td>
+          <td><span class="pill {% if provider.zdr is sameas true or provider.prepaid_zdr %}good{% endif %}">{{ provider.zdr_label }}</span></td>
           <td><span class="pill {% if provider.confidential_compute is sameas true %}good{% endif %}">{% if provider.confidential_compute is sameas true %}yes{% elif provider.confidential_compute is sameas false %}no{% else %}unknown{% endif %}</span></td>
           <td><span class="pill {% if provider.provider_e2ee is sameas true %}good{% endif %}">{% if provider.provider_e2ee is sameas true %}yes{% elif provider.provider_e2ee is sameas false %}no{% else %}unknown{% endif %}</span></td>
           <td>{{ provider.data_access }}<br>{{ provider.policy }}</td>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -3,7 +3,7 @@
 <section class="panel">
   <div class="panel-head">
     <h2><code>{{ provider.id }}</code></h2>
-    <span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs'] %}good{% endif %}">{{ provider.privacy_tier }}</span>
+    <span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs', 'No logs (prepaid)'] %}good{% endif %}">{{ provider.privacy_tier }}</span>
   </div>
   <div class="panel-body">
     <p><a href="/providers">All providers</a></p>
@@ -13,7 +13,7 @@
         <tr><th>Models</th><td>{{ provider.served_model_count }} public model{{ '' if provider.served_model_count == 1 else 's' }}</td></tr>
         <tr><th>Prepaid routes</th><td>{{ provider.prepaid_model_count }}</td></tr>
         <tr><th>BYOK routes</th><td>{{ provider.byok_model_count }}</td></tr>
-        <tr><th>Zero data retention</th><td><span class="pill {% if provider.zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td></tr>
+        <tr><th>Zero data retention</th><td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td></tr>
         <tr><th>Confidential compute</th><td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td></tr>
         <tr><th>Provider E2EE</th><td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td></tr>
         <tr><th>Policy note</th><td>{{ provider.policy }}{% if provider.policy_url %}<br><a href="{{ provider.policy_url }}">Policy source</a>{% endif %}</td></tr>

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -33,10 +33,10 @@
         {% for provider in providers %}
         <tr>
           <td><a href="{{ provider.detail_href }}"><strong>{{ provider.name }}</strong></a><br><code>{{ provider.id }}</code></td>
-          <td><span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs'] %}good{% endif %}">{{ provider.privacy_tier }}</span></td>
+          <td><span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs', 'No logs (prepaid)'] %}good{% endif %}">{{ provider.privacy_tier }}</span></td>
           <td>{% if provider.supports_prepaid %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
           <td>{% if provider.supports_byok %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
-          <td><span class="pill {% if provider.zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td>
+          <td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td>
           <td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td>
           <td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td>
           <td>

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -493,7 +493,7 @@ def test_privacy_meta_models_expand_to_expected_provider_pools() -> None:
     assert eu_shape["trustedrouter"]["auto_candidates"]
 
 
-def test_reverification_required_providers_are_not_marked_zdr() -> None:
+def test_uncontracted_closed_providers_are_not_marked_zdr() -> None:
     """Keep public ZDR claims fail-closed for major closed providers.
 
     If Amazon/Bedrock or Google/Vertex are added as explicit providers later,
@@ -506,15 +506,21 @@ def test_reverification_required_providers_are_not_marked_zdr() -> None:
         "bedrock",
         "gemini",
         "google",
-        "openai",
         "vertex",
     }
     configured = provider_slugs_requiring_reverification & set(PROVIDERS)
 
-    assert {"anthropic", "gemini", "openai"} <= configured
+    assert {"anthropic", "gemini"} <= configured
     for provider in sorted(configured):
         assert PROVIDERS[provider].provider_zero_data_retention is not True
         assert provider_privacy_tier(PROVIDERS[provider]) < PRIVACY_TIER_ZERO_RETENTION
+
+    # OpenAI's guarantee is deliberately narrower: it belongs to
+    # TrustedRouter's managed prepaid account, starts on July 28, and is not
+    # activated until a live retention smoke passes.
+    assert PROVIDERS["openai"].provider_zero_data_retention is False
+    assert PROVIDERS["openai"].prepaid_zero_data_retention is False
+    assert PROVIDERS["openai"].prepaid_zero_data_retention_effective_on == "2026-07-28"
 
 
 def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
@@ -1234,7 +1240,7 @@ def test_privacy_meta_models_force_endpoint_privacy_floor() -> None:
     assert "gemini" not in {endpoint.provider for _model, endpoint in zdr_endpoints}
     assert "openai" not in {endpoint.provider for _model, endpoint in zdr_endpoints}
     assert all(
-        provider_privacy_tier(PROVIDERS[endpoint.provider]) >= PRIVACY_TIER_ZERO_RETENTION
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION
         for _model, endpoint in zdr_endpoints
     )
     assert all(
@@ -1543,13 +1549,14 @@ def test_wafer_kimi_k26_is_available_but_standard_tier_only() -> None:
     if not wafer_endpoints:
         pytest.skip("wafer no longer lists kimi-k2.6 — delisted upstream")
     assert all(
-        endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD
-        for endpoint in wafer_endpoints
+        endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD for endpoint in wafer_endpoints
     )
 
     shape = model_to_openrouter_shape(model)
     wafer_meta = [
-        endpoint for endpoint in shape["trustedrouter"]["endpoints"] if endpoint["provider"] == "wafer"
+        endpoint
+        for endpoint in shape["trustedrouter"]["endpoints"]
+        if endpoint["provider"] == "wafer"
     ]
     assert wafer_meta
     assert all(endpoint["provider_zero_data_retention"] is False for endpoint in wafer_meta)

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -567,6 +567,15 @@ def test_embeddings_and_model_endpoints(
         for item in openai_endpoints
         if item["provider"] == "openai"
     ] == ["Credits", "BYOK"]
+    openai_by_usage = {
+        item["trustedrouter"]["usage_type"]: item["trustedrouter"]
+        for item in openai_endpoints
+        if item["provider"] == "openai"
+    }
+    assert openai_by_usage["Credits"]["provider_zero_data_retention"] is False
+    assert openai_by_usage["Credits"]["zero_data_retention_scope"] is None
+    assert openai_by_usage["BYOK"]["provider_zero_data_retention"] is False
+    assert openai_by_usage["BYOK"]["zero_data_retention_scope"] is None
 
     us_filtered = client.get(
         "/v1/models/z-ai/glm-5.2/endpoints",
@@ -1042,9 +1051,14 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     # DeepInfra is memory-only / no-training — earns ZDR with a citation.
     assert provider_flags["deepinfra"]["provider_zero_data_retention"] is True
     assert provider_flags["openai"]["provider_zero_data_retention"] is False
+    assert provider_flags["openai"]["prepaid_zero_data_retention"] is False
+    assert provider_flags["openai"]["prepaid_zero_data_retention_effective_on"] == ("2026-07-28")
+    assert provider_flags["openai"]["zero_data_retention_scope"] is None
     assert provider_flags["gemini"]["provider_zero_data_retention"] is False
     assert "Not currently marked ZDR" in provider_flags["anthropic"]["provider_policy"]
-    assert "Not currently marked ZDR" in provider_flags["openai"]["provider_policy"]
+    assert "Contracted Zero Data Retention" in provider_flags["openai"]["provider_policy"]
+    assert "July 28, 2026" in provider_flags["openai"]["provider_policy"]
+    assert "customer BYOK" in provider_flags["openai"]["provider_policy"]
     assert "Not currently marked ZDR" in provider_flags["gemini"]["provider_policy"]
     # GMI runs VPC isolation, NOT an attested TEE — must NOT claim confidential.
     assert provider_flags["gmi"]["provider_confidential_compute"] is None
@@ -1070,6 +1084,12 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         assert provider_flags[provider]["provider_policy_url"] == source
     zdr = client.get("/v1/endpoints/zdr").json()["data"]
     assert zdr
+    for endpoint in zdr:
+        if (
+            endpoint["provider_zero_data_retention"] is not True
+            and endpoint["prepaid_zero_data_retention"] is not True
+        ):
+            assert endpoint["zero_data_retention_scope"] is None
     zdr_providers = {item["provider"] for item in zdr}
     assert {
         "trustedrouter",

--- a/tests/test_openai_contracted_zdr.py
+++ b/tests/test_openai_contracted_zdr.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+from trusted_router.catalog import (
+    MODELS,
+    PRIVACY_TIER_STANDARD,
+    PRIVACY_TIER_ZERO_RETENTION,
+    PROVIDERS,
+    ZDR_MODEL_ID,
+    ModelEndpoint,
+    endpoint_privacy_tier,
+    endpoint_zero_data_retention,
+    endpoints_for_model,
+    model_to_openrouter_shape,
+    provider_to_openrouter_shape,
+)
+from trusted_router.config import Settings
+from trusted_router.routing import chat_route_endpoint_candidates
+
+
+def _first_party_openai_endpoints() -> tuple[ModelEndpoint, ModelEndpoint]:
+    endpoints = [
+        endpoint
+        for endpoint in endpoints_for_model("openai/gpt-5.5")
+        if endpoint.provider == "openai"
+    ]
+    credits = next(endpoint for endpoint in endpoints if endpoint.usage_type == "Credits")
+    byok = next(endpoint for endpoint in endpoints if endpoint.usage_type == "BYOK")
+    return credits, byok
+
+
+def _activate_openai_prepaid_zdr(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        PROVIDERS,
+        "openai",
+        replace(PROVIDERS["openai"], prepaid_zero_data_retention=True),
+    )
+
+
+def test_openai_zdr_contract_is_scheduled_but_not_active() -> None:
+    provider = PROVIDERS["openai"]
+    credits, byok = _first_party_openai_endpoints()
+
+    assert provider.provider_zero_data_retention is False
+    assert provider.prepaid_zero_data_retention is False
+    assert provider.prepaid_zero_data_retention_effective_on == "2026-07-28"
+    assert endpoint_zero_data_retention(credits) is False
+    assert endpoint_privacy_tier(credits) == PRIVACY_TIER_STANDARD
+    assert endpoint_zero_data_retention(byok) is False
+    assert endpoint_privacy_tier(byok) == PRIVACY_TIER_STANDARD
+
+
+def test_openai_zdr_activation_is_scoped_to_trustedrouter_prepaid_routes(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _activate_openai_prepaid_zdr(monkeypatch)
+    credits, byok = _first_party_openai_endpoints()
+
+    assert endpoint_zero_data_retention(credits) is True
+    assert endpoint_privacy_tier(credits) == PRIVACY_TIER_ZERO_RETENTION
+    assert endpoint_zero_data_retention(byok) is False
+    assert endpoint_privacy_tier(byok) == PRIVACY_TIER_STANDARD
+
+
+def test_openai_catalog_metadata_does_not_extend_tr_contract_to_byok(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _activate_openai_prepaid_zdr(monkeypatch)
+    provider_shape = provider_to_openrouter_shape(PROVIDERS["openai"])
+    assert provider_shape["provider_zero_data_retention"] is False
+    assert provider_shape["prepaid_zero_data_retention"] is True
+    assert provider_shape["zero_data_retention_scope"] == "trustedrouter_prepaid"
+
+    shape = model_to_openrouter_shape(MODELS["openai/gpt-5.5"])
+    endpoint_shapes = [
+        endpoint
+        for endpoint in shape["trustedrouter"]["endpoints"]
+        if endpoint["provider"] == "openai"
+    ]
+    by_usage = {endpoint["usage_type"]: endpoint for endpoint in endpoint_shapes}
+    assert by_usage["Credits"]["provider_zero_data_retention"] is True
+    assert by_usage["Credits"]["zero_data_retention_scope"] == "trustedrouter_prepaid"
+    assert by_usage["BYOK"]["provider_zero_data_retention"] is False
+    assert by_usage["BYOK"]["zero_data_retention_scope"] is None
+
+
+def test_openai_zdr_filter_selects_credits_and_never_inherits_byok(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _activate_openai_prepaid_zdr(monkeypatch)
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "openai/gpt-5.5",
+            "provider": {"only": ["openai"], "min_privacy": "zdr"},
+        },
+        Settings(environment="test"),
+    )
+
+    assert candidates
+    assert all(endpoint.provider == "openai" for _model, endpoint in candidates)
+    assert all(endpoint.usage_type == "Credits" for _model, endpoint in candidates)
+    assert all(
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION
+        for _model, endpoint in candidates
+    )
+
+
+def test_zdr_alias_can_use_openai_only_through_contracted_credits_route(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _activate_openai_prepaid_zdr(monkeypatch)
+    candidates = chat_route_endpoint_candidates(
+        {"model": ZDR_MODEL_ID, "provider": {"only": ["openai"]}},
+        Settings(environment="test"),
+    )
+
+    assert candidates
+    assert all(endpoint.provider == "openai" for _model, endpoint in candidates)
+    assert all(endpoint.usage_type == "Credits" for _model, endpoint in candidates)
+
+
+def test_public_pages_explain_scheduled_openai_prepaid_scope(client: TestClient) -> None:
+    providers = client.get("/providers")
+    assert providers.status_code == 200
+    assert "scheduled 2026-07-28" in providers.text
+    assert "July 28, 2026" in providers.text
+    assert "customer BYOK credentials" in providers.text
+
+    model = client.get("/models/openai/gpt-5.5")
+    assert model.status_code == 200
+    assert "Credits" in model.text
+    assert "BYOK" in model.text
+    assert "upstream varies" in model.text


### PR DESCRIPTION
## Summary
- record the July 28, 2026 effective date for TrustedRouter managed OpenAI ZDR
- keep OpenAI excluded from trustedrouter/zdr until a live retention verification passes
- scope eventual ZDR eligibility to managed Credits endpoints only; OpenAI BYOK remains governed by each customer project
- expose endpoint-level privacy scope in catalog APIs and public provider/model pages

## Verification
- live managed-key test on July 17: Responses store=true remained retrievable, confirming ZDR is not active yet
- 1612 passed, 33 skipped (full suite before final metadata-only assertion)
- focused regression suite: 9 passed
- ruff clean
- mypy clean (170 source files)

## Safety
This PR does not activate OpenAI ZDR routing or make an active ZDR claim. Activation remains gated on a successful live verification on or after July 28.