### PR TITLE
Pricing: discovery-driven manifest rebuilds with tombstone pruning

### DIFF
--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -28,6 +28,7 @@ import tempfile
 import textwrap
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -331,6 +332,159 @@ def fetch_json(url: str, *, extra_headers: dict[str, str] | None = None) -> Any:
 
 
 # ----------------------------------------------------------------------
+# Workflow warnings and manifest safety.
+# ----------------------------------------------------------------------
+
+
+def emit_workflow_warning(message: str) -> None:
+    """Emit a warning locally and in the GitHub Actions step summary."""
+
+    line = f"WARNING: {message}"
+    print(line, file=sys.stderr)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    try:
+        with Path(summary_path).open("a", encoding="utf-8") as summary:
+            summary.write(f"{line}\n")
+    except OSError as exc:
+        print(f"WARNING: could not append to GITHUB_STEP_SUMMARY: {exc}", file=sys.stderr)
+
+
+def guard_manifest_prune(
+    old_rows: list[Any],
+    new_rows: list[Any],
+    *,
+    provider_slug: str | None = None,
+) -> list[Any]:
+    """Keep the old manifest when one pass would disable 50% of its routes.
+
+    Delisted tombstones remain in the baseline so repeated smaller upstream
+    changes cannot compound against a shrinking denominator. Curated
+    metadata-only rows and never-priced discovery rows were never routes and
+    therefore do not dilute that baseline.
+    """
+
+    def routable_ids(rows: list[Any]) -> set[str]:
+        return {
+            row["id"]
+            for row in rows
+            if isinstance(row, dict)
+            and row.get("routable") is not False
+            and isinstance(row.get("id"), str)
+            and row["id"]
+        }
+
+    old_routable_ids = routable_ids(old_rows)
+    new_routable_ids = routable_ids(new_rows)
+    baseline_ids = {
+        row["id"]
+        for row in old_rows
+        if isinstance(row, dict)
+        and isinstance(row.get("id"), str)
+        and row["id"]
+        and (
+            row.get("routable") is not False
+            or row.get("routable_reason") == "delisted-upstream"
+        )
+    }
+    disabled = old_routable_ids - new_routable_ids
+    emptied_manifest = bool(old_rows) and not new_rows
+    mass_prune = bool(disabled) and len(disabled) * 2 >= len(baseline_ids)
+    if not emptied_manifest and not mass_prune:
+        return new_rows
+
+    provider = f"{provider_slug}: " if provider_slug else ""
+    emit_workflow_warning(
+        f"{provider}manifest rebuild blocked by mass-prune guard "
+        f"(would disable {len(disabled)} of {len(baseline_ids)} baseline routes; "
+        f"old={len(old_rows)}, new={len(new_rows)}); kept old manifest unchanged"
+    )
+    return old_rows
+
+
+def reconcile_manifest_tombstones(
+    old_rows: list[Any],
+    present_rows: dict[str, dict[str, Any]],
+    *,
+    priced_ids: set[str],
+    source: str,
+    missing_date: str | None = None,
+) -> list[Any]:
+    """Merge a fresh discovery feed without deleting committed rows.
+
+    An absent route is stamped on its first fresh API miss and tombstoned on
+    its second. System-created tombstones recover when the model reappears;
+    hand-curated ``routable: false`` rows are preserved byte-for-byte at the
+    row-data level. ``present_rows`` must contain already-merged provider
+    metadata and prices for every feed-present model, including models whose
+    price failed to parse.
+    """
+
+    fresh = source == "api"
+    today = missing_date or datetime.now(UTC).date().isoformat()
+    existing_ids = {
+        row["id"]
+        for row in old_rows
+        if isinstance(row, dict)
+        and isinstance(row.get("id"), str)
+        and row["id"]
+    }
+    reconciled: list[Any] = []
+
+    for old_row in old_rows:
+        if not isinstance(old_row, dict):
+            reconciled.append(old_row)
+            continue
+        model_id = old_row.get("id")
+        if not isinstance(model_id, str) or not model_id:
+            reconciled.append(dict(old_row))
+            continue
+
+        # A false row without a machine-owned reason is curated metadata. Its
+        # contents and route state are outside discovery's authority.
+        curated_unroutable = (
+            old_row.get("routable") is False
+            and "routable_reason" not in old_row
+        )
+        if curated_unroutable:
+            reconciled.append(dict(old_row))
+            continue
+
+        present = present_rows.get(model_id)
+        if present is not None:
+            row = dict(present)
+            if fresh:
+                row.pop("missing_since", None)
+                reason = old_row.get("routable_reason")
+                if reason == "delisted-upstream" or (
+                    reason == "awaiting-price" and model_id in priced_ids
+                ):
+                    row["routable"] = True
+                    row.pop("routable_reason", None)
+            reconciled.append(row)
+            continue
+
+        row = dict(old_row)
+        if fresh:
+            if row.get("missing_since"):
+                row["routable"] = False
+                row["routable_reason"] = "delisted-upstream"
+            else:
+                row["missing_since"] = today
+        reconciled.append(row)
+
+    for model_id in sorted(present_rows.keys() - existing_ids):
+        row = dict(present_rows[model_id])
+        if model_id not in priced_ids:
+            row["routable"] = False
+            row["routable_reason"] = "awaiting-price"
+        reconciled.append(row)
+
+    return reconciled
+
+
+# ----------------------------------------------------------------------
 # Validation — applied to deterministic parser output AND self-healed
 # parser output. Same rules either way.
 # ----------------------------------------------------------------------
@@ -479,7 +633,7 @@ def validate(
     Checks:
       - non-empty
       - every tier's prompt/completion in [MIN, MAX]
-      - every model in `expected_models` is present (drift detector)
+      - warn when a model in `expected_models` is absent (drift detector)
       - units sanity: at least one tier across all models has nonzero
         price (otherwise the parser likely missed the price column)
     """
@@ -508,7 +662,10 @@ def validate(
                 )
     missing = [m for m in expected_models if m not in prices]
     if missing:
-        errors.append(f"expected models missing: {missing}")
+        emit_workflow_warning(
+            f"expected models missing from fresh provider feed: {missing}; "
+            "accepting feed so retired models can be pruned"
+        )
     has_nonzero = any(
         tier.prompt_micro_per_m > 0 or tier.completion_micro_per_m > 0
         for row in prices.values()

--- a/scripts/pricing/providers/friendli.py
+++ b/scripts/pricing/providers/friendli.py
@@ -16,7 +16,11 @@ guess.
 """
 from __future__ import annotations
 
+import json
 import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -26,12 +30,22 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_UA,
     ModelPrice,
     ProviderPricingResult,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
     validate,
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
 
 SLUG = "friendli"
 URL = "https://api.friendli.ai/serverless/v1/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "friendli.json"
+)
 DEPRECATED_NATIVE_IDS = {
     # Friendli notified customers that GLM-5 serverless Model APIs stop being
     # supported at 2026-07-03 00:00 UTC. Dedicated endpoints are unaffected, but
@@ -56,6 +70,35 @@ _NATIVE_TO_OR_ID = {
 }
 
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _discovered_manifest_row(
+    model_id: str, native_id: str, source_row: dict[str, Any]
+) -> dict[str, Any]:
+    row: dict[str, Any] = {"id": model_id, "upstream_id": native_id}
+    display_name = source_row.get("display_name") or source_row.get("name")
+    if isinstance(display_name, str) and display_name:
+        row["display_name"] = display_name
+    context_length = _positive_int(
+        source_row.get("context_length") or source_row.get("max_model_len")
+    )
+    if context_length is not None:
+        row["context_length"] = context_length
+    max_output_tokens = _positive_int(source_row.get("max_output_tokens"))
+    if max_output_tokens is not None:
+        row["max_output_tokens"] = max_output_tokens
+    return row
 
 
 def _price_to_micro_per_m(value: object) -> int | None:
@@ -70,6 +113,9 @@ def _price_to_micro_per_m(value: object) -> int | None:
 
 
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    _DISCOVERED_MANIFEST_ROWS = {}
     api_key = os.environ.get("FRIENDLI_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -88,6 +134,7 @@ def fetch() -> ProviderPricingResult:
     if not isinstance(rows, list):
         rows = []
     prices: dict[str, ModelPrice] = {}
+    manifest_rows: dict[str, dict[str, Any]] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
@@ -100,6 +147,7 @@ def fetch() -> ProviderPricingResult:
         if or_id is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
+        manifest_rows[or_id] = _discovered_manifest_row(or_id, native_id, row)
         pricing = row.get("pricing") or {}
         if not isinstance(pricing, dict):
             continue
@@ -116,6 +164,7 @@ def fetch() -> ProviderPricingResult:
             prompt_cached_micro_per_m=cache_read,
         )
 
+    _DISCOVERED_MANIFEST_ROWS = manifest_rows
     notes: list[str] = []
     errors = validate(prices, EXPECTED_MODELS)
     if errors:
@@ -129,3 +178,105 @@ def fetch() -> ProviderPricingResult:
         fetched_url=URL,
         notes=notes,
     )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Rebuild Friendli routes from its live serverless model feed."""
+
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("friendli manifest has no models list")
+
+    if not _DISCOVERED_MANIFEST_ROWS:
+        guarded = guard_manifest_prune(rows, [], provider_slug=SLUG)
+        if guarded is rows:
+            return ["friendli: kept old manifest (mass-prune guard)"]
+        raise RuntimeError("friendli discovery returned no supported model rows")
+
+    existing_by_id = {
+        row["id"]: row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
+    updated: list[str] = []
+    appended: list[str] = []
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        existing = existing_by_id.get(model_id)
+        if existing is None:
+            row: dict[str, Any] = {
+                "display_name": str(discovered.get("display_name") or model_id),
+                "title": str(discovered.get("upstream_id") or model_id),
+                "model_type": "chat",
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "endpoints": ["chat/completions"],
+                "status": 1,
+            }
+            appended.append(model_id)
+        else:
+            # Start from the committed row so annotations such as _note,
+            # feature flags, and an explicit routable:false survive rebuilds.
+            row = dict(existing)
+        row.update(discovered)
+
+        price = result.prices.get(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            row["input_token_price_per_m"] = tier.prompt_micro_per_m
+            row["output_token_price_per_m"] = tier.completion_micro_per_m
+            if tier.prompt_cached_micro_per_m is not None:
+                row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+            else:
+                row.pop("cached_input_token_price_per_m", None)
+            updated.append(model_id)
+        elif existing is None:
+            # Discovery without an authoritative price is useful metadata, but
+            # it must never become a zero-priced route.
+            row["routable"] = False
+        present_rows[model_id] = row
+
+    rebuilt = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, rebuilt, provider_slug=SLUG)
+    if guarded is rows:
+        return ["friendli: kept old manifest (mass-prune guard)"]
+
+    rebuilt_by_id = {
+        row["id"]: row
+        for row in rebuilt
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    tombstoned = sorted(
+        model_id
+        for model_id, old_row in existing_by_id.items()
+        if old_row.get("routable") is not False
+        and rebuilt_by_id.get(model_id, {}).get("routable") is False
+    )
+    raw["models"] = rebuilt
+    raw["provider"] = SLUG
+    raw["source"] = URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(rebuilt)
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    changes: list[str] = []
+    if appended:
+        changes.append(f"appended {len(appended)}")
+    if tombstoned:
+        changes.append(f"tombstoned {len(tombstoned)} unavailable")
+    suffix = f", {', '.join(changes)}" if changes else ""
+    return [
+        f"friendli: refreshed provider_models/friendli.json "
+        f"({len(updated)} priced rows{suffix})"
+    ]

--- a/scripts/pricing/providers/gemini.py
+++ b/scripts/pricing/providers/gemini.py
@@ -17,11 +17,34 @@ surface that TR doesn't route to and is intentionally ignored.
 """
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    fetch_json,
+    fetch_provider,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
+    validate,
+)
 
 SLUG = "gemini"
 URL = "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing"
+MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 JINA_HEADERS = {"X-Return-Format": "markdown"}
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "gemini.json"
+)
 
 EXPECTED_MODELS = [
     "google/gemini-2.5-pro",
@@ -29,12 +52,217 @@ EXPECTED_MODELS = [
     "google/gemini-2.5-flash-lite",
     "google/gemini-3.5-flash",
 ]
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if api_key:
+        headers["x-goog-api-key"] = api_key
+    rows: dict[str, dict[str, Any]] = {}
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
+    for page_index in range(10):
+        params = {"pageSize": "1000"}
+        if page_token is not None:
+            params["pageToken"] = page_token
+        payload = fetch_json(
+            f"{MODELS_URL}?{urlencode(params)}",
+            extra_headers=headers,
+        )
+        raw_rows = payload.get("models") if isinstance(payload, dict) else None
+        if not isinstance(raw_rows, list):
+            raise RuntimeError("gemini: /v1beta/models response has no models list")
+
+        for source_row in raw_rows:
+            if not isinstance(source_row, dict):
+                continue
+            raw_name = source_row.get("name")
+            if not isinstance(raw_name, str):
+                continue
+            native_id = raw_name.removeprefix("models/").strip()
+            if not native_id.casefold().startswith("gemini-"):
+                continue
+            methods = source_row.get("supportedGenerationMethods")
+            if isinstance(methods, list) and "generateContent" not in methods:
+                continue
+            model_id = f"google/{native_id.casefold()}"
+            row: dict[str, Any] = {"id": model_id, "upstream_id": native_id}
+            display_name = source_row.get("displayName")
+            if isinstance(display_name, str) and display_name:
+                row["display_name"] = display_name
+            context_length = _positive_int(source_row.get("inputTokenLimit"))
+            if context_length is not None:
+                row["context_length"] = context_length
+            max_output_tokens = _positive_int(source_row.get("outputTokenLimit"))
+            if max_output_tokens is not None:
+                row["max_output_tokens"] = max_output_tokens
+            rows[model_id] = row
+
+        next_token = payload.get("nextPageToken") if isinstance(payload, dict) else None
+        if not next_token:
+            break
+        if not isinstance(next_token, str) or next_token in seen_tokens:
+            raise RuntimeError("gemini: /v1beta/models pagination token did not advance")
+        seen_tokens.add(next_token)
+        page_token = next_token
+        if page_index == 9:
+            raise RuntimeError("gemini: /v1beta/models exceeded 10 pages")
+    if not rows:
+        raise RuntimeError("gemini: /v1beta/models returned no chat-capable Gemini rows")
+    return rows
+
+
+def _refresh_price(row: dict[str, Any], result: ProviderPricingResult, model_id: str) -> bool:
+    price = result.prices.get(model_id)
+    if price is None:
+        return False
+    tier = price.tiers[0]
+    row["input_token_price_per_m"] = tier.prompt_micro_per_m
+    row["output_token_price_per_m"] = tier.completion_micro_per_m
+    if len(price.tiers) > 1:
+        row["price_tiers"] = [
+            {
+                "max_prompt_tokens": price_tier.max_prompt_tokens,
+                "input_token_price_per_m": price_tier.prompt_micro_per_m,
+                "output_token_price_per_m": price_tier.completion_micro_per_m,
+                "cached_input_token_price_per_m": price_tier.prompt_cached_micro_per_m,
+            }
+            for price_tier in price.tiers
+        ]
+        row.pop("cached_input_token_price_per_m", None)
+    elif tier.prompt_cached_micro_per_m is not None:
+        row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+        row.pop("price_tiers", None)
+    else:
+        row.pop("cached_input_token_price_per_m", None)
+        row.pop("price_tiers", None)
+    return True
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    _DISCOVERED_MANIFEST_ROWS = {}
+    result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
         extra_headers=JINA_HEADERS,
     )
+    live_rows = _live_model_rows()
+    _DISCOVERED_MANIFEST_ROWS = live_rows
+    result.prices = {
+        model_id: price for model_id, price in result.prices.items() if model_id in live_rows
+    }
+    errors = validate(result.prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    if result.source != "stale_snapshot":
+        # The manifest's availability view came from a complete live API feed;
+        # use that freshness marker for consecutive-miss accounting.
+        result.source = "api"
+    return result
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Rebuild Gemini supplemental routes from Google's live models feed."""
+
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("gemini manifest has no models list")
+
+    if not _DISCOVERED_MANIFEST_ROWS:
+        guarded = guard_manifest_prune(rows, [], provider_slug=SLUG)
+        if guarded is rows:
+            return ["gemini: kept old manifest (mass-prune guard)"]
+        raise RuntimeError("gemini discovery returned no supported model rows")
+
+    existing_by_id = {
+        row["id"]: row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
+    updated: list[str] = []
+    appended: list[str] = []
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        existing = existing_by_id.get(model_id)
+        if existing is None:
+            row: dict[str, Any] = {
+                "display_name": str(discovered.get("display_name") or model_id),
+                "title": model_id,
+                "model_type": "chat",
+                "features": [],
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "endpoints": ["chat/completions"],
+                "status": 1,
+            }
+            appended.append(model_id)
+        else:
+            # Preserve human annotations and routable:false on known rows.
+            row = dict(existing)
+        row.update(discovered)
+        if _refresh_price(row, result, model_id):
+            updated.append(model_id)
+        elif existing is None:
+            row["routable"] = False
+        present_rows[model_id] = row
+
+    rebuilt = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, rebuilt, provider_slug=SLUG)
+    if guarded is rows:
+        return ["gemini: kept old manifest (mass-prune guard)"]
+
+    rebuilt_by_id = {
+        row["id"]: row
+        for row in rebuilt
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    tombstoned = sorted(
+        model_id
+        for model_id, old_row in existing_by_id.items()
+        if old_row.get("routable") is not False
+        and rebuilt_by_id.get(model_id, {}).get("routable") is False
+    )
+    raw["models"] = rebuilt
+    raw["provider"] = SLUG
+    raw["source"] = MODELS_URL
+    raw["pricing_source"] = URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(rebuilt)
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    changes: list[str] = []
+    if appended:
+        changes.append(f"appended {len(appended)}")
+    if tombstoned:
+        changes.append(f"tombstoned {len(tombstoned)} unavailable")
+    suffix = f", {', '.join(changes)}" if changes else ""
+    return [
+        f"gemini: refreshed provider_models/gemini.json "
+        f"({len(updated)} priced rows{suffix})"
+    ]

--- a/scripts/pricing/providers/wafer.py
+++ b/scripts/pricing/providers/wafer.py
@@ -23,6 +23,8 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_UA,
     ModelPrice,
     ProviderPricingResult,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
     validate,
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
@@ -109,7 +111,6 @@ def _manifest_row(
     model_id: str,
     native_id: str,
     source_row: dict[str, Any],
-    price: ModelPrice,
 ) -> dict[str, Any]:
     wafer = source_row.get("wafer")
     wafer = wafer if isinstance(wafer, dict) else {}
@@ -133,8 +134,6 @@ def _manifest_row(
         "upstream_id": native_id,
         "display_name": str(wafer.get("display_name") or native_id),
         "endpoints": ["chat/completions"],
-        "input_token_price_per_m": price.prompt_micro_per_m,
-        "output_token_price_per_m": price.completion_micro_per_m,
         "zdr_supported": bool(zdr_capabilities.get("supported")),
     }
     context_length = _positive_int(wafer.get("context_length"))
@@ -143,15 +142,13 @@ def _manifest_row(
     if supports_vision:
         row["input_modalities"] = ["text", "image"]
         row["output_modalities"] = ["text"]
-    tier = price.tiers[0]
-    if tier.prompt_cached_micro_per_m is not None:
-        row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
     return row
 
 
 def fetch() -> ProviderPricingResult:
-    global _DISCOVERED_MANIFEST_ROWS
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
 
+    _DISCOVERED_MANIFEST_ROWS = {}
     api_key = os.environ.get("WAFER_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -181,6 +178,14 @@ def fetch() -> ProviderPricingResult:
         if or_id is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
+        # Feed presence is authoritative even when Wafer renames a pricing
+        # key. Record it before parsing so a schema drift cannot look like a
+        # delisting and destroy the route's committed price.
+        manifest_rows[or_id] = _manifest_row(
+            model_id=or_id,
+            native_id=native_id,
+            source_row=row,
+        )
         pricing = _wafer_pricing(row)
         if not isinstance(pricing, dict):
             continue
@@ -195,12 +200,6 @@ def fetch() -> ProviderPricingResult:
             prompt_cached_micro_per_m=cache_read,
         )
         prices[or_id] = price
-        manifest_rows[or_id] = _manifest_row(
-            model_id=or_id,
-            native_id=native_id,
-            source_row=row,
-            price=price,
-        )
 
     _DISCOVERED_MANIFEST_ROWS = manifest_rows
 
@@ -233,40 +232,69 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not isinstance(rows, list):
         raise RuntimeError("wafer manifest has no models list")
 
-    previous_ids = {
-        row["id"] for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
+    if not _DISCOVERED_MANIFEST_ROWS:
+        guarded = guard_manifest_prune(rows, [], provider_slug=SLUG)
+        if guarded is rows:
+            return ["wafer: kept old manifest (mass-prune guard)"]
+        raise RuntimeError("wafer discovery returned no supported model rows")
+
+    existing_by_id: dict[str, dict[str, Any]] = {
+        row["id"]: row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
     }
     updated: list[str] = []
-    refreshed_rows: list[dict[str, Any]] = []
-    for model_id, price in sorted(result.prices.items()):
-        discovered = _DISCOVERED_MANIFEST_ROWS.get(model_id)
-        if discovered is None:
-            continue
-        row = dict(discovered)
+    present_rows: dict[str, dict[str, Any]] = {}
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        existing = existing_by_id.get(model_id)
+        # Preserve human annotations and routable:false for rows that persist.
+        row = dict(existing) if existing is not None else {}
+        row.update(discovered)
 
-        tier = price.tiers[0]
-        row["input_token_price_per_m"] = tier.prompt_micro_per_m
-        row["output_token_price_per_m"] = tier.completion_micro_per_m
-        if tier.prompt_cached_micro_per_m is not None:
-            row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
-        else:
-            row.pop("cached_input_token_price_per_m", None)
-        refreshed_rows.append(row)
-        updated.append(model_id)
+        price = result.prices.get(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            row["input_token_price_per_m"] = tier.prompt_micro_per_m
+            row["output_token_price_per_m"] = tier.completion_micro_per_m
+            if tier.prompt_cached_micro_per_m is not None:
+                row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+            else:
+                row.pop("cached_input_token_price_per_m", None)
+            updated.append(model_id)
+        present_rows[model_id] = row
 
-    missing = sorted(set(EXPECTED_MODELS) - set(updated))
-    if missing:
-        raise RuntimeError(f"wafer manifest did not update expected model(s): {missing}")
-    if not updated:
-        raise RuntimeError("wafer manifest update touched no rows")
+    refreshed_rows = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, refreshed_rows, provider_slug=SLUG)
+    if guarded is rows:
+        return ["wafer: kept old manifest (mass-prune guard)"]
 
     # Wafer's authenticated /v1/models feed is both the availability and
     # pricing source. Rebuild the provider supplement from that feed so
-    # retired models cannot remain routable with stale prices.
+    # retired models become reversible tombstones without losing metadata.
     rows[:] = refreshed_rows
-    current_ids = set(updated)
+    previous_ids = set(existing_by_id)
+    current_ids = {
+        row["id"]
+        for row in refreshed_rows
+        if isinstance(row.get("id"), str)
+    }
     appended = sorted(current_ids - previous_ids)
-    removed = sorted(previous_ids - current_ids)
+    refreshed_by_id = {
+        row["id"]: row
+        for row in refreshed_rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    tombstoned = sorted(
+        model_id
+        for model_id, old_row in existing_by_id.items()
+        if old_row.get("routable") is not False
+        and refreshed_by_id.get(model_id, {}).get("routable") is False
+    )
 
     raw["_about"] = (
         "Provider-native supplement for Wafer serverless API. Refreshed "
@@ -285,7 +313,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     changes: list[str] = []
     if appended:
         changes.append(f"appended {len(appended)}")
-    if removed:
-        changes.append(f"removed {len(removed)} unavailable")
+    if tombstoned:
+        changes.append(f"tombstoned {len(tombstoned)} unavailable")
     suffix = f", {', '.join(changes)}" if changes else ""
     return [f"wafer: refreshed provider_models/wafer.json ({len(updated)} priced rows{suffix})"]

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -48,6 +48,7 @@ from scripts.pricing.base import (
     ModelPrice,
     PriceTier,
     ProviderPricingResult,
+    guard_manifest_prune,
     log,
 )
 
@@ -745,8 +746,44 @@ def _write_provider_manifests(results: dict[str, ProviderPricingResult]) -> list
         module = _import_provider(slug)
         hook = getattr(module, "write_provider_manifest", None)
         if not callable(hook):
+            # TODO: vet novita/together/kimi discovery semantics separately
+            # before adding or expanding provider-owned rebuild behavior.
             continue
+        manifest_path_value = getattr(module, "MANIFEST_PATH", None)
+        manifest_path = (
+            Path(manifest_path_value) if manifest_path_value is not None else None
+        )
+        before_text: str | None = None
+        before_rows: list[Any] | None = None
+        if manifest_path is not None and manifest_path.exists():
+            before_text = manifest_path.read_text(encoding="utf-8")
+            try:
+                before_raw = json.loads(before_text)
+            except (TypeError, ValueError):
+                before_raw = None
+            if isinstance(before_raw, dict) and isinstance(before_raw.get("models"), list):
+                before_rows = before_raw["models"]
+
         raw_notes = hook(result)
+
+        # Provider hooks own their JSON shape, but this dispatch is the final
+        # shared safety boundary. Restore the exact old file if any hook omits
+        # its local guard or accidentally writes an invalid/empty manifest.
+        if before_text is not None and before_rows is not None and manifest_path is not None:
+            try:
+                after_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError):
+                after_raw = None
+            after_rows = after_raw.get("models") if isinstance(after_raw, dict) else None
+            candidate_rows = after_rows if isinstance(after_rows, list) else []
+            guarded = guard_manifest_prune(
+                before_rows,
+                candidate_rows,
+                provider_slug=slug,
+            )
+            if guarded is before_rows:
+                manifest_path.write_text(before_text, encoding="utf-8")
+                raw_notes = [f"{slug}: kept old manifest (mass-prune guard)"]
         if raw_notes is None:
             continue
         notes.extend(str(note) for note in raw_notes)

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -238,6 +238,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
         {
             "anthropic/claude-fable-5",
             "anthropic/claude-sonnet-5",
+            # route-health flag 2026-07-18 (post-first-sweep): 100% failure over 6 samples.
+            "google/gemini-3.5-flash",
             # route-health first sweep 2026-07-18, 100% failure.
             "z-ai/glm-5.1",
             "moonshotai/kimi-k2.7-code",
@@ -526,6 +528,9 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         price_scale = _provider_manifest_price_scale(raw)
         for raw_model in raw_models:
             if not isinstance(raw_model, dict):
+                continue
+            # Discovery-only metadata rows must never produce catalog routes.
+            if raw_model.get("routable") is False:
                 continue
             model_id = raw_model.get("id")
             if not isinstance(model_id, str) or not model_id:

--- a/tests/test_baseten_wafer_pricing.py
+++ b/tests/test_baseten_wafer_pricing.py
@@ -323,12 +323,13 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(tmp_path: Path, mo
 
     assert notes == [
         "wafer: refreshed provider_models/wafer.json "
-        "(5 priced rows, appended 3, removed 1 unavailable)"
+        "(5 priced rows, appended 3)"
     ]
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
     by_id = {row["id"]: row for row in raw["models"]}
-    assert raw["model_count"] == 5
-    assert "moonshotai/kimi-k2.7-code" not in by_id
+    assert raw["model_count"] == 6
+    assert by_id["moonshotai/kimi-k2.7-code"]["missing_since"]
+    assert by_id["moonshotai/kimi-k2.7-code"].get("routable") is not False
     assert by_id["z-ai/glm-5.2"]["input_token_price_per_m"] == 1_200_000
     assert by_id["z-ai/glm-5.2-fast"]["upstream_id"] == "glm5.2-fast"
     assert by_id["z-ai/glm-5.2-fast"]["input_token_price_per_m"] == 3_000_000
@@ -336,3 +337,66 @@ def test_wafer_provider_appends_new_priced_models_to_manifest(tmp_path: Path, mo
     assert by_id["z-ai/glm-5.2-fast"]["cached_input_token_price_per_m"] == 500_000
     assert by_id["z-ai/glm-5.2-fast"]["zdr_supported"] is True
     assert by_id["moonshotai/kimi-k2.6"]["input_modalities"] == ["text", "image"]
+
+
+def test_wafer_delisted_expected_model_reaches_manifest_prune(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "wafer.json"
+    live_ids = {
+        "z-ai/glm-5.1": "GLM-5.1",
+        "z-ai/glm-5.2": "GLM-5.2",
+        "z-ai/glm-5.2-fast": "glm5.2-fast",
+        "moonshotai/kimi-k2.6": "Kimi-K2.6",
+    }
+    old_ids = {**live_ids, "minimax/minimax-m3": "MiniMax-M3"}
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "wafer",
+                "models": [
+                    {
+                        "id": model_id,
+                        "upstream_id": native_id,
+                        "endpoints": ["chat/completions"],
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    }
+                    for model_id, native_id in old_ids.items()
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    prices = {model_id: wafer.ModelPrice(100, 200) for model_id in live_ids}
+    discovered = {
+        model_id: {
+            "id": model_id,
+            "upstream_id": native_id,
+            "endpoints": ["chat/completions"],
+        }
+        for model_id, native_id in live_ids.items()
+    }
+    result = wafer.ProviderPricingResult(slug="wafer", prices=prices, source="api")
+    monkeypatch.setattr(wafer, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(wafer, "_DISCOVERED_MANIFEST_ROWS", discovered)
+
+    assert wafer.validate(prices, wafer.EXPECTED_MODELS) == []
+    wafer.write_provider_manifest(result)
+
+    first_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    first_missing = next(
+        row for row in first_raw["models"] if row["id"] == "minimax/minimax-m3"
+    )
+    assert first_missing["missing_since"]
+    assert first_missing.get("routable") is not False
+
+    wafer.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    missing = next(row for row in raw["models"] if row["id"] == "minimax/minimax-m3")
+    assert missing["routable"] is False
+    assert missing["routable_reason"] == "delisted-upstream"
+    assert missing["missing_since"] == first_missing["missing_since"]
+    assert "minimax/minimax-m3" in capsys.readouterr().err

--- a/tests/test_kimi_pricing.py
+++ b/tests/test_kimi_pricing.py
@@ -125,6 +125,7 @@ def test_fetch_intersects_live_models_and_writes_manifest(
 
 def test_live_model_without_first_party_price_is_not_published(
     monkeypatch: Any,
+    capsys: Any,
 ) -> None:
     def docs_without_k3(url: str, *, extra_headers: dict[str, str] | None = None) -> str:
         del extra_headers
@@ -140,8 +141,10 @@ def test_live_model_without_first_party_price_is_not_published(
         lambda _url, **_kwargs: _live_payload(include_k3=True),
     )
 
-    with pytest.raises(RuntimeError, match="expected models missing.*moonshotai/kimi-k3"):
-        kimi.fetch()
+    result = kimi.fetch()
+
+    assert "moonshotai/kimi-k3" not in result.prices
+    assert "moonshotai/kimi-k3" in capsys.readouterr().err
 
 
 def test_manifest_removes_models_no_longer_live_or_priced(

--- a/tests/test_manifest_discovery_hooks.py
+++ b/tests/test_manifest_discovery_hooks.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import friendli, gemini, wafer
+from trusted_router import catalog_ingest
+
+
+def _manifest_row(model_id: str, upstream_id: str, **metadata: object) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "upstream_id": upstream_id,
+        "display_name": model_id,
+        "model_type": "chat",
+        "endpoints": ["chat/completions"],
+        "input_token_price_per_m": 1,
+        "output_token_price_per_m": 2,
+        **metadata,
+    }
+
+
+def _write_manifest(path: Path, provider: str, rows: list[dict[str, object]]) -> str:
+    text = json.dumps(
+        {
+            "_about": f"{provider} test manifest",
+            "provider": provider,
+            "generated_at": "2026-01-01T00:00:00Z",
+            "model_count": len(rows),
+            "models": rows,
+        },
+        indent=2,
+    ) + "\n"
+    path.write_text(text, encoding="utf-8")
+    return text
+
+
+def test_friendli_tombstones_second_miss_then_restores_annotations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "friendli.json"
+    _write_manifest(
+        manifest_path,
+        "friendli",
+        [
+            _manifest_row("z-ai/glm-5.2", "zai-org/GLM-5.2", _note="keep me"),
+            _manifest_row(
+                "meta-llama/llama-3.3-70b-instruct",
+                "meta-llama-3.3-70b-instruct",
+            ),
+            _manifest_row(
+                "qwen/qwen3-235b-a22b-2507",
+                "Qwen/Qwen3-235B-A22B-Instruct-2507",
+                _about="curated annotation: keep byte-identical",
+                note={"owner": "catalog", "reason": "manual"},
+            ),
+            _manifest_row("metadata/future", "future", routable=False, _note="staged"),
+        ],
+    )
+    payload = {
+        "data": [
+            {
+                "id": "zai-org/GLM-5.2",
+                "pricing": {"input": 1.4, "output": 4.4},
+            },
+            {
+                "id": "meta-llama-3.3-70b-instruct",
+                "pricing": {"input": 0.6, "output": 0.6},
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(friendli, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(friendli.httpx, "Client", FakeClient)
+
+    result = friendli.fetch()
+    friendli.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    missing = by_id["qwen/qwen3-235b-a22b-2507"]
+    assert missing["missing_since"]
+    assert missing.get("routable") is not False
+    assert by_id["z-ai/glm-5.2"]["_note"] == "keep me"
+    assert by_id["z-ai/glm-5.2"]["input_token_price_per_m"] == 1_400_000
+    assert by_id["metadata/future"]["routable"] is False
+    assert by_id["metadata/future"]["_note"] == "staged"
+
+    result = friendli.fetch()
+    friendli.write_provider_manifest(result)
+    tombstoned_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    tombstoned = {row["id"]: row for row in tombstoned_raw["models"]}[
+        "qwen/qwen3-235b-a22b-2507"
+    ]
+    assert tombstoned["routable"] is False
+    assert tombstoned["routable_reason"] == "delisted-upstream"
+    assert tombstoned["missing_since"] == missing["missing_since"]
+
+    payload["data"].append(
+        {
+            "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+            "pricing": {"input": 0.2, "output": 0.8},
+        }
+    )
+    result = friendli.fetch()
+    friendli.write_provider_manifest(result)
+    restored_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    restored = {row["id"]: row for row in restored_raw["models"]}[
+        "qwen/qwen3-235b-a22b-2507"
+    ]
+    assert restored["routable"] is True
+    assert "routable_reason" not in restored
+    assert "missing_since" not in restored
+    assert restored["_about"] == tombstoned["_about"]
+    assert restored["note"] == tombstoned["note"]
+
+
+def test_gemini_tombstones_second_miss_and_empty_discovery_keeps_old_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "gemini.json"
+    old_text = _write_manifest(
+        manifest_path,
+        "gemini",
+        [
+            _manifest_row("google/gemini-2.5-pro", "gemini-2.5-pro", _note="keep"),
+            _manifest_row("google/gemini-2.5-flash", "gemini-2.5-flash"),
+            _manifest_row("google/gemini-2.5-flash-lite", "gemini-2.5-flash-lite"),
+            _manifest_row("google/gemini-staged", "gemini-staged", routable=False),
+        ],
+    )
+    pricing = ProviderPricingResult(
+        slug="gemini",
+        prices={
+            "google/gemini-2.5-pro": ModelPrice(1_250_000, 10_000_000),
+            "google/gemini-2.5-flash": ModelPrice(300_000, 2_500_000),
+        },
+        source="api",
+        fetched_url=gemini.URL,
+    )
+    live_payload = {
+        "models": [
+            {
+                "name": "models/gemini-2.5-pro",
+                "displayName": "Gemini 2.5 Pro",
+                "inputTokenLimit": 1_048_576,
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/gemini-2.5-flash",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+        ]
+    }
+    monkeypatch.setattr(gemini, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(gemini, "fetch_provider", lambda **_kwargs: pricing)
+    monkeypatch.setattr(gemini, "fetch_json", lambda *_args, **_kwargs: live_payload)
+
+    result = gemini.fetch()
+    gemini.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert by_id["google/gemini-2.5-flash-lite"]["missing_since"]
+    assert by_id["google/gemini-2.5-flash-lite"].get("routable") is not False
+    assert by_id["google/gemini-2.5-pro"]["_note"] == "keep"
+    assert by_id["google/gemini-staged"]["routable"] is False
+
+    result = gemini.fetch()
+    gemini.write_provider_manifest(result)
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    tombstoned = {row["id"]: row for row in raw["models"]}[
+        "google/gemini-2.5-flash-lite"
+    ]
+    assert tombstoned["routable"] is False
+    assert tombstoned["routable_reason"] == "delisted-upstream"
+
+    # A failed/empty discovery pass cannot rewrite even top-level timestamps.
+    manifest_path.write_text(old_text, encoding="utf-8")
+    gemini._DISCOVERED_MANIFEST_ROWS = {}  # noqa: SLF001
+    gemini.write_provider_manifest(pricing)
+    assert manifest_path.read_text(encoding="utf-8") == old_text
+
+
+def test_wafer_feed_presence_survives_pricing_schema_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "wafer.json"
+    native_ids = {
+        "z-ai/glm-5.1": "GLM-5.1",
+        "z-ai/glm-5.2": "GLM-5.2",
+        "z-ai/glm-5.2-fast": "glm5.2-fast",
+        "moonshotai/kimi-k2.6": "Kimi-K2.6",
+        "minimax/minimax-m3": "MiniMax-M3",
+    }
+    _write_manifest(
+        manifest_path,
+        "wafer",
+        [
+            _manifest_row(
+                model_id,
+                native_id,
+                input_token_price_per_m=index + 100,
+                output_token_price_per_m=index + 200,
+            )
+            for index, (model_id, native_id) in enumerate(native_ids.items())
+        ],
+    )
+    payload_rows: list[dict[str, object]] = []
+    for index, native_id in enumerate(native_ids.values()):
+        pricing_key = "renamed_pricing" if index < 2 else "pricing"
+        payload_rows.append(
+            {
+                "id": native_id,
+                "wafer": {
+                    pricing_key: {
+                        "input_cents_per_million": 10 + index,
+                        "output_cents_per_million": 20 + index,
+                    }
+                },
+            }
+        )
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"data": payload_rows}
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(wafer, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(wafer.httpx, "Client", FakeClient)
+
+    result = wafer.fetch()
+    wafer.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert set(by_id) == set(native_ids)
+    assert set(result.prices) == set(native_ids) - {"z-ai/glm-5.1", "z-ai/glm-5.2"}
+    assert by_id["z-ai/glm-5.1"]["input_token_price_per_m"] == 100
+    assert by_id["z-ai/glm-5.2"]["input_token_price_per_m"] == 101
+    assert all("missing_since" not in row for row in by_id.values())
+    assert all(row.get("routable") is not False for row in by_id.values())
+
+
+def test_gemini_paginates_complete_feed_and_rejects_stuck_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "gemini.json"
+    _write_manifest(
+        manifest_path,
+        "gemini",
+        [
+            _manifest_row("google/gemini-2.5-pro", "gemini-2.5-pro"),
+            _manifest_row("google/gemini-2.5-flash", "gemini-2.5-flash"),
+            _manifest_row("google/gemini-2.5-flash-lite", "gemini-2.5-flash-lite"),
+        ],
+    )
+    pricing = ProviderPricingResult(
+        slug="gemini",
+        prices={
+            "google/gemini-2.5-pro": ModelPrice(1, 2),
+            "google/gemini-2.5-flash": ModelPrice(3, 4),
+        },
+        source="deterministic",
+    )
+    requested_urls: list[str] = []
+
+    def paginated_json(url: str, **_kwargs: object) -> dict[str, object]:
+        requested_urls.append(url)
+        if "pageToken=" not in url:
+            return {
+                "models": [{"name": "models/gemini-2.5-pro"}],
+                "nextPageToken": "page two",
+            }
+        return {"models": [{"name": "models/gemini-2.5-flash"}]}
+
+    monkeypatch.setattr(gemini, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(gemini, "fetch_provider", lambda **_kwargs: pricing)
+    monkeypatch.setattr(gemini, "fetch_json", paginated_json)
+
+    result = gemini.fetch()
+    gemini.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert set(result.prices) == {
+        "google/gemini-2.5-pro",
+        "google/gemini-2.5-flash",
+    }
+    assert by_id["google/gemini-2.5-flash"].get("routable") is not False
+    assert "missing_since" not in by_id["google/gemini-2.5-flash"]
+    assert "pageSize=1000" in requested_urls[0]
+    assert "pageToken=page+two" in requested_urls[1]
+
+    monkeypatch.setattr(
+        gemini,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "models": [{"name": "models/gemini-2.5-pro"}],
+            "nextPageToken": "stuck",
+        },
+    )
+    with pytest.raises(RuntimeError, match="pagination token did not advance"):
+        gemini._live_model_rows()  # noqa: SLF001
+
+
+def test_awaiting_price_auto_promotes_but_curated_false_row_is_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "friendli.json"
+    curated = _manifest_row(
+        "metadata/curated",
+        "curated",
+        routable=False,
+        _note="hands off",
+    )
+    _write_manifest(
+        manifest_path,
+        "friendli",
+        [
+            _manifest_row("z-ai/glm-5.2", "zai-org/GLM-5.2"),
+            curated,
+        ],
+    )
+    discovered = {
+        "z-ai/glm-5.2": {
+            "id": "z-ai/glm-5.2",
+            "upstream_id": "zai-org/GLM-5.2",
+        },
+        "meta-llama/llama-3.1-8b-instruct": {
+            "id": "meta-llama/llama-3.1-8b-instruct",
+            "upstream_id": "meta-llama-3.1-8b-instruct",
+        },
+        "metadata/curated": {
+            "id": "metadata/curated",
+            "upstream_id": "changed-by-feed",
+        },
+    }
+    first = ProviderPricingResult(
+        slug="friendli",
+        prices={"z-ai/glm-5.2": ModelPrice(10, 20)},
+        source="api",
+    )
+    monkeypatch.setattr(friendli, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(friendli, "_DISCOVERED_MANIFEST_ROWS", discovered)
+
+    friendli.write_provider_manifest(first)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    awaiting = by_id["meta-llama/llama-3.1-8b-instruct"]
+    assert awaiting["routable"] is False
+    assert awaiting["routable_reason"] == "awaiting-price"
+    assert by_id["metadata/curated"] == curated
+
+    second = ProviderPricingResult(
+        slug="friendli",
+        prices={
+            "z-ai/glm-5.2": ModelPrice(10, 20),
+            "meta-llama/llama-3.1-8b-instruct": ModelPrice(30, 40),
+        },
+        source="api",
+    )
+    friendli.write_provider_manifest(second)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    promoted = by_id["meta-llama/llama-3.1-8b-instruct"]
+    assert promoted["routable"] is True
+    assert "routable_reason" not in promoted
+    assert promoted["input_token_price_per_m"] == 30
+    assert by_id["metadata/curated"] == curated
+
+
+def test_routable_false_supplemental_row_produces_no_catalog_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_manifest(
+        tmp_path / "friendli.json",
+        "friendli",
+        [
+            _manifest_row(
+                "z-ai/metadata-only",
+                "metadata-only",
+                routable=False,
+            )
+        ],
+    )
+    monkeypatch.setattr(catalog_ingest, "_PROVIDER_MODELS_DIR", tmp_path)
+
+    models, endpoints = catalog_ingest._supplemental_provider_models_and_endpoints()
+
+    assert "z-ai/metadata-only" not in models
+    assert not [endpoint for endpoint in endpoints.values() if endpoint.provider == "friendli"]

--- a/tests/test_pricing_base.py
+++ b/tests/test_pricing_base.py
@@ -10,6 +10,7 @@ from scripts.pricing.base import (
     ModelPrice,
     _coerce_to_model_prices,
     ast_whitelist_check,
+    guard_manifest_prune,
     sandbox_run_parser,
     validate,
 )
@@ -31,10 +32,17 @@ def test_validate_fails_on_empty_dict() -> None:
     assert any("empty" in e for e in errors)
 
 
-def test_validate_fails_when_expected_model_missing() -> None:
+def test_validate_warns_when_expected_model_missing(
+    tmp_path, monkeypatch, capsys
+) -> None:  # noqa: ANN001
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
     prices = {"foo/bar": ModelPrice(1_000_000, 1_000_000)}
     errors = validate(prices, ["expected/missing"])
-    assert any("expected/missing" in e for e in errors)
+
+    assert errors == []
+    assert "expected/missing" in capsys.readouterr().err
+    assert "expected/missing" in summary_path.read_text(encoding="utf-8")
 
 
 def test_validate_fails_on_out_of_range_prompt_price() -> None:
@@ -60,6 +68,41 @@ def test_validate_allows_one_zero_row_when_others_nonzero() -> None:
         "a/b": ModelPrice(1_000_000, 2_000_000),
     }
     assert validate(prices, []) == []
+
+
+def test_guard_manifest_prune_blocks_half_or_more_and_empty(
+    tmp_path, monkeypatch, capsys
+) -> None:  # noqa: ANN001
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    old_rows = [{"id": "a"}, {"id": "b"}]
+
+    assert guard_manifest_prune(old_rows, [{"id": "a"}], provider_slug="test") is old_rows
+    assert guard_manifest_prune(old_rows, [], provider_slug="test") is old_rows
+    stderr = capsys.readouterr().err
+    assert stderr.count("mass-prune guard") == 2
+    assert summary_path.read_text(encoding="utf-8").count("mass-prune guard") == 2
+
+
+def test_guard_manifest_prune_allows_small_prune() -> None:
+    old_rows = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    new_rows = [{"id": "a"}, {"id": "b"}]
+
+    assert guard_manifest_prune(old_rows, new_rows) is new_rows
+
+
+def test_guard_manifest_prune_keeps_delisted_rows_in_baseline() -> None:
+    old_rows = [
+        {
+            "id": f"old-{index}",
+            "routable": False,
+            "routable_reason": "delisted-upstream",
+        }
+        for index in range(4)
+    ] + [{"id": "live-a"}, {"id": "live-b"}]
+    new_rows = [*old_rows[:-2], {"id": "live-a"}, {"id": "live-b", "routable": False}]
+
+    assert guard_manifest_prune(old_rows, new_rows) is new_rows
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_pricing_self_heal.py
+++ b/tests/test_pricing_self_heal.py
@@ -14,6 +14,7 @@ expectation is that fetch_provider:
 """
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 
@@ -554,3 +555,41 @@ def test_stale_snapshot_never_rewrites_provider_manifest(
 
     assert refresh._write_provider_manifests({"fireworks": stale}) == []
     assert calls == []
+
+
+def test_manifest_dispatch_restores_mass_pruned_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest_path = tmp_path / "fake.json"
+    old_text = json.dumps(
+        {"provider": "fake", "models": [{"id": "a"}, {"id": "b"}]},
+        indent=2,
+    ) + "\n"
+    manifest_path.write_text(old_text, encoding="utf-8")
+
+    class FakeProvider:
+        MANIFEST_PATH = manifest_path
+
+        @staticmethod
+        def write_provider_manifest(
+            _result: pricing_base.ProviderPricingResult,
+        ) -> list[str]:
+            manifest_path.write_text(
+                json.dumps({"provider": "fake", "models": [{"id": "a"}]}) + "\n",
+                encoding="utf-8",
+            )
+            return ["fake: rewrote manifest"]
+
+    monkeypatch.setattr(refresh, "_import_provider", lambda _slug: FakeProvider)
+    result = pricing_base.ProviderPricingResult(
+        slug="fake",
+        prices={"a": pricing_base.ModelPrice(1, 1)},
+        source="api",
+    )
+
+    refresh._write_provider_manifests({"fake": result})
+
+    assert manifest_path.read_text(encoding="utf-8") == old_text
+    assert "mass-prune guard" in capsys.readouterr().err


### PR DESCRIPTION
Closes the prune half of the route-health loop: friendli+gemini discovery hooks (paginated), EXPECTED_MODELS warn-not-raise (fixes the wafer rebuild deadlock), and tombstone-based pruning — routes are never deleted, only marked routable:false after absence across two consecutive healthy feed runs, with curated annotations preserved for flap recovery. Feed presence is tracked separately from pricing success so a parse failure can never prune; mass-prune guard + dispatch-level restore backstop everything; outages fall back to stale snapshots and never reach the rebuild. Two adversarial review rounds (second redesigned pruning around tombstones after confirmed partial-feed hazards). 1624 passed / 33 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)