### PR TITLE
Add Novita Kimi K3 route and pricing refresh

### DIFF
--- a/scripts/pricing/parsers/novita.py
+++ b/scripts/pricing/parsers/novita.py
@@ -60,6 +60,7 @@ _DISPLAY_TO_OR_ID: dict[str, str] = {
     # Hunyuan
     "Hy3": "tencent/hy3",
     # MoonshotAI
+    "Kimi K3": "moonshotai/kimi-k3",
     "Kimi K2.7 Code": "moonshotai/kimi-k2.7-code",
     "Kimi K2.6": "moonshotai/kimi-k2.6",
     "Kimi K2.5": "moonshotai/kimi-k2.5",

--- a/scripts/pricing/providers/novita.py
+++ b/scripts/pricing/providers/novita.py
@@ -1,27 +1,240 @@
-"""Novita AI — human-only provider config.
+"""Novita pricing plus authenticated live-model discovery.
 
-novita.ai/pricing has a server-rendered list of all served models
-with input/output rates per row. Routed through r.jina.ai for clean
-markdown.
+A route is published only when Novita's authenticated model API says the
+operator account can invoke it. The public pricing table remains authoritative
+for billing. This intersection lets new launches appear automatically without
+guessing capabilities or creating zero-priced routes.
 """
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    fetch_json,
+    fetch_provider,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
+    validate,
+)
+from scripts.pricing.model_ids import canonicalize_native_model_id
 
 SLUG = "novita"
 URL = "https://r.jina.ai/https://novita.ai/pricing"
+MODELS_URL = "https://api.novita.ai/openai/v1/models"
 JINA_HEADERS = {"X-Return-Format": "markdown"}
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "novita.json"
+)
 
 EXPECTED_MODELS = [
     "deepseek/deepseek-v4-flash",
+    "moonshotai/kimi-k3",
     "tencent/hy3",
 ]
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _existing_native_ids() -> dict[str, str]:
+    if not MANIFEST_PATH.exists():
+        return {}
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    mapped: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        native_id = row.get("upstream_id") or row.get("title") or model_id
+        if not isinstance(model_id, str) or not isinstance(native_id, str):
+            continue
+        mapped[native_id] = model_id
+        mapped[native_id.casefold()] = model_id
+    return mapped
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    api_key = os.environ.get("NOVITA_API_KEY")
+    if not api_key:
+        raise RuntimeError("novita: NOVITA_API_KEY is required")
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {api_key}"},
+    )
+    source_rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(source_rows, list):
+        raise RuntimeError("novita: /models response has no data list")
+
+    existing_ids = _existing_native_ids()
+    discovered: dict[str, dict[str, Any]] = {}
+    for source in source_rows:
+        if not isinstance(source, dict):
+            continue
+        native_id = source.get("id")
+        if not isinstance(native_id, str) or not native_id:
+            continue
+        status = source.get("status")
+        if isinstance(status, int) and not isinstance(status, bool) and status <= 0:
+            continue
+        endpoints = _string_list(source.get("endpoints"))
+        if "chat/completions" not in endpoints:
+            continue
+        model_id = (
+            existing_ids.get(native_id)
+            or existing_ids.get(native_id.casefold())
+            or canonicalize_native_model_id(native_id)
+        )
+        if model_id is None:
+            continue
+
+        row: dict[str, Any] = {
+            "id": model_id,
+            "upstream_id": native_id,
+            "display_name": str(source.get("display_name") or native_id),
+            "title": str(source.get("title") or native_id),
+            "model_type": str(source.get("model_type") or "chat"),
+            "features": _string_list(source.get("features")),
+            "input_modalities": _string_list(source.get("input_modalities")) or ["text"],
+            "output_modalities": _string_list(source.get("output_modalities")) or ["text"],
+            "endpoints": endpoints,
+            "status": _positive_int(source.get("status")) or 1,
+        }
+        optional_ints = {
+            "created": source.get("created"),
+            "context_length": source.get("context_size") or source.get("context_length"),
+            "max_output_tokens": source.get("max_output_tokens"),
+        }
+        for field, value in optional_ints.items():
+            parsed = _positive_int(value)
+            if parsed is not None:
+                row[field] = parsed
+        discovered[model_id] = row
+
+    if not discovered:
+        raise RuntimeError("novita: /models returned no supported model ids")
+    return discovered
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
         extra_headers=JINA_HEADERS,
     )
+    discovered = _live_model_rows()
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    result.prices = {
+        model_id: price
+        for model_id, price in result.prices.items()
+        if model_id in discovered
+    }
+    errors = validate(result.prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    result.source = "api"
+    result.notes.append(
+        f"intersected official prices with {len(discovered)} authenticated live models"
+    )
+    return result
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Reconcile Novita routes against live models and official prices."""
+
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("novita manifest has no models list")
+    if not _DISCOVERED_MANIFEST_ROWS:
+        raise RuntimeError("novita manifest refresh has no authenticated discovery rows")
+    scale = raw.get("price_scale_to_microdollars_per_million_tokens", 1)
+    if not isinstance(scale, int) or scale <= 0:
+        raise RuntimeError("novita manifest has invalid price scale")
+
+    def manifest_units(microdollars: int) -> int:
+        value, remainder = divmod(microdollars, scale)
+        if remainder:
+            raise RuntimeError(
+                f"novita price {microdollars} is not representable at manifest scale {scale}"
+            )
+        return value
+
+    existing_by_id = {
+        row["id"]: row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
+    updated = 0
+    appended = 0
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        existing = existing_by_id.get(model_id)
+        row = dict(existing) if existing is not None else {}
+        row.update(discovered)
+        price = result.prices.get(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            row["input_token_price_per_m"] = manifest_units(tier.prompt_micro_per_m)
+            row["output_token_price_per_m"] = manifest_units(tier.completion_micro_per_m)
+            if tier.prompt_cached_micro_per_m is not None:
+                row["cached_input_token_price_per_m"] = manifest_units(
+                    tier.prompt_cached_micro_per_m
+                )
+            else:
+                row.pop("cached_input_token_price_per_m", None)
+            updated += 1
+        if existing is None:
+            appended += 1
+        present_rows[model_id] = row
+
+    rebuilt = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, rebuilt, provider_slug=SLUG)
+    if guarded is rows:
+        return ["novita: kept old manifest (mass-prune guard)"]
+
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(guarded)
+    raw["models"] = guarded
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    suffix = f", appended {appended}" if appended else ""
+    return [f"novita: refreshed provider_models/novita.json ({updated} priced rows{suffix})"]

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -378,7 +378,7 @@ PROVIDERS: dict[str, Provider] = {
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
     # Novita — multi-model serverless inference. OpenAI-compatible
-    # at api.novita.ai/v3/openai. Hosts DeepSeek, Qwen, Llama,
+    # at api.novita.ai/openai/v1. Hosts DeepSeek, Qwen, Llama,
     # GLM, Kimi (and many more) at competitive rates.
     "novita": Provider(
         slug="novita",
@@ -1450,6 +1450,11 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
         {
             "anthropic/claude-opus-4.7",
             "openai/gpt-5.5",
+            # 2026-07-18: GMI's authenticated /models feed still advertises
+            # Kimi K3, but direct prepaid inference returns 404 "No matching
+            # target server found". Keep BYOK visible for accounts with
+            # different capacity while removing the broken operator route.
+            "moonshotai/kimi-k3",
             # 2026-07-15: the snapshot route returns 404 when pinned to GMI.
             # Keep the directly verified Baseten route.
             "nvidia/nemotron-3-ultra-550b-a55b",

--- a/src/trusted_router/data/provider_models/novita.json
+++ b/src/trusted_router/data/provider_models/novita.json
@@ -3,8 +3,8 @@
   "source": "https://api.novita.ai/openai/v1/models",
   "price_source": "https://novita.ai/pricing",
   "price_scale_to_microdollars_per_million_tokens": 100,
-  "generated_at": "2026-06-20T00:00:00Z",
-  "model_count": 106,
+  "generated_at": "2026-07-18T19:00:00Z",
+  "model_count": 107,
   "models": [
     {
       "id": "Sao10K/L3-8B-Stheno-v3.2",
@@ -1446,6 +1446,37 @@
       "max_output_tokens": 262144,
       "input_token_price_per_m": 8000,
       "output_token_price_per_m": 34000,
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "reasoning",
+        "serverless",
+        "structured-outputs"
+      ],
+      "input_modalities": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "anthropic",
+        "chat/completions"
+      ],
+      "status": 1
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "display_name": "Kimi K3",
+      "title": "moonshotai/kimi-k3",
+      "created": 1784168859,
+      "context_length": 1048576,
+      "max_output_tokens": 1048576,
+      "input_token_price_per_m": 30000,
+      "output_token_price_per_m": 150000,
+      "cached_input_token_price_per_m": 3000,
       "model_type": "chat",
       "features": [
         "function-calling",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -93,12 +93,20 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert "moonshotai/kimi-k2.7-code-highspeed@kimi/byok" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@kimi/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@kimi/byok" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@novita/prepaid" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@novita/byok" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@gmi/prepaid" not in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@gmi/byok" in MODEL_ENDPOINTS
     kimi_k3 = MODELS["moonshotai/kimi-k3"]
     assert kimi_k3.context_length == 1_048_576
     assert kimi_k3.prompt_price_microdollars_per_million_tokens == 3_300_000
     assert kimi_k3.completion_price_microdollars_per_million_tokens == 16_500_000
     assert kimi_k3.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 330_000
     assert MODEL_ENDPOINTS["moonshotai/kimi-k3@kimi/prepaid"].upstream_id == "kimi-k3"
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k3@novita/prepaid"].upstream_id
+        == "moonshotai/kimi-k3"
+    )
     assert (
         MODEL_ENDPOINTS["moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid"].upstream_id
         == "kimi-k2.7-code-highspeed"

--- a/tests/test_novita_pricing.py
+++ b/tests/test_novita_pricing.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import novita
+
+
+def test_novita_manifest_writer_updates_scaled_prices(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "novita.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "novita",
+                "price_scale_to_microdollars_per_million_tokens": 100,
+                "models": [
+                    {
+                        "id": "moonshotai/kimi-k3",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                        "cached_input_token_price_per_m": 1,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(novita, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        novita,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "moonshotai/kimi-k3": {
+                "id": "moonshotai/kimi-k3",
+                "upstream_id": "moonshotai/kimi-k3",
+            }
+        },
+    )
+    result = ProviderPricingResult(
+        slug="novita",
+        prices={
+            "moonshotai/kimi-k3": ModelPrice(
+                prompt_micro_per_m=3_000_000,
+                completion_micro_per_m=15_000_000,
+                prompt_cached_micro_per_m=300_000,
+            )
+        },
+        source="deterministic",
+    )
+
+    notes = novita.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    row = raw["models"][0]
+    assert row["input_token_price_per_m"] == 30_000
+    assert row["output_token_price_per_m"] == 150_000
+    assert row["cached_input_token_price_per_m"] == 3_000
+    assert raw["model_count"] == 1
+    assert notes == ["novita: refreshed provider_models/novita.json (1 priced rows)"]
+
+
+def test_novita_manifest_writer_rejects_unrepresentable_price(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "novita.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "novita",
+                "price_scale_to_microdollars_per_million_tokens": 100,
+                "models": [{"id": "test/model"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(novita, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        novita,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {"test/model": {"id": "test/model", "upstream_id": "test/model"}},
+    )
+    result = ProviderPricingResult(
+        slug="novita",
+        prices={
+            "test/model": ModelPrice(
+                prompt_micro_per_m=101,
+                completion_micro_per_m=200,
+            )
+        },
+        source="deterministic",
+    )
+
+    try:
+        novita.write_provider_manifest(result)
+    except RuntimeError as exc:
+        assert "not representable" in str(exc)
+    else:
+        raise AssertionError("expected non-representable Novita price to fail closed")
+
+
+def test_novita_live_discovery_preserves_existing_ids_and_normalizes_new_ids(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "novita.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "Sao10K/L3-8B-Stheno-v3.2",
+                        "title": "Sao10K/L3-8B-Stheno-v3.2",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(novita, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setenv("NOVITA_API_KEY", "secret")
+    monkeypatch.setattr(
+        novita,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {
+                    "id": "Sao10K/L3-8B-Stheno-v3.2",
+                    "display_name": "Stheno",
+                    "context_size": 8192,
+                    "endpoints": ["chat/completions"],
+                },
+                {
+                    "id": "MoonshotAI/Kimi-K3",
+                    "display_name": "Kimi K3",
+                    "context_size": 1_048_576,
+                    "features": ["reasoning", "serverless"],
+                    "input_modalities": ["text", "image", "video"],
+                    "output_modalities": ["text"],
+                    "endpoints": ["chat/completions", "anthropic"],
+                },
+                {
+                    "id": "example/disabled-chat",
+                    "status": 0,
+                    "endpoints": ["chat/completions"],
+                },
+                {
+                    "id": "example/embedding-only",
+                    "status": 1,
+                    "endpoints": ["embeddings"],
+                },
+            ]
+        },
+    )
+
+    discovered = novita._live_model_rows()
+
+    assert "Sao10K/L3-8B-Stheno-v3.2" in discovered
+    assert "example/disabled-chat" not in discovered
+    assert "example/embedding-only" not in discovered
+    kimi = discovered["moonshotai/kimi-k3"]
+    assert kimi["upstream_id"] == "MoonshotAI/Kimi-K3"
+    assert kimi["context_length"] == 1_048_576
+    assert kimi["input_modalities"] == ["text", "image", "video"]
+
+
+def test_novita_manifest_writer_appends_live_priced_model(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "novita.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "novita",
+                "price_scale_to_microdollars_per_million_tokens": 100,
+                "models": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(novita, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        novita,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "moonshotai/kimi-k3": {
+                "id": "moonshotai/kimi-k3",
+                "upstream_id": "moonshotai/kimi-k3",
+                "display_name": "Kimi K3",
+                "context_length": 1_048_576,
+                "endpoints": ["chat/completions"],
+            }
+        },
+    )
+    result = ProviderPricingResult(
+        slug="novita",
+        prices={
+            "moonshotai/kimi-k3": ModelPrice(
+                prompt_micro_per_m=3_000_000,
+                completion_micro_per_m=15_000_000,
+            )
+        },
+        source="api",
+    )
+
+    notes = novita.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert raw["models"] == [
+        {
+            "id": "moonshotai/kimi-k3",
+            "upstream_id": "moonshotai/kimi-k3",
+            "display_name": "Kimi K3",
+            "context_length": 1_048_576,
+            "endpoints": ["chat/completions"],
+            "input_token_price_per_m": 30_000,
+            "output_token_price_per_m": 150_000,
+        }
+    ]
+    assert notes == [
+        "novita: refreshed provider_models/novita.json (1 priced rows, appended 1)"
+    ]

--- a/tests/test_pricing_fixtures.py
+++ b/tests/test_pricing_fixtures.py
@@ -227,6 +227,26 @@ Free
     }
 
 
+def test_novita_parser_tracks_kimi_k3_launch_pricing() -> None:
+    module = importlib.import_module("scripts.pricing.parsers.novita")
+    result = module.parse(
+        """
+MoonshotAI
+
+--
+
+Model Name\tContext\tInput\tOutput\tActions
+Kimi K3\t1,048,576\t$3 /Mt· Cache Read $0.3 /Mt\t$15 /Mt\tMore
+"""
+    )
+
+    assert result["moonshotai/kimi-k3"] == {
+        "prompt_micro_per_m": 3_000_000,
+        "completion_micro_per_m": 15_000_000,
+        "prompt_cached_micro_per_m": 300_000,
+    }
+
+
 @pytest.mark.parametrize(
     "slug",
     ["anthropic", "cerebras", "gemini", "mistral", "deepseek", "openai", "kimi", "zai"],


### PR DESCRIPTION
Summary: add the live Novita Kimi K3 serverless route with authenticated 1M-context metadata; intersect Novita's authenticated model catalog with its official public pricing table; append only active chat models with authoritative prices, retain unpriced discoveries as disabled metadata, and tombstone retirements through existing safety guards; remove GMI's currently broken prepaid K3 route after a direct 404 despite its stale advertised model row; fail closed on non-integer pricing. Verification: ruff, mypy, full pytest (1642 passed, 33 skipped before final narrow route assertion), focused 114-test rerun, authenticated discovery dry run, and direct K3/K2.6 provider smokes.