### PR TITLE
Leaderboard: quarantine dead residue routes + first-party Claude (Vertex/Bedrock) + quiet transient alerts

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -186,6 +186,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "meta-llama/llama-3-70b-instruct",
             # route-health first sweep 2026-07-18, 100% failure.
             "zai-org/glm-4.5",
+            # route-health 2026-07-18, 100% failure, upstream 404.
+            "elephant",
         }
     ),
     # Friendli notified customers that GLM-5 serverless Model APIs stop being
@@ -209,6 +211,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
         {
             "google/gemini-3.1-flash-lite-preview",
             "gemini-3.1-flash-lite-preview",
+            # route-health 2026-07-18, 100% failure, upstream 404.
+            "google/gemma-3n-e4b-it",
         }
     ),
     "google-vertex": frozenset(
@@ -254,6 +258,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "z-ai/glm-5.1",
             "moonshotai/kimi-k2.7-code",
             "qwen/qwen3-32b",
+            # route-health 2026-07-18, 100% failure, upstream 404.
+            "nousresearch/hermes-3-llama-3.1-70b",
         }
     ),
     "phala": frozenset(
@@ -276,6 +282,16 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "mistralai/mistral-small-24b-instruct-2501",
             "moonshotai/kimi-k2.7-code",
             "minimax/minimax-m3",
+            # route-health 2026-07-18, 100% failure, upstream 404/400.
+            "z-ai/glm-4.6",
+            "z-ai/glm-4.7",
+            "z-ai/glm-5",
+            "z-ai/glm-5.1",
+            "qwen/qwen3.5-397b-a17b",
+            "qwen/qwen3-next-80b-a3b-instruct",
+            "meta-llama/llama-3.2-3b-instruct",
+            "deepseek/deepseek-r1-0528",
+            "openai/gpt-oss-20b",
         }
     ),
     # route-health first sweep 2026-07-18, 100% failure.
@@ -284,6 +300,12 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "openai/gpt-5.6-sol",
             "openai/gpt-5.6-luna",
             "openai/gpt-4-turbo-preview",
+            # route-health 2026-07-18, 100% failure, upstream provider_error
+            # before Lightning attempted an upstream request.
+            "openai/gpt-5",
+            "openai/gpt-5-mini",
+            "openai/o3",
+            "openai/o3-mini",
         }
     ),
     # route-health first sweep 2026-07-18, 100% failure. These ids may be
@@ -292,6 +314,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
         {
             "moonshotai/kimi-k2",
             "moonshotai/kimi-k2-0905",
+            # route-health 2026-07-18, 100% failure, upstream 404.
+            "moonshotai/kimi-k2-thinking",
         }
     ),
     # route-health first sweep 2026-07-18, 100% failure.
@@ -305,6 +329,8 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
     "mistral": frozenset(
         {
             "mistralai/mistral-small-24b-instruct-2501",
+            # route-health 2026-07-18, 100% failure, upstream 404.
+            "mistralai/mixtral-8x22b-instruct",
         }
     ),
     # route-health first sweep 2026-07-18, 100% failure.
@@ -317,6 +343,11 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
     "deepseek": frozenset(
         {
             "deepseek/deepseek-v3.1-terminus",
+            # route-health 2026-07-18, 100% failure, upstream 400.
+            "deepseek/deepseek-v3.2-exp",
+            "deepseek/deepseek-chat-v3-0324",
+            "deepseek/deepseek-r1-distill-llama-70b",
+            "deepseek/deepseek-r1-0528",
         }
     ),
 }
@@ -716,7 +747,12 @@ def _embedding_manifest_cost(spec: _EmbeddingSpec) -> int | None:
 # Credits. Anthropic-direct only today; add "vertex"/"bedrock" here if/when
 # first-party Claude routing through those surfaces is enabled. Resellers that
 # merely list Claude ids are intentionally excluded (see _keep policy below).
-_ANTHROPIC_FIRST_PARTY_PROVIDERS: frozenset[str] = frozenset({"anthropic"})
+_ANTHROPIC_FIRST_PARTY_PROVIDERS: frozenset[str] = frozenset(
+    # First-party Anthropic surfaces are OK for Claude Credits routing; resellers
+    # are not. Vertex + Bedrock included per product decision (2026-07-18) so
+    # Claude-on-Vertex/Bedrock Credits routes are permitted when they exist.
+    {"anthropic", "google-vertex", "bedrock", "aws-bedrock"}
+)
 
 
 def _filter_unserved_provider_endpoints(

--- a/src/trusted_router/synthetic/route_health.py
+++ b/src/trusted_router/synthetic/route_health.py
@@ -8,6 +8,34 @@ from trusted_router.synthetic.probes import rotation_candidates
 
 _SAMPLES_PER_ROUTE_LIMIT = 48
 
+# A route-health alert means "this route is structurally broken — quarantine
+# it". Transient/capacity failures (rate limits, gateway/no-upstream, timeouts,
+# dropped connections) are NOT actionable that way: the model may recover, and
+# quarantining it would stop us ever re-probing it. They still count toward the
+# public leaderboard's uptime display (a separate path); they just don't page.
+# Structural failures — 4xx model-not-found / bad-request / auth (except 429) —
+# do page.
+_TRANSIENT_ERROR_TYPES = frozenset(
+    {
+        "ReadTimeout",
+        "ConnectTimeout",
+        "WriteTimeout",
+        "PoolTimeout",
+        "ConnectError",
+        "ReadError",
+        "WriteError",
+        "RemoteProtocolError",
+    }
+)
+_TRANSIENT_ERROR_STATUSES = frozenset({429, 500, 502, 503, 504, 529})
+
+
+def _is_transient_failure(sample: object) -> bool:
+    status = getattr(sample, "error_status", None)
+    if status in _TRANSIENT_ERROR_STATUSES:
+        return True
+    return getattr(sample, "error_type", None) in _TRANSIENT_ERROR_TYPES
+
 
 @dataclass(frozen=True)
 class RouteHealthFlag:
@@ -55,6 +83,10 @@ def evaluate_route_health(
             if created_at is None or created_at < cutoff or sample.status == "unsupported":
                 continue
             if sample.status not in {"error", "success"}:
+                continue
+            # Transient/capacity failures don't page (and don't dilute the
+            # denominator) — they aren't a "quarantine me" signal.
+            if sample.status == "error" and _is_transient_failure(sample):
                 continue
 
             sample_count += 1

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -548,6 +548,11 @@ def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
         ("deepinfra", "anthropic/claude-sonnet-5"),
         ("phala", "anthropic/claude-sonnet-5"),
         ("phala", "anthropic/claude-opus-4.1"),
+        ("together", "z-ai/glm-5"),
+        ("deepseek", "deepseek/deepseek-r1-0528"),
+        ("kimi", "moonshotai/kimi-k2-thinking"),
+        ("mistral", "mistralai/mixtral-8x22b-instruct"),
+        ("lightning", "openai/gpt-5-mini"),
     ]
 
     for provider, model_id in quarantined_routes:
@@ -562,6 +567,9 @@ def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
     # for Credits — the reseller prepaid route is gone, its BYOK route stays.
     assert "anthropic/claude-fable-5@lightning/prepaid" not in MODEL_ENDPOINTS
     assert "anthropic/claude-fable-5@lightning/byok" in MODEL_ENDPOINTS
+    # Residue quarantine is provider-scoped: healthy siblings survive.
+    assert "z-ai/glm-5@zai/prepaid" in MODEL_ENDPOINTS
+    assert "deepseek/deepseek-v4-pro@deepseek/prepaid" in MODEL_ENDPOINTS
 
 
 def test_anthropic_opus_41_drops_prepaid_but_keeps_byok_until_retirement() -> None:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2424,6 +2424,7 @@ def _route_health_sample(
     status: str,
     age_hours: int = 0,
     error_type: str | None = None,
+    error_status: int | None = None,
     error_message: str | None = None,
     source: str = "synthetic",
 ) -> ProviderBenchmarkSample:
@@ -2437,10 +2438,55 @@ def _route_health_sample(
         usage_type="Credits",
         streamed=True,
         error_type=error_type,
+        error_status=error_status,
         error_message=error_message,
         source=source,
         created_at=created_at,
     )
+
+
+def test_evaluate_route_health_ignores_transient_failures() -> None:
+    # A route that is 100% failing on transient/capacity errors (rate limit,
+    # gateway/no-upstream, timeout) is NOT alert-worthy — it may recover and
+    # quarantining would stop us re-probing it. It must not flag.
+    transient = []
+    transient.extend(
+        _route_health_sample(
+            f"rl-{i}", provider="busy", model="m", status="error",
+            error_type="provider_error", error_status=429,
+        )
+        for i in range(4)
+    )
+    transient.extend(
+        _route_health_sample(
+            f"to-{i}", provider="busy", model="m", status="error",
+            error_type="ReadTimeout",
+        )
+        for i in range(4)
+    )
+    transient.extend(
+        _route_health_sample(
+            f"gw-{i}", provider="busy", model="m", status="error",
+            error_type="provider_error", error_status=502,
+        )
+        for i in range(4)
+    )
+    assert evaluate_route_health(  # type: ignore[arg-type]
+        _RouteHealthStore(transient), routes=[("busy", "m")]
+    ) == []
+
+    # A structurally-dead route (404 model-not-found) still flags.
+    structural = [
+        _route_health_sample(
+            f"nf-{i}", provider="dead", model="m", status="error",
+            error_type="provider_error", error_status=404,
+        )
+        for i in range(6)
+    ]
+    flags = evaluate_route_health(  # type: ignore[arg-type]
+        _RouteHealthStore(structural), routes=[("dead", "m")]
+    )
+    assert len(flags) == 1 and flags[0].failure_rate == 1.0
 
 
 def test_evaluate_route_health_flags_dead_route_but_not_healthy_or_thin_routes() -> None:


### PR DESCRIPTION
Turns route-health from backlog flood into actionable signal: (1) quarantine ~20 confirmed-dead routes the enriched-error sweep surfaced (together/deepseek-direct/kimi/gemini-gemma/mistral/deepinfra/novita-junk/lightning-openai), provider-scoped; (2) allow Claude Credits routing on first-party Vertex/Bedrock too (per product decision); (3) route-health stops paging on transient/capacity errors (429/5xx/timeouts) — they stay on the leaderboard uptime view but an alert now means 'structurally dead, quarantine it'. openai-direct gpt-5.1-chat/gpt-5.3-codex self-heal via the enriched unsupported_route classifier (no action). 1651 passed / 33 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)