### PR TITLE
synthetic: 2048-token probe budget for Gemini 2.5+/3.x (fix empty_stream false alarm)

### DIFF
--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -973,6 +973,11 @@ def _rotation_max_tokens(provider: str, model: str) -> int:
         or "/gpt-5" in model_l
     ):
         return 512
+    if "gemini-2.5" in model_l or "gemini-3" in model_l:
+        # Gemini thinks before visible content; hidden thinking consumes the
+        # budget but is absent from usage, so 16 yields empty_stream. Live
+        # verification on 2026-07-19 showed 2048 works; keep generous headroom.
+        return 2048
     if (
         "gpt-oss" in model_l
         or "glm-4.6" in model_l

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2009,6 +2009,12 @@ def test_sse_line_finish_reason_detects_length_stop() -> None:
 
 
 def test_rotation_probe_uses_reasoning_safe_request_budget() -> None:
+    assert _rotation_max_tokens("google-ai-studio", "google/gemini-2.5-flash") == 2048
+    assert _rotation_max_tokens("google-vertex", "google/gemini-3.5-flash") == 2048
+    assert (
+        _rotation_max_tokens("google-ai-studio", "google/gemini-3-flash-preview")
+        == 2048
+    )
     assert _rotation_max_tokens("cerebras", "cerebras/gpt-oss-120b") == 512
     assert _rotation_max_tokens("cerebras", "z-ai/glm-4.7") == 512
     assert _rotation_max_tokens("zai", "z-ai/glm-4.6") == 512
@@ -2021,6 +2027,9 @@ def test_rotation_probe_uses_reasoning_safe_request_budget() -> None:
     assert _rotation_max_tokens("anthropic", "anthropic/claude-sonnet-5") == 512
     # Non-thinking Claude models keep the small budget.
     assert _rotation_max_tokens("anthropic", "anthropic/claude-haiku-4.5") == 16
+    assert (
+        _rotation_max_tokens("together", "meta-llama/llama-3.1-8b-instruct") == 16
+    )
     assert _rotation_omits_temperature("openai", "openai/o3")
     assert _rotation_omits_temperature("openai", "openai/gpt-5.5")
     # Canary contract: probes mirror customer payloads. The enclave strips


### PR DESCRIPTION
## What
Give Google Gemini 2.5/3.x route-health probes a 2048-token budget in `_rotation_max_tokens`.

## Why
Gemini 2.5/3.x think internally before emitting visible content, and that hidden thinking consumes the output-token budget (thinking tokens aren't in `usage.completion_tokens`). At the default 16-token probe budget, `gemini-2.5-flash` streams zero visible content, so the probe records `empty_stream` and route-health raises a false alarm — the route is healthy for real callers.

Verified with a live probe: `google/gemini-2.5-flash` via `google-ai-studio` returns `PONG` (`finish_reason=stop`) at `max_tokens=2048` but emits nothing visible at 16 (0 output tokens, ~5s internal thinking). This is the same class as the fable-5/claude-5 reasoning-budget fix.

## Change
- `_rotation_max_tokens`: `gemini-2.5`/`gemini-3` → 2048 (placed before the existing 512 reasoning tier; 512 is untested for Gemini and risks a length/probe_config_error cycle).
- Unit tests for the Gemini budget, non-Gemini default (16), and existing reasoning tier (512) unchanged.

Probe-only change — cannot affect real traffic. Merging redeploys the synthetic monitor (path filter matches `src/trusted_router/`).