### PR TITLE
Harden Xiaomi overseas price parsing

### DIFF
--- a/scripts/pricing/parsers/xiaomi.py
+++ b/scripts/pricing/parsers/xiaomi.py
@@ -31,14 +31,26 @@ def _overseas_payg_prices(html: str) -> dict[str, dict[str, int]]:
         "mimo-v2.5": "xiaomi/mimo-v2.5",
     }
     prices: dict[str, dict[str, int]] = {}
-    row_pattern = re.compile(
+    table_row_pattern = re.compile(
         r"\|\s*`?(mimo-v2\.5(?:-pro)?)`?\s*"
         r"\|\s*\$([0-9.]+)\s*"
         r"\|\s*\$([0-9.]+)\s*"
         r"\|\s*\$([0-9.]+)\s*\|",
         flags=re.I,
     )
-    for model, cache, prompt, completion in row_pattern.findall(section_match.group(1)):
+    # Some renderers flatten the Markdown table while preserving the model and
+    # currency markers. Keep the three-dollar requirement so the preceding RMB
+    # table can never be interpreted as USD.
+    flat_row_pattern = re.compile(
+        r"`?(mimo-v2\.5(?:-pro)?)`?\s+"
+        r"\$([0-9.]+)\s+\$([0-9.]+)\s+\$([0-9.]+)",
+        flags=re.I,
+    )
+    section = section_match.group(1)
+    rows = table_row_pattern.findall(section)
+    if not rows:
+        rows = flat_row_pattern.findall(section)
+    for model, cache, prompt, completion in rows:
         model_id = mapping.get(model.casefold())
         if model_id is None:
             continue

--- a/scripts/pricing/providers/xiaomi.py
+++ b/scripts/pricing/providers/xiaomi.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "xiaomi"
-URL = "https://r.jina.ai/https://mimo.mi.com/docs/en-US/pricing"
+PUBLIC_PRICING_URL = "https://mimo.mi.com/docs/en-US/price/pay-as-you-go"
+URL = f"https://r.jina.ai/{PUBLIC_PRICING_URL}"
 JINA_HEADERS = {"X-Return-Format": "markdown"}
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
@@ -64,7 +65,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if missing:
         raise RuntimeError(f"xiaomi manifest did not update expected model(s): {missing}")
 
-    raw["source"] = "https://mimo.mi.com/docs/en-US/pricing"
+    raw["source"] = PUBLIC_PRICING_URL
     raw["_note"] = (
         "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and "
         "V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD "

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -5,6 +5,7 @@ import json
 from scripts.pricing.parsers import minimax as minimax_parser
 from scripts.pricing.parsers import xiaomi as xiaomi_parser
 from scripts.pricing.providers import nebius
+from scripts.pricing.providers import xiaomi as xiaomi_provider
 
 
 def test_minimax_parser_reads_official_token_plan_tiers() -> None:
@@ -93,6 +94,52 @@ def test_xiaomi_parser_reads_current_overseas_markdown_table() -> None:
             "prompt_cached_micro_per_m": 2_800,
         },
     }
+
+
+def test_xiaomi_parser_reads_flattened_overseas_table_without_using_domestic_prices() -> None:
+    html = """
+    ### Domestic Pricing of the Model
+    MiMo-V2.5 Series
+    Input (Cache Hit) Input (Cache Miss) Output
+    `mimo-v2.5-pro` ¥0.025 ¥3.00 ¥6.00
+    `mimo-v2.5` ¥0.02 ¥1.00 ¥2.00
+    ### Overseas Pricing of the Model
+    MiMo-V2.5 Series
+    Input (Cache Hit) Input (Cache Miss) Output
+    `mimo-v2.5-pro` $0.0036 $0.435 $0.87
+    `mimo-v2.5` $0.0028 $0.14 $0.28
+    ### Pricing for Web Search Plugins
+    """
+
+    assert xiaomi_parser.parse(html) == {
+        "xiaomi/mimo-v2.5-pro": {
+            "prompt_micro_per_m": 435_000,
+            "completion_micro_per_m": 870_000,
+            "prompt_cached_micro_per_m": 3_600,
+        },
+        "xiaomi/mimo-v2.5": {
+            "prompt_micro_per_m": 140_000,
+            "completion_micro_per_m": 280_000,
+            "prompt_cached_micro_per_m": 2_800,
+        },
+    }
+
+
+def test_xiaomi_parser_rejects_domestic_only_pricing_as_usd() -> None:
+    html = """
+    ### Domestic Pricing of the Model
+    `mimo-v2.5-pro` ¥0.025 ¥3.00 ¥6.00
+    `mimo-v2.5` ¥0.02 ¥1.00 ¥2.00
+    """
+
+    assert xiaomi_parser.parse(html) == {}
+
+
+def test_xiaomi_provider_uses_current_official_payg_page() -> None:
+    assert xiaomi_provider.PUBLIC_PRICING_URL == (
+        "https://mimo.mi.com/docs/en-US/price/pay-as-you-go"
+    )
+    assert xiaomi_provider.PUBLIC_PRICING_URL in xiaomi_provider.URL
 
 
 class _FakeResponse:


### PR DESCRIPTION
## Summary
- move Xiaomi discovery to its current official PAYG pricing page
- parse both Markdown-table and flattened renderer output only within the overseas section
- require explicit USD markers so domestic RMB prices cannot be interpreted as dollars
- add regressions for overseas flattening and domestic-only rejection

## Root cause
After the old Xiaomi pricing URL moved, the hourly self-healer saw an unrecognized page and generated a parser that treated the domestic RMB row as USD. The 2x price-spike gate correctly blocked a 6.9-7.1x proposed billing increase before commit or deploy.

Official current prices remain:
- MiMo V2.5: /bin/zsh.14 input / /bin/zsh.28 output per million
- MiMo V2.5 Pro: /bin/zsh.435 input / /bin/zsh.87 output per million

## Verification
- focused pricing/self-heal/tier/spike tests: 117 passed
- full suite: 1709 passed, 33 skipped
- ruff clean
- mypy clean