### PR TITLE
Quarantine deepinfra/google/gemini-3.5-flash (route-health flag)

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -238,6 +238,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
         {
             "anthropic/claude-fable-5",
             "anthropic/claude-sonnet-5",
+            # route-health flag 2026-07-18 (post-first-sweep): 100% failure over 6 samples.
+            "google/gemini-3.5-flash",
             # route-health first sweep 2026-07-18, 100% failure.
             "z-ai/glm-5.1",
             "moonshotai/kimi-k2.7-code",


### PR DESCRIPTION
31st dead route, flagged by route-health minutes after the first sweep (100% failure over 6 samples). Raced past #215's merge; cherry-picked onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)