### PR TITLE
Add Responses web-search billing contract and public docs

### DIFF
--- a/src/trusted_router/content/legal.py
+++ b/src/trusted_router/content/legal.py
@@ -56,6 +56,12 @@ SYSTEM_SUBPROCESSORS: tuple[dict[str, str], ...] = (
         "policy_url": "https://axiom.co/privacy",
     },
     {
+        "name": "Exa",
+        "purpose": "Optional hosted web search for Responses API requests that explicitly enable the web_search tool.",
+        "data_access": "A model-generated search query, requested domain and country filters, and search metadata. Search runs only inside the attested gateway. Exa does not receive the original prompt or model output directly, but a generated query can reflect prompt content. Web search is blocked on ZDR, E2E/confidential, and EU privacy routes until a compatible contractual posture is approved.",
+        "policy_url": "https://exa.ai/privacy",
+    },
+    {
         "name": "GitHub",
         "purpose": "Source control, CI, release workflows, and public open-source repositories.",
         "data_access": "Source code, CI metadata, and release artifacts. No production prompt/output content.",

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -130,6 +130,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/docs/mcp",
     "/docs/migrate-from-openrouter",
     "/docs/tagging",
+    "/docs/web-search",
     "/llms.txt",
     "/docs/llms.txt",
     "/docs/llms-full.txt",
@@ -342,6 +343,14 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         description=(
             "Attach AWS style tags and OpenRouter attribution metadata to LLM requests "
             "without adding them to model prompts or provider payloads."
+        ),
+    ),
+    "docs/web-search": PublicPage(
+        template="public/web_search.html",
+        title="Responses API Web Search",
+        description=(
+            "Use OpenAI-compatible web_search tools inside the attested TrustedRouter "
+            "gateway with citations, source controls, streaming events, and explicit privacy limits."
         ),
     ),
     "docs/agent-setup": PublicPage(
@@ -1883,6 +1892,7 @@ def llms_txt(settings: Settings) -> str:
         f"- MCP server: https://{domain}/docs/mcp",
         f"- Evals guide: https://{domain}/docs/evals",
         f"- Synth guide: https://{domain}/docs/synth",
+        f"- Responses web search: https://{domain}/docs/web-search",
         f"- Request tagging and cost allocation: https://{domain}/docs/tagging",
         f"- Blog: https://{domain}/blog",
         f"- Migration guide: https://{domain}/docs/migrate-from-openrouter",
@@ -1966,6 +1976,7 @@ def docs_llms_txt(settings: Settings) -> str:
             "- Raw agent playbook: https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md",
             f"- Evals guide: https://{domain}/docs/evals",
             f"- Synth guide: https://{domain}/docs/synth",
+            f"- Responses web search: https://{domain}/docs/web-search",
             f"- OpenRouter alternative: https://{domain}/openrouter-alternative",
             f"- Private LLM API: https://{domain}/private-llm-api",
             f"- Zero data retention LLM API: https://{domain}/llm-zero-data-retention",
@@ -1982,7 +1993,7 @@ def docs_llms_txt(settings: Settings) -> str:
             f"- Canonical live model API (public, no API key): https://{domain}/v1/models",
             f"- Provider transparency: https://{domain}/providers",
             f"- EU routing: https://{domain}/eu",
-        f"- TrustedOS for AI clouds: https://{domain}/trustedos",
+            f"- TrustedOS for AI clouds: https://{domain}/trustedos",
             "- Public status: https://status.trustedrouter.com/",
             "- Trust evidence: https://trust.trustedrouter.com/",
             "",
@@ -2072,6 +2083,7 @@ def docs_llms_full_txt(settings: Settings) -> str:
         "- Raw agent playbook: https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md",
         f"- Evals guide: https://{domain}/docs/evals",
         f"- Synth guide: https://{domain}/docs/synth",
+        f"- Responses web search: https://{domain}/docs/web-search",
         f"- Blog: https://{domain}/blog",
         f"- Migration guide: https://{domain}/docs/migrate-from-openrouter",
         f"- EU routing: https://{domain}/eu",

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -119,6 +119,10 @@ def _authorize_gateway_sync(
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
     assert_workspace_billing_active(workspace)
     body_dict = body.model_dump(exclude_none=True)
+    # Preserve pre-web-search idempotency fingerprints byte-for-byte for every
+    # ordinary request. A nonzero hosted-tool reservation remains fingerprinted.
+    if not body.additional_cost_reservation_microdollars:
+        body_dict.pop("additional_cost_reservation_microdollars", None)
     try:
         request_tags = validate_tags(body.tags)
         effective_tags = merge_tags(api_key.tags, body.tags)
@@ -163,6 +167,18 @@ def _authorize_gateway_sync(
     # resolver so the attested enclave can authorize + bill an
     # embeddings call exactly like a chat one.
     route_model_id = str(body_dict.get("model") or body.model)
+    if (
+        body.additional_cost_reservation_microdollars
+        and (
+            _is_web_search_restricted_model(route_model_id)
+            or _is_web_search_restricted_provider(body_dict.get("provider"))
+        )
+    ):
+        raise api_error(
+            400,
+            "web_search is not available for this privacy tier",
+            ErrorType.BAD_REQUEST,
+        )
     requested_model = MODELS.get(route_model_id) if route_model_id else None
     is_embeddings_request = (
         requested_model is not None
@@ -184,6 +200,21 @@ def _authorize_gateway_sync(
     endpoint_candidates = _eligible_gateway_endpoint_candidates(
         endpoint_candidates, workspace.id
     )
+    additional_cost_reservation = body.additional_cost_reservation_microdollars
+    if additional_cost_reservation:
+        if body.route_type != "responses.web_search.planner":
+            raise api_error(
+                400,
+                "additional cost reservations are only available for Responses web search",
+                ErrorType.BAD_REQUEST,
+            )
+        # The hosted search service is operator-funded, so its cost must settle
+        # against Credits even when this workspace also has BYOK routes.
+        endpoint_candidates = [
+            (candidate_model, candidate_endpoint)
+            for candidate_model, candidate_endpoint in endpoint_candidates
+            if UsageType.for_endpoint(candidate_endpoint) == UsageType.CREDITS
+        ]
     if not endpoint_candidates:
         raise api_error(
             400,
@@ -197,10 +228,11 @@ def _authorize_gateway_sync(
     if custom_model is not None and custom_model.hidden_prompt.strip():
         input_tokens += estimate_tokens_from_text(custom_model.hidden_prompt)
     output_tokens = body.output_estimate
-    estimate = max(
+    model_estimate = max(
         _endpoint_cost_microdollars(candidate_endpoint, input_tokens, output_tokens)
         for _candidate_model, candidate_endpoint in endpoint_candidates
     )
+    estimate = model_estimate + additional_cost_reservation
     model_usage_type = UsageType.for_endpoint(endpoint)
     has_credit_candidate = any(
         UsageType.for_endpoint(candidate_endpoint) == UsageType.CREDITS
@@ -331,6 +363,7 @@ def _authorize_gateway_sync(
             key_usage_shards=key_usage_shard_count(api_key),
             custom_model_id=custom_model.id if custom_model else None,
             custom_model_revision=custom_model.revision if custom_model else None,
+            additional_cost_reservation_microdollars=additional_cost_reservation,
             expires_at=expires_at,
             window_limits=window_limits or None,
         )
@@ -427,6 +460,7 @@ def _authorize_gateway_sync(
             idempotency_fingerprint=request_fingerprint,
             custom_model_id=custom_model.id if custom_model else None,
             custom_model_revision=custom_model.revision if custom_model else None,
+            additional_cost_reservation_microdollars=additional_cost_reservation,
         )
     byok_config = (
         _get_byok_provider(workspace.id, endpoint.provider)
@@ -739,6 +773,9 @@ def _gateway_authorize_response(
             "regions": region_payload(settings),
             "broadcast_destinations": broadcast_destinations,
             "idempotent_replay": idempotent_replay,
+            "additional_cost_reservation_microdollars": (
+                authorization.additional_cost_reservation_microdollars
+            ),
             "request_metadata_version": REQUEST_METADATA_VERSION,
             "tags": dict(authorization.tags),
             "custom_model": None
@@ -815,6 +852,29 @@ def _force_custom_model_credit_routes(body: dict[str, Any]) -> None:
         body["provider"] = {"usage": "credits"}
 
 
+def _is_web_search_restricted_model(model_id: str) -> bool:
+    model = model_id.strip().lower()
+    return any(
+        model == prefix
+        or model.startswith(f"{prefix}-")
+        or model.startswith(f"{prefix}/")
+        for prefix in (
+            "trustedrouter/zdr",
+            "trustedrouter/e2e",
+            "trustedrouter/confidential",
+            "trustedrouter/eu",
+        )
+    )
+
+
+def _is_web_search_restricted_provider(provider: Any) -> bool:
+    if not isinstance(provider, dict):
+        return False
+    return str(provider.get("data_collection") or "").strip().lower() == "deny" or (
+        str(provider.get("jurisdiction") or "").strip().lower() == "eu"
+    )
+
+
 def _settle_gateway_authorization(
     body: GatewaySettleRequest,
     *,
@@ -882,6 +942,27 @@ def _settle_gateway_authorization(
         cache_creation_tokens=cache_creation,
         effective_at=authorization.created_at,
     )
+    additional_cost = body.additional_cost_microdollars
+    if additional_cost:
+        if body.route_type != "responses.web_search.planner":
+            raise api_error(
+                400,
+                "additional cost settlement is only available for Responses web search",
+                ErrorType.BAD_REQUEST,
+            )
+        if additional_cost > authorization.additional_cost_reservation_microdollars:
+            raise api_error(
+                400,
+                "additional cost exceeds the authorized reservation",
+                ErrorType.BAD_REQUEST,
+            )
+        if UsageType.for_endpoint(selected_endpoint) != UsageType.CREDITS:
+            raise api_error(
+                400,
+                "additional cost settlement requires a Credits route",
+                ErrorType.BAD_REQUEST,
+            )
+        actual_cost += additional_cost
     input_tokens = total_input
     selected_usage_type = UsageType.for_endpoint(selected_endpoint)
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -338,6 +338,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def tagging_docs() -> str:
         return public_page_html(settings, "docs/tagging")
 
+    @public_html_route("/docs/web-search")
+    async def web_search_docs() -> str:
+        return public_page_html(settings, "docs/web-search")
+
     @public_html_route("/docs/mcp")
     async def mcp_docs() -> str:
         return public_page_html(settings, "docs/mcp")

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -199,6 +199,12 @@ class GatewayAuthorizeRequest(_Lenient):
     http_referer: str | None = Field(default=None, max_length=2048)
     app_categories: list[str] | None = None
     route_type: str | None = None
+    # Attested hosted tools may reserve a bounded non-token cost on the same
+    # atomic hold as their planner model call. This is internal-only and is
+    # currently accepted solely for the Responses web-search planner.
+    additional_cost_reservation_microdollars: int = Field(
+        default=0, ge=0, le=1_000_000
+    )
 
     @model_validator(mode="after")
     def key_identifier_required(self) -> GatewayAuthorizeRequest:
@@ -289,6 +295,7 @@ class GatewaySettleRequest(_Lenient):
     http_referer: str | None = Field(default=None, max_length=2048)
     app_categories: list[str] | None = None
     route_type: str | None = None
+    additional_cost_microdollars: int = Field(default=0, ge=0, le=1_000_000)
 
     @property
     def input_count(self) -> int:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -739,6 +739,7 @@ class InMemoryStore:
         idempotency_fingerprint: str | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
     ) -> GatewayAuthorization:
         return self.api_keys.create_gateway_authorization(
             workspace_id=workspace_id,
@@ -758,6 +759,7 @@ class InMemoryStore:
             idempotency_fingerprint=idempotency_fingerprint,
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
+            additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
         )
 
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None:

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1008,6 +1008,7 @@ class SpannerBigtableStore:
         idempotency_fingerprint: str | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
     ) -> GatewayAuthorization:
         return self.api_keys.create_gateway_authorization(
             workspace_id=workspace_id,
@@ -1027,6 +1028,7 @@ class SpannerBigtableStore:
             idempotency_fingerprint=idempotency_fingerprint,
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
+            additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
         )
 
     def get_gateway_authorization(
@@ -1160,6 +1162,7 @@ class SpannerBigtableStore:
         tags: dict[str, str] | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
         expires_at: Any = None,
         window_limits: dict[str, int] | None = None,
     ) -> tuple[str, GatewayAuthorization | None]:
@@ -1205,6 +1208,7 @@ class SpannerBigtableStore:
                 idempotency_fingerprint=idempotency_fingerprint,
                 custom_model_id=custom_model_id,
                 custom_model_revision=custom_model_revision,
+                additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
             )
             return _json_body(auth)
 

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -308,6 +308,7 @@ class SpannerApiKeys:
         idempotency_fingerprint: str | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
     ) -> GatewayAuthorization:
         existing = (
             self.get_gateway_authorization_by_idempotency_key(
@@ -337,6 +338,7 @@ class SpannerApiKeys:
             idempotency_fingerprint=idempotency_fingerprint,
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
+            additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
         )
         if idempotency_key is None:
             self._io.write_entity("gateway_authorization", auth.id, auth)

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -394,6 +394,7 @@ class InMemoryApiKeys:
         idempotency_fingerprint: str | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
     ) -> GatewayAuthorization:
         with self._lock:
             if idempotency_key is not None:
@@ -423,6 +424,7 @@ class InMemoryApiKeys:
                 idempotency_fingerprint=idempotency_fingerprint,
                 custom_model_id=custom_model_id,
                 custom_model_revision=custom_model_revision,
+                additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
             )
             self.gateway_authorizations[authorization.id] = authorization
             if idempotency_key is not None:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -322,6 +322,7 @@ class GatewayAuthorization:
     idempotency_fingerprint: str | None = None
     custom_model_id: str | None = None
     custom_model_revision: int | None = None
+    additional_cost_reservation_microdollars: int = 0
 
     def __post_init__(self) -> None:
         # JSON round-trip stores usage_type as a string; coerce so the field

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -362,6 +362,7 @@ class Store(Protocol):
         idempotency_fingerprint: str | None = ...,
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,
+        additional_cost_reservation_microdollars: int = ...,
     ) -> GatewayAuthorization: ...
     def get_gateway_authorization(
         self, authorization_id: str
@@ -516,6 +517,7 @@ class TypedBillingStore(Protocol):
         tags: dict[str, str] | None = ...,
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,
+        additional_cost_reservation_microdollars: int = ...,
         expires_at: Any = ...,
         window_limits: dict[str, int] | None = ...,
     ) -> tuple[str, GatewayAuthorization | None]: ...

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -41,6 +41,7 @@ const r = await client.chat.completions.create({
     <a class="marketing-card card-as-link" href="/docs/agent-setup#codex-skill"><h3>Agent skill</h3><p>Help Codex, Claude Code, Hermes, and other agents choose models using speed, cost, AI IQ, privacy, context length, and prompt-cache fit.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/migrate-from-openrouter"><h3>Migrate from OpenRouter</h3><p>Swap one base_url and keep your existing calls working.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/tagging"><h3>Request tagging</h3><p>Allocate cost and usage with AWS style tags while keeping metadata out of model prompts.</p><span class="card-link">Open →</span></a>
+    <a class="marketing-card card-as-link" href="/docs/web-search"><h3>Responses web search</h3><p>Search the live web inside the attested gateway and return source citations through the OpenAI Responses API.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/evals"><h3>Evals</h3><p>Run eval suites across providers through one API.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/synth"><h3>Synth</h3><p>Run Iris, Prometheus, Zeus, and code-tuned Synth presets inside the attested gateway.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/agent-setup#socrates"><h3>Socrates</h3><p>Run the advisor preset, or configure the generic advisor primitive directly.</p><span class="card-link">Open →</span></a>
@@ -93,6 +94,7 @@ const r = await client.chat.completions.create({
         <li><a href="https://github.com/Lore-Hex/LLM-advisor">trustedrouter-model-advisor</a> — source repo and <a href="https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md">raw playbook</a> for agent installation</li>
         <li><a href="/docs/agent-setup#socrates">Socrates</a> — advisor orchestration guide</li>
         <li><a href="/docs/synth">/docs/synth</a> — Synth model panel guide</li>
+        <li><a href="/docs/web-search">/docs/web-search</a> — Responses API web search, citations, controls, and privacy boundaries</li>
         <li><a href="https://github.com/Lore-Hex/quill-router">GitHub</a> — source + issues</li>
         <li><a href="/openai-compatible-llm-api">OpenAI-compatible API</a> — SDK migration surface</li>
         <li><a href="/llm-provider-latency-benchmarks">Latency benchmarks</a> — measured provider data</li>

--- a/src/trusted_router/templates/public/web_search.html
+++ b/src/trusted_router/templates/public/web_search.html
@@ -1,0 +1,96 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Responses web search quickstart">
+  <div class="marketing-copy">
+    <span class="eyebrow">Attested hosted tool</span>
+    <h2>Search the live web through the Responses API.</h2>
+    <p>Add an OpenAI-compatible <code>web_search</code> tool. TrustedRouter asks the selected model for bounded search queries, calls Exa from inside the attested gateway, and returns cited source material without sending the original request body through the control plane.</p>
+    <ul class="check-list">
+      <li><code>web_search</code> and <code>web_search_preview</code></li>
+      <li>Non-streaming and Responses SSE lifecycle events</li>
+      <li>URL citation annotations and optional full source lists</li>
+      <li>At most three search calls per response</li>
+    </ul>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>OpenAI Python SDK</span><span>Responses</span></div>
+    <pre><code>from openai import OpenAI
+
+client = OpenAI(
+    api_key="sk-tr-v1-...",
+    base_url="{{ api_base_url }}"
+)
+
+response = client.responses.create(
+    model="anthropic/claude-sonnet-5",
+    input="What changed in Python this week? Cite sources.",
+    tools=[{
+        "type": "web_search",
+        "search_context_size": "medium"
+    }],
+    tool_choice="required",
+    include=["web_search_call.action.sources"],
+    store=False
+)
+
+print(response.output_text)</code></pre>
+  </div>
+</section>
+
+<section style="margin-top:48px">
+  <h2 class="section-center">Search controls</h2>
+  <div class="marketing-grid three">
+    <div class="marketing-card">
+      <span class="card-label">Context</span>
+      <h3>Bound the evidence.</h3>
+      <p>Set <code>search_context_size</code> to <code>low</code>, <code>medium</code>, or <code>high</code>. Larger contexts return more source material and can increase latency and model input cost.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Domains</span>
+      <h3>Constrain sources.</h3>
+      <p>Use <code>filters.allowed_domains</code> or <code>filters.blocked_domains</code>. A request may use one list, not both.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Location</span>
+      <h3>Localize results.</h3>
+      <p>Pass <code>user_location</code> with a two-letter country code. Precise city, region, and timezone controls are rejected until implemented.</p>
+    </div>
+  </div>
+</section>
+
+<section class="marketing-split" style="margin-top:48px">
+  <div class="marketing-copy">
+    <span class="eyebrow">Streaming</span>
+    <h2>Observe the search lifecycle.</h2>
+    <p>Streaming responses emit <code>response.web_search_call.in_progress</code>, <code>response.web_search_call.searching</code>, and <code>response.web_search_call.completed</code> before normal output text events and <code>response.completed</code>.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Source filter</span><span>JSON</span></div>
+    <pre><code>{
+  "type": "web_search",
+  "search_context_size": "low",
+  "filters": {
+    "allowed_domains": ["python.org", "github.com"]
+  },
+  "user_location": {
+    "type": "approximate",
+    "country": "US"
+  }
+}</code></pre>
+  </div>
+</section>
+
+<section class="quote-feature" style="margin-top:48px">
+  <div>
+    <span class="eyebrow">Privacy boundary</span>
+    <h2>Search is an explicit external disclosure.</h2>
+  </div>
+  <div>
+    <p>The model can derive search queries from your prompt. Exa receives those queries plus configured filters and returns results to the enclave. Exa does not receive the original request body directly, but generated queries can contain prompt-derived information.</p>
+    <p>TrustedRouter therefore rejects hosted web search on <code>trustedrouter/zdr</code>, <code>trustedrouter/e2e</code>, <code>trustedrouter/confidential</code>, and <code>trustedrouter/eu</code> routes until Exa has an approved compatible posture. Do not attach <code>web_search</code> to sensitive requests unless this disclosure is acceptable.</p>
+    <p><a class="btn" href="/legal/subprocessors">Review subprocessors</a> <a class="btn ghost" href="https://trust.trustedrouter.com">Verify the gateway</a></p>
+  </div>
+</section>
+
+{% endblock %}

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
@@ -439,6 +440,153 @@ def test_internal_gateway_authorize_and_settle_records_metadata(
     )
     assert repeat.status_code == 200
     assert repeat.json()["data"]["already_settled"] is True
+
+
+def test_web_search_additional_cost_is_reserved_and_settled_exactly_once(
+    user_headers: dict[str, str],
+    client,
+) -> None:
+    created = client.post("/v1/keys", headers=user_headers, json={"name": "web search"}).json()
+    key_hash = created["data"]["hash"]
+    workspace_id = created["data"]["workspace_id"]
+    reserve_microdollars = 300_000
+    actual_search_microdollars = 7_000
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key_hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 20,
+            "max_output_tokens": 4,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_reservation_microdollars": reserve_microdollars,
+            "idempotency_key": "web-search-cost-once",
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    auth_data = authorize.json()["data"]
+    authorization = STORE.get_gateway_authorization(auth_data["authorization_id"])
+    assert authorization is not None
+    assert authorization.additional_cost_reservation_microdollars == reserve_microdollars
+    assert auth_data["additional_cost_reservation_microdollars"] == reserve_microdollars
+    assert auth_data["estimated_cost_microdollars"] == authorization.estimated_microdollars
+    assert STORE.credit_money[workspace_id].reserved_microdollars == authorization.estimated_microdollars
+    assert all(route["usage_type"] == "Credits" for route in auth_data["route_candidates"])
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth_data["authorization_id"],
+            "actual_input_tokens": 20,
+            "actual_output_tokens": 2,
+            "request_id": "web-search-cost-once",
+            "route_type": "responses.web_search.planner",
+            "additional_cost_microdollars": actual_search_microdollars,
+            "elapsed_seconds": 0.5,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    settled_cost = settle.json()["data"]["cost_microdollars"]
+    generation = STORE.generation_store.generations[settle.json()["data"]["generation_id"]]
+    assert settled_cost == generation.total_cost_microdollars
+    assert settled_cost >= actual_search_microdollars
+    assert STORE.credit_money[workspace_id].reserved_microdollars == 0
+    assert STORE.credit_money[workspace_id].total_usage_microdollars == settled_cost
+
+    replay = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth_data["authorization_id"],
+            "actual_input_tokens": 20,
+            "actual_output_tokens": 2,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_microdollars": actual_search_microdollars,
+        },
+    )
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert STORE.credit_money[workspace_id].total_usage_microdollars == settled_cost
+
+
+def test_web_search_additional_cost_fails_closed_outside_authorized_bound(
+    user_headers: dict[str, str],
+    client,
+) -> None:
+    created = client.post("/v1/keys", headers=user_headers, json={"name": "bounded search"}).json()
+    key_hash = created["data"]["hash"]
+
+    wrong_route = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key_hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 20,
+            "max_output_tokens": 4,
+            "route_type": "chat.completions",
+            "additional_cost_reservation_microdollars": 10_000,
+        },
+    )
+    assert wrong_route.status_code == 400, wrong_route.text
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key_hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 20,
+            "max_output_tokens": 4,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_reservation_microdollars": 10_000,
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    auth_id = authorize.json()["data"]["authorization_id"]
+    over_settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth_id,
+            "actual_input_tokens": 20,
+            "actual_output_tokens": 2,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_microdollars": 10_001,
+        },
+    )
+    assert over_settle.status_code == 400, over_settle.text
+    authorization = STORE.get_gateway_authorization(auth_id)
+    assert authorization is not None and authorization.settled is False
+    assert not STORE.generation_store.generations
+
+
+@pytest.mark.parametrize(
+    "provider",
+    (
+        {"data_collection": "deny"},
+        {"jurisdiction": "eu"},
+    ),
+)
+def test_web_search_additional_cost_rejects_private_provider_filters(
+    user_headers: dict[str, str],
+    client,
+    provider: dict[str, str],
+) -> None:
+    created = client.post("/v1/keys", headers=user_headers, json={"name": "private search"}).json()
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": created["data"]["hash"],
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 20,
+            "max_output_tokens": 4,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_reservation_microdollars": 100_000,
+            "provider": provider,
+        },
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["message"] == (
+        "web_search is not available for this privacy tier"
+    )
 
 
 def test_internal_gateway_authorize_replays_same_idempotency_key_once(

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -244,7 +244,6 @@ def test_gateway_authorizes_custom_model_against_base_model_and_revision(
         "hidden_prompt": "hidden billing prompt",
         "revision": 1,
     }
-
     authorization = STORE.get_gateway_authorization(data["authorization_id"])
     assert authorization is not None
     assert authorization.custom_model_id == custom["id"]
@@ -287,6 +286,41 @@ def test_gateway_authorizes_custom_model_against_base_model_and_revision(
         },
     )
     assert replay.status_code == 409
+
+
+def test_web_search_rejects_custom_models_with_private_routing_bases(
+    client: TestClient,
+) -> None:
+    key = _create_key(client)
+    for index, base_model_id in enumerate(
+        (
+            "trustedrouter/zdr",
+            "trustedrouter/e2e",
+            "trustedrouter/confidential",
+            "trustedrouter/eu",
+        )
+    ):
+        custom = _create_custom_model(
+            client,
+            name=f"private search {index}",
+            base_model_id=base_model_id,
+            hidden_prompt="private instructions",
+        )
+        authorize = client.post(
+            "/v1/internal/gateway/authorize",
+            json={
+                "api_key_hash": key["hash"],
+                "model": custom["id"],
+                "estimated_input_tokens": 20,
+                "max_output_tokens": 4,
+                "route_type": "responses.web_search.planner",
+                "additional_cost_reservation_microdollars": 100_000,
+            },
+        )
+        assert authorize.status_code == 400, (base_model_id, authorize.text)
+        assert authorize.json()["error"]["message"] == (
+            "web_search is not available for this privacy tier"
+        )
 
 
 def test_gateway_custom_models_are_credits_only_even_when_base_supports_byok(

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -69,6 +69,73 @@ def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() 
     assert ("reservation", data["credit_reservation_id"]) not in db.rows
 
 
+def test_gateway_web_search_cost_uses_typed_reservation_and_finalize() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_gcp_web_search_cost"
+    store._write_entity("workspace", ws, Workspace(id=ws, name="GCP", owner_user_id="u"))
+    store._write_entity("credit", ws, CreditAccount(workspace_id=ws))
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws,
+        "shard": 0,
+        "total_credits": 10_000_000,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    _raw, api_key = store.create_api_key(
+        workspace_id=ws,
+        name="typed web search",
+        creator_user_id="u",
+    )
+    configure_store(store)
+    client = TestClient(
+        create_app(
+            Settings(environment="test"),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 20,
+            "max_output_tokens": 4,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_reservation_microdollars": 300_000,
+            "idempotency_key": "typed-web-search",
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    auth_data = authorize.json()["data"]
+    authorization = store.get_gateway_authorization(auth_data["authorization_id"])
+    assert authorization is not None
+    assert authorization.additional_cost_reservation_microdollars == 300_000
+    reservation = db.reservations[auth_data["credit_reservation_id"]]
+    assert reservation["credit_reserved_micro"] == authorization.estimated_microdollars
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth_data["authorization_id"],
+            "actual_input_tokens": 20,
+            "actual_output_tokens": 2,
+            "route_type": "responses.web_search.planner",
+            "additional_cost_microdollars": 7_000,
+            "elapsed_seconds": 0.2,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    settled_cost = settle.json()["data"]["cost_microdollars"]
+    balance = db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]
+    assert balance["reserved"] == 0
+    assert balance["total_usage"] == settled_cost
+    assert settled_cost >= 7_000
+
+
 def test_gateway_authorizes_every_liberty_alias_to_working_nemotron_hosts() -> None:
     client, key = _client_and_key()
 

--- a/tests/test_web_search_docs.py
+++ b/tests/test_web_search_docs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_web_search_docs_publish_contract_and_privacy_boundary(client: TestClient) -> None:
+    response = client.get("/docs/web-search")
+
+    assert response.status_code == 200
+    assert '"type": "web_search"' in response.text
+    assert "response.web_search_call.completed" in response.text
+    assert "web_search_call.action.sources" in response.text
+    assert "Exa receives those queries" in response.text
+    assert "trustedrouter/zdr" in response.text
+    assert "trustedrouter/e2e" in response.text
+
+
+def test_web_search_docs_are_discoverable(client: TestClient) -> None:
+    assert 'href="/docs/web-search"' in client.get("/docs").text
+    assert "/docs/web-search" in client.get("/docs/llms.txt").text
+    assert "/docs/web-search" in client.get("/docs/llms-full.txt").text
+    assert (
+        "<loc>https://trustedrouter.com/docs/web-search</loc>"
+        in client.get("/sitemap-core.xml").text
+    )
+
+
+def test_exa_is_disclosed_as_a_system_subprocessor(client: TestClient) -> None:
+    response = client.get("/legal/subprocessors.json")
+
+    assert response.status_code == 200
+    exa = next(item for item in response.json()["system_subprocessors"] if item["name"] == "Exa")
+    assert "model-generated search query" in exa["data_access"]
+    assert "blocked on ZDR, E2E/confidential, and EU" in exa["data_access"]
+    assert exa["policy_url"] == "https://exa.ai/privacy"


### PR DESCRIPTION
## Summary
- publish an OpenAI Responses web-search guide with controls, citations, streaming events, and privacy limits
- disclose Exa in the public subprocessor packet before enabling hosted search
- reserve a bounded Exa cost on the planner authorization and settle the exact provider-reported integer microdollar amount
- force hosted search onto Credits routes and reject ZDR, E2E, confidential, EU, and equivalent provider filters
- preserve legacy idempotency fingerprints when hosted-tool billing is unused
- expose the reservation echo required by the enclave mixed-version fail-closed gate

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 1676 passed, 33 skipped
- focused in-memory and fake-Spanner exact-once billing tests
- privacy and legacy-idempotency regression tests