### PR TITLE
Align production smoke with Charter homepage

### DIFF
--- a/tests/test_smoke_prod.py
+++ b/tests/test_smoke_prod.py
@@ -263,7 +263,7 @@ def test_marketing_page_advertises_production_not_alpha(client: httpx.Client) ->
     assert response.status_code == 200
     body = response.text
     assert "Public Alpha" not in body
-    assert "Production" in body
+    assert "Live regions" in body
     assert "regional routing" in body or "multi-region" in body
     assert "world-map.svg" in body or "<svg" in body  # map renders
 


### PR DESCRIPTION
## Summary
- keep the alpha-removal smoke invariant
- verify the Charter homepage's live-region production signal instead of deleted legacy copy

## Verification
- full production smoke: 30 passed, one stale copy assertion reproduced
- corrected production assertion: passed
- uv run ruff check tests/test_smoke_prod.py