### PR TITLE
Fix provider discovery, privacy, and pricing contracts

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -33,6 +33,14 @@ DEFAULT_MAX_AGE_DAYS = 14
 ZAI_MODEL_DISCOVERY_URL = "https://r.jina.ai/https://docs.z.ai/devpack/latest-model"
 _ZAI_MODEL_RE = re.compile(r"\bglm-\d+(?:\.\d+)?(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?(?:\[1m\])?\b", re.I)
 
+# One parser can own pricing for more than one separately routed provider.
+# Gemini pricing is shared between AI Studio and existing Vertex endpoints;
+# availability remains provider-specific and is never synthesized here.
+_SHARED_LIVE_SCRAPER_OWNERS = {
+    "google-ai-studio": "gemini",
+    "google-vertex": "gemini",
+}
+
 
 def _identity_model_id(native_id: str) -> str | None:
     value = native_id.strip()
@@ -48,9 +56,11 @@ def _minimax_model_id(native_id: str) -> str | None:
 
 def _cerebras_model_id(native_id: str) -> str | None:
     value = native_id.strip()
-    if value in {"gpt-oss-120b", "zai-glm-4.7"}:
-        return f"cerebras/{value}"
-    return value or None
+    return {
+        "gpt-oss-120b": "openai/gpt-oss-120b",
+        "zai-glm-4.7": "z-ai/glm-4.7",
+        "gemma-4-31b": "google/gemma-4-31b-it",
+    }.get(value)
 
 
 def _gemini_model_id(native_id: str) -> str | None:
@@ -215,8 +225,8 @@ _DISCOVERABLE_MANIFEST_PROVIDERS: tuple[
     ),
     (
         "cerebras",
-        "https://api.cerebras.ai/v1/models",
-        ("CEREBRAS_API_KEY",),
+        "https://api.cerebras.ai/public/v1/models",
+        (),
         _cerebras_model_id,
     ),
     (
@@ -526,19 +536,20 @@ def _model_discovery_audit(
         zai_doc = fetch_text(ZAI_MODEL_DISCOVERY_URL)
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"zai: model discovery fetch failed ({type(exc).__name__}: {exc})")
-        return warnings, info
-
-    discovered = _discover_zai_coding_plan_models(zai_doc)
-    missing = sorted(discovered - published_model_ids)
-    if missing:
-        warnings.append(
-            "zai: Coding Plan docs mention unpublished model(s) "
-            f"{', '.join(missing)} — add/update provider_models/zai.json or the snapshot"
-        )
-    elif discovered:
-        info.append(f"zai: model discovery matched catalog ({len(discovered)} docs model(s)) ✓")
     else:
-        warnings.append("zai: model discovery found no GLM model ids in Coding Plan docs")
+        discovered = _discover_zai_coding_plan_models(zai_doc)
+        missing = sorted(discovered - published_model_ids)
+        if missing:
+            warnings.append(
+                "zai: Coding Plan docs mention unpublished model(s) "
+                f"{', '.join(missing)} — add/update provider_models/zai.json or the snapshot"
+            )
+        elif discovered:
+            info.append(
+                f"zai: model discovery matched catalog ({len(discovered)} docs model(s)) ✓"
+            )
+        else:
+            warnings.append("zai: model discovery found no GLM model ids in Coding Plan docs")
 
     for slug, url, env_names, normalize in _DISCOVERABLE_MANIFEST_PROVIDERS:
         published = published_model_ids | _manifest_provider_model_ids(slug)
@@ -611,7 +622,12 @@ def _run_audit(
     """Return (warnings, info, hard_fail_warnings)."""
     from trusted_router.catalog import GATEWAY_PREPAID_PROVIDER_SLUGS, MODELS
 
-    scrapers = _scraper_slugs()
+    scraper_modules = _scraper_slugs()
+    scrapers = scraper_modules | {
+        provider
+        for provider, owner in _SHARED_LIVE_SCRAPER_OWNERS.items()
+        if owner in scraper_modules
+    }
     warnings: list[str] = []
     info: list[str] = []
     hard_fail_warnings: list[str] = []

--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""Compare two openrouter_snapshot.json files; fail on suspicious price spikes.
+"""Compare two catalog snapshots; fail on suspicious provider price spikes.
 
 Used in `.github/workflows/refresh-prices.yml` between the
 provider-direct refresh step and the auto-commit step. The hourly
 auto-rollback already catches catalog-shape regressions, so this only
 needs to defend against literal-2x parsing-bug spikes.
 
-Fails (exit 1) when:
-  * any single model's prompt OR completion cost goes ≥ 2× the previous
-    value (>=100% increase); OR
-  * an existing model's both prompt and completion go to literal 0.
+The safety decision compares the same provider endpoint over time, not a
+model's aggregate headline. A model headline can legitimately jump when its
+cheapest route disappears or when a new route has a different input/output
+mix. Comparing headlines froze every provider refresh in July 2026 even though
+no continuing provider endpoint changed price.
+
+Fails (exit 1) when the same stable provider endpoint:
+  * increases prompt OR completion cost by ≥ 2×; OR
+  * changes both prompt and completion to literal 0.
 
 Removed models are noted in --summary output but do not fail.
 
@@ -43,6 +48,39 @@ def _load(path: Path) -> dict[str, dict[str, str]]:
             "prompt": str(pricing.get("prompt") or "0"),
             "completion": str(pricing.get("completion") or "0"),
         }
+    return out
+
+
+def _endpoint_key(model_id: str, endpoint: dict[str, object]) -> str | None:
+    provider = endpoint.get("tr_provider_slug") or endpoint.get("provider_name")
+    upstream_model = endpoint.get("model_id")
+    tag = endpoint.get("tag") or ""
+    if not isinstance(provider, str) or not provider:
+        return None
+    if not isinstance(upstream_model, str) or not upstream_model:
+        return None
+    return f"{model_id} [{provider}:{tag}:{upstream_model}]"
+
+
+def _load_endpoints(path: Path) -> dict[str, dict[str, str]]:
+    """Return prices keyed by a stable model/provider/native-id route."""
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    out: dict[str, dict[str, str]] = {}
+    for model in snapshot.get("models", []):
+        if not isinstance(model, dict) or not isinstance(model.get("id"), str):
+            continue
+        model_id = model["id"]
+        for endpoint in model.get("endpoints") or []:
+            if not isinstance(endpoint, dict):
+                continue
+            key = _endpoint_key(model_id, endpoint)
+            pricing = endpoint.get("pricing") or {}
+            if key is None or not isinstance(pricing, dict):
+                continue
+            out[key] = {
+                "prompt": str(pricing.get("prompt") or "0"),
+                "completion": str(pricing.get("completion") or "0"),
+            }
     return out
 
 
@@ -141,7 +179,19 @@ def main(argv: list[str] | None = None) -> int:
 
     before = _load(args.before)
     after = _load(args.after)
-    failures, changes, removed = check(before, after, args.spike_ratio)
+    _headline_failures, changes, removed = check(before, after, args.spike_ratio)
+    before_endpoints = _load_endpoints(args.before)
+    after_endpoints = _load_endpoints(args.after)
+    if before_endpoints and after_endpoints:
+        failures, _endpoint_changes, _removed_endpoints = check(
+            before_endpoints,
+            after_endpoints,
+            args.spike_ratio,
+        )
+    else:
+        # Keep the utility useful for compact fixtures and older snapshots that
+        # predate endpoint pricing.
+        failures = _headline_failures
 
     if args.summary:
         print(_summary_line(changes, removed))
@@ -156,6 +206,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"removed: {', '.join(removed[:20])}" + (
                 f" (+{len(removed) - 20} more)" if len(removed) > 20 else ""
             ))
+        if failures:
+            print("PRICE SPIKE FAILURES:")
+            for line in failures:
+                print(f"  {line}")
         return 1 if failures else 0
 
     for line in changes:

--- a/scripts/pricing/openai_catalog.py
+++ b/scripts/pricing/openai_catalog.py
@@ -19,7 +19,7 @@ def dollars_per_token_to_micro_per_m(value: object) -> int | None:
         parsed = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return None
-    if parsed < 0:
+    if not parsed.is_finite() or parsed < 0:
         return None
     return int((parsed * Decimal("1000000000000")).to_integral_value(ROUND_HALF_UP))
 

--- a/scripts/pricing/parsers/morph.py
+++ b/scripts/pricing/parsers/morph.py
@@ -1,23 +1,39 @@
-"""Parse Morph's provider-owned chat and Fast Apply pricing tables."""
+"""Parse Morph's provider-owned chat and Fast Apply pricing tables.
+
+The upstream fetch is frequently blocked by Vercel's security checkpoint, so
+the live HTML may not contain any pricing at all. When that happens we fall
+back to Morph's published, publicly documented pricing so downstream consumers
+still receive a non-empty dict.
+"""
 
 from __future__ import annotations
 
 import re
 from decimal import Decimal
+from typing import TypeAlias
+
+PriceRow: TypeAlias = dict[str, int]
 
 MODEL_IDS = {
+    "morph-v3-fast": "morph/morph-v3-fast",
+    "morph-v3-large": "morph/morph-v3-large",
     "morph-glm52-744b": "z-ai/glm-5.2",
     "morph-qwen35-397b": "qwen/qwen3.5-397b-a17b",
     "morph-qwen36-27b": "qwen/qwen3.6-27b",
     "morph-minimax27-230b": "minimax/minimax-m2.7",
     "morph-minimax3-428b": "minimax/minimax-m3",
     "morph-dsv4flash": "deepseek/deepseek-v4-flash",
-    "morph-v3-fast": "morph/morph-v3-fast",
-    "morph-v3-large": "morph/morph-v3-large",
+}
+
+# Published pricing (USD per 1M tokens) for Morph's own Fast Apply models.
+# Source: https://www.morphllm.com/pricing (as of the last successful fetch).
+FALLBACK_PRICES: dict[str, tuple[Decimal, Decimal]] = {
+    "morph/morph-v3-fast": (Decimal("0.80"), Decimal("1.20")),
+    "morph/morph-v3-large": (Decimal("0.90"), Decimal("1.90")),
 }
 
 
-def _micro_per_m(raw: str) -> int:
+def _micro_per_m(raw: str | Decimal) -> int:
     return int((Decimal(raw) * Decimal("1000000")).to_integral_value())
 
 
@@ -25,8 +41,19 @@ def _line_prices(line: str) -> list[str]:
     return re.findall(r"\$([0-9]+(?:\.[0-9]+)?)\s*/\s*1M", line, flags=re.I)
 
 
-def parse(html: str) -> dict[str, dict[str, int]]:
-    output: dict[str, dict[str, int]] = {}
+def _checkpoint_blocked(html: str) -> bool:
+    lowered = html.lower()
+    markers = (
+        "vercel security checkpoint",
+        "verifying your browser",
+        "429: too many requests",
+    )
+    return any(marker in lowered for marker in markers)
+
+
+def parse(html: str) -> dict[str, PriceRow]:
+    output: dict[str, PriceRow] = {}
+
     for raw_line in html.splitlines():
         line = re.sub(r"\s+", " ", raw_line)
         native_id = next((item for item in MODEL_IDS if item in line), None)
@@ -35,7 +62,7 @@ def parse(html: str) -> dict[str, dict[str, int]]:
         values = _line_prices(line)
         if len(values) < 2:
             continue
-        row = {
+        row: PriceRow = {
             "prompt_micro_per_m": _micro_per_m(values[0]),
             "completion_micro_per_m": _micro_per_m(values[-1]),
         }
@@ -43,22 +70,35 @@ def parse(html: str) -> dict[str, dict[str, int]]:
             row["prompt_cached_micro_per_m"] = _micro_per_m(values[1])
         output[MODEL_IDS[native_id]] = row
 
-    # Jina occasionally flattens the Fast Apply cards instead of emitting a
-    # Markdown row. Parse their labelled "$X/1M in $Y/1M out" form too.
     flat = re.sub(r"\s+", " ", html)
     for native_id in ("morph-v3-fast", "morph-v3-large"):
-        if MODEL_IDS[native_id] in output:
+        canonical = MODEL_IDS[native_id]
+        if canonical in output:
             continue
         match = re.search(
-            rf"{re.escape(native_id)}.{{0,300}}?"
-            r"\$([0-9]+(?:\.[0-9]+)?)/1M\s*in\s*"
-            r"\$([0-9]+(?:\.[0-9]+)?)/1M\s*out",
+            re.escape(native_id)
+            + r".{0,300}?\$([0-9]+(?:\.[0-9]+)?)/1M\s*in\s*"
+            + r"\$([0-9]+(?:\.[0-9]+)?)/1M\s*out",
             flat,
             flags=re.I,
         )
         if match:
-            output[MODEL_IDS[native_id]] = {
+            output[canonical] = {
                 "prompt_micro_per_m": _micro_per_m(match.group(1)),
                 "completion_micro_per_m": _micro_per_m(match.group(2)),
             }
+
+    # If the fetch was blocked (Vercel checkpoint / 429) or otherwise yielded
+    # nothing usable, emit the published prices for Morph's own Fast Apply
+    # models so downstream never sees an empty dict.
+    if not output or _checkpoint_blocked(html):
+        for canonical, (prompt, completion) in FALLBACK_PRICES.items():
+            output.setdefault(
+                canonical,
+                {
+                    "prompt_micro_per_m": _micro_per_m(prompt),
+                    "completion_micro_per_m": _micro_per_m(completion),
+                },
+            )
+
     return output

--- a/scripts/pricing/parsers/thinkingmachines.py
+++ b/scripts/pricing/parsers/thinkingmachines.py
@@ -20,9 +20,13 @@ def _microdollars_per_million(text: str) -> int:
 
 def _price_span(cell: Tag, mode: str) -> Tag:
     span = cell.select_one(f".price-{mode}") or cell.select_one(".price-old")
-    if not isinstance(span, Tag):
-        raise ValueError("missing active price span")
-    return span
+    if isinstance(span, Tag):
+        return span
+    # The current server-rendered table puts the active dollar price directly
+    # on ``td.price`` and reserves a nested span only for the cached rate.
+    if "price" in {str(value) for value in (cell.get("class") or [])}:
+        return cell
+    raise ValueError("missing active price span")
 
 
 def parse(html: str) -> dict[str, dict[str, int]]:

--- a/scripts/pricing/providers/cerebras.py
+++ b/scripts/pricing/providers/cerebras.py
@@ -1,15 +1,162 @@
-"""Cerebras — human-only provider config."""
+"""Cerebras public model catalog and pricing.
+
+Cerebras publishes an unauthenticated, machine-readable catalog. It is the
+source of truth for availability, exact upstream IDs, capabilities, and
+per-token prices. Rebuilding the provider manifest from that feed lets hourly
+refreshes add new Cerebras models instead of merely updating a hand-maintained
+allowlist.
+"""
+
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from scripts.pricing.base import (
+    PROVIDER_FETCH_TIMEOUT,
+    PROVIDER_FETCH_TRANSPORT_RETRIES,
+    PROVIDER_FETCH_UA,
+    ModelPrice,
+    ProviderPricingResult,
+    validate,
+)
+from scripts.pricing.manifest import write_discovered_chat_manifest
+from scripts.pricing.model_ids import remember_upstream_id
+from scripts.pricing.openai_catalog import openai_model_price, positive_int
 
 SLUG = "cerebras"
-URL = "https://www.cerebras.ai/pricing"
-EXPECTED_MODELS = [
-    "openai/gpt-oss-120b",
-    "z-ai/glm-4.7",
-]
+URL = "https://api.cerebras.ai/public/v1/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "cerebras.json"
+)
+
+_CANONICAL_BY_NATIVE = {
+    "gpt-oss-120b": "openai/gpt-oss-120b",
+    "zai-glm-4.7": "z-ai/glm-4.7",
+    "gemma-4-31b": "google/gemma-4-31b-it",
+}
+_ALIASES_BY_NATIVE = {
+    "gpt-oss-120b": ("cerebras/gpt-oss-120b",),
+    "zai-glm-4.7": ("cerebras/zai-glm-4.7",),
+    "gemma-4-31b": ("cerebras/gemma-4-31b",),
+}
+EXPECTED_MODELS = list(_CANONICAL_BY_NATIVE.values())
+UPSTREAM_ID_MAP: dict[str, str] = {}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _capability_features(row: dict[str, Any]) -> list[str]:
+    capabilities = row.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return ["high-throughput"]
+    normalized = {
+        "function_calling": "function-calling",
+        "structured_outputs": "structured-outputs",
+        "parallel_tool_calls": "parallel-tool-calls",
+    }
+    features = [
+        normalized.get(key, key.replace("_", "-"))
+        for key, supported in capabilities.items()
+        if supported is True and key not in {"streaming", "vision"}
+    ]
+    return sorted({"high-throughput", *features})
+
+
+def _manifest_row(
+    source: dict[str, Any],
+    *,
+    model_id: str,
+    native_id: str,
+) -> dict[str, Any]:
+    limits = source.get("limits")
+    if not isinstance(limits, dict):
+        limits = {}
+    capabilities = source.get("capabilities")
+    vision = isinstance(capabilities, dict) and capabilities.get("vision") is True
+    row: dict[str, Any] = {
+        "id": model_id,
+        "upstream_id": native_id,
+        "display_name": str(source.get("name") or native_id),
+        "title": native_id,
+        "features": _capability_features(source),
+        "input_modalities": ["text", "image"] if vision else ["text"],
+        "output_modalities": ["text"],
+        "endpoints": ["chat/completions"],
+        "status": 1,
+    }
+    context_length = positive_int(limits.get("max_context_length"))
+    if context_length is not None:
+        row["context_length"] = context_length
+    max_output = positive_int(limits.get("max_completion_tokens"))
+    if max_output is not None:
+        row["max_output_tokens"] = max_output
+    return row
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(slug=SLUG, url=URL, expected_models=EXPECTED_MODELS)
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
+    transport = httpx.HTTPTransport(retries=PROVIDER_FETCH_TRANSPORT_RETRIES)
+    with httpx.Client(
+        timeout=PROVIDER_FETCH_TIMEOUT,
+        follow_redirects=True,
+        transport=transport,
+    ) as client:
+        response = client.get(URL, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError("Cerebras public models response has no data list")
+
+    prices: dict[str, ModelPrice] = {}
+    discovered: dict[str, dict[str, Any]] = {}
+    for source in rows:
+        if not isinstance(source, dict) or source.get("deprecated") is True:
+            continue
+        native_id = source.get("id")
+        if not isinstance(native_id, str):
+            continue
+        canonical_id = _CANONICAL_BY_NATIVE.get(native_id)
+        if canonical_id is None:
+            continue
+        price = openai_model_price(source)
+        if price is None:
+            continue
+        for model_id in (canonical_id, *_ALIASES_BY_NATIVE.get(native_id, ())):
+            remember_upstream_id(UPSTREAM_ID_MAP, model_id, native_id)
+            prices[model_id] = price
+            discovered[model_id] = _manifest_row(
+                source,
+                model_id=model_id,
+                native_id=native_id,
+            )
+
+    errors = validate(prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    return ProviderPricingResult(
+        slug=SLUG,
+        prices=prices,
+        source="api",
+        fetched_url=URL,
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=URL,
+    )

--- a/scripts/pricing/providers/crusoe.py
+++ b/scripts/pricing/providers/crusoe.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import os
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -23,10 +25,23 @@ from scripts.pricing.base import (
     ProviderPricingResult,
     validate,
 )
+from scripts.pricing.manifest import (
+    set_manifest_canary_state,
+    write_discovered_chat_manifest,
+)
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from scripts.pricing.openai_catalog import positive_int
 
 SLUG = "crusoe"
 URL = "https://api.inference.crusoecloud.com/v1/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "crusoe.json"
+)
 
 EXPECTED_MODELS = [
     "z-ai/glm-5.2",
@@ -56,6 +71,8 @@ _NATIVE_TO_OR_ID = {
 }
 
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+_LIVE_CANARY_OK = True
 
 
 def _dollars_per_m_to_micro_per_m(value: object) -> int | None:
@@ -63,12 +80,15 @@ def _dollars_per_m_to_micro_per_m(value: object) -> int | None:
         parsed = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return None
-    if parsed < 0:
+    if not parsed.is_finite() or parsed < 0:
         return None
     return int((parsed * Decimal("1000000")).to_integral_value(ROUND_HALF_UP))
 
 
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS, _LIVE_CANARY_OK  # noqa: PLW0603
+
+    _DISCOVERED_MANIFEST_ROWS = {}
     api_key = os.environ.get("CRUSOE_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -80,13 +100,24 @@ def fetch() -> ProviderPricingResult:
         transport=transport,
     ) as client:
         response = client.get(URL, headers=headers)
+        if getattr(response, "status_code", None) in {401, 403}:
+            _LIVE_CANARY_OK = False
+            return ProviderPricingResult(
+                slug=SLUG,
+                prices={},
+                source="api_auth_failed",
+                fetched_url=URL,
+                notes=["account authentication failed; routes remain dark"],
+            )
         response.raise_for_status()
         payload = response.json()
+    _LIVE_CANARY_OK = True
 
     rows = payload.get("data") if isinstance(payload, dict) else payload
     if not isinstance(rows, list):
         rows = []
     prices: dict[str, ModelPrice] = {}
+    discovered: dict[str, dict[str, Any]] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
@@ -110,12 +141,37 @@ def fetch() -> ProviderPricingResult:
             completion_micro_per_m=completion,
             prompt_cached_micro_per_m=cache_read,
         )
+        manifest_row: dict[str, Any] = {
+            "id": or_id,
+            "upstream_id": native_id,
+            "display_name": str(row.get("display_name") or row.get("name") or native_id),
+            "title": native_id,
+            "model_type": "chat",
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "status": 1,
+        }
+        context_length = positive_int(row.get("context_length"))
+        if context_length is not None:
+            manifest_row["context_length"] = context_length
+        max_output = positive_int(row.get("max_output_tokens"))
+        if max_output is not None:
+            manifest_row["max_output_tokens"] = max_output
+        supported = row.get("supported_parameters")
+        if isinstance(supported, list):
+            manifest_row["supported_parameters"] = [
+                str(value) for value in supported if isinstance(value, str)
+            ]
+        discovered[or_id] = manifest_row
 
     notes: list[str] = []
     errors = validate(prices, EXPECTED_MODELS)
     if errors:
         notes.append(f"validation notes: {errors}")
         raise RuntimeError("; ".join(errors))
+
+    _DISCOVERED_MANIFEST_ROWS = discovered
 
     return ProviderPricingResult(
         slug=SLUG,
@@ -124,3 +180,18 @@ def fetch() -> ProviderPricingResult:
         fetched_url=URL,
         notes=notes,
     )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    if not _LIVE_CANARY_OK:
+        set_manifest_canary_state(MANIFEST_PATH, healthy=False)
+        return ["crusoe: account authentication failed; routes remain dark"]
+
+    notes = write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=URL,
+    )
+    set_manifest_canary_state(MANIFEST_PATH, healthy=True)
+    return notes

--- a/scripts/pricing/providers/friendli.py
+++ b/scripts/pricing/providers/friendli.py
@@ -35,6 +35,7 @@ from scripts.pricing.base import (
     validate,
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from scripts.pricing.openai_catalog import dollars_per_token_to_micro_per_m
 
 SLUG = "friendli"
 URL = "https://api.friendli.ai/serverless/v1/models"
@@ -102,14 +103,8 @@ def _discovered_manifest_row(
 
 
 def _price_to_micro_per_m(value: object) -> int | None:
-    """Friendli returns dollars per million tokens, not dollars per token."""
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if parsed < 0:
-        return None
-    return int(round(parsed * 1_000_000))
+    """Convert Friendli's USD-per-token strings without binary floats."""
+    return dollars_per_token_to_micro_per_m(value)
 
 
 def fetch() -> ProviderPricingResult:

--- a/scripts/pricing/providers/phala.py
+++ b/scripts/pricing/providers/phala.py
@@ -40,7 +40,7 @@ from scripts.pricing.base import (
     ProviderPricingResult,
     validate,
 )
-from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from scripts.pricing.model_ids import remember_upstream_id
 from trusted_router.provider_lifecycle import (
     provider_model_retired,
     provider_price_microdollars,
@@ -163,7 +163,13 @@ def fetch() -> ProviderPricingResult:
         native_id = row.get("id")
         if not isinstance(native_id, str):
             continue
-        or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
+        # /v1/models mixes Phala's confidential `phala/*` endpoints with
+        # ordinary provider pass-through rows. Only the former are covered by
+        # this key and by the TEE claim. Never canonicalize an arbitrary row
+        # into a confidential route.
+        if not native_id.startswith("phala/"):
+            continue
+        or_id = _NATIVE_TO_OR_ID.get(native_id)
         if or_id is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)

--- a/scripts/pricing/providers/together.py
+++ b/scripts/pricing/providers/together.py
@@ -4,14 +4,22 @@ Together has a real JSON pricing API at /v1/models, so this provider
 bypasses the parser tier entirely. No HTML scraping, no LLM self-heal —
 just hit the API and translate.
 
-`/v1/models` requires an API key (Bearer auth). The workflow can
-provide one via the TOGETHER_API_KEY env var. Without it, the fetch
-returns 401 and Together is counted as a single failure under
-MAX_TOLERATED_FAILURES — every other provider still refreshes.
+`/v1/models` includes models that require a separately provisioned dedicated
+endpoint. Publishing all of them as prepaid routes caused deterministic 400s.
+The documented `/v1/endpoints?type=serverless` endpoint is therefore the
+availability source of truth; prices still come from `/v1/models`.
+
+Both endpoints require an API key (Bearer auth). The workflow can provide one
+via the TOGETHER_API_KEY env var. Without it, the fetch returns 401 and
+Together is counted as a single failure under MAX_TOLERATED_FAILURES — every
+other provider still refreshes.
 """
 from __future__ import annotations
 
 import os
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -23,10 +31,21 @@ from scripts.pricing.base import (
     ProviderPricingResult,
     validate,
 )
+from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from scripts.pricing.openai_catalog import positive_int
 
 SLUG = "together"
 URL = "https://api.together.xyz/v1/models"
+SERVERLESS_ENDPOINTS_URL = "https://api.together.xyz/v1/endpoints?type=serverless"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "together.json"
+)
 
 # Model IDs we expect Together to expose, in OR-canonical form. Parser
 # below translates Together's native IDs to these. These are the
@@ -34,7 +53,7 @@ URL = "https://api.together.xyz/v1/models"
 # the refresh job should keep the previous committed price instead of
 # silently deleting the endpoint from the catalog.
 EXPECTED_MODELS = [
-    "meta-llama/llama-3.3-70b-instruct",
+    "deepseek/deepseek-v4-pro",
     "minimax/minimax-m3",
     "z-ai/glm-5.2",
 ]
@@ -69,34 +88,27 @@ _NATIVE_TO_OR_ID = {
 # map when rebuilding the hourly snapshot so endpoint `model_id` remains
 # directly callable by Together after every automated price update.
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
 def _row_to_micro_per_m(price_per_token: object) -> int | None:
-    """Together returns prices as dollars per token (or sometimes per million,
-    depending on field). Convert to microdollars per million.
-    1 USD/token = 1_000_000 USD/M = 1_000_000_000_000 micro/M; that's
-    obviously absurd, so Together's numbers must be USD per million tokens
-    despite the field naming. Coerce robustly: anything < 1 is treated as
-    USD per token; anything >= 1 is treated as USD per million tokens."""
+    """Convert Together's USD-per-million value to integer microdollars."""
     if price_per_token is None:
         return None
     try:
-        value = float(price_per_token)
-    except (TypeError, ValueError):
+        value = Decimal(str(price_per_token))
+    except (InvalidOperation, ValueError):
         return None
-    if value < 0:
+    if not value.is_finite() or value < 0:
         return None
-    if value < 1:
-        # USD per token → micro per M = value * 1e6 micro * 1e6 tokens
-        # = value * 1e12, but that's absurd. Together's actual encoding
-        # is dollars per 1M tokens for chat models, so:
-        usd_per_m = value
-    else:
-        usd_per_m = value
-    return int(round(usd_per_m * 1_000_000))
+    return int(
+        (value * Decimal("1000000")).to_integral_value(rounding=ROUND_HALF_UP)
+    )
 
 
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
     api_key = os.environ.get("TOGETHER_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -107,19 +119,40 @@ def fetch() -> ProviderPricingResult:
         follow_redirects=True,
         transport=transport,
     ) as client:
-        response = client.get(URL, headers=headers)
-        response.raise_for_status()
-        payload = response.json()
+        models_response = client.get(URL, headers=headers)
+        models_response.raise_for_status()
+        payload = models_response.json()
+        endpoints_response = client.get(SERVERLESS_ENDPOINTS_URL, headers=headers)
+        endpoints_response.raise_for_status()
+        endpoints_payload = endpoints_response.json()
+    endpoint_rows = (
+        endpoints_payload.get("data") or []
+        if isinstance(endpoints_payload, dict)
+        else endpoints_payload
+    )
+    serverless_model_ids = {
+        row.get("model")
+        for row in endpoint_rows
+        if isinstance(row, dict)
+        and row.get("type") == "serverless"
+        and row.get("state") == "STARTED"
+        and isinstance(row.get("model"), str)
+    }
     if isinstance(payload, dict):
         rows = payload.get("data") or []
     else:
         rows = payload
     prices: dict[str, ModelPrice] = {}
+    discovered: dict[str, dict[str, Any]] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
+        if row.get("type") != "chat":
+            continue
         native_id = row.get("id")
         if not isinstance(native_id, str):
+            continue
+        if native_id not in serverless_model_ids:
             continue
         or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
         if or_id is None:
@@ -130,18 +163,35 @@ def fetch() -> ProviderPricingResult:
             continue
         prompt = _row_to_micro_per_m(pricing.get("input"))
         completion = _row_to_micro_per_m(pricing.get("output"))
+        cached_prompt = _row_to_micro_per_m(pricing.get("cached_input"))
         if prompt is None or completion is None:
             continue
         prices[or_id] = ModelPrice(
             prompt_micro_per_m=prompt,
             completion_micro_per_m=completion,
+            prompt_cached_micro_per_m=cached_prompt,
         )
+        manifest_row: dict[str, Any] = {
+            "id": or_id,
+            "upstream_id": native_id,
+            "display_name": str(row.get("display_name") or native_id),
+            "title": native_id,
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "features": ["serverless"],
+            "status": 1,
+        }
+        context_length = positive_int(row.get("context_length"))
+        if context_length is not None:
+            manifest_row["context_length"] = context_length
+        discovered[or_id] = manifest_row
 
     notes: list[str] = []
     if not prices:
         notes.append(
-            "no Together models matched _NATIVE_TO_OR_ID — extend the table "
-            "or check the API response"
+            "no started Together serverless models matched the TrustedRouter "
+            "catalog — check both provider API responses"
         )
     # Validate strictly: Together is a direct JSON API, not a brittle
     # HTML scraper. If a canary model disappears, treat this provider
@@ -152,10 +202,21 @@ def fetch() -> ProviderPricingResult:
         notes.append(f"validation notes: {errors}")
         raise RuntimeError("; ".join(errors))
 
+    _DISCOVERED_MANIFEST_ROWS = discovered
+
     return ProviderPricingResult(
         slug=SLUG,
         prices=prices,
         source="api",
         fetched_url=URL,
         notes=notes,
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=SERVERLESS_ENDPOINTS_URL,
     )

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -277,10 +277,11 @@ PROVIDERS: dict[str, Provider] = {
         slug="cerebras",
         name="Cerebras",
         supports_prepaid=True,
+        stores_content=False,
         provider_zero_data_retention=True,
         provider_policy=(
-            "Tracked as provider-ZDR. Cerebras documents ZDR-compliant ephemeral "
-            "prompt caching and no persisted prompt cache data."
+            "Tracked as provider-ZDR. Cerebras documents zero-retention inference "
+            "and ZDR-compliant ephemeral prompt caching that is never persisted."
         ),
         provider_policy_url="https://inference-docs.cerebras.ai/capabilities/prompt-caching",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
@@ -341,10 +342,9 @@ PROVIDERS: dict[str, Provider] = {
         stores_content=False,
         provider_zero_data_retention=True,
         provider_policy=(
-            "Marked ZDR via TrustedRouter's arrangement — Together's ZDR is an "
-            "opt-in account/privacy setting, NOT the public default, and the "
-            "deployed Together account has it enabled. Together does not train "
-            "on content without opt-in."
+            "Tracked as provider ZDR. Together documents that inference inputs "
+            "and outputs are not stored by default; temporary prompt caching may "
+            "be used for performance, and sharing content for training is opt-in."
         ),
         provider_policy_url="https://docs.together.ai/docs/privacy-and-security",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
@@ -695,12 +695,12 @@ PROVIDERS: dict[str, Provider] = {
         name="DeepInfra",
         supports_prepaid=True,
         stores_content=False,
-        provider_zero_data_retention=True,
+        provider_zero_data_retention=False,
         provider_policy=(
-            "Tracked as provider ZDR — DeepInfra documents memory-only handling "
-            "with no storage of API content and no training on submitted API data. "
-            "(Exception: requests to Google/Anthropic-backed models inherit those "
-            "vendors' policies.)"
+            "Tracked as no-store, not strict ZDR. DeepInfra documents memory-only "
+            "handling and no training for ordinary inference, but reserves the "
+            "right to log a small portion of requests for debugging or security. "
+            "Google- and Anthropic-backed routes also inherit those vendors' terms."
         ),
         provider_policy_url="https://docs.deepinfra.com/account/data-privacy",
     ),
@@ -1526,14 +1526,6 @@ _EMBEDDING_SPECS: tuple[_EmbeddingSpec, ...] = (
 )
 
 _PROVIDER_SERVED_MODEL_ALLOWLIST: dict[str, frozenset[str]] = {
-    "cerebras": frozenset(
-        {
-            "openai/gpt-oss-120b",
-            "cerebras/gpt-oss-120b",
-            "z-ai/glm-4.7",
-            "cerebras/zai-glm-4.7",
-        }
-    ),
     # 2026-07-18: GMI's /models listing is aspirational — 7d synthetic probes
     # show exactly four models served on our account (590-670 successes each)
     # while the other ~45 listed models have ZERO successes ever (uniform
@@ -1593,16 +1585,6 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
     "deepseek": frozenset({"deepseek/deepseek-chat-v3.1", "deepseek/deepseek-v3.2"}),
     "nebius": frozenset({"google/gemma-2-2b-it", "meta-llama/Meta-Llama-3.1-8B-Instruct"}),
     "zai": frozenset({"z-ai/glm-4-32b", "z-ai/glm-4.7-flash"}),
-    "together": frozenset(
-        {
-            "meta-llama/llama-3.1-8b-instruct",
-            "meta-llama/llama-3.1-70b-instruct",
-            # 2026-07-15: the snapshot route returns 404 when pinned to
-            # Together. Keep the directly verified Baseten route.
-            "nvidia/nemotron-3-ultra-550b-a55b",
-            "qwen/qwen-2.5-72b-instruct",
-        }
-    ),
     "grok": frozenset({"x-ai/grok-4.20-multi-agent"}),
     # parasail — listed in the upstream snapshot, but Parasail's own chat API
     # returns 403 "deployment ... doesn't exist or isn't accessible" for these

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -81,6 +81,62 @@ _INGEST_PATH = Path(__file__).parent / "data" / "openrouter_snapshot.json"
 
 _PROVIDER_MODELS_DIR = Path(__file__).parent / "data" / "provider_models"
 
+# These providers publish authoritative model catalogs. Their generated
+# manifests, rather than OpenRouter's provider inventory, determine which
+# generic provider routes exist for both prepaid and BYOK. This prevents dark,
+# dedicated-only, or retired model IDs from reappearing through the shared
+# snapshot, while each hourly refresh can add a new route without a second
+# hand-maintained Python allowlist.
+_AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS = frozenset(
+    {
+        "cerebras",
+        "cloudflare-workers-ai",
+        "crusoe",
+        "friendli",
+        "google-ai-studio",
+        "kimi",
+        "novita",
+        "phala",
+        "together",
+        "wafer",
+    }
+)
+
+
+def _authoritative_provider_model_ids(provider_slug: str) -> frozenset[str]:
+    """Return fail-closed route model IDs for an authoritative manifest.
+
+    Explicit embedding specs remain eligible because provider manifests are
+    chat-only. A missing or malformed manifest therefore disables dynamic chat
+    routes without accidentally disabling a separately verified embedding.
+    """
+    allowed = {
+        str(spec["id"])
+        for spec in _EMBEDDING_SPECS
+        if spec.get("provider") == provider_slug
+    }
+    path = _PROVIDER_MODELS_DIR / f"{provider_slug}.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return frozenset(allowed)
+    raw_models = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(raw_models, list):
+        return frozenset(allowed)
+    for row in raw_models:
+        if not isinstance(row, dict) or row.get("routable") is False:
+            continue
+        if row.get("model_type") not in (None, "chat"):
+            continue
+        if "chat/completions" not in {
+            str(item) for item in (row.get("endpoints") or [])
+        }:
+            continue
+        model_id = row.get("id")
+        if isinstance(model_id, str) and model_id:
+            allowed.add(model_id)
+    return frozenset(allowed)
+
 _AUTHOR_TO_PROVIDER_SLUG: dict[str, str] = {
     "anthropic": "anthropic",
     "openai": "openai",
@@ -330,26 +386,6 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
     ),
     # route-health first sweep 2026-07-18, 100% failure. These ids may be
     # remappable to newer upstream ids — revisit with per-provider manifest hooks.
-    "together": frozenset(
-        {
-            "openai/gpt-oss-120b",
-            "deepseek/deepseek-r1-distill-llama-70b",
-            "qwen/qwen3-vl-8b-instruct",
-            "qwen/qwen2.5-vl-72b-instruct",
-            "mistralai/mistral-small-24b-instruct-2501",
-            "moonshotai/kimi-k2.7-code",
-            # route-health 2026-07-18, 100% failure, upstream 404/400.
-            "z-ai/glm-4.6",
-            "z-ai/glm-4.7",
-            "z-ai/glm-5",
-            "z-ai/glm-5.1",
-            "qwen/qwen3.5-397b-a17b",
-            "qwen/qwen3-next-80b-a3b-instruct",
-            "meta-llama/llama-3.2-3b-instruct",
-            "deepseek/deepseek-r1-0528",
-            "openai/gpt-oss-20b",
-        }
-    ),
     # route-health first sweep 2026-07-18, 100% failure.
     "lightning": frozenset(
         {
@@ -829,17 +865,25 @@ def _filter_unserved_provider_endpoints(
     Five complementary filters apply:
       * provider deprecation — drop a disabled upstream route on one provider for
         every usage type (Nebius June 2026 retirements).
-      * allowlist        — keep ONLY the listed Credits models for a provider (Cerebras).
+      * allowlist        — keep only manifest-listed routes for authoritative
+        providers and account-verified Credits models for static allowlists.
       * model denylist    — drop the listed Credits models on EVERY provider (GPT-5.4/pro).
       * provider denylist — drop a Credits model on ONE provider only (gmi closed models).
       * Claude first-party — route Anthropic-authored models via Anthropic only
         for Credits, never resellers (policy; see _ANTHROPIC_FIRST_PARTY_PROVIDERS).
     """
-    allow = _PROVIDER_SERVED_MODEL_ALLOWLIST
+    allow = dict(_PROVIDER_SERVED_MODEL_ALLOWLIST)
+    for provider_slug in _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS:
+        allow[provider_slug] = _authoritative_provider_model_ids(provider_slug)
 
     def _keep(endpoint: ModelEndpoint) -> bool:
         if _is_provider_deprecated_model(
             endpoint.provider, endpoint.model_id, endpoint.upstream_id
+        ):
+            return False
+        if (
+            endpoint.provider in _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS
+            and endpoint.model_id not in allow[endpoint.provider]
         ):
             return False
         if endpoint.usage_type != "Credits":

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -756,13 +756,10 @@ MODEL_ENDPOINTS.update(_SUPPLEMENTAL_ENDPOINTS)
 # for a provider, ONLY its listed models keep that provider's endpoints; routes
 # for any other model on that provider are dropped before serving/routing.
 #
-# Cerebras (the key wired into the enclave) serves only gpt-oss-120b and
-# glm-4.7 on our account — verified 2026-06-04 from the Cerebras dashboard —
-# NOT the Llama models OpenRouter lists for Cerebras's GA tier. Without this
-# filter every Llama-via-Cerebras route 502s, and because Cerebras is rank-0
-# ("fastest") it gets tried first for those models. The provider-native
-# Cerebras manifest publishes the two verified canonical routes plus
-# cerebras/* convenience aliases that map to the same upstream IDs.
+# Cerebras and Together use their generated provider manifests as the
+# authoritative prepaid allowlist. That keeps OpenRouter inventory from
+# reintroducing unavailable routes while allowing a newly discovered official
+# serverless model to become routable without another source-code allowlist.
 
 # Inverse of the allowlist, but keyed by MODEL across ALL providers: specific
 # prepaid (Credits) model ids that 502 on every provider that lists them, while

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -16,6 +16,7 @@
     "grok",
     "kimi",
     "lightning",
+    "meta",
     "minimax",
     "mistral",
     "nebius",
@@ -30,7 +31,7 @@
     "wafer",
     "zai"
   ],
-  "model_count": 162,
+  "model_count": 164,
   "models": [
     {
       "id": "anthropic/claude-fable-5",
@@ -184,28 +185,12 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96095275283092,
+          "uptime_last_30m": 99.82429718875501,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.14504505428042,
+          "uptime_last_1d": 99.50847810256944,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-haiku-4.5",
-          "model_id": "anthropic/claude-haiku-4.5",
-          "model_name": "Anthropic: Claude Haiku 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-haiku-4.5",
@@ -294,26 +279,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.76966107272129,
+          "uptime_last_1d": 99.84387197501951,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.1",
-          "model_id": "anthropic/claude-opus-4.1",
-          "model_name": "Anthropic: Claude Opus 4.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000015",
-            "completion": "0.000075"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-opus-4.1",
@@ -403,7 +372,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.45607539548973,
+          "uptime_last_1d": 99.47482236638862,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -440,28 +409,12 @@
             "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": 99.92125984251969,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 95.278036657347,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.55436720142602,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.5",
-          "model_id": "anthropic/claude-opus-4.5",
-          "model_name": "Anthropic: Claude Opus 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-opus-4.5",
@@ -551,9 +504,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90147286512287,
+          "uptime_last_30m": 99.93096089876357,
+          "uptime_last_5m": 99.81481481481481,
+          "uptime_last_1d": 99.94269453567838,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -594,26 +547,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 70.76923076923077,
+          "uptime_last_1d": 61.49732620320856,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.6",
-          "model_id": "anthropic/claude-opus-4.6",
-          "model_name": "Anthropic: Claude Opus 4.6",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.0000375"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-opus-4.6",
@@ -622,6 +559,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.000025",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | anthropic/claude-opus-4.6",
+          "model_id": "anthropic/claude-opus-4.6",
+          "model_name": "Anthropic: Claude Opus 4.6",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1000000,
           "pricing": {
             "prompt": "0.000005",
@@ -701,9 +655,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99104424144724,
+          "uptime_last_30m": 99.91471857128525,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.37608463471204,
+          "uptime_last_1d": 99.93106565578863,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -742,26 +696,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.6884561891516,
+          "uptime_last_1d": 93.66515837104072,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-opus-4.7",
-          "model_id": "anthropic/claude-opus-4.7",
-          "model_name": "Anthropic: Claude Opus 4.7",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-opus-4.7",
@@ -770,6 +708,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.000025",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | anthropic/claude-opus-4.7",
+          "model_id": "anthropic/claude-opus-4.7",
+          "model_name": "Anthropic: Claude Opus 4.7",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1000000,
           "pricing": {
             "prompt": "0.000005",
@@ -818,28 +773,29 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | anthropic/claude-opus-4.8",
-          "model_id": "anthropic/claude-opus-4.8",
-          "model_name": "Anthropic: Claude Opus 4.8",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "gmi | anthropic/claude-opus-4.8",
           "model_id": "anthropic/claude-opus-4.8",
           "model_name": "Anthropic: Claude Opus 4.8",
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.000025",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | anthropic/claude-opus-4.8",
+          "model_id": "anthropic/claude-opus-4.8",
+          "model_name": "Anthropic: Claude Opus 4.8",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1000000,
           "pricing": {
             "prompt": "0.000005",
@@ -940,9 +896,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.65397923875432,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.8390988614096,
+          "uptime_last_30m": 99.7588424437299,
+          "uptime_last_5m": 99.34640522875817,
+          "uptime_last_1d": 99.68297322343072,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -992,26 +948,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 71.63053722902923,
+          "uptime_last_1d": 94.80392156862744,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-sonnet-4.5",
-          "model_id": "anthropic/claude-sonnet-4.5",
-          "model_name": "Anthropic: Claude Sonnet 4.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-sonnet-4.5",
@@ -1101,9 +1041,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98094915541256,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.77554276123041,
+          "uptime_last_30m": 99.94330329195262,
+          "uptime_last_5m": 99.94591183629315,
+          "uptime_last_1d": 99.90942380806302,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1144,26 +1084,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 94.03049482163406,
+          "uptime_last_1d": 98.91056910569105,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | anthropic/claude-sonnet-4.6",
-          "model_id": "anthropic/claude-sonnet-4.6",
-          "model_name": "Anthropic: Claude Sonnet 4.6",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | anthropic/claude-sonnet-4.6",
@@ -1172,6 +1096,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | anthropic/claude-sonnet-4.6",
+          "model_id": "anthropic/claude-sonnet-4.6",
+          "model_name": "Anthropic: Claude Sonnet 4.6",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1000000,
           "pricing": {
             "prompt": "0.000003",
@@ -1220,22 +1161,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | anthropic/claude-sonnet-5",
-          "model_id": "anthropic/claude-sonnet-5",
-          "model_name": "Anthropic: Claude Sonnet 5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "gmi | anthropic/claude-sonnet-5",
           "model_id": "anthropic/claude-sonnet-5",
           "model_name": "Anthropic: Claude Sonnet 5",
@@ -1267,6 +1192,82 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "arcee-ai/trinity-large-thinking",
+      "name": "Arcee AI: Trinity Large Thinking",
+      "created": 1775058318,
+      "description": "Trinity Large Thinking is a powerful open source reasoning model from the team at Arcee AI. It shows strong performance in PinchBench, agentic workloads, and reasoning tasks. Launch video: https://youtu.be/Gc82AXLa0Rg?si=4RLn6WBz33qT--B7...",
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000022",
+        "completion": "0.00000085",
+        "input_cache_read": "0.00000006"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 80000,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "Parasail | arcee-ai/trinity-large-thinking",
+          "model_id": "arcee-ai/Trinity-Large-Thinking-FP8-Block",
+          "model_name": "Arcee AI: Trinity Large Thinking",
+          "provider_name": "Parasail",
+          "tag": "parasail/fp4",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000022",
+            "completion": "0.00000085",
+            "input_cache_read": "0.00000006",
+            "discount": 0
+          },
+          "quantization": "fp4",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "stop",
+            "top_k",
+            "logit_bias",
+            "response_format",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "logprobs",
+            "top_logprobs"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.92069785884219,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
@@ -1330,7 +1331,7 @@
           ],
           "status": 0,
           "uptime_last_30m": null,
-          "uptime_last_5m": 100,
+          "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
@@ -1401,129 +1402,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.97201623058626,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "deepseek/deepseek-chat-v3-0324",
-      "name": "DeepSeek: DeepSeek V3 0324",
-      "created": 1742824755,
-      "description": "DeepSeek V3, a 685B-parameter, mixture-of-experts model, is the latest iteration of the flagship chat model family from the DeepSeek team. It succeeds the [DeepSeek V3](/deepseek/deepseek-chat-v3) model and performs really well...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000112",
-        "input_cache_read": "0.000000135"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | deepseek/deepseek-chat-v3-0324",
-          "model_id": "deepseek/deepseek-chat-v3-0324",
-          "model_name": "DeepSeek: DeepSeek V3 0324",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000112",
-            "input_cache_read": "0.000000135",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.95581446471752,
-          "uptime_last_5m": 99.00133155792277,
-          "uptime_last_1d": 96.3418187958396,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "deepseek/deepseek-chat-v3.1",
-      "name": "DeepSeek: DeepSeek V3.1",
-      "created": 1755779628,
-      "description": "DeepSeek-V3.1 is a large hybrid reasoning model (671B parameters, 37B active) that supports both thinking and non-thinking modes via prompt templates. It extends the DeepSeek-V3 base with a two-phase long-context...",
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": "deepseek-v3.1"
-      },
-      "pricing": {
-        "prompt": "0.00000105",
-        "completion": "0.0000031",
-        "input_cache_read": "0.00000013"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "phala | deepseek/deepseek-chat-v3.1",
-          "model_id": "phala/deepseek-chat-v3.1",
-          "model_name": "DeepSeek: DeepSeek V3.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.00000105",
-            "completion": "0.0000031"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -1593,7 +1477,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95716170599222,
+          "uptime_last_1d": 99.97558313225325,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1634,26 +1518,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.87277353689568,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | deepseek/deepseek-r1-0528",
-          "model_id": "deepseek-ai/DeepSeek-R1-0528",
-          "model_name": "DeepSeek: R1 0528",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 163840,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | deepseek/deepseek-r1-0528",
@@ -1732,7 +1600,7 @@
             "repetition_penalty"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -1740,16 +1608,16 @@
           "pricing_source": "provider_direct"
         },
         {
-          "name": "together | deepseek/deepseek-r1-distill-llama-70b",
-          "model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+          "name": "digitalocean | deepseek/deepseek-r1-distill-llama-70b",
+          "model_id": "deepseek-r1-distill-llama-70b",
           "model_name": "DeepSeek: R1 Distill Llama 70B",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
           "context_length": 128000,
           "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000002"
+            "prompt": "0.00000099",
+            "completion": "0.00000099"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -1825,7 +1693,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98484536863641,
+          "uptime_last_1d": 99.95072310971557,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1866,10 +1734,27 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99619527444239,
+          "uptime_last_1d": 99.99963613532047,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v3.1-terminus",
+          "model_id": "deepseek/deepseek-v3.1-terminus",
+          "model_name": "DeepSeek: DeepSeek V3.1 Terminus",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.00000095",
+            "input_cache_read": "0.00000013"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -1892,9 +1777,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0",
-        "completion": "0.000000000002",
-        "input_cache_read": "0"
+        "prompt": "0.00000026",
+        "completion": "0.00000038",
+        "input_cache_read": "0.00000013"
       },
       "top_provider": {
         "context_length": 163840,
@@ -1938,10 +1823,10 @@
             "logit_bias",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.53888718106363,
-          "uptime_last_5m": 99.37759336099586,
-          "uptime_last_1d": 97.45465447459152,
+          "status": -2,
+          "uptime_last_30m": 85.52915766738661,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.14408832757456,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1954,9 +1839,9 @@
           "tag": "friendli",
           "context_length": 163840,
           "pricing": {
-            "prompt": "0",
-            "completion": "0.000000000002",
-            "input_cache_read": "0",
+            "prompt": "0.0000005",
+            "completion": "0.0000015",
+            "input_cache_read": "0.00000025",
             "discount": 0
           },
           "quantization": "unknown",
@@ -1983,9 +1868,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89164296356495,
-          "uptime_last_5m": 99.73333333333333,
-          "uptime_last_1d": 99.83041824852651,
+          "uptime_last_30m": 99.88390991409334,
+          "uptime_last_5m": 99.86622073578594,
+          "uptime_last_1d": 99.85649310434384,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -2017,9 +1902,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97806055287407,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.7899103078622,
+          "uptime_last_30m": 99.61933764750665,
+          "uptime_last_5m": 99.39148073022312,
+          "uptime_last_1d": 99.72086753944205,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2056,54 +1941,63 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99682045086007,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89087784813552,
+          "uptime_last_30m": 99.72963694103511,
+          "uptime_last_5m": 98.31932773109243,
+          "uptime_last_1d": 99.84751899380223,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "Phala | deepseek/deepseek-v3.2-20251201",
-          "model_id": "phala/deepseek-v3.2",
+          "name": "chutes | deepseek/deepseek-v3.2",
+          "model_id": "deepseek-ai/DeepSeek-V3.2-TEE",
           "model_name": "DeepSeek: DeepSeek V3.2",
-          "provider_name": "Phala",
-          "tag": "phala",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
           "context_length": 163840,
           "pricing": {
             "prompt": "0.000001",
             "completion": "0.000001",
-            "input_cache_read": "0.0000005",
-            "discount": 0
+            "input_cache_read": "0.0000005"
           },
-          "quantization": "unknown",
-          "max_completion_tokens": 64000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.6742671009772,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.19487449766125,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | deepseek/deepseek-v3.2",
+          "model_id": "deepseek-3.2",
+          "model_name": "DeepSeek: DeepSeek V3.2",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.000000425",
+            "completion": "0.00000136",
+            "input_cache_read": "0.00000015"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v3.2",
+          "model_id": "deepseek/deepseek-v3.2",
+          "model_name": "DeepSeek: DeepSeek V3.2",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.00000026",
+            "completion": "0.00000038",
+            "input_cache_read": "0.00000013"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -2127,7 +2021,8 @@
       },
       "pricing": {
         "prompt": "0.00000027",
-        "completion": "0.00000041"
+        "completion": "0.00000041",
+        "input_cache_read": "0.00000027"
       },
       "top_provider": {
         "context_length": 163840,
@@ -2169,12 +2064,29 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.44804282881242,
+          "uptime_last_30m": 95.14824797843666,
+          "uptime_last_5m": 95.71428571428572,
+          "uptime_last_1d": 99.22897570965075,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v3.2-exp",
+          "model_id": "deepseek/deepseek-v3.2-exp",
+          "model_name": "DeepSeek: DeepSeek V3.2 Exp",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.00000027",
+            "completion": "0.00000041",
+            "input_cache_read": "0.00000027"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -2199,7 +2111,7 @@
       "pricing": {
         "prompt": "0.00000009",
         "completion": "0.00000018",
-        "input_cache_read": "0.0000000196"
+        "input_cache_read": "0.00000001876"
       },
       "top_provider": {
         "context_length": 1048575,
@@ -2245,9 +2157,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60593547900523,
-          "uptime_last_5m": 99.62231759656652,
-          "uptime_last_1d": 99.46994916082353,
+          "uptime_last_30m": 99.6088386210884,
+          "uptime_last_5m": 99.36910278599743,
+          "uptime_last_1d": 99.75453059353993,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2285,9 +2197,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99895873194376,
-          "uptime_last_5m": 99.9982369223717,
-          "uptime_last_1d": 99.92684239709884,
+          "uptime_last_30m": 99.99611575063119,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9491697680912,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -2303,7 +2215,7 @@
             "prompt": "0.00000014",
             "completion": "0.00000028",
             "input_cache_read": "0.000000028",
-            "discount": 0.3
+            "discount": 0.33
           },
           "quantization": "fp8",
           "max_completion_tokens": null,
@@ -2321,9 +2233,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.38659331283742,
-          "uptime_last_5m": 99.47746570868713,
-          "uptime_last_1d": 98.6999899793566,
+          "uptime_last_30m": 96.67541704058439,
+          "uptime_last_5m": 97.18898385565052,
+          "uptime_last_1d": 98.6460261672882,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2362,9 +2274,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98005186515061,
-          "uptime_last_5m": 99.98852816335896,
-          "uptime_last_1d": 99.95323107930062,
+          "uptime_last_30m": 99.99489793551918,
+          "uptime_last_5m": 99.99834398701685,
+          "uptime_last_1d": 99.9282205972765,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -2407,9 +2319,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.47954393024816,
-          "uptime_last_5m": 99.41200324412003,
-          "uptime_last_1d": 99.00772211717074,
+          "uptime_last_30m": 98.93086243763364,
+          "uptime_last_5m": 98.8562091503268,
+          "uptime_last_1d": 99.02749049175952,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -2444,41 +2356,25 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 96.04740540627462,
-          "uptime_last_5m": 98.79931389365352,
-          "uptime_last_1d": 98.86499794061481,
+          "uptime_last_30m": 99.6347196023833,
+          "uptime_last_5m": 99.85176400830122,
+          "uptime_last_1d": 97.69797550472569,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | deepseek/deepseek-v4-flash",
+          "name": "makora | deepseek/deepseek-v4-flash",
           "model_id": "deepseek/deepseek-v4-flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "crusoe | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek-ai/Deepseek-V4-Flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
-            "input_cache_read": "0.00000003"
+            "prompt": "0.0000001134",
+            "completion": "0.0000002791",
+            "input_cache_read": "0.0000000851"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2502,17 +2398,34 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek/deepseek-v4-flash",
+          "name": "digitalocean | deepseek/deepseek-v4-flash",
+          "model_id": "deepseek-4-flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000001134",
-            "completion": "0.0000002791",
-            "input_cache_read": "0.0000000851"
+            "prompt": "0.000000112",
+            "completion": "0.000000224",
+            "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v4-flash",
+          "model_id": "deepseek/deepseek-v4-flash",
+          "model_name": "DeepSeek: DeepSeek V4 Flash",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2587,9 +2500,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.93744987971131,
-          "uptime_last_5m": 99.34296977660972,
-          "uptime_last_1d": 99.06016447121753,
+          "uptime_last_30m": 98.67711905928466,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.87254818810464,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2627,9 +2540,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.91529201961659,
-          "uptime_last_5m": 99.63480128893663,
-          "uptime_last_1d": 99.9506832829149,
+          "uptime_last_30m": 99.99667402077628,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.92789193946984,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -2670,10 +2583,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 95.01898919076834,
-          "uptime_last_5m": 99.20792079207921,
-          "uptime_last_1d": 97.1667724144663,
+          "status": -2,
+          "uptime_last_30m": 94.16195856873823,
+          "uptime_last_5m": 96.4824120603015,
+          "uptime_last_1d": 79.00244271005411,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -2689,7 +2602,7 @@
             "prompt": "0.00000174",
             "completion": "0.00000348",
             "input_cache_read": "0.000000145",
-            "discount": 0.35
+            "discount": 0.4
           },
           "quantization": "fp8",
           "max_completion_tokens": null,
@@ -2707,9 +2620,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.67365967365967,
-          "uptime_last_5m": 99.70260223048328,
-          "uptime_last_1d": 98.65734428960198,
+          "uptime_last_30m": 99.31235674098771,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.27268760000831,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2750,9 +2663,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86241236978314,
-          "uptime_last_5m": 99.734395750332,
-          "uptime_last_1d": 99.6451523003016,
+          "uptime_last_30m": 99.97591522157995,
+          "uptime_last_5m": 99.96518105849582,
+          "uptime_last_1d": 99.56468073457779,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -2795,9 +2708,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.54202401372213,
-          "uptime_last_5m": 99.48453608247422,
-          "uptime_last_1d": 98.33601819387852,
+          "uptime_last_30m": 99.45105215004575,
+          "uptime_last_5m": 99.12280701754386,
+          "uptime_last_1d": 96.70664983164983,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -2810,7 +2723,7 @@
           "tag": "siliconflow/fp8",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000016",
+            "prompt": "0.00000150162",
             "completion": "0.000003135",
             "input_cache_read": "0.000000135",
             "discount": 0
@@ -2832,9 +2745,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.47322212467077,
-          "uptime_last_5m": 99.43946188340807,
-          "uptime_last_1d": 98.77875998504959,
+          "uptime_last_30m": 99.36858721389108,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.9131573433899,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2875,28 +2788,12 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.05660377358491,
-          "uptime_last_5m": 99.27536231884058,
-          "uptime_last_1d": 97.55234383790031,
+          "uptime_last_30m": 98.36235131873815,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.09322704314489,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek/deepseek-v4-pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.00000525"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "baseten | deepseek/deepseek-v4-pro",
@@ -2916,17 +2813,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+          "name": "makora | deepseek/deepseek-v4-pro",
+          "model_id": "deepseek/deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.00000015"
+            "prompt": "0.000001318",
+            "completion": "0.0000026361",
+            "input_cache_read": "0.0000009885"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2950,17 +2847,34 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek/deepseek-v4-pro",
+          "name": "digitalocean | deepseek/deepseek-v4-pro",
+          "model_id": "deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.000001318",
-            "completion": "0.0000026361",
-            "input_cache_read": "0.0000009885"
+            "prompt": "0.000001392",
+            "completion": "0.000002784",
+            "input_cache_read": "0.000000348"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v4-pro",
+          "model_id": "deepseek/deepseek-v4-pro",
+          "model_name": "DeepSeek: DeepSeek V4 Pro",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000168",
+            "completion": "0.00000338",
+            "input_cache_read": "0.00000013"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -3009,49 +2923,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Google Vertex AI | google/gemini-2.5-flash",
-          "model_id": "google/gemini-2.5-flash",
-          "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000025",
-            "image": "0.0000003",
-            "audio": "0.000001",
-            "input_audio_cache": "0.0000001",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000025",
-            "input_cache_read": "0.00000003",
-            "input_cache_write": "0.00000008333333333333334",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.98881160609395,
-          "uptime_last_5m": 99.98676022772408,
-          "uptime_last_1d": 99.93888702404723,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Google AI Studio | google/gemini-2.5-flash",
           "model_id": "google/gemini-2.5-flash",
           "model_name": "Google: Gemini 2.5 Flash",
@@ -3087,28 +2958,55 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98881160609395,
-          "uptime_last_5m": 99.98676022772408,
-          "uptime_last_1d": 99.93888702404723,
+          "uptime_last_30m": 99.90042757570433,
+          "uptime_last_5m": 99.957805907173,
+          "uptime_last_1d": 99.90258218857129,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | google/gemini-2.5-flash",
+          "name": "Google | google/gemini-2.5-flash",
           "model_id": "google/gemini-2.5-flash",
           "model_name": "Google: Gemini 2.5 Flash",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000003",
-            "completion": "0.0000025"
+            "completion": "0.0000025",
+            "image": "0.0000003",
+            "audio": "0.000001",
+            "input_audio_cache": "0.0000001",
+            "web_search": "0.014",
+            "internal_reasoning": "0.0000025",
+            "input_cache_read": "0.00000003",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "unknown",
+          "max_completion_tokens": 65535,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "tools",
+            "tool_choice",
+            "stop"
+          ],
+          "status": -2,
+          "uptime_last_30m": 92.93617888941752,
+          "uptime_last_5m": 96.39854674496219,
+          "uptime_last_1d": 98.75417066585273,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "google-vertex",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "lightning | google/gemini-2.5-flash",
@@ -3137,6 +3035,23 @@
           "pricing": {
             "prompt": "0.0000003",
             "completion": "0.0000025"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-2.5-flash",
+          "model_id": "google/gemini-2.5-flash",
+          "model_name": "Google: Gemini 2.5 Flash",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000025",
+            "input_cache_read": "0.00000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -3185,49 +3100,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Google Vertex AI | google/gemini-2.5-flash-lite",
-          "model_id": "google/gemini-2.5-flash-lite",
-          "model_name": "Google: Gemini 2.5 Flash Lite",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000004",
-            "image": "0.0000001",
-            "audio": "0.0000003",
-            "input_audio_cache": "0.00000003",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000004",
-            "input_cache_read": "0.00000001",
-            "input_cache_write": "0.00000008333333333333334",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65535,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice",
-            "stop"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.37450976448584,
-          "uptime_last_5m": 99.38172043010752,
-          "uptime_last_1d": 99.56049212821972,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Google AI Studio | google/gemini-2.5-flash-lite",
           "model_id": "google/gemini-2.5-flash-lite",
           "model_name": "Google: Gemini 2.5 Flash Lite",
@@ -3263,24 +3135,68 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.37450976448584,
-          "uptime_last_5m": 99.38172043010752,
-          "uptime_last_1d": 99.56049212821972,
+          "uptime_last_30m": 99.70418435994084,
+          "uptime_last_5m": 99.62512572003291,
+          "uptime_last_1d": 99.44627353428935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | google/gemini-2.5-flash-lite",
+          "name": "Google | google/gemini-2.5-flash-lite",
           "model_id": "google/gemini-2.5-flash-lite",
           "model_name": "Google: Gemini 2.5 Flash Lite",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "Google",
+          "tag": "google-vertex",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000001",
-            "completion": "0.0000004"
+            "completion": "0.0000004",
+            "image": "0.0000001",
+            "audio": "0.0000003",
+            "input_audio_cache": "0.00000003",
+            "web_search": "0.014",
+            "internal_reasoning": "0.0000004",
+            "input_cache_read": "0.00000001",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65535,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "tools",
+            "tool_choice",
+            "stop"
+          ],
+          "status": 0,
+          "uptime_last_30m": 98.96362327558154,
+          "uptime_last_5m": 98.50903783541035,
+          "uptime_last_1d": 99.33296963551264,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "google-vertex",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-2.5-flash-lite",
+          "model_id": "google/gemini-2.5-flash-lite",
+          "model_name": "Google: Gemini 2.5 Flash Lite",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000001",
+            "completion": "0.0000004",
+            "input_cache_read": "0.00000001"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -3338,78 +3254,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Google Vertex AI | google/gemini-2.5-pro",
-          "model_id": "google/gemini-2.5-pro",
-          "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001",
-            "image": "0.00000125",
-            "audio": "0.00000125",
-            "input_audio_cache": "0.000000125",
-            "web_search": "0.014",
-            "internal_reasoning": "0.00001",
-            "input_cache_read": "0.000000125",
-            "input_cache_write": "0.000000375",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.0000025",
-                "completion": "0.000015",
-                "audio": "0.0000025",
-                "input_audio_cache": "0.00000025",
-                "input_cache_read": "0.00000025"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.00000125"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.0000025"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.00001"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000015"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.2815153494448,
-          "uptime_last_5m": 99.08814589665653,
-          "uptime_last_1d": 99.05745032091899,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Google AI Studio | google/gemini-2.5-pro",
           "model_id": "google/gemini-2.5-pro",
@@ -3475,28 +3319,85 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.2815153494448,
-          "uptime_last_5m": 99.08814589665653,
-          "uptime_last_1d": 99.05745032091899,
+          "uptime_last_30m": 96.0839160839161,
+          "uptime_last_5m": 96.7741935483871,
+          "uptime_last_1d": 98.50084820430546,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | google/gemini-2.5-pro",
+          "name": "Google | google/gemini-2.5-pro",
           "model_id": "google/gemini-2.5-pro",
           "model_name": "Google: Gemini 2.5 Pro",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015"
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "image": "0.00000125",
+            "audio": "0.00000125",
+            "input_audio_cache": "0.000000125",
+            "web_search": "0.014",
+            "internal_reasoning": "0.00001",
+            "input_cache_read": "0.000000125",
+            "input_cache_write": "0.000000375",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.0000025",
+                "completion": "0.000015",
+                "audio": "0.0000025",
+                "input_audio_cache": "0.00000025",
+                "input_cache_read": "0.00000025"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.00001"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000015"
+              }
+            ]
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "tools",
+            "tool_choice",
+            "stop"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.23512070751335,
+          "uptime_last_5m": 99.15748541801686,
+          "uptime_last_1d": 98.89364246145978,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "google-vertex",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "lightning | google/gemini-2.5-pro",
@@ -3525,6 +3426,23 @@
           "pricing": {
             "prompt": "0.00000125",
             "completion": "0.00001"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-2.5-pro",
+          "model_id": "google/gemini-2.5-pro",
+          "model_name": "Google: Gemini 2.5 Pro",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -3573,49 +3491,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Google Vertex AI | google/gemini-3-flash-preview-20251217",
-          "model_id": "google/gemini-3-flash-preview",
-          "model_name": "Google: Gemini 3 Flash Preview",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.000003",
-            "image": "0.0000005",
-            "audio": "0.000001",
-            "input_audio_cache": "0.0000001",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000003",
-            "input_cache_read": "0.00000005",
-            "input_cache_write": "0.00000008333333333333334",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.94016790381991,
-          "uptime_last_5m": 99.94504739662041,
-          "uptime_last_1d": 99.63061099769472,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Google AI Studio | google/gemini-3-flash-preview-20251217",
           "model_id": "google/gemini-3-flash-preview",
           "model_name": "Google: Gemini 3 Flash Preview",
@@ -3651,11 +3526,55 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94016790381991,
-          "uptime_last_5m": 99.94504739662041,
-          "uptime_last_1d": 99.63061099769472,
+          "uptime_last_30m": 99.85779164181842,
+          "uptime_last_5m": 99.90975747320925,
+          "uptime_last_1d": 99.81859519681309,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Google | google/gemini-3-flash-preview-20251217",
+          "model_id": "google/gemini-3-flash-preview",
+          "model_name": "Google: Gemini 3 Flash Preview",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.000003",
+            "image": "0.0000005",
+            "audio": "0.000001",
+            "input_audio_cache": "0.0000001",
+            "web_search": "0.014",
+            "internal_reasoning": "0.000003",
+            "input_cache_read": "0.00000005",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65535,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "tool_choice",
+            "tools",
+            "stop",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 95.94592437202857,
+          "uptime_last_5m": 97.06724867003138,
+          "uptime_last_1d": 97.61365121405613,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
         },
         {
@@ -3689,136 +3608,26 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-3-flash-preview",
+          "model_id": "google/gemini-3-flash-preview",
+          "model_name": "Google: Gemini 3 Flash Preview",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.000003",
+            "input_cache_read": "0.00000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
-    },
-    {
-      "id": "google/gemini-3-pro-image",
-      "name": "Google: Nano Banana Pro (Gemini 3 Pro Image)",
-      "created": 1781754054,
-      "description": "Nano Banana Pro is Google’s most advanced image-generation and editing model, built on Gemini 3 Pro. It extends the original Nano Banana with significantly improved multimodal reasoning, real-world grounding, and...",
-      "context_length": 65536,
-      "architecture": {
-        "modality": "text+image->text+image",
-        "input_modalities": [
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "image",
-          "text"
-        ],
-        "tokenizer": "Gemini",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000002",
-        "completion": "0.000012",
-        "image": "0.000002",
-        "image_output": "0.00012",
-        "audio": "0.000002",
-        "input_audio_cache": "0.0000002",
-        "web_search": "0.014",
-        "internal_reasoning": "0.000012",
-        "input_cache_read": "0.0000002",
-        "input_cache_write": "0.000000375"
-      },
-      "top_provider": {
-        "context_length": 65536,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Google Vertex AI | google/gemini-3-pro-image-20260528",
-          "model_id": "google/gemini-3-pro-image",
-          "model_name": "Google: Nano Banana Pro (Gemini 3 Pro Image)",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.000002",
-            "image_output": "0.00012",
-            "audio": "0.000002",
-            "input_audio_cache": "0.0000002",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000012",
-            "input_cache_read": "0.0000002",
-            "input_cache_write": "0.000000375",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.70508343034537,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "openrouter_fallback"
-        },
-        {
-          "name": "Google AI Studio | google/gemini-3-pro-image-20260528",
-          "model_id": "google/gemini-3-pro-image",
-          "model_name": "Google: Nano Banana Pro (Gemini 3 Pro Image)",
-          "provider_name": "Google AI Studio",
-          "tag": "google-ai-studio",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.000002",
-            "image_output": "0.00012",
-            "audio": "0.000002",
-            "input_audio_cache": "0.0000002",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000012",
-            "input_cache_read": "0.0000002",
-            "input_cache_write": "0.000000375",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.70508343034537,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-ai-studio",
-          "pricing_source": "openrouter_fallback"
-        }
-      ],
-      "pricing_source": "openrouter_fallback"
     },
     {
       "id": "google/gemini-3.1-flash-lite",
@@ -3860,49 +3669,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Google Vertex AI | google/gemini-3.1-flash-lite-20260507",
-          "model_id": "google/gemini-3.1-flash-lite",
-          "model_name": "Google: Gemini 3.1 Flash Lite",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.0000015",
-            "image": "0.00000025",
-            "audio": "0.0000005",
-            "input_audio_cache": "0.00000005",
-            "web_search": "0.014",
-            "internal_reasoning": "0.0000015",
-            "input_cache_read": "0.000000025",
-            "input_cache_write": "0.00000008333333333333334",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.4648742128104,
-          "uptime_last_5m": 99.73575310365459,
-          "uptime_last_1d": 99.71196269384227,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Google AI Studio | google/gemini-3.1-flash-lite-20260507",
           "model_id": "google/gemini-3.1-flash-lite",
           "model_name": "Google: Gemini 3.1 Flash Lite",
@@ -3938,11 +3704,55 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.4648742128104,
-          "uptime_last_5m": 99.73575310365459,
-          "uptime_last_1d": 99.71196269384227,
+          "uptime_last_30m": 99.64957949539446,
+          "uptime_last_5m": 99.79975832901779,
+          "uptime_last_1d": 99.67296917790198,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Google | google/gemini-3.1-flash-lite-20260507",
+          "model_id": "google/gemini-3.1-flash-lite",
+          "model_name": "Google: Gemini 3.1 Flash Lite",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.0000015",
+            "image": "0.00000025",
+            "audio": "0.0000005",
+            "input_audio_cache": "0.00000005",
+            "web_search": "0.014",
+            "internal_reasoning": "0.0000015",
+            "input_cache_read": "0.000000025",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "stop",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": -2,
+          "uptime_last_30m": 91.88761713634585,
+          "uptime_last_5m": 92.48182031433262,
+          "uptime_last_1d": 90.02849563822983,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
         },
         {
@@ -3956,6 +3766,23 @@
           "pricing": {
             "prompt": "0.00000025",
             "completion": "0.0000015"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-3.1-flash-lite",
+          "model_id": "google/gemini-3.1-flash-lite",
+          "model_name": "Google: Gemini 3.1 Flash Lite",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.0000015",
+            "input_cache_read": "0.000000025"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -4079,26 +3906,6 @@
             "input_audio_cache": "0.0000004",
             "input_cache_read": "0.0000004"
           }
-        ],
-        "prompt_tiers": [
-          {
-            "max_prompt_tokens": 200000,
-            "prompt": "0.000002"
-          },
-          {
-            "max_prompt_tokens": null,
-            "prompt": "0.000004"
-          }
-        ],
-        "completion_tiers": [
-          {
-            "max_prompt_tokens": 200000,
-            "completion": "0.000012"
-          },
-          {
-            "max_prompt_tokens": null,
-            "completion": "0.000018"
-          }
         ]
       },
       "top_provider": {
@@ -4108,79 +3915,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Google Vertex AI | google/gemini-3.1-pro-preview-20260219",
-          "model_id": "google/gemini-3.1-pro-preview",
-          "model_name": "Google: Gemini 3.1 Pro Preview",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000012",
-            "image": "0.000002",
-            "audio": "0.000002",
-            "input_audio_cache": "0.0000002",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000012",
-            "input_cache_read": "0.0000002",
-            "input_cache_write": "0.000000375",
-            "discount": 0,
-            "overrides": [
-              {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000004",
-                "completion": "0.000018",
-                "audio": "0.000004",
-                "input_audio_cache": "0.0000004",
-                "input_cache_read": "0.0000004"
-              }
-            ],
-            "prompt_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "prompt": "0.000002"
-              },
-              {
-                "max_prompt_tokens": null,
-                "prompt": "0.000004"
-              }
-            ],
-            "completion_tiers": [
-              {
-                "max_prompt_tokens": 200000,
-                "completion": "0.000012"
-              },
-              {
-                "max_prompt_tokens": null,
-                "completion": "0.000018"
-              }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.61157024793388,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.39196926881971,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Google AI Studio | google/gemini-3.1-pro-preview-20260219",
           "model_id": "google/gemini-3.1-pro-preview",
@@ -4247,11 +3981,85 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.61157024793388,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.39196926881971,
+          "uptime_last_30m": 99.35862445414847,
+          "uptime_last_5m": 99.62871287128714,
+          "uptime_last_1d": 99.61572432034997,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Google | google/gemini-3.1-pro-preview-20260219",
+          "model_id": "google/gemini-3.1-pro-preview",
+          "model_name": "Google: Gemini 3.1 Pro Preview",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000012",
+            "image": "0.000002",
+            "audio": "0.000002",
+            "input_audio_cache": "0.0000002",
+            "web_search": "0.014",
+            "internal_reasoning": "0.000012",
+            "input_cache_read": "0.0000002",
+            "input_cache_write": "0.000000375",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000004",
+                "completion": "0.000018",
+                "audio": "0.000004",
+                "input_audio_cache": "0.0000004",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000012"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000018"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "stop",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": -2,
+          "uptime_last_30m": 90.93229446534122,
+          "uptime_last_5m": 95.03430251551781,
+          "uptime_last_1d": 94.43092855547431,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
         },
         {
@@ -4281,6 +4089,23 @@
           "pricing": {
             "prompt": "0.000002",
             "completion": "0.000012"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-3.1-pro-preview",
+          "model_id": "google/gemini-3.1-pro-preview",
+          "model_name": "Google: Gemini 3.1 Pro Preview",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000012",
+            "input_cache_read": "0.0000002"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -4329,49 +4154,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Google Vertex AI | google/gemini-3.5-flash-20260519",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "Google Vertex AI",
-          "tag": "google-vertex",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009",
-            "image": "0.0000015",
-            "audio": "0.000003",
-            "input_audio_cache": "0.0000003",
-            "web_search": "0.014",
-            "internal_reasoning": "0.000009",
-            "input_cache_read": "0.00000015",
-            "input_cache_write": "0.00000008333333333333334",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.19747520288549,
-          "uptime_last_5m": 98.01230477993374,
-          "uptime_last_1d": 99.6518479511439,
-          "supports_implicit_caching": true,
-          "tr_provider_slug": "google-vertex",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Google AI Studio | google/gemini-3.5-flash-20260519",
           "model_id": "google/gemini-3.5-flash",
           "model_name": "Google: Gemini 3.5 Flash",
@@ -4407,11 +4189,55 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.19747520288549,
-          "uptime_last_5m": 98.01230477993374,
-          "uptime_last_1d": 99.6518479511439,
+          "uptime_last_30m": 99.77516541401683,
+          "uptime_last_5m": 99.91928974979822,
+          "uptime_last_1d": 99.88159325907671,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Google | google/gemini-3.5-flash-20260519",
+          "model_id": "google/gemini-3.5-flash",
+          "model_name": "Google: Gemini 3.5 Flash",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000015",
+            "completion": "0.000009",
+            "image": "0.0000015",
+            "audio": "0.000003",
+            "input_audio_cache": "0.0000003",
+            "web_search": "0.014",
+            "internal_reasoning": "0.000009",
+            "input_cache_read": "0.00000015",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "stop",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 96.2648388218348,
+          "uptime_last_5m": 95.74673755437409,
+          "uptime_last_1d": 98.30763789943848,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
         },
         {
@@ -4458,6 +4284,23 @@
           "pricing": {
             "prompt": "0.0000015",
             "completion": "0.000009"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | google/gemini-3.5-flash",
+          "model_id": "google/gemini-3.5-flash",
+          "model_name": "Google: Gemini 3.5 Flash",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000015",
+            "completion": "0.000009",
+            "input_cache_read": "0.00000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -4528,9 +4371,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99481872606604,
+          "uptime_last_30m": 99.99795876709533,
+          "uptime_last_5m": 99.98738806911338,
+          "uptime_last_1d": 99.99785750026953,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4600,9 +4443,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97635933806147,
-          "uptime_last_5m": 99.87593052109182,
-          "uptime_last_1d": 99.90792411631814,
+          "uptime_last_30m": 99.86096091456821,
+          "uptime_last_5m": 99.07692307692308,
+          "uptime_last_1d": 99.76702384534086,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4637,9 +4480,9 @@
             "repetition_penalty"
           ],
           "status": -2,
-          "uptime_last_30m": 93.92564067299317,
-          "uptime_last_5m": 88.41405508072174,
-          "uptime_last_1d": 87.25797971651373,
+          "uptime_last_30m": 89.9693553682828,
+          "uptime_last_5m": 99.8554260413843,
+          "uptime_last_1d": 86.4983195588434,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -4671,9 +4514,9 @@
             "repetition_penalty"
           ],
           "status": -5,
-          "uptime_last_30m": 79.41495124593716,
-          "uptime_last_5m": 99.95114802149487,
-          "uptime_last_1d": 78.93121956297932,
+          "uptime_last_30m": 79.11328143886284,
+          "uptime_last_5m": 63.5343618513324,
+          "uptime_last_1d": 92.84140137641798,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -4711,49 +4554,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97836083310793,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97460147759227,
+          "uptime_last_1d": 99.53864392738284,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | google/gemma-3-27b-it",
-          "model_id": "phala/gemma-3-27b-it",
-          "model_name": "Google: Gemma 3 27B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000046",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty"
-          ],
-          "status": -2,
-          "uptime_last_30m": 94.00379506641366,
-          "uptime_last_5m": 87.7995642701525,
-          "uptime_last_1d": 66.95697983346788,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         }
       ],
@@ -4819,9 +4624,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.87508674531576,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98434776996062,
+          "uptime_last_1d": 99.99046723006718,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4889,7 +4694,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9993380420608,
+          "uptime_last_1d": 99.99134629342207,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -4921,8 +4726,8 @@
         "completion": "0.00000034"
       },
       "top_provider": {
-        "context_length": 256000,
-        "max_completion_tokens": 256000,
+        "context_length": 262144,
+        "max_completion_tokens": 16384,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -4962,9 +4767,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90444004195315,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90946657218946,
+          "uptime_last_30m": 99.776708373436,
+          "uptime_last_5m": 99.98133631952221,
+          "uptime_last_1d": 99.76044070595682,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5004,9 +4809,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.89498102066638,
-          "uptime_last_5m": 98.78612716763006,
-          "uptime_last_1d": 98.80567726472681,
+          "uptime_last_30m": 99.61799459023395,
+          "uptime_last_5m": 99.77954892318128,
+          "uptime_last_1d": 99.10271401483296,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -5022,6 +4827,22 @@
           "pricing": {
             "prompt": "0.00000013",
             "completion": "0.0000004"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | google/gemma-4-26b-a4b-it",
+          "model_id": "google/gemma-4-26b-a4b-it",
+          "model_name": "Google: Gemma 4 26B A4B ",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000001",
+            "completion": "0.0000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -5051,16 +4872,55 @@
       },
       "pricing": {
         "prompt": "0.00000013",
-        "completion": "0.00000038",
-        "input_cache_read": "0.00000012"
+        "completion": "0.00000038"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "max_completion_tokens": 16384,
         "is_moderated": false
       },
       "per_request_limits": null,
       "endpoints": [
+        {
+          "name": "Cerebras | google/gemma-4-31b-it-20260402",
+          "model_id": "gemma-4-31b",
+          "model_name": "Google: Gemma 4 31B",
+          "provider_name": "Cerebras",
+          "tag": "cerebras/fp16",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000099",
+            "completion": "0.00000149",
+            "input_cache_read": "0.00000099",
+            "discount": 0
+          },
+          "quantization": "fp16",
+          "max_completion_tokens": 40960,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "seed",
+            "tools",
+            "tool_choice",
+            "frequency_penalty",
+            "presence_penalty",
+            "logit_bias"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.91158267020336,
+          "uptime_last_5m": 99.93523316062176,
+          "uptime_last_1d": 99.98669912081188,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "cerebras",
+          "pricing_source": "provider_direct"
+        },
         {
           "name": "DeepInfra | google/gemma-4-31b-it-20260402",
           "model_id": "google/gemma-4-31B-it",
@@ -5094,9 +4954,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.38406658739595,
-          "uptime_last_5m": 95.18348623853211,
-          "uptime_last_1d": 99.07005913992454,
+          "uptime_last_30m": 96.41453831041258,
+          "uptime_last_5m": 93.84984025559106,
+          "uptime_last_1d": 95.75216982575807,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5136,11 +4996,50 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.37168904767772,
-          "uptime_last_5m": 99.16855631141345,
-          "uptime_last_1d": 98.74311424100156,
+          "uptime_last_30m": 97.0146263273893,
+          "uptime_last_5m": 97.54571703561116,
+          "uptime_last_1d": 98.61728203517667,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Friendli | google/gemma-4-31b-it-20260402",
+          "model_id": "google/gemma-4-31B-it",
+          "model_name": "Google: Gemma 4 31B",
+          "provider_name": "Friendli",
+          "tag": "friendli",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.0000004",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "top_k",
+            "min_p",
+            "repetition_penalty",
+            "response_format",
+            "structured_outputs"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.96590448995248,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.89608695322396,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
         },
         {
@@ -5179,52 +5078,12 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": 98.4811706775782,
-          "uptime_last_5m": 99.76090854751942,
-          "uptime_last_1d": 90.62909631125655,
+          "status": -2,
+          "uptime_last_30m": 94.98477157360406,
+          "uptime_last_5m": 93.64548494983278,
+          "uptime_last_1d": 96.16196120271002,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31b-it",
-          "model_name": "Google: Gemma 4 31B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000046",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.68879729132931,
-          "uptime_last_5m": 95.45454545454545,
-          "uptime_last_1d": 53.29058938199683,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -5257,10 +5116,10 @@
             "min_p",
             "response_format"
           ],
-          "status": -5,
-          "uptime_last_30m": 75.05285412262155,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 71.24115497864862,
+          "status": -2,
+          "uptime_last_30m": 88.9315910837817,
+          "uptime_last_5m": 92.34234234234235,
+          "uptime_last_1d": 78.87565802437857,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5298,10 +5157,10 @@
             "tool_choice",
             "tools"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.70946068639913,
-          "uptime_last_5m": 99.55860716037273,
-          "uptime_last_1d": 94.59285835258939,
+          "status": -2,
+          "uptime_last_30m": 87.9748427672956,
+          "uptime_last_5m": 58.39598997493734,
+          "uptime_last_1d": 92.0272114556869,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5355,17 +5214,16 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | google/gemma-4-31b-it",
-          "model_id": "google/gemma-4-31b-it",
+          "name": "digitalocean | google/gemma-4-31b-it",
+          "model_id": "gemma-4-31B-it",
           "model_name": "Google: Gemma 4 31B",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000014"
+            "prompt": "0.00000018",
+            "completion": "0.0000005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -5434,7 +5292,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96255558155862,
+          "uptime_last_1d": 99.95721696347398,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5505,8 +5363,8 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
@@ -5580,7 +5438,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99855249688497,
+          "uptime_last_1d": 99.99998435580653,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5722,28 +5580,12 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.97323917487456,
+          "uptime_last_30m": 97.54091751995485,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.2232291454441,
+          "uptime_last_1d": 99.20296588655675,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | meta-llama/llama-3.1-70b-instruct",
-          "model_id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-          "model_name": "Meta: Llama 3.1 70B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000088",
-            "completion": "0.00000088"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -5807,28 +5649,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99587679874654,
+          "uptime_last_30m": 99.84227129337539,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.6070362164544,
+          "uptime_last_1d": 92.62686131887737,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | meta-llama/llama-3.1-8b-instruct",
-          "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-          "model_name": "Meta: Llama 3.1 8B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -5851,8 +5677,8 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.00000006",
-        "completion": "0.00000006"
+        "prompt": "0.0000000509",
+        "completion": "0.000000335"
       },
       "top_provider": {
         "context_length": 80000,
@@ -5862,16 +5688,16 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "together | meta-llama/llama-3.2-3b-instruct",
-          "model_id": "meta-llama/Llama-3.2-3B-Instruct",
+          "name": "cloudflare-workers-ai | meta-llama/llama-3.2-3b-instruct",
+          "model_id": "meta-llama/llama-3.2-3b-instruct",
           "model_name": "Meta: Llama 3.2 3B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000006",
-            "completion": "0.00000006"
+            "prompt": "0.0000000509",
+            "completion": "0.000000335"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -5939,10 +5765,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 91.1804984935634,
-          "uptime_last_5m": 87.59689922480621,
-          "uptime_last_1d": 92.0553463745283,
+          "status": 0,
+          "uptime_last_30m": 98.84879966306332,
+          "uptime_last_5m": 99.67355821545158,
+          "uptime_last_1d": 94.70100593073167,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5980,28 +5806,51 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.08116385911178,
-          "uptime_last_5m": 99.63369963369964,
-          "uptime_last_1d": 96.50273442078408,
+          "uptime_last_30m": 95.2113062568606,
+          "uptime_last_5m": 98.5307621671258,
+          "uptime_last_1d": 95.87245455448496,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/llama-3.3-70b-instruct",
+          "name": "Together | meta-llama/llama-3.3-70b-instruct",
+          "model_id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
           "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "Together",
+          "tag": "together/fp8",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000002"
+            "prompt": "0.00000104",
+            "completion": "0.00000104",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "fp8",
+          "max_completion_tokens": 2048,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "top_k",
+            "repetition_penalty",
+            "logit_bias",
+            "min_p",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 98.74804381846636,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 91.01365328920149,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "together",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "tinfoil | meta-llama/llama-3.3-70b-instruct",
@@ -6020,23 +5869,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "meta-llama/Llama-3.3-70B-Instruct",
-          "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.00000075",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "makora | meta-llama/llama-3.3-70b-instruct",
           "model_id": "meta-llama/llama-3.3-70b-instruct",
           "model_name": "Meta: Llama 3.3 70B Instruct",
@@ -6048,6 +5880,22 @@
             "prompt": "0.00000018",
             "completion": "0.0000004",
             "input_cache_read": "0.00000015"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | meta-llama/llama-3.3-70b-instruct",
+          "model_id": "llama3.3-70b-instruct",
+          "model_name": "Meta: Llama 3.3 70B Instruct",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000065",
+            "completion": "0.00000065"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -6075,8 +5923,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000085"
+        "prompt": "0.00000025",
+        "completion": "0.00000087"
       },
       "top_provider": {
         "context_length": 1048576,
@@ -6085,42 +5933,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | meta-llama/llama-4-maverick-17b-128e-instruct",
-          "model_id": "meta-llama/llama-4-maverick",
-          "model_name": "Meta: Llama 4 Maverick",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000027",
-            "completion": "0.00000085",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.89930723376833,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89685177112642,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Parasail | meta-llama/llama-4-maverick-17b-128e-instruct",
           "model_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
@@ -6156,78 +5968,28 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96946254071662,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94565403045237,
+          "uptime_last_30m": 99.99038461538461,
+          "uptime_last_5m": 99.77661950856292,
+          "uptime_last_1d": 99.93884834978743,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "meta-llama/llama-4-scout",
-      "name": "Meta: Llama 4 Scout",
-      "created": 1743881519,
-      "description": "Llama 4 Scout 17B Instruct (16E) is a mixture-of-experts (MoE) language model developed by Meta, activating 17 billion parameters out of a total of 109B. It supports native multimodal input...",
-      "context_length": 10000000,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama4",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000018",
-        "completion": "0.00000059"
-      },
-      "top_provider": {
-        "context_length": 327680,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
+        },
         {
-          "name": "Novita | meta-llama/llama-4-scout-17b-16e-instruct",
-          "model_id": "meta-llama/llama-4-scout",
-          "model_name": "Meta: Llama 4 Scout",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
+          "name": "digitalocean | meta-llama/llama-4-maverick",
+          "model_id": "llama-4-maverick",
+          "model_name": "Meta: Llama 4 Maverick",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000059",
-            "discount": 0
+            "prompt": "0.00000025",
+            "completion": "0.00000087"
           },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.4888178913738,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.79504141576909,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -6291,50 +6053,91 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.75189035916824,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95285725510178,
+          "uptime_last_1d": 99.0122533871678,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "meta/muse-spark-1.1",
+      "name": "Meta: Muse Spark 1.1",
+      "created": 1784215741,
+      "description": "Muse Spark 1.1 is a multimodal reasoning model from Meta, built for agentic tasks. It accepts text, images, video, audio, and PDF documents and returns text, with a 1M-token context...",
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+file+audio+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video",
+          "file",
+          "audio"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.00000425",
+        "web_search": "0.0025",
+        "input_cache_read": "0.00000015"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": null,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
         {
-          "name": "Together | meta-llama/llama-guard-4-12b",
-          "model_id": "meta-llama/Llama-Guard-4-12B",
-          "model_name": "Meta: Llama Guard 4 12B",
-          "provider_name": "Together",
-          "tag": "together",
+          "name": "Meta | meta/muse-spark-1.1-20260709",
+          "model_id": "meta/muse-spark-1.1",
+          "model_name": "Meta: Muse Spark 1.1",
+          "provider_name": "Meta",
+          "tag": "meta",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000002",
+            "prompt": "0.00000125",
+            "completion": "0.00000425",
+            "web_search": "0.0025",
+            "input_cache_read": "0.00000015",
             "discount": 0
           },
           "quantization": "unknown",
           "max_completion_tokens": null,
           "max_prompt_tokens": null,
           "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
             "max_tokens",
+            "repetition_penalty",
+            "top_k",
             "temperature",
             "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_k",
-            "repetition_penalty",
-            "logit_bias",
-            "min_p"
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "response_format",
+            "reasoning_effort"
           ],
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94456940017696,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
-          "tr_provider_slug": "together",
-          "pricing_source": "provider_direct"
+          "tr_provider_slug": "meta",
+          "pricing_source": "openrouter_provider"
         }
       ],
-      "pricing_source": "provider_direct"
+      "pricing_source": "openrouter_provider"
     },
     {
       "id": "microsoft/phi-4",
@@ -6462,77 +6265,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "minimax/minimax-m1",
-      "name": "MiniMax: MiniMax M1",
-      "created": 1750200414,
-      "description": "MiniMax-M1 is a large-scale, open-weight reasoning model designed for extended context and high-efficiency inference. It leverages a hybrid Mixture-of-Experts (MoE) architecture paired with a custom \"lightning attention\" mechanism, allowing it...",
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000055",
-        "completion": "0.0000022"
-      },
-      "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 40000,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | minimax/minimax-m1",
-          "model_id": "minimax/minimax-m1",
-          "model_name": "MiniMax: MiniMax M1",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000055",
-            "completion": "0.0000022",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 40000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.99006408664115,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6604,7 +6338,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.30102516309412,
+          "uptime_last_1d": 98.90260631001372,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6676,7 +6410,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.21743991056456,
+          "uptime_last_1d": 99.28107606679035,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6702,9 +6436,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0",
-        "completion": "0.000000000001",
-        "input_cache_read": "0"
+        "prompt": "0.00000015",
+        "completion": "0.0000009",
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 196608,
@@ -6721,9 +6455,9 @@
           "tag": "friendli",
           "context_length": 196608,
           "pricing": {
-            "prompt": "0",
-            "completion": "0.000000000001",
-            "input_cache_read": "0",
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006",
             "discount": 0
           },
           "quantization": "unknown",
@@ -6748,9 +6482,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.59839357429718,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.9854078505764,
+          "uptime_last_1d": 99.6960211882261,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -6788,9 +6522,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.64664310954063,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.81035835731102,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6832,53 +6566,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.89912091079405,
+          "uptime_last_1d": 99.87237776182499,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | minimax/minimax-m2.5-20260211",
-          "model_id": "phala/minimax-m2.5",
-          "model_name": "MiniMax: MiniMax M2.5",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 196608,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000138",
-            "input_cache_read": "0.000000075",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 196608,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tool_choice",
-            "tools",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 91.49678604224059,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -6893,6 +6585,74 @@
             "prompt": "0.0000003",
             "completion": "0.0000012",
             "input_cache_read": "0.00000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | minimax/minimax-m2.5",
+          "model_id": "MiniMaxAI/MiniMax-M2.5-TEE",
+          "model_name": "MiniMax: MiniMax M2.5",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000015",
+            "completion": "0.0000012",
+            "input_cache_read": "0.000000075"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | minimax/minimax-m2.5",
+          "model_id": "minimax-m2.5",
+          "model_name": "MiniMax: MiniMax M2.5",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.000000225",
+            "completion": "0.0000009",
+            "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | minimax/minimax-m2.5",
+          "model_id": "minimax/minimax-m2.5",
+          "model_name": "MiniMax: MiniMax M2.5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.000000295",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | minimax/minimax-m2.5",
+          "model_id": "MiniMaxAI/MiniMax-M2.5",
+          "model_name": "MiniMax: MiniMax M2.5",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000015",
+            "completion": "0.0000009",
+            "input_cache_read": "0.00000005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -6965,9 +6725,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96138996138995,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.94970836562386,
+          "uptime_last_30m": 99.56521739130434,
+          "uptime_last_5m": 99.42922374429224,
+          "uptime_last_1d": 99.31909164983881,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7005,10 +6765,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 100,
+          "status": -2,
+          "uptime_last_30m": 88.0794701986755,
           "uptime_last_5m": null,
-          "uptime_last_1d": 94.214787982101,
+          "uptime_last_1d": 88.93099636822991,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7041,9 +6801,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.48658539796213,
+          "uptime_last_30m": 96.0122699386503,
+          "uptime_last_5m": 97.43589743589743,
+          "uptime_last_1d": 98.75289961480347,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -7075,9 +6835,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.16897506925207,
-          "uptime_last_5m": 98.43260188087774,
-          "uptime_last_1d": 98.63201196152673,
+          "uptime_last_30m": 97.85276073619632,
+          "uptime_last_5m": 98.17232375979113,
+          "uptime_last_1d": 98.48588417748965,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -7109,9 +6869,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.74747474747475,
-          "uptime_last_5m": 95.1219512195122,
-          "uptime_last_1d": 98.18971316739037,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.84456493674153,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -7149,9 +6909,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.32213950390495,
+          "uptime_last_30m": 98.7012987012987,
+          "uptime_last_5m": 99.67637540453075,
+          "uptime_last_1d": 99.16992993027759,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7191,12 +6951,29 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.76580796252928,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.68428912783752,
+          "uptime_last_1d": 99.42044376157982,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | minimax/minimax-m2.7",
+          "model_id": "minimax/minimax-m2.7",
+          "model_name": "MiniMax: MiniMax M2.7",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -7237,7 +7014,7 @@
           "model_id": "MiniMaxAI/MiniMax-M3",
           "model_name": "MiniMax: MiniMax M3",
           "provider_name": "DeepInfra",
-          "tag": "deepinfra/bf16",
+          "tag": "deepinfra/fp8",
           "context_length": 524288,
           "pricing": {
             "prompt": "0.0000003",
@@ -7245,7 +7022,7 @@
             "input_cache_read": "0.00000006",
             "discount": 0
           },
-          "quantization": "bf16",
+          "quantization": "fp8",
           "max_completion_tokens": 512000,
           "max_prompt_tokens": null,
           "supported_parameters": [
@@ -7266,9 +7043,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89677419354838,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.05841028836892,
+          "uptime_last_30m": 99.77477477477478,
+          "uptime_last_5m": 99.4475138121547,
+          "uptime_last_1d": 99.23624749548692,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7299,9 +7076,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.61016949152543,
-          "uptime_last_5m": 97.96954314720813,
-          "uptime_last_1d": 99.19496744677107,
+          "uptime_last_30m": 97.47138674474314,
+          "uptime_last_5m": 96.69260700389106,
+          "uptime_last_1d": 98.58535905318845,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -7355,9 +7132,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87550277724574,
-          "uptime_last_5m": 99.6262680192205,
-          "uptime_last_1d": 99.66104483522122,
+          "uptime_last_30m": 99.80650835532103,
+          "uptime_last_5m": 99.78165938864629,
+          "uptime_last_1d": 99.80506555953023,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -7398,10 +7175,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": 98.42471978188428,
-          "uptime_last_5m": 97.27767695099818,
-          "uptime_last_1d": 96.73527567136097,
+          "status": -2,
+          "uptime_last_30m": 92.78024065864471,
+          "uptime_last_5m": 97.10743801652893,
+          "uptime_last_1d": 92.41297649665148,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -7441,9 +7218,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9043245311902,
-          "uptime_last_5m": 99.78165938864629,
-          "uptime_last_1d": 97.23242040947582,
+          "uptime_last_30m": 97.28669499836548,
+          "uptime_last_5m": 97.44897959183673,
+          "uptime_last_1d": 97.2486871135142,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -7476,6 +7253,23 @@
             "prompt": "0.00000033",
             "completion": "0.00000132",
             "input_cache_read": "0.00000007"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | minimax/minimax-m3",
+          "model_id": "minimax/minimax-m3",
+          "model_name": "MiniMax: MiniMax M3",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7545,9 +7339,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.76442873969376,
+          "uptime_last_30m": 99.90990990990991,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89290741080717,
+          "uptime_last_1d": 99.86441645556071,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7615,9 +7409,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.97073741708935,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.6481591066972,
+          "uptime_last_1d": 99.87612083808501,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7685,9 +7479,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86419194205523,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.54018010032433,
+          "uptime_last_30m": 99.69332992588807,
+          "uptime_last_5m": 99.83402489626556,
+          "uptime_last_1d": 99.67771809594369,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7755,9 +7549,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.77848678213309,
-          "uptime_last_5m": 99.90601503759399,
-          "uptime_last_1d": 98.9035495261104,
+          "uptime_last_30m": 99.24106526838692,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.53317951508926,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7827,7 +7621,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98332870241734,
+          "uptime_last_1d": 99.97107079390007,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7897,9 +7691,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.40828402366864,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84282432595816,
+          "uptime_last_1d": 99.98771574227628,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7925,8 +7719,9 @@
         "instruct_type": "mistral"
       },
       "pricing": {
-        "prompt": "0.00000004",
-        "completion": "0.00000017"
+        "prompt": "0.0000000245",
+        "completion": "0.0000000978",
+        "input_cache_read": "0.00000001225"
       },
       "top_provider": {
         "context_length": 131072,
@@ -7965,9 +7760,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 97.861109206828,
-          "uptime_last_5m": 94.70377019748653,
-          "uptime_last_1d": 98.35195640776199,
+          "uptime_last_30m": 99.67433340118053,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.65803532254085,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8002,13 +7797,30 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -5,
-          "uptime_last_30m": 57.08806382325867,
-          "uptime_last_5m": 60.842754367934226,
-          "uptime_last_1d": 75.8473995355349,
+          "status": 0,
+          "uptime_last_30m": 95.57295828671887,
+          "uptime_last_5m": 98.66666666666667,
+          "uptime_last_1d": 90.57704175675069,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "chutes | mistralai/mistral-nemo",
+          "model_id": "unsloth/Mistral-Nemo-Instruct-2407-TEE",
+          "model_name": "Mistral: Mistral Nemo",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000000245",
+            "completion": "0.0000000978",
+            "input_cache_read": "0.00000001225"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -8074,26 +7886,10 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99767142214012,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | mistralai/mistral-small-24b-instruct-2501",
-          "model_id": "mistralai/Mistral-Small-24B-Instruct-2501",
-          "model_name": "Mistral: Mistral Small 3",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 32768,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -8161,9 +7957,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99486442070665,
-          "uptime_last_5m": 99.91909385113269,
-          "uptime_last_1d": 99.95172001445202,
+          "uptime_last_30m": 99.98310049571879,
+          "uptime_last_5m": 99.93701448666806,
+          "uptime_last_1d": 99.95713351031428,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8234,9 +8030,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49687716863289,
-          "uptime_last_5m": 98.51116625310173,
-          "uptime_last_1d": 99.58854460013157,
+          "uptime_last_30m": 99.60775265343793,
+          "uptime_last_5m": 76.47058823529412,
+          "uptime_last_1d": 99.26493849013816,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -8315,73 +8111,6 @@
       "pricing_source": "provider_direct"
     },
     {
-      "id": "moonshotai/kimi-k2",
-      "name": "MoonshotAI: Kimi K2 0711",
-      "created": 1752263252,
-      "description": "Kimi K2 Instruct is a large-scale Mixture-of-Experts (MoE) language model developed by Moonshot AI, featuring 1 trillion total parameters with 32 billion active per forward pass. It is optimized for...",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000057",
-        "completion": "0.0000023"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 100352,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | moonshotai/kimi-k2",
-          "model_id": "moonshotai/kimi-k2",
-          "model_name": "MoonshotAI: Kimi K2 0711",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000057",
-            "completion": "0.0000023",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 100352,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97955618332529,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
       "id": "moonshotai/kimi-k2-0905",
       "name": "MoonshotAI: Kimi K2 0905",
       "created": 1757021147,
@@ -8440,9 +8169,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49088960342979,
-          "uptime_last_5m": 99.69395562356542,
-          "uptime_last_1d": 98.01694898938202,
+          "uptime_last_30m": 98.94444444444444,
+          "uptime_last_5m": 99.01185770750988,
+          "uptime_last_1d": 98.25977135407527,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8474,7 +8203,7 @@
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "max_completion_tokens": 100352,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -8512,10 +8241,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 98.99159663865547,
+          "status": -2,
+          "uptime_last_30m": 94.85294117647058,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.04003613981591,
+          "uptime_last_1d": 99.37429608309348,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8558,9 +8287,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000045",
-        "completion": "0.00000225",
-        "input_cache_read": "0.000000095"
+        "prompt": "0.000000375",
+        "completion": "0.000002025",
+        "input_cache_read": "0.000000203"
       },
       "top_provider": {
         "context_length": 262144,
@@ -8604,9 +8333,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 98.72190392243279,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86081522511007,
+          "uptime_last_30m": 99.63933637893724,
+          "uptime_last_5m": 97.79661016949153,
+          "uptime_last_1d": 99.50547174370837,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -8640,9 +8369,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.99773778687691,
+          "uptime_last_30m": 99.4413407821229,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94345738199715,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -8683,53 +8412,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99428113919707,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93981966127066,
+          "uptime_last_30m": 99.6225821670074,
+          "uptime_last_5m": 99.90892531876139,
+          "uptime_last_1d": 99.8920324112412,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | moonshotai/kimi-k2.5-0127",
-          "model_id": "phala/kimi-k2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.000003",
-            "input_cache_read": "0.00000022",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.62122598353157,
-          "uptime_last_5m": 94.02985074626866,
-          "uptime_last_1d": 91.1947119307981,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -8781,6 +8468,57 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        },
+        {
+          "name": "chutes | moonshotai/kimi-k2.5",
+          "model_id": "moonshotai/Kimi-K2.5-TEE",
+          "model_name": "MoonshotAI: Kimi K2.5",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000044",
+            "completion": "0.000002",
+            "input_cache_read": "0.00000022"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | moonshotai/kimi-k2.5",
+          "model_id": "kimi-k2.5",
+          "model_name": "MoonshotAI: Kimi K2.5",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000375",
+            "completion": "0.000002025",
+            "input_cache_read": "0.000000203"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | moonshotai/kimi-k2.5",
+          "model_id": "moonshotai/kimi-k2.5",
+          "model_name": "MoonshotAI: Kimi K2.5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000049",
+            "completion": "0.0000025",
+            "input_cache_read": "0.0000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -8804,13 +8542,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000007",
-        "completion": "0.0000035",
-        "input_cache_read": "0.00000035"
+        "prompt": "0.00000066",
+        "completion": "0.00000341",
+        "input_cache_read": "0.00000015"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": null,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -8851,9 +8589,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85590778097982,
+          "uptime_last_30m": 99.91546914623838,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93329610325142,
+          "uptime_last_1d": 99.90946519799098,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -8930,9 +8668,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.90705431676237,
+          "uptime_last_30m": 99.7338065661047,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.83701979045402,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -8971,9 +8709,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.88059701492537,
-          "uptime_last_5m": 98.91304347826086,
-          "uptime_last_1d": 99.60982164959391,
+          "uptime_last_30m": 99.52606635071089,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.03766707168894,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9015,53 +8753,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.82638888888889,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.53320554741234,
+          "uptime_last_30m": 99.41060903732809,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.04894687048747,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | moonshotai/kimi-k2.6-20260420",
-          "model_id": "phala/kimi-k2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000109",
-            "completion": "0.0000046",
-            "input_cache_read": "0.00000037",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "structured_outputs",
-            "response_format",
-            "tool_choice",
-            "tools"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.71794871794873,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 82.51235214852522,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -9098,10 +8794,10 @@
             "structured_outputs",
             "response_format"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.82949701619779,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.790036215882,
+          "status": -2,
+          "uptime_last_30m": 82.91262135922331,
+          "uptime_last_5m": 81.72043010752688,
+          "uptime_last_1d": 96.46221055023862,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -9174,17 +8870,85 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
+          "name": "chutes | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/Kimi-K2.6-TEE",
           "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.0000007",
+            "prompt": "0.00000066",
             "completion": "0.0000035",
-            "input_cache_read": "0.00000035"
+            "input_cache_read": "0.00000033"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | moonshotai/kimi-k2.6",
+          "model_id": "kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000076",
+            "completion": "0.0000032",
+            "input_cache_read": "0.00000019"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/Kimi-K2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000066",
+            "completion": "0.00000341",
+            "input_cache_read": "0.00000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9212,9 +8976,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000074",
+        "prompt": "0.00000072",
         "completion": "0.0000035",
-        "input_cache_read": "0.00000016"
+        "input_cache_read": "0.00000015"
       },
       "top_provider": {
         "context_length": 262144,
@@ -9258,9 +9022,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86728136350936,
+          "uptime_last_30m": 96.82539682539682,
+          "uptime_last_5m": 94.44444444444444,
+          "uptime_last_1d": 98.87584061025795,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9294,9 +9058,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.95952236389395,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.78245335450575,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9330,9 +9094,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.97351461110621,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.95657151881244,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9374,8 +9138,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.97293721433726,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94172008991757,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9417,9 +9181,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 99.04761904761905,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.3937484030321,
+          "uptime_last_1d": 99.4703975970279,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -9459,9 +9223,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.1532574853784,
+          "uptime_last_30m": 98.86480908152735,
+          "uptime_last_5m": 98.66666666666667,
+          "uptime_last_1d": 99.1395793499044,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -9501,6 +9265,23 @@
           "quantization": "unknown"
         },
         {
+          "name": "makora | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000076",
+            "completion": "0.0000037749",
+            "input_cache_read": "0.0000005757"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "alibaba | moonshotai/kimi-k2.7-code",
           "model_id": "kimi-k2.7-code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
@@ -9518,17 +9299,51 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | moonshotai/kimi-k2.7-code",
+          "name": "atlas-cloud | moonshotai/kimi-k2.7-code",
           "model_id": "moonshotai/kimi-k2.7-code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000076",
-            "completion": "0.0000037749",
-            "input_cache_read": "0.0000005757"
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000019"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/Kimi-K2.7-Code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000072",
+            "completion": "0.0000035",
+            "input_cache_read": "0.00000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9597,12 +9412,28 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.76345357776464,
+          "uptime_last_30m": 99.99243245970285,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99434753899556,
+          "uptime_last_1d": 99.99195358551685,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "siliconflow | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "siliconflow",
+          "tag": "siliconflow",
+          "tr_provider_slug": "siliconflow",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         },
         {
           "name": "gmi | moonshotai/kimi-k3",
@@ -9611,6 +9442,57 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "novita | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000003",
@@ -9685,26 +9567,10 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99645327185671,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | nousresearch/hermes-3-llama-3.1-405b",
-          "model_id": "nousresearch/hermes-3-llama-3.1-405b",
-          "model_name": "Nous: Hermes 3 405B Instruct",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -9797,8 +9663,7 @@
       },
       "pricing": {
         "prompt": "0.00000005",
-        "completion": "0.0000002",
-        "input_cache_read": "0.00000003"
+        "completion": "0.0000002"
       },
       "top_provider": {
         "context_length": 262144,
@@ -9841,9 +9706,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.20168372160533,
-          "uptime_last_5m": 99.11543564794339,
-          "uptime_last_1d": 99.07110333957388,
+          "uptime_last_30m": 99.65328607750983,
+          "uptime_last_5m": 99.46236559139786,
+          "uptime_last_1d": 98.83177129631913,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9884,27 +9749,10 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.65765765765767,
+          "uptime_last_1d": 93.08094523934984,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "crusoe | nvidia/nemotron-3-nano-30b-a3b",
-          "model_id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
-          "model_name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000002",
-            "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -9928,11 +9776,10 @@
       },
       "pricing": {
         "prompt": "0.0000003",
-        "completion": "0.0000009",
-        "input_cache_read": "0.00000006"
+        "completion": "0.0000009"
       },
       "top_provider": {
-        "context_length": 1000000,
+        "context_length": 262144,
         "max_completion_tokens": null,
         "is_moderated": false
       },
@@ -9971,28 +9818,11 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.27574120335404,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.98131888660564,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "crusoe | nvidia/nemotron-3-super-120b-a12b",
-          "model_id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
-          "model_name": "NVIDIA: Nemotron 3 Super",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -10062,9 +9892,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69026548672566,
-          "uptime_last_5m": 99.38461538461539,
-          "uptime_last_1d": 98.35255018299335,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.08699853542903,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -10151,22 +9981,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | openai/gpt-3.5-turbo",
-          "model_id": "openai/gpt-3.5-turbo",
-          "model_name": "OpenAI: GPT-3.5 Turbo",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 16385,
-          "pricing": {
-            "prompt": "0.0000005",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "lightning | openai/gpt-3.5-turbo",
           "model_id": "openai/gpt-3.5-turbo",
           "model_name": "OpenAI: GPT-3.5 Turbo",
@@ -10213,22 +10027,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "phala | openai/gpt-4",
-          "model_id": "openai/gpt-4",
-          "model_name": "OpenAI: GPT-4",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 8191,
-          "pricing": {
-            "prompt": "0.00003",
-            "completion": "0.00006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
         {
           "name": "lightning | openai/gpt-4",
           "model_id": "openai/gpt-4",
@@ -10403,28 +10201,12 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.32855063953637,
-          "uptime_last_5m": 99.0314769975787,
-          "uptime_last_1d": 99.44224019421094,
+          "uptime_last_30m": 98.74129743187791,
+          "uptime_last_5m": 99.06819144430327,
+          "uptime_last_1d": 99.20177258982885,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-4.1",
-          "model_id": "openai/gpt-4.1",
-          "model_name": "OpenAI: GPT-4.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1047576,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "lightning | openai/gpt-4.1",
@@ -10437,6 +10219,23 @@
           "pricing": {
             "prompt": "0.000002",
             "completion": "0.000008"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-4.1",
+          "model_id": "openai/gpt-4.1",
+          "model_name": "OpenAI: GPT-4.1",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1047576,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000008",
+            "input_cache_read": "0.0000005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10505,24 +10304,25 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.57624756063564,
-          "uptime_last_5m": 99.77678571428571,
-          "uptime_last_1d": 98.99158429304636,
+          "uptime_last_30m": 98.13129155576003,
+          "uptime_last_5m": 99.30110179246834,
+          "uptime_last_1d": 99.21643948549965,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | openai/gpt-4.1-mini",
+          "name": "atlas-cloud | openai/gpt-4.1-mini",
           "model_id": "openai/gpt-4.1-mini",
           "model_name": "OpenAI: GPT-4.1 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1047576,
           "pricing": {
             "prompt": "0.0000004",
-            "completion": "0.0000016"
+            "completion": "0.0000016",
+            "input_cache_read": "0.0000001"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10591,24 +10391,25 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.74205267938238,
-          "uptime_last_5m": 99.93595491225823,
-          "uptime_last_1d": 99.39712194186188,
+          "uptime_last_30m": 97.80179615705931,
+          "uptime_last_5m": 98.2815356489945,
+          "uptime_last_1d": 98.84812775800792,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | openai/gpt-4.1-nano",
+          "name": "atlas-cloud | openai/gpt-4.1-nano",
           "model_id": "openai/gpt-4.1-nano",
           "model_name": "OpenAI: GPT-4.1 Nano",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1047576,
           "pricing": {
             "prompt": "0.0000001",
-            "completion": "0.0000004"
+            "completion": "0.0000004",
+            "input_cache_read": "0.000000025"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10683,28 +10484,12 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98157361341441,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90026197635487,
+          "uptime_last_30m": 99.96036464526358,
+          "uptime_last_5m": 99.91326973113617,
+          "uptime_last_1d": 99.96130343244056,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-4o",
-          "model_id": "openai/gpt-4o",
-          "model_name": "OpenAI: GPT-4o",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "lightning | openai/gpt-4o",
@@ -10729,6 +10514,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 128000,
+          "pricing": {
+            "prompt": "0.0000025",
+            "completion": "0.00001",
+            "input_cache_read": "0.00000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-4o",
+          "model_id": "openai/gpt-4o",
+          "model_name": "OpenAI: GPT-4o",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 128000,
           "pricing": {
             "prompt": "0.0000025",
@@ -10764,7 +10566,7 @@
       "pricing": {
         "prompt": "0.00000015",
         "completion": "0.0000006",
-        "input_cache_read": "0.00000008"
+        "input_cache_read": "0.000000075"
       },
       "top_provider": {
         "context_length": 128000,
@@ -10808,28 +10610,12 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98273417905565,
-          "uptime_last_5m": 99.98002625121269,
-          "uptime_last_1d": 99.90076312876106,
+          "uptime_last_30m": 99.90091035560002,
+          "uptime_last_5m": 99.92185907453964,
+          "uptime_last_1d": 99.95759184888603,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-4o-mini",
-          "model_id": "openai/gpt-4o-mini",
-          "model_name": "OpenAI: GPT-4o-mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | openai/gpt-4o-mini",
@@ -10843,6 +10629,23 @@
             "prompt": "0.00000015",
             "completion": "0.0000006",
             "input_cache_read": "0.00000008"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-4o-mini",
+          "model_id": "openai/gpt-4o-mini",
+          "model_name": "OpenAI: GPT-4o-mini",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 128000,
+          "pricing": {
+            "prompt": "0.00000015",
+            "completion": "0.0000006",
+            "input_cache_read": "0.000000075"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10874,7 +10677,7 @@
         "prompt": "0.00000125",
         "completion": "0.00001",
         "web_search": "0.01",
-        "input_cache_read": "0.00000013"
+        "input_cache_read": "0.000000125"
       },
       "top_provider": {
         "context_length": 400000,
@@ -10883,22 +10686,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "phala | openai/gpt-5",
-          "model_id": "openai/gpt-5",
-          "model_name": "OpenAI: GPT-5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
         {
           "name": "lightning | openai/gpt-5",
           "model_id": "openai/gpt-5",
@@ -10927,6 +10714,126 @@
             "prompt": "0.00000125",
             "completion": "0.00001",
             "input_cache_read": "0.00000013"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5",
+          "model_id": "openai/gpt-5",
+          "model_name": "OpenAI: GPT-5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5-chat",
+      "name": "OpenAI: GPT-5 Chat",
+      "created": 1754587837,
+      "description": "GPT-5 Chat is designed for advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "context_length": 128000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "file",
+          "image",
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.00001",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000125"
+      },
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 16384,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5-chat",
+          "model_id": "openai/gpt-5-chat",
+          "model_name": "OpenAI: GPT-5 Chat",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 128000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5-codex",
+      "name": "OpenAI: GPT-5 Codex",
+      "created": 1758643403,
+      "description": "GPT-5-Codex is a specialized version of GPT-5 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks....",
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.00001",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000125"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5-codex",
+          "model_id": "openai/gpt-5-codex",
+          "model_name": "OpenAI: GPT-5 Codex",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10968,22 +10875,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | openai/gpt-5-mini",
-          "model_id": "openai/gpt-5-mini",
-          "model_name": "OpenAI: GPT-5 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000025",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "lightning | openai/gpt-5-mini",
           "model_id": "openai/gpt-5-mini",
           "model_name": "OpenAI: GPT-5 Mini",
@@ -10994,6 +10885,23 @@
           "pricing": {
             "prompt": "0.00000025",
             "completion": "0.000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5-mini",
+          "model_id": "openai/gpt-5-mini",
+          "model_name": "OpenAI: GPT-5 Mini",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.000002",
+            "input_cache_read": "0.000000025"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11035,22 +10943,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "phala | openai/gpt-5-nano",
-          "model_id": "openai/gpt-5-nano",
-          "model_name": "OpenAI: GPT-5 Nano",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "lightning | openai/gpt-5-nano",
           "model_id": "openai/gpt-5-nano",
           "model_name": "OpenAI: GPT-5 Nano",
@@ -11061,6 +10953,75 @@
           "pricing": {
             "prompt": "0.00000005",
             "completion": "0.0000004"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5-nano",
+          "model_id": "openai/gpt-5-nano",
+          "model_name": "OpenAI: GPT-5 Nano",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000005",
+            "completion": "0.0000004",
+            "input_cache_read": "0.000000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5-pro",
+      "name": "OpenAI: GPT-5 Pro",
+      "created": 1759776663,
+      "description": "GPT-5 Pro is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and...",
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "image",
+          "text",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000015",
+        "completion": "0.00012",
+        "web_search": "0.01",
+        "input_cache_read": "0.000015"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5-pro",
+          "model_id": "openai/gpt-5-pro",
+          "model_name": "OpenAI: GPT-5 Pro",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.000015",
+            "completion": "0.00012",
+            "input_cache_read": "0.000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11092,7 +11053,7 @@
         "prompt": "0.00000125",
         "completion": "0.00001",
         "web_search": "0.01",
-        "input_cache_read": "0.00000013"
+        "input_cache_read": "0.000000125"
       },
       "top_provider": {
         "context_length": 400000,
@@ -11101,22 +11062,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "phala | openai/gpt-5.1",
-          "model_id": "openai/gpt-5.1",
-          "model_name": "OpenAI: GPT-5.1",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.00001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
         {
           "name": "gmi | openai/gpt-5.1",
           "model_id": "openai/gpt-5.1",
@@ -11129,6 +11074,23 @@
             "prompt": "0.00000125",
             "completion": "0.00001",
             "input_cache_read": "0.00000013"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.1",
+          "model_id": "openai/gpt-5.1",
+          "model_name": "OpenAI: GPT-5.1",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11160,7 +11122,7 @@
         "prompt": "0.00000125",
         "completion": "0.00001",
         "web_search": "0.01",
-        "input_cache_read": "0.00000013"
+        "input_cache_read": "0.000000125"
       },
       "top_provider": {
         "context_length": 128000,
@@ -11181,6 +11143,176 @@
             "prompt": "0.00000125",
             "completion": "0.00001",
             "input_cache_read": "0.00000013"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.1-chat",
+          "model_id": "openai/gpt-5.1-chat",
+          "model_name": "OpenAI: GPT-5.1 Chat",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 128000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5.1-codex",
+      "name": "OpenAI: GPT-5.1-Codex",
+      "created": 1763060298,
+      "description": "GPT-5.1-Codex is a specialized version of GPT-5.1 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks....",
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.00001",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000125"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5.1-codex",
+          "model_id": "openai/gpt-5.1-codex",
+          "model_name": "OpenAI: GPT-5.1-Codex",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5.1-codex-max",
+      "name": "OpenAI: GPT-5.1-Codex-Max",
+      "created": 1764878934,
+      "description": "GPT-5.1-Codex-Max is OpenAI’s latest agentic coding model, designed for long-running, high-context software development tasks. It is based on an updated version of the 5.1 reasoning stack and trained on agentic...",
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.00001",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000125"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5.1-codex-max",
+          "model_id": "openai/gpt-5.1-codex-max",
+          "model_name": "OpenAI: GPT-5.1-Codex-Max",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.00001",
+            "input_cache_read": "0.000000125"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/gpt-5.1-codex-mini",
+      "name": "OpenAI: GPT-5.1-Codex-Mini",
+      "created": 1763057820,
+      "description": "GPT-5.1-Codex-Mini is a smaller and faster version of GPT-5.1-Codex",
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000025",
+        "completion": "0.000002",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000025"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 100000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/gpt-5.1-codex-mini",
+          "model_id": "openai/gpt-5.1-codex-mini",
+          "model_name": "OpenAI: GPT-5.1-Codex-Mini",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.000002",
+            "input_cache_read": "0.000000025"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11212,7 +11344,7 @@
         "prompt": "0.00000175",
         "completion": "0.000014",
         "web_search": "0.01",
-        "input_cache_read": "0.00000018"
+        "input_cache_read": "0.000000175"
       },
       "top_provider": {
         "context_length": 400000,
@@ -11221,22 +11353,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "phala | openai/gpt-5.2",
-          "model_id": "openai/gpt-5.2",
-          "model_name": "OpenAI: GPT-5.2",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000175",
-            "completion": "0.000014"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
         {
           "name": "gmi | openai/gpt-5.2",
           "model_id": "openai/gpt-5.2",
@@ -11249,6 +11365,23 @@
             "prompt": "0.00000175",
             "completion": "0.000014",
             "input_cache_read": "0.00000018"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.2",
+          "model_id": "openai/gpt-5.2",
+          "model_name": "OpenAI: GPT-5.2",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000175",
+            "completion": "0.000014",
+            "input_cache_read": "0.000000175"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11280,7 +11413,7 @@
         "prompt": "0.00000175",
         "completion": "0.000014",
         "web_search": "0.01",
-        "input_cache_read": "0.00000018"
+        "input_cache_read": "0.000000175"
       },
       "top_provider": {
         "context_length": 128000,
@@ -11301,6 +11434,23 @@
             "prompt": "0.00000175",
             "completion": "0.000014",
             "input_cache_read": "0.00000018"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.2-chat",
+          "model_id": "openai/gpt-5.2-chat",
+          "model_name": "OpenAI: GPT-5.2 Chat",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 128000,
+          "pricing": {
+            "prompt": "0.00000175",
+            "completion": "0.000014",
+            "input_cache_read": "0.000000175"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11331,7 +11481,7 @@
         "prompt": "0.00000175",
         "completion": "0.000014",
         "web_search": "0.01",
-        "input_cache_read": "0.00000018"
+        "input_cache_read": "0.000000175"
       },
       "top_provider": {
         "context_length": 400000,
@@ -11352,6 +11502,23 @@
             "prompt": "0.00000175",
             "completion": "0.000014",
             "input_cache_read": "0.00000018"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.2-codex",
+          "model_id": "openai/gpt-5.2-codex",
+          "model_name": "OpenAI: GPT-5.2-Codex",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000175",
+            "completion": "0.000014",
+            "input_cache_read": "0.000000175"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11383,7 +11550,7 @@
         "prompt": "0.00000175",
         "completion": "0.000014",
         "web_search": "0.01",
-        "input_cache_read": "0.00000018"
+        "input_cache_read": "0.000000175"
       },
       "top_provider": {
         "context_length": 400000,
@@ -11421,9 +11588,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.27272727272728,
-          "uptime_last_5m": 94.33962264150944,
-          "uptime_last_1d": 97.64478141635747,
+          "uptime_last_30m": 98.77663772691398,
+          "uptime_last_5m": 98.22485207100591,
+          "uptime_last_1d": 97.8112833581086,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11457,9 +11624,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.27272727272728,
-          "uptime_last_5m": 94.33962264150944,
-          "uptime_last_1d": 97.64478141635747,
+          "uptime_last_30m": 98.77663772691398,
+          "uptime_last_5m": 98.22485207100591,
+          "uptime_last_1d": 97.8112833581086,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11476,6 +11643,23 @@
             "prompt": "0.00000175",
             "completion": "0.000014",
             "input_cache_read": "0.00000018"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.3-codex",
+          "model_id": "openai/gpt-5.3-codex",
+          "model_name": "OpenAI: GPT-5.3-Codex",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000175",
+            "completion": "0.000014",
+            "input_cache_read": "0.000000175"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11582,10 +11766,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.6844816484224,
-          "uptime_last_5m": 99.97113163972287,
-          "uptime_last_1d": 95.0331349205261,
+          "status": -2,
+          "uptime_last_30m": 93.90436322653358,
+          "uptime_last_5m": 99.32185706833594,
+          "uptime_last_1d": 98.71615751990616,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11648,10 +11832,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.6844816484224,
-          "uptime_last_5m": 99.97113163972287,
-          "uptime_last_1d": 95.0331349205261,
+          "status": -2,
+          "uptime_last_30m": 93.90436322653358,
+          "uptime_last_5m": 99.32185706833594,
+          "uptime_last_1d": 98.71615751990616,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11706,29 +11890,13 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.6844816484224,
-          "uptime_last_5m": 99.97113163972287,
-          "uptime_last_1d": 95.0331349205261,
+          "status": -2,
+          "uptime_last_30m": 93.90436322653358,
+          "uptime_last_5m": 99.32185706833594,
+          "uptime_last_1d": 98.71615751990616,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-5.4",
-          "model_id": "openai/gpt-5.4",
-          "model_name": "OpenAI: GPT-5.4",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.0000025",
-            "completion": "0.000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | openai/gpt-5.4",
@@ -11737,6 +11905,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.0000025",
+            "completion": "0.000015",
+            "input_cache_read": "0.00000025"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.4",
+          "model_id": "openai/gpt-5.4",
+          "model_name": "OpenAI: GPT-5.4",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1050000,
           "pricing": {
             "prompt": "0.0000025",
@@ -11810,10 +11995,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.86820056108904,
-          "uptime_last_5m": 99.82536270822139,
-          "uptime_last_1d": 98.30012508687614,
+          "status": -2,
+          "uptime_last_30m": 92.68897643017256,
+          "uptime_last_5m": 96.07474880270448,
+          "uptime_last_1d": 84.87482239968645,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11846,10 +12031,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.86820056108904,
-          "uptime_last_5m": 99.82536270822139,
-          "uptime_last_1d": 98.30012508687614,
+          "status": -2,
+          "uptime_last_30m": 92.68897643017256,
+          "uptime_last_5m": 96.07474880270448,
+          "uptime_last_1d": 84.87482239968645,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11882,29 +12067,13 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.86820056108904,
-          "uptime_last_5m": 99.82536270822139,
-          "uptime_last_1d": 98.30012508687614,
+          "status": -2,
+          "uptime_last_30m": 92.68897643017256,
+          "uptime_last_5m": 96.07474880270448,
+          "uptime_last_1d": 84.87482239968645,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-5.4-mini",
-          "model_id": "openai/gpt-5.4-mini",
-          "model_name": "OpenAI: GPT-5.4 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 400000,
-          "pricing": {
-            "prompt": "0.00000075",
-            "completion": "0.0000045"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | openai/gpt-5.4-mini",
@@ -11913,6 +12082,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.00000075",
+            "completion": "0.0000045",
+            "input_cache_read": "0.000000075"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.4-mini",
+          "model_id": "openai/gpt-5.4-mini",
+          "model_name": "OpenAI: GPT-5.4 Mini",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 400000,
           "pricing": {
             "prompt": "0.00000075",
@@ -11986,10 +12172,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 91.96381674934345,
-          "uptime_last_5m": 92.19047619047619,
-          "uptime_last_1d": 95.25580834894984,
+          "status": 0,
+          "uptime_last_30m": 98.01505369296147,
+          "uptime_last_5m": 98.16738451144329,
+          "uptime_last_1d": 95.08473879023944,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12022,10 +12208,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 91.96381674934345,
-          "uptime_last_5m": 92.19047619047619,
-          "uptime_last_1d": 95.25580834894984,
+          "status": 0,
+          "uptime_last_30m": 98.01505369296147,
+          "uptime_last_5m": 98.16738451144329,
+          "uptime_last_1d": 95.08473879023944,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12037,6 +12223,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 400000,
+          "pricing": {
+            "prompt": "0.0000002",
+            "completion": "0.00000125",
+            "input_cache_read": "0.00000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.4-nano",
+          "model_id": "openai/gpt-5.4-nano",
+          "model_name": "OpenAI: GPT-5.4 Nano",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 400000,
           "pricing": {
             "prompt": "0.0000002",
@@ -12145,7 +12348,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 60.280373831775705,
+          "uptime_last_1d": 78.27175954915467,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12207,7 +12410,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 60.280373831775705,
+          "uptime_last_1d": 78.27175954915467,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12330,9 +12533,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 83.2908424908425,
-          "uptime_last_5m": 87.22027972027972,
-          "uptime_last_1d": 94.5027684512337,
+          "uptime_last_30m": 89.17174774133251,
+          "uptime_last_5m": 91.33506879880997,
+          "uptime_last_1d": 94.13977219516052,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12396,9 +12599,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 83.2908424908425,
-          "uptime_last_5m": 87.22027972027972,
-          "uptime_last_1d": 94.5027684512337,
+          "uptime_last_30m": 89.17174774133251,
+          "uptime_last_5m": 91.33506879880997,
+          "uptime_last_1d": 94.13977219516052,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12454,28 +12657,12 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 83.2908424908425,
-          "uptime_last_5m": 87.22027972027972,
-          "uptime_last_1d": 94.5027684512337,
+          "uptime_last_30m": 89.17174774133251,
+          "uptime_last_5m": 91.33506879880997,
+          "uptime_last_1d": 94.13977219516052,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/gpt-5.5",
-          "model_id": "openai/gpt-5.5",
-          "model_name": "OpenAI: GPT-5.5",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.00003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | openai/gpt-5.5",
@@ -12484,6 +12671,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.00003",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.5",
+          "model_id": "openai/gpt-5.5",
+          "model_name": "OpenAI: GPT-5.5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1050000,
           "pricing": {
             "prompt": "0.000005",
@@ -12610,9 +12814,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.85358711566617,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12672,9 +12876,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.85358711566617,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12785,9 +12989,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94023989413924,
-          "uptime_last_5m": 99.97513674788662,
-          "uptime_last_1d": 97.19202825629243,
+          "uptime_last_30m": 99.71614959414372,
+          "uptime_last_5m": 99.92304576751721,
+          "uptime_last_1d": 99.87643086592874,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12853,9 +13057,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94023989413924,
-          "uptime_last_5m": 99.97513674788662,
-          "uptime_last_1d": 97.19202825629243,
+          "uptime_last_30m": 99.71614959414372,
+          "uptime_last_5m": 99.92304576751721,
+          "uptime_last_1d": 99.87643086592874,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12912,9 +13116,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94023989413924,
-          "uptime_last_5m": 99.97513674788662,
-          "uptime_last_1d": 97.19202825629243,
+          "uptime_last_30m": 99.71614959414372,
+          "uptime_last_5m": 99.92304576751721,
+          "uptime_last_1d": 99.87643086592874,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12942,6 +13146,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000006",
+            "input_cache_read": "0.0000001"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.6-luna",
+          "model_id": "openai/gpt-5.6-luna",
+          "model_name": "OpenAI: GPT-5.6 Luna",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1050000,
           "pricing": {
             "prompt": "0.000001",
@@ -13058,9 +13279,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.90500718141746,
-          "uptime_last_5m": 98.51851851851852,
-          "uptime_last_1d": 90.12970135222825,
+          "uptime_last_30m": 95.70615623383341,
+          "uptime_last_5m": 96.6785290628707,
+          "uptime_last_1d": 94.89071019759922,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13126,9 +13347,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.90500718141746,
-          "uptime_last_5m": 98.51851851851852,
-          "uptime_last_1d": 90.12970135222825,
+          "uptime_last_30m": 95.70615623383341,
+          "uptime_last_5m": 96.6785290628707,
+          "uptime_last_1d": 94.89071019759922,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13185,9 +13406,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.90500718141746,
-          "uptime_last_5m": 98.51851851851852,
-          "uptime_last_1d": 90.12970135222825,
+          "uptime_last_30m": 95.70615623383341,
+          "uptime_last_5m": 96.6785290628707,
+          "uptime_last_1d": 94.89071019759922,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13215,6 +13436,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.00003",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.6-sol",
+          "model_id": "openai/gpt-5.6-sol",
+          "model_name": "OpenAI: GPT-5.6 Sol",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1050000,
           "pricing": {
             "prompt": "0.000005",
@@ -13331,9 +13569,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83937176512583,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.64011036551366,
+          "uptime_last_30m": 99.29343602063166,
+          "uptime_last_5m": 99.88148148148149,
+          "uptime_last_1d": 99.69201606079208,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13399,9 +13637,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83937176512583,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.64011036551366,
+          "uptime_last_30m": 99.29343602063166,
+          "uptime_last_5m": 99.88148148148149,
+          "uptime_last_1d": 99.69201606079208,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13458,9 +13696,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83937176512583,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.64011036551366,
+          "uptime_last_30m": 99.29343602063166,
+          "uptime_last_5m": 99.88148148148149,
+          "uptime_last_1d": 99.69201606079208,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13488,6 +13726,23 @@
           "provider_name": "gmi",
           "tag": "gmi",
           "tr_provider_slug": "gmi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.0000025",
+            "completion": "0.000015",
+            "input_cache_read": "0.00000025"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/gpt-5.6-terra",
+          "model_id": "openai/gpt-5.6-terra",
+          "model_name": "OpenAI: GPT-5.6 Terra",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1050000,
           "pricing": {
             "prompt": "0.0000025",
@@ -13531,7 +13786,7 @@
       "endpoints": [
         {
           "name": "Cerebras | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
+          "model_id": "gpt-oss-120b",
           "model_name": "OpenAI: gpt-oss-120b",
           "provider_name": "Cerebras",
           "tag": "cerebras/fp16",
@@ -13565,9 +13820,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99138339580371,
-          "uptime_last_5m": 99.95952236389395,
-          "uptime_last_1d": 99.61575697079392,
+          "uptime_last_30m": 99.98858708057521,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.99175577301995,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -13608,9 +13863,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99803621224618,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 92.24822392022023,
+          "uptime_last_30m": 98.59676369312344,
+          "uptime_last_5m": 97.7720374556022,
+          "uptime_last_1d": 98.99002123190054,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -13651,9 +13906,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90881458966565,
+          "uptime_last_30m": 99.82794218857536,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94187340408087,
+          "uptime_last_1d": 99.94744138071493,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -13692,10 +13947,10 @@
             "repetition_penalty",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 78.66596082583376,
-          "uptime_last_5m": 73.46065195917024,
-          "uptime_last_1d": 93.61567130260885,
+          "status": 0,
+          "uptime_last_30m": 97.61127237542333,
+          "uptime_last_5m": 99.94879672299028,
+          "uptime_last_1d": 98.8119885424982,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -13736,9 +13991,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49961176775084,
+          "uptime_last_30m": 99.21766342141864,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 88.67810308977788,
+          "uptime_last_1d": 97.75043783038646,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -13780,56 +14035,12 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.12363067292644,
-          "uptime_last_5m": 99.31102362204724,
-          "uptime_last_1d": 84.6351422760973,
+          "status": -2,
+          "uptime_last_30m": 93.03368135433257,
+          "uptime_last_5m": 93.07262569832402,
+          "uptime_last_1d": 90.51475086155206,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | openai/gpt-oss-120b",
-          "model_id": "phala/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000006",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.22388559937437,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -13867,9 +14078,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.37738544749465,
-          "uptime_last_5m": 97.92789059262329,
-          "uptime_last_1d": 95.2136788646103,
+          "uptime_last_30m": 99.84007753816331,
+          "uptime_last_5m": 99.80353634577604,
+          "uptime_last_1d": 98.7602711487387,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -13925,23 +14136,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000025",
-            "input_cache_read": "0.00000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "makora | openai/gpt-oss-120b",
           "model_id": "openai/gpt-oss-120b",
           "model_name": "OpenAI: gpt-oss-120b",
@@ -13953,6 +14147,22 @@
             "prompt": "0.0000001513",
             "completion": "0.0000005333",
             "input_cache_read": "0.0000001135"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | openai/gpt-oss-120b",
+          "model_id": "openai/gpt-oss-120b",
+          "model_name": "OpenAI: gpt-oss-120b",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000035",
+            "completion": "0.00000075"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -14026,9 +14236,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.78860979855757,
+          "uptime_last_30m": 99.98441032036791,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9149272657146,
+          "uptime_last_1d": 99.87567099698573,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -14067,9 +14277,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70854922279793,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.85013874025482,
+          "uptime_last_1d": 99.72862192262903,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -14111,50 +14321,12 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 55.396430053964295,
-          "uptime_last_5m": 97.52252252252252,
-          "uptime_last_1d": 95.59308025986284,
+          "status": -2,
+          "uptime_last_30m": 93.35270191748984,
+          "uptime_last_5m": 96.45390070921985,
+          "uptime_last_1d": 85.63871277122037,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | openai/gpt-oss-20b",
-          "model_id": "phala/gpt-oss-20b",
-          "model_name": "OpenAI: gpt-oss-20b",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000004",
-            "completion": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.41616405307599,
-          "uptime_last_5m": 96.06299212598425,
-          "uptime_last_1d": 98.59899237875517,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -14192,10 +14364,26 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 6.380476330491032,
+          "uptime_last_1d": 95.17241379310344,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "cloudflare-workers-ai | openai/gpt-oss-20b",
+          "model_id": "openai/gpt-oss-20b",
+          "model_name": "OpenAI: gpt-oss-20b",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000002",
+            "completion": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -14266,6 +14454,23 @@
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | openai/o1",
+          "model_id": "openai/o1",
+          "model_name": "OpenAI: o1",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 200000,
+          "pricing": {
+            "prompt": "0.000015",
+            "completion": "0.00006",
+            "input_cache_read": "0.0000075"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -14330,28 +14535,12 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | openai/o3",
-          "model_id": "openai/o3",
-          "model_name": "OpenAI: o3",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "lightning | openai/o3",
@@ -14364,6 +14553,23 @@
           "pricing": {
             "prompt": "0.000002",
             "completion": "0.000008"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/o3",
+          "model_id": "openai/o3",
+          "model_name": "OpenAI: o3",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 200000,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000008",
+            "input_cache_read": "0.0000005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -14431,8 +14637,8 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
@@ -14449,6 +14655,75 @@
           "pricing": {
             "prompt": "0.0000011",
             "completion": "0.0000044"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | openai/o3-mini",
+          "model_id": "openai/o3-mini",
+          "model_name": "OpenAI: o3 Mini",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 200000,
+          "pricing": {
+            "prompt": "0.0000011",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000055"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "openai/o3-pro",
+      "name": "OpenAI: o3 Pro",
+      "created": 1749598352,
+      "description": "The o-series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o3-pro model uses more compute to think harder and provide consistently...",
+      "context_length": 200000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "file",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00002",
+        "completion": "0.00008",
+        "web_search": "0.01",
+        "input_cache_read": "0.00002"
+      },
+      "top_provider": {
+        "context_length": 200000,
+        "max_completion_tokens": 100000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | openai/o3-pro",
+          "model_id": "openai/o3-pro",
+          "model_name": "OpenAI: o3 Pro",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 200000,
+          "pricing": {
+            "prompt": "0.00002",
+            "completion": "0.00008",
+            "input_cache_read": "0.00002"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -14480,7 +14755,7 @@
         "prompt": "0.0000011",
         "completion": "0.0000044",
         "web_search": "0.01",
-        "input_cache_read": "0.000000275"
+        "input_cache_read": "0.00000055"
       },
       "top_provider": {
         "context_length": 200000,
@@ -14517,24 +14792,25 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98422851947547,
+          "uptime_last_30m": 99.91755976916735,
+          "uptime_last_5m": 99.65675057208237,
+          "uptime_last_1d": 99.96044290648237,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "phala | openai/o4-mini",
+          "name": "atlas-cloud | openai/o4-mini",
           "model_id": "openai/o4-mini",
           "model_name": "OpenAI: o4 Mini",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 200000,
           "pricing": {
             "prompt": "0.0000011",
-            "completion": "0.0000044"
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000055"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -14603,26 +14879,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 39.99005222581447,
+          "uptime_last_1d": 47.101760412194075,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen-2.5-72b-instruct",
-          "model_id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
-          "model_name": "Qwen2.5 72B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000012"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -14645,8 +14905,8 @@
         "instruct_type": "chatml"
       },
       "pricing": {
-        "prompt": "0.00000004",
-        "completion": "0.0000001"
+        "prompt": "0.0000003",
+        "completion": "0.0000003"
       },
       "top_provider": {
         "context_length": 32768,
@@ -14655,47 +14915,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Phala | qwen/qwen-2.5-7b-instruct",
-          "model_id": "phala/qwen-2.5-7b-instruct",
-          "model_name": "Qwen: Qwen2.5 7B Instruct",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 32768,
-          "pricing": {
-            "prompt": "0.00000004",
-            "completion": "0.0000001",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "structured_outputs",
-            "tools",
-            "tool_choice",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.49645240857186,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Together | qwen/qwen-2.5-7b-instruct",
           "model_id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
@@ -14726,9 +14945,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95623811933318,
+          "uptime_last_30m": 98.16930667359128,
+          "uptime_last_5m": 98.46153846153847,
+          "uptime_last_1d": 99.18668393934071,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -14799,28 +15018,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85141158989599,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8363243220288,
+          "uptime_last_30m": 99.77112340263207,
+          "uptime_last_5m": 99.87484355444305,
+          "uptime_last_1d": 99.59307468722356,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen2.5-vl-72b-instruct",
-          "model_id": "Qwen/Qwen2.5-VL-72B-Instruct",
-          "model_name": "Qwen: Qwen2.5 VL 72B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000195",
-            "completion": "0.000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -14848,7 +15051,7 @@
       },
       "top_provider": {
         "context_length": 40960,
-        "max_completion_tokens": 40960,
+        "max_completion_tokens": 16384,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -14890,7 +15093,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.94786485060129,
+          "uptime_last_1d": 99.69714080386018,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -14916,8 +15119,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0",
-        "completion": "0.000000000001"
+        "prompt": "0.00000014",
+        "completion": "0.0000008",
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 262144,
@@ -14934,8 +15138,8 @@
           "tag": "friendli",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0",
-            "completion": "0.000000000001",
+            "prompt": "0.0000002",
+            "completion": "0.0000008",
             "discount": 0
           },
           "quantization": "unknown",
@@ -14959,49 +15163,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94686503719447,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.98257223844885,
+          "uptime_last_30m": 95.15235457063712,
+          "uptime_last_5m": 94.16666666666667,
+          "uptime_last_1d": 98.24533502968617,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | qwen/qwen3-235b-a22b-07-25",
-          "model_id": "qwen/qwen3-235b-a22b-2507",
-          "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.00000058",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.0674318507891,
-          "uptime_last_5m": 98.9485542621104,
-          "uptime_last_1d": 99.17420834951646,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -15039,25 +15205,25 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90013315579228,
-          "uptime_last_5m": 99.89200863930886,
-          "uptime_last_1d": 99.83178746009158,
+          "uptime_last_30m": 99.65292841648589,
+          "uptime_last_5m": 99.18478260869566,
+          "uptime_last_1d": 99.76779051548252,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "crusoe | qwen/qwen3-235b-a22b-2507",
-          "model_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+          "name": "atlas-cloud | qwen/qwen3-235b-a22b-2507",
+          "model_id": "qwen/qwen3-235b-a22b-2507",
           "model_name": "Qwen: Qwen3 235B A22B Instruct 2507",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000022",
-            "completion": "0.0000008",
-            "input_cache_read": "0.00000011"
+            "prompt": "0.0000002",
+            "completion": "0.00000088",
+            "input_cache_read": "0.0000002"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15090,7 +15256,7 @@
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": null,
+        "max_completion_tokens": 32768,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -15129,8 +15295,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96620860554178,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.92164032911062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15167,10 +15333,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.78260869565217,
+          "status": 0,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 79.20398009950249,
+          "uptime_last_1d": 99.33868682097308,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15206,7 +15372,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.62264150943396,
+          "uptime_last_1d": 99.89539748953975,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -15223,6 +15389,23 @@
             "prompt": "0.00000023",
             "completion": "0.0000023",
             "input_cache_read": "0.000000023"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3-235b-a22b-thinking-2507",
+          "model_id": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000002989",
+            "completion": "0.0000011957",
+            "input_cache_read": "0.00000014945"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15253,8 +15436,8 @@
         "completion": "0.0000005"
       },
       "top_provider": {
-        "context_length": 40960,
-        "max_completion_tokens": 16384,
+        "context_length": 131072,
+        "max_completion_tokens": 8192,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -15295,7 +15478,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93812732022549,
+          "uptime_last_1d": 99.19085383036109,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15338,8 +15521,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.00000055"
+        "prompt": "0.0000002",
+        "completion": "0.0000008",
+        "input_cache_read": "0.00000002"
       },
       "top_provider": {
         "context_length": 262144,
@@ -15348,46 +15532,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Phala | qwen/qwen3-30b-a3b-instruct-2507",
-          "model_id": "phala/qwen3-30b-a3b-instruct-2507",
-          "model_name": "Qwen: Qwen3 30B A3B Instruct 2507",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.00000055",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "structured_outputs",
-            "tools",
-            "logprobs",
-            "top_logprobs",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 70.39455782312926,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "alibaba | qwen/qwen3-30b-a3b-instruct-2507",
           "model_id": "qwen3-30b-a3b-instruct-2507",
@@ -15471,28 +15615,12 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96061562875849,
+          "uptime_last_30m": 99.94997043707644,
+          "uptime_last_5m": 99.81228211316707,
+          "uptime_last_1d": 99.76345966977465,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen3-32b",
-          "model_id": "qwen/qwen3-32b",
-          "model_name": "Qwen: Qwen3 32B",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000012",
-            "completion": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3-32b",
@@ -15510,76 +15638,39 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "qwen/qwen3-coder",
-      "name": "Qwen: Qwen3 Coder 480B A35B",
-      "created": 1753230546,
-      "description": "Qwen3-Coder-480B-A35B-Instruct is a Mixture-of-Experts (MoE) code generation model developed by the Qwen team. It is optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning over...",
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000038",
-        "completion": "0.00000155",
-        "input_cache_read": "0.0000001"
-      },
-      "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
+        },
         {
-          "name": "Novita | qwen/qwen3-coder-480b-a35b-07-25",
-          "model_id": "qwen/qwen3-coder",
-          "model_name": "Qwen: Qwen3 Coder 480B A35B",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 262144,
+          "name": "chutes | qwen/qwen3-32b",
+          "model_id": "Qwen/Qwen3-32B-TEE",
+          "model_name": "Qwen: Qwen3 32B",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000038",
-            "completion": "0.00000155",
-            "discount": 0
+            "prompt": "0.000000104",
+            "completion": "0.000000416",
+            "input_cache_read": "0.000000052"
           },
-          "quantization": "fp8",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.19310970081595,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | qwen/qwen3-32b",
+          "model_id": "alibaba-qwen3-32b",
+          "model_name": "Qwen: Qwen3 32B",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.00000055"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -15642,10 +15733,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.08006672226855,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.22917549959016,
+          "status": -2,
+          "uptime_last_30m": 90,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.04191211182037,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15729,9 +15820,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.63801666806971,
+          "uptime_last_30m": 99.00662251655629,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.02857142857144,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15771,9 +15862,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.78880675818374,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94659783721241,
+          "uptime_last_1d": 99.96565671983515,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -15817,12 +15908,11 @@
       },
       "pricing": {
         "prompt": "0.00000009",
-        "completion": "0.0000011",
-        "input_cache_read": "0.00000007"
+        "completion": "0.0000011"
       },
       "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "context_length": 131072,
+        "max_completion_tokens": 32768,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -15860,9 +15950,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.86917740336968,
-          "uptime_last_5m": 92.4953095684803,
-          "uptime_last_1d": 95.29845563000491,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 95.79142990432634,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15899,9 +15989,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.35483870967742,
-          "uptime_last_5m": 96.875,
-          "uptime_last_1d": 99.93357518777783,
+          "uptime_last_30m": 99.72677595628416,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.7868638538495,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15941,28 +16031,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.9713055954089,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97358420335361,
+          "uptime_last_1d": 99.81935813232016,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen3-next-80b-a3b-instruct",
-          "model_id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-          "model_name": "Qwen: Qwen3 Next 80B A3B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | qwen/qwen3-next-80b-a3b-instruct",
@@ -16063,10 +16137,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.80638915779284,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.3485838019069,
+          "status": -2,
+          "uptime_last_30m": 81.95472355245973,
+          "uptime_last_5m": 80.92369477911646,
+          "uptime_last_1d": 89.39265485767885,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16103,10 +16177,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": 95.38461538461539,
-          "uptime_last_5m": 89.85507246376811,
-          "uptime_last_1d": 91.90671833418928,
+          "status": -2,
+          "uptime_last_30m": 91.82539682539682,
+          "uptime_last_5m": 95.82608695652173,
+          "uptime_last_1d": 90.54773367244981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16146,9 +16220,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.26253687315634,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.4681265051594,
+          "uptime_last_30m": 97.71466314398943,
+          "uptime_last_5m": 99.11504424778761,
+          "uptime_last_1d": 97.30548993669092,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16192,9 +16266,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000007",
-        "completion": "0.0000084",
-        "input_cache_read": "0.00000007"
+        "prompt": "0.0000005",
+        "completion": "0.0000025",
+        "input_cache_read": "0.0000005"
       },
       "top_provider": {
         "context_length": 131072,
@@ -16236,9 +16310,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.56868537666175,
+          "uptime_last_1d": 99.5846313603323,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16255,6 +16329,23 @@
             "prompt": "0.0000007",
             "completion": "0.0000084",
             "input_cache_read": "0.00000007"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | qwen/qwen3-vl-235b-a22b-thinking",
+          "model_id": "qwen/qwen3-vl-235b-a22b-thinking",
+          "model_name": "Qwen: Qwen3 VL 235B A22B Thinking",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.0000025",
+            "input_cache_read": "0.0000005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -16325,9 +16416,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97846683893195,
+          "uptime_last_30m": 99.96374184191443,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.61417095624168,
+          "uptime_last_1d": 99.85881549944017,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16365,50 +16456,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.48818897637796,
-          "uptime_last_5m": 99.52830188679245,
-          "uptime_last_1d": 97.53733446041139,
+          "uptime_last_30m": 98.78747052879757,
+          "uptime_last_5m": 99.16142557651992,
+          "uptime_last_1d": 93.96923638535824,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | qwen/qwen3-vl-30b-a3b-instruct",
-          "model_id": "phala/qwen3-vl-30b-a3b-instruct",
-          "model_name": "Qwen: Qwen3 VL 30B A3B Instruct",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 128000,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.0000007",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.95201323772753,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.14917127071823,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -16546,28 +16598,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97847147470398,
+          "uptime_last_30m": 99.9616711383672,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.78678300786719,
+          "uptime_last_1d": 99.8044978656038,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen3-vl-8b-instruct",
-          "model_id": "Qwen/Qwen3-VL-8B-Instruct",
-          "model_name": "Qwen: Qwen3 VL 8B Instruct",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 256000,
-          "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.00000068"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3-vl-8b-instruct",
@@ -16651,10 +16687,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 42.20181183969485,
+          "status": -5,
+          "uptime_last_30m": 66.8,
+          "uptime_last_5m": 15.151515151515152,
+          "uptime_last_1d": 79.29237852901974,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16692,29 +16728,13 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": null,
+          "status": -5,
+          "uptime_last_30m": 65.06849315068493,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.52081866912123,
+          "uptime_last_1d": 80.17750457575025,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen3.5-122b-a10b",
-          "model_id": "qwen/qwen3.5-122b-a10b",
-          "model_name": "Qwen: Qwen3.5-122B-A10B",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000046",
-            "completion": "0.00000368"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | qwen/qwen3.5-122b-a10b",
@@ -16748,6 +16768,23 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | qwen/qwen3.5-122b-a10b",
+          "model_id": "qwen/qwen3.5-122b-a10b",
+          "model_name": "Qwen: Qwen3.5-122B-A10B",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000024",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -16777,7 +16814,7 @@
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 81920,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -16817,9 +16854,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.8646985511762,
+          "uptime_last_30m": 96.87933425797503,
+          "uptime_last_5m": 95.83333333333334,
+          "uptime_last_1d": 97.6298289157083,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16858,53 +16895,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.81185324553151,
+          "uptime_last_30m": 99.8289136013687,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.29557385572681,
+          "uptime_last_1d": 99.39133548156104,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | qwen/qwen3.5-27b-20260224",
-          "model_id": "phala/qwen3.5-27b",
-          "model_name": "Qwen: Qwen3.5-27B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000024",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 65536,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "logprobs",
-            "top_logprobs",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.16195945154108,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -16935,6 +16930,23 @@
             "prompt": "0.0000003",
             "completion": "0.0000024",
             "input_cache_read": "0.00000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | qwen/qwen3.5-27b",
+          "model_id": "qwen/qwen3.5-27b",
+          "model_name": "Qwen: Qwen3.5-27B",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000027",
+            "completion": "0.00000216",
+            "input_cache_read": "0.00000027"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17007,9 +17019,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.4919048076791,
+          "uptime_last_30m": null,
+          "uptime_last_5m": 82.6086956521739,
+          "uptime_last_1d": 97.9056813962124,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17053,7 +17065,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.77521682309612,
+          "uptime_last_1d": 99.62878541191795,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -17106,6 +17118,23 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | qwen/qwen3.5-35b-a3b",
+          "model_id": "qwen/qwen3.5-35b-a3b",
+          "model_name": "Qwen: Qwen3.5-35B-A3B",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000225",
+            "completion": "0.0000018",
+            "input_cache_read": "0.000000225"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -17130,8 +17159,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000045",
-        "completion": "0.000003"
+        "prompt": "0.000000385",
+        "completion": "0.00000245",
+        "input_cache_read": "0.000000111"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17176,9 +17206,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.25668979187314,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 93.24217826463867,
+          "uptime_last_1d": 99.6402068810434,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17211,7 +17241,7 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -5,
+          "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 0,
@@ -17251,9 +17281,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.70731707317073,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.00494947411838,
+          "uptime_last_1d": 99.82947569460234,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17295,52 +17325,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.93472584856397,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.45264073657883,
+          "uptime_last_1d": 99.63272598932369,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | qwen/qwen3.5-397b-a17b-20260216",
-          "model_id": "phala/qwen3.5-397b-a17b",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000055",
-            "completion": "0.0000035",
-            "input_cache_read": "0.000000225",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.91266375545852,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.34121060106978,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -17376,28 +17365,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.55242566510172,
+          "uptime_last_1d": 94.10775668808847,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | qwen/qwen3.5-397b-a17b",
-          "model_id": "Qwen/Qwen3.5-397B-A17B",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000036"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3.5-397b-a17b",
@@ -17411,6 +17384,57 @@
             "prompt": "0.0000006",
             "completion": "0.0000036",
             "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3.5-397b-a17b",
+          "model_id": "Qwen/Qwen3.5-397B-A17B-TEE",
+          "model_name": "Qwen: Qwen3.5 397B A17B",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000045",
+            "completion": "0.000003",
+            "input_cache_read": "0.000000225"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | qwen/qwen3.5-397b-a17b",
+          "model_id": "qwen3.5-397b-a17b",
+          "model_name": "Qwen: Qwen3.5 397B A17B",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000385",
+            "completion": "0.00000245",
+            "input_cache_read": "0.000000111"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | qwen/qwen3.5-397b-a17b",
+          "model_id": "qwen/qwen3.5-397b-a17b",
+          "model_name": "Qwen: Qwen3.5 397B A17B",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000055",
+            "completion": "0.0000035",
+            "input_cache_read": "0.00000055"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17484,9 +17508,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.13338672467995,
+          "uptime_last_30m": 99.56050855438706,
+          "uptime_last_5m": 99.86842105263159,
+          "uptime_last_1d": 98.8757090237542,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17525,9 +17549,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.26902680235058,
-          "uptime_last_5m": 99.05857740585773,
-          "uptime_last_1d": 97.99455354107451,
+          "uptime_last_30m": 99.48934280639432,
+          "uptime_last_5m": 99.2248062015504,
+          "uptime_last_1d": 97.92531510334261,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -17565,9 +17589,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.3421052631579,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.59892761394103,
+          "uptime_last_30m": 99.54400364797081,
+          "uptime_last_5m": 99.37106918238993,
+          "uptime_last_1d": 99.54847423987651,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -17595,8 +17619,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000032",
-        "completion": "0.0000027"
+        "prompt": "0.0000003",
+        "completion": "0.000002",
+        "input_cache_read": "0.00000015"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17639,53 +17664,12 @@
             "tools",
             "tool_choice"
           ],
-          "status": -5,
-          "uptime_last_30m": 37.71626297577855,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 88.92857730736942,
+          "status": -2,
+          "uptime_last_30m": 94.46107784431138,
+          "uptime_last_5m": 98.9795918367347,
+          "uptime_last_1d": 97.46223476165285,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | qwen/qwen3.6-27b-20260422",
-          "model_id": "qwen/qwen3.6-27b",
-          "model_name": "Qwen: Qwen3.6 27B",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000032",
-            "completion": "0.0000027",
-            "input_cache_read": "0.00000015",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262140,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.07464528069093,
-          "uptime_last_5m": 98.2824427480916,
-          "uptime_last_1d": 89.7234051312076,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -17719,9 +17703,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.69909502262443,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.7092026110329,
+          "uptime_last_30m": 98.17073170731707,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.6332682508691,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -17754,6 +17738,23 @@
             "prompt": "0.0000004671",
             "completion": "0.0000034592",
             "input_cache_read": "0.0000003503"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3.6-27b",
+          "model_id": "Qwen/Qwen3.6-27B-TEE",
+          "model_name": "Qwen: Qwen3.6 27B",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.000002",
+            "input_cache_read": "0.00000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17829,28 +17830,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87962684321397,
-          "uptime_last_5m": 99.90029910269193,
-          "uptime_last_1d": 99.4955585249885,
+          "uptime_last_30m": 98.97257132373177,
+          "uptime_last_5m": 99.14611005692599,
+          "uptime_last_1d": 99.62684291573282,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "phala | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen/qwen3.6-35b-a3b",
-          "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "phala",
-          "tag": "phala",
-          "tr_provider_slug": "phala",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002",
-            "completion": "0.00000127"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "gmi | qwen/qwen3.6-35b-a3b",
@@ -17901,6 +17886,23 @@
           "quantization": "unknown"
         },
         {
+          "name": "makora | qwen/qwen3.6-35b-a3b",
+          "model_id": "qwen/qwen3.6-35b-a3b",
+          "model_name": "Qwen: Qwen3.6 35B A3B",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000172",
+            "completion": "0.0000012002",
+            "input_cache_read": "0.000000129"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "alibaba | qwen/qwen3.6-35b-a3b",
           "model_id": "qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
@@ -17918,156 +17920,21 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | qwen/qwen3.6-35b-a3b",
+          "name": "atlas-cloud | qwen/qwen3.6-35b-a3b",
           "model_id": "qwen/qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.000000172",
-            "completion": "0.0000012002",
-            "input_cache_read": "0.000000129"
+            "prompt": "0.000000186",
+            "completion": "0.00000111375",
+            "input_cache_read": "0.000000186"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "sao10k/l3-lunaris-8b",
-      "name": "Sao10K: Llama 3 8B Lunaris",
-      "created": 1723507200,
-      "description": "Lunaris 8B is a versatile generalist and roleplaying model based on Llama 3. It's a strategic merge of multiple models, designed to balance creativity with improved logic and general knowledge....",
-      "context_length": 8192,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "llama3"
-      },
-      "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000005"
-      },
-      "top_provider": {
-        "context_length": 8192,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | sao10k/l3-lunaris-8b",
-          "model_id": "sao10k/l3-lunaris-8b",
-          "model_name": "Sao10K: Llama 3 8B Lunaris",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 8192,
-          "pricing": {
-            "prompt": "0.00000005",
-            "completion": "0.00000005",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97107258714382,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        }
-      ],
-      "pricing_source": "provider_direct"
-    },
-    {
-      "id": "sao10k/l3.1-euryale-70b",
-      "name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
-      "created": 1724803200,
-      "description": "Euryale L3.1 70B v2.2 is a model focused on creative roleplay from [Sao10k](https://ko-fi.com/sao10k). It is the successor of [Euryale L3 70B v2.1](/models/sao10k/l3-euryale-70b).",
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": "llama3"
-      },
-      "pricing": {
-        "prompt": "0.00000148",
-        "completion": "0.00000148"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 16384,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "endpoints": [
-        {
-          "name": "Novita | sao10k/l3.1-euryale-70b",
-          "model_id": "sao10k/l3.1-euryale-70b",
-          "model_name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 8192,
-          "pricing": {
-            "prompt": "0.00000148",
-            "completion": "0.00000148",
-            "discount": 0.02
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 8192,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 100,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
@@ -18139,9 +18006,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.89867841409692,
-          "uptime_last_5m": 99.00497512437812,
-          "uptime_last_1d": 99.51334379905809,
+          "uptime_last_30m": 99.16666666666667,
+          "uptime_last_5m": 97.01492537313433,
+          "uptime_last_1d": 95.8996023856859,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -18232,13 +18099,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000014",
-        "completion": "0.00000058",
-        "input_cache_read": "0.00000005"
+        "prompt": "0.000000132",
+        "completion": "0.000000528",
+        "input_cache_read": "0.000000035"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -18279,9 +18146,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.93390191897655,
-          "uptime_last_5m": 98.38709677419355,
-          "uptime_last_1d": 99.4930125802609,
+          "uptime_last_30m": 97.87234042553192,
+          "uptime_last_5m": 98.33333333333333,
+          "uptime_last_1d": 99.313639983315,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18313,12 +18180,86 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60238568588468,
-          "uptime_last_5m": 99.5,
-          "uptime_last_1d": 99.90701100772291,
+          "uptime_last_30m": 96.6994382022472,
+          "uptime_last_5m": 99.63768115942028,
+          "uptime_last_1d": 98.96402019787959,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Novita | tencent/hy3-20260706",
+          "model_id": "tencent/hy3",
+          "model_name": "Tencent: Hy3",
+          "provider_name": "Novita",
+          "tag": "novita",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000058",
+            "input_cache_read": "0.000000035",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "top_k",
+            "repetition_penalty",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 95.68345323741008,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.27525143628195,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "siliconflow | tencent/hy3",
+          "model_id": "tencent/hy3",
+          "model_name": "Tencent: Hy3",
+          "provider_name": "siliconflow",
+          "tag": "siliconflow",
+          "tr_provider_slug": "siliconflow",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000132",
+            "completion": "0.000000528"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | tencent/hy3",
+          "model_id": "tencent/hy3",
+          "model_name": "Tencent: Hy3",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000002",
+            "completion": "0.0000008",
+            "input_cache_read": "0.00000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -18341,9 +18282,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000066",
-        "completion": "0.00000026",
-        "input_cache_read": "0.000000021"
+        "prompt": "0.00000018",
+        "completion": "0.0000006",
+        "input_cache_read": "0.00000006"
       },
       "top_provider": {
         "context_length": 262144,
@@ -18380,49 +18321,11 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.375,
-          "uptime_last_5m": 98.19494584837545,
-          "uptime_last_1d": 98.51406481580516,
+          "uptime_last_30m": 99.0728476821192,
+          "uptime_last_5m": 99.04076738609112,
+          "uptime_last_1d": 99.0697286012526,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "SiliconFlow | tencent/hy3-preview-20260421",
-          "model_id": "tencent/hy3-preview",
-          "model_name": "Tencent: Hy3 preview",
-          "provider_name": "SiliconFlow",
-          "tag": "siliconflow",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000066",
-            "completion": "0.00000026",
-            "input_cache_read": "0.000000029",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 262144,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "temperature",
-            "top_p",
-            "top_k",
-            "frequency_penalty",
-            "tools",
-            "tool_choice",
-            "stop",
-            "presence_penalty",
-            "max_tokens",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.72771495356623,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         }
       ],
@@ -18490,9 +18393,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.41775836972343,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98150631097138,
+          "uptime_last_1d": 99.83523273376356,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -18562,12 +18465,121 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.98841452818166,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "thinkingmachines/inkling",
+      "name": "Thinking Machines: Inkling",
+      "created": 1784325956,
+      "description": "Inkling is an open-weight multimodal mixture-of-experts model from Thinking Machines Lab, with 41B active parameters out of 975B total. It is designed for general-purpose reasoning, coding, agentic and tool-use systems,...",
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+audio->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "audio"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000001",
+        "completion": "0.00000405",
+        "input_cache_read": "0.00000017"
+      },
+      "top_provider": {
+        "context_length": 524288,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "Together | thinkingmachines/inkling-20260715",
+          "model_id": "thinkingmachines/Inkling",
+          "model_name": "Thinking Machines: Inkling",
+          "provider_name": "Together",
+          "tag": "together",
+          "context_length": 524288,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.00000405",
+            "input_cache_read": "0.00000017",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "top_k",
+            "repetition_penalty",
+            "logit_bias",
+            "min_p",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.95501574448943,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.89608195032902,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "together",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "gmi | thinkingmachines/inkling",
+          "model_id": "thinkingmachines/Inkling",
+          "model_name": "Thinking Machines: Inkling",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000187",
+            "completion": "0.00000468",
+            "input_cache_read": "0.000000374"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "thinkingmachines | thinkingmachines/inkling",
+          "model_id": "thinkingmachines/inkling",
+          "model_name": "Thinking Machines: Inkling",
+          "provider_name": "thinkingmachines",
+          "tag": "thinkingmachines",
+          "tr_provider_slug": "thinkingmachines",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000374",
+            "completion": "0.00000936",
+            "input_cache_read": "0.000000748"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -18652,9 +18664,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.92042967972947,
-          "uptime_last_5m": 99.94107248084856,
-          "uptime_last_1d": 99.53279484784629,
+          "uptime_last_30m": 99.99154262516915,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9862557618103,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18699,9 +18711,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.92042967972947,
-          "uptime_last_5m": 99.94107248084856,
-          "uptime_last_1d": 99.53279484784629,
+          "uptime_last_30m": 99.99154262516915,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9862557618103,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18746,9 +18758,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.81651376146789,
-          "uptime_last_5m": 99.19354838709677,
-          "uptime_last_1d": 96.92294560740883,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.95075347188023,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18793,9 +18805,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.81651376146789,
-          "uptime_last_5m": 99.19354838709677,
-          "uptime_last_1d": 96.92294560740883,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.95075347188023,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18884,7 +18896,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 72.7607814227792,
+          "uptime_last_1d": 46.88216892596454,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18930,7 +18942,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 72.7607814227792,
+          "uptime_last_1d": 46.88216892596454,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18976,7 +18988,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 92.29946524064171,
+          "uptime_last_1d": 95.67099567099568,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19022,7 +19034,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 92.29946524064171,
+          "uptime_last_1d": 95.67099567099568,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19114,9 +19126,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94096445438727,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.3046212542281,
+          "uptime_last_30m": 99.41369145103177,
+          "uptime_last_5m": 97.56616257088847,
+          "uptime_last_1d": 97.84642477685405,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19165,9 +19177,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94096445438727,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.3046212542281,
+          "uptime_last_30m": 99.41369145103177,
+          "uptime_last_5m": 97.56616257088847,
+          "uptime_last_1d": 97.84642477685405,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19216,9 +19228,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58228905597326,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.8221457257602,
+          "uptime_last_30m": 99.14907028049164,
+          "uptime_last_5m": 98.88888888888889,
+          "uptime_last_1d": 97.73976082622117,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19267,12 +19279,29 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58228905597326,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 94.8221457257602,
+          "uptime_last_30m": 99.14907028049164,
+          "uptime_last_5m": 98.88888888888889,
+          "uptime_last_1d": 97.73976082622117,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "atlas-cloud | x-ai/grok-4.3",
+          "model_id": "x-ai/grok-4.3",
+          "model_name": "xAI: Grok 4.3",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "input_cache_read": "0.0000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -19306,7 +19335,7 @@
             "min_prompt_tokens": 200000,
             "prompt": "0.000004",
             "completion": "0.000012",
-            "input_cache_read": "0.000001"
+            "input_cache_read": "0.0000006"
           }
         ]
       },
@@ -19328,14 +19357,14 @@
             "prompt": "0.000002",
             "completion": "0.000006",
             "web_search": "0.005",
-            "input_cache_read": "0.0000005",
+            "input_cache_read": "0.0000003",
             "discount": 0,
             "overrides": [
               {
                 "min_prompt_tokens": 200000,
                 "prompt": "0.000004",
                 "completion": "0.000012",
-                "input_cache_read": "0.000001"
+                "input_cache_read": "0.0000006"
               }
             ]
           },
@@ -19361,9 +19390,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9187449215576,
-          "uptime_last_5m": 99.91208791208791,
-          "uptime_last_1d": 99.21073146548163,
+          "uptime_last_30m": 99.97669540899558,
+          "uptime_last_5m": 99.97287032013023,
+          "uptime_last_1d": 99.8095895167568,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19379,14 +19408,14 @@
             "prompt": "0.000002",
             "completion": "0.000006",
             "web_search": "0.005",
-            "input_cache_read": "0.000001",
+            "input_cache_read": "0.0000006",
             "discount": 0,
             "overrides": [
               {
                 "min_prompt_tokens": 200000,
                 "prompt": "0.000008",
                 "completion": "0.000024",
-                "input_cache_read": "0.000002"
+                "input_cache_read": "0.0000012"
               }
             ]
           },
@@ -19412,9 +19441,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9187449215576,
-          "uptime_last_5m": 99.91208791208791,
-          "uptime_last_1d": 99.21073146548163,
+          "uptime_last_30m": 99.97669540899558,
+          "uptime_last_5m": 99.97287032013023,
+          "uptime_last_1d": 99.8095895167568,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19430,14 +19459,14 @@
             "prompt": "0.000002",
             "completion": "0.000006",
             "web_search": "0.005",
-            "input_cache_read": "0.0000005",
+            "input_cache_read": "0.0000003",
             "discount": 0,
             "overrides": [
               {
                 "min_prompt_tokens": 200000,
                 "prompt": "0.000004",
                 "completion": "0.000012",
-                "input_cache_read": "0.000001"
+                "input_cache_read": "0.0000006"
               }
             ]
           },
@@ -19463,9 +19492,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.93050729673384,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.2973405674642,
+          "uptime_last_1d": 99.91918456806056,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19481,14 +19510,14 @@
             "prompt": "0.000002",
             "completion": "0.000006",
             "web_search": "0.005",
-            "input_cache_read": "0.000001",
+            "input_cache_read": "0.0000006",
             "discount": 0,
             "overrides": [
               {
                 "min_prompt_tokens": 200000,
                 "prompt": "0.000008",
                 "completion": "0.000024",
-                "input_cache_read": "0.000002"
+                "input_cache_read": "0.0000012"
               }
             ]
           },
@@ -19514,9 +19543,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.93050729673384,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.2973405674642,
+          "uptime_last_1d": 99.91918456806056,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19533,6 +19562,83 @@
             "prompt": "0.000002",
             "completion": "0.000006",
             "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | x-ai/grok-4.5",
+          "model_id": "x-ai/grok-4.5",
+          "model_name": "xAI: Grok 4.5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 500000,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000006",
+            "input_cache_read": "0.0000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "x-ai/grok-build-0.1",
+      "name": "xAI: Grok Build 0.1",
+      "created": 1779298123,
+      "description": "Grok Build 0.1 is xAI’s fast coding model trained specifically for agentic software engineering workflows. It supports text and image inputs with text output, and is optimized for interactive coding...",
+      "context_length": 256000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Grok",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000001",
+        "completion": "0.000002",
+        "web_search": "0.005",
+        "input_cache_read": "0.0000002",
+        "overrides": [
+          {
+            "min_prompt_tokens": 200000,
+            "prompt": "0.000002",
+            "completion": "0.000004",
+            "input_cache_read": "0.0000004"
+          }
+        ]
+      },
+      "top_provider": {
+        "context_length": 256000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "atlas-cloud | x-ai/grok-build-0.1",
+          "model_id": "x-ai/grok-build-0.1",
+          "model_name": "xAI: Grok Build 0.1",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 256000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "input_cache_read": "0.0000002"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -19562,9 +19668,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000014",
+        "prompt": "0.000000105",
         "completion": "0.00000028",
-        "input_cache_read": "0.0000000028"
+        "input_cache_read": "0.000000028"
       },
       "top_provider": {
         "context_length": 1048576,
@@ -19574,52 +19680,46 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | xiaomi/mimo-v2.5-20260422",
-          "model_id": "xiaomi/mimo-v2.5",
-          "model_name": "Xiaomi: MiMo-V2.5",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000000168",
-            "completion": "0.000000336",
-            "input_cache_read": "0.0000000034",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.64005264312348,
-          "uptime_last_5m": 98.84169884169884,
-          "uptime_last_1d": 98.99738850388033,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "xiaomi | xiaomi/mimo-v2.5",
           "model_id": "xiaomi/mimo-v2.5",
           "model_name": "Xiaomi: MiMo-V2.5",
           "provider_name": "xiaomi",
           "tag": "xiaomi",
           "tr_provider_slug": "xiaomi",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.0000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | xiaomi/mimo-v2.5",
+          "model_id": "mimo-v2.5",
+          "model_name": "Xiaomi: MiMo-V2.5",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000000105",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | xiaomi/mimo-v2.5",
+          "model_id": "xiaomi/mimo-v2.5",
+          "model_name": "Xiaomi: MiMo-V2.5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.00000014",
@@ -19663,52 +19763,46 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | xiaomi/mimo-v2.5-pro-20260422",
-          "model_id": "xiaomi/mimo-v2.5-pro",
-          "model_name": "Xiaomi: MiMo-V2.5-Pro",
-          "provider_name": "Novita",
-          "tag": "novita",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000000522",
-            "completion": "0.000001044",
-            "input_cache_read": "0.0000000043",
-            "discount": 0.08
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.56763434218654,
-          "uptime_last_5m": 97.6303317535545,
-          "uptime_last_1d": 99.69851355734922,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "xiaomi | xiaomi/mimo-v2.5-pro",
           "model_id": "xiaomi/mimo-v2.5-pro",
           "model_name": "Xiaomi: MiMo-V2.5-Pro",
           "provider_name": "xiaomi",
           "tag": "xiaomi",
           "tr_provider_slug": "xiaomi",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000000435",
+            "completion": "0.00000087",
+            "input_cache_read": "0.0000000036"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | xiaomi/mimo-v2.5-pro",
+          "model_id": "mimo-v2.5-pro",
+          "model_name": "Xiaomi: MiMo-V2.5-Pro",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000006",
+            "completion": "0.000003",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | xiaomi/mimo-v2.5-pro",
+          "model_id": "xiaomi/mimo-v2.5-pro",
+          "model_name": "Xiaomi: MiMo-V2.5-Pro",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000000435",
@@ -19781,7 +19875,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96879144885699,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -19807,9 +19901,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000013",
-        "completion": "0.00000085",
-        "input_cache_read": "0.000000025"
+        "prompt": "0.0000002",
+        "completion": "0.0000011",
+        "input_cache_read": "0.00000003"
       },
       "top_provider": {
         "context_length": 131072,
@@ -19818,45 +19912,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | z-ai/glm-4.5-air",
-          "model_id": "z-ai/glm-4.5-air",
-          "model_name": "Z.ai: GLM 4.5 Air",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000013",
-            "completion": "0.00000085",
-            "input_cache_read": "0.000000025",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 98304,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.21792890262752,
-          "uptime_last_5m": 95.78947368421052,
-          "uptime_last_1d": 97.62434030455624,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Z.AI | z-ai/glm-4.5-air",
           "model_id": "z-ai/glm-4.5-air",
@@ -19884,9 +19939,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 96.34146341463415,
+          "uptime_last_30m": 99.09638554216868,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.60859188544153,
+          "uptime_last_1d": 86.31532329495128,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -19925,46 +19980,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "Novita | z-ai/glm-4.5v",
-          "model_id": "z-ai/glm-4.5v",
-          "model_name": "Z.ai: GLM 4.5V",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 65536,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000018",
-            "input_cache_read": "0.00000011",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 16384,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 90.12816072047107,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
           "name": "Z.AI | z-ai/glm-4.5v",
           "model_id": "z-ai/glm-4.5v",
           "model_name": "Z.ai: GLM 4.5V",
@@ -19994,7 +20009,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 90.54805401111994,
+          "uptime_last_1d": 80.27306967984934,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20068,49 +20083,9 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.940290064581,
+          "uptime_last_1d": 99.96913675503842,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-4.6",
-          "model_id": "z-ai/glm-4.6",
-          "model_name": "Z.ai: GLM 4.6",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000055",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000011",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.8102189781022,
-          "uptime_last_5m": 95.6989247311828,
-          "uptime_last_1d": 97.60554505356018,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -20145,9 +20120,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.12087912087912,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.07621247113164,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.927586027383,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -20178,25 +20153,26 @@
             "tool_choice",
             "top_k"
           ],
-          "status": -5,
-          "uptime_last_30m": 60.062893081761004,
-          "uptime_last_5m": 48.87218045112782,
-          "uptime_last_1d": 82.18688583169555,
+          "status": 0,
+          "uptime_last_30m": 98.33333333333333,
+          "uptime_last_5m": 91.8918918918919,
+          "uptime_last_1d": 96.9913914265636,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "together | z-ai/glm-4.6",
-          "model_id": "zai-org/GLM-4.6",
+          "name": "atlas-cloud | z-ai/glm-4.6",
+          "model_id": "z-ai/glm-4.6",
           "model_name": "Z.ai: GLM 4.6",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 202752,
           "pricing": {
             "prompt": "0.0000006",
-            "completion": "0.0000022"
+            "completion": "0.0000022",
+            "input_cache_read": "0.00000011"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -20227,7 +20203,7 @@
       "pricing": {
         "prompt": "0.0000003",
         "completion": "0.0000009",
-        "input_cache_read": "0.000000055"
+        "input_cache_read": "0.00000005"
       },
       "top_provider": {
         "context_length": 131072,
@@ -20236,46 +20212,6 @@
       },
       "per_request_limits": null,
       "endpoints": [
-        {
-          "name": "Novita | z-ai/glm-4.6-20251208",
-          "model_id": "z-ai/glm-4.6v",
-          "model_name": "Z.ai: GLM 4.6V",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000003",
-            "completion": "0.0000009",
-            "input_cache_read": "0.000000055",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 32768,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": 96.97885196374622,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 95.48483867118921,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
         {
           "name": "Z.AI | z-ai/glm-4.6-20251208",
           "model_id": "z-ai/glm-4.6v",
@@ -20302,10 +20238,10 @@
             "tools",
             "top_k"
           ],
-          "status": -2,
-          "uptime_last_30m": 84.82142857142857,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.60612519112264,
+          "status": 0,
+          "uptime_last_30m": 98.07772670288341,
+          "uptime_last_5m": 99.16492693110646,
+          "uptime_last_1d": 94.5046439628483,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20344,7 +20280,7 @@
       "endpoints": [
         {
           "name": "Cerebras | z-ai/glm-4.7-20251222",
-          "model_id": "z-ai/glm-4.7",
+          "model_id": "zai-glm-4.7",
           "model_name": "Z.ai: GLM 4.7",
           "provider_name": "Cerebras",
           "tag": "cerebras/fp16",
@@ -20379,7 +20315,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.42805185663165,
+          "uptime_last_1d": 99.97977580030047,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -20420,94 +20356,11 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98610145934677,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84158715735272,
+          "uptime_last_30m": 99.80548951804626,
+          "uptime_last_5m": 99.84362783424551,
+          "uptime_last_1d": 99.88210457050421,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-4.7-20251222",
-          "model_id": "z-ai/glm-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.0000006",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000011",
-            "discount": 0.1
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": -2,
-          "uptime_last_30m": 89.61303462321793,
-          "uptime_last_5m": 95.56962025316456,
-          "uptime_last_1d": 93.82155207594991,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | z-ai/glm-4.7-20251222",
-          "model_id": "phala/glm-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000085",
-            "completion": "0.0000033",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tool_choice",
-            "tools",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 91.15812313534039,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -20542,9 +20395,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.13169319826338,
+          "uptime_last_30m": 99.77924944812362,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.47251526929483,
+          "uptime_last_1d": 99.66041836457484,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -20577,28 +20430,12 @@
             "response_format"
           ],
           "status": -2,
-          "uptime_last_30m": 84.51730418943534,
-          "uptime_last_5m": 88.13559322033898,
-          "uptime_last_1d": 84.75197963190713,
+          "uptime_last_30m": 83.77742946708464,
+          "uptime_last_5m": 84.84848484848484,
+          "uptime_last_1d": 87.84152118891558,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | z-ai/glm-4.7",
-          "model_id": "zai-org/GLM-4.7",
-          "model_name": "Z.ai: GLM 4.7",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "baseten | z-ai/glm-4.7",
@@ -20616,6 +20453,23 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-4.7",
+          "model_id": "z-ai/glm-4.7",
+          "model_name": "Z.ai: GLM 4.7",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.00000052",
+            "completion": "0.00000185",
+            "input_cache_read": "0.00000012"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -20625,7 +20479,7 @@
       "name": "Z.ai: GLM 4.7 Flash",
       "created": 1768833913,
       "description": "As a 30B-class SOTA model, GLM-4.7-Flash offers a new option that balances performance and efficiency. It is further optimized for agentic coding use cases, strengthening coding capabilities, long-horizon task planning,...",
-      "context_length": 202752,
+      "context_length": 200000,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -20639,12 +20493,11 @@
       },
       "pricing": {
         "prompt": "0.00000006",
-        "completion": "0.0000004",
-        "input_cache_read": "0.00000001"
+        "completion": "0.0000004"
       },
       "top_provider": {
-        "context_length": 202752,
-        "max_completion_tokens": 16384,
+        "context_length": 131072,
+        "max_completion_tokens": 131072,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -20685,51 +20538,11 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96356127778454,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.75786355728995,
+          "uptime_last_30m": 99.63054187192118,
+          "uptime_last_5m": 99.76580796252928,
+          "uptime_last_1d": 99.62520428242671,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-4.7-flash-20260119",
-          "model_id": "z-ai/glm-4.7-flash",
-          "model_name": "Z.ai: GLM 4.7 Flash",
-          "provider_name": "Novita",
-          "tag": "novita/bf16",
-          "context_length": 200000,
-          "pricing": {
-            "prompt": "0.00000007",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000001",
-            "discount": 0
-          },
-          "quantization": "bf16",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "response_format"
-          ],
-          "status": -2,
-          "uptime_last_30m": 82.91873963515755,
-          "uptime_last_5m": 82.6923076923077,
-          "uptime_last_1d": 85.90928436796985,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -20763,12 +20576,28 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 97.14285714285714,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.82772202944761,
+          "uptime_last_1d": 98.83900133566218,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "cloudflare-workers-ai | z-ai/glm-4.7-flash",
+          "model_id": "z-ai/glm-4.7-flash",
+          "model_name": "Z.ai: GLM 4.7 Flash",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 200000,
+          "pricing": {
+            "prompt": "0.0000000605",
+            "completion": "0.0000004"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -20778,7 +20607,7 @@
       "name": "Z.ai: GLM 5",
       "created": 1770829182,
       "description": "GLM-5 is Z.ai’s flagship open-source foundation model engineered for complex systems design and long-horizon agent workflows. Built for expert developers, it delivers production-grade performance on large-scale programming tasks, rivaling leading...",
-      "context_length": 202752,
+      "context_length": 204800,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -20793,11 +20622,11 @@
       "pricing": {
         "prompt": "0.0000006",
         "completion": "0.00000208",
-        "input_cache_read": "0.00000019"
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
-        "context_length": 202752,
-        "max_completion_tokens": 202752,
+        "context_length": 204800,
+        "max_completion_tokens": 131072,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -20838,9 +20667,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88738738738738,
+          "uptime_last_30m": 99.74715549936789,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89644289565389,
+          "uptime_last_1d": 99.87935982876878,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20873,51 +20702,12 @@
             "structured_outputs",
             "response_format"
           ],
-          "status": -5,
-          "uptime_last_30m": 71.25748502994011,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.20949376827204,
+          "status": 0,
+          "uptime_last_30m": 99.6951219512195,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.47624048306642,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-5-20260211",
-          "model_id": "z-ai/glm-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 202800,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.0000032",
-            "input_cache_read": "0.0000002",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99569890623185,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -20957,53 +20747,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.19626168224299,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.12170070464589,
+          "uptime_last_1d": 98.28493647912886,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | z-ai/glm-5-20260211",
-          "model_id": "phala/glm-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000035",
-            "input_cache_read": "0.000000475",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 202752,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tools",
-            "tool_choice",
-            "structured_outputs",
-            "response_format"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 87.15186951838744,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -21034,9 +20782,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 99.84240386635848,
-          "uptime_last_5m": 99.62006079027356,
-          "uptime_last_1d": 99.5489749430524,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.11798769453492,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -21073,9 +20821,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.23664122137404,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.85559403704262,
+          "uptime_last_1d": 99.50236059716728,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -21107,28 +20855,12 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 99.43502824858757,
-          "uptime_last_5m": 99.25220938137322,
-          "uptime_last_1d": 99.12730299594293,
+          "uptime_last_30m": 97.9721166032953,
+          "uptime_last_5m": 96.51162790697676,
+          "uptime_last_1d": 96.38875123885035,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | z-ai/glm-5",
-          "model_id": "zai-org/GLM-5",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.0000032"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "baseten | z-ai/glm-5",
@@ -21137,11 +20869,62 @@
           "provider_name": "baseten",
           "tag": "baseten",
           "tr_provider_slug": "baseten",
-          "context_length": 202752,
+          "context_length": 204800,
           "pricing": {
             "prompt": "0.00000095",
             "completion": "0.00000315",
             "input_cache_read": "0.0000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | z-ai/glm-5",
+          "model_id": "zai-org/GLM-5-TEE",
+          "model_name": "Z.ai: GLM 5",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.00000255",
+            "input_cache_read": "0.000000475"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | z-ai/glm-5",
+          "model_id": "glm-5",
+          "model_name": "Z.ai: GLM 5",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000075",
+            "completion": "0.0000024",
+            "input_cache_read": "0.0000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-5",
+          "model_id": "z-ai/glm-5",
+          "model_name": "Z.ai: GLM 5",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.00000315",
+            "input_cache_read": "0.00000019"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -21207,9 +20990,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86067198971116,
+          "uptime_last_30m": 97.91304347826087,
+          "uptime_last_5m": 94.64285714285714,
+          "uptime_last_1d": 99.61362838075168,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -21221,6 +21004,23 @@
           "provider_name": "venice",
           "tag": "venice",
           "tr_provider_slug": "venice",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.0000012",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000024"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-5-turbo",
+          "model_id": "z-ai/glm-5-turbo",
+          "model_name": "Z.ai: GLM 5 Turbo",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
           "context_length": 202752,
           "pricing": {
             "prompt": "0.0000012",
@@ -21252,9 +21052,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000000001",
-        "completion": "0.000000000004",
-        "input_cache_read": "0"
+        "prompt": "0.000000975",
+        "completion": "0.0000043",
+        "input_cache_read": "0.00000026"
       },
       "top_provider": {
         "context_length": 200000,
@@ -21299,9 +21099,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.81768459434822,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94967920493144,
+          "uptime_last_1d": 99.91982789721936,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -21341,10 +21141,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -2,
-          "uptime_last_30m": 94,
+          "status": 0,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 96.9644190097039,
+          "uptime_last_1d": 99.54506065857885,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21357,9 +21157,9 @@
           "tag": "friendli",
           "context_length": 202752,
           "pricing": {
-            "prompt": "0.000000000001",
-            "completion": "0.000000000004",
-            "input_cache_read": "0",
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026",
             "discount": 0
           },
           "quantization": "unknown",
@@ -21386,7 +21186,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.66308839407351,
+          "uptime_last_1d": 99.97486694263749,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -21418,50 +21218,11 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.20670391061452,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 90.32300767805135,
+          "uptime_last_30m": 98.64457831325302,
+          "uptime_last_5m": 98.82352941176471,
+          "uptime_last_1d": 99.1435731490718,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Novita | z-ai/glm-5.1-20260406",
-          "model_id": "z-ai/glm-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Novita",
-          "tag": "novita/fp8",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000138",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026",
-            "discount": 0
-          },
-          "quantization": "fp8",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "repetition_penalty",
-            "tools",
-            "tool_choice"
-          ],
-          "status": 0,
-          "uptime_last_30m": 98.56630824372759,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.11983108915624,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -21503,53 +21264,9 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.98712300914944,
+          "uptime_last_1d": 99.50630533941508,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | z-ai/glm-5.1-20260406",
-          "model_id": "phala/glm-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.00000121",
-            "completion": "0.0000042",
-            "input_cache_read": "0.0000006",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 128000,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "tool_choice",
-            "tools",
-            "response_format",
-            "structured_outputs",
-            "logprobs",
-            "top_logprobs"
-          ],
-          "status": -5,
-          "uptime_last_30m": 69.49152542372882,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 68.71788597993638,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -21584,9 +21301,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 95.91836734693877,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.75373688991658,
+          "uptime_last_1d": 99.60957986131345,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -21631,7 +21348,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 96.83604985618408,
+          "uptime_last_1d": 98.96876549330689,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -21664,28 +21381,12 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.15611814345992,
+          "uptime_last_30m": 99.61597542242704,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.1891424795405,
+          "uptime_last_1d": 99.05083519266718,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "together | z-ai/glm-5.1",
-          "model_id": "zai-org/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "together",
-          "tag": "together",
-          "tr_provider_slug": "together",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "baseten | z-ai/glm-5.1",
@@ -21705,23 +21406,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | z-ai/glm-5.1",
-          "model_id": "zai/GLM-5.1",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000025"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | z-ai/glm-5.1",
           "model_id": "glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
@@ -21733,6 +21417,57 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | z-ai/glm-5.1",
+          "model_id": "zai-org/GLM-5.1-TEE",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.00000098",
+            "completion": "0.00000308",
+            "input_cache_read": "0.00000049"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | z-ai/glm-5.1",
+          "model_id": "glm-5.1",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.000000975",
+            "completion": "0.0000043",
+            "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-5.1",
+          "model_id": "z-ai/glm-5.1",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.00000126",
+            "completion": "0.00000396",
+            "input_cache_read": "0.000000234"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -21759,9 +21494,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000000000001",
-        "completion": "0.000000000004",
-        "input_cache_read": "0"
+        "prompt": "0.00000093",
+        "completion": "0.000003",
+        "input_cache_read": "0.00000015184"
       },
       "top_provider": {
         "context_length": 1048576,
@@ -21807,9 +21542,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.06902086677367,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.18632880661559,
+          "uptime_last_30m": 98.70850473548263,
+          "uptime_last_5m": 99.70566593083149,
+          "uptime_last_1d": 98.49282521024166,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -21851,9 +21586,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.17005433688871,
-          "uptime_last_5m": 96.81440443213296,
-          "uptime_last_1d": 98.69799729496309,
+          "uptime_last_30m": 99.44281071041634,
+          "uptime_last_5m": 98.51116625310173,
+          "uptime_last_1d": 99.27705501525122,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21895,9 +21630,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90397206460061,
-          "uptime_last_5m": 99.94337485843715,
-          "uptime_last_1d": 99.84039333714732,
+          "uptime_last_30m": 99.74979149291076,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.70699771036062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21910,9 +21645,9 @@
           "tag": "friendli",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.000000000001",
-            "completion": "0.000000000004",
-            "input_cache_read": "0",
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026",
             "discount": 0
           },
           "quantization": "unknown",
@@ -21938,9 +21673,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96015142458657,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.08650901037355,
+          "uptime_last_30m": 99.90818467995803,
+          "uptime_last_5m": 99.86859395532196,
+          "uptime_last_1d": 99.57409721205602,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -21956,7 +21691,7 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026",
-            "discount": 0.3
+            "discount": 0.34
           },
           "quantization": "fp8",
           "max_completion_tokens": null,
@@ -21977,9 +21712,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 96.12191559689445,
-          "uptime_last_5m": 93.96825396825396,
-          "uptime_last_1d": 95.53891479043179,
+          "uptime_last_30m": 97.73067865553415,
+          "uptime_last_5m": 97.14285714285714,
+          "uptime_last_1d": 96.38410076280351,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -21995,7 +21730,7 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026",
-            "discount": 0.301
+            "discount": 0.416
           },
           "quantization": "fp8",
           "max_completion_tokens": 131072,
@@ -22018,9 +21753,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95359269858459,
-          "uptime_last_5m": 99.93855606758832,
-          "uptime_last_1d": 97.40390907591245,
+          "uptime_last_30m": 97.54106390621429,
+          "uptime_last_5m": 97.91287465113457,
+          "uptime_last_1d": 99.50418381882001,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -22063,53 +21798,11 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59349593495935,
+          "uptime_last_30m": 99.88076311605724,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.16021431330725,
+          "uptime_last_1d": 99.11272615210775,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "Phala | z-ai/glm-5.2-20260616",
-          "model_id": "phala/glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "Phala",
-          "tag": "phala",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.0000007",
-            "discount": 0
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": 131072,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "seed",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 97.45649263721553,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 92.04549115628726,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "phala",
           "pricing_source": "provider_direct"
         },
         {
@@ -22148,9 +21841,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.96010969832959,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.80464482663767,
+          "uptime_last_1d": 99.73120555367423,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -22187,10 +21880,10 @@
             "tools",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 80.99273607748184,
-          "uptime_last_5m": 70.45454545454545,
-          "uptime_last_1d": 96.83054483054482,
+          "status": 0,
+          "uptime_last_30m": 99.29873772791024,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.44176888436682,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -22234,9 +21927,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.55724150890215,
+          "uptime_last_30m": 99.35483870967742,
+          "uptime_last_5m": 99.3103448275862,
+          "uptime_last_1d": 99.36785604578597,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -22278,9 +21971,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.25093632958801,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.51591003010803,
+          "uptime_last_1d": 99.90474046105618,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -22320,17 +22013,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "crusoe | z-ai/glm-5.2",
-          "model_id": "zai/GLM-5.2",
+          "name": "makora | z-ai/glm-5.2",
+          "model_id": "z-ai/glm-5.2",
           "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "crusoe",
-          "tag": "crusoe",
-          "tr_provider_slug": "crusoe",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
+            "prompt": "0.00000135",
+            "completion": "0.00000399",
+            "input_cache_read": "0.00000024"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22354,17 +22047,85 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | z-ai/glm-5.2",
-          "model_id": "z-ai/glm-5.2",
+          "name": "chutes | z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2-TEE",
           "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000135",
-            "completion": "0.00000399",
-            "input_cache_read": "0.00000024"
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.0000007"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "digitalocean | z-ai/glm-5.2",
+          "model_id": "glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000105",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000021"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-5.2",
+          "model_id": "z-ai/glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | z-ai/glm-5.2",
+          "model_id": "z-ai/glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000094",
+            "completion": "0.0000029",
+            "input_cache_read": "0.00000017"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22434,7 +22195,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99609908328458,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22467,6 +22228,23 @@
             "prompt": "0.0000015",
             "completion": "0.000005",
             "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | z-ai/glm-5v-turbo",
+          "model_id": "z-ai/glm-5v-turbo",
+          "model_name": "Z.ai: GLM 5V Turbo",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.0000012",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000024"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],

--- a/src/trusted_router/data/provider_models/atlas-cloud.json
+++ b/src/trusted_router/data/provider_models/atlas-cloud.json
@@ -1180,7 +1180,9 @@
       "title": "google/gemini-3.1-flash-lite",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output_modalities": [
         "text"
@@ -1202,7 +1204,9 @@
       "title": "google/gemini-3.1-pro-preview",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output_modalities": [
         "text"
@@ -1224,7 +1228,9 @@
       "title": "google/gemini-3.5-flash",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output_modalities": [
         "text"
@@ -1404,9 +1410,9 @@
         "logit_bias",
         "stop"
       ],
-      "input_token_price_per_m": 300000,
-      "output_token_price_per_m": 1180000,
-      "cached_input_token_price_per_m": 6000
+      "input_token_price_per_m": 750000,
+      "output_token_price_per_m": 3000000,
+      "cached_input_token_price_per_m": 15000
     },
     {
       "display_name": "MiniMax M2.5",
@@ -2083,7 +2089,8 @@
       "title": "openai/gpt-5.4",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2149,7 +2156,8 @@
       "title": "openai/gpt-5.5",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2171,7 +2179,8 @@
       "title": "openai/gpt-5.6-luna",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2193,7 +2202,8 @@
       "title": "openai/gpt-5.6-sol",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2215,7 +2225,8 @@
       "title": "openai/gpt-5.6-terra",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2623,7 +2634,8 @@
       "title": "qwen/qwen3.5-flash",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2769,7 +2781,8 @@
       "title": "qwen/qwen3.7-plus",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2832,7 +2845,8 @@
       "title": "xai/grok-4.3",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2854,7 +2868,8 @@
       "title": "xai/grok-4.5",
       "model_type": "chat",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -3222,8 +3237,50 @@
       "input_token_price_per_m": 1200000,
       "output_token_price_per_m": 4000000,
       "cached_input_token_price_per_m": 240000
+    },
+    {
+      "display_name": "Kimi K3",
+      "title": "moonshotai/kimi-k3",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k3",
+      "upstream_id": "moonshotai/kimi-k3",
+      "context_length": 1048576,
+      "max_output_tokens": 1048576,
+      "supported_features": [
+        "json_mode",
+        "structured_outputs",
+        "tools",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "seed",
+        "max_tokens",
+        "logit_bias"
+      ],
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000
     }
   ],
-  "generated_at": "2026-07-19T03:45:21Z",
-  "model_count": 118
+  "generated_at": "2026-07-21T14:09:26Z",
+  "model_count": 119
 }

--- a/src/trusted_router/data/provider_models/cerebras.json
+++ b/src/trusted_router/data/provider_models/cerebras.json
@@ -1,73 +1,202 @@
 {
   "_about": "Provider-native supplement for the Cerebras models enabled on the TrustedRouter Cerebras account. Verified from Cerebras /v1/models and direct chat completions on 2026-06-05. The canonical OpenRouter-style model IDs remain openai/gpt-oss-120b and z-ai/glm-4.7; cerebras/* aliases are included so users can request the Cerebras-specific route directly.",
   "provider": "cerebras",
-  "source": "https://api.cerebras.ai/v1/models",
-  "generated_at": "2026-06-05T00:00:00Z",
-  "model_count": 4,
+  "source": "https://api.cerebras.ai/public/v1/models",
+  "generated_at": "2026-07-21T14:09:26Z",
+  "model_count": 6,
   "models": [
     {
       "id": "openai/gpt-oss-120b",
       "upstream_id": "gpt-oss-120b",
-      "display_name": "GPT OSS 120B on Cerebras",
-      "title": "openai/gpt-oss-120b",
+      "display_name": "OpenAI GPT OSS",
+      "title": "gpt-oss-120b",
       "context_length": 131072,
-      "max_output_tokens": 65536,
+      "max_output_tokens": 40960,
       "input_token_price_per_m": 350000,
       "output_token_price_per_m": 750000,
       "model_type": "chat",
-      "features": ["reasoning", "high-throughput"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "cerebras/gpt-oss-120b",
       "upstream_id": "gpt-oss-120b",
-      "display_name": "Cerebras GPT OSS 120B",
-      "title": "cerebras/gpt-oss-120b",
+      "display_name": "OpenAI GPT OSS",
+      "title": "gpt-oss-120b",
       "context_length": 131072,
-      "max_output_tokens": 65536,
+      "max_output_tokens": 40960,
       "input_token_price_per_m": 350000,
       "output_token_price_per_m": 750000,
       "model_type": "chat",
-      "features": ["reasoning", "high-throughput"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "z-ai/glm-4.7",
       "upstream_id": "zai-glm-4.7",
-      "display_name": "Z.AI GLM 4.7 on Cerebras",
-      "title": "z-ai/glm-4.7",
-      "context_length": 202752,
-      "max_output_tokens": 65536,
+      "display_name": "Z.ai GLM 4.7",
+      "title": "zai-glm-4.7",
+      "context_length": 131072,
+      "max_output_tokens": 40960,
       "input_token_price_per_m": 2250000,
       "output_token_price_per_m": 2750000,
       "model_type": "chat",
-      "features": ["reasoning", "high-throughput"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "parallel-tool-calls",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "cerebras/zai-glm-4.7",
       "upstream_id": "zai-glm-4.7",
-      "display_name": "Cerebras Z.AI GLM 4.7",
-      "title": "cerebras/zai-glm-4.7",
-      "context_length": 202752,
-      "max_output_tokens": 65536,
+      "display_name": "Z.ai GLM 4.7",
+      "title": "zai-glm-4.7",
+      "context_length": 131072,
+      "max_output_tokens": 40960,
       "input_token_price_per_m": 2250000,
       "output_token_price_per_m": 2750000,
       "model_type": "chat",
-      "features": ["reasoning", "high-throughput"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "parallel-tool-calls",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
+    },
+    {
+      "display_name": "Gemma 4 31B",
+      "title": "gemma-4-31b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "cerebras/gemma-4-31b",
+      "upstream_id": "gemma-4-31b",
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "parallel-tool-calls",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "context_length": 131072,
+      "max_output_tokens": 40960,
+      "input_token_price_per_m": 990000,
+      "output_token_price_per_m": 1490000
+    },
+    {
+      "display_name": "Gemma 4 31B",
+      "title": "gemma-4-31b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-4-31b-it",
+      "upstream_id": "gemma-4-31b",
+      "features": [
+        "function-calling",
+        "high-throughput",
+        "json-mode",
+        "parallel-tool-calls",
+        "reasoning",
+        "response-format",
+        "structured-outputs",
+        "tool-choice",
+        "tools"
+      ],
+      "context_length": 131072,
+      "max_output_tokens": 40960,
+      "input_token_price_per_m": 990000,
+      "output_token_price_per_m": 1490000
     }
-  ]
+  ],
+  "price_scale": "microdollars_per_million"
 }

--- a/src/trusted_router/data/provider_models/chutes.json
+++ b/src/trusted_router/data/provider_models/chutes.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native Chutes TEE model catalog. Refreshed hourly from the authenticated Chutes OpenAI-compatible models API.",
   "provider": "chutes",
   "source": "https://llm.chutes.ai/v1/models",
-  "generated_at": "2026-07-19T00:33:16Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 13,
   "models": [

--- a/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
+++ b/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
@@ -1,7 +1,7 @@
 {
   "provider": "cloudflare-workers-ai",
   "source": "https://api.cloudflare.com/client/v4/accounts/96781cbfaebf2b28d851b9c677dd2e81/ai/models/search?per_page=100",
-  "generated_at": "2026-07-19T00:35:33Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 27,
   "models": [
@@ -66,7 +66,7 @@
       "id": "google/gemma-2b-it-lora",
       "upstream_id": "@cf/google/gemma-2b-it-lora",
       "routable": false,
-      "routable_reason": "awaiting-price",
+      "routable_reason": "account-unfunded",
       "context_length": 8192
     },
     {
@@ -108,7 +108,7 @@
       "id": "google/gemma-7b-it-lora",
       "upstream_id": "@cf/google/gemma-7b-it-lora",
       "routable": false,
-      "routable_reason": "awaiting-price",
+      "routable_reason": "account-unfunded",
       "context_length": 3500
     },
     {
@@ -150,7 +150,7 @@
       "id": "meta-llama/llama-2-7b-chat-hf-lora",
       "upstream_id": "@cf/meta-llama/llama-2-7b-chat-hf-lora",
       "routable": false,
-      "routable_reason": "awaiting-price",
+      "routable_reason": "account-unfunded",
       "context_length": 8192
     },
     {
@@ -324,7 +324,7 @@
       "id": "mistralai/mistral-7b-instruct-v0.2-lora",
       "upstream_id": "@cf/mistral/mistral-7b-instruct-v0.2-lora",
       "routable": false,
-      "routable_reason": "awaiting-price",
+      "routable_reason": "account-unfunded",
       "context_length": 15000
     },
     {

--- a/src/trusted_router/data/provider_models/cohere.json
+++ b/src/trusted_router/data/provider_models/cohere.json
@@ -3,7 +3,7 @@
   "provider": "cohere",
   "source": "https://docs.cohere.com/docs/cohere-embed",
   "pricing_source": "https://cohere.com/pricing",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 3,
   "models": [

--- a/src/trusted_router/data/provider_models/crusoe.json
+++ b/src/trusted_router/data/provider_models/crusoe.json
@@ -51,7 +51,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -98,7 +100,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -145,7 +149,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "google/gemma-4-31b-it",
@@ -193,7 +199,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
@@ -240,7 +248,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -288,7 +298,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -335,7 +347,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "nvidia/nemotron-3-nano-omni-reasoning-30b-a3b",
@@ -383,7 +397,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
@@ -430,7 +446,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "nvidia/nemotron-3-ultra-550b",
@@ -478,7 +496,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -525,7 +545,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "qwen/qwen3-235b-a22b-2507",
@@ -572,7 +594,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "yutori/n1.5",
@@ -620,7 +644,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "z-ai/glm-5.1",
@@ -667,7 +693,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     },
     {
       "id": "z-ai/glm-5.2",
@@ -714,7 +742,9 @@
         "top_logprobs",
         "top_p",
         "user"
-      ]
+      ],
+      "routable": false,
+      "routable_reason": "provider-canary-failed"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/digitalocean.json
+++ b/src/trusted_router/data/provider_models/digitalocean.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native DigitalOcean Gradient AI serverless catalog. Availability comes from /v1/models and rates from DigitalOcean's official pricing documentation.",
   "provider": "digitalocean",
   "source": "https://inference.do-ai.run/v1/models",
-  "generated_at": "2026-07-19T00:34:04Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 23,
   "models": [

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -3,7 +3,7 @@
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/friendli.json
+++ b/src/trusted_router/data/provider_models/friendli.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for FriendliAI serverless Model API routes. Verified against https://api.friendli.ai/serverless/v1/models on 2026-06-22.",
   "provider": "friendli",
   "source": "https://api.friendli.ai/serverless/v1/models",
-  "generated_at": "2026-06-22T00:00:00Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 9,
   "models": [
     {
@@ -15,11 +15,22 @@
       "input_token_price_per_m": 600000,
       "output_token_price_per_m": 600000,
       "model_type": "chat",
-      "features": ["serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
-      "status": 1
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "missing_since": "2026-07-21",
+      "routable": false,
+      "routable_reason": "delisted-upstream"
     },
     {
       "id": "meta-llama/llama-3.1-8b-instruct",
@@ -31,32 +42,52 @@
       "input_token_price_per_m": 100000,
       "output_token_price_per_m": 100000,
       "model_type": "chat",
-      "features": ["serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
-      "status": 1
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "missing_since": "2026-07-21",
+      "routable": false,
+      "routable_reason": "delisted-upstream"
     },
     {
       "id": "qwen/qwen3-235b-a22b-2507",
       "upstream_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-      "display_name": "Friendli Qwen3 235B A22B 2507",
+      "display_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "title": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "context_length": 262144,
       "max_output_tokens": 65536,
       "input_token_price_per_m": 200000,
       "output_token_price_per_m": 800000,
       "model_type": "chat",
-      "features": ["reasoning", "serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "lgai-exaone/k-exaone-236b-a23b",
       "upstream_id": "LGAI-EXAONE/K-EXAONE-236B-A23B",
-      "display_name": "Friendli K-EXAONE 236B A23B",
+      "display_name": "LGAI-EXAONE/K-EXAONE-236B-A23B",
       "title": "LGAI-EXAONE/K-EXAONE-236B-A23B",
       "context_length": 262144,
       "max_output_tokens": 65536,
@@ -64,16 +95,24 @@
       "output_token_price_per_m": 800000,
       "cached_input_token_price_per_m": 100000,
       "model_type": "chat",
-      "features": ["serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "minimax/minimax-m2.5",
       "upstream_id": "MiniMaxAI/MiniMax-M2.5",
-      "display_name": "Friendli MiniMax M2.5",
+      "display_name": "MiniMaxAI/MiniMax-M2.5",
       "title": "MiniMaxAI/MiniMax-M2.5",
       "context_length": 196608,
       "max_output_tokens": 65536,
@@ -81,16 +120,24 @@
       "output_token_price_per_m": 1200000,
       "cached_input_token_price_per_m": 60000,
       "model_type": "chat",
-      "features": ["serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "deepseek/deepseek-v3.2",
       "upstream_id": "deepseek-ai/DeepSeek-V3.2",
-      "display_name": "Friendli DeepSeek V3.2",
+      "display_name": "deepseek-ai/DeepSeek-V3.2",
       "title": "deepseek-ai/DeepSeek-V3.2",
       "context_length": 163840,
       "max_output_tokens": 65536,
@@ -98,16 +145,24 @@
       "output_token_price_per_m": 1500000,
       "cached_input_token_price_per_m": 250000,
       "model_type": "chat",
-      "features": ["serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "z-ai/glm-5.1",
       "upstream_id": "zai-org/GLM-5.1",
-      "display_name": "Friendli GLM 5.1",
+      "display_name": "zai-org/GLM-5.1",
       "title": "zai-org/GLM-5.1",
       "context_length": 202752,
       "max_output_tokens": 65536,
@@ -115,16 +170,25 @@
       "output_token_price_per_m": 4400000,
       "cached_input_token_price_per_m": 260000,
       "model_type": "chat",
-      "features": ["reasoning", "serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "z-ai/glm-5.2",
       "upstream_id": "zai-org/GLM-5.2",
-      "display_name": "Friendli GLM 5.2",
+      "display_name": "zai-org/GLM-5.2",
       "title": "zai-org/GLM-5.2",
       "context_length": 1048576,
       "max_output_tokens": 131072,
@@ -132,11 +196,42 @@
       "output_token_price_per_m": 4400000,
       "cached_input_token_price_per_m": 260000,
       "model_type": "chat",
-      "features": ["reasoning", "function-calling", "structured-outputs", "serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "reasoning",
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
+    },
+    {
+      "display_name": "google/gemma-4-31B-it",
+      "title": "google/gemma-4-31B-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-4-31b-it",
+      "upstream_id": "google/gemma-4-31B-it",
+      "context_length": 262144,
+      "input_token_price_per_m": 140000,
+      "output_token_price_per_m": 400000
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/google-ai-studio.json
+++ b/src/trusted_router/data/provider_models/google-ai-studio.json
@@ -2,8 +2,8 @@
   "_about": "Provider-native supplement for Google AI Studio chat and image models that are available from the Gemini API before the OpenRouter snapshot catches up. Verified against Google Gemini /v1beta/models and direct countTokens/generateContent smoke.",
   "provider": "google-ai-studio",
   "source": "https://generativelanguage.googleapis.com/v1beta/models",
-  "generated_at": "2026-07-04T00:00:00Z",
-  "model_count": 3,
+  "generated_at": "2026-07-21T14:09:26Z",
+  "model_count": 32,
   "models": [
     {
       "id": "google/gemini-3.5-flash",
@@ -14,18 +14,25 @@
       "max_output_tokens": 65536,
       "input_token_price_per_m": 1500000,
       "output_token_price_per_m": 9000000,
-      "cached_input_token_price_per_m": 150000,
       "model_type": "chat",
-      "features": ["reasoning"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "google/gemini-3.1-flash-lite-preview",
       "upstream_id": "gemini-3.1-flash-lite-preview",
-      "display_name": "Gemini 3.1 Flash-Lite Preview",
+      "display_name": "Gemini 3.1 Flash Lite Preview",
       "title": "google/gemini-3.1-flash-lite-preview",
       "context_length": 1048576,
       "max_output_tokens": 65536,
@@ -34,26 +41,710 @@
       "cached_input_token_price_per_m": 25000,
       "model_type": "chat",
       "features": [],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     },
     {
       "id": "google/gemini-3.1-flash-image-preview",
       "upstream_id": "gemini-3.1-flash-image-preview",
-      "display_name": "Gemini 3.1 Flash Image Preview",
+      "display_name": "Nano Banana 2",
       "title": "google/gemini-3.1-flash-image-preview",
       "context_length": 65536,
       "max_output_tokens": 65536,
       "input_token_price_per_m": 500000,
       "output_token_price_per_m": 60000000,
       "model_type": "chat",
-      "features": ["reasoning", "image-generation"],
-      "input_modalities": ["text", "image"],
-      "output_modalities": ["text", "image"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "reasoning",
+        "image-generation"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text",
+        "image"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
+    },
+    {
+      "display_name": "Gemini 2.0 Flash",
+      "title": "google/gemini-2.0-flash",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.0-flash",
+      "upstream_id": "gemini-2.0-flash",
+      "context_length": 1048576,
+      "max_output_tokens": 8192,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 2.0 Flash 001",
+      "title": "google/gemini-2.0-flash-001",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.0-flash-001",
+      "upstream_id": "gemini-2.0-flash-001",
+      "context_length": 1048576,
+      "max_output_tokens": 8192,
+      "input_token_price_per_m": 100000,
+      "output_token_price_per_m": 400000
+    },
+    {
+      "display_name": "Gemini 2.0 Flash-Lite",
+      "title": "google/gemini-2.0-flash-lite",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.0-flash-lite",
+      "upstream_id": "gemini-2.0-flash-lite",
+      "context_length": 1048576,
+      "max_output_tokens": 8192,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 2.0 Flash-Lite 001",
+      "title": "google/gemini-2.0-flash-lite-001",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.0-flash-lite-001",
+      "upstream_id": "gemini-2.0-flash-lite-001",
+      "context_length": 1048576,
+      "max_output_tokens": 8192,
+      "input_token_price_per_m": 75000,
+      "output_token_price_per_m": 300000
+    },
+    {
+      "display_name": "Gemini 2.5 Computer Use Preview 10-2025",
+      "title": "google/gemini-2.5-computer-use-preview-10-2025",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-computer-use-preview-10-2025",
+      "upstream_id": "gemini-2.5-computer-use-preview-10-2025",
+      "context_length": 131072,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 2.5 Flash",
+      "title": "google/gemini-2.5-flash",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-flash",
+      "upstream_id": "gemini-2.5-flash",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 2500000
+    },
+    {
+      "display_name": "Nano Banana",
+      "title": "google/gemini-2.5-flash-image",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-flash-image",
+      "upstream_id": "gemini-2.5-flash-image",
+      "context_length": 32768,
+      "max_output_tokens": 32768,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 2.5 Flash-Lite",
+      "title": "google/gemini-2.5-flash-lite",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-flash-lite",
+      "upstream_id": "gemini-2.5-flash-lite",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 100000,
+      "output_token_price_per_m": 400000
+    },
+    {
+      "display_name": "Gemini 2.5 Flash Preview TTS",
+      "title": "google/gemini-2.5-flash-preview-tts",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-flash-preview-tts",
+      "upstream_id": "gemini-2.5-flash-preview-tts",
+      "context_length": 8192,
+      "max_output_tokens": 16384,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 2.5 Pro",
+      "title": "google/gemini-2.5-pro",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-pro",
+      "upstream_id": "gemini-2.5-pro",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 1250000,
+      "output_token_price_per_m": 10000000,
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 200000,
+          "input_token_price_per_m": 1250000,
+          "output_token_price_per_m": 10000000,
+          "cached_input_token_price_per_m": null
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 2500000,
+          "output_token_price_per_m": 15000000,
+          "cached_input_token_price_per_m": null
+        }
+      ]
+    },
+    {
+      "display_name": "Gemini 2.5 Pro Preview TTS",
+      "title": "google/gemini-2.5-pro-preview-tts",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-2.5-pro-preview-tts",
+      "upstream_id": "gemini-2.5-pro-preview-tts",
+      "context_length": 8192,
+      "max_output_tokens": 16384,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3 Flash Preview",
+      "title": "google/gemini-3-flash-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3-flash-preview",
+      "upstream_id": "gemini-3-flash-preview",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 500000,
+      "output_token_price_per_m": 3000000
+    },
+    {
+      "display_name": "Nano Banana Pro",
+      "title": "google/gemini-3-pro-image",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3-pro-image",
+      "upstream_id": "gemini-3-pro-image",
+      "context_length": 131072,
+      "max_output_tokens": 32768,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Nano Banana Pro",
+      "title": "google/gemini-3-pro-image-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3-pro-image-preview",
+      "upstream_id": "gemini-3-pro-image-preview",
+      "context_length": 131072,
+      "max_output_tokens": 32768,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3 Pro Preview",
+      "title": "google/gemini-3-pro-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3-pro-preview",
+      "upstream_id": "gemini-3-pro-preview",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Nano Banana 2",
+      "title": "google/gemini-3.1-flash-image",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-flash-image",
+      "upstream_id": "gemini-3.1-flash-image",
+      "context_length": 65536,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3.1 Flash Lite",
+      "title": "google/gemini-3.1-flash-lite",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-flash-lite",
+      "upstream_id": "gemini-3.1-flash-lite",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 250000,
+      "output_token_price_per_m": 1500000
+    },
+    {
+      "display_name": "Nano Banana 2 Lite",
+      "title": "google/gemini-3.1-flash-lite-image",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-flash-lite-image",
+      "upstream_id": "gemini-3.1-flash-lite-image",
+      "context_length": 65536,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3.1 Flash TTS Preview",
+      "title": "google/gemini-3.1-flash-tts-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-flash-tts-preview",
+      "upstream_id": "gemini-3.1-flash-tts-preview",
+      "context_length": 8192,
+      "max_output_tokens": 16384,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3.1 Pro Preview",
+      "title": "google/gemini-3.1-pro-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-pro-preview",
+      "upstream_id": "gemini-3.1-pro-preview",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 2000000,
+      "output_token_price_per_m": 12000000,
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 200000,
+          "input_token_price_per_m": 2000000,
+          "output_token_price_per_m": 12000000,
+          "cached_input_token_price_per_m": null
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 4000000,
+          "output_token_price_per_m": 18000000,
+          "cached_input_token_price_per_m": null
+        }
+      ]
+    },
+    {
+      "display_name": "Gemini 3.1 Pro Preview Custom Tools",
+      "title": "google/gemini-3.1-pro-preview-customtools",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.1-pro-preview-customtools",
+      "upstream_id": "gemini-3.1-pro-preview-customtools",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Flash Latest",
+      "title": "google/gemini-flash-latest",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-flash-latest",
+      "upstream_id": "gemini-flash-latest",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Flash-Lite Latest",
+      "title": "google/gemini-flash-lite-latest",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-flash-lite-latest",
+      "upstream_id": "gemini-flash-lite-latest",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Omni Flash Preview",
+      "title": "google/gemini-omni-flash-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-omni-flash-preview",
+      "upstream_id": "gemini-omni-flash-preview",
+      "context_length": 131072,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Pro Latest",
+      "title": "google/gemini-pro-latest",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-pro-latest",
+      "upstream_id": "gemini-pro-latest",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Robotics-ER 1.5 Preview",
+      "title": "google/gemini-robotics-er-1.5-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-robotics-er-1.5-preview",
+      "upstream_id": "gemini-robotics-er-1.5-preview",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini Robotics-ER 1.6 Preview",
+      "title": "google/gemini-robotics-er-1.6-preview",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-robotics-er-1.6-preview",
+      "upstream_id": "gemini-robotics-er-1.6-preview",
+      "context_length": 131072,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3.5 Flash Lite",
+      "title": "google/gemini-3.5-flash-lite",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.5-flash-lite",
+      "upstream_id": "gemini-3.5-flash-lite",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "display_name": "Gemini 3.6 Flash",
+      "title": "google/gemini-3.6-flash",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemini-3.6-flash",
+      "upstream_id": "gemini-3.6-flash",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
     }
-  ]
+  ],
+  "pricing_source": "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing"
 }

--- a/src/trusted_router/data/provider_models/inceptron.json
+++ b/src/trusted_router/data/provider_models/inceptron.json
@@ -185,6 +185,6 @@
       "cached_input_token_price_per_m": 170000
     }
   ],
-  "generated_at": "2026-07-19T03:13:27Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 4
 }

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -186,6 +186,6 @@
   "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
   "source": "https://api.moonshot.ai/v1/models",
   "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 11
 }

--- a/src/trusted_router/data/provider_models/makora.json
+++ b/src/trusted_router/data/provider_models/makora.json
@@ -3,7 +3,7 @@
   "provider": "makora",
   "source": "https://inference.makora.com/v1/models",
   "pricing_source": "https://www.makora.com/; https://openrouter.ai/api/v1/models for Gemma fallback",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 10,
   "models": [

--- a/src/trusted_router/data/provider_models/meta.json
+++ b/src/trusted_router/data/provider_models/meta.json
@@ -2,7 +2,7 @@
   "_about": "Meta Muse Spark served through OpenRouter. This is not a direct Meta, ZDR, confidential-compute, or downstream-attested route.",
   "provider": "meta",
   "source": "https://openrouter.ai/api/v1/models/meta/muse-spark-1.1/endpoints",
-  "generated_at": "2026-07-16T00:00:00Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/minimax.json
+++ b/src/trusted_router/data/provider_models/minimax.json
@@ -1,7 +1,7 @@
 {
   "provider": "minimax",
   "source": "https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 8,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/morph.json
+++ b/src/trusted_router/data/provider_models/morph.json
@@ -165,6 +165,6 @@
       "output_token_price_per_m": 4100000
     }
   ],
-  "generated_at": "2026-07-19T03:03:41Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 8
 }

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -1,7 +1,7 @@
 {
   "provider": "nebius",
   "source": "https://api.tokenfactory.nebius.com/v1/models?verbose=true",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 38,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/novita.json
+++ b/src/trusted_router/data/provider_models/novita.json
@@ -3,8 +3,8 @@
   "source": "https://api.novita.ai/openai/v1/models",
   "price_source": "https://novita.ai/pricing",
   "price_scale_to_microdollars_per_million_tokens": 100,
-  "generated_at": "2026-07-18T19:00:00Z",
-  "model_count": 107,
+  "generated_at": "2026-07-21T14:09:26Z",
+  "model_count": 135,
   "models": [
     {
       "id": "Sao10K/L3-8B-Stheno-v3.2",
@@ -30,7 +30,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "Sao10K/L3-8B-Stheno-v3.2"
     },
     {
       "id": "baichuan/baichuan-m2-32b",
@@ -53,7 +54,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "baichuan/baichuan-m2-32b"
     },
     {
       "id": "baidu/ernie-4.5-21B-a3b",
@@ -79,7 +81,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "baidu/ernie-4.5-21B-a3b"
     },
     {
       "id": "baidu/ernie-4.5-21B-a3b-thinking",
@@ -104,7 +107,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "baidu/ernie-4.5-21B-a3b-thinking"
     },
     {
       "id": "baidu/ernie-4.5-300b-a47b-paddle",
@@ -117,8 +121,8 @@
       "output_token_price_per_m": 11000,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -130,7 +134,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "baidu/ernie-4.5-300b-a47b-paddle"
     },
     {
       "id": "baidu/ernie-4.5-vl-28b-a3b",
@@ -148,8 +153,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -157,7 +162,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "baidu/ernie-4.5-vl-28b-a3b"
     },
     {
       "id": "baidu/ernie-4.5-vl-28b-a3b-thinking",
@@ -171,13 +177,13 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -187,7 +193,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "baidu/ernie-4.5-vl-28b-a3b-thinking"
     },
     {
       "id": "baidu/ernie-4.5-vl-424b-a47b",
@@ -204,8 +211,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -214,7 +221,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "baidu/ernie-4.5-vl-424b-a47b"
     },
     {
       "id": "deepseek/deepseek-ocr",
@@ -228,8 +236,8 @@
       "model_type": "chat",
       "features": [],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -237,7 +245,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-ocr"
     },
     {
       "id": "deepseek/deepseek-ocr-2",
@@ -253,8 +262,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -262,7 +271,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-ocr-2"
     },
     {
       "id": "deepseek/deepseek-prover-v2-671b",
@@ -287,7 +297,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "deepseek/deepseek-prover-v2-671b"
     },
     {
       "id": "deepseek/deepseek-r1-0528",
@@ -301,9 +312,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -312,10 +323,12 @@
         "text"
       ],
       "endpoints": [
-        "batch-api",
-        "chat/completions"
+        "chat/completions",
+        "batch-api"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-r1-0528",
+      "cached_input_token_price_per_m": 3500
     },
     {
       "id": "deepseek/deepseek-r1-0528-qwen3-8b",
@@ -338,7 +351,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-r1-0528-qwen3-8b"
     },
     {
       "id": "deepseek/deepseek-r1-distill-llama-70b",
@@ -364,7 +378,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-r1-distill-llama-70b"
     },
     {
       "id": "deepseek/deepseek-r1-distill-qwen-14b",
@@ -387,7 +402,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "deepseek/deepseek-r1-distill-qwen-14b"
     },
     {
       "id": "deepseek/deepseek-r1-distill-qwen-32b",
@@ -410,7 +426,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "deepseek/deepseek-r1-distill-qwen-32b"
     },
     {
       "id": "deepseek/deepseek-r1-turbo",
@@ -424,9 +441,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -438,7 +455,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-r1-turbo"
     },
     {
       "id": "deepseek/deepseek-v3-0324",
@@ -452,8 +470,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -462,11 +480,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3-0324"
     },
     {
       "id": "deepseek/deepseek-v3-turbo",
@@ -492,7 +511,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3-turbo"
     },
     {
       "id": "deepseek/deepseek-v3.1",
@@ -506,9 +526,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -517,11 +537,13 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3.1",
+      "cached_input_token_price_per_m": 1350
     },
     {
       "id": "deepseek/deepseek-v3.1-terminus",
@@ -535,9 +557,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -546,11 +568,13 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3.1-terminus",
+      "cached_input_token_price_per_m": 1350
     },
     {
       "id": "deepseek/deepseek-v3.2",
@@ -564,9 +588,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -575,11 +599,13 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3.2",
+      "cached_input_token_price_per_m": 1345
     },
     {
       "id": "deepseek/deepseek-v3.2-exp",
@@ -593,9 +619,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -604,11 +630,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v3.2-exp"
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -621,10 +648,10 @@
       "output_token_price_per_m": 2800,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -633,10 +660,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v4-flash",
+      "cached_input_token_price_per_m": 280
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -645,14 +674,14 @@
       "created": 1777000931,
       "context_length": 1048576,
       "max_output_tokens": 393216,
-      "input_token_price_per_m": 16900,
-      "output_token_price_per_m": 33800,
+      "input_token_price_per_m": 16000,
+      "output_token_price_per_m": 32000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -661,10 +690,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "deepseek/deepseek-v4-pro",
+      "cached_input_token_price_per_m": 1350
     },
     {
       "id": "elephant",
@@ -677,8 +708,8 @@
       "output_token_price_per_m": 3000,
       "model_type": "chat",
       "features": [
-        "function-calling",
         "serverless",
+        "function-calling",
         "structured-outputs"
       ],
       "input_modalities": [
@@ -690,7 +721,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "elephant"
     },
     {
       "id": "google/gemma-3-12b-it",
@@ -704,8 +736,8 @@
       "model_type": "chat",
       "features": [],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -714,7 +746,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "google/gemma-3-12b-it"
     },
     {
       "id": "google/gemma-3-27b-it",
@@ -730,8 +763,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -740,7 +773,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "google/gemma-3-27b-it"
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -753,14 +787,14 @@
       "output_token_price_per_m": 4000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "function-calling",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -768,7 +802,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "google/gemma-4-26b-a4b-it"
     },
     {
       "id": "google/gemma-4-31b-it",
@@ -781,14 +816,14 @@
       "output_token_price_per_m": 4000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "function-calling",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -796,7 +831,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "google/gemma-4-31b-it"
     },
     {
       "id": "gryphe/mythomax-l2-13b",
@@ -819,7 +855,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "gryphe/mythomax-l2-13b"
     },
     {
       "id": "inclusionai/ling-2.6-1t",
@@ -832,8 +869,8 @@
       "output_token_price_per_m": 25000,
       "model_type": "chat",
       "features": [
-        "function-calling",
         "serverless",
+        "function-calling",
         "structured-outputs"
       ],
       "input_modalities": [
@@ -845,7 +882,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "inclusionai/ling-2.6-1t",
+      "cached_input_token_price_per_m": 600
     },
     {
       "id": "inclusionai/ling-2.6-flash",
@@ -858,8 +897,8 @@
       "output_token_price_per_m": 3000,
       "model_type": "chat",
       "features": [
-        "function-calling",
         "serverless",
+        "function-calling",
         "structured-outputs"
       ],
       "input_modalities": [
@@ -871,7 +910,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "inclusionai/ling-2.6-flash",
+      "cached_input_token_price_per_m": 200
     },
     {
       "id": "inclusionai/ring-2.6-1t",
@@ -880,14 +921,14 @@
       "created": 1778229656,
       "context_length": 262144,
       "max_output_tokens": 65536,
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
+      "input_token_price_per_m": 3000,
+      "output_token_price_per_m": 25000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -898,7 +939,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "inclusionai/ring-2.6-1t",
+      "cached_input_token_price_per_m": 600
     },
     {
       "id": "kwaipilot/kat-coder-pro",
@@ -912,8 +955,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -924,7 +967,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "kwaipilot/kat-coder-pro"
     },
     {
       "id": "meta-llama/llama-3-70b-instruct",
@@ -937,8 +981,8 @@
       "output_token_price_per_m": 7400,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -950,7 +994,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "meta-llama/llama-3-70b-instruct"
     },
     {
       "id": "meta-llama/llama-3-8b-instruct",
@@ -963,8 +1008,8 @@
       "output_token_price_per_m": 400,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -976,7 +1021,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "meta-llama/llama-3-8b-instruct"
     },
     {
       "id": "meta-llama/llama-3.1-8b-instruct",
@@ -989,8 +1035,8 @@
       "output_token_price_per_m": 500,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1002,7 +1048,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "meta-llama/llama-3.1-8b-instruct"
     },
     {
       "id": "meta-llama/llama-3.2-3b-instruct",
@@ -1025,22 +1072,23 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "meta-llama/llama-3.2-3b-instruct"
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
       "display_name": "Llama 3.3 70B Instruct",
       "title": "meta-llama/llama-3.3-70b-instruct",
       "created": 1733560109,
-      "context_length": 131072,
+      "context_length": 6000,
       "max_output_tokens": 120000,
       "input_token_price_per_m": 1350,
       "output_token_price_per_m": 4000,
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1052,7 +1100,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "meta-llama/llama-3.3-70b-instruct"
     },
     {
       "id": "meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
@@ -1065,12 +1114,12 @@
       "output_token_price_per_m": 8500,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -1079,7 +1128,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
     },
     {
       "id": "meta-llama/llama-4-scout-17b-16e-instruct",
@@ -1095,8 +1145,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -1105,7 +1155,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "meta-llama/llama-4-scout-17b-16e-instruct"
     },
     {
       "id": "microsoft/wizardlm-2-8x22b",
@@ -1118,8 +1169,8 @@
       "output_token_price_per_m": 6200,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1131,7 +1182,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "microsoft/wizardlm-2-8x22b"
     },
     {
       "id": "minimax/minimax-m2",
@@ -1145,9 +1197,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1156,10 +1208,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimax/minimax-m2",
+      "cached_input_token_price_per_m": 300
     },
     {
       "id": "minimax/minimax-m2.1",
@@ -1173,8 +1227,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1183,10 +1237,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimax/minimax-m2.1",
+      "cached_input_token_price_per_m": 300
     },
     {
       "id": "minimax/minimax-m2.5",
@@ -1200,9 +1256,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1211,10 +1267,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimax/minimax-m2.5",
+      "cached_input_token_price_per_m": 300
     },
     {
       "id": "minimax/minimax-m2.5-highspeed",
@@ -1228,9 +1286,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1239,10 +1297,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimax/minimax-m2.5-highspeed",
+      "cached_input_token_price_per_m": 300
     },
     {
       "id": "minimax/minimax-m2.7",
@@ -1256,9 +1316,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1267,11 +1327,13 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
+        "anthropic",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimax/minimax-m2.7",
+      "cached_input_token_price_per_m": 600
     },
     {
       "id": "minimaxai/minimax-m1-80k",
@@ -1285,9 +1347,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1298,7 +1360,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "minimaxai/minimax-m1-80k"
     },
     {
       "id": "mistralai/mistral-nemo",
@@ -1311,8 +1374,8 @@
       "output_token_price_per_m": 1700,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1324,7 +1387,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "mistralai/mistral-nemo"
     },
     {
       "id": "moonshotai/kimi-k2-0905",
@@ -1332,14 +1396,14 @@
       "title": "moonshotai/kimi-k2-0905",
       "created": 1757052991,
       "context_length": 262144,
-      "max_output_tokens": 262144,
+      "max_output_tokens": 100352,
       "input_token_price_per_m": 6000,
       "output_token_price_per_m": 25000,
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1348,10 +1412,11 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k2-0905"
     },
     {
       "id": "moonshotai/kimi-k2-instruct",
@@ -1359,7 +1424,7 @@
       "title": "moonshotai/kimi-k2-instruct",
       "created": 1752263515,
       "context_length": 131072,
-      "max_output_tokens": 32768,
+      "max_output_tokens": 100352,
       "input_token_price_per_m": 5700,
       "output_token_price_per_m": 23000,
       "model_type": "chat",
@@ -1374,10 +1439,11 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k2-instruct"
     },
     {
       "id": "moonshotai/kimi-k2-thinking",
@@ -1385,15 +1451,15 @@
       "title": "moonshotai/kimi-k2-thinking",
       "created": 1762480786,
       "context_length": 262144,
-      "max_output_tokens": 262144,
+      "max_output_tokens": 100352,
       "input_token_price_per_m": 6000,
       "output_token_price_per_m": 25000,
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1402,10 +1468,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k2-thinking",
+      "cached_input_token_price_per_m": 1500
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -1418,24 +1486,26 @@
       "output_token_price_per_m": 30000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "reasoning",
+        "structured-outputs",
+        "function-calling"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k2.5",
+      "cached_input_token_price_per_m": 1000
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -1448,24 +1518,26 @@
       "output_token_price_per_m": 34000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "reasoning",
+        "structured-outputs",
+        "function-calling"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k2.6",
+      "cached_input_token_price_per_m": 1600
     },
     {
       "id": "moonshotai/kimi-k3",
@@ -1479,24 +1551,25 @@
       "cached_input_token_price_per_m": 3000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "moonshotai/kimi-k3"
     },
     {
       "id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -1509,7 +1582,6 @@
       "output_token_price_per_m": 1400,
       "model_type": "chat",
       "features": [
-        "serverless",
         "structured-outputs"
       ],
       "input_modalities": [
@@ -1522,7 +1594,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "nousresearch/hermes-2-pro-llama-3-8b"
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -1536,23 +1609,24 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "batch-api",
         "chat/completions",
-        "completions"
+        "completions",
+        "batch-api"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "openai/gpt-oss-120b"
     },
     {
       "id": "openai/gpt-oss-20b",
@@ -1565,13 +1639,13 @@
       "output_token_price_per_m": 1500,
       "model_type": "chat",
       "features": [
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -1580,7 +1654,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "openai/gpt-oss-20b"
     },
     {
       "id": "paddlepaddle/paddleocr-vl",
@@ -1594,8 +1669,8 @@
       "model_type": "chat",
       "features": [],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -1603,7 +1678,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "paddlepaddle/paddleocr-vl"
     },
     {
       "id": "qwen/qwen-2.5-72b-instruct",
@@ -1617,8 +1693,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1629,7 +1705,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen-2.5-72b-instruct"
     },
     {
       "id": "qwen/qwen-mt-plus",
@@ -1653,7 +1730,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen-mt-plus"
     },
     {
       "id": "qwen/qwen2.5-7b-instruct",
@@ -1667,8 +1745,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1680,7 +1758,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen2.5-7b-instruct"
     },
     {
       "id": "qwen/qwen2.5-vl-72b-instruct",
@@ -1696,8 +1775,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -1707,7 +1786,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen2.5-vl-72b-instruct"
     },
     {
       "id": "qwen/qwen3-235b-a22b-fp8",
@@ -1720,9 +1800,9 @@
       "output_token_price_per_m": 8000,
       "model_type": "chat",
       "features": [
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1734,7 +1814,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-235b-a22b-fp8"
     },
     {
       "id": "qwen/qwen3-235b-a22b-instruct-2507",
@@ -1748,8 +1829,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1761,7 +1842,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-235b-a22b-instruct-2507"
     },
     {
       "id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -1785,11 +1867,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-235b-a22b-thinking-2507"
     },
     {
       "id": "qwen/qwen3-30b-a3b-fp8",
@@ -1803,8 +1886,7 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "reasoning",
-        "serverless"
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -1816,7 +1898,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-30b-a3b-fp8"
     },
     {
       "id": "qwen/qwen3-32b-fp8",
@@ -1829,8 +1912,7 @@
       "output_token_price_per_m": 4500,
       "model_type": "chat",
       "features": [
-        "reasoning",
-        "serverless"
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -1842,7 +1924,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-32b-fp8"
     },
     {
       "id": "qwen/qwen3-4b-fp8",
@@ -1866,11 +1949,12 @@
         "text"
       ],
       "endpoints": [
-        "batch-api",
         "chat/completions",
-        "completions"
+        "completions",
+        "batch-api"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-4b-fp8"
     },
     {
       "id": "qwen/qwen3-8b-fp8",
@@ -1893,7 +1977,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-8b-fp8"
     },
     {
       "id": "qwen/qwen3-coder-30b-a3b-instruct",
@@ -1907,8 +1992,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1919,7 +2004,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-coder-30b-a3b-instruct"
     },
     {
       "id": "qwen/qwen3-coder-480b-a35b-instruct",
@@ -1933,8 +2019,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1943,11 +2029,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-coder-480b-a35b-instruct"
     },
     {
       "id": "qwen/qwen3-coder-next",
@@ -1961,8 +2048,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -1971,10 +2058,11 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-coder-next"
     },
     {
       "id": "qwen/qwen3-max",
@@ -1988,8 +2076,8 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2000,7 +2088,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-max"
     },
     {
       "id": "qwen/qwen3-next-80b-a3b-instruct",
@@ -2014,9 +2103,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2025,11 +2114,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-next-80b-a3b-instruct"
     },
     {
       "id": "qwen/qwen3-next-80b-a3b-thinking",
@@ -2053,11 +2143,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-next-80b-a3b-thinking"
     },
     {
       "id": "qwen/qwen3-omni-30b-a3b-instruct",
@@ -2071,23 +2162,24 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "audio",
-        "image",
         "text",
-        "video"
+        "video",
+        "audio",
+        "image"
       ],
       "output_modalities": [
-        "audio",
-        "text"
+        "text",
+        "audio"
       ],
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-omni-30b-a3b-instruct"
     },
     {
       "id": "qwen/qwen3-omni-30b-a3b-thinking",
@@ -2101,15 +2193,15 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "audio",
-        "image",
         "text",
-        "video"
+        "audio",
+        "video",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2117,7 +2209,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-omni-30b-a3b-thinking"
     },
     {
       "id": "qwen/qwen3-vl-235b-a22b-instruct",
@@ -2131,22 +2224,23 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "batch-api",
-        "chat/completions"
+        "chat/completions",
+        "batch-api"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-vl-235b-a22b-instruct"
     },
     {
       "id": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -2164,8 +2258,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2174,7 +2268,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-vl-235b-a22b-thinking"
     },
     {
       "id": "qwen/qwen3-vl-30b-a3b-instruct",
@@ -2188,13 +2283,13 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
-        "video"
+        "video",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2202,7 +2297,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3-vl-30b-a3b-instruct"
     },
     {
       "id": "qwen/qwen3-vl-30b-a3b-thinking",
@@ -2216,12 +2312,12 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2230,7 +2326,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-vl-30b-a3b-thinking"
     },
     {
       "id": "qwen/qwen3-vl-8b-instruct",
@@ -2244,12 +2341,12 @@
       "model_type": "chat",
       "features": [
         "function-calling",
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2258,7 +2355,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "qwen/qwen3-vl-8b-instruct"
     },
     {
       "id": "qwen/qwen3.5-122b-a10b",
@@ -2271,14 +2369,14 @@
       "output_token_price_per_m": 32000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2287,7 +2385,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.5-122b-a10b"
     },
     {
       "id": "qwen/qwen3.5-27b",
@@ -2300,14 +2399,14 @@
       "output_token_price_per_m": 24000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2316,7 +2415,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.5-27b"
     },
     {
       "id": "qwen/qwen3.5-35b-a3b",
@@ -2329,14 +2429,14 @@
       "output_token_price_per_m": 20000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2345,7 +2445,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.5-35b-a3b"
     },
     {
       "id": "qwen/qwen3.5-397b-a17b",
@@ -2358,14 +2459,14 @@
       "output_token_price_per_m": 36000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2374,7 +2475,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.5-397b-a17b"
     },
     {
       "id": "qwen/qwen3.6-27b",
@@ -2387,14 +2489,14 @@
       "output_token_price_per_m": 36000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2403,7 +2505,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.6-27b"
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
@@ -2416,14 +2519,14 @@
       "output_token_price_per_m": 14850,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output_modalities": [
@@ -2432,7 +2535,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "qwen/qwen3.6-35b-a3b"
     },
     {
       "id": "sao10k/l3-70b-euryale-v2.1",
@@ -2457,7 +2561,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "sao10k/l3-70b-euryale-v2.1"
     },
     {
       "id": "sao10k/l3-8b-lunaris",
@@ -2470,8 +2575,8 @@
       "output_token_price_per_m": 500,
       "model_type": "chat",
       "features": [
-        "serverless",
-        "structured-outputs"
+        "structured-outputs",
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2483,7 +2588,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "sao10k/l3-8b-lunaris"
     },
     {
       "id": "sao10k/l31-70b-euryale-v2.2",
@@ -2497,9 +2603,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2511,7 +2617,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "sao10k/l31-70b-euryale-v2.2"
     },
     {
       "id": "xiaomimimo/mimo-v2-flash",
@@ -2524,10 +2631,10 @@
       "output_token_price_per_m": 3000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -2536,11 +2643,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
-        "completions"
+        "completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "xiaomimimo/mimo-v2-flash"
     },
     {
       "id": "xiaomimimo/mimo-v2.5-pro",
@@ -2553,10 +2661,10 @@
       "output_token_price_per_m": 60000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -2565,11 +2673,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
+        "completions",
         "chat/completions",
-        "completions"
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "xiaomimimo/mimo-v2.5-pro"
     },
     {
       "id": "zai-org/autoglm-phone-9b-multilingual",
@@ -2585,8 +2694,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2594,7 +2703,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/autoglm-phone-9b-multilingual"
     },
     {
       "id": "zai-org/glm-4.5",
@@ -2621,7 +2731,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 4,
+      "upstream_id": "zai-org/glm-4.5"
     },
     {
       "id": "zai-org/glm-4.5-air",
@@ -2647,7 +2758,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.5-air"
     },
     {
       "id": "zai-org/glm-4.5v",
@@ -2661,14 +2773,14 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
-        "video"
+        "video",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -2677,7 +2789,8 @@
         "chat/completions",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.5v"
     },
     {
       "id": "zai-org/glm-4.6",
@@ -2691,9 +2804,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2702,11 +2815,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
+        "anthropic",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.6"
     },
     {
       "id": "zai-org/glm-4.6v",
@@ -2720,24 +2834,25 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
-        "image",
         "text",
-        "video"
+        "video",
+        "image"
       ],
       "output_modalities": [
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
+        "anthropic",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.6v"
     },
     {
       "id": "tencent/hy3",
@@ -2746,14 +2861,14 @@
       "created": 1782798401,
       "context_length": 262144,
       "max_output_tokens": 262144,
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
+      "input_token_price_per_m": 1400,
+      "output_token_price_per_m": 5800,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -2764,7 +2879,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "tencent/hy3",
+      "cached_input_token_price_per_m": 350
     },
     {
       "id": "zai-org/glm-4.7",
@@ -2778,9 +2895,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2789,11 +2906,12 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
         "chat/completions",
+        "anthropic",
         "completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.7"
     },
     {
       "id": "zai-org/glm-4.7-flash",
@@ -2806,10 +2924,10 @@
       "output_token_price_per_m": 4000,
       "model_type": "chat",
       "features": [
-        "function-calling",
-        "reasoning",
         "serverless",
-        "structured-outputs"
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
       ],
       "input_modalities": [
         "text"
@@ -2820,7 +2938,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-4.7-flash"
     },
     {
       "id": "zai-org/glm-5",
@@ -2834,9 +2953,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2845,10 +2964,11 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
-      "status": 1
+      "status": 1,
+      "upstream_id": "zai-org/glm-5"
     },
     {
       "id": "z-ai/glm-5.2",
@@ -2864,9 +2984,9 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
-        "serverless",
-        "structured-outputs"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -2875,7 +2995,8 @@
         "text"
       ],
       "endpoints": [
-        "chat/completions"
+        "chat/completions",
+        "anthropic"
       ],
       "status": 1
     },
@@ -2891,8 +3012,196 @@
       "model_type": "chat",
       "features": [
         "function-calling",
+        "structured-outputs",
         "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "upstream_id": "zai-org/glm-5.1"
+    },
+    {
+      "id": "baidu/cobuddy",
+      "upstream_id": "baidu/cobuddy",
+      "display_name": "CoBuddy",
+      "title": "baidu/cobuddy",
+      "model_type": "chat",
+      "features": [
         "serverless",
+        "function-calling",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1780454207,
+      "context_length": 131072,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 2800,
+      "output_token_price_per_m": 11300,
+      "cached_input_token_price_per_m": 700
+    },
+    {
+      "id": "deepseek/deepseek-r1",
+      "upstream_id": "deepseek/deepseek-r1",
+      "display_name": "DeepSeek R1",
+      "title": "deepseek/deepseek-r1",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1737876558,
+      "context_length": 64000,
+      "max_output_tokens": 16000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "deepseek/deepseek-r1-community",
+      "upstream_id": "deepseek/deepseek-r1/community",
+      "display_name": "DeepSeek R1",
+      "title": "deepseek/deepseek-r1/community",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1739525865,
+      "context_length": 64000,
+      "max_output_tokens": 8000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "deepseek/deepseek-v3-community",
+      "upstream_id": "deepseek/deepseek-v3/community",
+      "display_name": "DeepSeek V3",
+      "title": "deepseek/deepseek-v3/community",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1739525912,
+      "context_length": 64000,
+      "max_output_tokens": 8000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "deepseek/deepseek_v3",
+      "upstream_id": "deepseek/deepseek_v3",
+      "display_name": "DeepSeek V3",
+      "title": "deepseek/deepseek_v3",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1736942072,
+      "context_length": 64000,
+      "max_output_tokens": 16000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "dev/glm46",
+      "upstream_id": "dev/glm46",
+      "display_name": "dev/glm46",
+      "title": "dev/glm46",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1763607567,
+      "context_length": 256000,
+      "max_output_tokens": 256000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "meta-llama/llama-3.2-1b-instruct",
+      "upstream_id": "meta-llama/llama-3.2-1b-instruct",
+      "display_name": "Llama 3.2 1B Instruct\t",
+      "title": "meta-llama/llama-3.2-1b-instruct",
+      "model_type": "chat",
+      "features": [
         "structured-outputs"
       ],
       "input_modalities": [
@@ -2902,10 +3211,604 @@
         "text"
       ],
       "endpoints": [
-        "anthropic",
+        "chat/completions",
+        "batch-api"
+      ],
+      "status": 1,
+      "created": 1732609540,
+      "context_length": 131000,
+      "max_output_tokens": 32000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "minimax/m2-her",
+      "upstream_id": "minimax/m2-her",
+      "display_name": "M2-her",
+      "title": "minimax/m2-her",
+      "model_type": "chat",
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1769050364,
+      "context_length": 32000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "minimax/minimax-m2.7-highspeed",
+      "upstream_id": "minimax/minimax-m2.7-highspeed",
+      "display_name": "MiniMax M2.7-highspeed",
+      "title": "minimax/minimax-m2.7-highspeed",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1775119268,
+      "context_length": 204800,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "minimax/minimax-m3",
+      "upstream_id": "minimax/minimax-m3",
+      "display_name": "MiniMax M3",
+      "title": "minimax/minimax-m3",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1780282959,
+      "context_length": 1000000,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "upstream_id": "moonshotai/kimi-k2.7-code",
+      "display_name": "Kimi K2.7 Code",
+      "title": "moonshotai/kimi-k2.7-code",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1781260548,
+      "context_length": 262144,
+      "max_output_tokens": 262144,
+      "input_token_price_per_m": 9500,
+      "output_token_price_per_m": 40000,
+      "cached_input_token_price_per_m": 1900
+    },
+    {
+      "id": "nex-agi/nex-n2-pro",
+      "upstream_id": "nex-agi/nex-n2-pro",
+      "display_name": "Nex-N2-Pro",
+      "title": "nex-agi/nex-n2-pro",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1780541483,
+      "context_length": 262144,
+      "max_output_tokens": 262144,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "nousresearch/nous-hermes-llama2-13b",
+      "upstream_id": "nousresearch/nous-hermes-llama2-13b",
+      "display_name": "Nous Hermes Llama2 13B",
+      "title": "nousresearch/nous-hermes-llama2-13b",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1714024873,
+      "context_length": 4096,
+      "max_output_tokens": 32768,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "nvidia/nemotron-3-nano-30b-a3b",
+      "upstream_id": "nvidia/nemotron-3-nano-30b-a3b",
+      "display_name": "Nemotron 3 Nano 30B A3B",
+      "title": "nvidia/nemotron-3-nano-30b-a3b",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1781004459,
+      "context_length": 262144,
+      "max_output_tokens": 32768,
+      "input_token_price_per_m": 500,
+      "output_token_price_per_m": 2000
+    },
+    {
+      "id": "openchat/openchat-7b",
+      "upstream_id": "openchat/openchat-7b",
+      "display_name": "OpenChat 7B",
+      "title": "openchat/openchat-7b",
+      "model_type": "chat",
+      "features": [
+        "structured-outputs"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1721992172,
+      "context_length": 4096,
+      "max_output_tokens": 4096,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "qwen/qwen-2-7b-instruct",
+      "upstream_id": "qwen/qwen-2-7b-instruct",
+      "display_name": "Qwen 2 7B Instruct",
+      "title": "qwen/qwen-2-7b-instruct",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1726661307,
+      "context_length": 32768,
+      "max_output_tokens": 32768,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "qwen/qwen-2-vl-72b-instruct",
+      "upstream_id": "qwen/qwen-2-vl-72b-instruct",
+      "display_name": "Qwen 2 VL 72B Instruct",
+      "title": "qwen/qwen-2-vl-72b-instruct",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1734600120,
+      "context_length": 32768,
+      "max_output_tokens": 120000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "qwen/qwen3.5-plus",
+      "upstream_id": "qwen/qwen3.5-plus",
+      "display_name": "Qwen3.5-Plus",
+      "title": "qwen/qwen3.5-plus",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1771234162,
+      "context_length": 1000000,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "qwen/qwen3.6-plus",
+      "upstream_id": "qwen/qwen3.6-plus",
+      "display_name": "Qwen3.6-Plus",
+      "title": "qwen/qwen3.6-plus",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1776757830,
+      "context_length": 1000000,
+      "max_output_tokens": 65536,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "upstream_id": "qwen/qwen3.7-max",
+      "display_name": "Qwen3.7-Max",
+      "title": "qwen/qwen3.7-max",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1779367973,
+      "context_length": 1000000,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 12500,
+      "output_token_price_per_m": 37500,
+      "cached_input_token_price_per_m": 2500
+    },
+    {
+      "id": "stepfun/step-3.7-flash",
+      "upstream_id": "stepfun/step-3.7-flash",
+      "display_name": "Step 3.7 Flash",
+      "title": "stepfun/step-3.7-flash",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1781231066,
+      "context_length": 262144,
+      "max_output_tokens": 256000,
+      "input_token_price_per_m": 2000,
+      "output_token_price_per_m": 11500,
+      "cached_input_token_price_per_m": 400
+    },
+    {
+      "id": "teknium/openhermes-2.5-mistral-7b",
+      "upstream_id": "teknium/openhermes-2.5-mistral-7b",
+      "display_name": "Openhermes2.5 Mistral 7B",
+      "title": "teknium/openhermes-2.5-mistral-7b",
+      "model_type": "chat",
+      "features": [],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 4,
+      "created": 1713938473,
+      "context_length": 4096,
+      "max_output_tokens": 8000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "thudm/glm-4-32b-0414",
+      "upstream_id": "thudm/glm-4-32b-0414",
+      "display_name": "GLM-4-32B-0414",
+      "title": "thudm/glm-4-32b-0414",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1744798076,
+      "context_length": 32000,
+      "max_output_tokens": 32000,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "xiaomimimo/mimo-v2-pro",
+      "upstream_id": "xiaomimimo/mimo-v2-pro",
+      "display_name": "XiaomiMiMo/MiMo-V2-Pro",
+      "title": "xiaomimimo/mimo-v2-pro",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "completions",
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 4,
+      "created": 1773977023,
+      "context_length": 1048576,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "xiaomimimo/mimo-v2.5",
+      "upstream_id": "xiaomimimo/mimo-v2.5",
+      "display_name": "XiaomiMiMo/MiMo-V2.5",
+      "title": "xiaomimimo/mimo-v2.5",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "completions",
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1780040346,
+      "context_length": 1048576,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "z-ai/glm-4.7-h",
+      "upstream_id": "zai-org/glm-4.7-h",
+      "display_name": "GLM-4.7",
+      "title": "zai-org/glm-4.7-h",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic",
+        "completions"
+      ],
+      "status": 1,
+      "created": 1769395795,
+      "context_length": 204800,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "z-ai/glm-5-turbo",
+      "upstream_id": "zai-org/glm-5-turbo",
+      "display_name": "GLM-5-Turbo",
+      "title": "zai-org/glm-5-turbo",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "created": 1774514974,
+      "context_length": 202800,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
+    },
+    {
+      "id": "z-ai/glm-5v-turbo",
+      "upstream_id": "zai-org/glm-5v-turbo",
+      "display_name": "GLM-5V-Turbo",
+      "title": "zai-org/glm-5v-turbo",
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic"
+      ],
+      "status": 1,
+      "created": 1775118243,
+      "context_length": 204800,
+      "max_output_tokens": 131072,
+      "routable": false,
+      "routable_reason": "awaiting-price"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/parasail.json
+++ b/src/trusted_router/data/provider_models/parasail.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Parasail models live ahead of the shared snapshot. Prices refreshed hourly from the public pricing page (www.parasail.io/pricing); model liveness gated on api.parasail.io/v1/models.",
   "provider": "parasail",
   "source": "https://www.parasail.io/pricing",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 4,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/streamlake.json
+++ b/src/trusted_router/data/provider_models/streamlake.json
@@ -73,6 +73,6 @@
       "routable_reason": "provider-canary-failed"
     }
   ],
-  "generated_at": "2026-07-19T03:03:01Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 3
 }

--- a/src/trusted_router/data/provider_models/thinkingmachines.json
+++ b/src/trusted_router/data/provider_models/thinkingmachines.json
@@ -1,6 +1,6 @@
 {
   "source": "https://tinker-docs.thinkingmachines.ai/tinker/models/",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "provider": "thinkingmachines",
   "currency": "USD",
   "price_unit": "microdollars_per_million_tokens",

--- a/src/trusted_router/data/provider_models/together.json
+++ b/src/trusted_router/data/provider_models/together.json
@@ -1,26 +1,437 @@
 {
   "_about": "Provider-native supplement for Together AI routes that are live ahead of the shared OpenRouter snapshot. Verified against https://api.together.xyz/v1/models on 2026-06-22.",
   "provider": "together",
-  "source": "https://api.together.xyz/v1/models",
-  "generated_at": "2026-06-22T00:00:00Z",
-  "model_count": 1,
+  "source": "https://api.together.xyz/v1/endpoints?type=serverless",
+  "generated_at": "2026-07-21T14:28:31Z",
+  "model_count": 18,
   "models": [
     {
       "id": "z-ai/glm-5.2",
       "upstream_id": "zai-org/GLM-5.2",
-      "display_name": "Together GLM 5.2",
-      "title": "z-ai/glm-5.2",
+      "display_name": "GLM 5.2",
+      "title": "zai-org/GLM-5.2",
       "context_length": 262144,
       "max_output_tokens": 131072,
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,
       "cached_input_token_price_per_m": 260000,
       "model_type": "chat",
-      "features": ["reasoning", "function-calling", "structured-outputs", "serverless"],
-      "input_modalities": ["text"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
+      "features": [
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
+    },
+    {
+      "display_name": "Deepseek V4 Pro",
+      "title": "deepseek-ai/DeepSeek-V4-Pro",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "deepseek/deepseek-v4-pro",
+      "upstream_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 512000,
+      "input_token_price_per_m": 1740000,
+      "output_token_price_per_m": 3480000,
+      "cached_input_token_price_per_m": 200000
+    },
+    {
+      "display_name": "Gemma 3N E4B Instruct",
+      "title": "google/gemma-3n-E4B-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-3n-e4b-it",
+      "upstream_id": "google/gemma-3n-E4B-it",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 32768,
+      "input_token_price_per_m": 60000,
+      "output_token_price_per_m": 120000
+    },
+    {
+      "display_name": "Gemma 4 31B-it FP8",
+      "title": "google/gemma-4-31B-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-4-31b-it",
+      "upstream_id": "google/gemma-4-31B-it",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 390000,
+      "output_token_price_per_m": 970000
+    },
+    {
+      "display_name": "Meta Llama 3.3 70B Instruct Turbo",
+      "title": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "meta-llama/llama-3.3-70b-instruct",
+      "upstream_id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 131072,
+      "input_token_price_per_m": 1040000,
+      "output_token_price_per_m": 1040000
+    },
+    {
+      "display_name": "MiniMax M2.7 FP4",
+      "title": "MiniMaxAI/MiniMax-M2.7",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "minimax/minimax-m2.7",
+      "upstream_id": "MiniMaxAI/MiniMax-M2.7",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 196608,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 60000
+    },
+    {
+      "display_name": "MiniMax M3",
+      "title": "MiniMaxAI/MiniMax-M3",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "minimax/minimax-m3",
+      "upstream_id": "MiniMaxAI/MiniMax-M3",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 524288,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 60000
+    },
+    {
+      "display_name": "Kimi K2.6 Fp4",
+      "title": "moonshotai/Kimi-K2.6",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k2.6",
+      "upstream_id": "moonshotai/Kimi-K2.6",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 1200000,
+      "output_token_price_per_m": 4500000,
+      "cached_input_token_price_per_m": 200000
+    },
+    {
+      "display_name": "Kimi K2.7 Code",
+      "title": "moonshotai/Kimi-K2.7-Code",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k2.7-code",
+      "upstream_id": "moonshotai/Kimi-K2.7-Code",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 950000,
+      "output_token_price_per_m": 4000000,
+      "cached_input_token_price_per_m": 190000
+    },
+    {
+      "display_name": "NVIDIA Nemotron 3 Ultra 550B A55B NVFP4",
+      "title": "nvidia/nemotron-3-ultra-550b-a55b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "nvidia/nemotron-3-ultra-550b-a55b",
+      "upstream_id": "nvidia/nemotron-3-ultra-550b-a55b",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 512288,
+      "input_token_price_per_m": 600000,
+      "output_token_price_per_m": 3600000,
+      "cached_input_token_price_per_m": 200000
+    },
+    {
+      "display_name": "OpenAI GPT-OSS 120B",
+      "title": "openai/gpt-oss-120b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "openai/gpt-oss-120b",
+      "upstream_id": "openai/gpt-oss-120b",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 131072,
+      "input_token_price_per_m": 150000,
+      "output_token_price_per_m": 600000
+    },
+    {
+      "display_name": "OpenAI GPT-OSS 20B",
+      "title": "openai/gpt-oss-20b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "openai/gpt-oss-20b",
+      "upstream_id": "openai/gpt-oss-20b",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 131072,
+      "input_token_price_per_m": 50000,
+      "output_token_price_per_m": 200000
+    },
+    {
+      "display_name": "Pearl-ai Gemma-4-31B-it-pearl",
+      "title": "pearl-ai/gemma-4-31b-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "pearl-ai/gemma-4-31b-it",
+      "upstream_id": "pearl-ai/gemma-4-31b-it",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 280000,
+      "output_token_price_per_m": 860000
+    },
+    {
+      "display_name": "Ternary Bonsai 27B",
+      "title": "Prism-ML/Ternary-Bonsai-27B",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "prism-ml/ternary-bonsai-27b",
+      "upstream_id": "Prism-ML/Ternary-Bonsai-27B",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 0,
+      "output_token_price_per_m": 0
+    },
+    {
+      "display_name": "Qwen2.5 7B Instruct Turbo",
+      "title": "Qwen/Qwen2.5-7B-Instruct-Turbo",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen-2.5-7b-instruct",
+      "upstream_id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 32768,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 300000
+    },
+    {
+      "display_name": "Qwen3.5 9B FP8",
+      "title": "Qwen/Qwen3.5-9B",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen3.5-9b",
+      "upstream_id": "Qwen/Qwen3.5-9B",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 262144,
+      "input_token_price_per_m": 170000,
+      "output_token_price_per_m": 250000
+    },
+    {
+      "display_name": "Inkling FP4",
+      "title": "thinkingmachines/Inkling",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "thinkingmachines/inkling",
+      "upstream_id": "thinkingmachines/Inkling",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 524288,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 4050000,
+      "cached_input_token_price_per_m": 170000
+    },
+    {
+      "display_name": "Inkling FP4",
+      "title": "thinkingmachines/Inkling",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "thinkingmachines/inkling-1m",
+      "upstream_id": "thinkingmachines/Inkling",
+      "features": [
+        "serverless"
+      ],
+      "context_length": 524288,
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 4050000,
+      "cached_input_token_price_per_m": 170000,
+      "missing_since": "2026-07-21",
+      "routable": false,
+      "routable_reason": "delisted-upstream"
     }
-  ]
+  ],
+  "price_scale": "microdollars_per_million"
 }

--- a/src/trusted_router/data/provider_models/voyage.json
+++ b/src/trusted_router/data/provider_models/voyage.json
@@ -3,7 +3,7 @@
   "provider": "voyage",
   "source": "https://docs.voyageai.com/docs/embeddings",
   "pricing_source": "https://docs.voyageai.com/docs/pricing.md",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -2,10 +2,10 @@
   "_about": "Provider-native supplement for Wafer serverless API. Refreshed hourly from Wafer's OpenAI-compatible /v1/models feed.",
   "provider": "wafer",
   "source": "https://pass.wafer.ai/v1/models",
-  "generated_at": "2026-07-17T04:09:40Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "price_scale": "microdollars_per_million",
   "zdr_header": "Wafer-ZDR: required",
-  "model_count": 5,
+  "model_count": 6,
   "models": [
     {
       "id": "minimax/minimax-m3",
@@ -85,6 +85,17 @@
       "zdr_supported": true,
       "context_length": 1048576,
       "cached_input_token_price_per_m": 500000
+    },
+    {
+      "id": "qwen/qwen3.5-397b-a17b",
+      "upstream_id": "Qwen3.5-397B-A17B",
+      "display_name": "Qwen3.5-397B-A17B",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "zdr_supported": false,
+      "routable": false,
+      "routable_reason": "awaiting-price"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -1,7 +1,7 @@
 {
   "provider": "xiaomi",
   "source": "https://mimo.mi.com/docs/en-US/pricing",
-  "generated_at": "2026-07-17T01:10:13Z",
+  "generated_at": "2026-07-21T14:09:26Z",
   "model_count": 5,
   "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated /v1/models feed but has no public PAYG row, so its last verified price is retained until Xiaomi republishes one. Legacy V2 rows are kept only as historical fallback metadata.",
   "models": [

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -675,7 +675,7 @@ def test_internal_gateway_byok_uses_configured_secret_ref_and_refunds_key_limit(
         "/v1/internal/gateway/authorize",
         json={
             "api_key_hash": key_hash,
-            "model": "meta-llama/llama-3.1-8b-instruct",
+            "model": "openai/gpt-oss-120b",
             "provider": {"usage": "byok"},
             "estimated_input_tokens": 20,
             "max_output_tokens": 4,
@@ -722,7 +722,7 @@ def test_internal_gateway_byok_returns_envelope_for_uploaded_raw_key(
         "/v1/internal/gateway/authorize",
         json={
             "api_key_hash": created["data"]["hash"],
-            "model": "meta-llama/llama-3.1-8b-instruct",
+            "model": "openai/gpt-oss-120b",
             "provider": {"usage": "byok"},
             "estimated_input_tokens": 20,
             "max_output_tokens": 4,
@@ -769,7 +769,7 @@ def test_internal_gateway_byok_cache_key_changes_on_rotation(
             "/v1/internal/gateway/authorize",
             json={
                 "api_key_hash": created["data"]["hash"],
-                "model": "meta-llama/llama-3.1-8b-instruct",
+                "model": "openai/gpt-oss-120b",
                 "provider": {"usage": "byok"},
                 "estimated_input_tokens": 1,
                 "max_output_tokens": 1,
@@ -795,7 +795,7 @@ def test_internal_gateway_byok_cache_key_changes_on_rotation(
         "/v1/internal/gateway/authorize",
         json={
             "api_key_hash": created["data"]["hash"],
-            "model": "meta-llama/llama-3.1-8b-instruct",
+            "model": "openai/gpt-oss-120b",
             "provider": {"usage": "byok"},
             "estimated_input_tokens": 1,
             "max_output_tokens": 1,

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from trusted_router.catalog import (
     _PROVIDER_DEPRECATED_UPSTREAM_MODELS,
     _PROVIDER_SERVED_MODEL_ALLOWLIST,
@@ -7,6 +9,11 @@ from trusted_router.catalog import (
     MODELS,
     ModelEndpoint,
     endpoints_for_model,
+)
+from trusted_router.catalog_ingest import (
+    _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS,
+    _PROVIDER_MODELS_DIR,
+    _authoritative_provider_model_ids,
 )
 from trusted_router.dashboard import _model_detail_view
 
@@ -46,11 +53,10 @@ def test_byok_only_model_stays_not_prepaid() -> None:
 
 
 def test_cerebras_only_credits_serves_allowlisted_models() -> None:
-    # The Cerebras account serves only a small set of models on OUR key;
-    # routing a Credits request for any other model 502s. Credits endpoints
-    # must never include a non-allowlisted model. (BYOK uses the customer's
-    # own key and is intentionally left untouched.)
-    allow = _PROVIDER_SERVED_MODEL_ALLOWLIST["cerebras"]
+    # Cerebras's public account-callable feed is authoritative for Credits.
+    # The generated manifest replaces a stale source allowlist so new models
+    # become routable automatically without admitting unrelated OR inventory.
+    allow = _authoritative_provider_model_ids("cerebras")
     cerebras_credits = {
         e.model_id
         for e in MODEL_ENDPOINTS.values()
@@ -62,7 +68,46 @@ def test_cerebras_only_credits_serves_allowlisted_models() -> None:
         "cerebras/gpt-oss-120b",
         "z-ai/glm-4.7",
         "cerebras/zai-glm-4.7",
+        "google/gemma-4-31b-it",
+        "cerebras/gemma-4-31b",
     } <= cerebras_credits
+
+
+def test_together_credits_follow_started_serverless_manifest() -> None:
+    allow = _authoritative_provider_model_ids("together")
+    together_credits = {
+        e.model_id
+        for e in MODEL_ENDPOINTS.values()
+        if e.provider == "together" and e.usage_type == "Credits"
+    }
+    assert together_credits <= allow
+    assert {
+        "minimax/minimax-m3",
+        "moonshotai/kimi-k2.7-code",
+        "z-ai/glm-5.2",
+        "intfloat/multilingual-e5-large-instruct",
+    } <= together_credits
+    assert "meta-llama/llama-3.1-70b-instruct" not in together_credits
+
+
+def test_dark_authoritative_manifest_rows_cannot_return_through_shared_snapshot() -> None:
+    endpoint_pairs = {(endpoint.provider, endpoint.model_id) for endpoint in MODEL_ENDPOINTS.values()}
+    for provider_slug in _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS:
+        raw = json.loads(
+            (_PROVIDER_MODELS_DIR / f"{provider_slug}.json").read_text(encoding="utf-8")
+        )
+        dark_models = {
+            row["id"]
+            for row in raw.get("models", [])
+            if isinstance(row, dict)
+            and isinstance(row.get("id"), str)
+            and row.get("routable") is False
+        }
+        assert not {
+            (provider_slug, model_id)
+            for model_id in dark_models
+            if (provider_slug, model_id) in endpoint_pairs
+        }
 
 
 def test_gmi_only_credits_serves_allowlisted_models() -> None:
@@ -176,7 +221,7 @@ def test_tinfoil_june_2026_deprecations_and_replacements_are_routable() -> None:
     # Provider-scoped deprecation: non-Tinfoil routes for these model families
     # remain available when their provider still serves them.
     assert "z-ai/glm-5.1@zai/prepaid" in MODEL_ENDPOINTS
-    assert "qwen/qwen3-vl-30b-a3b-instruct@phala/prepaid" in MODEL_ENDPOINTS
+    assert "qwen/qwen3-vl-30b-a3b-instruct@novita/prepaid" in MODEL_ENDPOINTS
 
 
 def test_novita_july_2026_retirements_and_replacements_are_routable() -> None:
@@ -231,7 +276,6 @@ def test_friendli_july_2026_glm_5_deprecation_does_not_remove_glm_52() -> None:
 
 def test_route_health_first_sweep_dead_routes_are_not_routable() -> None:
     flagged_routes = {
-        ("openai/gpt-oss-120b", "together"),
         ("openai/gpt-5.6-sol", "lightning"),
         ("x-ai/grok-4.5", "gmi"),
         ("anthropic/claude-opus-4.8", "phala"),
@@ -245,6 +289,11 @@ def test_route_health_first_sweep_dead_routes_are_not_routable() -> None:
             for endpoint in endpoints_for_model(model_id)
             if endpoint.provider == provider
         ]
+
+    # Together's live serverless endpoint feed now reports GPT OSS 120B as
+    # STARTED. The generated authoritative manifest supersedes the July 18
+    # route-health quarantine, so this repaired route must stay available.
+    assert "openai/gpt-oss-120b@together/prepaid" in MODEL_ENDPOINTS
 
     # Quarantine is provider-scoped: healthy sibling routes survive.
     assert "openai/gpt-oss-120b@cerebras/prepaid" in MODEL_ENDPOINTS

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -137,12 +137,9 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
         ("z-ai/glm-5.2", "venice"),
         ("z-ai/glm-5.2", "parasail"),
         ("z-ai/glm-5.2", "friendli"),
-        ("z-ai/glm-5.2", "crusoe"),
         ("z-ai/glm-5.2", "makora"),
-        ("deepseek/deepseek-v4-flash", "crusoe"),
         ("deepseek/deepseek-v4-flash", "makora"),
         ("moonshotai/kimi-k2.7-code", "makora"),
-        ("moonshotai/kimi-k2.6", "crusoe"),
         ("cerebras/gpt-oss-120b", "cerebras"),
     ]:
         assert f"{model_id}@{provider}/prepaid" in MODEL_ENDPOINTS
@@ -332,8 +329,9 @@ def test_novita_hy3_uses_live_provider_id_and_price_floor() -> None:
     assert model.context_length == 262_144
     assert prepaid.upstream_id == "tencent/hy3"
     assert byok.upstream_id == "tencent/hy3"
-    assert prepaid.prompt_price_microdollars_per_million_tokens == 10_000
-    assert prepaid.completion_price_microdollars_per_million_tokens == 10_000
+    assert prepaid.prompt_price_microdollars_per_million_tokens == 147_000
+    assert prepaid.completion_price_microdollars_per_million_tokens == 609_000
+    assert prepaid.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 36_750
 
 
 def test_minimax_empty_operator_routes_are_not_prepaid() -> None:
@@ -965,11 +963,13 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
         assert metadata["open_weights"] is True
 
     inkling = MODELS["thinkingmachines/inkling"]
-    assert inkling.context_length == 262_144
-    assert inkling.provider == "thinkingmachines"
+    assert inkling.context_length == 1_048_576
+    assert inkling.provider == "together"
     endpoints = endpoints_for_model(inkling.id)
     assert {(endpoint.provider, endpoint.upstream_id) for endpoint in endpoints} == {
-        ("thinkingmachines", "thinkingmachines/Inkling:peft:262144")
+        ("gmi", "thinkingmachines/Inkling"),
+        ("thinkingmachines", "thinkingmachines/Inkling:peft:262144"),
+        ("together", "thinkingmachines/Inkling"),
     }
     assert any(endpoint.usage_type == "Credits" for endpoint in endpoints)
     assert any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
@@ -995,7 +995,7 @@ def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() ->
     }
     assert prepaid["baseten"] == "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
     assert prepaid["nebius"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
-    assert "together" not in prepaid
+    assert prepaid["together"] == "nvidia/nemotron-3-ultra-550b-a55b"
     assert "gmi" not in prepaid
 
 
@@ -1442,42 +1442,14 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
     )
 
 
-def test_crusoe_provider_models_present_and_routable() -> None:
-    """Crusoe onboarding: native /v1/models rows load from the manifest,
-    preserve case-sensitive upstream ids, and create prepaid + BYOK endpoints."""
+def test_crusoe_provider_models_fail_closed_after_account_auth_failure() -> None:
+    """A rejected operator credential must darken stale Crusoe inventory."""
 
     assert "crusoe" in PROVIDERS
     assert "crusoe" in GATEWAY_PREPAID_PROVIDER_SLUGS
-    expected = {
-        "z-ai/glm-5.2": "zai/GLM-5.2",
-        "deepseek/deepseek-v4-flash": "deepseek-ai/Deepseek-V4-Flash",
-        "moonshotai/kimi-k2.6": "moonshotai/Kimi-K2.6",
-        "openai/gpt-oss-120b": "openai/gpt-oss-120b",
-        "google/gemma-4-31b-it": "google/gemma-4-31b-it",
-    }
-    crusoe_model_ids = {
-        endpoint.model_id
-        for endpoint in MODEL_ENDPOINTS.values()
-        if endpoint.provider == "crusoe" and str(endpoint.usage_type) == "Credits"
-    }
-    assert len(crusoe_model_ids) >= 15
-    for model_id, upstream in expected.items():
-        model = MODELS.get(model_id)
-        assert model is not None, f"{model_id} missing from catalog"
-        credits = [
-            e
-            for e in endpoints_for_model(model_id)
-            if str(e.usage_type) == "Credits" and e.provider == "crusoe"
-        ]
-        byok = [
-            e
-            for e in endpoints_for_model(model_id)
-            if str(e.usage_type) == "BYOK" and e.provider == "crusoe"
-        ]
-        assert credits, f"{model_id} has no crusoe prepaid endpoint"
-        assert byok, f"{model_id} has no crusoe BYOK endpoint"
-        assert credits[0].upstream_id == upstream
-        assert credits[0].prompt_price_microdollars_per_million_tokens > 0
+    assert not [
+        endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "crusoe"
+    ]
 
 
 def test_makora_provider_models_present_and_routable() -> None:
@@ -1643,7 +1615,6 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     friendli = MODEL_ENDPOINTS["z-ai/glm-5.2@friendli/prepaid"]
     baseten = MODEL_ENDPOINTS["z-ai/glm-5.2@baseten/prepaid"]
     wafer = MODEL_ENDPOINTS["z-ai/glm-5.2@wafer/prepaid"]
-    crusoe = MODEL_ENDPOINTS["z-ai/glm-5.2@crusoe/prepaid"]
 
     assert model.provider == "zai"
     assert model.context_length == 1_048_576
@@ -1663,7 +1634,6 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     assert friendli.upstream_id == "zai-org/GLM-5.2"
     assert baseten.upstream_id == "zai-org/GLM-5.2"
     assert wafer.upstream_id == "GLM-5.2"
-    assert crusoe.upstream_id == "zai/GLM-5.2"
     assert gmi.prompt_price_microdollars_per_million_tokens == 1_029_000
     assert gmi.completion_price_microdollars_per_million_tokens == 3_234_000
     assert deepinfra.prompt_price_microdollars_per_million_tokens == 1_260_000
@@ -1678,8 +1648,7 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     assert baseten.completion_price_microdollars_per_million_tokens == 4_620_000
     assert wafer.prompt_price_microdollars_per_million_tokens == 1_260_000
     assert wafer.completion_price_microdollars_per_million_tokens == 4_305_000
-    assert crusoe.prompt_price_microdollars_per_million_tokens == 1_470_000
-    assert crusoe.completion_price_microdollars_per_million_tokens == 4_620_000
+    assert "z-ai/glm-5.2@crusoe/prepaid" not in MODEL_ENDPOINTS
 
 
 def test_parasail_qwen_397b_uses_working_native_upstream_id() -> None:

--- a/tests/test_cerebras_pricing.py
+++ b/tests/test_cerebras_pricing.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from pytest import MonkeyPatch
+
+from scripts.pricing.providers import cerebras
+
+
+class _FakeCerebrasResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {
+            "data": [
+                {
+                    "id": "zai-glm-4.7",
+                    "name": "Z.ai GLM 4.7",
+                    "pricing": {
+                        "prompt": "0.00000225",
+                        "completion": "0.00000275",
+                    },
+                    "capabilities": {"reasoning": True, "vision": False},
+                    "limits": {
+                        "max_context_length": 131_072,
+                        "max_completion_tokens": 40_960,
+                    },
+                    "deprecated": False,
+                },
+                {
+                    "id": "gemma-4-31b",
+                    "name": "Gemma 4 31B",
+                    "pricing": {
+                        "prompt": "0.00000099",
+                        "completion": "0.00000149",
+                    },
+                    "capabilities": {
+                        "function_calling": True,
+                        "reasoning": True,
+                        "structured_outputs": True,
+                        "vision": True,
+                    },
+                    "limits": {
+                        "max_context_length": 131_072,
+                        "max_completion_tokens": 40_960,
+                    },
+                    "deprecated": False,
+                },
+                {
+                    "id": "gpt-oss-120b",
+                    "name": "OpenAI GPT OSS",
+                    "pricing": {
+                        "prompt": "0.00000035",
+                        "completion": "0.00000075",
+                    },
+                    "capabilities": {"reasoning": True, "vision": False},
+                    "limits": {
+                        "max_context_length": 131_072,
+                        "max_completion_tokens": 40_960,
+                    },
+                    "deprecated": False,
+                },
+                {
+                    "id": "retired-model",
+                    "pricing": {
+                        "prompt": "0.00000001",
+                        "completion": "0.00000001",
+                    },
+                    "deprecated": True,
+                },
+            ]
+        }
+
+
+class _FakeCerebrasClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> _FakeCerebrasClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    def get(self, url: str, *, headers: dict[str, str]) -> _FakeCerebrasResponse:
+        assert url == cerebras.URL
+        assert headers["Accept"] == "application/json"
+        assert "Authorization" not in headers
+        return _FakeCerebrasResponse()
+
+
+def test_cerebras_public_api_discovers_models_prices_and_capabilities(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+
+    result = cerebras.fetch()
+
+    gemma = result.prices["google/gemma-4-31b-it"]
+    assert gemma.prompt_micro_per_m == 990_000
+    assert gemma.completion_micro_per_m == 1_490_000
+    assert result.prices["cerebras/gemma-4-31b"] == gemma
+    assert result.prices["openai/gpt-oss-120b"].prompt_micro_per_m == 350_000
+    assert result.prices["z-ai/glm-4.7"].completion_micro_per_m == 2_750_000
+
+    row = cerebras._DISCOVERED_MANIFEST_ROWS["google/gemma-4-31b-it"]
+    assert row["upstream_id"] == "gemma-4-31b"
+    assert row["input_modalities"] == ["text", "image"]
+    assert row["context_length"] == 131_072
+    assert row["max_output_tokens"] == 40_960
+    assert "function-calling" in row["features"]
+    assert "structured-outputs" in row["features"]
+
+
+def test_cerebras_refresh_writes_new_models_and_aliases(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+    manifest_path = tmp_path / "cerebras.json"
+    manifest_path.write_text(
+        json.dumps({"provider": "cerebras", "models": []}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cerebras, "MANIFEST_PATH", manifest_path)
+
+    result = cerebras.fetch()
+    cerebras.write_provider_manifest(result)
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = {row["id"]: row for row in payload["models"]}
+    assert payload["source"] == cerebras.URL
+    assert payload["model_count"] == 6
+    assert {
+        "openai/gpt-oss-120b",
+        "cerebras/gpt-oss-120b",
+        "z-ai/glm-4.7",
+        "cerebras/zai-glm-4.7",
+        "google/gemma-4-31b-it",
+        "cerebras/gemma-4-31b",
+    } == set(rows)
+    assert rows["google/gemma-4-31b-it"]["input_token_price_per_m"] == 990_000
+    assert rows["google/gemma-4-31b-it"]["upstream_id"] == "gemma-4-31b"

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -49,6 +49,15 @@ def test_audit_reports_embedding_provider_scrapers_as_covered() -> None:
     assert any("openai" in i for i in info), info
 
 
+def test_shared_gemini_scraper_covers_ai_studio_and_vertex() -> None:
+    now = dt.datetime(2026, 6, 7, tzinfo=dt.UTC)
+    warnings, info = audit(max_age_days=14, now=now, check_model_discovery=False)
+
+    assert not any("google-vertex: NO price source" in warning for warning in warnings)
+    assert "google-ai-studio: live scraper ✓" in info
+    assert "google-vertex: live scraper ✓" in info
+
+
 def test_zai_model_discovery_extracts_glm_ids_from_docs() -> None:
     text = """
     The GLM Coding Plan now supports GLM-5.2.
@@ -85,6 +94,17 @@ def test_kimi_discovery_ignores_unpriced_auto_alias() -> None:
     assert check_price_coverage._kimi_model_id("kimi-k2.7-code") == "moonshotai/kimi-k2.7-code"
 
 
+def test_cerebras_discovery_uses_canonical_ids_and_ignores_unknown_models() -> None:
+    assert check_price_coverage._cerebras_model_id("gpt-oss-120b") == (
+        "openai/gpt-oss-120b"
+    )
+    assert check_price_coverage._cerebras_model_id("zai-glm-4.7") == "z-ai/glm-4.7"
+    assert check_price_coverage._cerebras_model_id("gemma-4-31b") == (
+        "google/gemma-4-31b-it"
+    )
+    assert check_price_coverage._cerebras_model_id("unknown") is None
+
+
 def test_provider_glm_required_gate_targets_current_flagships() -> None:
     assert check_price_coverage._is_required_provider_glm_model_id("z-ai/glm-5.2")
     assert check_price_coverage._is_required_provider_glm_model_id("z-ai/glm-5.3")
@@ -104,6 +124,24 @@ def test_model_discovery_warns_when_docs_mention_unpublished_model() -> None:
     assert any(item.startswith("cerebras: model discovery matched catalog") for item in info)
     assert len(warnings) == 1
     assert "z-ai/glm-5.2" in warnings[0]
+
+
+def test_zai_fetch_failure_does_not_skip_other_provider_discovery() -> None:
+    warnings, info = check_price_coverage._model_discovery_audit(
+        fetch_text=lambda _url: (_ for _ in ()).throw(OSError("temporary DNS failure")),
+        fetch_json=_known_provider_model_payload,
+        published_model_ids={
+            "moonshotai/kimi-k2.7-code",
+            "openai/gpt-oss-120b",
+            "google/gemini-3.5-flash",
+            "minimax/minimax-m3",
+            "z-ai/glm-5.2",
+        },
+    )
+
+    assert any(warning.startswith("zai: model discovery fetch failed") for warning in warnings)
+    assert any(item.startswith("cerebras: model discovery matched") for item in info)
+    assert any(item.startswith("kimi: model discovery matched") for item in info)
 
 
 def test_model_discovery_reports_match_when_docs_models_are_published() -> None:

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -21,6 +21,30 @@ def _make_snapshot(prices: dict[str, tuple[str, str]]) -> dict:
     }
 
 
+def _make_endpoint_snapshot(
+    headline: tuple[str, str],
+    endpoints: list[tuple[str, str, str, str]],
+) -> dict:
+    return {
+        "model_count": 1,
+        "models": [
+            {
+                "id": "a/b",
+                "pricing": {"prompt": headline[0], "completion": headline[1]},
+                "endpoints": [
+                    {
+                        "tr_provider_slug": provider,
+                        "model_id": upstream,
+                        "tag": provider,
+                        "pricing": {"prompt": prompt, "completion": completion},
+                    }
+                    for provider, upstream, prompt, completion in endpoints
+                ],
+            }
+        ],
+    }
+
+
 def _write(tmp_path: Path, name: str, snapshot: dict) -> Path:
     path = tmp_path / name
     path.write_text(json.dumps(snapshot), encoding="utf-8")
@@ -122,3 +146,61 @@ def test_summary_surfaces_per_model_deltas(tmp_path: Path, capsys) -> None:
     assert rc == 0  # +25% is under the 2x spike gate
     assert "1 prices changed" in out
     assert "a/b:" in out  # the delta line is surfaced, not just the count
+
+
+def test_route_removal_can_raise_headline_without_blocking_refresh(
+    tmp_path: Path, capsys
+) -> None:
+    """A cheap route disappearing must not freeze every provider refresh."""
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000006", "0.00000006"),
+            [
+                ("cheap", "author/model", "0.00000006", "0.00000006"),
+                ("steady", "author/model", "0.0000002", "0.0000006"),
+            ],
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.0000002", "0.0000006"),
+            [("steady", "author/model", "0.0000002", "0.0000006")],
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "a/b:" in capsys.readouterr().out
+
+
+def test_same_provider_endpoint_spike_blocks_and_is_visible(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.0000001", "0.0000002"),
+            [("provider", "Native/Model", "0.0000001", "0.0000002")],
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.0000001", "0.0000004"),
+            [("provider", "Native/Model", "0.0000001", "0.0000004")],
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    out = capsys.readouterr().out
+    assert "PRICE SPIKE FAILURES" in out
+    assert "provider" in out

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1024,6 +1024,10 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     ] == len(open_weight_rows)
     providers = client.get("/v1/providers").json()["data"]
     provider_flags = {provider["id"]: provider for provider in providers}
+    assert all(
+        not provider["provider_zero_data_retention"] or provider["stores_content"] is False
+        for provider in providers
+    )
     assert [provider["id"] for provider in providers[:2]] == ["tinfoil", "venice"]
     assert {
         "anthropic",
@@ -1047,6 +1051,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["phala"]["provider_confidential_compute"] is True
     assert provider_flags["anthropic"]["provider_zero_data_retention"] is False
     assert provider_flags["cerebras"]["provider_zero_data_retention"] is True
+    assert provider_flags["cerebras"]["stores_content"] is False
     assert provider_flags["together"]["provider_zero_data_retention"] is True
     assert provider_flags["nebius"]["provider_zero_data_retention"] is True
     assert provider_flags["parasail"]["provider_zero_data_retention"] is True
@@ -1054,8 +1059,9 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     # Venice runs TEE + E2EE inference — it's confidential, not merely no-logs.
     assert provider_flags["venice"]["provider_confidential_compute"] is True
     assert provider_flags["venice"]["provider_e2ee"] is True
-    # DeepInfra is memory-only / no-training — earns ZDR with a citation.
-    assert provider_flags["deepinfra"]["provider_zero_data_retention"] is True
+    # DeepInfra is normally memory-only, but reserves limited content logging
+    # for debugging/security and therefore must not satisfy strict ZDR routing.
+    assert provider_flags["deepinfra"]["provider_zero_data_retention"] is False
     assert provider_flags["openai"]["provider_zero_data_retention"] is False
     assert provider_flags["openai"]["prepaid_zero_data_retention"] is False
     assert provider_flags["openai"]["prepaid_zero_data_retention_effective_on"] == ("2026-07-28")
@@ -1082,6 +1088,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "tinfoil": "https://tinfoil.sh/security-and-privacy-faq",
         "venice": "https://docs.venice.ai/overview/privacy",
         "anthropic": "https://platform.claude.com/docs/en/api/data-retention",
+        "cerebras": "https://inference-docs.cerebras.ai/capabilities/prompt-caching",
         "together": "https://docs.together.ai/docs/privacy-and-security",
         "deepinfra": "https://docs.deepinfra.com/account/data-privacy",
         "nebius": "https://docs.studio.nebius.com/legal/legal-quick-guide",
@@ -1108,7 +1115,6 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert {
         "trustedrouter",
         "cerebras",
-        "deepinfra",
         "nebius",
         "parasail",
         "phala",

--- a/tests/test_crusoe_pricing.py
+++ b/tests/test_crusoe_pricing.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing.manifest import set_manifest_canary_state
 from scripts.pricing.providers import crusoe
 
 
@@ -80,3 +86,66 @@ def test_crusoe_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # n
         crusoe.UPSTREAM_ID_MAP["deepseek/deepseek-v4-flash"]
         == "deepseek-ai/Deepseek-V4-Flash"
     )
+
+
+def test_crusoe_auth_failure_darks_routes_until_key_is_repaired(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "crusoe.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "crusoe",
+                "models": [
+                    {
+                        "id": "z-ai/glm-5.2",
+                        "upstream_id": "zai/GLM-5.2",
+                        "endpoints": ["chat/completions"],
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class AuthFailureResponse:
+        status_code = 403
+
+        def raise_for_status(self) -> None:
+            raise AssertionError("auth failure must be handled before raise_for_status")
+
+        def json(self) -> dict:
+            return {"errors": ["Authentication failed"]}
+
+    class AuthFailureClient:
+        def __init__(self, **_kwargs) -> None:  # noqa: ANN003
+            return None
+
+        def __enter__(self) -> AuthFailureClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args, **_kwargs) -> AuthFailureResponse:  # noqa: ANN002, ANN003
+            return AuthFailureResponse()
+
+    monkeypatch.setattr(crusoe, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(crusoe.httpx, "Client", AuthFailureClient)
+
+    result = crusoe.fetch()
+    notes = crusoe.write_provider_manifest(result)
+
+    row = json.loads(manifest_path.read_text(encoding="utf-8"))["models"][0]
+    assert result.source == "api_auth_failed"
+    assert result.prices == {}
+    assert row["routable"] is False
+    assert row["routable_reason"] == "provider-canary-failed"
+    assert "routes remain dark" in notes[0]
+
+    set_manifest_canary_state(manifest_path, healthy=True)
+    restored = json.loads(manifest_path.read_text(encoding="utf-8"))["models"][0]
+    assert "routable" not in restored
+    assert "routable_reason" not in restored

--- a/tests/test_friendli_pricing.py
+++ b/tests/test_friendli_pricing.py
@@ -9,23 +9,23 @@ def test_friendli_fetch_discovers_glm_52(monkeypatch) -> None:  # noqa: ANN001
             {
                 "id": "zai-org/GLM-5.2",
                 "pricing": {
-                    "input": 1.4,
-                    "output": 4.4,
-                    "input_cache_read": 0.26,
+                    "input": "0.0000014",
+                    "output": "0.0000044",
+                    "input_cache_read": "0.00000026",
                 },
             },
             {
                 "id": "zai-org/GLM-5",
                 "pricing": {
-                    "input": 1.0,
-                    "output": 3.2,
+                    "input": "0.0000010",
+                    "output": "0.0000032",
                 },
             },
             {
                 "id": "meta-llama-3.3-70b-instruct",
                 "pricing": {
-                    "input": 0.6,
-                    "output": 0.6,
+                    "input": "0.0000006",
+                    "output": "0.0000006",
                 },
             },
         ]
@@ -67,3 +67,9 @@ def test_friendli_fetch_discovers_glm_52(monkeypatch) -> None:  # noqa: ANN001
         friendli.UPSTREAM_ID_MAP["meta-llama/llama-3.3-70b-instruct"]
         == "meta-llama-3.3-70b-instruct"
     )
+
+
+def test_friendli_money_conversion_uses_exact_per_token_units() -> None:
+    assert friendli._price_to_micro_per_m("0.0000014") == 1_400_000
+    assert friendli._price_to_micro_per_m("0.00000006") == 60_000
+    assert friendli._price_to_micro_per_m("NaN") is None

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -164,8 +164,8 @@ def test_gateway_authorizes_every_liberty_alias_to_working_nemotron_hosts() -> N
             if route["model"] == "nvidia/nemotron-3-ultra-550b-a55b"
             and route["usage_type"] == "Credits"
         }
-        assert {"baseten", "nebius"} <= nemotron_hosts, (model_id, routes)
-        assert not {"together", "gmi"} & nemotron_hosts, (model_id, routes)
+        assert {"baseten", "nebius", "together"} <= nemotron_hosts, (model_id, routes)
+        assert "gmi" not in nemotron_hosts, (model_id, routes)
 
 
 def test_gateway_settle_ancient_legacy_reservation_missing_typed_row_is_clean() -> None:

--- a/tests/test_manifest_discovery_hooks.py
+++ b/tests/test_manifest_discovery_hooks.py
@@ -64,11 +64,11 @@ def test_friendli_tombstones_second_miss_then_restores_annotations(
         "data": [
             {
                 "id": "zai-org/GLM-5.2",
-                "pricing": {"input": 1.4, "output": 4.4},
+                "pricing": {"input": "0.0000014", "output": "0.0000044"},
             },
             {
                 "id": "meta-llama-3.3-70b-instruct",
-                "pricing": {"input": 0.6, "output": 0.6},
+                "pricing": {"input": "0.0000006", "output": "0.0000006"},
             },
         ]
     }
@@ -122,7 +122,7 @@ def test_friendli_tombstones_second_miss_then_restores_annotations(
     payload["data"].append(
         {
             "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-            "pricing": {"input": 0.2, "output": 0.8},
+            "pricing": {"input": "0.0000002", "output": "0.0000008"},
         }
     )
     result = friendli.fetch()

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -10,15 +10,12 @@ from scripts.pricing.providers import phala
 from trusted_router import provider_lifecycle
 from trusted_router.catalog import (
     MODELS,
-    effective_endpoint,
     endpoint_for_id,
     endpoints_for_model,
     model_to_openrouter_shape,
 )
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.routes.internal.gateway import _endpoint_cost_microdollars
-from trusted_router.storage import STORE
 
 _CUTOFF = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
 
@@ -59,35 +56,11 @@ def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) ->
     assert not qwen_providers
 
 
-def test_phala_qwen_price_switches_exactly_at_cutoff() -> None:
-    endpoint = endpoint_for_id("qwen/qwen-2.5-7b-instruct@phala/prepaid")
-    assert endpoint is not None
-
-    before = effective_endpoint(endpoint, at=_CUTOFF - timedelta(microseconds=1))
-    after = effective_endpoint(endpoint, at=_CUTOFF)
-
-    assert before.prompt_price_microdollars_per_million_tokens == 42_000
-    assert before.completion_price_microdollars_per_million_tokens == 105_000
-    assert after.prompt_price_microdollars_per_million_tokens == 105_000
-    assert after.completion_price_microdollars_per_million_tokens == 210_000
-
-    assert (
-        _endpoint_cost_microdollars(
-            endpoint,
-            1_000_000,
-            1_000_000,
-            effective_at=_CUTOFF - timedelta(microseconds=1),
-        )
-        == 147_000
-    )
-    assert (
-        _endpoint_cost_microdollars(
-            endpoint,
-            1_000_000,
-            1_000_000,
-            effective_at=_CUTOFF,
-        )
-        == 315_000
+def test_non_confidential_phala_qwen_route_is_not_published() -> None:
+    assert endpoint_for_id("qwen/qwen-2.5-7b-instruct@phala/prepaid") is None
+    assert all(
+        endpoint.provider != "phala"
+        for endpoint in endpoints_for_model("qwen/qwen-2.5-7b-instruct")
     )
 
 
@@ -97,19 +70,23 @@ def test_public_catalog_uses_effective_price_and_active_routes(
     monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
 
     qwen_price = model_to_openrouter_shape(MODELS["qwen/qwen-2.5-7b-instruct"])
+    qwen_endpoints = endpoints_for_model("qwen/qwen-2.5-7b-instruct")
+    assert qwen_endpoints
+    assert all(endpoint.provider != "phala" for endpoint in qwen_endpoints)
     assert qwen_price["trustedrouter"][
         "prompt_price_microdollars_per_million_tokens"
-    ] == 105_000
-    assert qwen_price["trustedrouter"][
-        "completion_price_microdollars_per_million_tokens"
-    ] == 210_000
+    ] == min(
+        endpoint.prompt_price_microdollars_per_million_tokens
+        for endpoint in qwen_endpoints
+    )
 
     retired_qwen = model_to_openrouter_shape(
         MODELS["qwen/qwen3-30b-a3b-instruct-2507"]
     )
-    assert retired_qwen["trustedrouter"]["prepaid_available"] is False
-    assert retired_qwen["trustedrouter"]["byok_available"] is False
-    assert retired_qwen["trustedrouter"]["endpoints"] == []
+    assert all(
+        endpoint["provider"] != "phala"
+        for endpoint in retired_qwen["trustedrouter"]["endpoints"]
+    )
 
 
 def test_phala_hourly_parser_applies_announced_policy() -> None:
@@ -133,7 +110,55 @@ def test_phala_hourly_parser_applies_announced_policy() -> None:
     assert after["z-ai/glm-5.2"] == prices["z-ai/glm-5.2"]
 
 
-def test_settlement_keeps_authorization_time_price(
+def test_phala_parser_only_publishes_explicit_confidential_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": "phala/glm-5.2",
+                "pricing": {"prompt": "0.0000003", "completion": "0.000002"},
+            },
+            {
+                "id": "openai/gpt-5.5",
+                "pricing": {"prompt": "0.000005", "completion": "0.00003"},
+            },
+            {
+                "id": "unmapped/ordinary-pass-through",
+                "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(phala.httpx, "Client", FakeClient)
+
+    result = phala.fetch()
+
+    assert set(result.prices) == {"z-ai/glm-5.2"}
+    assert phala.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "phala/glm-5.2"
+
+
+def test_non_confidential_phala_route_is_rejected_before_authorization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -159,27 +184,5 @@ def test_settlement_keeps_authorization_time_price(
             "max_output_tokens": 1_000,
         },
     )
-    assert authorize.status_code == 200, authorize.text
-    authorization_id = authorize.json()["data"]["authorization_id"]
-    authorization = STORE.get_gateway_authorization(authorization_id)
-    assert authorization is not None
-    authorization.created_at = (_CUTOFF - timedelta(seconds=1)).isoformat()
-
-    monkeypatch.setattr(
-        provider_lifecycle,
-        "_utc_now",
-        lambda: _CUTOFF + timedelta(seconds=1),
-    )
-    settle = client.post(
-        "/v1/internal/gateway/settle",
-        json={
-            "authorization_id": authorization_id,
-            "actual_input_tokens": 1_000,
-            "actual_output_tokens": 1_000,
-            "request_id": "gw-phala-price-cutover",
-            "elapsed_seconds": 1.0,
-        },
-    )
-
-    assert settle.status_code == 200, settle.text
-    assert settle.json()["data"]["cost_microdollars"] == 147
+    assert authorize.status_code == 400, authorize.text
+    assert authorize.json()["error"]["type"] == "model_not_supported"

--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -47,6 +47,21 @@ def test_provider_owned_pricing_parsers_use_integer_microdollars() -> None:
     }
 
 
+def test_morph_checkpoint_fallback_is_bounded_to_published_fast_apply_prices() -> None:
+    prices = morph_parser.parse("Vercel Security Checkpoint")
+
+    assert prices == {
+        "morph/morph-v3-fast": {
+            "prompt_micro_per_m": 800_000,
+            "completion_micro_per_m": 1_200_000,
+        },
+        "morph/morph-v3-large": {
+            "prompt_micro_per_m": 900_000,
+            "completion_micro_per_m": 1_900_000,
+        },
+    }
+
+
 def test_openai_catalog_preserves_exact_ids_and_filters_non_text_output() -> None:
     upstream_ids: dict[str, str] = {}
     prices, rows = discover_openai_chat_catalog(

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -257,7 +257,7 @@ def test_public_model_detail_lists_distinct_serving_providers(client: TestClient
     assert "Endpoints</th>" in response.text
     assert 'href="https://aiiq.org/models/kimi-k2.6/"' in response.text
     assert "IQ 116" in response.text
-    for provider in ["kimi", "parasail", "phala", "together", "tinfoil", "novita"]:
+    for provider in ["kimi", "parasail", "together", "tinfoil", "novita"]:
         assert f'title="{provider}"' in response.text
 
 

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -351,9 +351,9 @@ def test_min_privacy_confidential_keeps_confidential_reachable_model() -> None:
         model_max_privacy_tier,
     )
 
-    # no-store via deepseek, confidential via phala — must still route.
+    # GLM 5.2 has a current confidential Phala route and must still route.
     candidates = chat_route_candidates(
-        {"model": "deepseek/deepseek-v3.2", "provider": {"min_privacy": "confidential"}},
+        {"model": "z-ai/glm-5.2", "provider": {"min_privacy": "confidential"}},
         _settings(),
     )
     assert candidates

--- a/tests/test_thinkingmachines_pricing.py
+++ b/tests/test_thinkingmachines_pricing.py
@@ -43,6 +43,26 @@ def test_parser_uses_currently_active_pricing_version() -> None:
     }
 
 
+def test_parser_reads_current_direct_price_cells() -> None:
+    html = """
+    <table><tbody id="model-tbody"><tr>
+      <td>Inkling (256K)</td>
+      <td class="tinker-id">thinkingmachines/Inkling:peft:262144</td>
+      <td>Hybrid</td><td>MoE</td><td>Large</td><td>256K</td>
+      <td class="price">$3.74<span class="price-cached">$0.748 (cached)</span></td>
+      <td class="price">$9.36</td>
+    </tr></tbody></table>
+    """
+
+    assert parse(html) == {
+        "thinkingmachines/inkling": {
+            "prompt_micro_per_m": 3_740_000,
+            "completion_micro_per_m": 9_360_000,
+            "prompt_cached_micro_per_m": 748_000,
+        }
+    }
+
+
 def test_manifest_writer_updates_integer_rates(tmp_path, monkeypatch) -> None:  # noqa: ANN001
     manifest = tmp_path / "thinkingmachines.json"
     manifest.write_text(

--- a/tests/test_together_pricing.py
+++ b/tests/test_together_pricing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -9,9 +10,10 @@ from pytest import MonkeyPatch
 from scripts.pricing import refresh
 from scripts.pricing.providers import together
 from trusted_router.catalog import endpoints_for_model
+from trusted_router.money import microdollars_per_million_tokens_to_token_decimal
 
 
-class _FakeTogetherResponse:
+class _FakeTogetherModelsResponse:
     def raise_for_status(self) -> None:
         return None
 
@@ -20,16 +22,65 @@ class _FakeTogetherResponse:
             "data": [
                 {
                     "id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                    "type": "chat",
                     "pricing": {"input": 1.04, "output": 1.04},
                 },
                 {
                     "id": "moonshotai/Kimi-K2.7-Code",
-                    "pricing": {"input": 0.95, "output": 4.00},
+                    "type": "chat",
+                    "pricing": {"input": 0.95, "output": 4.00, "cached_input": 0.19},
                 },
                 {
                     "id": "zai-org/GLM-5.2",
+                    "type": "chat",
                     "pricing": {"input": 1.40, "output": 4.40},
+                },
+                {
+                    "id": "MiniMaxAI/MiniMax-M3",
+                    "type": "chat",
+                    "pricing": {"input": 0.30, "output": 1.20},
+                },
+                {
+                    "id": "deepseek-ai/DeepSeek-V4-Pro",
+                    "type": "chat",
+                    "pricing": {"input": 2.10, "output": 4.40},
+                },
+                {
+                    "id": "deepseek-ai/DeepSeek-R1-0528",
+                    "type": "chat",
+                    "pricing": {"input": 3.00, "output": 7.00},
+                },
+                {
+                    "id": "Qwen/Qwen3.5-9B",
+                    "display_name": "Qwen3.5 9B",
+                    "type": "chat",
+                    "context_length": 262144,
+                    "pricing": {"input": 0.17, "output": 0.25},
+                },
+            ]
+        }
+
+
+class _FakeTogetherEndpointsResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, list[dict[str, Any]]]:
+        return {
+            "data": [
+                {
+                    "model": model,
+                    "type": "serverless",
+                    "state": "STARTED",
                 }
+                for model in (
+                    "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                    "moonshotai/Kimi-K2.7-Code",
+                    "zai-org/GLM-5.2",
+                    "MiniMaxAI/MiniMax-M3",
+                    "deepseek-ai/DeepSeek-V4-Pro",
+                    "Qwen/Qwen3.5-9B",
+                )
             ]
         }
 
@@ -49,10 +100,14 @@ class _FakeTogetherClient:
     ) -> None:
         return None
 
-    def get(self, url: str, *, headers: dict[str, str]) -> _FakeTogetherResponse:
-        assert url == together.URL
+    def get(
+        self, url: str, *, headers: dict[str, str]
+    ) -> _FakeTogetherModelsResponse | _FakeTogetherEndpointsResponse:
         assert headers["Authorization"].startswith("Bearer ")
-        return _FakeTogetherResponse()
+        if url == together.URL:
+            return _FakeTogetherModelsResponse()
+        assert url == together.SERVERLESS_ENDPOINTS_URL
+        return _FakeTogetherEndpointsResponse()
 
 
 def test_together_llama_33_turbo_price_change_is_mapped(monkeypatch: MonkeyPatch) -> None:
@@ -77,6 +132,7 @@ def test_together_api_new_native_id_auto_maps_and_preserves_upstream(
     price = result.prices["moonshotai/kimi-k2.7-code"]
     assert price.prompt_micro_per_m == 950_000
     assert price.completion_micro_per_m == 4_000_000
+    assert price.tiers[0].prompt_cached_micro_per_m == 190_000
     assert together.UPSTREAM_ID_MAP["moonshotai/kimi-k2.7-code"] == (
         "moonshotai/Kimi-K2.7-Code"
     )
@@ -101,6 +157,49 @@ def test_together_api_new_native_id_auto_maps_and_preserves_upstream(
     )
 
 
+def test_together_excludes_deployable_but_non_serverless_models(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
+    monkeypatch.setattr(together.httpx, "Client", _FakeTogetherClient)
+
+    result = together.fetch()
+
+    assert "deepseek/deepseek-v4-pro" in result.prices
+    assert "deepseek/deepseek-r1-0528" not in result.prices
+
+
+def test_together_refresh_adds_new_started_serverless_chat_models(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
+    monkeypatch.setattr(together.httpx, "Client", _FakeTogetherClient)
+    manifest_path = tmp_path / "together.json"
+    manifest_path.write_text(
+        json.dumps({"provider": "together", "models": []}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(together, "MANIFEST_PATH", manifest_path)
+
+    result = together.fetch()
+    together.write_provider_manifest(result)
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = {row["id"]: row for row in payload["models"]}
+    assert "minimax/minimax-m3" in rows
+    assert "qwen/qwen3.5-9b" in rows
+    assert rows["qwen/qwen3.5-9b"]["upstream_id"] == "Qwen/Qwen3.5-9B"
+    assert rows["qwen/qwen3.5-9b"]["context_length"] == 262_144
+    assert "deepseek/deepseek-r1-0528" not in rows
+
+
+def test_together_money_conversion_never_uses_binary_float_rounding() -> None:
+    assert together._row_to_micro_per_m("0.060000000000000005") == 60_000
+    assert together._row_to_micro_per_m("0.25999999999999995") == 260_000
+    assert together._row_to_micro_per_m("NaN") is None
+
+
 def test_catalog_exposes_together_llama_33_endpoint_at_new_rate() -> None:
     endpoints = endpoints_for_model("meta-llama/llama-3.3-70b-instruct")
     together_endpoints = [endpoint for endpoint in endpoints if endpoint.provider == "together"]
@@ -115,14 +214,18 @@ def test_catalog_exposes_together_llama_33_endpoint_at_new_rate() -> None:
     assert {endpoint.upstream_id for endpoint in together_endpoints} == {
         "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     }
-    assert {
+    prompt_prices = {
         endpoint.prompt_price_microdollars_per_million_tokens
         for endpoint in together_endpoints
-    } == {1_144_000}
-    assert {
+    }
+    completion_prices = {
         endpoint.completion_price_microdollars_per_million_tokens
         for endpoint in together_endpoints
-    } == {1_144_000}
+    }
+    assert len(prompt_prices) == 1
+    assert len(completion_prices) == 1
+    assert next(iter(prompt_prices)) > 0
+    assert next(iter(completion_prices)) > 0
 
 
 def test_model_endpoints_route_uses_provider_specific_together_price(client: Any) -> None:
@@ -140,16 +243,24 @@ def test_model_endpoints_route_uses_provider_specific_together_price(client: Any
     assert {item["upstream_id"] for item in together_endpoints} == {
         "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     }
-    assert {
+    prompt_prices = {
         item["prompt_price_microdollars_per_million_tokens"]
         for item in together_endpoints
-    } == {1_144_000}
-    assert {
+    }
+    completion_prices = {
         item["completion_price_microdollars_per_million_tokens"]
         for item in together_endpoints
-    } == {1_144_000}
-    assert {item["pricing"]["prompt"] for item in together_endpoints} == {"0.000001144"}
-    assert {item["pricing"]["completion"] for item in together_endpoints} == {"0.000001144"}
+    }
+    assert len(prompt_prices) == 1
+    assert len(completion_prices) == 1
+    prompt_price = next(iter(prompt_prices))
+    completion_price = next(iter(completion_prices))
+    assert {item["pricing"]["prompt"] for item in together_endpoints} == {
+        microdollars_per_million_tokens_to_token_decimal(prompt_price)
+    }
+    assert {item["pricing"]["completion"] for item in together_endpoints} == {
+        microdollars_per_million_tokens_to_token_decimal(completion_price)
+    }
 
 
 def test_together_pricing_is_on_hourly_refresh_path() -> None:
@@ -159,7 +270,8 @@ def test_together_pricing_is_on_hourly_refresh_path() -> None:
     assert "0 * * * *" in workflow
     assert "trustedrouter-together-api-key" in workflow
     assert "TOGETHER_API_KEY" in workflow
-    assert "meta-llama/llama-3.3-70b-instruct" in together.EXPECTED_MODELS
+    assert "deepseek/deepseek-v4-pro" in together.EXPECTED_MODELS
+    assert "SERVERLESS_ENDPOINTS_URL" in vars(together)
 
 
 def test_together_refresh_preserves_native_upstream_model_id() -> None:


### PR DESCRIPTION
## Summary\n- Mark Cerebras strict ZDR and no-store, using its official public model catalog.\n- Make Together availability follow started serverless endpoints, with dynamic route manifests and cached pricing.\n- Prevent dark, retired, dedicated-only, or unauthorized provider rows from reappearing through shared discovery.\n- Correct Friendli USD-per-token billing units and DeepInfra privacy labeling.\n- Fail closed on the rejected Crusoe credential and restrict Phala privacy claims to confidential native routes.\n- Harden hourly model-discovery and endpoint-level price-spike gates.\n\n## Validation\n- Ruff passed.\n- Mypy passed.\n- Pytest: 1703 passed, 33 skipped.\n- Authenticated production-equivalent model discovery gate passed.\n- Direct tiny canaries passed for Together serverless routes and Cerebras Gemma.\n