### PR TITLE
Catalog: route Anthropic-authored models via Anthropic directly for Credits

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -712,6 +712,13 @@ def _embedding_manifest_cost(spec: _EmbeddingSpec) -> int | None:
     return None
 
 
+# Providers through which we route Anthropic-authored (anthropic/*) models on
+# Credits. Anthropic-direct only today; add "vertex"/"bedrock" here if/when
+# first-party Claude routing through those surfaces is enabled. Resellers that
+# merely list Claude ids are intentionally excluded (see _keep policy below).
+_ANTHROPIC_FIRST_PARTY_PROVIDERS: frozenset[str] = frozenset({"anthropic"})
+
+
 def _filter_unserved_provider_endpoints(
     endpoints: dict[str, ModelEndpoint],
 ) -> dict[str, ModelEndpoint]:
@@ -720,12 +727,14 @@ def _filter_unserved_provider_endpoints(
     those 502 on an account mismatch — BYOK routes use the customer's own key
     (their account may serve a different model set), so they're left intact.
 
-    Four complementary filters apply:
+    Five complementary filters apply:
       * provider deprecation — drop a disabled upstream route on one provider for
         every usage type (Nebius June 2026 retirements).
       * allowlist        — keep ONLY the listed Credits models for a provider (Cerebras).
       * model denylist    — drop the listed Credits models on EVERY provider (GPT-5.4/pro).
       * provider denylist — drop a Credits model on ONE provider only (gmi closed models).
+      * Claude first-party — route Anthropic-authored models via Anthropic only
+        for Credits, never resellers (policy; see _ANTHROPIC_FIRST_PARTY_PROVIDERS).
     """
     allow = _PROVIDER_SERVED_MODEL_ALLOWLIST
 
@@ -736,6 +745,18 @@ def _filter_unserved_provider_endpoints(
             return False
         if endpoint.usage_type != "Credits":
             return True
+        # Policy (2026-07-18): serve Anthropic-authored models via Anthropic
+        # directly for Credits, not resellers. Resellers list Claude ids they
+        # mostly don't actually serve (uniform upstream 404s) and add no value
+        # over first-party; keeping them only produced dead routes and alert
+        # noise. BYOK is untouched — a customer's own reseller key is their
+        # choice. Extend _ANTHROPIC_FIRST_PARTY_PROVIDERS if first-party
+        # Vertex/Bedrock Claude routing is ever enabled.
+        if (
+            endpoint.model_id.startswith("anthropic/")
+            and endpoint.provider not in _ANTHROPIC_FIRST_PARTY_PROVIDERS
+        ):
+            return False
         if endpoint.provider in allow and endpoint.model_id not in allow[endpoint.provider]:
             return False
         if endpoint.model_id in _UNSERVED_CREDITS_MODELS:

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -91,6 +91,27 @@ def test_gmi_only_credits_serves_allowlisted_models() -> None:
     assert len(gmi_byok) > len(gmi_credits)
 
 
+def test_anthropic_models_credits_route_first_party_only() -> None:
+    # Policy: Anthropic-authored (anthropic/*) models route via Anthropic
+    # directly for Credits, never resellers (which list Claude ids they mostly
+    # don't serve). BYOK is untouched — a customer's own reseller key is theirs.
+    credits_providers = {
+        e.provider
+        for e in MODEL_ENDPOINTS.values()
+        if e.model_id.startswith("anthropic/") and e.usage_type == "Credits"
+    }
+    assert credits_providers <= {"anthropic"}
+    # Anthropic-direct Credits lineup stays fully routable.
+    assert "anthropic/claude-fable-5@anthropic/prepaid" in MODEL_ENDPOINTS
+    # A reseller that lists Claude keeps its BYOK route but loses Credits.
+    byok_providers = {
+        e.provider
+        for e in MODEL_ENDPOINTS.values()
+        if e.model_id.startswith("anthropic/") and e.usage_type != "Credits"
+    }
+    assert byok_providers - {"anthropic"}, "expected reseller Claude BYOK routes to remain"
+
+
 def test_cerebras_native_routes_use_verified_upstream_ids() -> None:
     assert MODEL_ENDPOINTS["openai/gpt-oss-120b@cerebras/prepaid"].upstream_id == (
         "gpt-oss-120b"

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -558,7 +558,10 @@ def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
         ], f"{provider}/{model_id} should be quarantined"
 
     assert "anthropic/claude-fable-5@anthropic/prepaid" in MODEL_ENDPOINTS
-    assert "anthropic/claude-fable-5@lightning/prepaid" in MODEL_ENDPOINTS
+    # Policy (2026-07-18): Anthropic-authored models route via Anthropic only
+    # for Credits — the reseller prepaid route is gone, its BYOK route stays.
+    assert "anthropic/claude-fable-5@lightning/prepaid" not in MODEL_ENDPOINTS
+    assert "anthropic/claude-fable-5@lightning/byok" in MODEL_ENDPOINTS
 
 
 def test_anthropic_opus_41_drops_prepaid_but_keeps_byok_until_retirement() -> None:


### PR DESCRIPTION
Policy: Claude (anthropic/*) models route via first-party Anthropic only for Credits — never resellers, which list Claude ids they mostly don't serve (404s) and add no value while producing dead-route alert noise. One self-maintaining filter rule (author-prefix + _ANTHROPIC_FIRST_PARTY_PROVIDERS allowlist) covers current + future resellers/models. BYOK untouched (customer's own key). Extensible to Vertex/Bedrock if first-party Claude routing there is enabled. 1650 passed / 33 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)