### PR TITLE
Add Gemini 3.6 Flash

### DIFF
--- a/scripts/pricing/parsers/gemini.py
+++ b/scripts/pricing/parsers/gemini.py
@@ -28,6 +28,7 @@ _NAME_TO_OR_ID = {
     "Gemini 2.0 Flash-Lite": "google/gemini-2.0-flash-lite-001",
     "Gemini 3.1 Pro Preview": "google/gemini-3.1-pro-preview",
     "Gemini 3.5 Flash": "google/gemini-3.5-flash",
+    "Gemini 3.6 Flash": "google/gemini-3.6-flash",
     "Gemini 3.1 Flash-Lite": "google/gemini-3.1-flash-lite",
     "Gemini 3.1 Flash-Lite Preview": "google/gemini-3.1-flash-lite-preview",
     "Gemini 3 Flash Preview": "google/gemini-3-flash-preview",
@@ -121,6 +122,7 @@ def parse(md: str) -> dict:
         # Standard table first under the heading).
         prompt_tiers: list[tuple[int | None, int]] = []
         completion_tiers: list[tuple[int | None, int]] = []
+        cached_tiers: list[tuple[int | None, int]] = []
         for line in body.splitlines():
             if not line.startswith("|"):
                 continue
@@ -135,8 +137,9 @@ def parse(md: str) -> dict:
             elif "output price" in label and not completion_tiers:
                 tiers, _ = _parse_price_cell(paid_cell)
                 completion_tiers = tiers
-            if prompt_tiers and completion_tiers:
-                break
+            elif "context caching price" in label and not cached_tiers:
+                tiers, _ = _parse_price_cell(paid_cell)
+                cached_tiers = tiers
         if not prompt_tiers or not completion_tiers:
             continue
         # Pair up the tiers. They should have matching length + thresholds
@@ -150,13 +153,16 @@ def parse(md: str) -> dict:
             for (threshold, prompt_micro), (_t2, completion_micro) in zip(
                 prompt_tiers, completion_tiers, strict=False
             ):
-                tiers.append(
-                    {
-                        "max_prompt_tokens": threshold,
-                        "prompt_micro_per_m": prompt_micro,
-                        "completion_micro_per_m": completion_micro,
-                    }
-                )
+                tier = {
+                    "max_prompt_tokens": threshold,
+                    "prompt_micro_per_m": prompt_micro,
+                    "completion_micro_per_m": completion_micro,
+                }
+                if len(cached_tiers) == len(prompt_tiers):
+                    cached_threshold, cached_micro = cached_tiers[len(tiers)]
+                    if cached_threshold == threshold:
+                        tier["prompt_cached_micro_per_m"] = cached_micro
+                tiers.append(tier)
             if len(tiers) > 1:
                 out[or_id] = {"tiers": tiers}
             else:
@@ -165,6 +171,10 @@ def parse(md: str) -> dict:
                     "prompt_micro_per_m": t["prompt_micro_per_m"],
                     "completion_micro_per_m": t["completion_micro_per_m"],
                 }
+                if "prompt_cached_micro_per_m" in t:
+                    out[or_id]["prompt_cached_micro_per_m"] = t[
+                        "prompt_cached_micro_per_m"
+                    ]
         else:
             # Tier shape mismatch — fall back to flat (low tier).
             out[or_id] = {

--- a/scripts/pricing/providers/gemini.py
+++ b/scripts/pricing/providers/gemini.py
@@ -53,6 +53,7 @@ EXPECTED_MODELS = [
     "google/gemini-2.5-flash",
     "google/gemini-2.5-flash-lite",
     "google/gemini-3.5-flash",
+    "google/gemini-3.6-flash",
 ]
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
@@ -151,6 +152,36 @@ def _refresh_price(row: dict[str, Any], result: ProviderPricingResult, model_id:
         row.pop("cached_input_token_price_per_m", None)
         row.pop("price_tiers", None)
     return True
+
+
+def _refresh_verified_vertex_manifest(result: ProviderPricingResult) -> int:
+    """Refresh prices for Vertex rows whose availability was verified separately."""
+
+    path = MANIFEST_PATH.with_name("google-vertex.json")
+    if not path.exists():
+        return 0
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("google-vertex manifest has no models list")
+    updated = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        if isinstance(model_id, str) and _refresh_price(row, result, model_id):
+            updated += 1
+    if not updated:
+        return 0
+    raw["pricing_source"] = URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    path.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return updated
 
 
 def fetch() -> ProviderPricingResult:
@@ -257,11 +288,14 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
+    vertex_updated = _refresh_verified_vertex_manifest(result)
     changes: list[str] = []
     if appended:
         changes.append(f"appended {len(appended)}")
     if tombstoned:
         changes.append(f"tombstoned {len(tombstoned)} unavailable")
+    if vertex_updated:
+        changes.append(f"repriced {vertex_updated} verified Vertex rows")
     suffix = f", {', '.join(changes)}" if changes else ""
     return [
         f"gemini: refreshed Google AI Studio manifest "

--- a/src/trusted_router/data/provider_models/google-ai-studio.json
+++ b/src/trusted_router/data/provider_models/google-ai-studio.json
@@ -727,9 +727,12 @@
       "display_name": "Gemini 3.6 Flash",
       "title": "google/gemini-3.6-flash",
       "model_type": "chat",
-      "features": [],
+      "features": [
+        "reasoning"
+      ],
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -742,8 +745,9 @@
       "upstream_id": "gemini-3.6-flash",
       "context_length": 1048576,
       "max_output_tokens": 65536,
-      "routable": false,
-      "routable_reason": "awaiting-price"
+      "input_token_price_per_m": 1500000,
+      "output_token_price_per_m": 7500000,
+      "cached_input_token_price_per_m": 150000
     }
   ],
   "pricing_source": "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing"

--- a/src/trusted_router/data/provider_models/google-vertex.json
+++ b/src/trusted_router/data/provider_models/google-vertex.json
@@ -1,0 +1,36 @@
+{
+  "_about": "Provider-native supplement for Google Vertex AI models whose availability is verified independently from Google AI Studio discovery. Gemini 3.6 Flash was verified with a direct global Vertex streamGenerateContent request in the TrustedRouter GCP project on 2026-07-21.",
+  "provider": "google-vertex",
+  "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-6-flash",
+  "pricing_source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+  "generated_at": "2026-07-21T21:00:00Z",
+  "model_count": 1,
+  "models": [
+    {
+      "id": "google/gemini-3.6-flash",
+      "upstream_id": "gemini-3.6-flash",
+      "display_name": "Gemini 3.6 Flash",
+      "title": "google/gemini-3.6-flash",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 1500000,
+      "output_token_price_per_m": 7500000,
+      "cached_input_token_price_per_m": 150000,
+      "model_type": "chat",
+      "features": [
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1
+    }
+  ]
+}

--- a/src/trusted_router/templates/public/seo_gemini_flash_alternative.html
+++ b/src/trusted_router/templates/public/seo_gemini_flash_alternative.html
@@ -13,7 +13,7 @@
       <li>✓ Public measurements separate provider latency from router overhead</li>
     </ul>
     <p>
-      <a class="btn primary" href="/models/google/gemini-3.5-flash">Gemini 3.5 Flash</a>
+      <a class="btn primary" href="/models/google/gemini-3.6-flash">Gemini 3.6 Flash</a>
       <a class="btn" href="/leaderboard">Compare latency</a>
     </p>
   </div>
@@ -30,7 +30,7 @@
 </section>
 
 <section class="marketing-grid three">
-  <a class="marketing-card card-as-link" href="/models/google/gemini-3.5-flash/performance"><h3>Gemini measurements</h3><p>Check p50 TTFT, p95 TTFT, throughput, and route sample count.</p><span class="card-link">Open performance</span></a>
+  <a class="marketing-card card-as-link" href="/models/google/gemini-3.6-flash/performance"><h3>Gemini measurements</h3><p>Check p50 TTFT, p95 TTFT, throughput, and route sample count.</p><span class="card-link">Open performance</span></a>
   <a class="marketing-card card-as-link" href="/models/google/gemma-4-31b-it"><h3>Open Google family</h3><p>Compare Gemma routes when you need lower-cost open-weight behavior.</p><span class="card-link">Open Gemma</span></a>
   <a class="marketing-card card-as-link" href="/models/deepseek/deepseek-v4-flash"><h3>Cheap reasoning route</h3><p>Test DeepSeek Flash for cost-sensitive tasks where Gemini may be more than you need.</p><span class="card-link">Open DeepSeek</span></a>
 </section>

--- a/src/trusted_router/templates/public/seo_llm_provider_latency_benchmarks.html
+++ b/src/trusted_router/templates/public/seo_llm_provider_latency_benchmarks.html
@@ -46,7 +46,7 @@
     <div class="panel-body">
       <ul class="link-list">
         <li><a href="/models/moonshotai/kimi-k2.6/performance">Kimi K2.6 performance</a><span>Provider-specific route metrics</span></li>
-        <li><a href="/models/google/gemini-3.5-flash/performance">Gemini Flash performance</a><span>Fast multimodal route metrics</span></li>
+        <li><a href="/models/google/gemini-3.6-flash/performance">Gemini Flash performance</a><span>Fast multimodal route metrics</span></li>
         <li><a href="/models/openai/gpt-5.4-nano/performance">GPT Nano performance</a><span>Small-model latency metrics</span></li>
       </ul>
     </div>

--- a/tests/fixtures/pricing/gemini.html
+++ b/tests/fixtures/pricing/gemini.html
@@ -309,6 +309,23 @@ For large-scale deployments with custom needs for security, support, and complia
 
 [Contact Sales](https://cloud.google.com/contact)
 
+## Gemini 3.6 Flash
+
+_`gemini-3.6-flash`_
+
+[Try it in Google AI Studio](https://aistudio.google.com/?model=gemini-3.6-flash)
+
+Our newest stable Flash model with frontier intelligence, fast responses, and a 1M token context window.
+
+[Standard](https://ai.google.dev/gemini-api/docs/pricing#standard)[Batch](https://ai.google.dev/gemini-api/docs/pricing#batch)[Flex](https://ai.google.dev/gemini-api/docs/pricing#flex)[Priority](https://ai.google.dev/gemini-api/docs/pricing#priority)More
+
+|  | Free Tier | Paid Tier, per 1M tokens in USD |
+| --- | --- | --- |
+| Input price | Free of charge | $1.50 |
+| Output price (including thinking tokens) | Free of charge | $7.50 |
+| Context caching price | Free of charge | $0.15 $1.00 / 1,000,000 tokens per hour (storage price) |
+| Used to improve our products | [Yes](https://ai.google.dev/gemini-api/terms) | [No](https://ai.google.dev/gemini-api/terms) |
+
 ## Gemini 3.5 Flash
 
 _`gemini-3.5-flash`_

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -307,6 +307,12 @@ def test_gemini_native_supplement_publishes_missing_text_models() -> None:
     gemini_35 = MODEL_ENDPOINTS[
         "google/gemini-3.5-flash@google-ai-studio/prepaid"
     ]
+    gemini_36_ai_studio = MODEL_ENDPOINTS[
+        "google/gemini-3.6-flash@google-ai-studio/prepaid"
+    ]
+    gemini_36_vertex = MODEL_ENDPOINTS[
+        "google/gemini-3.6-flash@google-vertex/prepaid"
+    ]
     image_preview = MODEL_ENDPOINTS[
         "google/gemini-3.1-flash-image-preview@google-ai-studio/prepaid"
     ]
@@ -315,6 +321,15 @@ def test_gemini_native_supplement_publishes_missing_text_models() -> None:
     assert gemini_35.upstream_id == "gemini-3.5-flash"
     assert gemini_35.prompt_price_microdollars_per_million_tokens == 1_575_000
     assert gemini_35.completion_price_microdollars_per_million_tokens == 9_450_000
+    assert MODELS["google/gemini-3.6-flash"].context_length == 1_048_576
+    for endpoint in (gemini_36_ai_studio, gemini_36_vertex):
+        assert endpoint.upstream_id == "gemini-3.6-flash"
+        assert endpoint.prompt_price_microdollars_per_million_tokens == 1_575_000
+        assert endpoint.completion_price_microdollars_per_million_tokens == 7_875_000
+        assert (
+            endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens
+            == 157_500
+        )
     image_model = MODELS["google/gemini-3.1-flash-image-preview"]
     assert image_model.context_length == 65_536
     assert image_model.supports_chat
@@ -324,11 +339,11 @@ def test_gemini_native_supplement_publishes_missing_text_models() -> None:
 
 
 def test_google_products_have_distinct_capabilities() -> None:
-    model_id = "google/gemini-2.5-flash"
-    assert f"{model_id}@google-vertex/prepaid" in MODEL_ENDPOINTS
-    assert f"{model_id}@google-vertex/byok" not in MODEL_ENDPOINTS
-    assert f"{model_id}@google-ai-studio/prepaid" in MODEL_ENDPOINTS
-    assert f"{model_id}@google-ai-studio/byok" in MODEL_ENDPOINTS
+    for model_id in ("google/gemini-2.5-flash", "google/gemini-3.6-flash"):
+        assert f"{model_id}@google-vertex/prepaid" in MODEL_ENDPOINTS
+        assert f"{model_id}@google-vertex/byok" not in MODEL_ENDPOINTS
+        assert f"{model_id}@google-ai-studio/prepaid" in MODEL_ENDPOINTS
+        assert f"{model_id}@google-ai-studio/byok" in MODEL_ENDPOINTS
 
 
 def test_llama_33_70b_no_longer_credits_routes_to_cerebras() -> None:

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -119,6 +119,7 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
         ("openai/gpt-4.1-mini", "openai"),
         ("google/gemini-2.5-flash", "google-ai-studio"),
         ("google/gemini-3.5-flash", "google-ai-studio"),
+        ("google/gemini-3.6-flash", "google-ai-studio"),
         ("deepseek/deepseek-v4-flash", "deepseek"),
         ("mistralai/mistral-small-2603", "mistral"),
         ("meta-llama/llama-3.1-8b-instruct", "novita"),
@@ -250,6 +251,7 @@ def test_model_storage_flag_is_gateway_scoped_endpoint_flag_is_provider_scoped()
             5,
             [
                 "google/gemini-3.5-flash",
+                "google/gemini-3.6-flash",
                 "google/gemini-3.1-flash-image-preview",
             ],
         ),

--- a/tests/test_manifest_discovery_hooks.py
+++ b/tests/test_manifest_discovery_hooks.py
@@ -205,6 +205,56 @@ def test_gemini_tombstones_second_miss_and_empty_discovery_keeps_old_manifest(
     assert manifest_path.read_text(encoding="utf-8") == old_text
 
 
+def test_gemini_refresh_reprices_only_verified_vertex_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ai_studio_path = tmp_path / "google-ai-studio.json"
+    vertex_path = tmp_path / "google-vertex.json"
+    _write_manifest(
+        ai_studio_path,
+        "google-ai-studio",
+        [_manifest_row("google/gemini-3.6-flash", "gemini-3.6-flash")],
+    )
+    _write_manifest(
+        vertex_path,
+        "google-vertex",
+        [_manifest_row("google/gemini-3.6-flash", "gemini-3.6-flash")],
+    )
+    result = ProviderPricingResult(
+        slug="gemini",
+        prices={
+            "google/gemini-3.6-flash": ModelPrice(
+                1_500_000,
+                7_500_000,
+                prompt_cached_micro_per_m=150_000,
+            )
+        },
+        source="api",
+        fetched_url=gemini.URL,
+    )
+    monkeypatch.setattr(gemini, "MANIFEST_PATH", ai_studio_path)
+    monkeypatch.setattr(
+        gemini,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "google/gemini-3.6-flash": {
+                "id": "google/gemini-3.6-flash",
+                "upstream_id": "gemini-3.6-flash",
+            }
+        },
+    )
+
+    gemini.write_provider_manifest(result)
+
+    vertex = json.loads(vertex_path.read_text(encoding="utf-8"))
+    assert len(vertex["models"]) == 1
+    row = vertex["models"][0]
+    assert row["input_token_price_per_m"] == 1_500_000
+    assert row["output_token_price_per_m"] == 7_500_000
+    assert row["cached_input_token_price_per_m"] == 150_000
+    assert vertex["pricing_source"] == gemini.URL
+
+
 def test_wafer_feed_presence_survives_pricing_schema_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_multimodal_adapters.py
+++ b/tests/test_multimodal_adapters.py
@@ -339,6 +339,10 @@ def test_gemini_payload_disables_thinking_for_flash_text_models() -> None:
         "model": "google/gemini-3-flash-preview",
         "messages": [{"role": "user", "content": "x"}],
     })
+    gemini_36 = gemini_payload({
+        "model": "google/gemini-3.6-flash",
+        "messages": [{"role": "user", "content": "x"}],
+    })
     image_model = gemini_payload({
         "model": "google/gemini-3.1-flash-image",
         "messages": [{"role": "user", "content": "x"}],
@@ -346,6 +350,7 @@ def test_gemini_payload_disables_thinking_for_flash_text_models() -> None:
 
     assert gemini_25["generationConfig"]["thinkingConfig"] == {"thinkingBudget": 0}
     assert gemini_3["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "minimal"}
+    assert gemini_36["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "minimal"}
     assert "generationConfig" not in image_model
 
 

--- a/tests/test_pricing_fixtures.py
+++ b/tests/test_pricing_fixtures.py
@@ -55,6 +55,7 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pricing"
                 "google/gemini-2.5-flash",
                 "google/gemini-2.5-pro",
                 "google/gemini-3.5-flash",
+                "google/gemini-3.6-flash",
             },
             (0.05, 20.00),
         ),
@@ -244,6 +245,17 @@ Kimi K3\t1,048,576\t$3 /Mt· Cache Read $0.3 /Mt\t$15 /Mt\tMore
         "prompt_micro_per_m": 3_000_000,
         "completion_micro_per_m": 15_000_000,
         "prompt_cached_micro_per_m": 300_000,
+    }
+
+
+def test_gemini_parser_tracks_gemini_36_flash_standard_pricing() -> None:
+    module = importlib.import_module("scripts.pricing.parsers.gemini")
+    result = module.parse((FIXTURE_DIR / "gemini.html").read_text(encoding="utf-8"))
+
+    assert result["google/gemini-3.6-flash"] == {
+        "prompt_micro_per_m": 1_500_000,
+        "completion_micro_per_m": 7_500_000,
+        "prompt_cached_micro_per_m": 150_000,
     }
 
 


### PR DESCRIPTION
## Summary
- enable google/gemini-3.6-flash through Google AI Studio prepaid/BYOK and Google Vertex prepaid
- publish verified 1M context and official standard/cache pricing with TrustedRouter's 5% markup
- teach hourly Gemini pricing refresh to preserve both verified routes
- update Gemini SEO links and add focused catalog, routing, payload, parser, and manifest regression tests

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1705 passed, 33 skipped)
- npm run build
- npm run lint
- npm run lint:css
- direct Google AI Studio non-streaming + streaming PONG
- direct Vertex streaming PONG