### PR TITLE
Make provider model discovery source-native

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -201,7 +201,7 @@ jobs:
         if: always()
         run: |
           set -o pipefail
-          uv run python scripts/check_price_coverage.py --strict-model-discovery \
+          uv run python -m scripts.check_price_coverage --strict-model-discovery \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Validate generated catalog before commit

--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -26,11 +26,16 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from scripts.pricing.model_ids import (
+    canonicalize_native_model_id,
+    canonicalize_unqualified_model_id,
+)
+
 ROOT = Path(__file__).resolve().parent.parent
 PROVIDERS_DIR = ROOT / "scripts" / "pricing" / "providers"
 MANIFEST_DIR = ROOT / "src" / "trusted_router" / "data" / "provider_models"
 DEFAULT_MAX_AGE_DAYS = 14
-ZAI_MODEL_DISCOVERY_URL = "https://r.jina.ai/https://docs.z.ai/devpack/latest-model"
+ZAI_MODEL_DISCOVERY_URL = "https://docs.z.ai/devpack/latest-model.md"
 _ZAI_MODEL_RE = re.compile(r"\bglm-\d+(?:\.\d+)?(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?(?:\[1m\])?\b", re.I)
 
 # One parser can own pricing for more than one separately routed provider.
@@ -60,7 +65,7 @@ def _cerebras_model_id(native_id: str) -> str | None:
         "gpt-oss-120b": "openai/gpt-oss-120b",
         "zai-glm-4.7": "z-ai/glm-4.7",
         "gemma-4-31b": "google/gemma-4-31b-it",
-    }.get(value)
+    }.get(value) or canonicalize_unqualified_model_id(value)
 
 
 def _gemini_model_id(native_id: str) -> str | None:
@@ -68,6 +73,15 @@ def _gemini_model_id(native_id: str) -> str | None:
     if not value:
         return None
     return f"google/{value.casefold()}"
+
+
+def _novita_model_id(native_id: str) -> str | None:
+    """Match the conservative normalization used by the Novita refresher."""
+
+    value = native_id.strip()
+    if not value:
+        return None
+    return canonicalize_native_model_id(value) or canonicalize_unqualified_model_id(value)
 
 
 _FIREWORKS_MODEL_IDS = {
@@ -86,7 +100,7 @@ def _fireworks_model_id(native_id: str) -> str | None:
     value = native_id.strip()
     if not value:
         return None
-    return _FIREWORKS_MODEL_IDS.get(value, value)
+    return _FIREWORKS_MODEL_IDS.get(value) or canonicalize_unqualified_model_id(value)
 
 
 _BASETEN_MODEL_IDS = {
@@ -257,7 +271,7 @@ _DISCOVERABLE_MANIFEST_PROVIDERS: tuple[
         "novita",
         "https://api.novita.ai/openai/v1/models",
         ("NOVITA_API_KEY",),
-        _identity_model_id,
+        _novita_model_id,
     ),
     (
         "friendli",
@@ -436,22 +450,82 @@ def _json_model_rows(payload: Any) -> list[dict[str, Any]]:
 
 
 def _manifest_provider_model_ids(slug: str) -> set[str]:
+    routable, unresolved, classified, _new_unresolved = _manifest_provider_model_state(slug)
+    return routable | unresolved | classified
+
+
+def _manifest_provider_model_state(
+    slug: str,
+) -> tuple[set[str], set[str], set[str], set[str]]:
+    """Return routable, awaiting-price, classified, and new-awaiting IDs."""
+
     path = MANIFEST_DIR / f"{slug}.json"
     if not path.exists():
-        return set()
+        return set(), set(), set(), set()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return set()
-    ids: set[str] = set()
+        return set(), set(), set(), set()
+    routable: set[str] = set()
+    unresolved: set[str] = set()
+    classified: set[str] = set()
+    new_unresolved: set[str] = set()
     for row in raw.get("models") or []:
         if not isinstance(row, dict):
             continue
+        row_ids: set[str] = set()
         for key in ("id", "upstream_id"):
             value = row.get(key)
             if isinstance(value, str) and value:
-                ids.add(value)
-    return ids
+                row_ids.add(value)
+        if row.get("routable") is not False:
+            routable.update(row_ids)
+        elif row.get("routable_reason") == "awaiting-price":
+            unresolved.update(row_ids)
+            if row.get("unresolved_since"):
+                new_unresolved.update(row_ids)
+        else:
+            classified.update(row_ids)
+    return routable, unresolved, classified, new_unresolved
+
+
+def _active_discovery_row(row: dict[str, Any]) -> bool:
+    status = row.get("status")
+    if isinstance(status, int) and not isinstance(status, bool) and status != 1:
+        return False
+    if isinstance(status, str) and status.casefold() in {
+        "disabled",
+        "inactive",
+        "offline",
+        "retired",
+        "deprecated",
+    }:
+        return False
+    endpoints = row.get("endpoints")
+    if isinstance(endpoints, list) and endpoints:
+        normalized = {str(value).casefold() for value in endpoints}
+        if "chat/completions" not in normalized and "responses" not in normalized:
+            return False
+    output_modalities = row.get("output_modalities")
+    if isinstance(output_modalities, list) and output_modalities:
+        if "text" not in {str(value).casefold() for value in output_modalities}:
+            return False
+    return True
+
+
+_STANDARD_GEMINI_TEXT_ID_RE = re.compile(r"^google/gemini-\d+(?:\.\d+)?-(?:pro|flash|flash-lite)$")
+
+
+def _required_discovery_model(slug: str, model_id: str) -> bool:
+    if slug == "google-ai-studio":
+        return _STANDARD_GEMINI_TEXT_ID_RE.fullmatch(model_id) is not None
+    return slug in {
+        "cerebras",
+        "kimi",
+        "makora",
+        "minimax",
+        "novita",
+    }
 
 
 def _discover_zai_coding_plan_models(text: str) -> set[str]:
@@ -545,14 +619,16 @@ def _model_discovery_audit(
                 f"{', '.join(missing)} — add/update provider_models/zai.json or the snapshot"
             )
         elif discovered:
-            info.append(
-                f"zai: model discovery matched catalog ({len(discovered)} docs model(s)) ✓"
-            )
+            info.append(f"zai: model discovery matched catalog ({len(discovered)} docs model(s)) ✓")
         else:
             warnings.append("zai: model discovery found no GLM model ids in Coding Plan docs")
 
     for slug, url, env_names, normalize in _DISCOVERABLE_MANIFEST_PROVIDERS:
-        published = published_model_ids | _manifest_provider_model_ids(slug)
+        routable, unresolved, classified, new_unresolved = _manifest_provider_model_state(slug)
+        # Provider-specific manifests are authoritative for provider route
+        # coverage.  The global catalog can contain the same model through a
+        # different provider and must not hide this provider's unresolved row.
+        published = routable or published_model_ids
         try:
             payload = fetch_json(url, env_names)
         except Exception as exc:  # noqa: BLE001
@@ -560,27 +636,62 @@ def _model_discovery_audit(
             continue
         discovered_ids: set[str] = set()
         for row in _json_model_rows(payload):
+            if not _active_discovery_row(row):
+                continue
             raw_id = row.get("id") or row.get("name")
             if not isinstance(raw_id, str):
+                continue
+            provider_alias = raw_id.removeprefix("models/")
+            # Preserve already-classified provider-native IDs even when they
+            # do not belong to a public model family. New unknown aliases do
+            # not become launch blockers merely because an API leaked them.
+            if provider_alias in published | unresolved | classified:
+                discovered_ids.add(provider_alias)
                 continue
             normalized = normalize(raw_id)
             if normalized:
                 discovered_ids.add(normalized)
-                provider_alias = raw_id.removeprefix("models/")
                 if provider_alias:
                     discovered_ids.add(provider_alias)
-        missing = sorted(discovered_ids - published)
-        if missing:
-            sample = ", ".join(missing[:8])
-            extra = f" (+{len(missing) - 8} more)" if len(missing) > 8 else ""
+        missing = discovered_ids - published - unresolved - classified
+        unresolved_live = discovered_ids & unresolved
+        required_missing = sorted(
+            model_id for model_id in missing if _required_discovery_model(slug, model_id)
+        )
+        optional_missing = sorted(missing - set(required_missing))
+        required_new_unresolved = sorted(
+            model_id
+            for model_id in unresolved_live & new_unresolved
+            if _required_discovery_model(slug, model_id)
+        )
+        older_unresolved = sorted(unresolved_live - set(required_new_unresolved))
+        if required_missing:
+            sample = ", ".join(required_missing[:8])
+            extra = f" (+{len(required_missing) - 8} more)" if len(required_missing) > 8 else ""
             warnings.append(
-                f"{slug}: live model API lists unpublished model(s) {sample}{extra} "
-                f"— refresh provider_models/{slug}.json or add a provider-direct price source"
+                f"{slug}: live model API lists required unpublished model(s) "
+                f"{sample}{extra} — refresh provider_models/{slug}.json or add a "
+                "provider-direct price source"
             )
-        elif discovered_ids:
-            info.append(f"{slug}: model discovery matched catalog ({len(discovered_ids)} id(s)) ✓")
-        else:
+        if required_new_unresolved:
+            warnings.append(
+                f"{slug}: newly discovered required model(s) still await a price: "
+                f"{', '.join(required_new_unresolved[:8])}"
+            )
+        if optional_missing:
+            warnings.append(
+                f"{slug}: live model API lists review-only unpublished model(s) "
+                f"{', '.join(optional_missing[:8])}"
+            )
+        if older_unresolved:
+            warnings.append(
+                f"{slug}: manifest has unresolved live model(s) awaiting price review: "
+                f"{', '.join(older_unresolved[:8])}"
+            )
+        if not discovered_ids:
             warnings.append(f"{slug}: model discovery returned no model ids")
+        elif not (missing or unresolved_live):
+            info.append(f"{slug}: model discovery matched catalog ({len(discovered_ids)} id(s)) ✓")
 
     for slug, url, env_names in _GLM_DISCOVERABLE_PROVIDER_APIS:
         published = published_model_ids | _manifest_provider_model_ids(slug)
@@ -665,6 +776,8 @@ def _run_audit(
             for warning in discovery_warnings
             if warning.startswith("zai:")
             or warning.startswith("kimi:")
+            or "required unpublished model" in warning
+            or "newly discovered required model" in warning
             or "live GLM current model API lists unpublished" in warning
         )
         info.extend(discovery_info)

--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -14,6 +14,7 @@ LLM-rewriteable code never imports this module — it lives in
 `scripts/pricing/parsers/<slug>.py` as pure `parse(html: str) -> dict`.
 Everything in this file is human-maintained.
 """
+
 from __future__ import annotations
 
 import ast
@@ -30,9 +31,11 @@ import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 import httpx
+from bs4 import BeautifulSoup
 
 log = logging.getLogger("pricing")
 
@@ -101,6 +104,13 @@ PARSER_NORMALIZE_TIMEOUT_SECONDS = 10.0
 # design — if the rewrite fails, we don't loop; the next hourly run
 # retries from scratch.
 MAX_SELF_HEAL_ATTEMPTS_PER_HOUR = 1
+
+# ``refresh.py`` computes this once from the fresh upstream model catalog
+# before provider fetches start.  The mapping is immutable after publication,
+# so parser workers can read it safely from the thread pool.  Provider-native
+# discovery (Gemini, Novita, and similar adapters) can add stricter per-call
+# requirements through ``fetch_provider(required_models=...)``.
+_RUNTIME_REQUIRED_MODELS: MappingProxyType[str, frozenset[str]] = MappingProxyType({})
 
 # TR's own API for self-heal calls. Eats own dogfood; free for us.
 # Inference API (NOT trustedrouter.com — that's the marketing/control
@@ -191,21 +201,16 @@ class ModelPrice:
                 or completion_micro_per_m is not None
                 or prompt_cached_micro_per_m is not None
             ):
-                raise ValueError(
-                    "ModelPrice: pass either flat rates OR `tiers=`, not both"
-                )
+                raise ValueError("ModelPrice: pass either flat rates OR `tiers=`, not both")
             if not tiers:
                 raise ValueError("ModelPrice: `tiers` cannot be empty")
             if tiers[-1].max_prompt_tokens is not None:
-                raise ValueError(
-                    "ModelPrice: last tier must have max_prompt_tokens=None"
-                )
+                raise ValueError("ModelPrice: last tier must have max_prompt_tokens=None")
             self.tiers = list(tiers)
             return
         if prompt_micro_per_m is None or completion_micro_per_m is None:
             raise ValueError(
-                "ModelPrice: must supply prompt_micro_per_m + "
-                "completion_micro_per_m OR tiers="
+                "ModelPrice: must supply prompt_micro_per_m + completion_micro_per_m OR tiers="
             )
         self.tiers = [
             PriceTier(
@@ -251,6 +256,31 @@ class ProviderPricingResult:
     notes: list[str] = field(default_factory=list)
 
 
+def configure_runtime_required_models(
+    required_by_slug: dict[str, set[str] | frozenset[str]],
+) -> None:
+    """Publish newly discovered model IDs that parsers must price this run.
+
+    Static ``EXPECTED_MODELS`` lists are useful regression floors but cannot
+    anticipate launches.  The hourly refresh compares the new provider/model
+    catalog with the last committed one and places only newly observed text
+    models here.  Missing runtime-required IDs are validation errors, which
+    invokes the normal sandboxed parser self-heal instead of silently leaving
+    the model unpublished.
+    """
+
+    global _RUNTIME_REQUIRED_MODELS  # noqa: PLW0603
+    _RUNTIME_REQUIRED_MODELS = MappingProxyType(
+        {slug: frozenset(model_ids) for slug, model_ids in required_by_slug.items() if model_ids}
+    )
+
+
+def runtime_required_models(slug: str) -> frozenset[str]:
+    """Return the immutable dynamic parser requirements for ``slug``."""
+
+    return _RUNTIME_REQUIRED_MODELS.get(slug, frozenset())
+
+
 # ----------------------------------------------------------------------
 # Network IO — the ONLY place we make outbound HTTP calls. Provider
 # modules pass their hardcoded URL constants in.
@@ -293,27 +323,83 @@ def _get_with_retries(client: httpx.Client, url: str, headers: dict[str, str]) -
     return last_response
 
 
-def fetch_html(url: str, *, extra_headers: dict[str, str] | None = None) -> str:
+def fetch_html(
+    url: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+    accepted_status_codes: frozenset[int] = frozenset(),
+) -> str:
     """Fetch one provider's pricing page. Network IO lives here, only here.
 
     URL must be passed in by the caller from a hardcoded constant in
     `scripts/pricing/providers/<slug>.py`. The LLM-rewriteable parser
     tier never sees a URL and cannot make network calls.
 
-    `extra_headers` lets a provider config request specific headers —
-    notably `X-Return-Format: markdown` for r.jina.ai-proxied URLs,
-    which we use for providers whose pricing pages are JS-rendered or
-    Cloudflare-blocked (OpenAI, Gemini, Z.AI). Anthropic / Cerebras /
-    Mistral / DeepSeek don't need this; they return server-rendered
-    HTML directly.
+    ``accepted_status_codes`` is intentionally narrow and opt-in. It lets a
+    provider parser consume a known anti-bot checkpoint response and use its
+    checked-in public-price fallback instead of making an external reader
+    proxy a production dependency.
     """
     headers = {"User-Agent": PROVIDER_FETCH_UA}
     if extra_headers:
         headers.update(extra_headers)
     with _provider_client() as client:
         response = _get_with_retries(client, url, headers)
-        response.raise_for_status()
+        if response.status_code not in accepted_status_codes:
+            response.raise_for_status()
         return response.text
+
+
+def normalize_parser_input(source: str, *, include_raw_html: bool = True) -> str:
+    """Project official HTML and Markdown into a stable parser input.
+
+    Provider pages vary between server-rendered tables, documentation
+    Markdown, and visual site-builder cards. Parsers historically depended on
+    a third-party HTML-to-Markdown mirror, so a mirror outage disabled many
+    otherwise healthy sources at once. This projection preserves the raw HTML
+    for DOM-aware parsers and appends deterministic headings, table rows, and
+    visible text for line-oriented parsers.
+
+    ``include_raw_html=False`` returns only the compact projection. The
+    self-heal model receives that form so scripts, styles, and application
+    bundles cannot inflate its context or distract it from pricing evidence.
+    """
+
+    unescaped = source.replace(r"\$", "$")
+    # Documentation Markdown can legitimately embed JSX tables and ``<div>``
+    # examples. Treat only an actual document shell as HTML; parsing mixed
+    # Markdown/JSX through BeautifulSoup would rewrite operators and destroy
+    # the price-row syntax.
+    if not re.search(r"<\s*(?:!doctype|html|body)\b", unescaped, re.I):
+        return unescaped
+
+    soup = BeautifulSoup(unescaped, "html.parser")
+    compact_soup = BeautifulSoup(unescaped, "html.parser")
+    for element in compact_soup(["script", "style", "noscript", "template", "svg"]):
+        element.decompose()
+
+    lines: list[str] = []
+    for heading in compact_soup.find_all(re.compile(r"^h[1-6]$")):
+        title = heading.get_text(" ", strip=True)
+        if title:
+            level = int(heading.name[1])
+            lines.append(f"{'#' * level} {title}")
+
+    for table in compact_soup.find_all("table"):
+        for row in table.find_all("tr"):
+            cells = [cell.get_text(" ", strip=True) for cell in row.find_all(["th", "td"])]
+            if not any(cells):
+                continue
+            lines.append("| " + " | ".join(cells) + " |")
+            lines.append("\t".join(cells))
+
+    visible = compact_soup.get_text("\n", strip=True)
+    projection = "\n".join([*lines, visible]).replace(r"\$", "$")
+    if not include_raw_html:
+        return projection
+    # Keep the original DOM first so BeautifulSoup parsers see exactly what
+    # the provider served. The appended projection is inert text to the DOM.
+    return f"{str(soup)}\n\n<!-- trustedrouter-normalized -->\n{projection}"
 
 
 def fetch_json(url: str, *, extra_headers: dict[str, str] | None = None) -> Any:
@@ -383,10 +469,7 @@ def guard_manifest_prune(
         if isinstance(row, dict)
         and isinstance(row.get("id"), str)
         and row["id"]
-        and (
-            row.get("routable") is not False
-            or row.get("routable_reason") == "delisted-upstream"
-        )
+        and (row.get("routable") is not False or row.get("routable_reason") == "delisted-upstream")
     }
     disabled = old_routable_ids - new_routable_ids
     emptied_manifest = bool(old_rows) and not new_rows
@@ -426,9 +509,7 @@ def reconcile_manifest_tombstones(
     existing_ids = {
         row["id"]
         for row in old_rows
-        if isinstance(row, dict)
-        and isinstance(row.get("id"), str)
-        and row["id"]
+        if isinstance(row, dict) and isinstance(row.get("id"), str) and row["id"]
     }
     reconciled: list[Any] = []
 
@@ -443,10 +524,7 @@ def reconcile_manifest_tombstones(
 
         # A false row without a machine-owned reason is curated metadata. Its
         # contents and route state are outside discovery's authority.
-        curated_unroutable = (
-            old_row.get("routable") is False
-            and "routable_reason" not in old_row
-        )
+        curated_unroutable = old_row.get("routable") is False and "routable_reason" not in old_row
         if curated_unroutable:
             reconciled.append(dict(old_row))
             continue
@@ -462,6 +540,7 @@ def reconcile_manifest_tombstones(
                 ):
                     row["routable"] = True
                     row.pop("routable_reason", None)
+                    row.pop("unresolved_since", None)
             reconciled.append(row)
             continue
 
@@ -479,6 +558,7 @@ def reconcile_manifest_tombstones(
         if model_id not in priced_ids:
             row["routable"] = False
             row["routable_reason"] = "awaiting-price"
+            row["unresolved_since"] = today
         reconciled.append(row)
 
     return reconciled
@@ -534,9 +614,7 @@ def _coerce_to_model_prices(raw: object) -> tuple[dict[str, ModelPrice] | None, 
             errors.append(f"{model_id}: prompt_micro_per_m must be int, got {prompt!r}")
             continue
         if not isinstance(completion, int) or isinstance(completion, bool):
-            errors.append(
-                f"{model_id}: completion_micro_per_m must be int, got {completion!r}"
-            )
+            errors.append(f"{model_id}: completion_micro_per_m must be int, got {completion!r}")
             continue
         if cached is not None and (not isinstance(cached, int) or isinstance(cached, bool)):
             errors.append(
@@ -551,9 +629,7 @@ def _coerce_to_model_prices(raw: object) -> tuple[dict[str, ModelPrice] | None, 
     return (out if not errors else None), errors
 
 
-def _coerce_tiers(
-    model_id: str, raw_tiers: object
-) -> tuple[list[PriceTier], list[str]]:
+def _coerce_tiers(model_id: str, raw_tiers: object) -> tuple[list[PriceTier], list[str]]:
     """Coerce a parser-supplied `tiers` array into a list of PriceTier.
     Returns (tiers, errors); on errors, tiers is empty and errors lists
     every problem found."""
@@ -570,27 +646,19 @@ def _coerce_tiers(
         completion = tier.get("completion_micro_per_m")
         cached = tier.get("prompt_cached_micro_per_m")
         if max_prompt is not None and not isinstance(max_prompt, int):
-            errors.append(
-                f"{model_id}: tiers[{idx}].max_prompt_tokens must be int or None"
-            )
+            errors.append(f"{model_id}: tiers[{idx}].max_prompt_tokens must be int or None")
             continue
         if isinstance(max_prompt, bool):  # bool is a subclass of int — guard it
-            errors.append(
-                f"{model_id}: tiers[{idx}].max_prompt_tokens must be int, got bool"
-            )
+            errors.append(f"{model_id}: tiers[{idx}].max_prompt_tokens must be int, got bool")
             continue
         if not isinstance(prompt, int) or isinstance(prompt, bool):
             errors.append(f"{model_id}: tiers[{idx}].prompt_micro_per_m must be int")
             continue
         if not isinstance(completion, int) or isinstance(completion, bool):
-            errors.append(
-                f"{model_id}: tiers[{idx}].completion_micro_per_m must be int"
-            )
+            errors.append(f"{model_id}: tiers[{idx}].completion_micro_per_m must be int")
             continue
         if cached is not None and (not isinstance(cached, int) or isinstance(cached, bool)):
-            errors.append(
-                f"{model_id}: tiers[{idx}].prompt_cached_micro_per_m must be int or None"
-            )
+            errors.append(f"{model_id}: tiers[{idx}].prompt_cached_micro_per_m must be int or None")
             continue
         coerced.append(
             PriceTier(
@@ -605,10 +673,7 @@ def _coerce_tiers(
     if coerced[-1].max_prompt_tokens is not None:
         return (
             [],
-            [
-                f"{model_id}: last tier must have max_prompt_tokens=None "
-                "(uncapped fallback)"
-            ],
+            [f"{model_id}: last tier must have max_prompt_tokens=None (uncapped fallback)"],
         )
     # Verify thresholds are strictly ascending (None always last).
     last_threshold = -1
@@ -626,14 +691,18 @@ def _coerce_tiers(
 
 
 def validate(
-    prices: dict[str, ModelPrice], expected_models: list[str]
+    prices: dict[str, ModelPrice],
+    expected_models: list[str],
+    *,
+    required_models: list[str] | tuple[str, ...] | frozenset[str] = (),
 ) -> list[str]:
     """Return a list of validation errors. Empty list = pass.
 
     Checks:
       - non-empty
       - every tier's prompt/completion in [MIN, MAX]
-      - warn when a model in `expected_models` is absent (drift detector)
+      - warn when a model in `expected_models` is absent (retirement detector)
+      - fail when a newly discovered model in `required_models` is absent
       - units sanity: at least one tier across all models has nonzero
         price (otherwise the parser likely missed the price column)
     """
@@ -666,6 +735,9 @@ def validate(
             f"expected models missing from fresh provider feed: {missing}; "
             "accepting feed so retired models can be pruned"
         )
+    missing_required = sorted(set(required_models) - set(prices))
+    if missing_required:
+        errors.append(f"newly discovered models missing from parser output: {missing_required}")
     has_nonzero = any(
         tier.prompt_micro_per_m > 0 or tier.completion_micro_per_m > 0
         for row in prices.values()
@@ -673,8 +745,7 @@ def validate(
     )
     if not has_nonzero:
         errors.append(
-            "all prices are zero — parser likely missed the price column "
-            "(units mismatch?)"
+            "all prices are zero — parser likely missed the price column (units mismatch?)"
         )
     return errors
 
@@ -728,8 +799,7 @@ def ast_whitelist_check(source: str) -> list[str]:
                     top_level_names.add(target.id)
                 else:
                     errors.append(
-                        f"complex top-level assignment target not allowed: "
-                        f"{ast.dump(target)}"
+                        f"complex top-level assignment target not allowed: {ast.dump(target)}"
                     )
         elif isinstance(node, ast.AnnAssign):
             if isinstance(node.target, ast.Name):
@@ -777,8 +847,7 @@ def ast_whitelist_check(source: str) -> list[str]:
             if isinstance(func, ast.Name) and func.id == "getattr":
                 # Only allow getattr(x, "literal") — no dynamic attrs.
                 if len(sub.args) >= 2 and not (
-                    isinstance(sub.args[1], ast.Constant)
-                    and isinstance(sub.args[1].value, str)
+                    isinstance(sub.args[1], ast.Constant) and isinstance(sub.args[1].value, str)
                 ):
                     errors.append("getattr with non-literal attr name not allowed")
 
@@ -792,7 +861,7 @@ def ast_whitelist_check(source: str) -> list[str]:
 
 
 _SANDBOX_RUNNER_TEMPLATE = textwrap.dedent(
-    '''
+    """
     {parser_source}
 
     import json as _sandbox_json
@@ -802,7 +871,7 @@ _SANDBOX_RUNNER_TEMPLATE = textwrap.dedent(
         html = _sandbox_sys.stdin.read()
         result = parse(html)
         _sandbox_sys.stdout.write(_sandbox_json.dumps(result))
-    '''
+    """
 ).strip()
 
 
@@ -903,9 +972,7 @@ the new HTML and write fresh CSS/regex extraction logic. Prefer BeautifulSoup
 """
 
 
-_FILE_CONTENT_RE = re.compile(
-    r"<file_content>\s*(.*?)\s*</file_content>", re.DOTALL
-)
+_FILE_CONTENT_RE = re.compile(r"<file_content>\s*(.*?)\s*</file_content>", re.DOTALL)
 
 
 def self_heal_parser(
@@ -924,9 +991,7 @@ def self_heal_parser(
     """
     api_key = os.environ.get(TR_API_KEY_ENV)
     if not api_key:
-        raise RuntimeError(
-            f"{TR_API_KEY_ENV} not set; cannot call TR for self-heal"
-        )
+        raise RuntimeError(f"{TR_API_KEY_ENV} not set; cannot call TR for self-heal")
     user_message = (
         f"Provider slug: {slug}\n\n"
         f"Validation errors from the current parser:\n"
@@ -961,14 +1026,10 @@ def self_heal_parser(
     except (KeyError, IndexError, TypeError) as exc:
         raise RuntimeError(f"unexpected TR response shape: {exc}") from exc
     if not isinstance(content, str):
-        raise RuntimeError(
-            f"unexpected TR content type: {type(content).__name__}"
-        )
+        raise RuntimeError(f"unexpected TR content type: {type(content).__name__}")
     match = _FILE_CONTENT_RE.search(content)
     if not match:
-        raise RuntimeError(
-            "TR response missing <file_content>...</file_content> block"
-        )
+        raise RuntimeError("TR response missing <file_content>...</file_content> block")
     new_src = match.group(1).strip()
     if not new_src:
         raise RuntimeError("TR response had empty <file_content> block")
@@ -1042,16 +1103,12 @@ def _normalize_and_lint_parser_source(*, slug: str, source: str) -> str:
                     check=False,
                 )
             except subprocess.TimeoutExpired as exc:
-                raise RuntimeError(
-                    f"{slug}: self-heal Ruff normalization timed out"
-                ) from exc
+                raise RuntimeError(f"{slug}: self-heal Ruff normalization timed out") from exc
             if result.returncode != 0:
                 details = "\n".join(
                     part.strip() for part in (result.stdout, result.stderr) if part.strip()
                 )
-                raise RuntimeError(
-                    f"{slug}: self-heal Ruff normalization failed: {details[:2000]}"
-                )
+                raise RuntimeError(f"{slug}: self-heal Ruff normalization failed: {details[:2000]}")
         return candidate_path.read_text(encoding="utf-8")
 
 
@@ -1060,6 +1117,7 @@ def _assert_fixture_compatibility(
     slug: str,
     current_parse_fn: Any,
     candidate_source: str,
+    allowed_added_models: frozenset[str] = frozenset(),
 ) -> None:
     """Reject a self-heal that breaks a previously understood page shape.
 
@@ -1071,7 +1129,7 @@ def _assert_fixture_compatibility(
     fixture_path = PRICING_FIXTURES_DIR / f"{slug}.html"
     if not fixture_path.exists():
         return
-    fixture_html = fixture_path.read_text(encoding="utf-8")
+    fixture_html = normalize_parser_input(fixture_path.read_text(encoding="utf-8"))
     try:
         current_raw = current_parse_fn(fixture_html)
     except Exception:
@@ -1080,21 +1138,17 @@ def _assert_fixture_compatibility(
     if current_errors or current_prices is None or not current_prices:
         return
 
-    candidate_prices, candidate_errors = sandbox_run_parser(
-        candidate_source, fixture_html
-    )
+    candidate_prices, candidate_errors = sandbox_run_parser(candidate_source, fixture_html)
     if candidate_errors or candidate_prices is None:
-        raise RuntimeError(
-            f"{slug}: self-heal fixture regression: {candidate_errors}"
-        )
-    if candidate_prices != current_prices:
-        removed = sorted(set(current_prices) - set(candidate_prices))
-        changed = sorted(
-            model_id
-            for model_id in set(current_prices) & set(candidate_prices)
-            if current_prices[model_id] != candidate_prices[model_id]
-        )
-        added = sorted(set(candidate_prices) - set(current_prices))
+        raise RuntimeError(f"{slug}: self-heal fixture regression: {candidate_errors}")
+    removed = sorted(set(current_prices) - set(candidate_prices))
+    changed = sorted(
+        model_id
+        for model_id in set(current_prices) & set(candidate_prices)
+        if current_prices[model_id] != candidate_prices[model_id]
+    )
+    added = sorted(set(candidate_prices) - set(current_prices) - allowed_added_models)
+    if removed or changed or added:
         raise RuntimeError(
             f"{slug}: self-heal fixture regression: "
             f"removed={removed}, changed={changed}, added={added}"
@@ -1111,7 +1165,9 @@ def fetch_provider(
     slug: str,
     url: str,
     expected_models: list[str],
+    required_models: list[str] | tuple[str, ...] | frozenset[str] = (),
     extra_headers: dict[str, str] | None = None,
+    accepted_status_codes: frozenset[int] = frozenset(),
 ) -> ProviderPricingResult:
     """Fetch one provider's prices via the deterministic parser, with
     LLM self-heal as fallback.
@@ -1132,8 +1188,22 @@ def fetch_provider(
       9. validate the sandbox output.
       10. only after all pass, write the new source to disk and return.
     """
-    log.info("pricing.fetch slug=%s url=%s", slug, url)
-    html = fetch_html(url, extra_headers=extra_headers)
+    strict_models = frozenset(required_models) | runtime_required_models(slug)
+    log.info(
+        "pricing.fetch slug=%s url=%s required_models=%d",
+        slug,
+        url,
+        len(strict_models),
+    )
+    if accepted_status_codes:
+        raw_html = fetch_html(
+            url,
+            extra_headers=extra_headers,
+            accepted_status_codes=accepted_status_codes,
+        )
+    else:
+        raw_html = fetch_html(url, extra_headers=extra_headers)
+    html = normalize_parser_input(raw_html)
 
     # Exec the parser source in a fresh namespace each call — sidesteps
     # importlib.reload edge cases (the parser file may have been
@@ -1156,7 +1226,11 @@ def fetch_provider(
         prices = None
     errors = schema_errors[:] if schema_errors else []
     if prices is not None:
-        errors = validate(prices, expected_models)
+        errors = validate(
+            prices,
+            expected_models,
+            required_models=strict_models,
+        )
     if not errors:
         return ProviderPricingResult(
             slug=slug,
@@ -1173,7 +1247,7 @@ def fetch_provider(
         new_src = self_heal_parser(
             slug=slug,
             current_src=current_src,
-            html=html,
+            html=normalize_parser_input(raw_html, include_raw_html=False),
             errors=errors,
         )
     except Exception as exc:
@@ -1181,34 +1255,32 @@ def fetch_provider(
 
     ast_errors = ast_whitelist_check(new_src)
     if ast_errors:
-        raise RuntimeError(
-            f"{slug}: self-heal AST whitelist failed: {ast_errors}"
-        )
+        raise RuntimeError(f"{slug}: self-heal AST whitelist failed: {ast_errors}")
 
     new_src = _normalize_and_lint_parser_source(slug=slug, source=new_src)
     normalized_ast_errors = ast_whitelist_check(new_src)
     if normalized_ast_errors:
         raise RuntimeError(
-            f"{slug}: normalized self-heal AST whitelist failed: "
-            f"{normalized_ast_errors}"
+            f"{slug}: normalized self-heal AST whitelist failed: {normalized_ast_errors}"
         )
 
     sandbox_prices, sandbox_errors = sandbox_run_parser(new_src, html)
     if sandbox_errors:
-        raise RuntimeError(
-            f"{slug}: self-heal sandbox failed: {sandbox_errors}"
-        )
+        raise RuntimeError(f"{slug}: self-heal sandbox failed: {sandbox_errors}")
     assert sandbox_prices is not None  # for type checker
-    final_errors = validate(sandbox_prices, expected_models)
+    final_errors = validate(
+        sandbox_prices,
+        expected_models,
+        required_models=strict_models,
+    )
     if final_errors:
-        raise RuntimeError(
-            f"{slug}: self-heal output failed validation: {final_errors}"
-        )
+        raise RuntimeError(f"{slug}: self-heal output failed validation: {final_errors}")
 
     _assert_fixture_compatibility(
         slug=slug,
         current_parse_fn=parse_fn,
         candidate_source=new_src,
+        allowed_added_models=strict_models,
     )
 
     # All gates passed — persist the new parser source.
@@ -1220,7 +1292,5 @@ def fetch_provider(
         source="self_healed",
         heal_diff=diff,
         fetched_url=url,
-        notes=[
-            f"self-healed parser (validation errors: {len(errors)} → 0)"
-        ],
+        notes=[f"self-healed parser (validation errors: {len(errors)} → 0)"],
     )

--- a/scripts/pricing/model_ids.py
+++ b/scripts/pricing/model_ids.py
@@ -6,6 +6,7 @@ API-backed provider adapter needs the same conservative normalization:
 explicit hand maps win for tricky aliases, and simple vendor/model IDs are
 lowercased with known author namespace rewrites.
 """
+
 from __future__ import annotations
 
 import re
@@ -23,6 +24,48 @@ _AUTHOR_ALIASES = {
 }
 
 _MODEL_CHARS_RE = re.compile(r"[^a-z0-9._-]+")
+
+
+def canonicalize_unqualified_model_id(native_id: str) -> str | None:
+    """Normalize common provider model-family slugs without an author.
+
+    Aggregators such as Cerebras, Fireworks, Phala, and Wafer often expose
+    short IDs like ``gpt-oss-120b`` or ``glm-5p2``.  Explicit provider maps
+    still win for aliases and quantizations; this fallback handles ordinary
+    future releases whose family unambiguously identifies the public author.
+    """
+
+    value = native_id.strip().casefold()
+    for prefix in (
+        "accounts/fireworks/models/",
+        "accounts/fireworks/routers/",
+        "phala/",
+        "models/",
+    ):
+        value = value.removeprefix(prefix)
+    value = value.replace("_", "-")
+    value = re.sub(r"-(\d+)p(\d+)(?=$|-)", r"-\1.\2", value)
+    value = re.sub(r"([km])(\d+)p(\d+)(?=$|-)", r"\1\2.\3", value)
+    value = re.sub(r"-{2,}", "-", value).strip("-")
+    if not value:
+        return None
+    if value.startswith("zai-glm-"):
+        return f"z-ai/{value.removeprefix('zai-')}"
+    family_authors = (
+        (("glm-",), "z-ai"),
+        (("gpt-oss-",), "openai"),
+        (("kimi-",), "moonshotai"),
+        (("deepseek-",), "deepseek"),
+        (("minimax-",), "minimax"),
+        (("qwen", "qwq-"), "qwen"),
+        (("gemma-",), "google"),
+        (("llama-",), "meta-llama"),
+        (("mimo-",), "xiaomi"),
+    )
+    for prefixes, author in family_authors:
+        if value.startswith(prefixes):
+            return f"{author}/{value}"
+    return None
 
 
 def canonicalize_native_model_id(native_id: str) -> str | None:

--- a/scripts/pricing/parsers/gemini.py
+++ b/scripts/pricing/parsers/gemini.py
@@ -1,6 +1,8 @@
 # LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
 #
-# Parses ai.google.dev/gemini-api/docs/pricing as rendered by r.jina.ai.
+# Parses the server-rendered HTML at ai.google.dev/gemini-api/docs/pricing.
+# The parser also accepts the historical normalized Markdown format so captured
+# fixtures remain useful during the migration away from that mirror.
 # Captured fixture lives at tests/fixtures/pricing/gemini.html.
 #
 # Page format: each model lives under a `## Gemini X.Y Flavor` heading,
@@ -14,10 +16,13 @@
 # We extract the Paid Tier column. When a price line carries
 # "<= 200k / > 200k" markers, we emit two PriceTier rows; otherwise
 # a single uncapped tier.
-"""Google Gemini pricing parser (Jina-rendered markdown)."""
+"""Google Gemini pricing parser for official HTML and legacy Markdown."""
+
 from __future__ import annotations
 
 import re
+
+from bs4 import BeautifulSoup, Tag
 
 # Markdown heading text → OR-canonical id.
 _NAME_TO_OR_ID = {
@@ -36,6 +41,25 @@ _NAME_TO_OR_ID = {
     "Gemini 1.5 Flash": "google/gemini-1.5-flash",
 }
 
+_STANDARD_MODEL_HEADING_RE = re.compile(
+    r"^Gemini\s+(?P<version>\d+(?:\.\d+)?)\s+"
+    r"(?P<variant>Pro|Flash(?:[ -]Lite)?)$",
+    re.IGNORECASE,
+)
+
+
+def _model_id_from_heading(heading: str) -> str | None:
+    """Map stable Gemini pricing headings without a per-release code edit."""
+
+    mapped = _NAME_TO_OR_ID.get(heading)
+    if mapped is not None:
+        return mapped
+    match = _STANDARD_MODEL_HEADING_RE.fullmatch(heading.strip())
+    if match is None:
+        return None
+    variant = match.group("variant").casefold().replace(" ", "-")
+    return f"google/gemini-{match.group('version')}-{variant}"
+
 
 # "$1.25, prompts <= 200k tokens $2.50, prompts > 200k tokens" — a
 # tiered price line with an explicit threshold.
@@ -45,11 +69,6 @@ _TIERED_PRICE_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
-# "$0.30 (text / image / video) $1.00 (audio)" or just "$0.30" — a
-# flat price (we take the first text/image/video price for chat).
-_FLAT_TEXT_PRICE_RE = re.compile(
-    r"\$([\d.]+)(?:\s*\(text|\s*$|\s*[a-zA-Z]?[^,$])"
-)
 _ANY_DOLLAR_RE = re.compile(r"\$([\d.]+)")
 
 
@@ -93,7 +112,8 @@ def _parse_price_cell(text: str) -> tuple[list[tuple[int | None, int]], bool]:
         )
     # Flat: take the first $-amount in the cell. Skip cells that say
     # "Free of charge" or "Not available".
-    if "Free" in text or "Not available" in text:
+    lowered = text.casefold()
+    if "free" in lowered or "not available" in lowered:
         return [], False
     flat_match = _ANY_DOLLAR_RE.search(text)
     if flat_match:
@@ -101,9 +121,65 @@ def _parse_price_cell(text: str) -> tuple[list[tuple[int | None, int]], bool]:
     return [], False
 
 
-def parse(md: str) -> dict:
-    out: dict = {}
-    # Walk every "## Heading" + the table directly under it.
+def _price_from_rows(rows: list[tuple[str, str]]) -> dict[str, object] | None:
+    """Build one model price from label/paid-tier cell pairs."""
+
+    prompt_tiers: list[tuple[int | None, int]] = []
+    completion_tiers: list[tuple[int | None, int]] = []
+    cached_tiers: list[tuple[int | None, int]] = []
+    for raw_label, paid_cell in rows:
+        label = raw_label.casefold()
+        if "input price" in label and not prompt_tiers:
+            prompt_tiers, _ = _parse_price_cell(paid_cell)
+        elif "output price" in label and not completion_tiers:
+            completion_tiers, _ = _parse_price_cell(paid_cell)
+        elif "context caching price" in label and not cached_tiers:
+            cached_tiers, _ = _parse_price_cell(paid_cell)
+    if not prompt_tiers or not completion_tiers:
+        return None
+
+    # Gemini tiers prompt and completion at the same thresholds. If the page
+    # ever diverges, keep billing conservative and use the low flat tier until
+    # the hourly parser review adapts the richer shape.
+    if len(prompt_tiers) != len(completion_tiers) or any(
+        prompt[0] != completion[0]
+        for prompt, completion in zip(prompt_tiers, completion_tiers, strict=False)
+    ):
+        return {
+            "prompt_micro_per_m": prompt_tiers[0][1],
+            "completion_micro_per_m": completion_tiers[0][1],
+        }
+
+    tiers: list[dict[str, int | None]] = []
+    for index, ((threshold, prompt_micro), (_threshold, completion_micro)) in enumerate(
+        zip(prompt_tiers, completion_tiers, strict=False)
+    ):
+        tier: dict[str, int | None] = {
+            "max_prompt_tokens": threshold,
+            "prompt_micro_per_m": prompt_micro,
+            "completion_micro_per_m": completion_micro,
+        }
+        if len(cached_tiers) == len(prompt_tiers):
+            cached_threshold, cached_micro = cached_tiers[index]
+            if cached_threshold == threshold:
+                tier["prompt_cached_micro_per_m"] = cached_micro
+        tiers.append(tier)
+
+    if len(tiers) > 1:
+        return {"tiers": tiers}
+    only = tiers[0]
+    price: dict[str, object] = {
+        "prompt_micro_per_m": only["prompt_micro_per_m"],
+        "completion_micro_per_m": only["completion_micro_per_m"],
+    }
+    if "prompt_cached_micro_per_m" in only:
+        price["prompt_cached_micro_per_m"] = only["prompt_cached_micro_per_m"]
+    return price
+
+
+def _parse_markdown(md: str) -> dict[str, dict[str, object]]:
+    out: dict[str, dict[str, object]] = {}
+    # Walk every "## Heading" and the first (Standard) table under it.
     sections = re.split(r"(?m)^## ", md)
     for section in sections:
         if not section:
@@ -114,71 +190,77 @@ def parse(md: str) -> dict:
         if first_newline == -1:
             continue
         heading = section[:first_newline].strip()
-        or_id = _NAME_TO_OR_ID.get(heading)
+        or_id = _model_id_from_heading(heading)
         if or_id is None:
             continue
         body = section[first_newline + 1 :]
-        # Find the first table block (Standard tier — Jina puts the
-        # Standard table first under the heading).
-        prompt_tiers: list[tuple[int | None, int]] = []
-        completion_tiers: list[tuple[int | None, int]] = []
-        cached_tiers: list[tuple[int | None, int]] = []
+        rows: list[tuple[str, str]] = []
         for line in body.splitlines():
             if not line.startswith("|"):
+                if rows:
+                    break
                 continue
             cells = [c.strip() for c in line.strip("|").split("|")]
             if len(cells) < 3:
                 continue
-            label = cells[0].lower()
-            paid_cell = cells[-1]  # Last column is "Paid Tier, per 1M tokens"
-            if "input price" in label and not prompt_tiers:
-                tiers, _ = _parse_price_cell(paid_cell)
-                prompt_tiers = tiers
-            elif "output price" in label and not completion_tiers:
-                tiers, _ = _parse_price_cell(paid_cell)
-                completion_tiers = tiers
-            elif "context caching price" in label and not cached_tiers:
-                tiers, _ = _parse_price_cell(paid_cell)
-                cached_tiers = tiers
-        if not prompt_tiers or not completion_tiers:
-            continue
-        # Pair up the tiers. They should have matching length + thresholds
-        # (Gemini tiers prompt and completion the same way). If they
-        # don't match, fall back to flat using the cheapest.
-        if len(prompt_tiers) == len(completion_tiers) and all(
-            p[0] == c[0]
-            for p, c in zip(prompt_tiers, completion_tiers, strict=False)
-        ):
-            tiers = []
-            for (threshold, prompt_micro), (_t2, completion_micro) in zip(
-                prompt_tiers, completion_tiers, strict=False
-            ):
-                tier = {
-                    "max_prompt_tokens": threshold,
-                    "prompt_micro_per_m": prompt_micro,
-                    "completion_micro_per_m": completion_micro,
-                }
-                if len(cached_tiers) == len(prompt_tiers):
-                    cached_threshold, cached_micro = cached_tiers[len(tiers)]
-                    if cached_threshold == threshold:
-                        tier["prompt_cached_micro_per_m"] = cached_micro
-                tiers.append(tier)
-            if len(tiers) > 1:
-                out[or_id] = {"tiers": tiers}
-            else:
-                t = tiers[0]
-                out[or_id] = {
-                    "prompt_micro_per_m": t["prompt_micro_per_m"],
-                    "completion_micro_per_m": t["completion_micro_per_m"],
-                }
-                if "prompt_cached_micro_per_m" in t:
-                    out[or_id]["prompt_cached_micro_per_m"] = t[
-                        "prompt_cached_micro_per_m"
-                    ]
-        else:
-            # Tier shape mismatch — fall back to flat (low tier).
-            out[or_id] = {
-                "prompt_micro_per_m": prompt_tiers[0][1],
-                "completion_micro_per_m": completion_tiers[0][1],
-            }
+            rows.append((cells[0], cells[-1]))
+        price = _price_from_rows(rows)
+        if price is not None:
+            out[or_id] = price
     return out
+
+
+def _standard_table(heading: Tag) -> Tag | None:
+    """Return the official page's Standard table before the next model."""
+
+    in_standard_section = False
+    for element in heading.find_all_next(["h2", "h3", "table"]):
+        if not isinstance(element, Tag):
+            continue
+        if element.name == "h2":
+            return None
+        if element.name == "h3":
+            in_standard_section = element.get_text(" ", strip=True).casefold() == "standard"
+            continue
+        if element.name == "table" and in_standard_section:
+            return element
+    return None
+
+
+def _parse_html(html: str) -> dict[str, dict[str, object]]:
+    out: dict[str, dict[str, object]] = {}
+    soup = BeautifulSoup(html, "html.parser")
+    for heading in soup.find_all("h2"):
+        if not isinstance(heading, Tag):
+            continue
+        or_id = _model_id_from_heading(heading.get_text(" ", strip=True))
+        if or_id is None:
+            continue
+        table = _standard_table(heading)
+        if table is None:
+            continue
+        rows: list[tuple[str, str]] = []
+        for row in table.find_all("tr"):
+            cells = row.find_all(["th", "td"], recursive=False)
+            if len(cells) < 3:
+                continue
+            rows.append(
+                (
+                    cells[0].get_text(" ", strip=True),
+                    cells[-1].get_text(" ", strip=True),
+                )
+            )
+        price = _price_from_rows(rows)
+        if price is not None:
+            out[or_id] = price
+    return out
+
+
+def parse(content: str) -> dict[str, dict[str, object]]:
+    """Parse Gemini pricing from the official HTML or a legacy Markdown copy."""
+
+    if re.search(r"<h2\b", content, re.IGNORECASE) and re.search(
+        r"<table\b", content, re.IGNORECASE
+    ):
+        return _parse_html(content)
+    return _parse_markdown(content)

--- a/scripts/pricing/parsers/grok.py
+++ b/scripts/pricing/parsers/grok.py
@@ -1,36 +1,22 @@
-# LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
-#
-# Parses docs.x.ai/developers/pricing (Jina-rendered markdown). The page
-# has a single chat-models table:
-#
-#   | [grok-4.5](https://docs.x.ai/developers/models/grok-4.5) | 500k | $2.00 | $0.50 | $6.00 |
-#   | [grok-4.3](https://docs.x.ai/developers/models/grok-4.3) | 1M | $1.25 | $0.20 | $2.50 |
-#   | [grok-4.20-multi-agent-0309](...) | 2M | $1.25 | $0.20 | $2.50 |
-#
-# Columns are: Model | Context | Input | Cached | Output. The model
-# cell is a markdown link — strip the [text](url) wrapper to extract
-# the slug. Image / video / TTS rows have only 3 cells and are skipped
-# because they don't have the Input + Output columns we need for cost.
-"""xAI Grok pricing parser (Jina-rendered markdown)."""
+"""Parse xAI's official text-model pricing table."""
+
 from __future__ import annotations
 
 import re
 
 _NAME_TO_OR_ID = {
-    "grok-4.5": "x-ai/grok-4.5",
-    "grok-4.3": "x-ai/grok-4.3",
     "grok-4.20-multi-agent-0309": "x-ai/grok-4.20-multi-agent",
     "grok-4.20-0309-reasoning": "x-ai/grok-4.20-reasoning",
     "grok-4.20-0309-non-reasoning": "x-ai/grok-4.20",
     "grok-4-1-fast-reasoning": "x-ai/grok-4-1-fast-reasoning",
     "grok-4-1-fast-non-reasoning": "x-ai/grok-4-1-fast",
 }
-
 _DOLLAR_RE = re.compile(r"\$([\d.]+)")
-# Markdown link wrapper [name](url) — extract just the name. Also tolerate
-# `**name**` or bare names so the parser keeps working if the page sheds
-# its link decoration in a future redesign.
 _MD_LINK_RE = re.compile(r"^\s*\**\s*\[([^\]]+)\]\([^)]+\)\s*\**\s*$")
+_CONTEXT_QUALIFIER_RE = re.compile(
+    r"\s*\((?P<operator><|&lt;|≥|>=|&gt;=)\s*200k\s+prompt\s+tokens\)\s*$",
+    re.I,
+)
 
 
 def _strip_link(cell: str) -> str:
@@ -50,41 +36,53 @@ def _to_micro(text: str) -> int | None:
         return None
 
 
-def parse(md: str) -> dict:
-    out: dict = {}
-    for line in md.splitlines():
-        if not line.startswith("|"):
+def _canonical_id(native_name: str) -> str | None:
+    if not native_name.casefold().startswith("grok-"):
+        return None
+    return _NAME_TO_OR_ID.get(native_name) or f"x-ai/{native_name.casefold()}"
+
+
+def parse(markdown: str) -> dict:
+    grouped: dict[str, dict[str, dict[str, int]]] = {}
+    for line in markdown.replace(r"\$", "$").splitlines():
+        if not line.lstrip().startswith("|"):
             continue
-        cells = [c.strip() for c in line.strip("|").split("|")]
-        # New layout has 5 cells: Model | Context | Input | Cached | Output.
-        # Pricing-only rows (image/video) have 2 cells and skip the check
-        # below. Old layout was 5 cells with cached last, so we detect the
-        # layout heuristically: if cells[3] looks like the output price
-        # (always > cached when both present) we treat it as old layout.
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
         if len(cells) < 5:
             continue
-        name = _strip_link(cells[0])
-        or_id = _NAME_TO_OR_ID.get(name)
-        if or_id is None:
-            continue
-        if or_id in out:
+        decorated_name = _strip_link(cells[0])
+        qualifier = _CONTEXT_QUALIFIER_RE.search(decorated_name)
+        native_name = _CONTEXT_QUALIFIER_RE.sub("", decorated_name).strip()
+        model_id = _canonical_id(native_name)
+        if model_id is None:
             continue
         prompt = _to_micro(cells[2])
-        # New page: cells[3] is cached input, cells[4] is output.
-        # Old page: cells[3] was output, cells[4] was cached input.
-        # Pick the LARGER of cells[3] and cells[4] as completion — output
-        # is always strictly greater than the cached-input rate for the
-        # chat models in this table (cached rate is by definition a
-        # discount). Falls through correctly whichever column ordering
-        # the page is currently in.
-        cell3 = _to_micro(cells[3])
-        cell4 = _to_micro(cells[4]) if len(cells) >= 5 else None
-        candidates = [c for c in (cell3, cell4) if c is not None]
-        if prompt is None or not candidates:
+        cached = _to_micro(cells[3])
+        completion = _to_micro(cells[4])
+        # Compatibility with the older Input | Output | Cached layout.
+        if completion is None or (cached is not None and completion < cached):
+            cached, completion = completion, cached
+        if prompt is None or completion is None:
             continue
-        completion = max(candidates)
-        out[or_id] = {
+        row = {
             "prompt_micro_per_m": prompt,
             "completion_micro_per_m": completion,
         }
-    return out
+        if cached is not None:
+            row["prompt_cached_micro_per_m"] = cached
+        operator = qualifier.group("operator") if qualifier else ""
+        tier = "long" if operator in {"≥", ">=", "&gt;="} else "short"
+        grouped.setdefault(model_id, {}).setdefault(tier, row)
+
+    output: dict = {}
+    for model_id, rows in grouped.items():
+        if "short" in rows and "long" in rows:
+            output[model_id] = {
+                "tiers": [
+                    {"max_prompt_tokens": 200_000, **rows["short"]},
+                    {"max_prompt_tokens": None, **rows["long"]},
+                ]
+            }
+        else:
+            output[model_id] = rows.get("short") or rows["long"]
+    return output

--- a/scripts/pricing/parsers/minimax.py
+++ b/scripts/pricing/parsers/minimax.py
@@ -10,8 +10,37 @@ def _money_to_micro_per_m(value: str) -> int:
 
 
 def parse(html: str) -> dict[str, dict[str, object]]:
+    html = html.replace(r"\$", "$")
     text = re.sub(r"\s+", " ", html)
     prices: dict[str, dict[str, object]] = {}
+
+    standard_match = re.search(
+        r'<Tab\s+title="Standard">(.*?)</Tab>',
+        html,
+        flags=re.I | re.S,
+    )
+    if standard_match:
+        tiers: list[dict[str, int | None]] = []
+        for line in standard_match.group(1).splitlines():
+            if "MiniMax-M3" not in line or not line.lstrip().startswith("|"):
+                continue
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if len(cells) < 4:
+                continue
+            amounts = [re.findall(r"\$([0-9.]+)", cell) for cell in cells[1:4]]
+            if any(not values for values in amounts):
+                continue
+            tiers.append(
+                {
+                    "max_prompt_tokens": 512_000 if "512k" in cells[0] and "≤" in cells[0] else None,
+                    "prompt_micro_per_m": _money_to_micro_per_m(amounts[0][-1]),
+                    "completion_micro_per_m": _money_to_micro_per_m(amounts[1][-1]),
+                    "prompt_cached_micro_per_m": _money_to_micro_per_m(amounts[2][-1]),
+                }
+            )
+        if len(tiers) >= 2:
+            tiers.sort(key=lambda tier: tier["max_prompt_tokens"] is None)
+            prices["minimax/minimax-m3"] = {"tiers": tiers[:2]}
 
     m3_tiers = re.findall(
         r"MiniMax-M3\s+Context\s+([^$]+?)\s+\$([0-9.]+)\$([0-9.]+)\s+\$([0-9.]+)\$([0-9.]+)\s+\$([0-9.]+)\$([0-9.]+)",
@@ -19,8 +48,16 @@ def parse(html: str) -> dict[str, dict[str, object]]:
     )
     if len(m3_tiers) >= 2:
         tiers: list[dict[str, int | None]] = []
-        for label, _input_list, input_discounted, _output_list, output_discounted, _cache_list, cache_discounted in m3_tiers[:2]:
-            max_prompt_tokens = 512_000 if "≤ 512K" in label else None
+        for (
+            label,
+            _input_list,
+            input_discounted,
+            _output_list,
+            output_discounted,
+            _cache_list,
+            cache_discounted,
+        ) in m3_tiers[:2]:
+            max_prompt_tokens = 512_000 if "≤ 512K" in label or "<= 512K" in label else None
             tiers.append(
                 {
                     "max_prompt_tokens": max_prompt_tokens,
@@ -31,20 +68,44 @@ def parse(html: str) -> dict[str, dict[str, object]]:
             )
         prices["minimax/minimax-m3"] = {"tiers": tiers}
 
-    for native, model_id in (
-        ("MiniMax-M2.7", "minimax/minimax-m2.7"),
-        ("MiniMax-M2.7-highspeed", "minimax/minimax-m2.7-highspeed"),
-    ):
-        match = re.search(
-            rf"{re.escape(native)}\s+\$([0-9.]+)\s*/\s*M tokens\s+\$([0-9.]+)\s*/\s*M tokens\s+\$([0-9.]+)\s*/\s*M tokens",
-            text,
-        )
-        if not match:
+    markdown_row_re = re.compile(
+        r"^\|\s*\**(?P<native>MiniMax-[A-Za-z0-9._-]+)\**\s*\|"
+        r"(?P<input>[^|]+)\|(?P<output>[^|]+)\|(?P<cached>[^|]+)\|",
+        re.IGNORECASE | re.MULTILINE,
+    )
+    for match in markdown_row_re.finditer(html):
+        native = match.group("native")
+        if native.casefold() == "minimax-m3":
             continue
-        prices[model_id] = {
-            "prompt_micro_per_m": _money_to_micro_per_m(match.group(1)),
-            "completion_micro_per_m": _money_to_micro_per_m(match.group(2)),
-            "prompt_cached_micro_per_m": _money_to_micro_per_m(match.group(3)),
-        }
+        values = [
+            re.findall(r"\$([0-9.]+)", match.group(field))
+            for field in ("input", "output", "cached")
+        ]
+        if any(not item for item in values):
+            continue
+        prices.setdefault(
+            f"minimax/{native.casefold()}",
+            {
+                "prompt_micro_per_m": _money_to_micro_per_m(values[0][-1]),
+                "completion_micro_per_m": _money_to_micro_per_m(values[1][-1]),
+                "prompt_cached_micro_per_m": _money_to_micro_per_m(values[2][-1]),
+            },
+        )
+
+    simple_row_re = re.compile(
+        r"\b(?P<native>MiniMax-[A-Za-z0-9._-]+)\s+"
+        r"\$(?P<input>[0-9.]+)\s*/\s*M tokens\s+"
+        r"\$(?P<output>[0-9.]+)\s*/\s*M tokens\s+"
+        r"\$(?P<cached>[0-9.]+)\s*/\s*M tokens",
+        re.IGNORECASE,
+    )
+    for match in simple_row_re.finditer(text):
+        native = match.group("native")
+        model_id = f"minimax/{native.casefold()}"
+        prices.setdefault(model_id, {
+            "prompt_micro_per_m": _money_to_micro_per_m(match.group("input")),
+            "completion_micro_per_m": _money_to_micro_per_m(match.group("output")),
+            "prompt_cached_micro_per_m": _money_to_micro_per_m(match.group("cached")),
+        })
 
     return prices

--- a/scripts/pricing/parsers/morph.py
+++ b/scripts/pricing/parsers/morph.py
@@ -25,11 +25,17 @@ MODEL_IDS = {
     "morph-dsv4flash": "deepseek/deepseek-v4-flash",
 }
 
-# Published pricing (USD per 1M tokens) for Morph's own Fast Apply models.
+# Published pricing (USD per 1M tokens) for Morph's current chat catalog.
 # Source: https://www.morphllm.com/pricing (as of the last successful fetch).
-FALLBACK_PRICES: dict[str, tuple[Decimal, Decimal]] = {
-    "morph/morph-v3-fast": (Decimal("0.80"), Decimal("1.20")),
-    "morph/morph-v3-large": (Decimal("0.90"), Decimal("1.90")),
+FALLBACK_PRICES: dict[str, tuple[Decimal, Decimal, Decimal | None]] = {
+    "z-ai/glm-5.2": (Decimal("1.10"), Decimal("4.10"), None),
+    "qwen/qwen3.5-397b-a17b": (Decimal("0.50"), Decimal("3.50"), Decimal("0.30")),
+    "qwen/qwen3.6-27b": (Decimal("0.29"), Decimal("2.40"), None),
+    "minimax/minimax-m2.7": (Decimal("0.28"), Decimal("1.20"), None),
+    "minimax/minimax-m3": (Decimal("0.60"), Decimal("2.40"), None),
+    "deepseek/deepseek-v4-flash": (Decimal("0.14"), Decimal("0.28"), None),
+    "morph/morph-v3-fast": (Decimal("0.80"), Decimal("1.20"), None),
+    "morph/morph-v3-large": (Decimal("0.90"), Decimal("1.90"), None),
 }
 
 
@@ -92,13 +98,13 @@ def parse(html: str) -> dict[str, PriceRow]:
     # nothing usable, emit the published prices for Morph's own Fast Apply
     # models so downstream never sees an empty dict.
     if not output or _checkpoint_blocked(html):
-        for canonical, (prompt, completion) in FALLBACK_PRICES.items():
-            output.setdefault(
-                canonical,
-                {
-                    "prompt_micro_per_m": _micro_per_m(prompt),
-                    "completion_micro_per_m": _micro_per_m(completion),
-                },
-            )
+        for canonical, (prompt, completion, cached) in FALLBACK_PRICES.items():
+            row = {
+                "prompt_micro_per_m": _micro_per_m(prompt),
+                "completion_micro_per_m": _micro_per_m(completion),
+            }
+            if cached is not None:
+                row["prompt_cached_micro_per_m"] = _micro_per_m(cached)
+            output.setdefault(canonical, row)
 
     return output

--- a/scripts/pricing/parsers/novita.py
+++ b/scripts/pricing/parsers/novita.py
@@ -1,7 +1,12 @@
-"""Novita pricing parser for markdown-link and plain-text table layouts."""
+"""Novita pricing parser for its server-rendered catalog and legacy tables."""
+
 from __future__ import annotations
 
+import json
 import re
+from decimal import Decimal, InvalidOperation
+
+from bs4 import BeautifulSoup
 
 # Display name (as shown in the Model Name column) → OR-canonical id.
 _DISPLAY_TO_OR_ID: dict[str, str] = {
@@ -138,11 +143,184 @@ _ROW_RE = re.compile(
 _INPUT_PRICE_RE = re.compile(r"\$([\d.]+)\s*/Mt")
 _CACHE_PRICE_RE = re.compile(r"Cache Read\s*\$([\d.]+)\s*/Mt")
 _FREE_RE = re.compile(r"\bFree\b")
+_NEXT_PUSH_PREFIX = "self.__next_f.push("
+_NEXT_MODELS_KEY = "initialFullLLMModels"
+_NEXT_MODELS_MARKER = '"initialFullLLMModels":'
+_PRICE_TEXT_RE = re.compile(r"\$+([\d.]+)\s*/\s*M(?:t|\s+tokens)", re.I)
+
+
+def _usd_per_m_to_micro(raw: object) -> int | None:
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, ValueError):
+        return None
+    if not value.is_finite() or value < 0:
+        return None
+    return int((value * Decimal(1_000_000)).to_integral_value())
+
+
+def _embedded_price(
+    source: dict,
+    *,
+    info_field: str,
+    numeric_field: str,
+) -> int | None:
+    infos = source.get("infos")
+    if isinstance(infos, dict):
+        match = _PRICE_TEXT_RE.search(str(infos.get(info_field) or ""))
+        if match:
+            return _usd_per_m_to_micro(match.group(1))
+
+    # Novita's numeric pricePerM unit is 1/10,000 USD per million tokens.
+    # Prefer the human-readable USD field above, but retain this fallback for
+    # catalog rows whose display string is absent.
+    pricing = source.get(numeric_field)
+    if not isinstance(pricing, dict):
+        return None
+    raw = pricing.get("pricePerM")
+    try:
+        value = Decimal(str(raw)) * Decimal(100)
+    except (InvalidOperation, ValueError):
+        return None
+    if not value.is_finite() or value < 0:
+        return None
+    return int(value.to_integral_value())
+
+
+def _canonical_embedded_id(source: dict) -> str | None:
+    raw_id = source.get("id")
+    display_name = source.get("displayName")
+    if isinstance(display_name, str) and display_name in _DISPLAY_TO_OR_ID:
+        return _DISPLAY_TO_OR_ID[display_name]
+    if not isinstance(raw_id, str) or "/" not in raw_id:
+        return None
+    if raw_id.startswith("zai-org/"):
+        return f"z-ai/{raw_id.removeprefix('zai-org/')}"
+    return raw_id
+
+
+def _next_catalog_rows(html: str) -> list[dict]:
+    """Decode the model list embedded in Novita's server-rendered Next page."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.find_all("script"):
+        text = script.string or script.get_text()
+        if _NEXT_MODELS_KEY not in text or not text.startswith(_NEXT_PUSH_PREFIX):
+            continue
+        try:
+            payload = json.loads(text[len(_NEXT_PUSH_PREFIX) : -1])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(payload, list) or len(payload) < 2 or not isinstance(payload[1], str):
+            continue
+        flight = payload[1]
+        marker_index = flight.find(_NEXT_MODELS_MARKER)
+        if marker_index < 0:
+            continue
+        start = marker_index + len(_NEXT_MODELS_MARKER)
+        try:
+            rows, _end = json.JSONDecoder().raw_decode(flight, start)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+    return []
+
+
+def _parse_embedded_catalog(html: str) -> dict:
+    out: dict = {}
+    for source in _next_catalog_rows(html):
+        if source.get("type") != "Chat":
+            continue
+        status = source.get("status")
+        if isinstance(status, int) and status <= 0:
+            continue
+        model_id = _canonical_embedded_id(source)
+        if model_id is None:
+            continue
+        prompt = _embedded_price(
+            source,
+            info_field="inputPricing",
+            numeric_field="input_pricing",
+        )
+        completion = _embedded_price(
+            source,
+            info_field="outputPricing",
+            numeric_field="output_pricing",
+        )
+        if prompt is None or completion is None:
+            continue
+        row: dict = {
+            "prompt_micro_per_m": prompt,
+            "completion_micro_per_m": completion,
+        }
+        cached = _embedded_price(
+            source,
+            info_field="cacheReadPricing",
+            numeric_field="cache_read_input_pricing",
+        )
+        # A zero cache field in Novita's payload means the model has no cache
+        # price, not that cache reads are free.
+        if cached is not None and cached > 0:
+            row["prompt_cached_micro_per_m"] = cached
+        out[model_id] = row
+    return out
+
+
+def _parse_dom_tables(html: str) -> dict:
+    """Parse one model at a time from Novita's server-rendered table rows."""
+
+    out: dict = {}
+    soup = BeautifulSoup(html, "html.parser")
+    for table_row in soup.find_all("tr"):
+        cells = table_row.find_all(["th", "td"], recursive=False)
+        if len(cells) < 4:
+            continue
+        name = cells[0].get_text(" ", strip=True)
+        model_id = _DISPLAY_TO_OR_ID.get(name)
+        if model_id is None:
+            link = cells[0].find("a")
+            link_text = link.get_text(" ", strip=True) if link else ""
+            if "/" in link_text:
+                model_id = link_text
+        if model_id is None:
+            continue
+
+        input_text = cells[2].get_text(" ", strip=True)
+        output_text = cells[3].get_text(" ", strip=True)
+        input_match = _PRICE_TEXT_RE.search(input_text)
+        output_match = _PRICE_TEXT_RE.search(output_text)
+        if input_match and output_match:
+            prompt = _usd_per_m_to_micro(input_match.group(1))
+            completion = _usd_per_m_to_micro(output_match.group(1))
+        elif _FREE_RE.search(input_text) and _FREE_RE.search(output_text):
+            prompt = completion = 0
+        else:
+            continue
+        if prompt is None or completion is None:
+            continue
+        row = {
+            "prompt_micro_per_m": prompt,
+            "completion_micro_per_m": completion,
+        }
+        cache_match = _CACHE_PRICE_RE.search(input_text)
+        if cache_match:
+            cached = _usd_per_m_to_micro(cache_match.group(1))
+            if cached is not None:
+                row["prompt_cached_micro_per_m"] = cached
+        out[model_id] = row
+    return out
 
 
 def parse(html: str) -> dict:
-    out: dict = {}
-    # Older Jina renders use markdown links with canonical model IDs.
+    # The embedded catalog carries canonical IDs and row-local prices. Parsing
+    # it first prevents a flattened page projection from associating one
+    # model's input price with another model's output price.
+    out: dict = _parse_embedded_catalog(html)
+    for model_id, row in _parse_dom_tables(html).items():
+        out.setdefault(model_id, row)
+
+    # Historical captured renders use markdown links with canonical model IDs.
     for match in _LINK_PRICE_RE.finditer(html):
         model_id, input_usd, cached_usd, output_usd = match.groups()
         if model_id in out:
@@ -150,17 +328,13 @@ def parse(html: str) -> dict:
         try:
             row: dict = {
                 "prompt_micro_per_m": int(round(float(input_usd) * 1_000_000)),
-                "completion_micro_per_m": int(
-                    round(float(output_usd) * 1_000_000)
-                ),
+                "completion_micro_per_m": int(round(float(output_usd) * 1_000_000)),
             }
         except ValueError:
             continue
         if cached_usd:
             try:
-                row["prompt_cached_micro_per_m"] = int(
-                    round(float(cached_usd) * 1_000_000)
-                )
+                row["prompt_cached_micro_per_m"] = int(round(float(cached_usd) * 1_000_000))
             except ValueError:
                 pass
         out[model_id] = row
@@ -174,9 +348,12 @@ def parse(html: str) -> dict:
                 "completion_micro_per_m": 0,
             }
 
-    # Current renders use display names in a tab-delimited table. Preserve
-    # link-layout values above if both layouts appear in one response.
-    for match in _ROW_RE.finditer(html):
+    # Historical plain-text renders use display names in a tab-delimited table.
+    # Never run this loose compatibility parser over a live HTML document.
+    plain_text_matches = (
+        () if re.search(r"<\s*(?:!doctype|html|body)\b", html, re.I) else _ROW_RE.finditer(html)
+    )
+    for match in plain_text_matches:
         name = match.group("name").strip()
         if not name or name not in _DISPLAY_TO_OR_ID:
             continue
@@ -220,9 +397,7 @@ def parse(html: str) -> dict:
         }
         if cache_usd is not None:
             try:
-                row["prompt_cached_micro_per_m"] = int(
-                    round(float(cache_usd) * 1_000_000)
-                )
+                row["prompt_cached_micro_per_m"] = int(round(float(cache_usd) * 1_000_000))
             except ValueError:
                 pass
         out[or_id] = row

--- a/scripts/pricing/parsers/openai.py
+++ b/scripts/pricing/parsers/openai.py
@@ -1,6 +1,6 @@
 # LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
 #
-# Parses platform.openai.com/docs/pricing as rendered by r.jina.ai.
+# Parses the normalized projection of OpenAI's official developer pricing page.
 # Captured fixture lives at tests/fixtures/pricing/openai.html.
 #
 # The page format changed in mid-2026: the flagship Standard table now has
@@ -21,7 +21,7 @@
 # We only extract the Standard tier (first flagship table on the page);
 # Batch/Flex/Priority variants come later in the doc and are skipped via
 # the `_live_seen` guard.
-"""OpenAI pricing parser (Jina-rendered markdown)."""
+"""OpenAI pricing parser for provider-owned HTML or normalized Markdown."""
 from __future__ import annotations
 
 import re

--- a/scripts/pricing/parsers/phala.py
+++ b/scripts/pricing/parsers/phala.py
@@ -1,6 +1,6 @@
 # LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
 #
-# Parses red-pill.ai/ (Phala's marketing landing page) via Jina.
+# Parses a captured rendering of Phala's historical marketing page.
 # The page renders each model as a card with inline price text:
 #
 #   "Qwen: Qwen3.5-27B GPU TEE ... by phala|262K context|$0.30/M input|$2.40/M output Intel TDX NVIDIA CC"
@@ -8,7 +8,7 @@
 # Each card has a `[Display: model-id](https://red-pill.ai/models/<vendor>/<slug>)`
 # link, plus the pipe-delimited price stanza. We pull the link href
 # (which carries the canonical id) and the two $-amounts.
-"""Phala (RedPill) pricing parser (Jina-rendered markdown)."""
+"""Phala (RedPill) legacy captured-page parser used by fixture checks."""
 from __future__ import annotations
 
 import re

--- a/scripts/pricing/parsers/siliconflow.py
+++ b/scripts/pricing/parsers/siliconflow.py
@@ -1,111 +1,101 @@
-# LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
-#
-# Parses siliconflow.com/pricing as rendered by r.jina.ai.
-# Captured fixture lives at tests/fixtures/pricing/siliconflow.html.
-#
-# The Framer-built page renders each pricing row as a stack of lines:
-#
-#     Qwen3-VL-32B-Instruct
-#     262K                       <- context length
-#     $
-#     0.2                        <- input $ / M tokens
-#     $
-#     0.6                        <- output $ / M tokens
-#     [Details](https://siliconflow.com/models/qwen3-vl-32b-instruct)
-#
-# We anchor on the [Details] link (which carries the canonical model
-# slug) and walk back to find the model name + the two $-numbers.
-"""SiliconFlow pricing parser (Jina-rendered Framer markdown)."""
+"""Parse SiliconFlow's official Framer pricing cards and legacy Markdown."""
+
 from __future__ import annotations
 
 import re
 
-# Native SiliconFlow slug → OR-canonical id. Most native ids match
-# OR's `vendor/model-name` convention but lowercased. We pass through
-# unmodified and let the catalog reject anything we don't recognize.
-_NAME_TO_OR_ID: dict[str, str] = {}
+from bs4 import BeautifulSoup
 
-
-# Match the [Details](https://siliconflow.com/models/<slug>) anchor at
-# the end of each row, capturing the slug. We then look UP in the
-# preceding ~400 chars for the input/output $ amounts.
 _DETAILS_RE = re.compile(
     r"\[Details\]\(https://(?:www\.)?siliconflow\.com/models/([\w.\-]+)\)"
 )
 _PRICE_RE = re.compile(r"\$\s*\n?\s*([\d.]+)")
 
 
-def parse(md: str) -> dict:
-    out: dict = {}
-    for m in _DETAILS_RE.finditer(md):
-        slug = m.group(1)
-        # Look back in a 600-char window for the two $-prefixed numbers
-        # that come right before this [Details] link.
-        window_start = max(0, m.start() - 600)
-        window = md[window_start : m.start()]
-        prices = _PRICE_RE.findall(window)
-        if len(prices) < 2:
+def _normalize(native_slug: str) -> str:
+    if "/" in native_slug:
+        return native_slug
+    lower = native_slug.casefold()
+    if lower.startswith("deepseek"):
+        return f"deepseek/{lower}"
+    if lower.startswith("qwen"):
+        return f"qwen/{lower}"
+    if lower.startswith("glm"):
+        return f"z-ai/{lower}"
+    if lower.startswith("kimi") or lower.startswith("moonshot"):
+        return f"moonshotai/{lower}"
+    if lower.startswith("llama") or lower.startswith("meta"):
+        return f"meta-llama/{lower}"
+    if lower.startswith("hy3") or lower.startswith("hunyuan"):
+        return f"tencent/{lower}"
+    if lower.startswith("minimax"):
+        return f"minimax/{lower}"
+    if lower.startswith("gpt-oss"):
+        return f"openai/{lower}"
+    if lower.startswith("gemma"):
+        return f"google/{lower}"
+    return lower
+
+
+def _skip_non_text(slug: str) -> bool:
+    return any(
+        tag in slug.casefold()
+        for tag in ("flux", "z-image", "wan2", "vidu", "sora", "kling")
+    )
+
+
+def _parse_cards(html: str) -> dict:
+    soup = BeautifulSoup(html, "html.parser")
+    output: dict = {}
+    for card in soup.select('[data-framer-name="LLM - Desktop"]'):
+        strings = list(card.stripped_strings)
+        if len(strings) < 6:
             continue
-        # Some rows have 2 prices (Input, Output), some have 3 (Input,
-        # Cached Input, Output). Take prices[0] = Input and prices[-1]
-        # = Output regardless. We need to be careful not to grab
-        # leftovers from the previous row though — the regex window
-        # walks back 600 chars which can span multiple rows. Trim to
-        # only the prices that come AFTER the most recent
-        # context-length marker (e.g., "262K", "1049K", "33K"),
-        # which is the boundary between rows.
-        # Find the LAST context marker (e.g., "262K\n$") before this
-        # Details link — that's the start of THIS row's data. Earlier
-        # markers belong to previous rows that are still in the window.
-        ctx_matches = list(re.finditer(r"\b(\d+[KMkm])\s*\n+\s*\$", window))
-        if not ctx_matches:
+        native_name = strings[0]
+        if _skip_non_text(native_name):
             continue
-        ctx_match = ctx_matches[-1]
-        row_window = window[ctx_match.end() - 1 :]
-        row_prices = _PRICE_RE.findall(row_window)
-        if len(row_prices) < 2:
+        values = _PRICE_RE.findall(card.get_text(" ", strip=True))
+        if len(values) < 2:
             continue
         try:
-            input_usd = float(row_prices[0])
-            output_usd = float(row_prices[-1])
+            prompt = int(round(float(values[0]) * 1_000_000))
+            completion = int(round(float(values[-1]) * 1_000_000))
+            cached = int(round(float(values[1]) * 1_000_000)) if len(values) >= 3 else None
         except ValueError:
             continue
-        # Skip image/video models (their slugs include 'flux', 'image',
-        # 'video', 'sora', etc., and their prices aren't per-token).
-        lowered = slug.lower()
-        if any(
-            tag in lowered
-            for tag in ("flux", "z-image", "wan2", "vidu", "sora", "kling")
-        ):
-            continue
-        or_id = _normalize(slug)
-        if or_id in out:
-            continue
-        out[or_id] = {
-            "prompt_micro_per_m": int(round(input_usd * 1_000_000)),
-            "completion_micro_per_m": int(round(output_usd * 1_000_000)),
+        row = {
+            "prompt_micro_per_m": prompt,
+            "completion_micro_per_m": completion,
         }
-    return out
+        if cached is not None:
+            row["prompt_cached_micro_per_m"] = cached
+        output.setdefault(_normalize(native_name), row)
+    return output
 
 
-def _normalize(native_slug: str) -> str:
-    """Convert SiliconFlow's slug ('qwen3-vl-32b-instruct') to OR-canonical
-    ('qwen/qwen3-vl-32b-instruct'). Adds vendor prefix when missing."""
-    if "/" in native_slug or native_slug in _NAME_TO_OR_ID:
-        return _NAME_TO_OR_ID.get(native_slug, native_slug)
-    lower = native_slug.lower()
-    if lower.startswith("deepseek"):
-        return f"deepseek/{native_slug}"
-    if lower.startswith("qwen"):
-        return f"qwen/{native_slug}"
-    if lower.startswith("glm"):
-        return f"z-ai/{native_slug.lower()}"
-    if lower.startswith("kimi") or lower.startswith("moonshot"):
-        return f"moonshotai/{native_slug}"
-    if lower.startswith("llama") or lower.startswith("meta"):
-        return f"meta-llama/{native_slug}"
-    if lower.startswith("hy") or lower.startswith("hunyuan"):
-        return f"tencent/{native_slug}"
-    if lower.startswith("minimax"):
-        return f"minimax/{native_slug}"
-    return native_slug
+def _parse_legacy_markdown(markdown: str) -> dict:
+    output: dict = {}
+    for match in _DETAILS_RE.finditer(markdown):
+        slug = match.group(1)
+        if _skip_non_text(slug):
+            continue
+        window = markdown[max(0, match.start() - 600) : match.start()]
+        context_matches = list(re.finditer(r"\b(\d+[KMkm])\s*\n+\s*\$", window))
+        if not context_matches:
+            continue
+        row_window = window[context_matches[-1].end() - 1 :]
+        values = _PRICE_RE.findall(row_window)
+        if len(values) < 2:
+            continue
+        row = {
+            "prompt_micro_per_m": int(round(float(values[0]) * 1_000_000)),
+            "completion_micro_per_m": int(round(float(values[-1]) * 1_000_000)),
+        }
+        if len(values) >= 3:
+            row["prompt_cached_micro_per_m"] = int(round(float(values[1]) * 1_000_000))
+        output.setdefault(_normalize(slug), row)
+    return output
+
+
+def parse(source: str) -> dict:
+    return _parse_cards(source) or _parse_legacy_markdown(source.replace(r"\$", "$"))

--- a/scripts/pricing/parsers/xiaomi.py
+++ b/scripts/pricing/parsers/xiaomi.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from decimal import Decimal
 
+from bs4 import BeautifulSoup
+
 
 def _money_to_micro_per_m(value: str) -> int:
     return int((Decimal(value) * Decimal(1_000_000)).to_integral_value())
@@ -26,13 +28,9 @@ def _overseas_payg_prices(html: str) -> dict[str, dict[str, int]]:
     if not section_match:
         return {}
 
-    mapping = {
-        "mimo-v2.5-pro": "xiaomi/mimo-v2.5-pro",
-        "mimo-v2.5": "xiaomi/mimo-v2.5",
-    }
     prices: dict[str, dict[str, int]] = {}
     table_row_pattern = re.compile(
-        r"\|\s*`?(mimo-v2\.5(?:-pro)?)`?\s*"
+        r"\|\s*`?(mimo-[a-z0-9._-]+)`?\s*"
         r"\|\s*\$([0-9.]+)\s*"
         r"\|\s*\$([0-9.]+)\s*"
         r"\|\s*\$([0-9.]+)\s*\|",
@@ -42,7 +40,7 @@ def _overseas_payg_prices(html: str) -> dict[str, dict[str, int]]:
     # currency markers. Keep the three-dollar requirement so the preceding RMB
     # table can never be interpreted as USD.
     flat_row_pattern = re.compile(
-        r"`?(mimo-v2\.5(?:-pro)?)`?\s+"
+        r"`?(mimo-[a-z0-9._-]+)`?\s+"
         r"\$([0-9.]+)\s+\$([0-9.]+)\s+\$([0-9.]+)",
         flags=re.I,
     )
@@ -51,9 +49,7 @@ def _overseas_payg_prices(html: str) -> dict[str, dict[str, int]]:
     if not rows:
         rows = flat_row_pattern.findall(section)
     for model, cache, prompt, completion in rows:
-        model_id = mapping.get(model.casefold())
-        if model_id is None:
-            continue
+        model_id = f"xiaomi/{model.casefold()}"
         prices[model_id] = {
             "prompt_micro_per_m": _money_to_micro_per_m(prompt),
             "completion_micro_per_m": _money_to_micro_per_m(completion),
@@ -67,13 +63,44 @@ def parse(html: str) -> dict[str, dict[str, int]]:
     # card parser below as a compatibility fallback for older captures and
     # for UltraSpeed if Xiaomi republishes its standalone PAYG card.
     prices = _overseas_payg_prices(html)
+    soup = BeautifulSoup(html, "html.parser")
+    for heading in soup.find_all("h4"):
+        title = heading.get_text(" ", strip=True)
+        if not re.fullmatch(r"MiMo-[A-Za-z0-9._-]+", title, flags=re.I):
+            continue
+        container = heading.parent
+        while container is not None:
+            if len(container.find_all("h4")) > 1:
+                container = None
+                break
+            block = container.get_text(" ", strip=True)
+            if re.search(r"Input\s*\(cache\s+miss\)", block, flags=re.I) and re.search(
+                r"\bOutput\b",
+                block,
+                flags=re.I,
+            ):
+                break
+            container = container.parent
+        if container is None:
+            continue
+        block = container.get_text(" ", strip=True)
+        cache = re.search(r"Input\s*\(cache\s+hit\)\s*\$\s*([0-9.]+)", block, flags=re.I)
+        prompt = re.search(r"Input\s*\(cache\s+miss\)\s*\$\s*([0-9.]+)", block, flags=re.I)
+        completion = re.search(r"\bOutput\s*\$\s*([0-9.]+)", block, flags=re.I)
+        if not prompt or not completion:
+            continue
+        row = {
+            "prompt_micro_per_m": _money_to_micro_per_m(prompt.group(1)),
+            "completion_micro_per_m": _money_to_micro_per_m(completion.group(1)),
+        }
+        if cache:
+            row["prompt_cached_micro_per_m"] = _money_to_micro_per_m(cache.group(1))
+        prices.setdefault(f"xiaomi/{title.casefold()}", row)
+
     text = re.sub(r"\s+", " ", html)
-    mapping = {
-        "MiMo-V2.5-Pro": "xiaomi/mimo-v2.5-pro",
-        "MiMo-V2.5-Pro-UltraSpeed": "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "MiMo-V2.5": "xiaomi/mimo-v2.5",
-    }
-    for title, model_id in mapping.items():
+    titles = dict.fromkeys(re.findall(r"####\s*(MiMo-[A-Za-z0-9._-]+)", html, flags=re.I))
+    for title in titles:
+        model_id = f"xiaomi/{title.casefold()}"
         block = _section(text, title)
         if not block:
             continue

--- a/scripts/pricing/parsers/zai.py
+++ b/scripts/pricing/parsers/zai.py
@@ -1,9 +1,9 @@
 # LLM-MAINTAINED FILE — re-validated every hour by scripts/pricing/refresh.py.
 #
-# Parses docs.z.ai/guides/overview/pricing as rendered by r.jina.ai.
+# Parses the official docs.z.ai pricing Markdown table.
 # Captured fixture lives at tests/fixtures/pricing/zai.html.
 #
-# Page format: Jina returns a clean markdown table.
+# Page format: the provider returns a clean Markdown table.
 #
 #   | Model | Input | Cached Input | Cached Input Storage | Output |
 #   | --- | --- | --- | --- | --- |
@@ -13,7 +13,7 @@
 #
 # Z.AI's GLM family is single-tier (no context conditioning), so we
 # emit flat ModelPrice rows.
-"""Z.AI / Zhipu pricing parser (Jina-rendered markdown)."""
+"""Z.AI / Zhipu official pricing Markdown parser."""
 from __future__ import annotations
 
 import re

--- a/scripts/pricing/providers/cerebras.py
+++ b/scripts/pricing/providers/cerebras.py
@@ -23,7 +23,10 @@ from scripts.pricing.base import (
     validate,
 )
 from scripts.pricing.manifest import write_discovered_chat_manifest
-from scripts.pricing.model_ids import remember_upstream_id
+from scripts.pricing.model_ids import (
+    canonicalize_unqualified_model_id,
+    remember_upstream_id,
+)
 from scripts.pricing.openai_catalog import openai_model_price, positive_int
 
 SLUG = "cerebras"
@@ -126,7 +129,9 @@ def fetch() -> ProviderPricingResult:
         native_id = source.get("id")
         if not isinstance(native_id, str):
             continue
-        canonical_id = _CANONICAL_BY_NATIVE.get(native_id)
+        canonical_id = _CANONICAL_BY_NATIVE.get(native_id) or canonicalize_unqualified_model_id(
+            native_id
+        )
         if canonical_id is None:
             continue
         price = openai_model_price(source)

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -20,11 +20,14 @@ from scripts.pricing.base import (
     fetch_provider,
     validate,
 )
+from scripts.pricing.model_ids import (
+    canonicalize_unqualified_model_id,
+    remember_upstream_id,
+)
 
 SLUG = "fireworks"
-URL = "https://r.jina.ai/https://docs.fireworks.ai/serverless/pricing"
+URL = "https://docs.fireworks.ai/serverless/pricing.md"
 MODELS_URL = "https://api.fireworks.ai/inference/v1/models"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -79,22 +82,24 @@ def _live_model_ids() -> set[str]:
         native_id = row.get("id")
         if not isinstance(native_id, str):
             continue
-        canonical = _NATIVE_TO_CANONICAL.get(native_id)
+        canonical = _NATIVE_TO_CANONICAL.get(native_id) or canonicalize_unqualified_model_id(
+            native_id
+        )
         if canonical is not None:
             discovered.add(canonical)
+            remember_upstream_id(UPSTREAM_ID_MAP, canonical, native_id)
     return discovered
 
 
 def fetch() -> ProviderPricingResult:
     global _DISCOVERED_LIVE_MODEL_IDS
 
+    live_model_ids = _live_model_ids()
     result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )
-    live_model_ids = _live_model_ids()
     _DISCOVERED_LIVE_MODEL_IDS = live_model_ids
     docs_only = sorted(set(result.prices) - live_model_ids)
     result.prices = {

--- a/scripts/pricing/providers/gemini.py
+++ b/scripts/pricing/providers/gemini.py
@@ -1,11 +1,9 @@
 """Google Gemini — human-only provider config.
 
-ai.google.dev/pricing 302-redirects to OAuth, so a direct fetch never
-returns HTML. We route through `r.jina.ai` against the docs path
-(`/gemini-api/docs/pricing`) which Jina renders server-side and
-returns as markdown. This bypass works because Jina hits the page
-from its own infrastructure (with whatever cookies/state it carries)
-and gives us back the rendered content.
+Google's official pricing page is server-rendered and is fetched directly.
+An earlier implementation depended on a Jina mirror, but that endpoint began
+returning HTTP 401 while the official page remained available. Keeping the
+official source as the fetch target removes that unnecessary failure mode.
 
 The Gemini docs pricing page has explicit context-tier breakdowns
 (e.g. "$1.25, prompts <= 200k tokens / $2.50, prompts > 200k tokens"
@@ -17,10 +15,12 @@ providers. This adapter owns AI Studio model discovery. The shared refresh may
 apply Google's standard Gemini token prices to existing Vertex endpoint rows,
 but it never invents Vertex availability from AI Studio discovery.
 """
+
 from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -36,9 +36,9 @@ from scripts.pricing.base import (
 )
 
 SLUG = "gemini"
-URL = "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing"
+URL = "https://ai.google.dev/gemini-api/docs/pricing"
+VERTEX_PRICING_URL = "https://cloud.google.com/vertex-ai/generative-ai/pricing"
 MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -56,6 +56,7 @@ EXPECTED_MODELS = [
     "google/gemini-3.6-flash",
 ]
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+_STANDARD_TEXT_MODEL_RE = re.compile(r"^google/gemini-\d+(?:\.\d+)?-(?:pro|flash|flash-lite)$")
 
 
 def _positive_int(value: object) -> int | None:
@@ -127,6 +128,41 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
     return rows
 
 
+def _known_manifest_model_ids() -> set[str]:
+    if not MANIFEST_PATH.exists():
+        return set()
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return set()
+    return {
+        model_id
+        for row in rows
+        if isinstance(row, dict) and isinstance((model_id := row.get("id")), str) and model_id
+    }
+
+
+def _new_required_price_ids(live_rows: dict[str, dict[str, Any]]) -> frozenset[str]:
+    """Require prices for newly launched stable Gemini text SKUs.
+
+    Google's model feed also contains aliases, TTS, image-output, robotics,
+    and experimental rows that do not correspond one-to-one with a token
+    pricing section.  Stable Pro, Flash, and Flash Lite release IDs do.  A new
+    stable release therefore triggers parser self-heal immediately, even when
+    OpenRouter has not listed it yet.
+    """
+
+    known = _known_manifest_model_ids()
+    return frozenset(
+        model_id
+        for model_id in live_rows
+        if model_id not in known and _STANDARD_TEXT_MODEL_RE.fullmatch(model_id)
+    )
+
+
 def _refresh_price(row: dict[str, Any], result: ProviderPricingResult, model_id: str) -> bool:
     price = result.prices.get(model_id)
     if price is None:
@@ -173,7 +209,7 @@ def _refresh_verified_vertex_manifest(result: ProviderPricingResult) -> int:
             updated += 1
     if not updated:
         return 0
-    raw["pricing_source"] = URL
+    raw["pricing_source"] = VERTEX_PRICING_URL
     raw["generated_at"] = (
         datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
@@ -188,13 +224,14 @@ def fetch() -> ProviderPricingResult:
     global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
 
     _DISCOVERED_MANIFEST_ROWS = {}
+    live_rows = _live_model_rows()
+    required_price_ids = _new_required_price_ids(live_rows)
     result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
+        required_models=required_price_ids,
     )
-    live_rows = _live_model_rows()
     _DISCOVERED_MANIFEST_ROWS = live_rows
     result.prices = {
         model_id: price for model_id, price in result.prices.items() if model_id in live_rows
@@ -224,9 +261,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         raise RuntimeError("gemini discovery returned no supported model rows")
 
     existing_by_id = {
-        row["id"]: row
-        for row in rows
-        if isinstance(row, dict) and isinstance(row.get("id"), str)
+        row["id"]: row for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
     }
     present_rows: dict[str, dict[str, Any]] = {}
     updated: list[str] = []
@@ -297,7 +332,4 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if vertex_updated:
         changes.append(f"repriced {vertex_updated} verified Vertex rows")
     suffix = f", {', '.join(changes)}" if changes else ""
-    return [
-        f"gemini: refreshed Google AI Studio manifest "
-        f"({len(updated)} priced rows{suffix})"
-    ]
+    return [f"gemini: refreshed Google AI Studio manifest ({len(updated)} priced rows{suffix})"]

--- a/scripts/pricing/providers/grok.py
+++ b/scripts/pricing/providers/grok.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "grok"
-URL = "https://r.jina.ai/https://docs.x.ai/developers/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://docs.x.ai/developers/pricing.md"
 
 EXPECTED_MODELS = [
     "x-ai/grok-4.5",
@@ -24,5 +23,4 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )

--- a/scripts/pricing/providers/kimi.py
+++ b/scripts/pricing/providers/kimi.py
@@ -26,6 +26,7 @@ from scripts.pricing.base import (
     fetch_json,
     log,
     parser_path,
+    runtime_required_models,
     validate,
 )
 
@@ -161,11 +162,40 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
     return rows
 
 
+def _known_manifest_model_ids() -> set[str]:
+    if not MANIFEST_PATH.exists():
+        return set()
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return set()
+    return {
+        model_id
+        for row in rows
+        if isinstance(row, dict) and isinstance((model_id := row.get("id")), str) and model_id
+    }
+
+
+def _new_required_price_ids(live_rows: dict[str, dict[str, Any]]) -> frozenset[str]:
+    known = _known_manifest_model_ids()
+    return frozenset(
+        model_id
+        for model_id in live_rows
+        if model_id not in known and model_id != "moonshotai/moonshot-v1-auto"
+    )
+
+
 def fetch() -> ProviderPricingResult:
     """Fetch first-party prices and intersect them with live account models."""
 
     global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
     _DISCOVERED_MANIFEST_ROWS = {}
+
+    live_rows = _live_model_rows()
+    required_price_ids = _new_required_price_ids(live_rows) | runtime_required_models(SLUG)
 
     html = _combined_html()
     if not html:
@@ -185,11 +215,14 @@ def fetch() -> ProviderPricingResult:
     if prices is None:
         raise RuntimeError(f"{SLUG}: parser returned None unexpectedly")
 
-    live_rows = _live_model_rows()
     prices = {model_id: price for model_id, price in prices.items() if model_id in live_rows}
     _DISCOVERED_MANIFEST_ROWS = live_rows
 
-    errors = validate(prices, EXPECTED_MODELS)
+    errors = validate(
+        prices,
+        EXPECTED_MODELS,
+        required_models=required_price_ids,
+    )
     if errors:
         raise RuntimeError(f"{SLUG}: validation failed: {errors}")
     return ProviderPricingResult(

--- a/scripts/pricing/providers/makora.py
+++ b/scripts/pricing/providers/makora.py
@@ -1,22 +1,33 @@
-"""Makora — provider-native pricing refresh.
+"""Makora provider-native model and pricing refresh.
 
-Makora's OpenAI-compatible `/v1/models` feed exposes model ids and context
-windows but not prices. The public homepage "lineup" publishes per-token
-prices for the headline models, so the hourly refresh parses that page and
-updates `data/provider_models/makora.json`, which is what the runtime catalog
-uses for Makora routes.
+Makora's authenticated OpenAI-compatible `/v1/models` feed exposes model IDs,
+capabilities, context windows, and the account's billable per-token prices.
+Using that single structured source means newly launched priced chat models can
+be published without adding a homepage label to a parser first.
 """
 
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from scripts.pricing.base import (
+    ModelPrice,
+    ProviderPricingResult,
+    fetch_json,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
+    validate,
+)
+from scripts.pricing.model_ids import canonicalize_native_model_id
+from scripts.pricing.openai_catalog import dollars_per_token_to_micro_per_m
 
 SLUG = "makora"
 URL = "https://www.makora.com/"
+MODELS_URL = "https://inference.makora.com/v1/models"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -36,13 +47,136 @@ EXPECTED_MODELS = [
     "qwen/qwen3.6-27b",
     "qwen/qwen3.6-35b-a3b",
 ]
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _existing_native_ids() -> tuple[dict[str, str], set[str]]:
+    if not MANIFEST_PATH.exists():
+        return {}, set()
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}, set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return {}, set()
+    native_to_canonical: dict[str, str] = {}
+    canonical_ids: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        native_id = row.get("upstream_id")
+        if not isinstance(model_id, str):
+            continue
+        canonical_ids.add(model_id)
+        if isinstance(native_id, str):
+            native_to_canonical[native_id] = model_id
+            native_to_canonical[native_id.casefold()] = model_id
+    return native_to_canonical, canonical_ids
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _live_catalog() -> tuple[dict[str, dict[str, Any]], dict[str, ModelPrice]]:
+    api_key = os.environ.get("MAKORA_API_KEY") or os.environ.get("MAKORA_OPTIMIZE_TOKEN")
+    if not api_key:
+        raise RuntimeError("makora: MAKORA_API_KEY is required")
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {api_key}"},
+    )
+    source_rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(source_rows, list):
+        raise RuntimeError("makora: /v1/models response has no data list")
+
+    existing_ids, _known = _existing_native_ids()
+    discovered: dict[str, dict[str, Any]] = {}
+    prices: dict[str, ModelPrice] = {}
+    for source in source_rows:
+        if not isinstance(source, dict):
+            continue
+        native_id = source.get("id")
+        if not isinstance(native_id, str) or not native_id:
+            continue
+        model_id = (
+            existing_ids.get(native_id)
+            or existing_ids.get(native_id.casefold())
+            or canonicalize_native_model_id(native_id)
+        )
+        if model_id is None:
+            continue
+        row: dict[str, Any] = {
+            "id": model_id,
+            "upstream_id": native_id,
+            "display_name": str(source.get("name") or native_id),
+            "title": str(source.get("name") or native_id),
+            "model_type": "chat",
+            "input_modalities": _string_list(source.get("input_modalities")) or ["text"],
+            "output_modalities": _string_list(source.get("output_modalities")) or ["text"],
+            "endpoints": ["chat/completions"],
+            "status": 1,
+        }
+        context_length = _positive_int(source.get("max_model_len") or source.get("context_length"))
+        if context_length is not None:
+            row["context_length"] = context_length
+        max_output_tokens = _positive_int(source.get("max_output_length"))
+        if max_output_tokens is not None:
+            row["max_output_tokens"] = max_output_tokens
+        features = _string_list(source.get("supported_features"))
+        if features:
+            row["features"] = features
+        supported_parameters = _string_list(source.get("supported_sampling_parameters"))
+        if supported_parameters:
+            row["supported_parameters"] = supported_parameters
+        discovered[model_id] = row
+
+        pricing = source.get("pricing")
+        if not isinstance(pricing, dict):
+            continue
+        prompt = dollars_per_token_to_micro_per_m(pricing.get("prompt"))
+        completion = dollars_per_token_to_micro_per_m(pricing.get("completion"))
+        if prompt is None or completion is None:
+            continue
+        cached = dollars_per_token_to_micro_per_m(pricing.get("input_cache_read"))
+        prices[model_id] = ModelPrice(
+            prompt_micro_per_m=prompt,
+            completion_micro_per_m=completion,
+            prompt_cached_micro_per_m=cached,
+        )
+    if not discovered:
+        raise RuntimeError("makora: /v1/models returned no supported model ids")
+    return discovered, prices
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    discovered, prices = _live_catalog()
+    errors = validate(prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    return ProviderPricingResult(
         slug=SLUG,
-        url=URL,
-        expected_models=EXPECTED_MODELS,
+        prices=prices,
+        source="api",
+        fetched_url=MODELS_URL,
+        notes=[f"discovered {len(discovered)} live models with {len(prices)} prices"],
     )
 
 
@@ -60,26 +194,27 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not isinstance(rows, list):
         raise RuntimeError("makora manifest has no models list")
 
+    if not _DISCOVERED_MANIFEST_ROWS:
+        raise RuntimeError("makora manifest refresh has no live discovery rows")
+    existing_by_id = {
+        row["id"]: row for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
     updated: list[str] = []
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        model_id = row.get("id")
-        if not isinstance(model_id, str):
-            continue
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        row = dict(existing_by_id.get(model_id) or {})
+        row.update(discovered)
         price = result.prices.get(model_id)
-        if price is None:
-            # Gemma is intentionally still a fallback row because Makora's
-            # public lineup does not publish a Gemma price today.
-            continue
-        tier = price.tiers[0]
-        row["input_token_price_per_m"] = tier.prompt_micro_per_m
-        row["output_token_price_per_m"] = tier.completion_micro_per_m
-        if tier.prompt_cached_micro_per_m is not None:
-            row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
-        else:
-            row.pop("cached_input_token_price_per_m", None)
-        updated.append(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            row["input_token_price_per_m"] = tier.prompt_micro_per_m
+            row["output_token_price_per_m"] = tier.completion_micro_per_m
+            if tier.prompt_cached_micro_per_m is not None:
+                row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+            else:
+                row.pop("cached_input_token_price_per_m", None)
+            updated.append(model_id)
+        present_rows[model_id] = row
 
     missing = sorted(set(EXPECTED_MODELS) - set(updated))
     if missing:
@@ -87,21 +222,28 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not updated:
         raise RuntimeError("makora manifest update touched no rows")
 
+    rebuilt = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, rebuilt, provider_slug=SLUG)
+    if guarded is rows:
+        return ["makora: kept old manifest (mass-prune guard)"]
+
     raw["_about"] = (
-        "Provider-native supplement for Makora Inference routes. Makora's "
-        "/v1/models feed publishes native model ids and context windows but "
-        "not pricing. Prices are refreshed hourly from Makora's public "
-        "homepage lineup where listed; Gemma keeps the OpenRouter canonical "
-        "price fallback because Makora does not currently publish a Gemma "
-        "price on its homepage/pricing page/API feed."
+        "Provider-native supplement for Makora Inference routes. Model IDs, "
+        "capabilities, context windows, and account-billable prices refresh "
+        "hourly from Makora's authenticated /v1/models feed."
     )
-    raw["pricing_source"] = (
-        "https://www.makora.com/; https://openrouter.ai/api/v1/models for Gemma fallback"
+    raw["source"] = MODELS_URL
+    raw["pricing_source"] = MODELS_URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )
-    raw["generated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
-    )
-    raw["model_count"] = len(rows)
+    raw["model_count"] = len(guarded)
+    raw["models"] = guarded
 
     MANIFEST_PATH.write_text(
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",

--- a/scripts/pricing/providers/minimax.py
+++ b/scripts/pricing/providers/minimax.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    fetch_json,
+    fetch_provider,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
+)
 
 SLUG = "minimax"
-URL = "https://r.jina.ai/https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://platform.minimax.io/docs/guides/pricing-paygo.md"
+MODELS_URL = "https://api.minimax.io/v1/models"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -25,15 +33,101 @@ EXPECTED_MODELS = [
     "minimax/minimax-m2.7",
     "minimax/minimax-m2.7-highspeed",
 ]
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _known_manifest_model_ids() -> set[str]:
+    if not MANIFEST_PATH.exists():
+        return set()
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return set()
+    return {
+        model_id
+        for row in rows
+        if isinstance(row, dict) and isinstance((model_id := row.get("id")), str) and model_id
+    }
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    api_key = os.environ.get("MINIMAX_API_KEY") or os.environ.get("MINIMAX_TOKEN_PLAN_API_KEY")
+    if not api_key:
+        raise RuntimeError("minimax: MINIMAX_API_KEY is required")
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {api_key}"},
+    )
+    source_rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(source_rows, list):
+        raise RuntimeError("minimax: /v1/models response has no data list")
+
+    discovered: dict[str, dict[str, Any]] = {}
+    for source in source_rows:
+        if not isinstance(source, dict):
+            continue
+        native_id = source.get("id")
+        if not isinstance(native_id, str) or not native_id:
+            continue
+        status = source.get("status")
+        if isinstance(status, int) and not isinstance(status, bool) and status != 1:
+            continue
+        model_id = f"minimax/{native_id.casefold()}"
+        row: dict[str, Any] = {
+            "id": model_id,
+            "upstream_id": native_id,
+            "display_name": str(source.get("display_name") or source.get("name") or native_id),
+            "title": str(source.get("title") or native_id),
+            "model_type": "chat",
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "status": 1,
+        }
+        for field, value in (
+            ("created", source.get("created")),
+            ("context_length", source.get("context_length")),
+            ("max_output_tokens", source.get("max_output_tokens")),
+        ):
+            parsed = _positive_int(value)
+            if parsed is not None:
+                row[field] = parsed
+        discovered[model_id] = row
+    if not discovered:
+        raise RuntimeError("minimax: /v1/models returned no active models")
+    return discovered
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
+    discovered = _live_model_rows()
+    required = frozenset(discovered) - _known_manifest_model_ids()
+    result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
+        required_models=required,
     )
+    result.prices = {
+        model_id: price for model_id, price in result.prices.items() if model_id in discovered
+    }
+    result.source = "api"
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    return result
 
 
 def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
@@ -42,46 +136,62 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     if not isinstance(rows, list):
         raise RuntimeError("minimax manifest has no models list")
 
+    if not _DISCOVERED_MANIFEST_ROWS:
+        raise RuntimeError("minimax manifest refresh has no live discovery rows")
+    existing_by_id = {
+        row["id"]: row for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
     updated: list[str] = []
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        model_id = row.get("id")
-        if not isinstance(model_id, str):
-            continue
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        row = dict(existing_by_id.get(model_id) or {})
+        row.update(discovered)
         price = result.prices.get(model_id)
-        if price is None:
-            continue
-        tier = price.tiers[0]
-        row["input_token_price_per_m"] = tier.prompt_micro_per_m
-        row["output_token_price_per_m"] = tier.completion_micro_per_m
-        if len(price.tiers) > 1:
-            row["price_tiers"] = [
-                {
-                    "max_prompt_tokens": price_tier.max_prompt_tokens,
-                    "input_token_price_per_m": price_tier.prompt_micro_per_m,
-                    "output_token_price_per_m": price_tier.completion_micro_per_m,
-                    "cached_input_token_price_per_m": price_tier.prompt_cached_micro_per_m,
-                }
-                for price_tier in price.tiers
-            ]
-        elif tier.prompt_cached_micro_per_m is not None:
-            row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
-            row.pop("price_tiers", None)
-        else:
-            row.pop("cached_input_token_price_per_m", None)
-            row.pop("price_tiers", None)
-        updated.append(model_id)
+        if price is not None:
+            tier = price.tiers[0]
+            row["input_token_price_per_m"] = tier.prompt_micro_per_m
+            row["output_token_price_per_m"] = tier.completion_micro_per_m
+            if len(price.tiers) > 1:
+                row["price_tiers"] = [
+                    {
+                        "max_prompt_tokens": price_tier.max_prompt_tokens,
+                        "input_token_price_per_m": price_tier.prompt_micro_per_m,
+                        "output_token_price_per_m": price_tier.completion_micro_per_m,
+                        "cached_input_token_price_per_m": (price_tier.prompt_cached_micro_per_m),
+                    }
+                    for price_tier in price.tiers
+                ]
+                row.pop("cached_input_token_price_per_m", None)
+            elif tier.prompt_cached_micro_per_m is not None:
+                row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
+                row.pop("price_tiers", None)
+            else:
+                row.pop("cached_input_token_price_per_m", None)
+                row.pop("price_tiers", None)
+            updated.append(model_id)
+        present_rows[model_id] = row
 
     missing = sorted(set(EXPECTED_MODELS) - set(updated))
     if missing:
         raise RuntimeError(f"minimax manifest did not update expected model(s): {missing}")
 
-    raw["source"] = "https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise"
-    raw["generated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
+    rebuilt = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
     )
-    raw["model_count"] = len(rows)
+    guarded = guard_manifest_prune(rows, rebuilt, provider_slug=SLUG)
+    if guarded is rows:
+        return ["minimax: kept old manifest (mass-prune guard)"]
+
+    raw["source"] = MODELS_URL
+    raw["pricing_source"] = URL
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(guarded)
+    raw["models"] = guarded
     MANIFEST_PATH.write_text(
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",

--- a/scripts/pricing/providers/morph.py
+++ b/scripts/pricing/providers/morph.py
@@ -21,8 +21,7 @@ from scripts.pricing.model_ids import remember_upstream_id
 
 SLUG = "morph"
 MODELS_URL = "https://api.morphllm.com/v1/models"
-URL = "https://r.jina.ai/https://www.morphllm.com/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://www.morphllm.com/pricing"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -65,7 +64,7 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
+        accepted_status_codes=frozenset({429}),
     )
     api_key = os.environ.get("MORPH_API_KEY")
     if not api_key:

--- a/scripts/pricing/providers/novita.py
+++ b/scripts/pricing/providers/novita.py
@@ -5,6 +5,7 @@ operator account can invoke it. The public pricing table remains authoritative
 for billing. This intersection lets new launches appear automatically without
 guessing capabilities or creating zero-priced routes.
 """
+
 from __future__ import annotations
 
 import json
@@ -21,12 +22,14 @@ from scripts.pricing.base import (
     reconcile_manifest_tombstones,
     validate,
 )
-from scripts.pricing.model_ids import canonicalize_native_model_id
+from scripts.pricing.model_ids import (
+    canonicalize_native_model_id,
+    canonicalize_unqualified_model_id,
+)
 
 SLUG = "novita"
-URL = "https://r.jina.ai/https://novita.ai/pricing"
+URL = "https://novita.ai/pricing"
 MODELS_URL = "https://api.novita.ai/openai/v1/models"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -80,6 +83,36 @@ def _existing_native_ids() -> dict[str, str]:
     return mapped
 
 
+def _known_manifest_model_ids() -> set[str]:
+    if not MANIFEST_PATH.exists():
+        return set()
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return set()
+    return {
+        model_id
+        for row in rows
+        if isinstance(row, dict) and isinstance((model_id := row.get("id")), str) and model_id
+    }
+
+
+def _new_required_price_ids(
+    discovered: dict[str, dict[str, Any]],
+) -> frozenset[str]:
+    """Return newly listed, live chat models that need a public price row."""
+
+    known = _known_manifest_model_ids()
+    return frozenset(
+        model_id
+        for model_id, row in discovered.items()
+        if model_id not in known and row.get("status") == 1
+    )
+
+
 def _live_model_rows() -> dict[str, dict[str, Any]]:
     api_key = os.environ.get("NOVITA_API_KEY")
     if not api_key:
@@ -110,6 +143,7 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
             existing_ids.get(native_id)
             or existing_ids.get(native_id.casefold())
             or canonicalize_native_model_id(native_id)
+            or canonicalize_unqualified_model_id(native_id)
         )
         if model_id is None:
             continue
@@ -145,18 +179,17 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
 def fetch() -> ProviderPricingResult:
     global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
 
+    discovered = _live_model_rows()
+    required_price_ids = _new_required_price_ids(discovered)
     result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
+        required_models=required_price_ids,
     )
-    discovered = _live_model_rows()
     _DISCOVERED_MANIFEST_ROWS = discovered
     result.prices = {
-        model_id: price
-        for model_id, price in result.prices.items()
-        if model_id in discovered
+        model_id: price for model_id, price in result.prices.items() if model_id in discovered
     }
     errors = validate(result.prices, EXPECTED_MODELS)
     if errors:
@@ -190,9 +223,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         return value
 
     existing_by_id = {
-        row["id"]: row
-        for row in rows
-        if isinstance(row, dict) and isinstance(row.get("id"), str)
+        row["id"]: row for row in rows if isinstance(row, dict) and isinstance(row.get("id"), str)
     }
     present_rows: dict[str, dict[str, Any]] = {}
     updated = 0

--- a/scripts/pricing/providers/openai.py
+++ b/scripts/pricing/providers/openai.py
@@ -1,14 +1,11 @@
 """OpenAI — human-only provider config.
 
-OpenAI's pricing pages are Cloudflare-blocked from script User-Agents
-(every direct fetch returns 403 even with a real Chrome UA). We work
-around this by routing through `r.jina.ai`, a free reader-proxy
-service that uses a headless browser to render the page server-side
-and returns clean markdown. The X-Return-Format header asks Jina for
-markdown specifically (the default truncates to a summary).
+OpenAI's current developer pricing page is server-rendered and fetched
+directly. The shared parser projection converts its tables into stable text,
+so pricing refreshes do not depend on an external reader proxy.
 
-We point at `platform.openai.com/docs/pricing` rather than the marketing
-`/api/pricing/` because the docs page has the comprehensive table —
+We point at the developer API pricing reference rather than the marketing
+pricing page because the docs page has the comprehensive table —
 GPT-5.5 / 5.4 family with full Short / Long context tier breakdowns
 and Standard / Batch / Flex / Priority processing tiers.
 
@@ -27,8 +24,7 @@ from __future__ import annotations
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "openai"
-URL = "https://r.jina.ai/https://platform.openai.com/docs/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://developers.openai.com/api/docs/pricing"
 
 # Models we expect to see on the page. Strict floor — parser must
 # extract these or validation triggers self-heal. Today the page
@@ -46,5 +42,4 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )

--- a/scripts/pricing/providers/phala.py
+++ b/scripts/pricing/providers/phala.py
@@ -25,6 +25,7 @@ To add a new Phala-served model: probe /v1/models, find the
 `phala/<bare>` row, and add the `phala/<bare>` → OR-canonical pair
 to `_NATIVE_TO_OR_ID`. Refresh.py overlays the price automatically.
 """
+
 from __future__ import annotations
 
 import os
@@ -40,7 +41,10 @@ from scripts.pricing.base import (
     ProviderPricingResult,
     validate,
 )
-from scripts.pricing.model_ids import remember_upstream_id
+from scripts.pricing.model_ids import (
+    canonicalize_unqualified_model_id,
+    remember_upstream_id,
+)
 from trusted_router.provider_lifecycle import (
     provider_model_retired,
     provider_price_microdollars,
@@ -140,9 +144,7 @@ def _extract_rates(pricing: object) -> tuple[float, float, float | None] | None:
 
 
 def fetch() -> ProviderPricingResult:
-    api_key = os.environ.get("PHALA_CONFIDENTIAL_API_KEY") or os.environ.get(
-        "PHALA_API_KEY"
-    )
+    api_key = os.environ.get("PHALA_CONFIDENTIAL_API_KEY") or os.environ.get("PHALA_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
@@ -169,7 +171,7 @@ def fetch() -> ProviderPricingResult:
         # into a confidential route.
         if not native_id.startswith("phala/"):
             continue
-        or_id = _NATIVE_TO_OR_ID.get(native_id)
+        or_id = _NATIVE_TO_OR_ID.get(native_id) or canonicalize_unqualified_model_id(native_id)
         if or_id is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)

--- a/scripts/pricing/providers/siliconflow.py
+++ b/scripts/pricing/providers/siliconflow.py
@@ -1,9 +1,7 @@
 """SiliconFlow — human-only provider config.
 
-SiliconFlow's pricing page is mostly image-rendered (Framer-built
-marketing site). We fetch /pricing for completeness but the parser
-relies on a hardcoded table for the routed models. The cross-check
-vs OpenRouter and the LLM self-heal will surface drift.
+SiliconFlow's pricing page is a Framer site whose server-rendered model cards
+contain the authoritative prices. The parser reads those cards directly.
 
 OpenAI-compatible chat completions at api.siliconflow.com/v1.
 """
@@ -12,8 +10,7 @@ from __future__ import annotations
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "siliconflow"
-URL = "https://r.jina.ai/https://www.siliconflow.com/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://www.siliconflow.com/pricing"
 
 EXPECTED_MODELS: list[str] = []  # parser tolerant of upstream renames
 
@@ -23,5 +20,4 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )

--- a/scripts/pricing/providers/streamlake.py
+++ b/scripts/pricing/providers/streamlake.py
@@ -15,8 +15,7 @@ from scripts.pricing.openai_catalog import probe_openai_chat
 
 SLUG = "streamlake"
 BASE_URL = "https://vanchin.streamlake.ai/api/gateway/v1/endpoints"
-URL = "https://r.jina.ai/https://www.streamlake.ai/document/DOC/mgrnm4xm362hvp5wyce"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://www.streamlake.ai/document/DOC/mgrnm4xm362hvp5wyce"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -45,7 +44,6 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )
     _LIVE_CANARY_OK = probe_openai_chat(
         base_url=BASE_URL,

--- a/scripts/pricing/providers/venice.py
+++ b/scripts/pricing/providers/venice.py
@@ -1,8 +1,7 @@
 """Venice — human-only provider config.
 
 docs.venice.ai/overview/pricing has a clean repeating-card layout
-with each model's input/output rates. Routed through r.jina.ai for
-clean markdown.
+with each model's input/output rates and an official Markdown representation.
 
 Venice uses its own model-id namespace (`zai-org-glm-4.6`, not
 `z-ai/glm-4.6` or `glm-4.6`). Until Nov 2026 the venice API
@@ -20,8 +19,7 @@ from __future__ import annotations
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "venice"
-URL = "https://r.jina.ai/https://docs.venice.ai/overview/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://docs.venice.ai/overview/pricing.md"
 
 EXPECTED_MODELS = [
     "z-ai/glm-4.6",
@@ -58,5 +56,4 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )

--- a/scripts/pricing/providers/xiaomi.py
+++ b/scripts/pricing/providers/xiaomi.py
@@ -10,8 +10,7 @@ from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "xiaomi"
 PUBLIC_PRICING_URL = "https://mimo.mi.com/docs/en-US/price/pay-as-you-go"
-URL = f"https://r.jina.ai/{PUBLIC_PRICING_URL}"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = PUBLIC_PRICING_URL
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -32,7 +31,6 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )
 
 

--- a/scripts/pricing/providers/zai.py
+++ b/scripts/pricing/providers/zai.py
@@ -2,9 +2,7 @@
 
 docs.z.ai/guides/llm/glm-4.6 is a per-model overview — not a price
 table. The dedicated pricing page lives at /guides/overview/pricing
-which has a clean text-models table. The page is partly JS-rendered
-so a direct fetch returns the navigation chrome only; we route
-through r.jina.ai which renders server-side and returns markdown.
+which has a clean text-models table and an official Markdown representation.
 
 All current Z.AI text models (GLM-5.1 down to GLM-4-32B-0414) are on
 the page with Input / Cached Input / Output prices.
@@ -14,8 +12,7 @@ from __future__ import annotations
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "zai"
-URL = "https://r.jina.ai/https://docs.z.ai/guides/overview/pricing"
-JINA_HEADERS = {"X-Return-Format": "markdown"}
+URL = "https://docs.z.ai/guides/overview/pricing.md"
 
 EXPECTED_MODELS = [
     "z-ai/glm-4.6",
@@ -27,5 +24,4 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
-        extra_headers=JINA_HEADERS,
     )

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -48,6 +48,7 @@ from scripts.pricing.base import (
     ModelPrice,
     PriceTier,
     ProviderPricingResult,
+    configure_runtime_required_models,
     guard_manifest_prune,
     log,
 )
@@ -61,6 +62,7 @@ from trusted_router.provider_lifecycle import provider_model_retired  # noqa: E4
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SNAPSHOT_PATH = REPO_ROOT / "src" / "trusted_router" / "data" / "openrouter_snapshot.json"
+PROVIDER_MANIFEST_DIR = SNAPSHOT_PATH.parent / "provider_models"
 
 # Provider modules in order of execution. Together stays first because existing
 # refresh contracts depend on it; Meta is another JSON API path that does not
@@ -79,8 +81,8 @@ PROVIDER_SLUGS = [
     "kimi",
     "zai",
     "fireworks",
-    # New backends added 2026-05-08. Each has a Jina-rendered or
-    # direct-fetch pricing source + a parser in scripts/pricing/parsers/.
+    # New backends added 2026-05-08. Each has a provider-owned pricing source
+    # plus a deterministic parser in scripts/pricing/parsers/.
     "grok",
     "novita",
     "phala",
@@ -128,6 +130,34 @@ _PRICING_RESULT_PROVIDER_ALIASES: dict[str, tuple[str, ...]] = {
     "cloudflare_workers_ai": ("cloudflare-workers-ai",),
     "atlas_cloud": ("atlas-cloud",),
 }
+
+# These providers run a pricing-page parser (Kimi has a custom multi-page
+# wrapper around the same parser contract). A new model seen in a fresh
+# upstream catalog is a strict parser requirement only for this set; API-priced
+# providers such as Cerebras, Makora, and Phala discover prices directly.
+_SELF_HEALING_PARSER_SLUGS = frozenset(
+    {
+        "anthropic",
+        "cohere",
+        "deepseek",
+        "fireworks",
+        "gemini",
+        "grok",
+        "kimi",
+        "minimax",
+        "mistral",
+        "morph",
+        "novita",
+        "openai",
+        "siliconflow",
+        "streamlake",
+        "thinkingmachines",
+        "venice",
+        "voyage",
+        "xiaomi",
+        "zai",
+    }
+)
 
 # A shared official price feed does not prove shared model availability.
 # Vertex routes must already exist in the endpoint snapshot before the merger
@@ -177,6 +207,127 @@ def _endpoint_pricing_source(slug: str, healed_slugs: set[str]) -> str:
 
 def _import_provider(slug: str):
     return importlib.import_module(f"scripts.pricing.providers.{slug}")
+
+
+def _result_slug_for_provider(provider_slug: str) -> str:
+    return next(
+        (
+            result_slug
+            for result_slug, provider_slugs in _PRICING_RESULT_PROVIDER_ALIASES.items()
+            if provider_slug in provider_slugs
+        ),
+        provider_slug,
+    )
+
+
+def _model_outputs_text(model: dict[str, Any]) -> bool:
+    """Return false only when upstream metadata explicitly excludes text."""
+
+    architecture = model.get("architecture")
+    if not isinstance(architecture, dict):
+        return True
+    output_modalities = architecture.get("output_modalities")
+    if isinstance(output_modalities, list) and output_modalities:
+        return "text" in {str(value).casefold() for value in output_modalities}
+    modality = architecture.get("modality")
+    if isinstance(modality, str) and "->" in modality:
+        return "text" in modality.rsplit("->", 1)[-1].casefold()
+    return True
+
+
+def _manifest_model_ids(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return set()
+    return {
+        model_id
+        for row in rows
+        if isinstance(row, dict) and isinstance((model_id := row.get("id")), str) and model_id
+    }
+
+
+def _known_model_ids(snapshot: dict[str, Any]) -> set[str]:
+    known = {
+        model_id
+        for model in snapshot.get("models", [])
+        if isinstance(model, dict) and isinstance((model_id := model.get("id")), str) and model_id
+    }
+    for path in PROVIDER_MANIFEST_DIR.glob("*.json"):
+        known.update(_manifest_model_ids(path))
+    return known
+
+
+def _latest_model_created(snapshot: dict[str, Any]) -> int:
+    created_values = [
+        created
+        for model in snapshot.get("models", [])
+        if isinstance(model, dict)
+        and isinstance((created := model.get("created")), int)
+        and not isinstance(created, bool)
+        and created > 0
+    ]
+    return max(created_values, default=0)
+
+
+def _is_launch_candidate(model_id: str) -> bool:
+    """Exclude catalog aliases that do not represent independently priced launches."""
+
+    return not model_id.startswith("~") and not model_id.endswith(":free")
+
+
+def _new_parser_requirements(
+    upstream_snapshot: dict[str, Any],
+    committed_snapshot: dict[str, Any],
+) -> dict[str, set[str]]:
+    """Find genuinely new model launches that need parsed prices.
+
+    This is deliberately launch-oriented.  Existing manifest rows, including
+    explicitly unresolved historical rows, are not reclassified here.  The
+    separate coverage audit reports those. OpenRouter frequently adds an old
+    model to another provider long after launch; treating that provider/model
+    pair as a launch produced hundreds of false parser failures. A hard gate
+    now requires all three signals: globally unknown ID, newer creation time
+    than the committed catalog, and a text endpoint on a parser-priced
+    provider. Provider-native discovery remains stricter for providers that
+    expose authenticated model lists.
+    """
+
+    known = _known_model_ids(committed_snapshot)
+    latest_known_created = _latest_model_created(committed_snapshot)
+    required: dict[str, set[str]] = {}
+    for model in upstream_snapshot.get("models", []):
+        if not isinstance(model, dict) or not _model_outputs_text(model):
+            continue
+        model_id = model.get("id")
+        endpoints = model.get("endpoints")
+        created = model.get("created")
+        if (
+            not isinstance(model_id, str)
+            or not isinstance(endpoints, list)
+            or model_id in known
+            or not _is_launch_candidate(model_id)
+            or not isinstance(created, int)
+            or isinstance(created, bool)
+            or created <= latest_known_created
+        ):
+            continue
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict):
+                continue
+            provider_slug = endpoint.get("tr_provider_slug")
+            if not isinstance(provider_slug, str):
+                continue
+            result_slug = _result_slug_for_provider(provider_slug)
+            if result_slug not in _SELF_HEALING_PARSER_SLUGS:
+                continue
+            required.setdefault(result_slug, set()).add(model_id)
+    return required
 
 
 def _upstream_id_map_for(slug: str) -> dict[str, str]:
@@ -678,9 +829,7 @@ def _merge_snapshot(
             new_model["pricing"] = new_pricing
             # Tag pricing_source as self-healed if ANY of the slugs that
             # priced this model went through the LLM rewrite.
-            new_model["pricing_source"] = _endpoint_pricing_source(
-                cheapest_slug, healed_slugs
-            )
+            new_model["pricing_source"] = _endpoint_pricing_source(cheapest_slug, healed_slugs)
         else:
             # Every keyed provider returned $0 for a model that OR prices
             # above $0 — a feed glitch across all of them at once. Fall
@@ -821,9 +970,7 @@ def _write_provider_manifests(results: dict[str, ProviderPricingResult]) -> list
             # before adding or expanding provider-owned rebuild behavior.
             continue
         manifest_path_value = getattr(module, "MANIFEST_PATH", None)
-        manifest_path = (
-            Path(manifest_path_value) if manifest_path_value is not None else None
-        )
+        manifest_path = Path(manifest_path_value) if manifest_path_value is not None else None
         before_text: str | None = None
         before_rows: list[Any] | None = None
         if manifest_path is not None and manifest_path.exists():
@@ -922,15 +1069,27 @@ def main(argv: list[str] | None = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
 
+    log.info("pricing.refresh.openrouter_ingest")
+    or_snapshot = build_openrouter_snapshot()
+    committed_snapshot = _read_existing_snapshot()
+    required_by_slug = _new_parser_requirements(or_snapshot, committed_snapshot)
+    configure_runtime_required_models(required_by_slug)
+    if required_by_slug:
+        log.info(
+            "pricing.refresh.new_parser_models providers=%d models=%d",
+            len(required_by_slug),
+            sum(len(model_ids) for model_ids in required_by_slug.values()),
+        )
+
     log.info("pricing.refresh.start providers=%d", len(PROVIDER_SLUGS))
     results, failures = _fetch_all_providers()
 
     unrecovered_failures = _apply_stale_fallbacks(
         results,
         failures,
-        _read_existing_snapshot(),
+        committed_snapshot,
     )
-    healed = [slug for slug, res in results.items() if res.source == "self_healed"]
+    healed = [slug for slug, res in results.items() if res.heal_diff is not None]
 
     if len(unrecovered_failures) > MAX_TOLERATED_FAILURES:
         log.error(
@@ -942,9 +1101,6 @@ def main(argv: list[str] | None = None) -> int:
         for line in _summary_lines(results, healed, failures, [], []):
             print(line)
         return 1
-
-    log.info("pricing.refresh.openrouter_ingest")
-    or_snapshot = build_openrouter_snapshot()
 
     provider_index = _index_provider_prices(results)
     disagreements = _cross_check(provider_index, or_snapshot)

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -578,9 +578,8 @@ PROVIDERS: dict[str, Provider] = {
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
     # Makora Inference — OpenAI-compatible API at inference.makora.com/v1.
-    # The public /v1/models feed exposes model IDs and context windows, but not
-    # prices. TR carries provider-native IDs in data/provider_models/makora.json
-    # and sources prices from Makora's public homepage lineup where published.
+    # Its authenticated /v1/models feed supplies model IDs, context windows,
+    # capabilities, and account-billable prices to the generated manifest.
     "makora": Provider(
         slug="makora",
         name="Makora",

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -31,7 +31,7 @@
     "wafer",
     "zai"
   ],
-  "model_count": 164,
+  "model_count": 165,
   "models": [
     {
       "id": "anthropic/claude-fable-5",
@@ -185,9 +185,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97391077484998,
+          "uptime_last_30m": 99.91124916796095,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.90293100609254,
+          "uptime_last_1d": 98.91513569883213,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -279,7 +279,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.71602434077079,
+          "uptime_last_1d": 99.70857618651124,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -372,7 +372,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.83464566929135,
+          "uptime_last_1d": 98.79594423320658,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -411,7 +411,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.43778110944528,
+          "uptime_last_1d": 99.3935948455562,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -504,9 +504,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90397311247149,
-          "uptime_last_5m": 99.80952380952381,
-          "uptime_last_1d": 99.88585478699657,
+          "uptime_last_30m": 99.9438202247191,
+          "uptime_last_5m": 99.91401547721411,
+          "uptime_last_1d": 99.87899481430424,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -547,7 +547,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 74.32432432432432,
+          "uptime_last_1d": 66.53225806451613,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -655,9 +655,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97037037037036,
-          "uptime_last_5m": 99.95404411764706,
-          "uptime_last_1d": 99.85326740496025,
+          "uptime_last_30m": 99.91352805534206,
+          "uptime_last_5m": 99.97550220480157,
+          "uptime_last_1d": 99.85052072251955,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -696,7 +696,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.99056603773585,
+          "uptime_last_1d": 96.58314350797266,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -896,9 +896,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.7946611909651,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.64925190090753,
+          "uptime_last_1d": 99.66223499820337,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -948,7 +948,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 81.53846153846153,
+          "uptime_last_1d": 73.87387387387388,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1041,9 +1041,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96080677741264,
-          "uptime_last_5m": 99.90022805017104,
-          "uptime_last_1d": 99.70505331423806,
+          "uptime_last_30m": 99.91944532351333,
+          "uptime_last_5m": 99.96535396697078,
+          "uptime_last_1d": 99.70233772332132,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1084,7 +1084,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.45141308555942,
+          "uptime_last_1d": 97.89264413518886,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1327,8 +1327,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89494326936546,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.89495798319328,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -1401,7 +1401,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9748971480371,
+          "uptime_last_1d": 99.97379093442215,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1442,7 +1442,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.83922829581994,
+          "uptime_last_1d": 99.84447900466563,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -1525,7 +1525,7 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
@@ -1615,9 +1615,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.5702005730659,
+          "uptime_last_30m": 99.93928354584092,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.92690140686678,
+          "uptime_last_1d": 99.9244031231665,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1658,9 +1658,45 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99971945675607,
+          "uptime_last_1d": 99.9998797414441,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | deepseek/deepseek-v3.1-terminus",
+          "model_id": "deepseek/deepseek-v3.1-terminus",
+          "model_name": "DeepSeek: DeepSeek V3.1 Terminus",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.00000027",
+            "completion": "0.000001",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 163840,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "tools",
+            "tool_choice",
+            "max_tokens"
+          ],
+          "status": -2,
+          "uptime_last_30m": 93.7641723356009,
+          "uptime_last_5m": 96.25,
+          "uptime_last_1d": 96.54579556111284,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -1748,9 +1784,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.53939008894537,
-          "uptime_last_5m": 99.34747145187602,
-          "uptime_last_1d": 98.20979886189816,
+          "uptime_last_30m": 99.44867844981353,
+          "uptime_last_5m": 97.875,
+          "uptime_last_1d": 98.25794100669832,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1792,9 +1828,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.95344506517691,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89893310613404,
+          "uptime_last_1d": 99.90214249159739,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -1826,9 +1862,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.75596529284165,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.65576040068635,
+          "uptime_last_30m": 99.85390796201608,
+          "uptime_last_5m": 99.71181556195965,
+          "uptime_last_1d": 99.64447334905022,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -1865,11 +1901,48 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.87125362277122,
+          "uptime_last_30m": 99.97184684684684,
+          "uptime_last_5m": 99.95460735360872,
+          "uptime_last_1d": 99.89563292407821,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | deepseek/deepseek-v3.2-20251201",
+          "model_id": "deepseek/deepseek-v3.2",
+          "model_name": "DeepSeek: DeepSeek V3.2",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.00000027",
+            "completion": "0.00000042",
+            "input_cache_read": "0.000000135",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 163840,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 98.76617514294313,
+          "uptime_last_5m": 99.22065270336094,
+          "uptime_last_1d": 94.95005611048765,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -1988,11 +2061,47 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.39387813657467,
+          "uptime_last_30m": 99.96454738832428,
+          "uptime_last_5m": 99.91813344248874,
+          "uptime_last_1d": 99.43547871709116,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | deepseek/deepseek-v3.2-exp",
+          "model_id": "deepseek/deepseek-v3.2-exp",
+          "model_name": "DeepSeek: DeepSeek V3.2 Exp",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 163840,
+          "pricing": {
+            "prompt": "0.00000027",
+            "completion": "0.00000041",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 163840,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "tools",
+            "tool_choice",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.09857516719977,
+          "uptime_last_5m": 99.38800489596083,
+          "uptime_last_1d": 95.97850664980913,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -2081,9 +2190,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.68941626184599,
-          "uptime_last_5m": 99.725011191405,
-          "uptime_last_1d": 99.68883376625762,
+          "uptime_last_30m": 99.7043691929663,
+          "uptime_last_5m": 99.72897743920305,
+          "uptime_last_1d": 99.67389972449467,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2121,9 +2230,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99819195964454,
+          "uptime_last_30m": 99.99581749645795,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96241109193615,
+          "uptime_last_1d": 99.96285967511368,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -2157,9 +2266,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.38661846850898,
-          "uptime_last_5m": 99.62039513415581,
-          "uptime_last_1d": 98.74753958648493,
+          "uptime_last_30m": 99.48477524331557,
+          "uptime_last_5m": 99.52100057657339,
+          "uptime_last_1d": 98.75552776926078,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2198,9 +2307,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99563429149147,
-          "uptime_last_5m": 99.99666522159603,
-          "uptime_last_1d": 99.96010452701222,
+          "uptime_last_30m": 99.996548574216,
+          "uptime_last_5m": 99.99497234791352,
+          "uptime_last_1d": 99.96730377906708,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -2243,9 +2352,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.53042133176193,
-          "uptime_last_5m": 99.53659533869428,
-          "uptime_last_1d": 98.56609673159684,
+          "uptime_last_30m": 99.44483485593815,
+          "uptime_last_5m": 99.55970647098066,
+          "uptime_last_1d": 98.58676396270319,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -2280,9 +2389,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99699410845257,
-          "uptime_last_5m": 99.9664654594232,
-          "uptime_last_1d": 98.21079258755876,
+          "uptime_last_30m": 99.99383724154931,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.23821540427879,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2313,9 +2422,9 @@
           "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000001134",
-            "completion": "0.0000002791",
-            "input_cache_read": "0.0000000851"
+            "prompt": "0.00000009",
+            "completion": "0.000000195",
+            "input_cache_read": "0.0000000196"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2367,6 +2476,22 @@
             "prompt": "0.00000014",
             "completion": "0.00000028",
             "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "morph | deepseek/deepseek-v4-flash",
+          "model_id": "morph-dsv4flash",
+          "model_name": "DeepSeek: DeepSeek V4 Flash",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2441,9 +2566,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.80181200453,
-          "uptime_last_5m": 99.56709956709958,
-          "uptime_last_1d": 98.60478688803641,
+          "uptime_last_30m": 98.65726753944276,
+          "uptime_last_5m": 96.91516709511568,
+          "uptime_last_1d": 98.55068890053325,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2481,9 +2606,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99753393916228,
+          "uptime_last_30m": 99.99482809893847,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95380122094092,
+          "uptime_last_1d": 99.9531998886641,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -2525,9 +2650,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 96.16282084521649,
-          "uptime_last_5m": 99.1554054054054,
-          "uptime_last_1d": 71.44375089830194,
+          "uptime_last_30m": 98.69546621043627,
+          "uptime_last_5m": 98.92966360856269,
+          "uptime_last_1d": 79.36014625228519,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -2561,9 +2686,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.54505686789152,
-          "uptime_last_5m": 98.97058823529412,
-          "uptime_last_1d": 97.4677301663186,
+          "uptime_last_30m": 99.61857379767828,
+          "uptime_last_5m": 99.8868778280543,
+          "uptime_last_1d": 97.55702222653596,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2604,9 +2729,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.91834382054854,
-          "uptime_last_5m": 99.91718426501035,
-          "uptime_last_1d": 99.62981845934415,
+          "uptime_last_30m": 99.96064762761412,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.6179540472333,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -2641,9 +2766,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9676427762498,
+          "uptime_last_30m": 99.49247462373118,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.15620747013459,
+          "uptime_last_1d": 99.21249052156516,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2683,13 +2808,30 @@
             "response_format",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 79.84532458401688,
-          "uptime_last_5m": 79.47368421052632,
-          "uptime_last_1d": 94.5739471106758,
+          "status": -2,
+          "uptime_last_30m": 82.15634989828538,
+          "uptime_last_5m": 96.29629629629629,
+          "uptime_last_1d": 93.72402868228326,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "baseten | deepseek/deepseek-v4-pro",
+          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+          "model_name": "DeepSeek: DeepSeek V4 Pro",
+          "provider_name": "baseten",
+          "tag": "baseten",
+          "tr_provider_slug": "baseten",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000174",
+            "completion": "0.00000348",
+            "input_cache_read": "0.000000145"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         },
         {
           "name": "crusoe | deepseek/deepseek-v4-pro",
@@ -2717,26 +2859,9 @@
           "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.000001318",
-            "completion": "0.0000026361",
-            "input_cache_read": "0.0000009885"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000174",
-            "completion": "0.00000348",
-            "input_cache_read": "0.000000145"
+            "prompt": "0.000000627",
+            "completion": "0.000001344",
+            "input_cache_read": "0.00000006886"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2871,9 +2996,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90705366008513,
+          "uptime_last_30m": 96.3209680376459,
+          "uptime_last_5m": 99.92732558139535,
+          "uptime_last_1d": 99.86155563501269,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -2914,9 +3039,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.77897564069086,
-          "uptime_last_5m": 99.8306951697128,
-          "uptime_last_1d": 98.34515223303349,
+          "uptime_last_30m": 99.03807288712866,
+          "uptime_last_5m": 99.80497213887698,
+          "uptime_last_1d": 98.29029377502717,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3048,9 +3173,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.44261917850248,
-          "uptime_last_5m": 99.29964035585841,
-          "uptime_last_1d": 99.49994400476835,
+          "uptime_last_30m": 99.34030660246832,
+          "uptime_last_5m": 99.48080845540515,
+          "uptime_last_1d": 99.5000070642644,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3091,9 +3216,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58987373053326,
-          "uptime_last_5m": 99.43830604929603,
-          "uptime_last_1d": 99.02136010145908,
+          "uptime_last_30m": 99.39975185272124,
+          "uptime_last_5m": 99.18240218026085,
+          "uptime_last_1d": 98.994437368302,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3234,9 +3359,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 96.53018736988203,
-          "uptime_last_5m": 98.61878453038673,
-          "uptime_last_1d": 98.53791345652552,
+          "uptime_last_30m": 97.9048697621744,
+          "uptime_last_5m": 93.45794392523365,
+          "uptime_last_1d": 98.49194561864503,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3309,9 +3434,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.3724998039062,
-          "uptime_last_5m": 99.66755319148936,
-          "uptime_last_1d": 99.46749478525967,
+          "uptime_last_30m": 99.54814327965823,
+          "uptime_last_5m": 99.2831541218638,
+          "uptime_last_1d": 99.46865089852008,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3443,9 +3568,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.66166685462953,
-          "uptime_last_5m": 99.8719262295082,
-          "uptime_last_1d": 99.78558450932078,
+          "uptime_last_30m": 99.73175235688599,
+          "uptime_last_5m": 99.72536903535874,
+          "uptime_last_1d": 99.78487360775183,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3487,9 +3612,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.06538296057548,
-          "uptime_last_5m": 98.32988793384833,
-          "uptime_last_1d": 97.36796847856435,
+          "uptime_last_30m": 97.34284326315115,
+          "uptime_last_5m": 97.2611992999478,
+          "uptime_last_1d": 97.33993108583276,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3621,9 +3746,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.52618380292078,
-          "uptime_last_5m": 99.45746091709199,
-          "uptime_last_1d": 99.64720147054508,
+          "uptime_last_30m": 99.48962850111333,
+          "uptime_last_5m": 99.56363950574614,
+          "uptime_last_1d": 99.64961379614178,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3665,9 +3790,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 88.8437487143621,
-          "uptime_last_5m": 88.92523364485982,
-          "uptime_last_1d": 89.68793954181245,
+          "uptime_last_30m": 92.03328123212992,
+          "uptime_last_5m": 90.60693641618496,
+          "uptime_last_1d": 89.62143138025954,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3900,9 +4025,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.75019007277072,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.48811745368711,
+          "uptime_last_30m": 99.82633863965268,
+          "uptime_last_5m": 99.92721979621543,
+          "uptime_last_1d": 99.50700345097584,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3976,9 +4101,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 94.87249050461205,
-          "uptime_last_5m": 96.14147909967846,
-          "uptime_last_1d": 94.80303621137652,
+          "uptime_last_30m": 93.41844159280328,
+          "uptime_last_5m": 96.64496745117677,
+          "uptime_last_1d": 94.84183442098728,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4110,9 +4235,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.57264957264957,
-          "uptime_last_5m": 99.32885906040269,
-          "uptime_last_1d": 99.8637776348025,
+          "uptime_last_30m": 99.43246311010215,
+          "uptime_last_5m": 99.83443708609272,
+          "uptime_last_1d": 99.8636979360876,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4154,9 +4279,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 96.80658671235484,
-          "uptime_last_5m": 97.57009345794393,
-          "uptime_last_1d": 97.65334667214435,
+          "uptime_last_30m": 97.01118298981997,
+          "uptime_last_5m": 95.90389917290271,
+          "uptime_last_1d": 97.55622213909783,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4226,6 +4351,133 @@
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "google/gemini-3.5-flash-lite",
+      "name": "Google: Gemini 3.5 Flash-Lite",
+      "created": 1784646726,
+      "description": "Gemini 3.5 Flash-Lite is a high-efficiency model from Google with upgraded agentic capabilities. It is suited for subagents that execute focused tasks within complex, multi-agent workflows.",
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+file+audio+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video",
+          "file",
+          "audio"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000003",
+        "completion": "0.0000025",
+        "image": "0.0000003",
+        "audio": "0.0000003",
+        "input_audio_cache": "0.00000003",
+        "web_search": "0.014",
+        "internal_reasoning": "0.0000025",
+        "input_cache_read": "0.00000003",
+        "input_cache_write": "0.00000008333333333333334"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "Google AI Studio | google/gemini-3.5-flash-lite-20260721",
+          "model_id": "google/gemini-3.5-flash-lite",
+          "model_name": "Google: Gemini 3.5 Flash-Lite",
+          "provider_name": "Google AI Studio",
+          "tag": "google-ai-studio",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000025",
+            "image": "0.0000003",
+            "audio": "0.0000003",
+            "input_audio_cache": "0.00000003",
+            "web_search": "0.014",
+            "internal_reasoning": "0.0000025",
+            "input_cache_read": "0.00000003",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "structured_outputs",
+            "tool_choice",
+            "tools",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.4072505953956,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.8544794302002,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "google-ai-studio",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Google | google/gemini-3.5-flash-lite-20260721",
+          "model_id": "google/gemini-3.5-flash-lite",
+          "model_name": "Google: Gemini 3.5 Flash-Lite",
+          "provider_name": "Google",
+          "tag": "google-vertex/global",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000025",
+            "image": "0.0000003",
+            "audio": "0.0000003",
+            "input_audio_cache": "0.00000003",
+            "web_search": "0.014",
+            "internal_reasoning": "0.0000025",
+            "input_cache_read": "0.00000003",
+            "input_cache_write": "0.00000008333333333333334",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "seed",
+            "response_format",
+            "stop",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.92502624081571,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.84930338356554,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "google-vertex",
+          "pricing_source": "provider_direct"
         }
       ],
       "pricing_source": "provider_direct"
@@ -4305,9 +4557,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.18426802621995,
-          "uptime_last_5m": 99.03100775193798,
-          "uptime_last_1d": 99.66455307833913,
+          "uptime_last_30m": 99.52123230641132,
+          "uptime_last_5m": 99.22178988326849,
+          "uptime_last_1d": 99.65846478979546,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4347,9 +4599,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.73284889933747,
-          "uptime_last_5m": 99.75024975024975,
-          "uptime_last_1d": 99.81220297409168,
+          "uptime_last_30m": 99.81026052689192,
+          "uptime_last_5m": 99.8509131569139,
+          "uptime_last_1d": 99.70751314396455,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4377,7 +4629,7 @@
       },
       "pricing": {
         "prompt": "0.00000005",
-        "completion": "0.00000015"
+        "completion": "0.0000001"
       },
       "top_provider": {
         "context_length": 131072,
@@ -4419,12 +4671,28 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.9940772328832,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99870741867817,
+          "uptime_last_1d": 99.9985161342577,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "novita | google/gemma-3-12b-it",
+          "model_id": "google/gemma-3-12b-it",
+          "model_name": "Google: Gemma 3 12B",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000005",
+            "completion": "0.0000001"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -4491,9 +4759,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8470363288719,
-          "uptime_last_5m": 99.82030548068283,
-          "uptime_last_1d": 99.83669358360065,
+          "uptime_last_30m": 99.80137233658361,
+          "uptime_last_5m": 99.91836734693878,
+          "uptime_last_1d": 99.82696297623681,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4527,10 +4795,10 @@
             "response_format",
             "repetition_penalty"
           ],
-          "status": 0,
-          "uptime_last_30m": 98.78744135691086,
-          "uptime_last_5m": 94.7470398277718,
-          "uptime_last_1d": 89.58536701470308,
+          "status": -5,
+          "uptime_last_30m": 54.958852973615,
+          "uptime_last_5m": 97.34199645599527,
+          "uptime_last_1d": 89.22917826744093,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -4561,10 +4829,10 @@
             "top_k",
             "repetition_penalty"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.61200657319674,
-          "uptime_last_5m": 99.69175443103005,
-          "uptime_last_1d": 87.4087968193329,
+          "status": -2,
+          "uptime_last_30m": 91.17459417310555,
+          "uptime_last_5m": 85.45821762181266,
+          "uptime_last_1d": 87.47651446315079,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -4602,9 +4870,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99693871303495,
-          "uptime_last_5m": 99.99020472132432,
-          "uptime_last_1d": 99.71668480316114,
+          "uptime_last_30m": 99.91037131882202,
+          "uptime_last_5m": 99.97461284589998,
+          "uptime_last_1d": 99.74203393257316,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -4672,9 +4940,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97844827586206,
-          "uptime_last_5m": 99.94275901545507,
-          "uptime_last_1d": 99.98952297402256,
+          "uptime_last_30m": 99.95853719213865,
+          "uptime_last_5m": 99.49238578680203,
+          "uptime_last_1d": 99.98781217297748,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4742,7 +5010,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99019817507842,
+          "uptime_last_1d": 99.9903113861764,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -4815,9 +5083,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 98.216649251132,
-          "uptime_last_5m": 89.28571428571429,
-          "uptime_last_1d": 99.77886010422553,
+          "uptime_last_30m": 99.87812309567336,
+          "uptime_last_5m": 99.5751911639762,
+          "uptime_last_1d": 99.78329142256106,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -4857,11 +5125,45 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.26467208971,
-          "uptime_last_5m": 99.25442684063374,
-          "uptime_last_1d": 99.14718068792402,
+          "uptime_last_30m": 99.0282636459548,
+          "uptime_last_5m": 98.76768598813327,
+          "uptime_last_1d": 99.17255712855032,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | google/gemma-4-26b-a4b-it-20260403",
+          "model_id": "google/gemma-4-26b-a4b-it",
+          "model_name": "Google: Gemma 4 26B A4B ",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000012",
+            "completion": "0.0000004",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs"
+          ],
+          "status": 0,
+          "uptime_last_30m": 98.91619895490614,
+          "uptime_last_5m": 95.86523736600306,
+          "uptime_last_1d": 71.64783582844157,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -4875,6 +5177,23 @@
           "pricing": {
             "prompt": "0.00000013",
             "completion": "0.0000004"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "makora | google/gemma-4-26b-a4b-it",
+          "model_id": "google/gemma-4-26b-a4b-it",
+          "model_name": "Google: Gemma 4 26B A4B ",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000001",
+            "completion": "0.00000034",
+            "input_cache_read": "0.000000034"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -4964,7 +5283,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98139811748949,
+          "uptime_last_1d": 99.9807447451206,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -5002,9 +5321,9 @@
             "structured_outputs"
           ],
           "status": -2,
-          "uptime_last_30m": 93.88391118036618,
-          "uptime_last_5m": 90.75907590759076,
-          "uptime_last_1d": 94.14899883151907,
+          "uptime_last_30m": 93.56775300171527,
+          "uptime_last_5m": 97.93388429752066,
+          "uptime_last_1d": 94.17539649077288,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5044,9 +5363,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 98.60851316209681,
-          "uptime_last_5m": 98.63065804488399,
-          "uptime_last_1d": 98.70047547039711,
+          "uptime_last_30m": 97.66484745459427,
+          "uptime_last_5m": 96.77303693079958,
+          "uptime_last_1d": 98.66245104544804,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5083,9 +5402,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9236825192802,
-          "uptime_last_5m": 99.9252801992528,
-          "uptime_last_1d": 99.90779437014572,
+          "uptime_last_30m": 99.91244468633901,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.91436462035458,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -5127,11 +5446,47 @@
             "top_logprobs"
           ],
           "status": -2,
-          "uptime_last_30m": 94.91783567134269,
-          "uptime_last_5m": 96.13832853025937,
-          "uptime_last_1d": 96.02288249337815,
+          "uptime_last_30m": 92.62076835298593,
+          "uptime_last_5m": 89.91660348749052,
+          "uptime_last_1d": 96.03297714287416,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | google/gemma-4-31b-it-20260402",
+          "model_id": "google/gemma-4-31b-it",
+          "model_name": "Google: Gemma 4 31B",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000013",
+            "completion": "0.0000004",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs",
+            "tool_choice",
+            "tools"
+          ],
+          "status": -2,
+          "uptime_last_30m": 83.99042962654738,
+          "uptime_last_5m": 99.59432048681542,
+          "uptime_last_1d": 49.85206808812797,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -5164,10 +5519,10 @@
             "min_p",
             "response_format"
           ],
-          "status": -5,
-          "uptime_last_30m": 75.98499061913697,
-          "uptime_last_5m": 90.67796610169492,
-          "uptime_last_1d": 75.73148743686802,
+          "status": -2,
+          "uptime_last_30m": 86.18342010412495,
+          "uptime_last_5m": 90.03215434083602,
+          "uptime_last_1d": 76.31851423962681,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5206,9 +5561,9 @@
             "tools"
           ],
           "status": -5,
-          "uptime_last_30m": 73.8295318127251,
-          "uptime_last_5m": 62.5,
-          "uptime_last_1d": 88.63820750743695,
+          "uptime_last_30m": 78.06398005816368,
+          "uptime_last_5m": 62.76595744680851,
+          "uptime_last_1d": 88.64911901067684,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5315,8 +5670,8 @@
         "instruct_type": "alpaca"
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000004"
+        "prompt": "0.00000009",
+        "completion": "0.00000009"
       },
       "top_provider": {
         "context_length": 4096,
@@ -5355,12 +5710,28 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.77116704805492,
-          "uptime_last_5m": 98.9247311827957,
-          "uptime_last_1d": 99.94764123776115,
+          "uptime_last_30m": 99.55849889624724,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.93769470404985,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
+        },
+        {
+          "name": "novita | gryphe/mythomax-l2-13b",
+          "model_id": "gryphe/mythomax-l2-13b",
+          "model_name": "MythoMax 13B",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 8192,
+          "pricing": {
+            "prompt": "0.00000009",
+            "completion": "0.00000009"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
         }
       ],
       "pricing_source": "provider_direct"
@@ -5503,7 +5874,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99998845572058,
+          "uptime_last_1d": 99.99998884339348,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5645,9 +6016,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59375396724641,
-          "uptime_last_5m": 99.89837398373984,
-          "uptime_last_1d": 99.09937678323891,
+          "uptime_last_30m": 99.08129175946549,
+          "uptime_last_5m": 99.14163090128756,
+          "uptime_last_1d": 99.07090237425001,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5714,9 +6085,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9738402511336,
+          "uptime_last_30m": 99.97859955487074,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 93.79205739668475,
+          "uptime_last_1d": 94.16218562368884,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5742,8 +6113,8 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.0000000509",
-        "completion": "0.000000335"
+        "prompt": "0.00000003",
+        "completion": "0.00000005"
       },
       "top_provider": {
         "context_length": 80000,
@@ -5752,6 +6123,22 @@
       },
       "per_request_limits": null,
       "endpoints": [
+        {
+          "name": "novita | meta-llama/llama-3.2-3b-instruct",
+          "model_id": "meta-llama/llama-3.2-3b-instruct",
+          "model_name": "Meta: Llama 3.2 3B Instruct",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000003",
+            "completion": "0.00000005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
         {
           "name": "cloudflare-workers-ai | meta-llama/llama-3.2-3b-instruct",
           "model_id": "meta-llama/llama-3.2-3b-instruct",
@@ -5789,8 +6176,9 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.000000135",
-        "completion": "0.0000004"
+        "prompt": "0.000000119",
+        "completion": "0.0000003825",
+        "input_cache_read": "0.00000008"
       },
       "top_provider": {
         "context_length": 131072,
@@ -5831,9 +6219,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 95.64606741573034,
-          "uptime_last_5m": 99.4475138121547,
-          "uptime_last_1d": 93.58272587890363,
+          "uptime_last_30m": 96.03102189781022,
+          "uptime_last_5m": 93.12714776632302,
+          "uptime_last_1d": 93.48400801763347,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5871,9 +6259,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 95.2009141115978,
-          "uptime_last_5m": 96.04395604395604,
-          "uptime_last_1d": 96.07090621892003,
+          "uptime_last_30m": 95.88688946015425,
+          "uptime_last_5m": 92.69005847953217,
+          "uptime_last_1d": 96.05483821787519,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -5910,9 +6298,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.92086330935251,
+          "uptime_last_30m": 98.23008849557522,
           "uptime_last_5m": null,
-          "uptime_last_1d": 92.04775022956841,
+          "uptime_last_1d": 96.70613991441934,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5959,9 +6347,9 @@
           "tr_provider_slug": "makora",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.00000018",
-            "completion": "0.0000004",
-            "input_cache_read": "0.00000015"
+            "prompt": "0.000000119",
+            "completion": "0.0000003825",
+            "input_cache_read": "0.00000008"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -6050,9 +6438,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.78848768696179,
+          "uptime_last_30m": 99.86648865153538,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90629730184281,
+          "uptime_last_1d": 99.90501285278064,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -6135,9 +6523,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98581560283688,
-          "uptime_last_5m": 99.89270386266095,
-          "uptime_last_1d": 99.62430316878196,
+          "uptime_last_30m": 99.06917027764403,
+          "uptime_last_5m": 93.77203290246769,
+          "uptime_last_1d": 99.63710185068614,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6348,7 +6736,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98868202139099,
+          "uptime_last_1d": 99.98891966759003,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6420,7 +6808,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.91909597117589,
+          "uptime_last_1d": 98.83401920438958,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6490,9 +6878,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.3006993006993,
+          "uptime_last_1d": 99.29230109371649,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6564,9 +6952,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.73913691585302,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.73956395565146,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -6604,9 +6992,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.78241693619523,
+          "uptime_last_1d": 99.78457059679768,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6648,11 +7036,48 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.58920558680401,
+          "uptime_last_1d": 99.56661632411846,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | minimax/minimax-m2.5-20260211",
+          "model_id": "minimax/minimax-m2.5",
+          "model_name": "MiniMax: MiniMax M2.5",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 196608,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000003",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 131072,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.95426829268293,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -6807,9 +7232,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 96.88572829818538,
-          "uptime_last_5m": 95.22998296422487,
-          "uptime_last_1d": 99.00046035579828,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.95411945023744,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6847,10 +7272,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -5,
-          "uptime_last_30m": 72.78582930756843,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 90.80394116807082,
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": 97.43589743589743,
+          "uptime_last_1d": 90.9447695161981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6883,9 +7308,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.5702005730659,
-          "uptime_last_5m": 98.44961240310077,
-          "uptime_last_1d": 98.66482201286865,
+          "uptime_last_30m": 99.66804979253112,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.65927155210062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -6917,9 +7342,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 97.74353329664281,
-          "uptime_last_5m": 97.71689497716895,
-          "uptime_last_1d": 98.15324255358279,
+          "uptime_last_30m": 98.00332778702163,
+          "uptime_last_5m": 97.5,
+          "uptime_last_1d": 98.131960980106,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -6951,9 +7376,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 95.39748953974896,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.88372093023256,
+          "uptime_last_1d": 98.91910499139415,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -6991,9 +7416,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.2824427480916,
-          "uptime_last_5m": 97.79005524861878,
-          "uptime_last_1d": 99.15128076506092,
+          "uptime_last_30m": 98.84196185286103,
+          "uptime_last_5m": 97.84946236559139,
+          "uptime_last_1d": 99.13328306537267,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7033,9 +7458,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.78700745473908,
-          "uptime_last_5m": 99.45945945945947,
-          "uptime_last_1d": 99.4317066127635,
+          "uptime_last_30m": 99.69262295081968,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.42544016832176,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -7052,6 +7477,22 @@
             "prompt": "0.0000003",
             "completion": "0.0000012",
             "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "morph | minimax/minimax-m2.7",
+          "model_id": "morph-minimax27-230b",
+          "model_name": "MiniMax: MiniMax M2.7",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000028",
+            "completion": "0.0000012"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7124,10 +7565,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.56962803565939,
-          "uptime_last_5m": 98.99665551839465,
-          "uptime_last_1d": 99.17552182163188,
+          "status": -2,
+          "uptime_last_30m": 94.81292517006803,
+          "uptime_last_5m": 42.63157894736842,
+          "uptime_last_1d": 99.05332882984312,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7158,9 +7599,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.730028224322,
-          "uptime_last_5m": 99.76945244956772,
-          "uptime_last_1d": 98.9313373630525,
+          "uptime_last_30m": 99.82920580700257,
+          "uptime_last_5m": 99.90215264187867,
+          "uptime_last_1d": 99.01348807354468,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -7214,11 +7655,50 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.73837555000594,
-          "uptime_last_5m": 99.67858577742065,
-          "uptime_last_1d": 99.77641649056991,
+          "uptime_last_30m": 99.74973185555953,
+          "uptime_last_5m": 99.90636704119851,
+          "uptime_last_1d": 99.77358339944219,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Novita | minimax/minimax-m3-20260531",
+          "model_id": "minimax/minimax-m3",
+          "model_name": "MiniMax: MiniMax M3",
+          "provider_name": "Novita",
+          "tag": "novita/fp8",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 131072,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "top_k",
+            "repetition_penalty",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.66836734693878,
+          "uptime_last_5m": 99.70304380103934,
+          "uptime_last_1d": 99.513875072047,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
@@ -7257,10 +7737,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -5,
-          "uptime_last_30m": 79.95951417004049,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 91.66769382472575,
+          "status": -2,
+          "uptime_last_30m": 88.10289389067523,
+          "uptime_last_5m": 86.5546218487395,
+          "uptime_last_1d": 91.5807369039864,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -7299,10 +7779,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 95.8282208588957,
-          "uptime_last_5m": 98.47908745247148,
-          "uptime_last_1d": 97.78025509033083,
+          "status": -2,
+          "uptime_last_30m": 94.5682451253482,
+          "uptime_last_5m": 93.00411522633745,
+          "uptime_last_1d": 97.76280170066092,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -7317,7 +7797,8 @@
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000003",
-            "completion": "0.0000012"
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7352,6 +7833,22 @@
             "prompt": "0.0000003",
             "completion": "0.0000012",
             "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "morph | minimax/minimax-m3",
+          "model_id": "morph-minimax3-428b",
+          "model_name": "MiniMax: MiniMax M3",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000006",
+            "completion": "0.0000024"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7423,7 +7920,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89164340830735,
+          "uptime_last_1d": 99.89358614685112,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7493,7 +7990,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.85118905667217,
+          "uptime_last_1d": 99.85252849206803,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7561,9 +8058,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9195278969957,
+          "uptime_last_30m": 99.87648221343873,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.69889392693764,
+          "uptime_last_1d": 99.70040046972389,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7631,9 +8128,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.43201259152809,
-          "uptime_last_5m": 97.3839110529758,
-          "uptime_last_1d": 99.62364926433655,
+          "uptime_last_30m": 99.44066681289756,
+          "uptime_last_5m": 99.8326359832636,
+          "uptime_last_1d": 99.62029919620801,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7703,7 +8200,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97289122246319,
+          "uptime_last_1d": 99.97288735409116,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7775,7 +8272,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98870056497175,
+          "uptime_last_1d": 99.98993609419816,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7842,9 +8339,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.65052072412107,
+          "uptime_last_30m": 99.74243399871216,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.74995734566485,
+          "uptime_last_1d": 99.7480926033495,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -7879,10 +8376,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 88.51530034000756,
-          "uptime_last_5m": 75.75462512171373,
-          "uptime_last_1d": 92.69183922046284,
+          "status": -5,
+          "uptime_last_30m": 76.47823261858349,
+          "uptime_last_5m": 42.132416165090284,
+          "uptime_last_1d": 92.32066577763199,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8039,9 +8536,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99267077103488,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96886314025167,
+          "uptime_last_30m": 99.98904349731565,
+          "uptime_last_5m": 99.9714937286203,
+          "uptime_last_1d": 99.96852662954197,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8112,9 +8609,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.57135202714771,
-          "uptime_last_5m": 99.72260748959778,
-          "uptime_last_1d": 99.22016882701857,
+          "uptime_last_30m": 99.8675057966214,
+          "uptime_last_5m": 99.87405541561712,
+          "uptime_last_1d": 99.22503831470458,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -8183,8 +8680,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98598065330155,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.98617065412806,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8251,9 +8748,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.43153318843004,
-          "uptime_last_5m": 99.89130434782608,
-          "uptime_last_1d": 98.43908985235144,
+          "uptime_last_30m": 96.21308464038434,
+          "uptime_last_5m": 96.66295884315906,
+          "uptime_last_1d": 98.40771247548935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8324,9 +8821,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.38271604938271,
-          "uptime_last_5m": 98.50746268656717,
-          "uptime_last_1d": 99.40497024851243,
+          "uptime_last_30m": 99.21722113502935,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.39929532721077,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8415,9 +8912,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.21085858585859,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.54207353037552,
+          "uptime_last_30m": 99.51834012597259,
+          "uptime_last_5m": 99.76689976689977,
+          "uptime_last_1d": 99.56318504190844,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -8453,7 +8950,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9301772361552,
+          "uptime_last_1d": 99.93110354496295,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -8494,11 +8991,48 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.978489997849,
+          "uptime_last_30m": 99.96751137102015,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86802357435845,
+          "uptime_last_1d": 99.87183500958791,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | moonshotai/kimi-k2.5-0127",
+          "model_id": "moonshotai/kimi-k2.5",
+          "model_name": "MoonshotAI: Kimi K2.5",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/int4",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000045",
+            "completion": "0.00000225",
+            "input_cache_read": "0.00000007",
+            "discount": 0
+          },
+          "quantization": "int4",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.93500162495937,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.81125732398425,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -8535,23 +9069,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "chutes | moonshotai/kimi-k2.5",
-          "model_id": "moonshotai/Kimi-K2.5-TEE",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000044",
-            "completion": "0.000002",
-            "input_cache_read": "0.00000022"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | moonshotai/kimi-k2.5",
           "model_id": "kimi-k2.5",
           "model_name": "MoonshotAI: Kimi K2.5",
@@ -8563,6 +9080,23 @@
             "prompt": "0.000000574",
             "completion": "0.000003011",
             "input_cache_read": "0.000000115"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | moonshotai/kimi-k2.5",
+          "model_id": "moonshotai/Kimi-K2.5-TEE",
+          "model_name": "MoonshotAI: Kimi K2.5",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000044",
+            "completion": "0.000002",
+            "input_cache_read": "0.00000022"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -8671,9 +9205,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 98.95337773549001,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89461898175591,
+          "uptime_last_1d": 99.86049614848062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -8752,7 +9286,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84409049837889,
+          "uptime_last_1d": 99.85313751668892,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -8793,7 +9327,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.13509461204204,
+          "uptime_last_1d": 99.185667752443,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8835,11 +9369,48 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.1506228765572,
-          "uptime_last_5m": 97.5,
-          "uptime_last_1d": 99.09339917441457,
+          "uptime_last_30m": 99.7805814591333,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.20431744274545,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | moonshotai/kimi-k2.6-20260420",
+          "model_id": "moonshotai/kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000077",
+            "completion": "0.0000034",
+            "input_cache_read": "0.00000014",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.93024709269882,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -8877,9 +9448,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 96.59477866061293,
+          "uptime_last_30m": 99.1638795986622,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 95.71249271594424,
+          "uptime_last_1d": 95.8543789059156,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -8918,6 +9489,23 @@
           "quantization": "unknown"
         },
         {
+          "name": "baseten | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/Kimi-K2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "baseten",
+          "tag": "baseten",
+          "tr_provider_slug": "baseten",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "crusoe | moonshotai/kimi-k2.6",
           "model_id": "moonshotai/Kimi-K2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
@@ -8935,17 +9523,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "baseten | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
+          "name": "wafer | moonshotai/kimi-k2.6",
+          "model_id": "Kimi-K2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
+          "provider_name": "wafer",
+          "tag": "wafer",
+          "tr_provider_slug": "wafer",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000016"
+            "prompt": "0.00000114",
+            "completion": "0.0000048",
+            "input_cache_read": "0.00000019"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -8986,29 +9574,29 @@
           "quantization": "unknown"
         },
         {
-          "name": "wafer | moonshotai/kimi-k2.6",
-          "model_id": "Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "wafer",
-          "tag": "wafer",
-          "tr_provider_slug": "wafer",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000114",
-            "completion": "0.0000048",
-            "input_cache_read": "0.00000019"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "atlas-cloud | moonshotai/kimi-k2.6",
           "model_id": "moonshotai/kimi-k2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
           "provider_name": "atlas-cloud",
           "tag": "atlas-cloud",
           "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000095",
@@ -9031,23 +9619,6 @@
             "prompt": "0.00000066",
             "completion": "0.00000341",
             "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/kimi-k2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "cloudflare-workers-ai",
-          "tag": "cloudflare-workers-ai",
-          "tr_provider_slug": "cloudflare-workers-ai",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000016"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9075,9 +9646,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000072",
-        "completion": "0.0000035",
-        "input_cache_read": "0.00000015"
+        "prompt": "0.000000328",
+        "completion": "0.0000013532",
+        "input_cache_read": "0.0000000646"
       },
       "top_provider": {
         "context_length": 262144,
@@ -9121,9 +9692,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.20634920634922,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.79273504273505,
+          "uptime_last_1d": 98.80926130099228,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9159,7 +9730,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.76517715311832,
+          "uptime_last_1d": 99.75277222323214,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9195,7 +9766,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96047714860592,
+          "uptime_last_1d": 99.96066089693156,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9237,8 +9808,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93768985123452,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.9406484160546,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9280,11 +9851,46 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.33774834437085,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.47942905121747,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.47992156194049,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | moonshotai/kimi-k2.7-code-20260612",
+          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000085916",
+            "completion": "0.0000038",
+            "input_cache_read": "0.00000017993",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.83870967741936,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.93825694609356,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -9322,9 +9928,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.79050279329608,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.41220146021533,
+          "uptime_last_30m": 99.3573264781491,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.47247844697655,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -9347,23 +9953,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000076",
-            "completion": "0.0000037749",
-            "input_cache_read": "0.0000005757"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "baseten | moonshotai/kimi-k2.7-code",
           "model_id": "moonshotai/Kimi-K2.7-Code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
@@ -9375,6 +9964,23 @@
             "prompt": "0.00000095",
             "completion": "0.000004",
             "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "makora | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000328",
+            "completion": "0.0000013532",
+            "input_cache_read": "0.0000000646"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9415,23 +10021,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "inceptron | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/Kimi-K2.7-Code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "inceptron",
-          "tag": "inceptron",
-          "tr_provider_slug": "inceptron",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000072",
-            "completion": "0.0000035",
-            "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "cloudflare-workers-ai | moonshotai/kimi-k2.7-code",
           "model_id": "moonshotai/kimi-k2.7-code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
@@ -9443,6 +10032,23 @@
             "prompt": "0.00000095",
             "completion": "0.000004",
             "input_cache_read": "0.00000019"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/Kimi-K2.7-Code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000072",
+            "completion": "0.0000035",
+            "input_cache_read": "0.00000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9513,18 +10119,18 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99355320616507,
+          "uptime_last_1d": 99.99362583353091,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "novita | moonshotai/kimi-k3",
+          "name": "siliconflow | moonshotai/kimi-k3",
           "model_id": "moonshotai/kimi-k3",
           "model_name": "MoonshotAI: Kimi K3",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
+          "provider_name": "siliconflow",
+          "tag": "siliconflow",
+          "tr_provider_slug": "siliconflow",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000003",
@@ -9553,16 +10159,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "siliconflow | moonshotai/kimi-k3",
+          "name": "novita | moonshotai/kimi-k3",
           "model_id": "moonshotai/kimi-k3",
           "model_name": "MoonshotAI: Kimi K3",
-          "provider_name": "siliconflow",
-          "tag": "siliconflow",
-          "tr_provider_slug": "siliconflow",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000003",
-            "completion": "0.000015"
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9806,9 +10413,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.35983611804622,
-          "uptime_last_5m": 99.45994599459947,
-          "uptime_last_1d": 98.93133995403643,
+          "uptime_last_30m": 98.75485868634297,
+          "uptime_last_5m": 97.84313725490196,
+          "uptime_last_1d": 98.91523923644337,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9847,9 +10454,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.96459704678882,
+          "uptime_last_30m": 99.73262032085562,
+          "uptime_last_5m": 97.5609756097561,
+          "uptime_last_1d": 93.92895490336434,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9934,9 +10541,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 95.58823529411765,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 96.70302733178086,
+          "uptime_last_1d": 96.20253164556962,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -10025,10 +10632,10 @@
             "response_format",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.11012235817576,
-          "uptime_last_5m": 96.29629629629629,
-          "uptime_last_1d": 97.75607806900341,
+          "status": -2,
+          "uptime_last_30m": 94.03217436429684,
+          "uptime_last_5m": 96.88888888888889,
+          "uptime_last_1d": 97.59754558725288,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -10051,22 +10658,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "nebius | nvidia/nemotron-3-ultra-550b-a55b",
-          "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
-          "model_name": "NVIDIA: Nemotron 3 Ultra",
-          "provider_name": "nebius",
-          "tag": "nebius",
-          "tr_provider_slug": "nebius",
-          "context_length": 512288,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "baseten | nvidia/nemotron-3-ultra-550b-a55b",
           "model_id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
           "model_name": "NVIDIA: Nemotron 3 Ultra",
@@ -10078,6 +10669,22 @@
             "prompt": "0.0000006",
             "completion": "0.0000024",
             "input_cache_read": "0.00000012"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "nebius | nvidia/nemotron-3-ultra-550b-a55b",
+          "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+          "model_name": "NVIDIA: Nemotron 3 Ultra",
+          "provider_name": "nebius",
+          "tag": "nebius",
+          "tr_provider_slug": "nebius",
+          "context_length": 512288,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10335,9 +10942,9 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.80119840958727,
-          "uptime_last_5m": 99.83704508419338,
-          "uptime_last_1d": 99.16124447435685,
+          "uptime_last_30m": 99.85171630489653,
+          "uptime_last_5m": 99.68415937803692,
+          "uptime_last_1d": 99.16887438669708,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -10438,9 +11045,9 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.34596261115962,
-          "uptime_last_5m": 99.27526506509193,
-          "uptime_last_1d": 99.0363664862173,
+          "uptime_last_30m": 99.22178180837156,
+          "uptime_last_5m": 99.88036233122544,
+          "uptime_last_1d": 99.03150898551041,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -10525,9 +11132,9 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.18724765350532,
-          "uptime_last_5m": 99.3103448275862,
-          "uptime_last_1d": 98.71307697870579,
+          "uptime_last_30m": 99.4254720771394,
+          "uptime_last_5m": 99.40928270042194,
+          "uptime_last_1d": 98.73601952868597,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -10618,9 +11225,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.93701070817961,
+          "uptime_last_30m": 99.95961880148603,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95828407334388,
+          "uptime_last_1d": 99.95943052091553,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -10744,9 +11351,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9620398633435,
-          "uptime_last_5m": 99.96634644802056,
-          "uptime_last_1d": 99.94910395474297,
+          "uptime_last_30m": 99.89928594266226,
+          "uptime_last_5m": 99.9147415858065,
+          "uptime_last_1d": 99.9490504715057,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11722,9 +12329,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.67637540453075,
-          "uptime_last_5m": 99.69758064516128,
-          "uptime_last_1d": 98.0688497061293,
+          "uptime_last_30m": 99.23404255319149,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.09016606656354,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11758,9 +12365,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.67637540453075,
-          "uptime_last_5m": 99.69758064516128,
-          "uptime_last_1d": 98.0688497061293,
+          "uptime_last_30m": 99.23404255319149,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.09016606656354,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11901,9 +12508,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8038936033659,
-          "uptime_last_5m": 99.88789237668162,
-          "uptime_last_1d": 98.75859256044885,
+          "uptime_last_30m": 99.86267927982911,
+          "uptime_last_5m": 99.96706192358367,
+          "uptime_last_1d": 98.8140442971935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -11967,9 +12574,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8038936033659,
-          "uptime_last_5m": 99.88789237668162,
-          "uptime_last_1d": 98.75859256044885,
+          "uptime_last_30m": 99.86267927982911,
+          "uptime_last_5m": 99.96706192358367,
+          "uptime_last_1d": 98.8140442971935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12025,9 +12632,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8038936033659,
-          "uptime_last_5m": 99.88789237668162,
-          "uptime_last_1d": 98.75859256044885,
+          "uptime_last_30m": 99.86267927982911,
+          "uptime_last_5m": 99.96706192358367,
+          "uptime_last_1d": 98.8140442971935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12129,10 +12736,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.63792027111388,
-          "uptime_last_5m": 99.66592427616926,
-          "uptime_last_1d": 85.572852311949,
+          "status": -2,
+          "uptime_last_30m": 94.32421739182563,
+          "uptime_last_5m": 91.11289746337978,
+          "uptime_last_1d": 85.72665678823218,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12165,10 +12772,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.63792027111388,
-          "uptime_last_5m": 99.66592427616926,
-          "uptime_last_1d": 85.572852311949,
+          "status": -2,
+          "uptime_last_30m": 94.32421739182563,
+          "uptime_last_5m": 91.11289746337978,
+          "uptime_last_1d": 85.72665678823218,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12201,10 +12808,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.63792027111388,
-          "uptime_last_5m": 99.66592427616926,
-          "uptime_last_1d": 85.572852311949,
+          "status": -2,
+          "uptime_last_30m": 94.32421739182563,
+          "uptime_last_5m": 91.11289746337978,
+          "uptime_last_1d": 85.72665678823218,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12307,9 +12914,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.67719136721817,
-          "uptime_last_5m": 98.69644192755636,
-          "uptime_last_1d": 95.60010853674744,
+          "uptime_last_30m": 98.60298453304304,
+          "uptime_last_5m": 99.0345937248592,
+          "uptime_last_1d": 95.67355551548417,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12343,9 +12950,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.67719136721817,
-          "uptime_last_5m": 98.69644192755636,
-          "uptime_last_1d": 95.60010853674744,
+          "uptime_last_30m": 98.60298453304304,
+          "uptime_last_5m": 99.0345937248592,
+          "uptime_last_1d": 95.67355551548417,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12482,7 +13089,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 58.22201750345462,
+          "uptime_last_1d": 58.81818181818181,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12544,7 +13151,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 58.22201750345462,
+          "uptime_last_1d": 58.81818181818181,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12667,9 +13274,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85967597907897,
-          "uptime_last_5m": 99.96460176991151,
-          "uptime_last_1d": 93.60635939503177,
+          "uptime_last_30m": 98.7318896070083,
+          "uptime_last_5m": 99.22151450813871,
+          "uptime_last_1d": 93.7153028603813,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12733,9 +13340,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85967597907897,
-          "uptime_last_5m": 99.96460176991151,
-          "uptime_last_1d": 93.60635939503177,
+          "uptime_last_30m": 98.7318896070083,
+          "uptime_last_5m": 99.22151450813871,
+          "uptime_last_1d": 93.7153028603813,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12791,9 +13398,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85967597907897,
-          "uptime_last_5m": 99.96460176991151,
-          "uptime_last_1d": 93.60635939503177,
+          "uptime_last_30m": 98.7318896070083,
+          "uptime_last_5m": 99.22151450813871,
+          "uptime_last_1d": 93.7153028603813,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12950,7 +13557,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.89850659707119,
+          "uptime_last_1d": 99.90264255910988,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13012,7 +13619,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.89850659707119,
+          "uptime_last_1d": 99.90264255910988,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13123,9 +13730,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95827770360481,
-          "uptime_last_5m": 99.9401913875598,
-          "uptime_last_1d": 99.83334282633069,
+          "uptime_last_30m": 99.98282554185415,
+          "uptime_last_5m": 99.94797086368366,
+          "uptime_last_1d": 99.83894267201454,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13191,9 +13798,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95827770360481,
-          "uptime_last_5m": 99.9401913875598,
-          "uptime_last_1d": 99.83334282633069,
+          "uptime_last_30m": 99.98282554185415,
+          "uptime_last_5m": 99.94797086368366,
+          "uptime_last_1d": 99.83894267201454,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13250,9 +13857,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95827770360481,
-          "uptime_last_5m": 99.9401913875598,
-          "uptime_last_1d": 99.83334282633069,
+          "uptime_last_30m": 99.98282554185415,
+          "uptime_last_5m": 99.94797086368366,
+          "uptime_last_1d": 99.83894267201454,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13413,9 +14020,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83054950375212,
-          "uptime_last_5m": 99.78659837814767,
-          "uptime_last_1d": 95.58380572861125,
+          "uptime_last_30m": 99.83460304731355,
+          "uptime_last_5m": 99.66587112171837,
+          "uptime_last_1d": 95.74637543423073,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13481,9 +14088,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83054950375212,
-          "uptime_last_5m": 99.78659837814767,
-          "uptime_last_1d": 95.58380572861125,
+          "uptime_last_30m": 99.83460304731355,
+          "uptime_last_5m": 99.66587112171837,
+          "uptime_last_1d": 95.74637543423073,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13540,9 +14147,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83054950375212,
-          "uptime_last_5m": 99.78659837814767,
-          "uptime_last_1d": 95.58380572861125,
+          "uptime_last_30m": 99.83460304731355,
+          "uptime_last_5m": 99.66587112171837,
+          "uptime_last_1d": 95.74637543423073,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13703,9 +14310,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87280590180616,
-          "uptime_last_5m": 99.86168741355463,
-          "uptime_last_1d": 99.34163770815616,
+          "uptime_last_30m": 99.8529411764706,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.35811081231596,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13771,9 +14378,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87280590180616,
-          "uptime_last_5m": 99.86168741355463,
-          "uptime_last_1d": 99.34163770815616,
+          "uptime_last_30m": 99.8529411764706,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.35811081231596,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13830,9 +14437,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87280590180616,
-          "uptime_last_5m": 99.86168741355463,
-          "uptime_last_1d": 99.34163770815616,
+          "uptime_last_30m": 99.8529411764706,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.35811081231596,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13954,9 +14561,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94433879122408,
-          "uptime_last_5m": 99.55947136563876,
-          "uptime_last_1d": 99.99093370054698,
+          "uptime_last_30m": 99.99191527205109,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.99069078635526,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -13997,9 +14604,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94653994653994,
-          "uptime_last_5m": 99.8566063502902,
-          "uptime_last_1d": 97.3301784332847,
+          "uptime_last_30m": 99.93961160728475,
+          "uptime_last_5m": 99.96524157108098,
+          "uptime_last_1d": 97.35004747178067,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -14040,9 +14647,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.64539007092199,
-          "uptime_last_5m": 99.43502824858757,
-          "uptime_last_1d": 99.93430876704247,
+          "uptime_last_30m": 99.68671679197995,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.92553188242583,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -14082,9 +14689,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.2841163310962,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.30580698668726,
+          "uptime_last_1d": 98.26022170677547,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -14125,9 +14732,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.62804794048768,
+          "uptime_last_30m": 99.24437056067704,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 96.30835744268497,
+          "uptime_last_1d": 96.13663373690856,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -14172,9 +14779,44 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 90.0721405404603,
+          "uptime_last_1d": 91.35705782845687,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | openai/gpt-oss-120b",
+          "model_id": "openai/gpt-oss-120b",
+          "model_name": "OpenAI: gpt-oss-120b",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000005",
+            "completion": "0.00000045",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 8192,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.93932038834951,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 78.4251510820682,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -14212,9 +14854,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.30947897049592,
-          "uptime_last_5m": 97.89473684210527,
-          "uptime_last_1d": 94.177894518037,
+          "uptime_last_30m": 99.46773120425814,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 94.05325361124305,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -14253,6 +14895,23 @@
           "quantization": "unknown"
         },
         {
+          "name": "baseten | openai/gpt-oss-120b",
+          "model_id": "openai/gpt-oss-120b",
+          "model_name": "OpenAI: gpt-oss-120b",
+          "provider_name": "baseten",
+          "tag": "baseten",
+          "tr_provider_slug": "baseten",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.0000001",
+            "completion": "0.0000005",
+            "input_cache_read": "0.0000001"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "crusoe | openai/gpt-oss-120b",
           "model_id": "openai/gpt-oss-120b",
           "model_name": "OpenAI: gpt-oss-120b",
@@ -14278,26 +14937,9 @@
           "tr_provider_slug": "makora",
           "context_length": 131072,
           "pricing": {
-            "prompt": "0.0000001513",
-            "completion": "0.0000005333",
-            "input_cache_read": "0.0000001135"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "baseten | openai/gpt-oss-120b",
-          "model_id": "openai/gpt-oss-120b",
-          "model_name": "OpenAI: gpt-oss-120b",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.0000001",
-            "completion": "0.0000005",
-            "input_cache_read": "0.0000001"
+            "prompt": "0.0000001286",
+            "completion": "0.0000004533",
+            "input_cache_read": "0.000000096475"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -14387,9 +15029,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97758601367254,
-          "uptime_last_5m": 99.88925802879291,
-          "uptime_last_1d": 99.87909477547188,
+          "uptime_last_30m": 99.87167736021998,
+          "uptime_last_5m": 99.5257854179016,
+          "uptime_last_1d": 99.88571335773344,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -14427,10 +15069,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.8965873836608,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.92499869183766,
+          "status": -5,
+          "uptime_last_30m": 42.57728803183349,
+          "uptime_last_5m": 29.005524861878452,
+          "uptime_last_1d": 98.826813027349,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -14473,11 +15115,46 @@
             "reasoning_effort"
           ],
           "status": -5,
-          "uptime_last_30m": 74.46682464454977,
-          "uptime_last_5m": 73.47670250896059,
-          "uptime_last_1d": 84.5206486999944,
+          "uptime_last_30m": 72.0514950166113,
+          "uptime_last_5m": 86.85446009389672,
+          "uptime_last_1d": 84.29228667229461,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | openai/gpt-oss-20b",
+          "model_id": "openai/gpt-oss-20b",
+          "model_name": "OpenAI: gpt-oss-20b",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000004",
+            "completion": "0.00000018",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 8192,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 98.48754448398577,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.74681454514668,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -14515,7 +15192,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.2027972027972,
+          "uptime_last_1d": 97.19298245614036,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -14687,7 +15364,7 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
@@ -14945,7 +15622,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96078135606004,
+          "uptime_last_1d": 99.96181896821727,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -15030,7 +15707,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 49.63295269168026,
+          "uptime_last_1d": 43.106617647058826,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15095,10 +15772,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": -2,
-          "uptime_last_30m": 89.12556053811659,
-          "uptime_last_5m": 94.86607142857143,
-          "uptime_last_1d": 98.13138919617748,
+          "status": 0,
+          "uptime_last_30m": 99.03545713897569,
+          "uptime_last_5m": 99.32235195996664,
+          "uptime_last_1d": 98.11006114508059,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -15169,9 +15846,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.84142086901365,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.22750707271484,
+          "uptime_last_30m": 95.90403744880047,
+          "uptime_last_5m": 98,
+          "uptime_last_1d": 99.13265760323536,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -15241,10 +15918,10 @@
             "logit_bias",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 100,
+          "status": -2,
+          "uptime_last_30m": 90.44183949504058,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.88907221492025,
+          "uptime_last_1d": 99.71366087810664,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15313,10 +15990,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.26315789473684,
-          "uptime_last_5m": 97,
-          "uptime_last_1d": 98.0457933972311,
+          "status": 0,
+          "uptime_last_30m": 99.53825857519789,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.00878477306003,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -15358,7 +16035,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.73804224889635,
+          "uptime_last_1d": 99.72697978112238,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -15462,9 +16139,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.9124215443001,
+          "uptime_last_1d": 99.89664845710911,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15504,7 +16181,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.3088194636439,
+          "uptime_last_1d": 99.71965236893749,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15540,27 +16217,10 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.7289972899729,
+          "uptime_last_1d": 99.73333333333333,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "chutes | qwen/qwen3-235b-a22b-thinking-2507",
-          "model_id": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
-          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.0000002989",
-            "completion": "0.0000011957",
-            "input_cache_read": "0.00000014945"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3-235b-a22b-thinking-2507",
@@ -15574,6 +16234,23 @@
             "prompt": "0.00000023",
             "completion": "0.0000023",
             "input_cache_read": "0.000000023"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3-235b-a22b-thinking-2507",
+          "model_id": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
+          "model_name": "Qwen: Qwen3 235B A22B Thinking 2507",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000002989",
+            "completion": "0.0000011957",
+            "input_cache_read": "0.00000014945"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15646,7 +16323,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.31153555627496,
+          "uptime_last_1d": 99.28580993616927,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15783,29 +16460,12 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95891349007076,
-          "uptime_last_5m": 99.98822282416675,
-          "uptime_last_1d": 99.82678289622004,
+          "uptime_last_30m": 99.783570451001,
+          "uptime_last_5m": 99.86781229345671,
+          "uptime_last_1d": 99.82221094570171,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "chutes | qwen/qwen3-32b",
-          "model_id": "Qwen/Qwen3-32B-TEE",
-          "model_name": "Qwen: Qwen3 32B",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.000000104",
-            "completion": "0.000000416",
-            "input_cache_read": "0.000000052"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3-32b",
@@ -15819,6 +16479,23 @@
             "prompt": "0.00000016",
             "completion": "0.00000064",
             "input_cache_read": "0.000000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3-32b",
+          "model_id": "Qwen/Qwen3-32B-TEE",
+          "model_name": "Qwen: Qwen3 32B",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.000000104",
+            "completion": "0.000000416",
+            "input_cache_read": "0.000000052"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -15901,10 +16578,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": -5,
-          "uptime_last_30m": 79.18424753867792,
-          "uptime_last_5m": 85.57692307692307,
-          "uptime_last_1d": 96.116259781472,
+          "status": -2,
+          "uptime_last_30m": 83.82352941176471,
+          "uptime_last_5m": 91.44736842105263,
+          "uptime_last_1d": 95.65742945803565,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15988,9 +16665,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60629921259843,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.97378832838774,
+          "uptime_last_1d": 98.940103524772,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16032,7 +16709,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96666444429628,
+          "uptime_last_1d": 99.96400346875664,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16117,10 +16794,10 @@
             "logit_bias",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.96271439224459,
-          "uptime_last_5m": 99.72677595628416,
-          "uptime_last_1d": 97.32662149080349,
+          "status": -2,
+          "uptime_last_30m": 90.13282732447819,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 97.11663367561549,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16158,8 +16835,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.79062574351654,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.7884587002509,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16199,9 +16876,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.94182664339732,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.83328758907423,
+          "uptime_last_1d": 99.84361642236077,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16305,10 +16982,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -5,
-          "uptime_last_30m": 61.2202380952381,
-          "uptime_last_5m": 96.61016949152543,
-          "uptime_last_1d": 87.22768664771432,
+          "status": -2,
+          "uptime_last_30m": 84.82168330955777,
+          "uptime_last_5m": 10.037174721189592,
+          "uptime_last_1d": 87.30330562536246,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16345,10 +17022,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.32683658170914,
-          "uptime_last_5m": 98.65881583251553,
-          "uptime_last_1d": 92.68945435860105,
+          "status": -2,
+          "uptime_last_30m": 92.68510258697592,
+          "uptime_last_5m": 93.69951534733441,
+          "uptime_last_1d": 92.83608907193185,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16388,9 +17065,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.2484289343495,
-          "uptime_last_5m": 98.51049424509141,
-          "uptime_last_1d": 97.55286014187512,
+          "uptime_last_30m": 95.9559916741005,
+          "uptime_last_5m": 93.99509803921569,
+          "uptime_last_1d": 97.47635376630373,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16480,7 +17157,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.70845481049562,
+          "uptime_last_1d": 99.74747474747475,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16584,9 +17261,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94293214632197,
-          "uptime_last_5m": 99.90958408679927,
-          "uptime_last_1d": 99.86580293550948,
+          "uptime_last_30m": 99.91207367300662,
+          "uptime_last_5m": 99.96144949884348,
+          "uptime_last_1d": 99.87484841135095,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16623,10 +17300,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.25418060200668,
-          "uptime_last_5m": 97.91666666666666,
-          "uptime_last_1d": 94.14940284704822,
+          "status": -2,
+          "uptime_last_30m": 93.81443298969072,
+          "uptime_last_5m": 93.21428571428572,
+          "uptime_last_1d": 94.18214806926201,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16766,9 +17443,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9402390438247,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.79864973381316,
+          "uptime_last_30m": 99.81688335469694,
+          "uptime_last_5m": 99.8898678414097,
+          "uptime_last_1d": 99.8046441415442,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16813,8 +17490,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000029",
-        "completion": "0.0000024"
+        "prompt": "0.00000026",
+        "completion": "0.00000208"
       },
       "top_provider": {
         "context_length": 262144,
@@ -16855,10 +17532,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -2,
-          "uptime_last_30m": 87.16814159292035,
+          "status": -5,
+          "uptime_last_30m": 79.26829268292683,
           "uptime_last_5m": null,
-          "uptime_last_1d": 79.59321203210195,
+          "uptime_last_1d": 79.13456909003371,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16897,11 +17574,47 @@
             "top_logprobs"
           ],
           "status": -5,
-          "uptime_last_30m": 71.02199223803363,
+          "uptime_last_30m": 52.72727272727272,
           "uptime_last_5m": null,
-          "uptime_last_1d": 78.55314792697492,
+          "uptime_last_1d": 78.26146947223181,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | qwen/qwen3.5-122b-a10b-20260224",
+          "model_id": "qwen/qwen3.5-122b-a10b",
+          "model_name": "Qwen: Qwen3.5-122B-A10B",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000026",
+            "completion": "0.00000208",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "repetition_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs"
+          ],
+          "status": -5,
+          "uptime_last_30m": 24.830699774266364,
+          "uptime_last_5m": 48.275862068965516,
+          "uptime_last_1d": 52.42643829600351,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -16977,8 +17690,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000026",
-        "completion": "0.0000026"
+        "prompt": "0.00000025",
+        "completion": "0.000002"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17022,9 +17735,9 @@
             "structured_outputs"
           ],
           "status": -2,
-          "uptime_last_30m": 91.12814895947426,
-          "uptime_last_5m": 95.72649572649573,
-          "uptime_last_1d": 97.03107402005134,
+          "uptime_last_30m": 93.6842105263158,
+          "uptime_last_5m": 94.16666666666667,
+          "uptime_last_1d": 96.8361645269197,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17063,11 +17776,49 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.5398773006135,
-          "uptime_last_5m": 99,
-          "uptime_last_1d": 99.4127738189496,
+          "uptime_last_30m": 99.85855728429985,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.42227064144465,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | qwen/qwen3.5-27b-20260224",
+          "model_id": "qwen/qwen3.5-27b",
+          "model_name": "Qwen: Qwen3.5-27B",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000025",
+            "completion": "0.000002",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "repetition_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 97.66734279918865,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.5249606755526,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -17186,10 +17937,10 @@
             "logit_bias",
             "structured_outputs"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.11764705882352,
-          "uptime_last_5m": 71.875,
-          "uptime_last_1d": 96.05670829030139,
+          "status": 0,
+          "uptime_last_30m": 95.15738498789347,
+          "uptime_last_5m": 76.47058823529412,
+          "uptime_last_1d": 95.93257603517772,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17231,20 +17982,20 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88179669030734,
-          "uptime_last_5m": 99.88738738738738,
-          "uptime_last_1d": 99.82364740250125,
+          "uptime_last_30m": 99.47155735156979,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.80592842455468,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "novita | qwen/qwen3.5-35b-a3b",
-          "model_id": "qwen/qwen3.5-35b-a3b",
+          "name": "gmi | qwen/qwen3.5-35b-a3b",
+          "model_id": "Qwen/Qwen3.5-35B-A3B",
           "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000025",
@@ -17255,12 +18006,12 @@
           "quantization": "unknown"
         },
         {
-          "name": "gmi | qwen/qwen3.5-35b-a3b",
-          "model_id": "Qwen/Qwen3.5-35B-A3B",
+          "name": "novita | qwen/qwen3.5-35b-a3b",
+          "model_id": "qwen/qwen3.5-35b-a3b",
           "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000025",
@@ -17374,9 +18125,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.61734693877551,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.53955063096338,
+          "uptime_last_30m": 99.87459941479727,
+          "uptime_last_5m": 99.7080291970803,
+          "uptime_last_1d": 99.55696273340568,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17449,9 +18200,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.40119760479041,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.81284658040666,
+          "uptime_last_30m": 99.90286546867412,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.82007760508118,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17493,9 +18244,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.59799829238213,
+          "uptime_last_30m": 99.87394201332613,
+          "uptime_last_5m": 99.82014388489209,
+          "uptime_last_1d": 99.62296730197588,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -17533,29 +18284,12 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.39698657058631,
+          "uptime_last_30m": 99.88095238095238,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.52287030200752,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "chutes | qwen/qwen3.5-397b-a17b",
-          "model_id": "Qwen/Qwen3.5-397B-A17B-TEE",
-          "model_name": "Qwen: Qwen3.5 397B A17B",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000045",
-            "completion": "0.000003",
-            "input_cache_read": "0.000000225"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "alibaba | qwen/qwen3.5-397b-a17b",
@@ -17569,6 +18303,23 @@
             "prompt": "0.0000006",
             "completion": "0.0000036",
             "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | qwen/qwen3.5-397b-a17b",
+          "model_id": "Qwen/Qwen3.5-397B-A17B-TEE",
+          "model_name": "Qwen: Qwen3.5 397B A17B",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000045",
+            "completion": "0.000003",
+            "input_cache_read": "0.000000225"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17603,6 +18354,23 @@
             "prompt": "0.00000055",
             "completion": "0.0000035",
             "input_cache_read": "0.00000055"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "morph | qwen/qwen3.5-397b-a17b",
+          "model_id": "morph-qwen35-397b",
+          "model_name": "Qwen: Qwen3.5 397B A17B",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.0000035",
+            "input_cache_read": "0.0000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17676,11 +18444,49 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.31999222848262,
-          "uptime_last_5m": 99.59016393442623,
-          "uptime_last_1d": 99.24451006732437,
+          "uptime_last_30m": 98.92595978062158,
+          "uptime_last_5m": 99.8076923076923,
+          "uptime_last_1d": 99.25726909532814,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | qwen/qwen3.5-9b-20260310",
+          "model_id": "qwen/qwen3.5-9b",
+          "model_name": "Qwen: Qwen3.5-9B",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000001",
+            "completion": "0.00000015",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "repetition_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs",
+            "tools",
+            "tool_choice"
+          ],
+          "status": -2,
+          "uptime_last_30m": 93.12087057909055,
+          "uptime_last_5m": 92.77899343544857,
+          "uptime_last_1d": 96.89652862074945,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -17717,9 +18523,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.45607808340728,
-          "uptime_last_5m": 98.58356940509914,
-          "uptime_last_1d": 99.02404892477271,
+          "uptime_last_30m": 99.6565934065934,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.07897702963191,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -17757,9 +18563,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.54470198675497,
-          "uptime_last_5m": 99.60159362549801,
-          "uptime_last_1d": 99.58126064526444,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.58840615536741,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -17787,9 +18593,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.000002",
-        "input_cache_read": "0.00000015"
+        "prompt": "0.00000027285",
+        "completion": "0.00000282285",
+        "input_cache_read": "0.0000002977"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17833,11 +18639,49 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.25511432009627,
-          "uptime_last_5m": 96.3963963963964,
-          "uptime_last_1d": 97.68237840160852,
+          "uptime_last_30m": 99.71830985915493,
+          "uptime_last_5m": 98.72773536895674,
+          "uptime_last_1d": 97.66798667420956,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | qwen/qwen3.6-27b-20260422",
+          "model_id": "qwen/qwen3.6-27b",
+          "model_name": "Qwen: Qwen3.6 27B",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000032",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "repetition_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs"
+          ],
+          "status": -5,
+          "uptime_last_30m": 45.47945205479452,
+          "uptime_last_5m": 23.52941176470588,
+          "uptime_last_1d": 91.14079883275579,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -17871,9 +18715,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.10650464617584,
+          "uptime_last_30m": 97.75280898876404,
+          "uptime_last_5m": 87.09677419354838,
+          "uptime_last_1d": 99.09762462953952,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -17903,9 +18747,9 @@
           "tr_provider_slug": "makora",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.0000004671",
-            "completion": "0.0000034592",
-            "input_cache_read": "0.0000003503"
+            "prompt": "0.00000027285",
+            "completion": "0.00000282285",
+            "input_cache_read": "0.0000002977"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17923,6 +18767,22 @@
             "prompt": "0.0000003",
             "completion": "0.000002",
             "input_cache_read": "0.00000015"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "morph | qwen/qwen3.6-27b",
+          "model_id": "morph-qwen36-27b",
+          "model_name": "Qwen: Qwen3.6 27B",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000029",
+            "completion": "0.0000024"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -17951,8 +18811,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.00000095"
+        "prompt": "0.000000143565",
+        "completion": "0.00000085",
+        "input_cache_read": "0.0000001096"
       },
       "top_provider": {
         "context_length": 262144,
@@ -17998,28 +18859,48 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.5399948888321,
-          "uptime_last_5m": 99.85652797704448,
-          "uptime_last_1d": 99.571549353706,
+          "uptime_last_30m": 99.67963386727689,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.57556202222457,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "novita | qwen/qwen3.6-35b-a3b",
+          "name": "SiliconFlow | qwen/qwen3.6-35b-a3b-20260415",
           "model_id": "qwen/qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.000000248",
-            "completion": "0.000001485"
+            "prompt": "0.0000002",
+            "completion": "0.0000016",
+            "discount": 0
           },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "repetition_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "structured_outputs",
+            "response_format"
+          ],
+          "status": 0,
+          "uptime_last_30m": 97.83223374175306,
+          "uptime_last_5m": 98.13084112149532,
+          "uptime_last_1d": 96.5962642447091,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
+          "pricing_source": "provider_direct"
         },
         {
           "name": "gmi | qwen/qwen3.6-35b-a3b",
@@ -18054,6 +18935,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "novita | qwen/qwen3.6-35b-a3b",
+          "model_id": "qwen/qwen3.6-35b-a3b",
+          "model_name": "Qwen: Qwen3.6 35B A3B",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.000000248",
+            "completion": "0.000001485"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "makora | qwen/qwen3.6-35b-a3b",
           "model_id": "qwen/qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
@@ -18062,9 +18959,9 @@
           "tr_provider_slug": "makora",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.000000172",
-            "completion": "0.0000012002",
-            "input_cache_read": "0.000000129"
+            "prompt": "0.000000143565",
+            "completion": "0.00000085",
+            "input_cache_read": "0.0000001096"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -18174,9 +19071,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.77578475336323,
+          "uptime_last_30m": 99.32432432432432,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.79307814601931,
+          "uptime_last_1d": 95.97641345820325,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -18269,7 +19166,7 @@
       "pricing": {
         "prompt": "0.000000132",
         "completion": "0.000000528",
-        "input_cache_read": "0.000000035"
+        "input_cache_read": "0.000000033"
       },
       "top_provider": {
         "context_length": 262144,
@@ -18314,9 +19211,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.61878453038673,
-          "uptime_last_5m": 96.61016949152543,
-          "uptime_last_1d": 98.9602533201002,
+          "uptime_last_30m": 97.75784753363229,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.90802385991918,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18348,9 +19245,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.44444444444444,
-          "uptime_last_5m": 98.9795918367347,
-          "uptime_last_1d": 99.08787727196932,
+          "uptime_last_30m": 99.52153110047847,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.06021697683444,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -18389,9 +19286,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.9539748953975,
-          "uptime_last_5m": 98.50746268656717,
-          "uptime_last_1d": 99.13040512890466,
+          "uptime_last_30m": 98.24341279799246,
+          "uptime_last_5m": 98.14814814814815,
+          "uptime_last_1d": 99.10346444561054,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -18406,7 +19303,8 @@
           "context_length": 262144,
           "pricing": {
             "prompt": "0.000000132",
-            "completion": "0.000000528"
+            "completion": "0.000000528",
+            "input_cache_read": "0.000000033"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -18489,9 +19387,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.25152692948362,
-          "uptime_last_5m": 98.06576402321083,
-          "uptime_last_1d": 98.13001998273865,
+          "uptime_last_30m": 96.85795897169567,
+          "uptime_last_5m": 97.62376237623762,
+          "uptime_last_1d": 98.01897023109468,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -18563,7 +19461,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.82981539697923,
+          "uptime_last_1d": 99.82756969058339,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -18634,8 +19532,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.98801246703428,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.98790298191496,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -18708,9 +19606,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.6510152284264,
+          "uptime_last_30m": 99.1701244813278,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8798861451798,
+          "uptime_last_1d": 99.8781400383918,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -18783,6 +19681,28 @@
             "completion": "0.000005",
             "input_cache_read": "0.0000004"
           }
+        ],
+        "prompt_tiers": [
+          {
+            "max_prompt_tokens": 200000,
+            "prompt": "0.00000125",
+            "input_cache_read": "0.0000002"
+          },
+          {
+            "max_prompt_tokens": null,
+            "prompt": "0.0000025",
+            "input_cache_read": "0.0000004"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 200000,
+            "completion": "0.0000025"
+          },
+          {
+            "max_prompt_tokens": null,
+            "completion": "0.000005"
+          }
         ]
       },
       "top_provider": {
@@ -18812,52 +19732,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98525455132165,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-20260309",
-          "model_id": "x-ai/grok-4.20",
-          "model_name": "xAI: Grok 4.20",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -18881,7 +19776,76 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98525455132165,
+          "uptime_last_1d": 99.98510508363495,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.20-20260309",
+          "model_id": "x-ai/grok-4.20",
+          "model_name": "xAI: Grok 4.20",
+          "provider_name": "xAI",
+          "tag": "xai/priority",
+          "context_length": 2000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.98510508363495,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -18906,52 +19870,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "structured_outputs"
-          ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94673089839497,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-20260309",
-          "model_id": "x-ai/grok-4.20",
-          "model_name": "xAI: Grok 4.20",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -18975,7 +19914,76 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94673089839497,
+          "uptime_last_1d": 99.94707777266451,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.20-20260309",
+          "model_id": "x-ai/grok-4.20",
+          "model_name": "xAI: Grok 4.20",
+          "provider_name": "xAI",
+          "tag": "xai/zdr/priority",
+          "context_length": 2000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "structured_outputs"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94707777266451,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19014,6 +20022,28 @@
             "completion": "0.000005",
             "input_cache_read": "0.0000004"
           }
+        ],
+        "prompt_tiers": [
+          {
+            "max_prompt_tokens": 200000,
+            "prompt": "0.00000125",
+            "input_cache_read": "0.0000002"
+          },
+          {
+            "max_prompt_tokens": null,
+            "prompt": "0.0000025",
+            "input_cache_read": "0.0000004"
+          }
+        ],
+        "completion_tiers": [
+          {
+            "max_prompt_tokens": 200000,
+            "completion": "0.0000025"
+          },
+          {
+            "max_prompt_tokens": null,
+            "completion": "0.000005"
+          }
         ]
       },
       "top_provider": {
@@ -19043,51 +20073,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 47.123349003805686,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
-          "model_id": "x-ai/grok-4.20-multi-agent",
-          "model_name": "xAI: Grok 4.20 Multi-Agent",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -19110,7 +20116,75 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 47.123349003805686,
+          "uptime_last_1d": 48.21296524525511,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
+          "model_id": "x-ai/grok-4.20-multi-agent",
+          "model_name": "xAI: Grok 4.20 Multi-Agent",
+          "provider_name": "xAI",
+          "tag": "xai/priority",
+          "context_length": 2000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 48.21296524525511,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19135,51 +20209,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "response_format",
-            "structured_outputs",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 93.51289833080425,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
-          "model_id": "x-ai/grok-4.20-multi-agent",
-          "model_name": "xAI: Grok 4.20 Multi-Agent",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 2000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -19202,7 +20252,75 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 93.51289833080425,
+          "uptime_last_1d": 92.88121314237574,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.20-multi-agent-20260309",
+          "model_id": "x-ai/grok-4.20-multi-agent",
+          "model_name": "xAI: Grok 4.20 Multi-Agent",
+          "provider_name": "xAI",
+          "tag": "xai/zdr/priority",
+          "context_length": 2000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 92.88121314237574,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19270,56 +20388,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 95.59585492227978,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.30200464993871,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.3-20260430",
-          "model_id": "x-ai/grok-4.3",
-          "model_name": "xAI: Grok 4.3",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -19345,9 +20434,82 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.59585492227978,
+          "uptime_last_30m": 99.96165252070763,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 96.30200464993871,
+          "uptime_last_1d": 96.40045731334172,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.3-20260430",
+          "model_id": "x-ai/grok-4.3",
+          "model_name": "xAI: Grok 4.3",
+          "provider_name": "xAI",
+          "tag": "xai/priority",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.96165252070763,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.40045731334172,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19372,56 +20534,27 @@
                 "completion": "0.000005",
                 "input_cache_read": "0.0000004"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": -2,
-          "uptime_last_30m": 93.96035039188565,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.06744760442237,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.3-20260430",
-          "model_id": "x-ai/grok-4.3",
-          "model_name": "xAI: Grok 4.3",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00000125",
-            "completion": "0.0000025",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000004",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000005",
-                "completion": "0.00001",
-                "input_cache_read": "0.0000008"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
               }
             ]
           },
@@ -19446,10 +20579,83 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.96035039188565,
+          "status": 0,
+          "uptime_last_30m": 99.91289198606272,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 96.06744760442237,
+          "uptime_last_1d": 95.99422322763458,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.3-20260430",
+          "model_id": "x-ai/grok-4.3",
+          "model_name": "xAI: Grok 4.3",
+          "provider_name": "xAI",
+          "tag": "xai/zdr/priority",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.00000125",
+            "completion": "0.0000025",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000005",
+                "completion": "0.00001",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.00000125",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.0000025",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.0000025"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000005"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.91289198606272,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 95.99422322763458,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19534,56 +20740,27 @@
                 "completion": "0.000012",
                 "input_cache_read": "0.0000006"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.8922692407136,
-          "uptime_last_5m": 99.93150684931507,
-          "uptime_last_1d": 99.88007702988662,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai/priority",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000006",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000008",
-                "completion": "0.000024",
-                "input_cache_read": "0.0000012"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000003"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000004",
+                "input_cache_read": "0.0000006"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000006"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000012"
               }
             ]
           },
@@ -19609,9 +20786,82 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8922692407136,
-          "uptime_last_5m": 99.93150684931507,
-          "uptime_last_1d": 99.88007702988662,
+          "uptime_last_30m": 99.93969364371004,
+          "uptime_last_5m": 99.9721293199554,
+          "uptime_last_1d": 99.88461718859931,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.5-20260708",
+          "model_id": "x-ai/grok-4.5",
+          "model_name": "xAI: Grok 4.5",
+          "provider_name": "xAI",
+          "tag": "xai/priority",
+          "context_length": 500000,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000006",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000003",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000008",
+                "completion": "0.000024",
+                "input_cache_read": "0.0000012"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000003"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000004",
+                "input_cache_read": "0.0000006"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000006"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000012"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.93969364371004,
+          "uptime_last_5m": 99.9721293199554,
+          "uptime_last_1d": 99.88461718859931,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19636,56 +20886,27 @@
                 "completion": "0.000012",
                 "input_cache_read": "0.0000006"
               }
-            ]
-          },
-          "quantization": "unknown",
-          "max_completion_tokens": null,
-          "max_prompt_tokens": null,
-          "supported_parameters": [
-            "reasoning",
-            "include_reasoning",
-            "structured_outputs",
-            "response_format",
-            "max_tokens",
-            "temperature",
-            "top_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "tools",
-            "tool_choice",
-            "reasoning_effort"
-          ],
-          "status": 0,
-          "uptime_last_30m": 99.98103905953735,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95782370307887,
-          "supports_implicit_caching": false,
-          "tr_provider_slug": "grok",
-          "pricing_source": "provider_direct"
-        },
-        {
-          "name": "xAI | x-ai/grok-4.5-20260708",
-          "model_id": "x-ai/grok-4.5",
-          "model_name": "xAI: Grok 4.5",
-          "provider_name": "xAI",
-          "tag": "xai/zdr/priority",
-          "context_length": 500000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.000006",
-            "web_search": "0.005",
-            "input_cache_read": "0.0000006",
-            "discount": 0,
-            "overrides": [
+            ],
+            "prompt_tiers": [
               {
-                "min_prompt_tokens": 200000,
-                "prompt": "0.000008",
-                "completion": "0.000024",
-                "input_cache_read": "0.0000012"
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000003"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000004",
+                "input_cache_read": "0.0000006"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000006"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000012"
               }
             ]
           },
@@ -19711,9 +20932,82 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98103905953735,
+          "uptime_last_30m": 99.93500866551126,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95782370307887,
+          "uptime_last_1d": 99.95588161145565,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-4.5-20260708",
+          "model_id": "x-ai/grok-4.5",
+          "model_name": "xAI: Grok 4.5",
+          "provider_name": "xAI",
+          "tag": "xai/zdr/priority",
+          "context_length": 500000,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.000006",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000003",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000008",
+                "completion": "0.000024",
+                "input_cache_read": "0.0000012"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000003"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000004",
+                "input_cache_read": "0.0000006"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000006"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000012"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.93500866551126,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.95588161145565,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -19796,6 +21090,294 @@
       "per_request_limits": null,
       "endpoints": [
         {
+          "name": "xAI | x-ai/grok-build-0.1-20260520",
+          "model_id": "x-ai/grok-build-0.1",
+          "model_name": "xAI: Grok Build 0.1",
+          "provider_name": "xAI",
+          "tag": "xai",
+          "context_length": 256000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "completion": "0.000004",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000001",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000004"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94129576262141,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-build-0.1-20260520",
+          "model_id": "x-ai/grok-build-0.1",
+          "model_name": "xAI: Grok Build 0.1",
+          "provider_name": "xAI",
+          "tag": "xai/priority",
+          "context_length": 256000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000004",
+                "completion": "0.000008",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000001",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000004"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.94129576262141,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-build-0.1-20260520",
+          "model_id": "x-ai/grok-build-0.1",
+          "model_name": "xAI: Grok Build 0.1",
+          "provider_name": "xAI",
+          "tag": "xai/zdr",
+          "context_length": 256000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000002",
+                "completion": "0.000004",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000001",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000004"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.90262901655306,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "xAI | x-ai/grok-build-0.1-20260520",
+          "model_id": "x-ai/grok-build-0.1",
+          "model_name": "xAI: Grok Build 0.1",
+          "provider_name": "xAI",
+          "tag": "xai/zdr/priority",
+          "context_length": 256000,
+          "pricing": {
+            "prompt": "0.000001",
+            "completion": "0.000002",
+            "web_search": "0.005",
+            "input_cache_read": "0.0000002",
+            "discount": 0,
+            "overrides": [
+              {
+                "min_prompt_tokens": 200000,
+                "prompt": "0.000004",
+                "completion": "0.000008",
+                "input_cache_read": "0.0000008"
+              }
+            ],
+            "prompt_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "prompt": "0.000001",
+                "input_cache_read": "0.0000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "prompt": "0.000002",
+                "input_cache_read": "0.0000004"
+              }
+            ],
+            "completion_tiers": [
+              {
+                "max_prompt_tokens": 200000,
+                "completion": "0.000002"
+              },
+              {
+                "max_prompt_tokens": null,
+                "completion": "0.000004"
+              }
+            ]
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "structured_outputs",
+            "response_format",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "tools",
+            "tool_choice"
+          ],
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.90262901655306,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "grok",
+          "pricing_source": "provider_direct"
+        },
+        {
           "name": "atlas-cloud | x-ai/grok-build-0.1",
           "model_id": "x-ai/grok-build-0.1",
           "model_name": "xAI: Grok Build 0.1",
@@ -19848,23 +21430,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "xiaomi | xiaomi/mimo-v2.5",
-          "model_id": "xiaomi/mimo-v2.5",
-          "model_name": "Xiaomi: MiMo-V2.5",
-          "provider_name": "xiaomi",
-          "tag": "xiaomi",
-          "tr_provider_slug": "xiaomi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
-            "input_cache_read": "0.0000000028"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "digitalocean | xiaomi/mimo-v2.5",
           "model_id": "mimo-v2.5",
           "model_name": "Xiaomi: MiMo-V2.5",
@@ -19876,6 +21441,23 @@
             "prompt": "0.000000105",
             "completion": "0.00000028",
             "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "xiaomi | xiaomi/mimo-v2.5",
+          "model_id": "xiaomi/mimo-v2.5",
+          "model_name": "Xiaomi: MiMo-V2.5",
+          "provider_name": "xiaomi",
+          "tag": "xiaomi",
+          "tr_provider_slug": "xiaomi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.0000000028"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -19931,23 +21513,6 @@
       "per_request_limits": null,
       "endpoints": [
         {
-          "name": "xiaomi | xiaomi/mimo-v2.5-pro",
-          "model_id": "xiaomi/mimo-v2.5-pro",
-          "model_name": "Xiaomi: MiMo-V2.5-Pro",
-          "provider_name": "xiaomi",
-          "tag": "xiaomi",
-          "tr_provider_slug": "xiaomi",
-          "context_length": 1050000,
-          "pricing": {
-            "prompt": "0.000000435",
-            "completion": "0.00000087",
-            "input_cache_read": "0.0000000036"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "digitalocean | xiaomi/mimo-v2.5-pro",
           "model_id": "mimo-v2.5-pro",
           "model_name": "Xiaomi: MiMo-V2.5-Pro",
@@ -19959,6 +21524,23 @@
             "prompt": "0.0000006",
             "completion": "0.000003",
             "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "xiaomi | xiaomi/mimo-v2.5-pro",
+          "model_id": "xiaomi/mimo-v2.5-pro",
+          "model_name": "Xiaomi: MiMo-V2.5-Pro",
+          "provider_name": "xiaomi",
+          "tag": "xiaomi",
+          "tr_provider_slug": "xiaomi",
+          "context_length": 1050000,
+          "pricing": {
+            "prompt": "0.000000435",
+            "completion": "0.00000087",
+            "input_cache_read": "0.0000000036"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -20069,9 +21651,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000011",
-        "input_cache_read": "0.00000003"
+        "prompt": "0.00000014",
+        "completion": "0.00000086",
+        "input_cache_read": "0.000000025"
       },
       "top_provider": {
         "context_length": 131072,
@@ -20080,6 +21662,40 @@
       },
       "per_request_limits": null,
       "endpoints": [
+        {
+          "name": "SiliconFlow | z-ai/glm-4.5-air",
+          "model_id": "z-ai/glm-4.5-air",
+          "model_name": "Z.ai: GLM 4.5 Air",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000086",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 131072,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "tools",
+            "tool_choice",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.70608788588811,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
+          "pricing_source": "provider_direct"
+        },
         {
           "name": "Z.AI | z-ai/glm-4.5-air",
           "model_id": "z-ai/glm-4.5-air",
@@ -20108,8 +21724,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 85.92003156648691,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 86.0026829826915,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20177,7 +21793,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 79.91071428571429,
+          "uptime_last_1d": 79.87421383647799,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20251,7 +21867,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.957318274345,
+          "uptime_last_1d": 99.95440436315171,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20288,9 +21904,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 97.69452449567724,
-          "uptime_last_5m": 97.36842105263158,
-          "uptime_last_1d": 99.01684617508975,
+          "uptime_last_30m": 99.12023460410558,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.02556522691192,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -20322,9 +21938,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 98.59402460456941,
-          "uptime_last_5m": 98.68421052631578,
-          "uptime_last_1d": 97.18121998932953,
+          "uptime_last_30m": 99.25233644859813,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 97.3325402635432,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20406,10 +22022,10 @@
             "tools",
             "top_k"
           ],
-          "status": -5,
-          "uptime_last_30m": 72.93233082706767,
+          "status": 0,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 94.6579545188412,
+          "uptime_last_1d": 94.66669784189483,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20483,7 +22099,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97867803837953,
+          "uptime_last_1d": 99.97875899423838,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -20524,9 +22140,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97455146965262,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8046776296506,
+          "uptime_last_30m": 99.74570883661794,
+          "uptime_last_5m": 99.87593052109182,
+          "uptime_last_1d": 99.80133837854758,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20565,7 +22181,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.617102744097,
+          "uptime_last_1d": 99.61693977442009,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -20598,9 +22214,9 @@
             "response_format"
           ],
           "status": -2,
-          "uptime_last_30m": 90.53497942386831,
-          "uptime_last_5m": 91.37931034482759,
-          "uptime_last_1d": 86.97787919122774,
+          "uptime_last_30m": 93.82530120481928,
+          "uptime_last_5m": 87.5,
+          "uptime_last_1d": 86.97370084713617,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -20706,9 +22322,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8435598818008,
-          "uptime_last_5m": 99.8800959232614,
-          "uptime_last_1d": 99.59823643261902,
+          "uptime_last_30m": 99.44538591896472,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.59015968925334,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20744,9 +22360,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.0484429065744,
+          "uptime_last_1d": 99.05833964714796,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -20835,9 +22451,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.44444444444444,
+          "uptime_last_30m": 99.8309144709032,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.8651282586753,
+          "uptime_last_1d": 99.86106315460628,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20871,9 +22487,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94129732902847,
-          "uptime_last_5m": 99.71181556195965,
-          "uptime_last_1d": 99.50183936235439,
+          "uptime_last_30m": 99.91050882127334,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.499310464784,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -20915,9 +22531,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.68619246861925,
-          "uptime_last_5m": 99.15966386554622,
-          "uptime_last_1d": 98.66020883129953,
+          "uptime_last_30m": 99.70351545955104,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.79360939028366,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -20950,9 +22566,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95735607675907,
-          "uptime_last_5m": 99.71830985915493,
-          "uptime_last_1d": 98.27634097819151,
+          "uptime_last_30m": 99.9066728884741,
+          "uptime_last_5m": 99.80237154150198,
+          "uptime_last_1d": 98.32427074070294,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -20989,9 +22605,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.53249475890985,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.60148021633931,
+          "uptime_last_1d": 99.6352266805628,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -21023,9 +22639,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 99.06676238334529,
-          "uptime_last_5m": 99.42857142857143,
-          "uptime_last_1d": 96.48230912476723,
+          "uptime_last_30m": 98.87928274095421,
+          "uptime_last_5m": 98.7864077669903,
+          "uptime_last_1d": 96.67252283907239,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -21158,9 +22774,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 99.62121212121212,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.59695645623022,
+          "uptime_last_1d": 99.59574786644707,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -21266,9 +22882,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.68404423380727,
-          "uptime_last_5m": 98.66666666666667,
-          "uptime_last_1d": 99.70750731231719,
+          "uptime_last_30m": 99.8272884283247,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.7083775185578,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -21309,9 +22925,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.93093922651933,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9131294771731,
+          "uptime_last_30m": 99.6548748921484,
+          "uptime_last_5m": 99.3103448275862,
+          "uptime_last_1d": 99.90523098279476,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -21352,9 +22968,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.72174657534246,
+          "uptime_last_1d": 99.84936518183774,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21396,7 +23012,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97556074512572,
+          "uptime_last_1d": 99.97856776778642,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -21428,9 +23044,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.52380952380952,
-          "uptime_last_5m": 99.20634920634922,
-          "uptime_last_1d": 99.1274865447993,
+          "uptime_last_30m": 99.7005988023952,
+          "uptime_last_5m": 99.12280701754386,
+          "uptime_last_1d": 99.13681889616025,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -21474,9 +23090,44 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.51698038044019,
+          "uptime_last_1d": 99.54096397565112,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | z-ai/glm-5.1-20260406",
+          "model_id": "z-ai/glm-5.1",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000119",
+            "completion": "0.00000374",
+            "input_cache_read": "0.0000006",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 131072,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "tools",
+            "tool_choice",
+            "max_tokens"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.84802431610942,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.49225495175216,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -21512,8 +23163,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.6860003554713,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.70660439494641,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -21556,9 +23207,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 95.98214285714286,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.68114817688131,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.84622842738025,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -21593,7 +23244,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.01488616462348,
+          "uptime_last_1d": 99.07814511623387,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -21616,23 +23267,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "chutes | z-ai/glm-5.1",
-          "model_id": "zai-org/GLM-5.1-TEE",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000098",
-            "completion": "0.00000308",
-            "input_cache_read": "0.00000049"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | z-ai/glm-5.1",
           "model_id": "glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
@@ -21644,6 +23278,23 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "chutes | z-ai/glm-5.1",
+          "model_id": "zai-org/GLM-5.1-TEE",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "chutes",
+          "tag": "chutes",
+          "tr_provider_slug": "chutes",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000098",
+            "completion": "0.00000308",
+            "input_cache_read": "0.00000049"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -21704,9 +23355,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000093",
-        "completion": "0.000003",
-        "input_cache_read": "0.00000014612"
+        "prompt": "0.00000044",
+        "completion": "0.0000015404",
+        "input_cache_read": "0.00000011"
       },
       "top_provider": {
         "context_length": 1048576,
@@ -21752,9 +23403,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.28944839515664,
-          "uptime_last_5m": 96.52173913043478,
-          "uptime_last_1d": 98.4841601453773,
+          "uptime_last_30m": 98.59053645908241,
+          "uptime_last_5m": 98.92051030421982,
+          "uptime_last_1d": 98.50109258672707,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -21796,9 +23447,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86256184716878,
+          "uptime_last_30m": 99.91643454038997,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.36941172901767,
+          "uptime_last_1d": 99.39475479136841,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21840,9 +23491,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.54000180391449,
-          "uptime_last_5m": 99.8468606431853,
-          "uptime_last_1d": 99.69353109639869,
+          "uptime_last_30m": 99.64881474978051,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.69032425053847,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -21883,9 +23534,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86870897155362,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.69354587017368,
+          "uptime_last_30m": 99.68389735961324,
+          "uptime_last_5m": 99.86876640419948,
+          "uptime_last_1d": 99.70007714202113,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -21922,9 +23573,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.61436991299468,
-          "uptime_last_5m": 98.59154929577466,
-          "uptime_last_1d": 96.43351914948913,
+          "uptime_last_30m": 98.83306320907617,
+          "uptime_last_5m": 98.34710743801654,
+          "uptime_last_1d": 96.44159083884459,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -21940,7 +23591,7 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026",
-            "discount": 0.438
+            "discount": 0.443
           },
           "quantization": "fp8",
           "max_completion_tokens": 131072,
@@ -21963,9 +23614,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.43396736193667,
-          "uptime_last_5m": 99.5437181663837,
-          "uptime_last_1d": 99.25257991351764,
+          "uptime_last_30m": 99.72780933993765,
+          "uptime_last_5m": 99.88805373420759,
+          "uptime_last_1d": 99.27149492675122,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -22008,11 +23659,47 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.62121212121212,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.40934789986353,
+          "uptime_last_1d": 99.40663229506697,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | z-ai/glm-5.2-20260616",
+          "model_id": "z-ai/glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000001302",
+            "completion": "0.000004092",
+            "input_cache_read": "0.00000026",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.92221934145708,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.74778284071019,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
@@ -22051,9 +23738,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.4945713216024,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.71429917737011,
+          "uptime_last_30m": 99.74143503555268,
+          "uptime_last_5m": 99.73821989528795,
+          "uptime_last_1d": 99.71347634557549,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -22091,9 +23778,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.68321013727561,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.51013800015419,
+          "uptime_last_1d": 98.54864616796696,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -22136,10 +23823,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.02832244008714,
+          "status": 0,
+          "uptime_last_30m": 99.91776315789474,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.99865239200419,
+          "uptime_last_1d": 98.9848684336062,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -22181,9 +23868,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.13479052823315,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84453328256869,
+          "uptime_last_1d": 99.84323376710942,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -22200,6 +23887,23 @@
             "prompt": "0.0000015",
             "completion": "0.00000525",
             "input_cache_read": "0.000000375"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "baseten | z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "baseten",
+          "tag": "baseten",
+          "tr_provider_slug": "baseten",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22231,21 +23935,21 @@
           "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000135",
-            "completion": "0.00000399",
-            "input_cache_read": "0.00000024"
+            "prompt": "0.00000044",
+            "completion": "0.0000015404",
+            "input_cache_read": "0.00000011"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
           "quantization": "unknown"
         },
         {
-          "name": "baseten | z-ai/glm-5.2",
-          "model_id": "zai-org/GLM-5.2",
+          "name": "alibaba | z-ai/glm-5.2",
+          "model_id": "glm-5.2",
           "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "baseten",
-          "tag": "baseten",
-          "tr_provider_slug": "baseten",
+          "provider_name": "alibaba",
+          "tag": "alibaba",
+          "tr_provider_slug": "alibaba",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000014",
@@ -22268,23 +23972,6 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.0000007"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "alibaba | z-ai/glm-5.2",
-          "model_id": "glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "alibaba",
-          "tag": "alibaba",
-          "tr_provider_slug": "alibaba",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22325,17 +24012,16 @@
           "quantization": "unknown"
         },
         {
-          "name": "inceptron | z-ai/glm-5.2",
-          "model_id": "zai-org/GLM-5.2",
+          "name": "morph | z-ai/glm-5.2",
+          "model_id": "morph-glm52-744b",
           "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "inceptron",
-          "tag": "inceptron",
-          "tr_provider_slug": "inceptron",
+          "provider_name": "morph",
+          "tag": "morph",
+          "tr_provider_slug": "morph",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000094",
-            "completion": "0.0000029",
-            "input_cache_read": "0.00000017"
+            "prompt": "0.0000011",
+            "completion": "0.0000041"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22353,6 +24039,23 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "inceptron | z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "inceptron",
+          "tag": "inceptron",
+          "tr_provider_slug": "inceptron",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000094",
+            "completion": "0.0000029",
+            "input_cache_read": "0.00000017"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -22428,6 +24131,23 @@
           "pricing_source": "provider_direct"
         },
         {
+          "name": "siliconflow | z-ai/glm-5v-turbo",
+          "model_id": "z-ai/glm-5v-turbo",
+          "model_name": "Z.ai: GLM 5V Turbo",
+          "provider_name": "siliconflow",
+          "tag": "siliconflow",
+          "tr_provider_slug": "siliconflow",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.0000012",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000024"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "venice | z-ai/glm-5v-turbo",
           "model_id": "z-ai-glm-5v-turbo",
           "model_name": "Z.ai: GLM 5V Turbo",
@@ -22439,22 +24159,6 @@
             "prompt": "0.0000015",
             "completion": "0.000005",
             "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "siliconflow | z-ai/glm-5v-turbo",
-          "model_id": "z-ai/glm-5v-turbo",
-          "model_name": "Z.ai: GLM 5V Turbo",
-          "provider_name": "siliconflow",
-          "tag": "siliconflow",
-          "tr_provider_slug": "siliconflow",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.000004"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],

--- a/src/trusted_router/data/provider_models/atlas-cloud.json
+++ b/src/trusted_router/data/provider_models/atlas-cloud.json
@@ -3281,6 +3281,6 @@
       "cached_input_token_price_per_m": 300000
     }
   ],
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 119
 }

--- a/src/trusted_router/data/provider_models/cerebras.json
+++ b/src/trusted_router/data/provider_models/cerebras.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for the Cerebras models enabled on the TrustedRouter Cerebras account. Verified from Cerebras /v1/models and direct chat completions on 2026-06-05. The canonical OpenRouter-style model IDs remain openai/gpt-oss-120b and z-ai/glm-4.7; cerebras/* aliases are included so users can request the Cerebras-specific route directly.",
   "provider": "cerebras",
   "source": "https://api.cerebras.ai/public/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/chutes.json
+++ b/src/trusted_router/data/provider_models/chutes.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native Chutes TEE model catalog. Refreshed hourly from the authenticated Chutes OpenAI-compatible models API.",
   "provider": "chutes",
   "source": "https://llm.chutes.ai/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 13,
   "models": [

--- a/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
+++ b/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
@@ -1,7 +1,7 @@
 {
   "provider": "cloudflare-workers-ai",
   "source": "https://api.cloudflare.com/client/v4/accounts/96781cbfaebf2b28d851b9c677dd2e81/ai/models/search?per_page=100",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 27,
   "models": [

--- a/src/trusted_router/data/provider_models/cohere.json
+++ b/src/trusted_router/data/provider_models/cohere.json
@@ -3,7 +3,7 @@
   "provider": "cohere",
   "source": "https://docs.cohere.com/docs/cohere-embed",
   "pricing_source": "https://cohere.com/pricing",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 3,
   "models": [

--- a/src/trusted_router/data/provider_models/crusoe.json
+++ b/src/trusted_router/data/provider_models/crusoe.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Crusoe Managed Inference routes. Generated from https://api.inference.crusoecloud.com/v1/models; prices are provider cost in integer microdollars per million tokens and catalog applies markup.",
   "provider": "crusoe",
   "source": "https://api.inference.crusoecloud.com/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 15,
   "models": [

--- a/src/trusted_router/data/provider_models/digitalocean.json
+++ b/src/trusted_router/data/provider_models/digitalocean.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native DigitalOcean Gradient AI serverless catalog. Availability comes from /v1/models and rates from DigitalOcean's official pricing documentation.",
   "provider": "digitalocean",
   "source": "https://inference.do-ai.run/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 23,
   "models": [

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -3,7 +3,7 @@
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/friendli.json
+++ b/src/trusted_router/data/provider_models/friendli.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for FriendliAI serverless Model API routes. Verified against https://api.friendli.ai/serverless/v1/models on 2026-06-22.",
   "provider": "friendli",
   "source": "https://api.friendli.ai/serverless/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 9,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/google-ai-studio.json
+++ b/src/trusted_router/data/provider_models/google-ai-studio.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Google AI Studio chat and image models that are available from the Gemini API before the OpenRouter snapshot catches up. Verified against Google Gemini /v1beta/models and direct countTokens/generateContent smoke.",
   "provider": "google-ai-studio",
   "source": "https://generativelanguage.googleapis.com/v1beta/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 32,
   "models": [
     {
@@ -726,8 +726,10 @@
       "upstream_id": "gemini-3.5-flash-lite",
       "context_length": 1048576,
       "max_output_tokens": 65536,
-      "routable": false,
-      "routable_reason": "awaiting-price"
+      "routable": true,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 2500000,
+      "cached_input_token_price_per_m": 30000
     },
     {
       "display_name": "Gemini 3.6 Flash",
@@ -756,5 +758,5 @@
       "cached_input_token_price_per_m": 150000
     }
   ],
-  "pricing_source": "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing"
+  "pricing_source": "https://ai.google.dev/gemini-api/docs/pricing"
 }

--- a/src/trusted_router/data/provider_models/google-vertex.json
+++ b/src/trusted_router/data/provider_models/google-vertex.json
@@ -2,8 +2,8 @@
   "_about": "Provider-native supplement for Google Vertex AI models whose availability is verified independently from Google AI Studio discovery. Gemini 3.6 Flash was verified with a direct global Vertex streamGenerateContent request in the TrustedRouter GCP project on 2026-07-21.",
   "provider": "google-vertex",
   "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-6-flash",
-  "pricing_source": "https://r.jina.ai/https://ai.google.dev/gemini-api/docs/pricing",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "pricing_source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 1,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/inceptron.json
+++ b/src/trusted_router/data/provider_models/inceptron.json
@@ -185,6 +185,6 @@
       "cached_input_token_price_per_m": 170000
     }
   ],
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 4
 }

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -186,6 +186,6 @@
   "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
   "source": "https://api.moonshot.ai/v1/models",
   "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 11
 }

--- a/src/trusted_router/data/provider_models/makora.json
+++ b/src/trusted_router/data/provider_models/makora.json
@@ -1,23 +1,23 @@
 {
-  "_about": "Provider-native supplement for Makora Inference routes. Makora's /v1/models feed publishes native model ids and context windows but not pricing. Prices are refreshed hourly from Makora's public homepage lineup where listed; Gemma keeps the OpenRouter canonical price fallback because Makora does not currently publish a Gemma price on its homepage/pricing page/API feed.",
+  "_about": "Provider-native supplement for Makora Inference routes. Model IDs, capabilities, context windows, and account-billable prices refresh hourly from Makora's authenticated /v1/models feed.",
   "provider": "makora",
   "source": "https://inference.makora.com/v1/models",
-  "pricing_source": "https://www.makora.com/; https://openrouter.ai/api/v1/models for Gemma fallback",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "pricing_source": "https://inference.makora.com/v1/models",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
-  "model_count": 10,
+  "model_count": 11,
   "models": [
     {
       "id": "deepseek/deepseek-v4-flash",
       "upstream_id": "deepseek-ai/DeepSeek-V4-Flash",
-      "display_name": "DeepSeek V4 Flash",
+      "display_name": "deepseek-ai/DeepSeek-V4-Flash",
       "context_length": 1048576,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 113400,
-      "output_token_price_per_m": 279100,
-      "cached_input_token_price_per_m": 85100,
+      "input_token_price_per_m": 90000,
+      "output_token_price_per_m": 195000,
+      "cached_input_token_price_per_m": 19600,
       "input_modalities": [
         "text"
       ],
@@ -25,28 +25,41 @@
         "text"
       ],
       "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
         "temperature",
-        "tool_choice",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "stop",
+        "logit_bias",
+        "max_tokens",
+        "repetition_penalty",
+        "presence_penalty",
+        "seed",
+        "min_p"
+      ],
+      "title": "deepseek-ai/DeepSeek-V4-Flash",
+      "model_type": "chat",
+      "status": 1,
+      "max_output_tokens": 384000,
+      "features": [
         "tools",
-        "top_p"
+        "reasoning",
+        "json_mode",
+        "structured_outputs",
+        "logprobs"
       ]
     },
     {
       "id": "deepseek/deepseek-v4-pro",
       "upstream_id": "deepseek-ai/DeepSeek-V4-Pro",
-      "display_name": "DeepSeek V4 Pro",
+      "display_name": "deepseek-ai/DeepSeek-V4-Pro",
       "context_length": 1048576,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 1318000,
-      "output_token_price_per_m": 2636100,
-      "cached_input_token_price_per_m": 988500,
+      "input_token_price_per_m": 627000,
+      "output_token_price_per_m": 1344000,
+      "cached_input_token_price_per_m": 68860,
       "input_modalities": [
         "text"
       ],
@@ -54,84 +67,40 @@
         "text"
       ],
       "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
         "temperature",
-        "tool_choice",
+        "min_p",
+        "presence_penalty",
+        "seed",
+        "top_p",
+        "repetition_penalty",
+        "max_tokens",
+        "logit_bias",
+        "stop",
+        "frequency_penalty",
+        "top_k"
+      ],
+      "title": "deepseek-ai/DeepSeek-V4-Pro",
+      "model_type": "chat",
+      "status": 1,
+      "max_output_tokens": 384000,
+      "features": [
         "tools",
-        "top_p"
+        "reasoning",
+        "json_mode",
+        "structured_outputs",
+        "logprobs"
       ]
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
       "upstream_id": "google/gemma-4-26B-A4B",
-      "display_name": "Gemma 4 26B A4B",
+      "display_name": "google/gemma-4-26B-A4B",
       "context_length": 262144,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 60000,
-      "output_token_price_per_m": 330000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
-    },
-    {
-      "id": "z-ai/glm-5.2",
-      "upstream_id": "zai-org/GLM-5.2-FP8",
-      "display_name": "GLM 5.2 FP8",
-      "context_length": 980000,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 1350000,
-      "output_token_price_per_m": 3990000,
-      "cached_input_token_price_per_m": 240000,
-      "input_modalities": [
-        "text"
-      ],
-      "output_modalities": [
-        "text"
-      ],
-      "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ]
-    },
-    {
-      "id": "moonshotai/kimi-k2.7-code",
-      "upstream_id": "moonshotai/Kimi-K2.7-Code",
-      "display_name": "Kimi K2.7 Code",
-      "context_length": 262144,
-      "endpoints": [
-        "chat/completions"
-      ],
-      "input_token_price_per_m": 760000,
-      "output_token_price_per_m": 3774900,
-      "cached_input_token_price_per_m": 575700,
+      "input_token_price_per_m": 100000,
+      "output_token_price_per_m": 340000,
       "input_modalities": [
         "text",
         "image"
@@ -140,15 +109,110 @@
         "text"
       ],
       "supported_parameters": [
-        "chat_template_kwargs",
-        "max_completion_tokens",
-        "max_tokens",
-        "response_format",
-        "stream_options",
         "temperature",
-        "tool_choice",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "seed",
+        "max_tokens"
+      ],
+      "title": "google/gemma-4-26B-A4B",
+      "model_type": "chat",
+      "status": 1,
+      "max_output_tokens": 384000,
+      "features": [
         "tools",
-        "top_p"
+        "logprobs",
+        "structured_outputs",
+        "reasoning",
+        "json_mode"
+      ],
+      "cached_input_token_price_per_m": 34000
+    },
+    {
+      "id": "z-ai/glm-5.2",
+      "upstream_id": "zai-org/GLM-5.2-FP8",
+      "display_name": "zai-org/GLM-5.2-FP8",
+      "context_length": 980000,
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_token_price_per_m": 440000,
+      "output_token_price_per_m": 1540400,
+      "cached_input_token_price_per_m": 110000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "seed",
+        "max_tokens",
+        "logit_bias",
+        "min_p"
+      ],
+      "title": "zai-org/GLM-5.2-FP8",
+      "model_type": "chat",
+      "status": 1,
+      "max_output_tokens": 128000,
+      "features": [
+        "tools",
+        "reasoning",
+        "json_mode",
+        "structured_outputs",
+        "logprobs"
+      ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "upstream_id": "moonshotai/Kimi-K2.7-Code",
+      "display_name": "moonshotai/Kimi-K2.7-Code",
+      "context_length": 262144,
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_token_price_per_m": 328000,
+      "output_token_price_per_m": 1353200,
+      "cached_input_token_price_per_m": 64600,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_parameters": [
+        "temperature",
+        "min_p",
+        "presence_penalty",
+        "seed",
+        "top_p",
+        "repetition_penalty",
+        "max_tokens",
+        "stop",
+        "logit_bias",
+        "frequency_penalty",
+        "top_k"
+      ],
+      "title": "moonshotai/Kimi-K2.7-Code",
+      "model_type": "chat",
+      "status": 1,
+      "features": [
+        "tools",
+        "reasoning",
+        "json_mode",
+        "logprobs"
       ]
     },
     {
@@ -177,19 +241,22 @@
         "tool_choice",
         "tools",
         "top_p"
-      ]
+      ],
+      "missing_since": "2026-07-21",
+      "routable": false,
+      "routable_reason": "delisted-upstream"
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
       "upstream_id": "meta-llama/Llama-3.3-70B-Instruct",
-      "display_name": "Llama 3.3 70B Instruct",
-      "context_length": 131072,
+      "display_name": "meta-llama/Llama-3.3-70B-Instruct",
+      "context_length": 4096,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 180000,
-      "output_token_price_per_m": 400000,
-      "cached_input_token_price_per_m": 150000,
+      "input_token_price_per_m": 119000,
+      "output_token_price_per_m": 382500,
+      "cached_input_token_price_per_m": 80000,
       "input_modalities": [
         "text"
       ],
@@ -205,77 +272,103 @@
         "tool_choice",
         "tools",
         "top_p"
+      ],
+      "title": "meta-llama/Llama-3.3-70B-Instruct",
+      "model_type": "chat",
+      "status": 1,
+      "features": [
+        "tools"
       ]
     },
     {
       "id": "qwen/qwen3.6-27b",
       "upstream_id": "unsloth/Qwen3.6-27B-NVFP4",
-      "display_name": "Qwen 3.6 27B NVFP4",
+      "display_name": "unsloth/Qwen3.6-27B-NVFP4",
       "context_length": 262144,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 467100,
-      "output_token_price_per_m": 3459200,
-      "cached_input_token_price_per_m": 350300,
+      "input_token_price_per_m": 272850,
+      "output_token_price_per_m": 2822850,
+      "cached_input_token_price_per_m": 297700,
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
       ],
       "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
+        "top_p",
         "temperature",
-        "tool_choice",
+        "top_k",
+        "frequency_penalty",
+        "top_a",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "max_tokens",
+        "seed"
+      ],
+      "title": "unsloth/Qwen3.6-27B-NVFP4",
+      "model_type": "chat",
+      "status": 1,
+      "features": [
         "tools",
-        "top_p"
+        "reasoning"
       ]
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
       "upstream_id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
-      "display_name": "Qwen 3.6 35B A3B NVFP4",
+      "display_name": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "context_length": 262144,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 172000,
-      "output_token_price_per_m": 1200200,
-      "cached_input_token_price_per_m": 129000,
+      "input_token_price_per_m": 143565,
+      "output_token_price_per_m": 850000,
+      "cached_input_token_price_per_m": 109600,
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
       ],
       "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
         "temperature",
-        "tool_choice",
+        "min_p",
+        "presence_penalty",
+        "seed",
+        "max_tokens",
+        "repetition_penalty",
+        "top_a",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "stop",
+        "logit_bias"
+      ],
+      "title": "unsloth/Qwen3.6-35B-A3B-NVFP4",
+      "model_type": "chat",
+      "status": 1,
+      "features": [
         "tools",
-        "top_p"
+        "reasoning"
       ]
     },
     {
       "id": "z-ai/glm-5.2-nvfp4",
       "upstream_id": "zai-org/GLM-5.2-NVFP4",
-      "display_name": "GLM 5.2 NVFP4",
+      "display_name": "zai-org/GLM-5.2-NVFP4",
       "context_length": 1048576,
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 1350000,
-      "output_token_price_per_m": 3990000,
-      "cached_input_token_price_per_m": 240000,
+      "input_token_price_per_m": 1020000,
+      "output_token_price_per_m": 3400000,
+      "cached_input_token_price_per_m": 161500,
       "input_modalities": [
         "text"
       ],
@@ -283,16 +376,50 @@
         "text"
       ],
       "supported_parameters": [
-        "max_completion_tokens",
-        "max_tokens",
-        "reasoning_effort",
-        "response_format",
-        "stream_options",
         "temperature",
-        "tool_choice",
+        "min_p",
+        "presence_penalty",
+        "seed",
+        "max_tokens",
+        "repetition_penalty",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "stop",
+        "logit_bias"
+      ],
+      "title": "zai-org/GLM-5.2-NVFP4",
+      "model_type": "chat",
+      "status": 1,
+      "max_output_tokens": 128000,
+      "features": [
         "tools",
-        "top_p"
+        "reasoning",
+        "structured_outputs",
+        "json_mode",
+        "logprobs"
       ]
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "upstream_id": "openai/gpt-oss-120b",
+      "display_name": "openai/gpt-oss-120b",
+      "title": "openai/gpt-oss-120b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "context_length": 131072,
+      "input_token_price_per_m": 128600,
+      "output_token_price_per_m": 453300,
+      "cached_input_token_price_per_m": 96475
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/meta.json
+++ b/src/trusted_router/data/provider_models/meta.json
@@ -2,7 +2,7 @@
   "_about": "Meta Muse Spark served through OpenRouter. This is not a direct Meta, ZDR, confidential-compute, or downstream-attested route.",
   "provider": "meta",
   "source": "https://openrouter.ai/api/v1/models/meta/muse-spark-1.1/endpoints",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/minimax.json
+++ b/src/trusted_router/data/provider_models/minimax.json
@@ -1,15 +1,15 @@
 {
   "provider": "minimax",
-  "source": "https://platform.minimax.io/subscribe/token-plan?tab=api-enterprise",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "source": "https://api.minimax.io/v1/models",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 8,
   "models": [
     {
       "id": "minimax/minimax-m3",
       "upstream_id": "MiniMax-M3",
-      "display_name": "MiniMax M3",
+      "display_name": "MiniMax-M3",
       "title": "MiniMax-M3",
-      "created": 1780185600,
+      "created": 1780272000,
       "context_length": 1000000,
       "max_output_tokens": 1000000,
       "input_token_price_per_m": 300000,
@@ -47,7 +47,7 @@
     {
       "id": "minimax/minimax-m2.7",
       "upstream_id": "MiniMax-M2.7",
-      "display_name": "MiniMax M2.7",
+      "display_name": "MiniMax-M2.7",
       "title": "MiniMax-M2.7",
       "created": 1773799200,
       "context_length": 204800,
@@ -74,7 +74,7 @@
     {
       "id": "minimax/minimax-m2.7-highspeed",
       "upstream_id": "MiniMax-M2.7-highspeed",
-      "display_name": "MiniMax M2.7 highspeed",
+      "display_name": "MiniMax-M2.7-highspeed",
       "title": "MiniMax-M2.7-highspeed",
       "created": 1773799200,
       "context_length": 204800,
@@ -101,7 +101,7 @@
     {
       "id": "minimax/minimax-m2.5",
       "upstream_id": "MiniMax-M2.5",
-      "display_name": "MiniMax M2.5",
+      "display_name": "MiniMax-M2.5",
       "title": "MiniMax-M2.5",
       "created": 1770948000,
       "context_length": 204800,
@@ -128,7 +128,7 @@
     {
       "id": "minimax/minimax-m2.5-highspeed",
       "upstream_id": "MiniMax-M2.5-highspeed",
-      "display_name": "MiniMax M2.5 highspeed",
+      "display_name": "MiniMax-M2.5-highspeed",
       "title": "MiniMax-M2.5-highspeed",
       "created": 1770948000,
       "context_length": 204800,
@@ -155,7 +155,7 @@
     {
       "id": "minimax/minimax-m2.1",
       "upstream_id": "MiniMax-M2.1",
-      "display_name": "MiniMax M2.1",
+      "display_name": "MiniMax-M2.1",
       "title": "MiniMax-M2.1",
       "created": 1766455200,
       "context_length": 204800,
@@ -182,7 +182,7 @@
     {
       "id": "minimax/minimax-m2.1-highspeed",
       "upstream_id": "MiniMax-M2.1-highspeed",
-      "display_name": "MiniMax M2.1 highspeed",
+      "display_name": "MiniMax-M2.1-highspeed",
       "title": "MiniMax-M2.1-highspeed",
       "created": 1766455200,
       "context_length": 204800,
@@ -209,7 +209,7 @@
     {
       "id": "minimax/minimax-m2",
       "upstream_id": "MiniMax-M2",
-      "display_name": "MiniMax M2",
+      "display_name": "MiniMax-M2",
       "title": "MiniMax-M2",
       "created": 1761530400,
       "context_length": 204800,
@@ -233,5 +233,6 @@
       ],
       "status": 1
     }
-  ]
+  ],
+  "pricing_source": "https://platform.minimax.io/docs/guides/pricing-paygo.md"
 }

--- a/src/trusted_router/data/provider_models/morph.json
+++ b/src/trusted_router/data/provider_models/morph.json
@@ -165,6 +165,6 @@
       "output_token_price_per_m": 4100000
     }
   ],
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 8
 }

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -1,7 +1,7 @@
 {
   "provider": "nebius",
   "source": "https://api.tokenfactory.nebius.com/v1/models?verbose=true",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 38,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/novita.json
+++ b/src/trusted_router/data/provider_models/novita.json
@@ -3,7 +3,7 @@
   "source": "https://api.novita.ai/openai/v1/models",
   "price_source": "https://novita.ai/pricing",
   "price_scale_to_microdollars_per_million_tokens": 100,
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 135,
   "models": [
     {
@@ -2157,8 +2157,8 @@
       "created": 1758695025,
       "context_length": 65536,
       "max_output_tokens": 16384,
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
+      "input_token_price_per_m": 2500,
+      "output_token_price_per_m": 9700,
       "model_type": "chat",
       "features": [
         "function-calling",
@@ -2188,8 +2188,8 @@
       "created": 1758695093,
       "context_length": 65536,
       "max_output_tokens": 16384,
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
+      "input_token_price_per_m": 2500,
+      "output_token_price_per_m": 9700,
       "model_type": "chat",
       "features": [
         "function-calling",
@@ -3302,8 +3302,10 @@
       "created": 1780282959,
       "context_length": 1000000,
       "max_output_tokens": 131072,
-      "routable": false,
-      "routable_reason": "awaiting-price"
+      "routable": true,
+      "input_token_price_per_m": 3000,
+      "output_token_price_per_m": 12000,
+      "cached_input_token_price_per_m": 600
     },
     {
       "id": "moonshotai/kimi-k2.7-code",

--- a/src/trusted_router/data/provider_models/parasail.json
+++ b/src/trusted_router/data/provider_models/parasail.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Parasail models live ahead of the shared snapshot. Prices refreshed hourly from the public pricing page (www.parasail.io/pricing); model liveness gated on api.parasail.io/v1/models.",
   "provider": "parasail",
   "source": "https://www.parasail.io/pricing",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 4,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/streamlake.json
+++ b/src/trusted_router/data/provider_models/streamlake.json
@@ -68,11 +68,11 @@
       "context_length": 262144,
       "input_token_price_per_m": 740000,
       "output_token_price_per_m": 2960000,
-      "cached_input_token_price_per_m": 150000,
+      "cached_input_token_price_per_m": 999900000,
       "routable": false,
       "routable_reason": "provider-canary-failed"
     }
   ],
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 3
 }

--- a/src/trusted_router/data/provider_models/thinkingmachines.json
+++ b/src/trusted_router/data/provider_models/thinkingmachines.json
@@ -1,6 +1,6 @@
 {
   "source": "https://tinker-docs.thinkingmachines.ai/tinker/models/",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "provider": "thinkingmachines",
   "currency": "USD",
   "price_unit": "microdollars_per_million_tokens",

--- a/src/trusted_router/data/provider_models/together.json
+++ b/src/trusted_router/data/provider_models/together.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Together AI routes that are live ahead of the shared OpenRouter snapshot. Verified against https://api.together.xyz/v1/models on 2026-06-22.",
   "provider": "together",
   "source": "https://api.together.xyz/v1/endpoints?type=serverless",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 18,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/voyage.json
+++ b/src/trusted_router/data/provider_models/voyage.json
@@ -3,7 +3,7 @@
   "provider": "voyage",
   "source": "https://docs.voyageai.com/docs/embeddings",
   "pricing_source": "https://docs.voyageai.com/docs/pricing.md",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Wafer serverless API. Refreshed hourly from Wafer's OpenAI-compatible /v1/models feed.",
   "provider": "wafer",
   "source": "https://pass.wafer.ai/v1/models",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "generated_at": "2026-07-21T20:47:51Z",
   "price_scale": "microdollars_per_million",
   "zdr_header": "Wafer-ZDR: required",
   "model_count": 6,

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -1,7 +1,7 @@
 {
   "provider": "xiaomi",
-  "source": "https://mimo.mi.com/docs/en-US/price/pay-as-you-go",
-  "generated_at": "2026-07-21T19:51:53Z",
+  "source": "https://mimo.mi.com/docs/en-US/pricing",
+  "generated_at": "2026-07-21T20:47:51Z",
   "model_count": 5,
   "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated /v1/models feed but has no public PAYG row, so its last verified price is retained until Xiaomi republishes one. Legacy V2 rows are kept only as historical fallback metadata.",
   "models": [

--- a/tests/fixtures/pricing/makora.html
+++ b/tests/fixtures/pricing/makora.html
@@ -1,0 +1,48 @@
+The lineup
+## The Latest Models. Competitive Pricing
+
+GLM-5.2
+z.AI
+Input $1.35/M tokens
+Output $3.99/M tokens
+Cache Read $0.24/M tokens
+[Try Now](https://app.makora.com/)
+
+Kimi-K2.7-Code
+moonshot ai
+Input $0.76/M tokens
+Output $3.7749/M tokens
+Cache $0.5757/M tokens
+[Try Now](https://app.makora.com/)
+
+DeepSeek-V4-Pro
+Input $1.3180/M tokens
+Output $2.6361/M tokens
+Cache $0.9885/M tokens
+[Try Now](https://app.makora.com/)
+
+Qwen3.6-27B-NVFP4
+Input $0.4671/M tokens
+Output $3.4592/M tokens
+Cache $0.3503/M tokens
+[Try Now](https://app.makora.com/)
+
+Llama-3.3-70B-Instruct
+Input $0.18/M tokens
+Output $0.40/M tokens
+Cache $0.15/M tokens
+[Try Now](https://app.makora.com/)
+
+DeepSeek V4 Flash
+deepseek
+Input $0.1134/M tokens
+Output $0.2791/M tokens
+Cache $0.0851/M tokens
+[Try Now](https://app.makora.com/)
+
+Qwen3.6-35B-A3B
+alibaba
+Input $0.1720/M tokens
+Output $1.2002/M tokens
+Cache $0.1290/M tokens
+[Try Now](https://app.makora.com/)

--- a/tests/fixtures/pricing/minimax.html
+++ b/tests/fixtures/pricing/minimax.html
@@ -1,0 +1,4 @@
+MiniMax-M3 Context <= 512K Permanent 50% off $0.6$0.3 $2.4$1.2 $0.12$0.06
+MiniMax-M3 Context 512K ~ 1M Permanent 50% off $1.2$0.6 $4.8$2.4 $0.24$0.12
+MiniMax-M2.7 $0.3/ M tokens $1.2/ M tokens $0.06/ M tokens $0.375/ M tokens
+MiniMax-M2.7-highspeed $0.6/ M tokens $2.4/ M tokens $0.06/ M tokens $0.375/ M tokens

--- a/tests/fixtures/pricing/thinkingmachines.html
+++ b/tests/fixtures/pricing/thinkingmachines.html
@@ -1,0 +1,16 @@
+<div id="pricing-toggle">
+  <button class="active" data-mode="old">Current</button>
+</div>
+<table>
+  <tbody id="model-tbody">
+    <tr>
+      <td>Inkling (256K)</td>
+      <td class="tinker-id">thinkingmachines/Inkling:peft:262144</td>
+      <td>Hybrid</td><td>MoE</td><td>Large</td><td>256K</td>
+      <td class="price">
+        <span class="price-old">$3.74 <span class="price-cached">$0.748 (cached)</span></span>
+      </td>
+      <td class="price"><span class="price-old">$9.36</span></td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/fixtures/pricing/xiaomi.html
+++ b/tests/fixtures/pricing/xiaomi.html
@@ -1,0 +1,6 @@
+### Overseas Pricing of the Model
+|  | **Input (Cache Hit)** | **Input (Cache Miss)** | **Output** |
+| --- | --- | --- | --- |
+| `mimo-v2.5-pro` | $0.0036 | $0.435 | $0.87 |
+| `mimo-v2.5` | $0.0028 | $0.14 | $0.28 |
+### Pricing for Web Search Plugins

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from trusted_router.catalog import (
@@ -1516,21 +1518,34 @@ def test_makora_provider_models_present_and_routable() -> None:
 
 
 def test_makora_provider_prices_follow_published_lineup() -> None:
-    """Makora publishes per-token model prices on its homepage lineup.
+    """Runtime prices follow Makora's generated authenticated catalog.
 
-    The provider manifest stores raw upstream cost in microdollars/M; the
-    catalog applies the standard 5% customer markup at load time.
+    Provider prices are mutable, so this contract compares the loaded routes
+    to the checked-in provider-native manifest rather than freezing a stale
+    homepage price table into source code.
     """
+    from trusted_router.catalog_ingest import (
+        _PROVIDER_MODELS_DIR,
+        _is_provider_deprecated_model,
+    )
+    from trusted_router.pricing import _customer_price
 
+    raw = json.loads((_PROVIDER_MODELS_DIR / "makora.json").read_text(encoding="utf-8"))
     expected_prices = {
-        "deepseek/deepseek-v4-flash": (119_070, 293_055, 89_355),
-        "deepseek/deepseek-v4-pro": (1_383_900, 2_767_905, 1_037_925),
-        "z-ai/glm-5.2": (1_417_500, 4_189_500, 252_000),
-        "moonshotai/kimi-k2.7-code": (798_000, 3_963_645, 604_485),
-        "meta-llama/llama-3.3-70b-instruct": (189_000, 420_000, 157_500),
-        "qwen/qwen3.6-35b-a3b": (180_600, 1_260_210, 135_450),
+        row["id"]: (
+            _customer_price(int(row["input_token_price_per_m"])),
+            _customer_price(int(row["output_token_price_per_m"])),
+            _customer_price(int(row["cached_input_token_price_per_m"])),
+        )
+        for row in raw["models"]
+        if row.get("routable") is not False
+        and int(row.get("cached_input_token_price_per_m") or 0) > 0
+        and not _is_provider_deprecated_model(
+            "makora", str(row["id"]), str(row.get("upstream_id") or row["id"])
+        )
     }
 
+    assert expected_prices
     for model_id, (prompt, completion, cached_prompt) in expected_prices.items():
         credits = [
             e

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 
 from scripts import check_price_coverage
 from scripts.check_price_coverage import audit
@@ -95,14 +96,21 @@ def test_kimi_discovery_ignores_unpriced_auto_alias() -> None:
 
 
 def test_cerebras_discovery_uses_canonical_ids_and_ignores_unknown_models() -> None:
-    assert check_price_coverage._cerebras_model_id("gpt-oss-120b") == (
-        "openai/gpt-oss-120b"
-    )
+    assert check_price_coverage._cerebras_model_id("gpt-oss-120b") == ("openai/gpt-oss-120b")
     assert check_price_coverage._cerebras_model_id("zai-glm-4.7") == "z-ai/glm-4.7"
-    assert check_price_coverage._cerebras_model_id("gemma-4-31b") == (
-        "google/gemma-4-31b-it"
-    )
+    assert check_price_coverage._cerebras_model_id("gemma-4-31b") == ("google/gemma-4-31b-it")
     assert check_price_coverage._cerebras_model_id("unknown") is None
+
+
+def test_novita_discovery_ignores_internal_aliases_but_catches_public_families() -> None:
+    assert check_price_coverage._novita_model_id("ai_infer_test_1") is None
+    assert check_price_coverage._novita_model_id("bunny") is None
+    assert check_price_coverage._novita_model_id("gt-4p") is None
+    assert check_price_coverage._novita_model_id("gpt-image-2-oai") is None
+    assert check_price_coverage._novita_model_id("Kimi-K3") == "moonshotai/kimi-k3"
+    assert check_price_coverage._novita_model_id("vendor/Future-Text-1") == (
+        "vendor/future-text-1"
+    )
 
 
 def test_provider_glm_required_gate_targets_current_flagships() -> None:
@@ -169,6 +177,119 @@ def test_provider_model_discovery_warns_on_unpublished_manifest_model() -> None:
     )
 
     assert any("minimax/minimax-m9" in warning for warning in warnings)
+
+
+def test_existing_provider_native_alias_does_not_reappear_as_canonical_launch(
+    monkeypatch,
+    tmp_path,
+) -> None:  # noqa: ANN001
+    manifest_dir = tmp_path / "provider_models"
+    manifest_dir.mkdir()
+    (manifest_dir / "novita.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "zai-org/glm-4.6",
+                        "upstream_id": "zai-org/glm-4.6",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_price_coverage, "MANIFEST_DIR", manifest_dir)
+
+    def fake_fetch_json(url: str, env_names: tuple[str, ...]) -> dict:
+        if "api.novita.ai" in url:
+            return {
+                "data": [
+                    {
+                        "id": "zai-org/glm-4.6",
+                        "status": 1,
+                        "endpoints": ["chat/completions"],
+                        "output_modalities": ["text"],
+                    }
+                ]
+            }
+        return _known_provider_model_payload(url, env_names)
+
+    warnings, _info = check_price_coverage._model_discovery_audit(
+        fetch_text=lambda _url: "Supported Models: GLM-5.2",
+        fetch_json=fake_fetch_json,
+        published_model_ids={"z-ai/glm-5.2"},
+    )
+
+    assert not any("novita: live model API lists required unpublished" in item for item in warnings)
+
+
+def test_new_awaiting_price_row_is_not_hidden_by_global_model(
+    monkeypatch,
+    tmp_path,
+) -> None:  # noqa: ANN001
+    manifest_dir = tmp_path / "provider_models"
+    manifest_dir.mkdir()
+    (manifest_dir / "novita.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "vendor/new-model",
+                        "upstream_id": "vendor/new-model",
+                        "routable": False,
+                        "routable_reason": "awaiting-price",
+                        "unresolved_since": "2026-07-21",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_price_coverage, "MANIFEST_DIR", manifest_dir)
+
+    def fake_fetch_json(url: str, env_names: tuple[str, ...]) -> dict:
+        if "api.novita.ai" in url:
+            return {
+                "data": [
+                    {
+                        "id": "vendor/new-model",
+                        "status": 1,
+                        "endpoints": ["chat/completions"],
+                        "output_modalities": ["text"],
+                    }
+                ]
+            }
+        return _known_provider_model_payload(url, env_names)
+
+    warnings, _info = check_price_coverage._model_discovery_audit(
+        fetch_text=lambda _url: "Supported Models: GLM-5.2",
+        fetch_json=fake_fetch_json,
+        published_model_ids={"vendor/new-model", "z-ai/glm-5.2"},
+    )
+
+    assert any(
+        warning.startswith("novita: newly discovered required model(s) still await a price")
+        for warning in warnings
+    )
+
+
+def test_inactive_provider_rows_do_not_trigger_model_discovery() -> None:
+    assert not check_price_coverage._active_discovery_row(
+        {
+            "id": "vendor/retired",
+            "status": 4,
+            "endpoints": ["chat/completions"],
+            "output_modalities": ["text"],
+        }
+    )
+    assert not check_price_coverage._active_discovery_row(
+        {
+            "id": "vendor/image-only",
+            "status": 1,
+            "endpoints": ["chat/completions"],
+            "output_modalities": ["image"],
+        }
+    )
 
 
 def test_provider_glm_discovery_warns_on_unpublished_route(monkeypatch, tmp_path) -> None:  # noqa: ANN001

--- a/tests/test_makora_pricing.py
+++ b/tests/test_makora_pricing.py
@@ -60,8 +60,69 @@ Cache $0.1290/M tokens
 """
 
 
-def test_makora_fetches_first_party_pricing_page() -> None:
-    assert makora.URL == "https://www.makora.com/"
+def test_makora_fetches_authenticated_model_pricing_api() -> None:
+    assert makora.MODELS_URL == "https://inference.makora.com/v1/models"
+
+
+def test_makora_live_api_discovers_and_prices_new_models_without_parser_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest = tmp_path / "makora.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "z-ai/glm-5.2",
+                        "upstream_id": "zai-org/GLM-5.2-FP8",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(makora, "MANIFEST_PATH", manifest)
+    monkeypatch.setattr(makora, "EXPECTED_MODELS", ["z-ai/glm-5.2"])
+    monkeypatch.setenv("MAKORA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        makora,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {
+                    "id": "zai-org/GLM-5.2-FP8",
+                    "context_length": 1_000_000,
+                    "pricing": {
+                        "prompt": "0.000001",
+                        "completion": "0.000002",
+                    },
+                },
+                {
+                    "id": "qwen/Qwen4-Next",
+                    "context_length": 1_000_000,
+                    "input_modalities": ["text", "image"],
+                    "pricing": {
+                        "prompt": "0.0000005",
+                        "completion": "0.0000015",
+                        "input_cache_read": "0.0000001",
+                    },
+                },
+            ]
+        },
+    )
+
+    result = makora.fetch()
+
+    assert set(result.prices) == {"z-ai/glm-5.2", "qwen/qwen4-next"}
+    assert result.prices["qwen/qwen4-next"] == ModelPrice(
+        500_000,
+        1_500_000,
+        prompt_cached_micro_per_m=100_000,
+    )
+    assert makora._DISCOVERED_MANIFEST_ROWS["qwen/qwen4-next"][  # noqa: SLF001
+        "input_modalities"
+    ] == ["text", "image"]
 
 
 def test_makora_parser_extracts_public_lineup_prices() -> None:
@@ -94,8 +155,7 @@ def test_makora_parser_extracts_public_lineup_prices() -> None:
         "prompt_cached_micro_per_m": 150_000,
     }
     assert (
-        prices["amd/llama-3.3-70b-instruct-fp8-kv"]
-        == prices["meta-llama/llama-3.3-70b-instruct"]
+        prices["amd/llama-3.3-70b-instruct-fp8-kv"] == prices["meta-llama/llama-3.3-70b-instruct"]
     )
     assert prices["qwen/qwen3.6-35b-a3b"] == {
         "prompt_micro_per_m": 172_000,
@@ -104,9 +164,7 @@ def test_makora_parser_extracts_public_lineup_prices() -> None:
     }
 
 
-def test_makora_provider_updates_supplemental_manifest(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_makora_provider_updates_supplemental_manifest(tmp_path: Path, monkeypatch) -> None:
     manifest_path = tmp_path / "makora.json"
     manifest_path.write_text(
         json.dumps(
@@ -193,6 +251,12 @@ def test_makora_provider_updates_supplemental_manifest(
         encoding="utf-8",
     )
     monkeypatch.setattr(makora, "MANIFEST_PATH", manifest_path)
+    manifest_rows = json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    monkeypatch.setattr(
+        makora,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {row["id"]: dict(row) for row in manifest_rows},
+    )
 
     parsed = makora_parser.parse(MAKORA_LINEUP_HTML)
     notes = makora.write_provider_manifest(
@@ -225,16 +289,13 @@ def test_makora_provider_updates_supplemental_manifest(
 def test_provider_model_manifests_have_hourly_refresh_path() -> None:
     legacy_manual: set[str] = set()
     manifest_slugs = {
-        path.stem
-        for path in (Path("src/trusted_router/data/provider_models")).glob("*.json")
+        path.stem for path in (Path("src/trusted_router/data/provider_models")).glob("*.json")
     }
-    provider_modules = {
-        path.stem for path in Path("scripts/pricing/providers").glob("*.py")
-    } - {"__init__"}
+    provider_modules = {path.stem for path in Path("scripts/pricing/providers").glob("*.py")} - {
+        "__init__"
+    }
     aliased_manifest_slugs = {
-        alias
-        for aliases in refresh._PRICING_RESULT_PROVIDER_ALIASES.values()
-        for alias in aliases
+        alias for aliases in refresh._PRICING_RESULT_PROVIDER_ALIASES.values() for alias in aliases
     }
     hourly = set(refresh.PROVIDER_SLUGS)
 

--- a/tests/test_manifest_discovery_hooks.py
+++ b/tests/test_manifest_discovery_hooks.py
@@ -24,16 +24,19 @@ def _manifest_row(model_id: str, upstream_id: str, **metadata: object) -> dict[s
 
 
 def _write_manifest(path: Path, provider: str, rows: list[dict[str, object]]) -> str:
-    text = json.dumps(
-        {
-            "_about": f"{provider} test manifest",
-            "provider": provider,
-            "generated_at": "2026-01-01T00:00:00Z",
-            "model_count": len(rows),
-            "models": rows,
-        },
-        indent=2,
-    ) + "\n"
+    text = (
+        json.dumps(
+            {
+                "_about": f"{provider} test manifest",
+                "provider": provider,
+                "generated_at": "2026-01-01T00:00:00Z",
+                "model_count": len(rows),
+                "models": rows,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
     path.write_text(text, encoding="utf-8")
     return text
 
@@ -112,9 +115,7 @@ def test_friendli_tombstones_second_miss_then_restores_annotations(
     result = friendli.fetch()
     friendli.write_provider_manifest(result)
     tombstoned_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-    tombstoned = {row["id"]: row for row in tombstoned_raw["models"]}[
-        "qwen/qwen3-235b-a22b-2507"
-    ]
+    tombstoned = {row["id"]: row for row in tombstoned_raw["models"]}["qwen/qwen3-235b-a22b-2507"]
     assert tombstoned["routable"] is False
     assert tombstoned["routable_reason"] == "delisted-upstream"
     assert tombstoned["missing_since"] == missing["missing_since"]
@@ -128,9 +129,7 @@ def test_friendli_tombstones_second_miss_then_restores_annotations(
     result = friendli.fetch()
     friendli.write_provider_manifest(result)
     restored_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-    restored = {row["id"]: row for row in restored_raw["models"]}[
-        "qwen/qwen3-235b-a22b-2507"
-    ]
+    restored = {row["id"]: row for row in restored_raw["models"]}["qwen/qwen3-235b-a22b-2507"]
     assert restored["routable"] is True
     assert "routable_reason" not in restored
     assert "missing_since" not in restored
@@ -192,9 +191,7 @@ def test_gemini_tombstones_second_miss_and_empty_discovery_keeps_old_manifest(
     result = gemini.fetch()
     gemini.write_provider_manifest(result)
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-    tombstoned = {row["id"]: row for row in raw["models"]}[
-        "google/gemini-2.5-flash-lite"
-    ]
+    tombstoned = {row["id"]: row for row in raw["models"]}["google/gemini-2.5-flash-lite"]
     assert tombstoned["routable"] is False
     assert tombstoned["routable_reason"] == "delisted-upstream"
 
@@ -252,7 +249,7 @@ def test_gemini_refresh_reprices_only_verified_vertex_rows(
     assert row["input_token_price_per_m"] == 1_500_000
     assert row["output_token_price_per_m"] == 7_500_000
     assert row["cached_input_token_price_per_m"] == 150_000
-    assert vertex["pricing_source"] == gemini.URL
+    assert vertex["pricing_source"] == gemini.VERTEX_PRICING_URL
 
 
 def test_wafer_feed_presence_survives_pricing_schema_drift(
@@ -392,6 +389,29 @@ def test_gemini_paginates_complete_feed_and_rejects_stuck_token(
         gemini._live_model_rows()  # noqa: SLF001
 
 
+def test_gemini_live_discovery_requires_only_new_stable_text_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "google-ai-studio.json"
+    _write_manifest(
+        manifest_path,
+        "google-ai-studio",
+        [_manifest_row("google/gemini-3.6-flash", "gemini-3.6-flash")],
+    )
+    monkeypatch.setattr(gemini, "MANIFEST_PATH", manifest_path)
+    live_rows = {
+        "google/gemini-3.6-flash": {"id": "google/gemini-3.6-flash"},
+        "google/gemini-3.7-flash": {"id": "google/gemini-3.7-flash"},
+        "google/gemini-3.7-flash-image": {"id": "google/gemini-3.7-flash-image"},
+        "google/gemini-flash-latest": {"id": "google/gemini-flash-latest"},
+    }
+
+    assert gemini._new_required_price_ids(live_rows) == frozenset(  # noqa: SLF001
+        {"google/gemini-3.7-flash"}
+    )
+
+
 def test_awaiting_price_auto_promotes_but_curated_false_row_is_untouched(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -439,6 +459,7 @@ def test_awaiting_price_auto_promotes_but_curated_false_row_is_untouched(
     awaiting = by_id["meta-llama/llama-3.1-8b-instruct"]
     assert awaiting["routable"] is False
     assert awaiting["routable_reason"] == "awaiting-price"
+    assert awaiting["unresolved_since"]
     assert by_id["metadata/curated"] == curated
 
     second = ProviderPricingResult(
@@ -456,6 +477,7 @@ def test_awaiting_price_auto_promotes_but_curated_false_row_is_untouched(
     promoted = by_id["meta-llama/llama-3.1-8b-instruct"]
     assert promoted["routable"] is True
     assert "routable_reason" not in promoted
+    assert "unresolved_since" not in promoted
     assert promoted["input_token_price_per_m"] == 30
     assert by_id["metadata/curated"] == curated
 

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.parsers import minimax as minimax_parser
 from scripts.pricing.parsers import xiaomi as xiaomi_parser
-from scripts.pricing.providers import nebius
+from scripts.pricing.providers import minimax, nebius
 from scripts.pricing.providers import xiaomi as xiaomi_provider
 
 
@@ -39,6 +41,58 @@ def test_minimax_parser_reads_official_token_plan_tiers() -> None:
         "completion_micro_per_m": 2_400_000,
         "prompt_cached_micro_per_m": 60_000,
     }
+
+
+def test_minimax_parser_normalizes_future_flat_price_rows() -> None:
+    prices = minimax_parser.parse("MiniMax-M4 $0.4/ M tokens $1.6/ M tokens $0.08/ M tokens")
+
+    assert prices["minimax/minimax-m4"] == {
+        "prompt_micro_per_m": 400_000,
+        "completion_micro_per_m": 1_600_000,
+        "prompt_cached_micro_per_m": 80_000,
+    }
+
+
+def test_minimax_live_discovery_requires_new_model_before_manifest_write(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest = tmp_path / "minimax.json"
+    manifest.write_text(
+        json.dumps({"models": [{"id": "minimax/minimax-m3", "upstream_id": "MiniMax-M3"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(minimax, "MANIFEST_PATH", manifest)
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setattr(
+        minimax,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {"id": "MiniMax-M3", "status": 1},
+                {"id": "MiniMax-M4", "status": 1},
+            ]
+        },
+    )
+    captured: dict[str, object] = {}
+
+    def fake_fetch_provider(**kwargs: object) -> ProviderPricingResult:
+        captured.update(kwargs)
+        return ProviderPricingResult(
+            slug="minimax",
+            prices={
+                "minimax/minimax-m3": ModelPrice(300_000, 1_200_000),
+                "minimax/minimax-m4": ModelPrice(400_000, 1_600_000),
+            },
+            source="deterministic",
+        )
+
+    monkeypatch.setattr(minimax, "fetch_provider", fake_fetch_provider)
+
+    result = minimax.fetch()
+
+    assert captured["required_models"] == frozenset({"minimax/minimax-m4"})
+    assert set(result.prices) == {"minimax/minimax-m3", "minimax/minimax-m4"}
 
 
 def test_xiaomi_parser_reads_official_mimo_payg_prices() -> None:
@@ -139,7 +193,25 @@ def test_xiaomi_provider_uses_current_official_payg_page() -> None:
     assert xiaomi_provider.PUBLIC_PRICING_URL == (
         "https://mimo.mi.com/docs/en-US/price/pay-as-you-go"
     )
-    assert xiaomi_provider.PUBLIC_PRICING_URL in xiaomi_provider.URL
+    assert xiaomi_provider.URL == xiaomi_provider.PUBLIC_PRICING_URL
+
+
+def test_xiaomi_parser_normalizes_future_payg_model_rows() -> None:
+    html = """
+    ### Overseas Pricing of the Model
+    |  | **Input (Cache Hit)** | **Input (Cache Miss)** | **Output** |
+    | --- | --- | --- | --- |
+    | `mimo-v2.6-pro` | $0.01 | $0.50 | $1.00 |
+    ### Pricing for Web Search Plugins
+    """
+
+    assert xiaomi_parser.parse(html) == {
+        "xiaomi/mimo-v2.6-pro": {
+            "prompt_micro_per_m": 500_000,
+            "completion_micro_per_m": 1_000_000,
+            "prompt_cached_micro_per_m": 10_000,
+        }
+    }
 
 
 class _FakeResponse:
@@ -154,7 +226,8 @@ class _FakeResponse:
 
 
 def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
-    tmp_path, monkeypatch  # noqa: ANN001
+    tmp_path,
+    monkeypatch,  # noqa: ANN001
 ) -> None:
     payload = {
         "data": [
@@ -224,10 +297,7 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
     assert result.prices[canonical].prompt_micro_per_m == 600_000
     assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in result.prices
     assert nebius._DISCOVERED_ROWS[canonical]["id"] == canonical
-    assert (
-        nebius._DISCOVERED_ROWS[canonical]["upstream_id"]
-        == "nvidia/Nemotron-3-Ultra-550b-a55b"
-    )
+    assert nebius._DISCOVERED_ROWS[canonical]["upstream_id"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
     assert "Qwen/Qwen3-Embedding-8B" not in result.prices
 
     manifest = tmp_path / "nebius.json"

--- a/tests/test_novita_pricing.py
+++ b/tests/test_novita_pricing.py
@@ -154,6 +154,18 @@ def test_novita_live_discovery_preserves_existing_ids_and_normalizes_new_ids(
                     "status": 1,
                     "endpoints": ["embeddings"],
                 },
+                {
+                    "id": "ai_infer_test_1",
+                    "status": 1,
+                    "endpoints": ["chat/completions"],
+                    "output_modalities": ["text"],
+                },
+                {
+                    "id": "Kimi-K4",
+                    "status": 1,
+                    "endpoints": ["chat/completions"],
+                    "output_modalities": ["text"],
+                },
             ]
         },
     )
@@ -163,6 +175,8 @@ def test_novita_live_discovery_preserves_existing_ids_and_normalizes_new_ids(
     assert "Sao10K/L3-8B-Stheno-v3.2" in discovered
     assert "example/disabled-chat" not in discovered
     assert "example/embedding-only" not in discovered
+    assert "ai_infer_test_1" not in discovered
+    assert "moonshotai/kimi-k4" in discovered
     kimi = discovered["moonshotai/kimi-k3"]
     assert kimi["upstream_id"] == "MoonshotAI/Kimi-K3"
     assert kimi["context_length"] == 1_048_576

--- a/tests/test_pricing_base.py
+++ b/tests/test_pricing_base.py
@@ -3,6 +3,7 @@
 The self-heal flow itself is covered in test_pricing_self_heal.py with
 mocked LLM responses. This file focuses on the standalone primitives.
 """
+
 from __future__ import annotations
 
 from scripts.pricing.base import (
@@ -11,9 +12,30 @@ from scripts.pricing.base import (
     _coerce_to_model_prices,
     ast_whitelist_check,
     guard_manifest_prune,
+    normalize_parser_input,
     sandbox_run_parser,
     validate,
 )
+
+
+def test_normalize_parser_input_projects_official_html_without_scripts() -> None:
+    html = r"""
+    <html><body><h2>Pricing</h2>
+    <table><tr><th>Model</th><th>Input</th></tr><tr><td>Model-X</td><td>\$0.20</td></tr></table>
+    <script>secretNoise = 'ignore me'</script></body></html>
+    """
+
+    full = normalize_parser_input(html)
+    compact = normalize_parser_input(html, include_raw_html=False)
+
+    assert "<table>" in full
+    assert "## Pricing" in full
+    assert "| Model-X | $0.20 |" in compact
+    assert "secretNoise" not in compact
+
+
+def test_normalize_parser_input_unescapes_markdown_dollars() -> None:
+    assert normalize_parser_input("| model | \\$0.20 |") == "| model | $0.20 |"
 
 # ----------------------------------------------------------------------
 # validate()
@@ -32,9 +54,7 @@ def test_validate_fails_on_empty_dict() -> None:
     assert any("empty" in e for e in errors)
 
 
-def test_validate_warns_when_expected_model_missing(
-    tmp_path, monkeypatch, capsys
-) -> None:  # noqa: ANN001
+def test_validate_warns_when_expected_model_missing(tmp_path, monkeypatch, capsys) -> None:  # noqa: ANN001
     summary_path = tmp_path / "summary.md"
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
     prices = {"foo/bar": ModelPrice(1_000_000, 1_000_000)}
@@ -43,6 +63,18 @@ def test_validate_warns_when_expected_model_missing(
     assert errors == []
     assert "expected/missing" in capsys.readouterr().err
     assert "expected/missing" in summary_path.read_text(encoding="utf-8")
+
+
+def test_validate_fails_when_newly_discovered_required_model_is_missing() -> None:
+    prices = {"foo/bar": ModelPrice(1_000_000, 1_000_000)}
+
+    errors = validate(
+        prices,
+        [],
+        required_models=["provider/new-model"],
+    )
+
+    assert errors == ["newly discovered models missing from parser output: ['provider/new-model']"]
 
 
 def test_validate_fails_on_out_of_range_prompt_price() -> None:
@@ -70,9 +102,7 @@ def test_validate_allows_one_zero_row_when_others_nonzero() -> None:
     assert validate(prices, []) == []
 
 
-def test_guard_manifest_prune_blocks_half_or_more_and_empty(
-    tmp_path, monkeypatch, capsys
-) -> None:  # noqa: ANN001
+def test_guard_manifest_prune_blocks_half_or_more_and_empty(tmp_path, monkeypatch, capsys) -> None:  # noqa: ANN001
     summary_path = tmp_path / "summary.md"
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
     old_rows = [{"id": "a"}, {"id": "b"}]
@@ -117,7 +147,9 @@ def test_coerce_rejects_non_dict() -> None:
 
 
 def test_coerce_rejects_non_string_model_id() -> None:
-    out, errors = _coerce_to_model_prices({123: {"prompt_micro_per_m": 1, "completion_micro_per_m": 1}})
+    out, errors = _coerce_to_model_prices(
+        {123: {"prompt_micro_per_m": 1, "completion_micro_per_m": 1}}
+    )
     assert out is None
     assert errors
 

--- a/tests/test_pricing_fixtures.py
+++ b/tests/test_pricing_fixtures.py
@@ -10,18 +10,133 @@ fixture stays the same — these tests verify the *initial* parser
 implementation. Re-capture the fixtures (run `curl` against the
 provider URL) to update the floor for future regressions.
 
-For providers whose page is JS-rendered (kimi, zai, openai, gemini),
-the parser is a hardcoded constants table; these tests verify the
-table is non-empty and well-shaped.
+Production feeds use provider-owned APIs, Markdown, or server-rendered HTML.
+The shared normalizer is exercised here so fixtures follow the same path as
+the hourly refresh.
 """
+
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 
 import pytest
 
+from scripts.pricing import refresh
+from scripts.pricing.base import ast_whitelist_check, normalize_parser_input
+
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pricing"
+
+PARSER_CASES: list[tuple[str, set[str], tuple[float, float]]] = [
+    (
+        "anthropic",
+        {
+            "anthropic/claude-opus-4.7",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-haiku-4.5",
+        },
+        (0.5, 100.0),
+    ),
+    ("cerebras", {"openai/gpt-oss-120b", "z-ai/glm-4.7"}, (0.05, 5.0)),
+    ("cohere", {"cohere/embed-v4.0"}, (0.0, 100.0)),
+    (
+        "gemini",
+        {
+            "google/gemini-2.5-flash",
+            "google/gemini-2.5-pro",
+            "google/gemini-3.5-flash",
+            "google/gemini-3.6-flash",
+        },
+        (0.05, 20.0),
+    ),
+    (
+        "mistral",
+        {"mistralai/mistral-medium-3-5", "mistralai/devstral-medium"},
+        (0.05, 10.0),
+    ),
+    (
+        "deepseek",
+        {"deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"},
+        (0.05, 5.0),
+    ),
+    (
+        "openai",
+        {"openai/gpt-5.5", "openai/gpt-5.4", "openai/gpt-5.4-mini"},
+        (0.05, 300.0),
+    ),
+    ("kimi", {"moonshotai/kimi-k2.6"}, (0.05, 10.0)),
+    ("zai", {"z-ai/glm-4.6", "z-ai/glm-4.5"}, (0.0, 15.0)),
+    (
+        "fireworks",
+        {
+            "moonshotai/kimi-k2.6",
+            "deepseek/deepseek-v4-pro",
+            "z-ai/glm-5.2",
+            "openai/gpt-oss-120b",
+        },
+        (0.05, 10.0),
+    ),
+    ("grok", {"x-ai/grok-4.3"}, (0.05, 5.0)),
+    ("makora", {"deepseek/deepseek-v4-flash"}, (0.05, 10.0)),
+    ("minimax", {"minimax/minimax-m3"}, (0.05, 5.0)),
+    ("morph", {"z-ai/glm-5.2"}, (0.01, 20.0)),
+    ("novita", {"deepseek/deepseek-v4-flash"}, (0.0, 20.0)),
+    ("phala", {"qwen/qwen3.5-27b"}, (0.0, 5.0)),
+    (
+        "siliconflow",
+        {"deepseek/deepseek-v4-flash", "qwen/qwen3-vl-32b-instruct"},
+        (0.0, 20.0),
+    ),
+    ("streamlake", {"kwaipilot/kat-coder-pro-v2.5"}, (0.01, 20.0)),
+    ("thinkingmachines", {"thinkingmachines/inkling"}, (0.5, 20.0)),
+    ("venice", {"z-ai/glm-4.6"}, (0.0, 10.0)),
+    ("voyage", {"voyage/voyage-4-large"}, (0.0, 100.0)),
+    ("xiaomi", {"xiaomi/mimo-v2.5-pro"}, (0.001, 5.0)),
+]
+
+
+def test_every_pricing_parser_has_a_fixture_and_contract_case() -> None:
+    parser_dir = Path(__file__).parents[1] / "scripts" / "pricing" / "parsers"
+    parser_slugs = {path.stem for path in parser_dir.glob("*.py") if path.stem != "__init__"}
+    case_slugs = {slug for slug, _models, _band in PARSER_CASES}
+
+    assert case_slugs == parser_slugs
+    assert not [
+        slug for slug in sorted(parser_slugs) if not (FIXTURE_DIR / f"{slug}.html").exists()
+    ]
+    assert refresh._SELF_HEALING_PARSER_SLUGS == parser_slugs - {
+        "cerebras",
+        "makora",
+        "phala",
+    }
+
+
+def test_provider_pricing_sources_do_not_depend_on_reader_proxies() -> None:
+    provider_dir = Path(__file__).parents[1] / "scripts" / "pricing" / "providers"
+
+    offenders = [
+        path.name
+        for path in provider_dir.glob("*.py")
+        if "r.jina.ai" in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []
+
+
+@pytest.mark.parametrize("slug", [slug for slug, _models, _band in PARSER_CASES])
+def test_every_pricing_parser_passes_the_self_heal_ast_policy(slug: str) -> None:
+    parser_path = Path(__file__).parents[1] / "scripts" / "pricing" / "parsers" / f"{slug}.py"
+
+    assert ast_whitelist_check(parser_path.read_text(encoding="utf-8")) == []
+
+
+@pytest.mark.parametrize("slug", [slug for slug, _models, _band in PARSER_CASES])
+def test_parser_result_is_stable_through_production_normalization(slug: str) -> None:
+    fixture = (FIXTURE_DIR / f"{slug}.html").read_text(encoding="utf-8")
+    module = importlib.import_module(f"scripts.pricing.parsers.{slug}")
+
+    assert module.parse(normalize_parser_input(fixture)) == module.parse(fixture)
 
 
 # Per-provider expectations. `expected_models` is a STRICT subset that
@@ -31,105 +146,7 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pricing"
 # means the parser misread the column.
 @pytest.mark.parametrize(
     "slug,expected_models,price_band",
-    [
-        (
-            "anthropic",
-            {
-                "anthropic/claude-opus-4.7",
-                "anthropic/claude-sonnet-4.6",
-                "anthropic/claude-haiku-4.5",
-            },
-            (0.5, 100.0),  # $0.50/M to $100/M
-        ),
-        (
-            "cerebras",
-            {
-                "openai/gpt-oss-120b",
-                "z-ai/glm-4.7",
-            },
-            (0.05, 5.00),
-        ),
-        (
-            "gemini",
-            {
-                "google/gemini-2.5-flash",
-                "google/gemini-2.5-pro",
-                "google/gemini-3.5-flash",
-                "google/gemini-3.6-flash",
-            },
-            (0.05, 20.00),
-        ),
-        (
-            "mistral",
-            {
-                "mistralai/mistral-medium-3-5",
-                "mistralai/devstral-medium",
-            },
-            (0.05, 10.00),
-        ),
-        (
-            "deepseek",
-            {
-                "deepseek/deepseek-v4-flash",
-                "deepseek/deepseek-v4-pro",
-            },
-            (0.05, 5.00),
-        ),
-        (
-            "openai",
-            {
-                "openai/gpt-5.5",
-                "openai/gpt-5.4",
-                "openai/gpt-5.4-mini",
-            },
-            (0.05, 300.0),  # gpt-5.4-pro completion is $180/M
-        ),
-        (
-            "kimi",
-            {"moonshotai/kimi-k2.6"},
-            (0.05, 10.0),
-        ),
-        (
-            "zai",
-            {"z-ai/glm-4.6", "z-ai/glm-4.5"},
-            (0.0, 15.0),  # GLM-4.5-X completion = $8.9/M; GLM-4.5-Flash is $0
-        ),
-        (
-            "fireworks",
-            {
-                "moonshotai/kimi-k2.6",
-                "deepseek/deepseek-v4-pro",
-                "z-ai/glm-5.2",
-                "openai/gpt-oss-120b",
-            },
-            (0.05, 10.0),
-        ),
-        (
-            "grok",
-            {"x-ai/grok-4.3"},
-            (0.05, 5.0),
-        ),
-        (
-            "novita",
-            {"deepseek/deepseek-v4-flash"},
-            (0.0, 20.0),  # Long tail of open-weight models with very low rates
-        ),
-        (
-            "phala",
-            {"qwen/qwen3.5-27b"},
-            (0.0, 5.0),  # Embeddings can be free; chat models cap ~$2-3/M
-        ),
-        (
-            "siliconflow",
-            {"deepseek/deepseek-v4-flash", "qwen/qwen3-vl-32b-instruct"},
-            (0.0, 20.0),
-        ),
-        (
-            "venice",
-            {"z-ai/glm-4.6"},
-            (0.0, 10.0),
-        ),
-    ],
+    PARSER_CASES,
 )
 def test_parser_extracts_expected_models_within_price_band(
     slug: str,
@@ -140,7 +157,7 @@ def test_parser_extracts_expected_models_within_price_band(
     assert fixture.exists(), f"missing fixture: {fixture}"
     html = fixture.read_text(encoding="utf-8")
     module = importlib.import_module(f"scripts.pricing.parsers.{slug}")
-    result = module.parse(html)
+    result = module.parse(normalize_parser_input(html))
 
     assert isinstance(result, dict), f"{slug}: parse() must return dict"
     assert result, f"{slug}: parse() returned empty dict"
@@ -156,8 +173,7 @@ def test_parser_extracts_expected_models_within_price_band(
         tiers = _row_tiers(row)
         for tier_idx, (prompt_d, completion_d) in enumerate(tiers):
             assert lo <= prompt_d <= hi, (
-                f"{slug}: {or_id} tiers[{tier_idx}].prompt ${prompt_d} "
-                f"outside ${lo}-${hi} band"
+                f"{slug}: {or_id} tiers[{tier_idx}].prompt ${prompt_d} outside ${lo}-${hi} band"
             )
             assert lo <= completion_d <= hi, (
                 f"{slug}: {or_id} tiers[{tier_idx}].completion ${completion_d} "
@@ -248,6 +264,70 @@ Kimi K3\t1,048,576\t$3 /Mt· Cache Read $0.3 /Mt\t$15 /Mt\tMore
     }
 
 
+def test_novita_parser_reads_row_local_prices_from_next_catalog() -> None:
+    module = importlib.import_module("scripts.pricing.parsers.novita")
+    catalog = [
+        {
+            "type": "Chat",
+            "id": "deepseek/deepseek-v4-flash",
+            "displayName": "Deepseek V4 Flash",
+            "status": 1,
+            "infos": {
+                "inputPricing": "$$0.14/Mt",
+                "outputPricing": "$$0.28/Mt",
+                "cacheReadPricing": "$$0.028/Mt",
+            },
+        },
+        {
+            "type": "Chat",
+            "id": "moonshotai/kimi-k3",
+            "displayName": "Kimi K3",
+            "status": 1,
+            "infos": {
+                "inputPricing": "$$3/Mt",
+                "outputPricing": "$$15/Mt",
+                "cacheReadPricing": "$$0.3/Mt",
+            },
+        },
+        {
+            "type": "Chat",
+            "id": "qwen/qwen4-next",
+            "displayName": "Qwen4 Next",
+            "status": 1,
+            "input_pricing": {"pricePerM": 1250},
+            "output_pricing": {"pricePerM": 8750},
+        },
+    ]
+    flight = f'11:["$",{{"initialFullLLMModels":{json.dumps(catalog)}}}]\n'
+    push = f"self.__next_f.push({json.dumps([1, flight])})"
+    result = module.parse(
+        normalize_parser_input(
+            "<html><body>"
+            f"<script>{push}</script>"
+            "<table><tr><td>Deepseek V4 Flash</td><td>1M</td>"
+            "<td>$0.14 /Mt</td><td>$0.28 /Mt</td></tr>"
+            "<tr><td>Kimi K3</td><td>1M</td>"
+            "<td>$3 /Mt</td><td>$15 /Mt</td></tr></table>"
+            "</body></html>"
+        )
+    )
+
+    assert result["deepseek/deepseek-v4-flash"] == {
+        "prompt_micro_per_m": 140_000,
+        "completion_micro_per_m": 280_000,
+        "prompt_cached_micro_per_m": 28_000,
+    }
+    assert result["moonshotai/kimi-k3"] == {
+        "prompt_micro_per_m": 3_000_000,
+        "completion_micro_per_m": 15_000_000,
+        "prompt_cached_micro_per_m": 300_000,
+    }
+    assert result["qwen/qwen4-next"] == {
+        "prompt_micro_per_m": 125_000,
+        "completion_micro_per_m": 875_000,
+    }
+
+
 def test_gemini_parser_tracks_gemini_36_flash_standard_pricing() -> None:
     module = importlib.import_module("scripts.pricing.parsers.gemini")
     result = module.parse((FIXTURE_DIR / "gemini.html").read_text(encoding="utf-8"))
@@ -259,9 +339,55 @@ def test_gemini_parser_tracks_gemini_36_flash_standard_pricing() -> None:
     }
 
 
+def test_gemini_parser_normalizes_future_stable_release_heading() -> None:
+    module = importlib.import_module("scripts.pricing.parsers.gemini")
+    result = module.parse(
+        """
+## Gemini 3.7 Flash
+|  | Free Tier | Paid Tier, per 1M tokens in USD |
+| --- | --- | --- |
+| Input price | Free of charge | $0.40 |
+| Output price | Free of charge | $2.50 |
+| Context caching price | Not available | $0.04 |
+"""
+    )
+
+    assert result["google/gemini-3.7-flash"] == {
+        "prompt_micro_per_m": 400_000,
+        "completion_micro_per_m": 2_500_000,
+        "prompt_cached_micro_per_m": 40_000,
+    }
+
+
+def test_gemini_parser_reads_official_server_rendered_html() -> None:
+    module = importlib.import_module("scripts.pricing.parsers.gemini")
+    result = module.parse(
+        """
+<html><body>
+  <h2 id="gemini-3.7-flash">Gemini 3.7 Flash</h2>
+  <section><h3>Standard</h3><table class="pricing-table"><tbody>
+    <tr><td>Input price</td><td>Free of charge</td><td>$0.40</td></tr>
+    <tr><td>Output price</td><td>Free of charge</td><td>$2.50</td></tr>
+    <tr><td>Context caching price</td><td>Free of charge</td><td>$0.04<br>$1 / hour</td></tr>
+  </tbody></table></section>
+  <section><h3>Batch</h3><table><tbody>
+    <tr><td>Input price</td><td>Not available</td><td>$0.20</td></tr>
+    <tr><td>Output price</td><td>Not available</td><td>$1.25</td></tr>
+  </tbody></table></section>
+</body></html>
+"""
+    )
+
+    assert result["google/gemini-3.7-flash"] == {
+        "prompt_micro_per_m": 400_000,
+        "completion_micro_per_m": 2_500_000,
+        "prompt_cached_micro_per_m": 40_000,
+    }
+
+
 @pytest.mark.parametrize(
     "slug",
-    ["anthropic", "cerebras", "gemini", "mistral", "deepseek", "openai", "kimi", "zai"],
+    [slug for slug, _models, _band in PARSER_CASES],
 )
 def test_parser_returns_well_shaped_dict(slug: str) -> None:
     """Schema check: every value is a dict with exactly the two int keys."""
@@ -289,8 +415,7 @@ def test_parser_returns_well_shaped_dict(slug: str) -> None:
                 )
                 threshold = tier["max_prompt_tokens"]
                 assert threshold is None or isinstance(threshold, int), (
-                    f"{slug}: {or_id} tiers[{idx}].max_prompt_tokens "
-                    f"must be int or None"
+                    f"{slug}: {or_id} tiers[{idx}].max_prompt_tokens must be int or None"
                 )
                 assert isinstance(tier["prompt_micro_per_m"], int)
                 assert isinstance(tier["completion_micro_per_m"], int)
@@ -298,8 +423,7 @@ def test_parser_returns_well_shaped_dict(slug: str) -> None:
                     cached = tier["prompt_cached_micro_per_m"]
                     assert cached is None or isinstance(cached, int)
             assert tiers[-1]["max_prompt_tokens"] is None, (
-                f"{slug}: {or_id} last tier must have "
-                "max_prompt_tokens=None (uncapped)"
+                f"{slug}: {or_id} last tier must have max_prompt_tokens=None (uncapped)"
             )
         else:
             _required = {"prompt_micro_per_m", "completion_micro_per_m"}
@@ -332,4 +456,51 @@ def test_grok_parser_extracts_grok_45_current_pricing_row() -> None:
     assert result["x-ai/grok-4.5"] == {
         "prompt_micro_per_m": 2_000_000,
         "completion_micro_per_m": 6_000_000,
+        "prompt_cached_micro_per_m": 500_000,
+    }
+
+
+def test_grok_parser_extracts_current_long_context_tiers_and_future_names() -> None:
+    from scripts.pricing.parsers import grok
+
+    result = grok.parse(
+        """
+| grok-6 (< 200k prompt tokens) | 1M | $1.00 | $0.10 | $3.00 |
+| grok-6 (≥ 200k prompt tokens) | 1M | $2.00 | $0.20 | $6.00 |
+"""
+    )
+
+    assert result["x-ai/grok-6"]["tiers"] == [
+        {
+            "max_prompt_tokens": 200_000,
+            "prompt_micro_per_m": 1_000_000,
+            "completion_micro_per_m": 3_000_000,
+            "prompt_cached_micro_per_m": 100_000,
+        },
+        {
+            "max_prompt_tokens": None,
+            "prompt_micro_per_m": 2_000_000,
+            "completion_micro_per_m": 6_000_000,
+            "prompt_cached_micro_per_m": 200_000,
+        },
+    ]
+
+
+def test_siliconflow_parser_reads_server_rendered_framer_card() -> None:
+    from scripts.pricing.parsers import siliconflow
+
+    result = siliconflow.parse(
+        """
+<div data-framer-name="LLM - Desktop">
+  <span>GLM-6</span><span>1049K</span>
+  <span>$</span><span>1.25</span><span>$</span><span>0.20</span>
+  <span>$</span><span>4.50</span><span>Details</span>
+</div>
+"""
+    )
+
+    assert result["z-ai/glm-6"] == {
+        "prompt_micro_per_m": 1_250_000,
+        "completion_micro_per_m": 4_500_000,
+        "prompt_cached_micro_per_m": 200_000,
     }

--- a/tests/test_pricing_model_ids.py
+++ b/tests/test_pricing_model_ids.py
@@ -1,22 +1,29 @@
 from __future__ import annotations
 
-from scripts.pricing.model_ids import canonicalize_native_model_id
+from scripts.pricing.model_ids import (
+    canonicalize_native_model_id,
+    canonicalize_unqualified_model_id,
+)
 from scripts.pricing.parsers import kimi
 from scripts.pricing.providers import tinfoil
 
 
 def test_canonicalize_provider_native_ids_for_new_model_discovery() -> None:
-    assert (
-        canonicalize_native_model_id("moonshotai/Kimi-K2.7-Code")
-        == "moonshotai/kimi-k2.7-code"
-    )
-    assert canonicalize_native_model_id("Qwen/Qwen3.5-397B-A17B") == (
-        "qwen/qwen3.5-397b-a17b"
-    )
+    assert canonicalize_native_model_id("moonshotai/Kimi-K2.7-Code") == "moonshotai/kimi-k2.7-code"
+    assert canonicalize_native_model_id("Qwen/Qwen3.5-397B-A17B") == ("qwen/qwen3.5-397b-a17b")
     assert canonicalize_native_model_id("zai-org/GLM-5.2") == "z-ai/glm-5.2"
-    assert canonicalize_native_model_id("MiniMaxAI/MiniMax-M2.7") == (
-        "minimax/minimax-m2.7"
+    assert canonicalize_native_model_id("MiniMaxAI/MiniMax-M2.7") == ("minimax/minimax-m2.7")
+
+
+def test_canonicalize_unqualified_aggregator_model_families() -> None:
+    assert canonicalize_unqualified_model_id("gpt-oss-120b") == ("openai/gpt-oss-120b")
+    assert canonicalize_unqualified_model_id("zai-glm-5p3") == "z-ai/glm-5.3"
+    assert (
+        canonicalize_unqualified_model_id("accounts/fireworks/models/kimi-k2p8-code")
+        == "moonshotai/kimi-k2.8-code"
     )
+    assert canonicalize_unqualified_model_id("phala/qwen3.7-max") == ("qwen/qwen3.7-max")
+    assert canonicalize_unqualified_model_id("unrelated-model") is None
 
 
 def test_kimi_parser_accepts_new_kimi_family_ids_without_hand_map() -> None:
@@ -35,15 +42,9 @@ def test_kimi_parser_accepts_new_kimi_family_ids_without_hand_map() -> None:
 
 
 def test_tinfoil_native_ids_track_june_2026_replacements() -> None:
-    assert (
-        tinfoil._NATIVE_TO_OR_ID["kimi-k2-7-code"]
-        == "moonshotai/kimi-k2.7-code"
-    )
+    assert tinfoil._NATIVE_TO_OR_ID["kimi-k2-7-code"] == "moonshotai/kimi-k2.7-code"
     assert tinfoil._NATIVE_TO_OR_ID["glm-5-2"] == "z-ai/glm-5.2"
     assert tinfoil._NATIVE_TO_OR_ID["gemma4-31b"] == "google/gemma-4-31b-it"
-    assert (
-        tinfoil._NATIVE_TO_OR_ID["qwen3-vl-30b"]
-        == "qwen/qwen3-vl-30b-a3b-instruct"
-    )
+    assert tinfoil._NATIVE_TO_OR_ID["qwen3-vl-30b"] == "qwen/qwen3-vl-30b-a3b-instruct"
     assert tinfoil.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "glm-5-2"
     assert tinfoil.UPSTREAM_ID_MAP["google/gemma-4-31b-it"] == "gemma4-31b"

--- a/tests/test_pricing_self_heal.py
+++ b/tests/test_pricing_self_heal.py
@@ -12,6 +12,7 @@ expectation is that fetch_provider:
   6. Persists the rewritten parser to disk.
   7. Returns ProviderPricingResult(source="self_healed").
 """
+
 from __future__ import annotations
 
 import json
@@ -33,13 +34,16 @@ def tmp_parser(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     parsers_dir.mkdir()
     monkeypatch.setattr(pricing_base, "PARSERS_DIR", parsers_dir)
 
-    initial_src = textwrap.dedent(
-        """
+    initial_src = (
+        textwrap.dedent(
+            """
         def parse(html: str) -> dict:
             # Intentionally returns nothing — triggers validation failure.
             return {}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
 
     parser_file = parsers_dir / "testslug.py"
     parser_file.write_text(initial_src, encoding="utf-8")
@@ -47,9 +51,7 @@ def tmp_parser(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _stub_fetch_html(monkeypatch: pytest.MonkeyPatch, html: str) -> None:
-    monkeypatch.setattr(
-        pricing_base, "fetch_html", lambda url, extra_headers=None: html
-    )
+    monkeypatch.setattr(pricing_base, "fetch_html", lambda url, extra_headers=None: html)
 
 
 def _stub_self_heal(monkeypatch: pytest.MonkeyPatch, returned_src: str) -> None:
@@ -60,8 +62,9 @@ def _stub_self_heal(monkeypatch: pytest.MonkeyPatch, returned_src: str) -> None:
     )
 
 
-_VALID_REWRITE = textwrap.dedent(
-    """
+_VALID_REWRITE = (
+    textwrap.dedent(
+        """
     def parse(html: str) -> dict:
         return {
             "test/model": {
@@ -70,7 +73,9 @@ _VALID_REWRITE = textwrap.dedent(
             }
         }
     """
-).strip() + "\n"
+    ).strip()
+    + "\n"
+)
 
 
 def test_self_heal_happy_path_persists_new_parser(
@@ -95,13 +100,102 @@ def test_self_heal_happy_path_persists_new_parser(
     assert result.heal_diff and "test/model" in result.heal_diff
 
 
+def test_new_runtime_required_model_triggers_self_heal(
+    tmp_parser: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tmp_parser.write_text(
+        textwrap.dedent(
+            """
+            def parse(html: str) -> dict:
+                return {
+                    "test/existing": {
+                        "prompt_micro_per_m": 1_000_000,
+                        "completion_micro_per_m": 2_000_000,
+                    }
+                }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    rewrite = (
+        textwrap.dedent(
+            """
+        def parse(html: str) -> dict:
+            return {
+                "test/existing": {
+                    "prompt_micro_per_m": 1_000_000,
+                    "completion_micro_per_m": 2_000_000,
+                },
+                "test/new-launch": {
+                    "prompt_micro_per_m": 3_000_000,
+                    "completion_micro_per_m": 4_000_000,
+                },
+            }
+        """
+        ).strip()
+        + "\n"
+    )
+    _stub_fetch_html(monkeypatch, "new launch pricing")
+    _stub_self_heal(monkeypatch, rewrite)
+
+    result = pricing_base.fetch_provider(
+        slug="testslug",
+        url="https://example.com/pricing",
+        expected_models=["test/existing"],
+        required_models=["test/new-launch"],
+    )
+
+    assert result.source == "self_healed"
+    assert set(result.prices) == {"test/existing", "test/new-launch"}
+
+
+def test_required_model_may_be_added_without_fixture_regression(
+    tmp_parser: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tmp_parser.write_text(
+        "def parse(html: str) -> dict:\n"
+        "    return {'test/existing': {'prompt_micro_per_m': 1, "
+        "'completion_micro_per_m': 2}}\n",
+        encoding="utf-8",
+    )
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    (fixture_dir / "testslug.html").write_text("captured-layout", encoding="utf-8")
+    monkeypatch.setattr(pricing_base, "PRICING_FIXTURES_DIR", fixture_dir)
+    _stub_fetch_html(monkeypatch, "live-layout")
+    rewrite = (
+        "def parse(html: str) -> dict:\n"
+        "    return {\n"
+        "        'test/existing': {'prompt_micro_per_m': 1, "
+        "'completion_micro_per_m': 2},\n"
+        "        'test/new-launch': {'prompt_micro_per_m': 3, "
+        "'completion_micro_per_m': 4},\n"
+        "    }\n"
+    )
+    _stub_self_heal(monkeypatch, rewrite)
+
+    result = pricing_base.fetch_provider(
+        slug="testslug",
+        url="https://example.com/pricing",
+        expected_models=["test/existing"],
+        required_models=["test/new-launch"],
+    )
+
+    assert set(result.prices) == {"test/existing", "test/new-launch"}
+
+
 def test_self_heal_normalizes_candidate_before_persisting(
     tmp_parser: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html>doesn't matter</html>")
-    unsorted_rewrite = textwrap.dedent(
-        """
+    unsorted_rewrite = (
+        textwrap.dedent(
+            """
         from __future__ import annotations
 
         import re
@@ -117,7 +211,9 @@ def test_self_heal_normalizes_candidate_before_persisting(
                 }
             }
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, unsorted_rewrite)
 
     result = pricing_base.fetch_provider(
@@ -137,8 +233,9 @@ def test_self_heal_rejects_candidate_with_unfixable_lint_violation(
 ) -> None:
     original = tmp_parser.read_text(encoding="utf-8")
     _stub_fetch_html(monkeypatch, "1")
-    invalid_rewrite = textwrap.dedent(
-        """
+    invalid_rewrite = (
+        textwrap.dedent(
+            """
         def parse(html: str) -> dict:
             try:
                 price = int(html) * 1_000_000
@@ -151,7 +248,9 @@ def test_self_heal_rejects_candidate_with_unfixable_lint_violation(
                 }
             }
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, invalid_rewrite)
 
     with pytest.raises(RuntimeError, match="Ruff normalization failed"):
@@ -179,8 +278,9 @@ def test_self_heal_rejects_captured_fixture_regression(
     monkeypatch: pytest.MonkeyPatch,
     fixture_result: str,
 ) -> None:
-    original = textwrap.dedent(
-        """
+    original = (
+        textwrap.dedent(
+            """
         def parse(html: str) -> dict:
             if "captured-layout" not in html:
                 return {}
@@ -191,17 +291,18 @@ def test_self_heal_rejects_captured_fixture_regression(
                 }
             }
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     tmp_parser.write_text(original, encoding="utf-8")
     fixture_dir = tmp_path / "fixtures"
     fixture_dir.mkdir()
-    (fixture_dir / "testslug.html").write_text(
-        "captured-layout", encoding="utf-8"
-    )
+    (fixture_dir / "testslug.html").write_text("captured-layout", encoding="utf-8")
     monkeypatch.setattr(pricing_base, "PRICING_FIXTURES_DIR", fixture_dir)
     _stub_fetch_html(monkeypatch, "live-layout")
-    candidate = textwrap.dedent(
-        f"""
+    candidate = (
+        textwrap.dedent(
+            f"""
         def parse(html: str) -> dict:
             if "live-layout" in html:
                 return {{
@@ -212,7 +313,9 @@ def test_self_heal_rejects_captured_fixture_regression(
                 }}
             {fixture_result}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, candidate)
 
     with pytest.raises(RuntimeError, match="fixture regression"):
@@ -230,14 +333,17 @@ def test_self_heal_rejects_subprocess_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
-    bad = textwrap.dedent(
-        """
+    bad = (
+        textwrap.dedent(
+            """
         import subprocess
 
         def parse(html: str) -> dict:
             return {"test/model": {"prompt_micro_per_m": 1, "completion_micro_per_m": 1}}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="AST whitelist"):
@@ -256,14 +362,17 @@ def test_self_heal_rejects_urllib_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
-    bad = textwrap.dedent(
-        """
+    bad = (
+        textwrap.dedent(
+            """
         import urllib.request
 
         def parse(html: str) -> dict:
             return {"test/model": {"prompt_micro_per_m": 1, "completion_micro_per_m": 1}}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="AST whitelist"):
@@ -280,13 +389,16 @@ def test_self_heal_rejects_dunder_escape_hatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
-    bad = textwrap.dedent(
-        """
+    bad = (
+        textwrap.dedent(
+            """
         def parse(html: str) -> dict:
             mod = ().__class__.__bases__[0].__subclasses__()
             return {"test/model": {"prompt_micro_per_m": 1, "completion_micro_per_m": 1}}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="AST whitelist"):
@@ -303,8 +415,9 @@ def test_self_heal_rejects_output_outside_plausibility_range(
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
     # Returns a price 10x above the plausibility ceiling.
-    bad = textwrap.dedent(
-        f"""
+    bad = (
+        textwrap.dedent(
+            f"""
         def parse(html: str) -> dict:
             return {{
                 "test/model": {{
@@ -313,7 +426,9 @@ def test_self_heal_rejects_output_outside_plausibility_range(
                 }}
             }}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="validation"):
@@ -332,12 +447,15 @@ def test_self_heal_rejects_missing_parse_function(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
-    bad = textwrap.dedent(
-        """
+    bad = (
+        textwrap.dedent(
+            """
         def not_parse(html: str) -> dict:
             return {}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="AST whitelist"):
@@ -353,12 +471,15 @@ def test_self_heal_rejects_extra_method_signature(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_fetch_html(monkeypatch, "<html></html>")
-    bad = textwrap.dedent(
-        """
+    bad = (
+        textwrap.dedent(
+            """
         def parse(html, extra):
             return {}
         """
-    ).strip() + "\n"
+        ).strip()
+        + "\n"
+    )
     _stub_self_heal(monkeypatch, bad)
 
     with pytest.raises(RuntimeError, match="AST whitelist"):
@@ -372,6 +493,99 @@ def test_self_heal_rejects_extra_method_signature(
 # ------------------------------------------------------------------
 # ID cross-check tests (refresh._cross_check_ids)
 # ------------------------------------------------------------------
+
+
+def test_new_parser_requirements_are_provider_specific_and_text_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_dir = tmp_path / "provider_models"
+    manifest_dir.mkdir()
+    (manifest_dir / "google-ai-studio.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "google/gemini-3.6-flash",
+                        "routable": False,
+                        "routable_reason": "awaiting-price",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(refresh, "PROVIDER_MANIFEST_DIR", manifest_dir)
+    committed = {
+        "models": [
+                {
+                    "id": "google/gemini-3.7-flash",
+                    "created": 100,
+                "architecture": {"output_modalities": ["text"]},
+                "endpoints": [{"tr_provider_slug": "lightning"}],
+            }
+        ]
+    }
+    upstream = {
+        "models": [
+                {
+                    "id": "google/gemini-3.6-flash",
+                    "created": 90,
+                "architecture": {"output_modalities": ["text"]},
+                "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+            },
+                {
+                    "id": "google/gemini-3.7-flash",
+                    "created": 100,
+                "architecture": {"output_modalities": ["text"]},
+                "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+            },
+                {
+                    "id": "google/gemini-3.7-image",
+                    "created": 101,
+                "architecture": {"output_modalities": ["image"]},
+                    "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+                },
+                {
+                    "id": "google/gemini-3.8-flash",
+                    "created": 102,
+                    "architecture": {"output_modalities": ["text"]},
+                    "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+                },
+                {
+                    "id": "google/gemini-3.8-flash:free",
+                    "created": 103,
+                    "architecture": {"output_modalities": ["text"]},
+                    "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+                },
+        ]
+    }
+
+    required = refresh._new_parser_requirements(upstream, committed)
+
+    assert required == {"gemini": {"google/gemini-3.8-flash"}}
+
+
+def test_new_parser_requirements_ignore_old_model_added_to_new_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_dir = tmp_path / "provider_models"
+    manifest_dir.mkdir()
+    monkeypatch.setattr(refresh, "PROVIDER_MANIFEST_DIR", manifest_dir)
+    committed = {"models": [{"id": "known/latest", "created": 200}]}
+    upstream = {
+        "models": [
+            {
+                "id": "openai/old-model",
+                "created": 100,
+                "architecture": {"output_modalities": ["text"]},
+                "endpoints": [{"tr_provider_slug": "openai"}],
+            }
+        ]
+    }
+
+    assert refresh._new_parser_requirements(upstream, committed) == {}
 
 
 def _fake_or_snapshot(model_endpoints: list[tuple[str, str]]) -> dict:
@@ -415,9 +629,7 @@ def test_cross_check_ids_flags_or_models_missing_from_parser() -> None:
 
 
 def test_cross_check_ids_flags_parser_models_or_does_not_list() -> None:
-    or_snapshot = _fake_or_snapshot(
-        [("anthropic/claude-opus-4.7", "anthropic")]
-    )
+    or_snapshot = _fake_or_snapshot([("anthropic/claude-opus-4.7", "anthropic")])
     results = {
         "anthropic": pricing_base.ProviderPricingResult(
             slug="anthropic",
@@ -563,10 +775,13 @@ def test_manifest_dispatch_restores_mass_pruned_file(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     manifest_path = tmp_path / "fake.json"
-    old_text = json.dumps(
-        {"provider": "fake", "models": [{"id": "a"}, {"id": "b"}]},
-        indent=2,
-    ) + "\n"
+    old_text = (
+        json.dumps(
+            {"provider": "fake", "models": [{"id": "a"}, {"id": "b"}]},
+            indent=2,
+        )
+        + "\n"
+    )
     manifest_path.write_text(old_text, encoding="utf-8")
 
     class FakeProvider:

--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -47,19 +47,15 @@ def test_provider_owned_pricing_parsers_use_integer_microdollars() -> None:
     }
 
 
-def test_morph_checkpoint_fallback_is_bounded_to_published_fast_apply_prices() -> None:
+def test_morph_checkpoint_fallback_covers_published_live_chat_catalog() -> None:
     prices = morph_parser.parse("Vercel Security Checkpoint")
 
-    assert prices == {
-        "morph/morph-v3-fast": {
-            "prompt_micro_per_m": 800_000,
-            "completion_micro_per_m": 1_200_000,
-        },
-        "morph/morph-v3-large": {
-            "prompt_micro_per_m": 900_000,
-            "completion_micro_per_m": 1_900_000,
-        },
+    assert set(prices) == set(morph_parser.MODEL_IDS.values())
+    assert prices["morph/morph-v3-fast"] == {
+        "prompt_micro_per_m": 800_000,
+        "completion_micro_per_m": 1_200_000,
     }
+    assert prices["qwen/qwen3.5-397b-a17b"]["prompt_cached_micro_per_m"] == 300_000
 
 
 def test_openai_catalog_preserves_exact_ids_and_filters_non_text_output() -> None:


### PR DESCRIPTION
## Summary
- replace reader-proxy dependencies with official provider pages and structured APIs
- automatically classify newly discovered text models and fail closed on required unpriced launches
- add resilient normalization for all pricing parsers, including Gemini 3.6 Flash, Novita structured rows, and Makora authenticated pricing
- expand parser fixtures and launch/regression coverage

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1799 passed, 33 skipped)
- strict live model-discovery audit passes
- endpoint price-spike gate passes