### PR TITLE
Quarantine 30 dead routes from route-health first sweep

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -180,6 +180,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "baidu/ernie-4.5-vl-28b-a3b",
             # 100% MODEL_NOT_AVAILABLE-class probe failures since 2026-06-23.
             "meta-llama/llama-3-70b-instruct",
+            # route-health first sweep 2026-07-18, 100% failure.
+            "zai-org/glm-4.5",
         }
     ),
     # Friendli notified customers that GLM-5 serverless Model APIs stop being
@@ -211,6 +213,9 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
         {
             "amd/llama-3.3-70b-instruct-fp8-kv",
             "amd/Llama-3.3-70B-Instruct-FP8-KV",
+            # route-health first sweep 2026-07-18, 100% failure.
+            "qwen/qwen3.6-27b",
+            "openai/gpt-oss-120b",
         }
     ),
     # These resellers list Claude ids their APIs do not actually serve: 100%
@@ -221,18 +226,85 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "anthropic/claude-fable-5",
             "anthropic/claude-sonnet-5",
             "anthropic/claude-opus-4.1",
+            # route-health first sweep 2026-07-18, 100% failure.
+            "x-ai/grok-4.5",
+            "anthropic/claude-sonnet-4.5",
+            "openai/gpt-5.6-luna",
+            "qwen/qwen3.5-27b",
+            "google/gemini-3-flash-preview",
         }
     ),
     "deepinfra": frozenset(
         {
             "anthropic/claude-fable-5",
             "anthropic/claude-sonnet-5",
+            # route-health first sweep 2026-07-18, 100% failure.
+            "z-ai/glm-5.1",
+            "moonshotai/kimi-k2.7-code",
+            "qwen/qwen3-32b",
         }
     ),
     "phala": frozenset(
         {
             "anthropic/claude-sonnet-5",
             "anthropic/claude-opus-4.1",
+            # route-health first sweep 2026-07-18, 100% failure.
+            "anthropic/claude-opus-4.8",
+            "deepseek/deepseek-v4-pro",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure. These ids may be
+    # remappable to newer upstream ids — revisit with per-provider manifest hooks.
+    "together": frozenset(
+        {
+            "openai/gpt-oss-120b",
+            "deepseek/deepseek-r1-distill-llama-70b",
+            "qwen/qwen3-vl-8b-instruct",
+            "qwen/qwen2.5-vl-72b-instruct",
+            "mistralai/mistral-small-24b-instruct-2501",
+            "moonshotai/kimi-k2.7-code",
+            "minimax/minimax-m3",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure.
+    "lightning": frozenset(
+        {
+            "openai/gpt-5.6-sol",
+            "openai/gpt-5.6-luna",
+            "openai/gpt-4-turbo-preview",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure. These ids may be
+    # remappable to newer upstream ids — revisit with per-provider manifest hooks.
+    "kimi": frozenset(
+        {
+            "moonshotai/kimi-k2",
+            "moonshotai/kimi-k2-0905",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure.
+    "openai": frozenset(
+        {
+            "openai/gpt-4-turbo-preview",
+            "openai/gpt-5.2-chat",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure.
+    "mistral": frozenset(
+        {
+            "mistralai/mistral-small-24b-instruct-2501",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure.
+    "meta": frozenset(
+        {
+            "meta/muse-spark-1.1",
+        }
+    ),
+    # route-health first sweep 2026-07-18, 100% failure.
+    "deepseek": frozenset(
+        {
+            "deepseek/deepseek-v3.1-terminus",
         }
     ),
 }

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -176,7 +176,7 @@ async def _post_route_health_if_due(
     # Fingerprinting groups emissions into one Sentry issue per route. Hourly
     # re-emission (~24/day/route) keeps the signal fresh without burning quota.
     every_pass = os.environ.get("TR_SYNTHETIC_ROUTE_HEALTH_EVERY_PASS") == "1"
-    if not every_pass and (now or dt.datetime.now(dt.UTC)).minute >= 5:
+    if not every_pass and (now or dt.datetime.now(dt.UTC)).minute >= 2:
         return
     await _post_route_health(client, url=url, internal_token=internal_token)
 

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -182,6 +182,31 @@ def test_friendli_july_2026_glm_5_deprecation_does_not_remove_glm_52() -> None:
     assert "z-ai/glm-5@zai/prepaid" in MODEL_ENDPOINTS
 
 
+def test_route_health_first_sweep_dead_routes_are_not_routable() -> None:
+    flagged_routes = {
+        ("openai/gpt-oss-120b", "together"),
+        ("openai/gpt-5.6-sol", "lightning"),
+        ("x-ai/grok-4.5", "gmi"),
+        ("anthropic/claude-opus-4.8", "phala"),
+        ("z-ai/glm-5.1", "deepinfra"),
+        ("moonshotai/kimi-k2", "kimi"),
+    }
+
+    for model_id, provider in flagged_routes:
+        assert not [
+            endpoint
+            for endpoint in endpoints_for_model(model_id)
+            if endpoint.provider == provider
+        ]
+
+    # Quarantine is provider-scoped: healthy sibling routes survive.
+    assert "openai/gpt-oss-120b@cerebras/prepaid" in MODEL_ENDPOINTS
+    assert (
+        "mistralai/mistral-small-24b-instruct-2501@deepinfra/prepaid"
+        in MODEL_ENDPOINTS
+    )
+
+
 def test_gemini_native_supplement_publishes_missing_text_models() -> None:
     gemini_35 = MODEL_ENDPOINTS["google/gemini-3.5-flash@gemini/prepaid"]
     image_preview = MODEL_ENDPOINTS[

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1452,7 +1452,6 @@ def test_makora_provider_models_present_and_routable() -> None:
         "z-ai/glm-5.2": "zai-org/GLM-5.2-FP8",
         "z-ai/glm-5.2-nvfp4": "zai-org/GLM-5.2-NVFP4",
         "moonshotai/kimi-k2.7-code": "moonshotai/Kimi-K2.7-Code",
-        "qwen/qwen3.6-27b": "unsloth/Qwen3.6-27B-NVFP4",
         "qwen/qwen3.6-35b-a3b": "unsloth/Qwen3.6-35B-A3B-NVFP4",
     }
     makora_model_ids = {
@@ -1460,7 +1459,9 @@ def test_makora_provider_models_present_and_routable() -> None:
         for endpoint in MODEL_ENDPOINTS.values()
         if endpoint.provider == "makora" and str(endpoint.usage_type) == "Credits"
     }
-    assert len(makora_model_ids) >= 9
+    assert len(makora_model_ids) >= 8
+    assert "qwen/qwen3.6-27b" not in makora_model_ids
+    assert "openai/gpt-oss-120b" not in makora_model_ids
     for model_id, upstream in expected.items():
         model = MODELS.get(model_id)
         assert model is not None, f"{model_id} missing from catalog"

--- a/tests/test_meta_muse_spark.py
+++ b/tests/test_meta_muse_spark.py
@@ -14,7 +14,7 @@ MODEL_ID = "meta/muse-spark-1.1"
 ENDPOINT_ID = f"{MODEL_ID}@meta/prepaid"
 
 
-def test_muse_spark_is_a_prepaid_openrouter_backed_route() -> None:
+def test_muse_spark_route_is_quarantined_but_provider_stays_configured() -> None:
     provider = PROVIDERS["meta"]
     assert provider.name == "Meta via OpenRouter"
     assert provider.supports_prepaid is True
@@ -27,18 +27,8 @@ def test_muse_spark_is_a_prepaid_openrouter_backed_route() -> None:
     assert provider.provider_policy_url
 
     assert "meta" in GATEWAY_PREPAID_PROVIDER_SLUGS
-    model = MODELS[MODEL_ID]
-    assert model.context_length == 1_048_576
-    assert model.prepaid_available is False
-    assert model.byok_available is False
-
-    endpoint = MODEL_ENDPOINTS[ENDPOINT_ID]
-    assert endpoint.provider == "meta"
-    assert endpoint.usage_type == "Credits"
-    assert endpoint.upstream_id == MODEL_ID
-    assert endpoint.prompt_price_microdollars_per_million_tokens == 1_375_000
-    assert endpoint.completion_price_microdollars_per_million_tokens == 4_675_000
-    assert endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 165_000
+    assert MODEL_ID not in MODELS
+    assert ENDPOINT_ID not in MODEL_ENDPOINTS
     assert f"{MODEL_ID}@meta/byok" not in MODEL_ENDPOINTS
 
 

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1783,8 +1783,8 @@ async def test_route_health_caller_logs_flags_and_does_not_fail_pass(
 @pytest.mark.parametrize(
     ("minute", "every_pass", "should_post"),
     [
-        (4, None, True),
-        (5, None, False),
+        (1, None, True),
+        (2, None, False),
         (37, "1", True),
     ],
 )


### PR DESCRIPTION
The new route-health alerting's first sweep flagged 30 routes at 100% failure over ≥6 samples — the accumulated backlog of dead reseller listings and stale upstream ids. All quarantined provider-scoped (healthy siblings asserted to survive, e.g. gpt-oss-120b@cerebras); together/kimi blocks commented as possibly remappable. Also narrows the hourly alert gate. 1613 passed / 33 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)