### PR TITLE
Catalog: allowlist GMI Credits routing to its four verified models

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -1434,6 +1434,20 @@ _PROVIDER_SERVED_MODEL_ALLOWLIST: dict[str, frozenset[str]] = {
             "cerebras/zai-glm-4.7",
         }
     ),
+    # 2026-07-18: GMI's /models listing is aspirational — 7d synthetic probes
+    # show exactly four models served on our account (590-670 successes each)
+    # while the other ~45 listed models have ZERO successes ever (uniform
+    # upstream 404 "No matching target server found"). Route Credits traffic
+    # only to the verified set; BYOK stays visible (customer accounts may
+    # differ). A new GMI model earns its way in via probe successes.
+    "gmi": frozenset(
+        {
+            "deepseek/deepseek-v4-pro",
+            "z-ai/glm-5",
+            "z-ai/glm-5.1",
+            "z-ai/glm-5.2",
+        }
+    ),
 }
 
 _UNSERVED_CREDITS_MODELS: frozenset[str] = frozenset(

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -65,6 +65,32 @@ def test_cerebras_only_credits_serves_allowlisted_models() -> None:
     } <= cerebras_credits
 
 
+def test_gmi_only_credits_serves_allowlisted_models() -> None:
+    # GMI's /models listing is aspirational: 7d probes (2026-07-18) show four
+    # models served on our account and ~45 listed phantoms with zero successes
+    # ever. Credits endpoints must stay within the verified set; BYOK uses the
+    # customer's own key and keeps GMI's full listing visible.
+    allow = _PROVIDER_SERVED_MODEL_ALLOWLIST["gmi"]
+    gmi_credits = {
+        e.model_id
+        for e in MODEL_ENDPOINTS.values()
+        if e.provider == "gmi" and e.usage_type == "Credits"
+    }
+    assert gmi_credits <= allow
+    assert gmi_credits == {
+        "deepseek/deepseek-v4-pro",
+        "z-ai/glm-5",
+        "z-ai/glm-5.1",
+        "z-ai/glm-5.2",
+    }
+    gmi_byok = {
+        e.model_id
+        for e in MODEL_ENDPOINTS.values()
+        if e.provider == "gmi" and e.usage_type != "Credits"
+    }
+    assert len(gmi_byok) > len(gmi_credits)
+
+
 def test_cerebras_native_routes_use_verified_upstream_ids() -> None:
     assert MODEL_ENDPOINTS["openai/gpt-oss-120b@cerebras/prepaid"].upstream_id == (
         "gpt-oss-120b"


### PR DESCRIPTION
GMI lists ~50 models; 7d probe data shows it serves exactly 4 on our account (590–670 successes each) — the rest have zero successes ever. Allowlist Credits routing + rotation probing to the verified set (mechanism precedent: cerebras). BYOK untouched. Ends GMI phantom-route Sentry noise structurally and protects prepaid routing. New GMI models enter after probe verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)