### PR TITLE
catalog: quarantine atlas-cloud router-not-found openai/* phantoms (#244 onboarding)

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -115,6 +115,63 @@ _AUTHOR_TO_PROVIDER_SLUG: dict[str, str] = {
 }
 
 _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
+    # atlas-cloud (onboarded #244) advertises these openai/* models but its
+    # router returns HTTP 400 "router not found" — 100% synthetic failure / 0
+    # success as of 2026-07-20. Provider-scoped: the same model ids on
+    # first-party OpenAI and other providers are unaffected, and atlas-cloud's
+    # open-weight catalog plus the six openai models it actually serves
+    # (gpt-4.1-mini, gpt-5.4-mini, gpt-5.5, gpt-5.6-luna, gpt-5.6-sol,
+    # gpt-5.6-terra) remain routable.
+    "atlas-cloud": frozenset(
+        {
+            "openai/gpt-4.1",
+            "gpt-4.1",
+            "openai/gpt-4.1-nano",
+            "gpt-4.1-nano",
+            "openai/gpt-4o",
+            "gpt-4o",
+            "openai/gpt-4o-mini",
+            "gpt-4o-mini",
+            "openai/gpt-5",
+            "gpt-5",
+            "openai/gpt-5-chat",
+            "gpt-5-chat",
+            "openai/gpt-5-codex",
+            "gpt-5-codex",
+            "openai/gpt-5-mini",
+            "gpt-5-mini",
+            "openai/gpt-5-nano",
+            "gpt-5-nano",
+            "openai/gpt-5-pro",
+            "gpt-5-pro",
+            "openai/gpt-5.1",
+            "gpt-5.1",
+            "openai/gpt-5.1-chat",
+            "gpt-5.1-chat",
+            "openai/gpt-5.1-codex",
+            "gpt-5.1-codex",
+            "openai/gpt-5.1-codex-mini",
+            "gpt-5.1-codex-mini",
+            "openai/gpt-5.2",
+            "gpt-5.2",
+            "openai/gpt-5.2-chat",
+            "gpt-5.2-chat",
+            "openai/gpt-5.2-codex",
+            "gpt-5.2-codex",
+            "openai/gpt-5.3-codex",
+            "gpt-5.3-codex",
+            "openai/o1",
+            "o1",
+            "openai/o3",
+            "o3",
+            "openai/o3-mini",
+            "o3-mini",
+            "openai/o3-pro",
+            "o3-pro",
+            "openai/o4-mini",
+            "o4-mini",
+        }
+    ),
     # Xiaomi retired the MiMo V2 family upstream on 2026-06-29; these manifest
     # rows are historical fallback metadata and have shown 100% probe failure
     # since 2026-06-29. Keep provider-scoped: V2.5 Xiaomi routes remain alive.

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -553,6 +553,12 @@ def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
         ("kimi", "moonshotai/kimi-k2-thinking"),
         ("mistral", "mistralai/mixtral-8x22b-instruct"),
         ("lightning", "openai/gpt-5-mini"),
+        # atlas-cloud (#244) advertises these openai/* models but its router
+        # returns 400 "router not found"; provider-scoped quarantine.
+        ("atlas-cloud", "openai/gpt-4.1"),
+        ("atlas-cloud", "openai/gpt-4o"),
+        ("atlas-cloud", "openai/gpt-5.1-codex"),
+        ("atlas-cloud", "openai/o3-pro"),
     ]
 
     for provider, model_id in quarantined_routes:
@@ -561,6 +567,16 @@ def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
             for endpoint in MODEL_ENDPOINTS.values()
             if endpoint.provider == provider and endpoint.model_id == model_id
         ], f"{provider}/{model_id} should be quarantined"
+
+    # atlas-cloud's healthy openai routes must stay live — only the
+    # router-not-found phantoms are quarantined, not the whole openai namespace.
+    for kept_model in ("openai/gpt-4.1-mini", "openai/gpt-5.5", "openai/gpt-5.6-sol"):
+        assert [
+            endpoint
+            for endpoint in MODEL_ENDPOINTS.values()
+            if endpoint.provider == "atlas-cloud"
+            and endpoint.model_id == kept_model
+        ], f"atlas-cloud/{kept_model} should remain routable"
 
     assert "anthropic/claude-fable-5@anthropic/prepaid" in MODEL_ENDPOINTS
     # Policy (2026-07-18): Anthropic-authored models route via Anthropic only


### PR DESCRIPTION
## What
Provider-scoped quarantine of 23 `atlas-cloud` `openai/*` routes that return HTTP 400 `router not found`.

## Why
The newly-onboarded `atlas-cloud` provider (#244) advertises ~30 `openai/*` models, but its router only serves a handful. The rest 400 with `model[openai/...] router not found` — 100% synthetic failure / 0 success (verified via live Bigtable synthetic health, 2026-07-20). These are dead routes real callers can't use either; they were tripping route-health Sentry alerts (QUILL-ROUTER-3M/3N and ~12 more about to cross the sample gate).

## Scope (evidence-based)
- **Quarantined (23, observed dead):** gpt-4.1, gpt-4.1-nano, gpt-4o, gpt-4o-mini, gpt-5, gpt-5-chat, gpt-5-codex, gpt-5-mini, gpt-5-nano, gpt-5-pro, gpt-5.1, gpt-5.1-chat, gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.2, gpt-5.2-chat, gpt-5.2-codex, gpt-5.3-codex, o1, o3, o3-mini, o3-pro, o4-mini
- **Kept (healthy, succ>0):** gpt-4.1-mini, gpt-5.4-mini, gpt-5.5, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra — plus all of atlas-cloud's open-weight catalog (unaffected).
- **Watch-item:** `openai/gpt-5.1-codex-max` left in — no synthetic samples yet, so not quarantined without evidence (same discipline as the gemini fix). Will add if it alerts.

Provider-scoped: identical model ids on first-party OpenAI / other providers are untouched. Verified post-change: atlas-cloud openai endpoints drop 30 → 7.

## Tests
Extended `test_provider_deprecated_models_have_no_catalog_endpoints` with the atlas-cloud dead routes + positive assertions that the healthy ones remain. `ruff check` clean; 100 catalog tests pass.

## Note
Authored directly (codex-cli is at its usage limit until Jul 24); self-reviewed, CI-gated. Merging redeploys the synthetic monitor (path filter matches `src/trusted_router/`), after which I'll resolve the atlas-cloud route-health issues.