### PR TITLE
Serve Charter fonts with WOFF2 MIME type

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -145,6 +145,8 @@ class _CachedStaticFiles(StaticFiles):
         status_code: int = 200,
     ) -> Response:
         response = super().file_response(full_path, stat_result, scope, status_code=status_code)
+        if str(full_path).casefold().endswith(".woff2"):
+            response.headers["content-type"] = "font/woff2"
         response.headers.setdefault("cache-control", f"public, max-age={self._max_age}")
         return response
 

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -385,8 +385,28 @@ def test_favicon_assets_are_served(client: TestClient) -> None:
     release = client.get("/trust/gcp-release.json")
     assert release.status_code == 200
     assert release.json()["platform"] == "gcp-confidential-space"
-    assert release.json()["source_repositories"]["control_plane"] == "https://github.com/Lore-Hex/quill-router"
-    assert release.json()["source_repositories"]["attested_gateway"] == "https://github.com/Lore-Hex/quill-cloud-proxy"
+    assert release.json()["source_repositories"]["control_plane"] == (
+        "https://github.com/Lore-Hex/quill-router"
+    )
+    assert release.json()["source_repositories"]["attested_gateway"] == (
+        "https://github.com/Lore-Hex/quill-cloud-proxy"
+    )
+
+
+def test_static_fonts_force_woff2_media_type(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Some minimal Linux images do not register WOFF2 in /etc/mime.types.
+    # Simulate that production environment so the application owns the
+    # browser-facing contract instead of relying on the host image.
+    monkeypatch.setattr(
+        "starlette.responses.guess_type", lambda _path: ("text/plain", None)
+    )
+
+    font = client.get("/static/fonts/archivo-latin.woff2")
+
+    assert font.status_code == 200
+    assert font.headers["content-type"] == "font/woff2"
 
 
 def test_read_only_blocks_writes_but_lets_reads_through() -> None:


### PR DESCRIPTION
## Summary
- force font/woff2 for self-hosted Charter fonts when the production image lacks a WOFF2 MIME registration
- add a regression test that simulates the observed text/plain fallback

## Verification
- regression test fails before the implementation and passes after it
- targeted static asset tests pass
- uv run ruff check src/trusted_router/routes/public.py tests/test_stubs_and_security.py
- uv run mypy