### PR TITLE
Make provider refresh validation credential-aware

### DIFF
--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1442,14 +1442,25 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
     )
 
 
-def test_crusoe_provider_models_fail_closed_after_account_auth_failure() -> None:
-    """A rejected operator credential must darken stale Crusoe inventory."""
+def test_crusoe_provider_models_follow_authoritative_manifest() -> None:
+    """Crusoe availability follows its generated, credential-aware manifest."""
+    from trusted_router.catalog_ingest import _authoritative_provider_model_ids
 
     assert "crusoe" in PROVIDERS
     assert "crusoe" in GATEWAY_PREPAID_PROVIDER_SLUGS
-    assert not [
-        endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "crusoe"
-    ]
+    expected = _authoritative_provider_model_ids("crusoe")
+    credits = {
+        endpoint.model_id
+        for endpoint in MODEL_ENDPOINTS.values()
+        if endpoint.provider == "crusoe" and endpoint.usage_type == "Credits"
+    }
+    byok = {
+        endpoint.model_id
+        for endpoint in MODEL_ENDPOINTS.values()
+        if endpoint.provider == "crusoe" and endpoint.usage_type == "BYOK"
+    }
+    assert credits == expected
+    assert byok == expected
 
 
 def test_makora_provider_models_present_and_routable() -> None:
@@ -1648,7 +1659,6 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     assert baseten.completion_price_microdollars_per_million_tokens == 4_620_000
     assert wafer.prompt_price_microdollars_per_million_tokens == 1_260_000
     assert wafer.completion_price_microdollars_per_million_tokens == 4_305_000
-    assert "z-ai/glm-5.2@crusoe/prepaid" not in MODEL_ENDPOINTS
 
 
 def test_parasail_qwen_397b_uses_working_native_upstream_id() -> None:


### PR DESCRIPTION
## Summary
- validate Crusoe runtime routes against its authoritative generated manifest
- preserve fail-closed behavior when credentials fail while accepting live routes when the production credential succeeds
- remove a stale GLM 5.2 assertion tied to one local credential state

## Verification
- `uv run ruff check tests/test_catalog_routing_contracts.py`
- `uv run mypy`
- `uv run pytest -q` (`1703 passed, 33 skipped`)

This fixes the final catalog-validation failure exposed by the manual production refresh run. The refresh itself correctly fetched 15 Crusoe models with the production Secret Manager credential and made no commit because validation failed closed.