### PR TITLE
Handle Together MiniMax M2.7 retirement

### DIFF
--- a/scripts/pricing/providers/together.py
+++ b/scripts/pricing/providers/together.py
@@ -35,6 +35,7 @@ URL = "https://api.together.xyz/v1/models"
 # silently deleting the endpoint from the catalog.
 EXPECTED_MODELS = [
     "meta-llama/llama-3.3-70b-instruct",
+    "minimax/minimax-m3",
     "z-ai/glm-5.2",
 ]
 
@@ -59,6 +60,8 @@ _NATIVE_TO_OR_ID = {
     "moonshotai/Kimi-K2.6": "moonshotai/kimi-k2.6",
     "moonshotai/Kimi-K2-Instruct": "moonshotai/kimi-k2-instruct",
     "moonshotai/Kimi-K2.5": "moonshotai/kimi-k2.5",
+    "MiniMaxAI/MiniMax-M2.7": "minimax/minimax-m2.7",
+    "MiniMaxAI/MiniMax-M3": "minimax/minimax-m3",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
 }
 

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -57,6 +57,8 @@ from scripts.pricing.base import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ingest_openrouter_catalog import build_snapshot as build_openrouter_snapshot  # noqa: E402
 
+from trusted_router.provider_lifecycle import provider_model_retired  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SNAPSHOT_PATH = REPO_ROOT / "src" / "trusted_router" / "data" / "openrouter_snapshot.json"
 
@@ -257,12 +259,25 @@ def _index_provider_prices(
     {model_id: {slug: price, slug2: price2, ...}}. A single model can be
     served by multiple keyed providers (e.g. meta-llama/llama-3.1-8b is
     on Cerebras AND Novita; moonshotai/kimi-k2.6 is on Kimi-direct AND
-    Together) — each gets its own provider-direct price for billing."""
+    Together) — each gets its own provider-direct price for billing. Effective-
+    dated provider retirements are filtered here so neither a fresh API result
+    nor a stale snapshot fallback can reintroduce a retired route."""
     out: dict[str, dict[str, ModelPrice]] = {}
+    upstream_id_maps: dict[str, dict[str, str]] = {}
     for slug, result in results.items():
         provider_slugs = _PRICING_RESULT_PROVIDER_ALIASES.get(slug, (slug,))
         for model_id, price in result.prices.items():
             for provider_slug in provider_slugs:
+                upstream_id_map = upstream_id_maps.get(provider_slug)
+                if upstream_id_map is None:
+                    upstream_id_map = _upstream_id_map_for(provider_slug)
+                    upstream_id_maps[provider_slug] = upstream_id_map
+                if provider_model_retired(
+                    provider_slug,
+                    model_id,
+                    upstream_id_map.get(model_id),
+                ):
+                    continue
                 out.setdefault(model_id, {})[provider_slug] = price
     return out
 

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -338,7 +338,6 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "qwen/qwen2.5-vl-72b-instruct",
             "mistralai/mistral-small-24b-instruct-2501",
             "moonshotai/kimi-k2.7-code",
-            "minimax/minimax-m3",
             # route-health 2026-07-18, 100% failure, upstream 404/400.
             "z-ai/glm-4.6",
             "z-ai/glm-4.7",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
+TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,15 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Together announced that its serverless MiniMax M2.7 route retires on
+    # 2026-07-27 and named MiniMax M3 as the replacement. The announcement did
+    # not include a time zone, so use 00:00 UTC as the conservative cutover.
+    _Retirement(
+        provider="together",
+        model_ids=frozenset({"minimax/minimax-m2.7"}),
+        upstream_ids=frozenset({"MiniMaxAI/MiniMax-M2.7"}),
+        effective_at=TOGETHER_MINIMAX_M27_RETIREMENT_AT,
+    ),
     _Retirement(
         provider="phala",
         model_ids=frozenset(

--- a/tests/test_together_july_2026_lifecycle.py
+++ b/tests/test_together_july_2026_lifecycle.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import together
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
+_M27 = "minimax/minimax-m2.7"
+_M27_UPSTREAM = "MiniMaxAI/MiniMax-M2.7"
+_M3 = "minimax/minimax-m3"
+_M3_UPSTREAM = "MiniMaxAI/MiniMax-M3"
+
+
+def test_together_minimax_m27_retires_at_announced_date() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "together",
+        _M27,
+        _M27_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "together",
+        _M27,
+        _M27_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "together",
+        _M3,
+        _M3_UPSTREAM,
+        at=_CUTOFF,
+    )
+
+
+def test_together_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    m27_providers = {endpoint.provider for endpoint in endpoints_for_model(_M27)}
+    m3_providers = {endpoint.provider for endpoint in endpoints_for_model(_M3)}
+
+    assert "together" not in m27_providers
+    assert m27_providers
+    assert "together" in m3_providers
+
+
+def test_hourly_refresh_drops_retired_together_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="together",
+        prices={
+            _M27: ModelPrice(300_000, 1_200_000),
+            _M3: ModelPrice(300_000, 1_200_000),
+        },
+        source="api",
+        fetched_url=together.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"together": result})
+    assert "together" in before[_M27]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"together": result})
+    assert _M27 not in after
+    assert "together" in after[_M3]
+
+
+def test_together_parser_pins_replacement_and_retiring_native_ids() -> None:
+    assert together.UPSTREAM_ID_MAP[_M27] == _M27_UPSTREAM
+    assert together.UPSTREAM_ID_MAP[_M3] == _M3_UPSTREAM
+    assert _M3 in together.EXPECTED_MODELS


### PR DESCRIPTION
## Summary
- retire only Together MiniMax M2.7 at 2026-07-27 00:00 UTC while preserving other providers
- require and pin Together MiniMax M3 as the replacement route
- apply effective-dated retirements in the shared hourly provider-price index so fresh or stale feeds cannot resurrect retired routes
- restore Together M3 after a direct authenticated PONG smoke confirmed the earlier quarantine is stale

## Verification
- regression tests failed 4/4 before the implementation
- direct Together `MiniMaxAI/MiniMax-M3` smoke returned `PONG`
- `uv run ruff check ...`
- `uv run mypy`
- `uv run pytest -q` (1686 passed, 33 skipped)