### PR TITLE
Catalog: mark Parasail inference routes ZDR

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -450,9 +450,14 @@ PROVIDERS: dict[str, Provider] = {
         slug="parasail",
         name="Parasail",
         supports_prepaid=True,
+        stores_content=False,
+        provider_zero_data_retention=True,
         provider_policy=(
-            "Parasail documents no input logging/storage for serverless and dedicated "
-            "service paths, with different handling for batch service."
+            "Tracked as ZDR for serverless and dedicated inference. Parasail documents "
+            "no storage or logging of submitted input on those service paths, retention "
+            "only while generating and delivering output, and no training on input or "
+            "output. Batch service is excluded from this claim; TrustedRouter does not "
+            "route Parasail traffic through batch."
         ),
         provider_policy_url=(
             "https://docs.parasail.io/parasail-docs/security-and-account-management/"

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1044,6 +1044,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["cerebras"]["provider_zero_data_retention"] is True
     assert provider_flags["together"]["provider_zero_data_retention"] is True
     assert provider_flags["nebius"]["provider_zero_data_retention"] is True
+    assert provider_flags["parasail"]["provider_zero_data_retention"] is True
     assert provider_flags["venice"]["provider_zero_data_retention"] is True
     # Venice runs TEE + E2EE inference — it's confidential, not merely no-logs.
     assert provider_flags["venice"]["provider_confidential_compute"] is True
@@ -1075,6 +1076,10 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "together": "https://docs.together.ai/docs/privacy-and-security",
         "deepinfra": "https://docs.deepinfra.com/account/data-privacy",
         "nebius": "https://docs.studio.nebius.com/legal/legal-quick-guide",
+        "parasail": (
+            "https://docs.parasail.io/parasail-docs/security-and-account-management/"
+            "data-privacy-retention"
+        ),
         "alibaba": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
         "deepseek": (
             "https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html?locale=en_US"
@@ -1096,6 +1101,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "cerebras",
         "deepinfra",
         "nebius",
+        "parasail",
         "phala",
         "tinfoil",
         "together",

--- a/tests/test_parasail_zdr.py
+++ b/tests/test_parasail_zdr.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.catalog import (
+    PRIVACY_TIER_ZERO_RETENTION,
+    PROVIDERS,
+    ZDR_MODEL_ID,
+    endpoint_privacy_tier,
+    endpoint_zero_data_retention,
+    endpoints_for_model,
+    provider_privacy_tier,
+)
+from trusted_router.config import Settings
+from trusted_router.routing import chat_route_endpoint_candidates
+
+
+def test_parasail_serverless_and_dedicated_routes_are_zdr() -> None:
+    provider = PROVIDERS["parasail"]
+    endpoints = [
+        endpoint
+        for endpoint in endpoints_for_model("z-ai/glm-5.2")
+        if endpoint.provider == "parasail"
+    ]
+
+    assert endpoints
+    assert provider.stores_content is False
+    assert provider.provider_zero_data_retention is True
+    assert provider_privacy_tier(provider) >= PRIVACY_TIER_ZERO_RETENTION
+    assert all(endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints)
+    assert all(
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION
+        for endpoint in endpoints
+    )
+    assert "serverless and dedicated" in provider.provider_policy
+    assert "batch" in provider.provider_policy
+
+
+def test_parasail_can_satisfy_direct_and_alias_zdr_routing() -> None:
+    settings = Settings(environment="test")
+    direct = chat_route_endpoint_candidates(
+        {
+            "model": "z-ai/glm-5.2",
+            "provider": {"only": ["parasail"], "min_privacy": "zdr"},
+        },
+        settings,
+    )
+    alias = chat_route_endpoint_candidates(
+        {"model": ZDR_MODEL_ID, "provider": {"only": ["parasail"]}},
+        settings,
+    )
+
+    assert direct
+    assert alias
+    assert all(endpoint.provider == "parasail" for _model, endpoint in direct)
+    assert all(endpoint.provider == "parasail" for _model, endpoint in alias)
+
+
+def test_parasail_zdr_is_published_with_policy_source(client: TestClient) -> None:
+    providers = {
+        item["id"]: item for item in client.get("/v1/providers").json()["data"]
+    }
+    parasail = providers["parasail"]
+
+    assert parasail["provider_zero_data_retention"] is True
+    assert parasail["stores_content"] is False
+    assert parasail["zero_data_retention_scope"] == "provider"
+    assert parasail["provider_policy_url"] == (
+        "https://docs.parasail.io/parasail-docs/security-and-account-management/"
+        "data-privacy-retention"
+    )
+
+    zdr = client.get("/v1/endpoints/zdr").json()["data"]
+    assert "parasail" in {item["provider"] for item in zdr}


### PR DESCRIPTION
## Summary
- mark Parasail serverless and dedicated inference routes as zero data retention
- explicitly exclude Parasail Batch from the claim
- allow Parasail endpoints to satisfy direct ZDR filters and trustedrouter/zdr
- publish the documented policy source in provider metadata

## Verification
- regression test failed against the previous posture, then passed after the change
- 1613 passed, 33 skipped
- ruff clean
- mypy clean (171 source files)

## Source
https://docs.parasail.io/parasail-docs/security-and-account-management/data-privacy-retention