### PR TITLE
Add first-party acquisition attribution

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -1,0 +1,77 @@
+# First-Party Acquisition Attribution
+
+TrustedRouter measures paid and organic acquisition without sending inference
+content to an advertising platform.
+
+## Collection Boundary
+
+The public website captures a signed, HttpOnly, SameSite=Lax cookie for 90
+days. Production sends it only over HTTPS. The cookie contains:
+
+- an anonymous random identifier
+- first and last source, medium, campaign, term, and creative
+- first and last landing path and external referring host
+- Google `gclid`, `gbraid`, and `wbraid`, when supplied
+- X `twclid`, when supplied
+- capture timestamps
+
+The cookie and durable attribution record never contain prompts, outputs, raw
+API keys, BYOK keys, email addresses, payment credentials, request bodies, IP
+addresses, or full referring URLs. Click identifiers are retained only in the
+private Spanner record for future consented offline conversion uploads. Logs
+contain booleans indicating which click identifier was present, never its raw
+value.
+
+Requests carrying `Sec-GPC: 1` or `DNT: 1` do not create or use attribution.
+Known crawler user agents do not receive attribution cookies.
+
+## Durable Record
+
+At first account creation, the campaign context is written once under the new
+workspace in Spanner's generic entity store. The record keeps first touch
+immutable and updates last touch in the browser before signup. Repeated OAuth
+callbacks and duplicate signups cannot overwrite the original acquisition
+record.
+
+## Funnel Events
+
+Structured metadata-only events are shipped through the existing Axiom logger:
+
+1. `acquisition.sign_in_opened`
+2. `acquisition.signup_completed`
+3. `acquisition.api_key_created`
+4. `acquisition.first_successful_api_call`
+5. `acquisition.credit_purchase_completed`
+6. `acquisition.retained_api_usage_7d`
+
+Workspace and anonymous identifiers are SHA-256 fingerprints in logs. Purchase
+amounts remain integer microdollars. Stripe, PayPal, and stablecoin events are
+recorded only after the credit ledger's existing idempotency check succeeds.
+The first API call is recorded only after settlement commits. The seven-day
+event is recorded on the first successful settled call at least seven days
+after signup.
+
+Attribution writes are failure-isolated. They cannot fail signup, inference,
+settlement, payment acknowledgement, or streaming.
+
+## Campaign Conventions
+
+Every paid destination must set:
+
+```text
+utm_source=<google|x>
+utm_medium=<paid_search|paid_social>
+utm_campaign=<stable_campaign_name>
+utm_content=<creative_name>
+```
+
+Google and X click identifiers can be appended by their respective auto-tagging
+features. Creative-specific `utm_content` values are required so Axiom can
+compare privacy, migration, and reliability messages within one campaign.
+
+## Initial Optimization Policy
+
+Use `signup_completed` as the first primary conversion while volume is low.
+Report activated CAC separately using `first_successful_api_call`. Move bidding
+optimization toward activated use or credited purchases only after each event
+has enough weekly volume to avoid unstable learning.

--- a/docs/marketing/paid-acquisition-ahrefs-2026-07-21.md
+++ b/docs/marketing/paid-acquisition-ahrefs-2026-07-21.md
@@ -1,0 +1,197 @@
+# Paid Acquisition Research: Ahrefs
+
+Date: 2026-07-21
+
+Market: Google US
+
+This report summarizes Ahrefs exports used to evaluate the first TrustedRouter
+Google and X campaigns. Ahrefs is useful for competitor and keyword discovery.
+Google Ads search terms and TrustedRouter first-party activation data must be
+the source of truth once the campaigns have traffic.
+
+## Decision Summary
+
+The current ads have the right differentiator but several low-demand search
+themes. Buy existing demand for routers and gateways, then explain provable
+privacy in the ad and landing page.
+
+At a $10 daily Google budget, use a focused Search campaign before relying on
+Performance Max. Performance Max currently has no meaningful conversion signal
+and can spread a small budget across weak inventory.
+
+Recommended primary query families:
+
+1. `llm router`
+2. `ai router`
+3. `llm gateway`
+4. `ai gateway`
+5. `openrouter alternative`
+6. `openai compatible api`
+
+Recommended privacy and compliance tests:
+
+1. `confidential ai`
+2. `ai data privacy`
+3. `hipaa compliant llm`
+4. `hipaa compliant ai`
+
+Keep zero-retention and no-log language in the copy. Do not depend on those
+exact phrases for search volume.
+
+## Seed Keyword Results
+
+| Keyword | US volume | KD | CPC | Recommendation |
+|---|---:|---:|---:|---|
+| `llm router` | 500 | 2 | $3.00 | Primary exact and phrase match |
+| `ai router` | 400 | 28 | $0.50 | Test with network-router negatives |
+| `glm api` | 300 | n/a | $0.60 | Model-specific ad group |
+| `openrouter alternative` | 200 | 1 | n/a | Primary exact and phrase match |
+| `openai compatible api` | 200 | 24 | $3.00 | Primary exact and phrase match |
+| `deepseek api privacy` | 20 | n/a | n/a | Landing page and copy, not a core buy |
+| `private llm api` | 10 | n/a | n/a | Landing page and copy, not a core buy |
+| `aws bedrock alternative` | 10 | n/a | n/a | Small exact-match test only |
+| `azure openai alternative` | 0 | n/a | n/a | Organic page, not paid priority |
+| `no log llm api` | 0 | n/a | n/a | Differentiating copy, not a keyword |
+
+## Broader Privacy Results
+
+| Keyword | US volume | KD | CPC | Recommendation |
+|---|---:|---:|---:|---|
+| `ai gateway` | 1,600 | 50 | $7.00 | High-volume commercial test with a bid cap |
+| `llm gateway` | 800 | 40 | $2.50 | Primary commercial test |
+| `ai data privacy` | 600 | 58 | $0.80 | Content and low-cost audience test |
+| `hipaa compliant ai` | 600 | 53 | $7.00 | Exact match only; requires careful claims |
+| `confidential ai` | 350 | 36 | $5.00 | Strongest privacy-positioning query |
+| `hipaa compliant llm` | 200 | 2 | $4.00 | High-intent exact and phrase match |
+| `gdpr compliant ai` | 150 | n/a | n/a | EU-focused page and exact test |
+| `confidential computing ai` | 100 | n/a | n/a | Technical buyer content |
+| `zero data retention ai` | 20 | n/a | n/a | Copy and organic page |
+| `soc 2 ai` | 20 | n/a | n/a | Procurement content only |
+| `end to end encrypted ai` | 10 | n/a | n/a | Copy and organic page |
+| `private ai api` | 10 | n/a | n/a | Copy and organic page |
+| `privacy preserving llm` | 0 | n/a | n/a | Research language, not paid demand |
+| `secure llm api` | 0 | n/a | n/a | Copy, not a keyword |
+
+## Competitor Findings
+
+Ahrefs detected no current US paid keywords or ads for `openrouter.ai` and no
+ads for `portkey.ai` in the six-month ads view. This does not prove that the
+companies never advertise. Ahrefs is a sampled third-party index and can miss
+paid activity.
+
+Organic US snapshot:
+
+| Domain | Ranking keywords | Estimated traffic | Main acquisition pattern |
+|---|---:|---:|---|
+| `openrouter.ai` | 1,594 | 243,764 | Brand, app pages, model pages, quickstart, free models, rankings |
+| `litellm.ai` | 224 | 3,739 | Brand, provider documentation, gateway terminology |
+| `portkey.ai` | 386 | 3,424 | Brand, gateway education, MCP and enterprise content |
+| `helicone.ai` | 290 | 2,167 | Brand and programmatic model pricing pages |
+
+OpenRouter's estimated traffic is not one generic landing page. About 75% is
+from OpenRouter-branded queries, 12% from app pages, 8% from model pages, 2%
+from the quickstart, 1.4% from free-model collections, and 0.9% from rankings.
+The percentages can overlap when a query and URL fit more than one group.
+
+The repeatable lessons for TrustedRouter are:
+
+1. Keep every model page current and indexable.
+2. Build high-quality quickstart and migration pages.
+3. Publish measured comparison, pricing, latency, and ranking pages.
+4. Add real integration pages when an integration works.
+5. Use programmatic pages only when each page contains distinct, current data.
+
+## Google Campaign Structure
+
+Create a focused Search campaign with these ad groups:
+
+### Router And Gateway
+
+Keywords: `llm router`, `ai router`, `llm gateway`, `ai gateway`, and
+`openai compatible api`.
+
+Landing pages: `/best-llm-router`, `/llm-failover`, and
+`/openai-compatible-llm-api`.
+
+### OpenRouter Alternative
+
+Keywords: `openrouter alternative`, `open router api`, and migration variants.
+
+Landing pages: `/openrouter-alternative`, `/compare/openrouter`, and
+`/docs/migrate-from-openrouter`.
+
+### Confidential AI
+
+Keywords: `confidential ai`, `ai data privacy`, and
+`confidential computing ai`.
+
+Landing pages: `/private-llm-api`, `/no-log-llm-api`,
+`/confidential-computing-llm`, and `/security`.
+
+### Compliance
+
+Keywords: `hipaa compliant llm`, `hipaa compliant ai`, and
+`gdpr compliant ai`.
+
+Landing pages: `/hipaa-llm-api`, `/gdpr-compliant-llm-api`, and the relevant
+readiness pages. Ads must say readiness rather than certification until an
+audit or certification is complete.
+
+Start with exact and phrase match. Add negatives for `wifi`, `wireless`,
+`modem`, `router hardware`, `cisco`, `tp-link`, `home network`, `vpn`, and
+other network-router intent. Inspect the Google search-terms report at least
+twice per week during the first month.
+
+## Ad Message Tests
+
+Use at least three independent messages instead of one all-purpose ad:
+
+1. **Every model. Provable privacy.** One OpenAI-compatible API with an
+   attested, open-source prompt path.
+2. **Switch from OpenRouter in one line.** Keep the SDK and change the base
+   URL. No prompt or output logs by default.
+3. **One provider can go down. Your API should not.** Route across providers
+   with measured fallback and public status data.
+
+For X, keep the current privacy creative as the control and add migration and
+reliability variants. One creative cannot distinguish message quality from
+audience quality.
+
+## Measurement Required Before Scaling
+
+Capture the following first-party attribution fields:
+
+- `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`
+- `gclid`, `gbraid`, `wbraid`, and `twclid`
+- first landing page and first-touch timestamp
+- last-touch source before signup
+
+Persist attribution through these product events:
+
+1. `sign_in_opened`
+2. `signup_completed`
+3. `api_key_created`
+4. `first_successful_api_call`
+5. `credit_purchase_completed`
+6. `retained_api_usage_7d`
+
+Do not send prompts, outputs, API keys, BYOK secrets, or request bodies to an
+ad platform. Use consented click identifiers and aggregate product events.
+
+The first Google primary conversion should be `signup_completed`. Move the
+primary optimization event to `first_successful_api_call` or a credit purchase
+only after there is enough volume for the bidding system to learn. Report both
+CAC and activated CAC; signup CAC alone is easy to make look good.
+
+## Raw Inputs
+
+The source CSVs were downloaded locally from Ahrefs on 2026-07-21:
+
+- `openrouter.ai` organic keywords, US
+- `portkey.ai` organic keywords, US
+- `helicone.ai` organic keywords, US
+- `litellm.ai` organic keywords, US
+- initial TrustedRouter campaign seed keywords, Google US
+- privacy and compliance seed keywords, Google US
+
+Raw Ahrefs exports are not committed to this public repository.

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -91,6 +91,18 @@ function openSigninModal(): void {
   }
 }
 
+function trackFunnelEvent(event: "sign_in_opened"): void {
+  void fetch("/analytics/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ event }),
+    credentials: "same-origin",
+    keepalive: true,
+  }).catch(() => {
+    /* measurement is best-effort and must never interrupt sign-in */
+  });
+}
+
 function setSigninError(message: string): void {
   const el = document.getElementById("signinError");
   if (!el) return;
@@ -221,6 +233,7 @@ function init(): void {
     const opener = target.closest('[data-action="open-signin"]') as HTMLElement | null;
     if (opener) {
       event.preventDefault();
+      trackFunnelEvent("sign_in_opened");
       openSigninModal();
       return;
     }

--- a/src/trusted_router/acquisition.py
+++ b/src/trusted_router/acquisition.py
@@ -1,0 +1,562 @@
+"""First-party, privacy-bounded acquisition attribution.
+
+This module never receives prompt or output content. It only handles public
+landing metadata, account/workspace conversion milestones, and integer money.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import hashlib
+import hmac
+import json
+import logging
+import re
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+from fastapi import Request, Response
+
+from trusted_router.config import Settings
+from trusted_router.storage import STORE
+from trusted_router.storage_models import AcquisitionAttribution, iso_now
+
+log = logging.getLogger(__name__)
+
+ATTRIBUTION_COOKIE_NAME = "tr_attribution"
+ATTRIBUTION_COOKIE_MAX_AGE = 60 * 60 * 24 * 90
+RETENTION_MILESTONE_SECONDS = 60 * 60 * 24 * 7
+_COOKIE_VERSION = 1
+_MAX_COOKIE_BYTES = 3_800
+_ANONYMOUS_ID_RE = re.compile(r"^[a-f0-9]{32}$")
+_CLICK_ID_RE = re.compile(r"^[A-Za-z0-9._~-]{1,256}$")
+_TOUCH_FIELDS = frozenset(
+    {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "gclid",
+        "gbraid",
+        "wbraid",
+        "twclid",
+        "landing_path",
+        "referer_host",
+        "captured_at",
+    }
+)
+_USAGE_CHECK_CACHE_MAX = 50_000
+_usage_check_after: OrderedDict[str, float] = OrderedDict()
+_usage_check_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class AttributionContext:
+    anonymous_id: str
+    first_touch: dict[str, str]
+    last_touch: dict[str, str]
+    created_at: str
+
+
+def prepare_request_attribution(
+    request: Request,
+    settings: Settings,
+) -> tuple[AttributionContext | None, bool]:
+    """Decode the current cookie and optionally capture a new public touch."""
+    if _privacy_signal_enabled(request):
+        request.state.acquisition_attribution = None
+        return None, False
+    context = decode_attribution_cookie(
+        request.cookies.get(ATTRIBUTION_COOKIE_NAME),
+        settings,
+    )
+    request.state.acquisition_attribution = context
+    if not _should_capture_request(request):
+        return context, False
+
+    touch = _touch_from_request(request)
+    now = iso_now()
+    if context is None:
+        context = AttributionContext(
+            anonymous_id=uuid.uuid4().hex,
+            first_touch=touch,
+            last_touch=touch,
+            created_at=now,
+        )
+        changed = True
+    elif _has_explicit_campaign_touch(request):
+        context = AttributionContext(
+            anonymous_id=context.anonymous_id,
+            first_touch=context.first_touch,
+            last_touch=touch,
+            created_at=context.created_at,
+        )
+        changed = touch != request.state.acquisition_attribution.last_touch
+    else:
+        changed = False
+    request.state.acquisition_attribution = context
+    return context, changed
+
+
+def set_attribution_cookie(
+    response: Response,
+    context: AttributionContext,
+    settings: Settings,
+) -> None:
+    response.set_cookie(
+        key=ATTRIBUTION_COOKIE_NAME,
+        value=encode_attribution_cookie(context, settings),
+        max_age=ATTRIBUTION_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=settings.environment.lower() == "production",
+        samesite="lax",
+        path="/",
+    )
+
+
+def encode_attribution_cookie(context: AttributionContext, settings: Settings) -> str:
+    payload = {
+        "v": _COOKIE_VERSION,
+        "anonymous_id": context.anonymous_id,
+        "first_touch": context.first_touch,
+        "last_touch": context.last_touch,
+        "created_at": context.created_at,
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(raw).rstrip(b"=")
+    signature = hmac.new(_cookie_signing_key(settings), encoded, hashlib.sha256).digest()
+    return f"{encoded.decode('ascii')}.{_b64encode(signature)}"
+
+
+def decode_attribution_cookie(
+    value: str | None,
+    settings: Settings,
+) -> AttributionContext | None:
+    if not value or len(value.encode("utf-8")) > _MAX_COOKIE_BYTES:
+        return None
+    try:
+        encoded, supplied_signature = value.split(".", 1)
+        expected_signature = hmac.new(
+            _cookie_signing_key(settings),
+            encoded.encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        if not hmac.compare_digest(_b64decode(supplied_signature), expected_signature):
+            return None
+        payload = json.loads(_b64decode(encoded))
+        if payload.get("v") != _COOKIE_VERSION:
+            return None
+        anonymous_id = str(payload.get("anonymous_id") or "")
+        created_at = str(payload.get("created_at") or "")
+        if not _ANONYMOUS_ID_RE.fullmatch(anonymous_id) or _cookie_expired(created_at):
+            return None
+        first_touch = _validated_touch(payload.get("first_touch"))
+        last_touch = _validated_touch(payload.get("last_touch"))
+        if not first_touch or not last_touch:
+            return None
+        return AttributionContext(
+            anonymous_id=anonymous_id,
+            first_touch=first_touch,
+            last_touch=last_touch,
+            created_at=created_at,
+        )
+    except (UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def request_attribution(request: Request) -> AttributionContext | None:
+    value = getattr(request.state, "acquisition_attribution", None)
+    return value if isinstance(value, AttributionContext) else None
+
+
+def record_signup_attribution(
+    request: Request,
+    *,
+    workspace_id: str,
+    signup_provider: str,
+) -> None:
+    context = request_attribution(request) or _direct_context(request)
+    occurred_at = iso_now()
+    record = AcquisitionAttribution(
+        workspace_id=workspace_id,
+        anonymous_id=context.anonymous_id,
+        first_touch=dict(context.first_touch),
+        last_touch=dict(context.last_touch),
+        signup_provider=signup_provider,
+        signup_at=occurred_at,
+        milestones={
+            "signup_completed": occurred_at,
+            "api_key_created": occurred_at,
+        },
+    )
+    try:
+        created = STORE.create_acquisition_attribution(record)
+    except Exception as exc:  # noqa: BLE001 - analytics must never block signup.
+        log.warning(
+            "acquisition.signup_write_failed",
+            extra={
+                "workspace_fingerprint": _fingerprint(workspace_id),
+                "error": type(exc).__name__,
+            },
+        )
+        return
+    if not created:
+        return
+    _clear_usage_check(workspace_id)
+    _log_conversion("acquisition.signup_completed", record)
+    _log_conversion("acquisition.api_key_created", record)
+
+
+def record_successful_api_call(
+    workspace_id: str,
+    *,
+    model: str,
+    provider: str,
+    occurred_at: str | None = None,
+) -> AcquisitionAttribution | None:
+    """Claim first-use and seven-day retained-use milestones atomically."""
+    occurred_at = occurred_at or iso_now()
+    record = STORE.get_acquisition_attribution(workspace_id)
+    if record is None:
+        return None
+    milestones = ["first_successful_api_call"]
+    if _age_seconds(record.signup_at, occurred_at) >= RETENTION_MILESTONE_SECONDS:
+        milestones.append("retained_api_usage_7d")
+    record, claimed = STORE.claim_acquisition_milestones(
+        workspace_id,
+        milestones,
+        occurred_at=occurred_at,
+    )
+    if record is None:
+        return None
+    extra: dict[str, object] = {"model": model[:200], "provider": provider[:100]}
+    for milestone in claimed:
+        _log_conversion(f"acquisition.{milestone}", record, extra=extra)
+    return record
+
+
+def record_successful_api_call_safely(
+    workspace_id: str,
+    *,
+    model: str,
+    provider: str,
+) -> None:
+    if not _usage_check_due(workspace_id):
+        return
+    try:
+        record = record_successful_api_call(
+            workspace_id,
+            model=model,
+            provider=provider,
+        )
+    except Exception as exc:  # noqa: BLE001 - analytics must never affect inference.
+        log.warning(
+            "acquisition.milestone_write_failed",
+            extra={
+                "workspace_fingerprint": _fingerprint(workspace_id),
+                "error": type(exc).__name__,
+            },
+        )
+        _defer_usage_check(workspace_id, 60)
+        return
+    if record is None:
+        _defer_usage_check(workspace_id, 60 * 60)
+        return
+    if "retained_api_usage_7d" in record.milestones:
+        _defer_usage_check(workspace_id, 60 * 60 * 24 * 7)
+        return
+    remaining = RETENTION_MILESTONE_SECONDS - _age_seconds(record.signup_at, iso_now())
+    _defer_usage_check(workspace_id, max(60, int(remaining)))
+
+
+def record_credit_purchase(
+    workspace_id: str,
+    *,
+    amount_microdollars: int,
+    payment_method: str,
+) -> None:
+    """Record a credited purchase. Call only after payment-ledger dedupe wins."""
+    occurred_at = iso_now()
+    try:
+        record = STORE.record_acquisition_purchase(
+            workspace_id,
+            amount_microdollars=amount_microdollars,
+            occurred_at=occurred_at,
+        )
+    except Exception as exc:  # noqa: BLE001 - payment already committed; never fail webhook.
+        log.warning(
+            "acquisition.purchase_write_failed",
+            extra={
+                "workspace_fingerprint": _fingerprint(workspace_id),
+                "error": type(exc).__name__,
+            },
+        )
+        return
+    if record is None:
+        return
+    _log_conversion(
+        "acquisition.credit_purchase_completed",
+        record,
+        extra={
+            "amount_microdollars": amount_microdollars,
+            "payment_method": payment_method[:32],
+            "purchase_number": record.purchase_count,
+        },
+    )
+
+
+def log_browser_funnel_event(request: Request, event: str) -> None:
+    context = request_attribution(request)
+    if context is None:
+        return
+    touch = context.last_touch
+    log.info(
+        f"acquisition.{event}",
+        extra={
+            "event": f"acquisition.{event}",
+            "anonymous_fingerprint": _fingerprint(context.anonymous_id),
+            **_safe_touch_log_fields(touch),
+        },
+    )
+
+
+def pageview_attribution_fields(request: Request) -> dict[str, object]:
+    context = request_attribution(request)
+    if context is None:
+        return {}
+    return {
+        "anonymous_fingerprint": _fingerprint(context.anonymous_id),
+        **_safe_touch_log_fields(context.last_touch),
+    }
+
+
+def _log_conversion(
+    event: str,
+    record: AcquisitionAttribution,
+    *,
+    extra: dict[str, object] | None = None,
+) -> None:
+    fields: dict[str, object] = {
+        "event": event,
+        "workspace_fingerprint": _fingerprint(record.workspace_id),
+        "anonymous_fingerprint": _fingerprint(record.anonymous_id),
+        "signup_provider": record.signup_provider,
+        **_safe_touch_log_fields(record.last_touch),
+        "first_utm_source": record.first_touch.get("utm_source"),
+        "first_utm_medium": record.first_touch.get("utm_medium"),
+        "first_utm_campaign": record.first_touch.get("utm_campaign"),
+        "first_landing_path": record.first_touch.get("landing_path"),
+    }
+    if extra:
+        fields.update(extra)
+    log.info(event, extra=fields)
+
+
+def _safe_touch_log_fields(touch: dict[str, str]) -> dict[str, object]:
+    return {
+        "utm_source": touch.get("utm_source"),
+        "utm_medium": touch.get("utm_medium"),
+        "utm_campaign": touch.get("utm_campaign"),
+        "utm_term": touch.get("utm_term"),
+        "utm_content": touch.get("utm_content"),
+        "landing_path": touch.get("landing_path"),
+        "referer_host": touch.get("referer_host"),
+        "has_gclid": bool(touch.get("gclid")),
+        "has_gbraid": bool(touch.get("gbraid")),
+        "has_wbraid": bool(touch.get("wbraid")),
+        "has_twclid": bool(touch.get("twclid")),
+    }
+
+
+def _touch_from_request(request: Request) -> dict[str, str]:
+    touch: dict[str, str] = {}
+    for name in ("utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"):
+        value = _safe_text(request.query_params.get(name), 128)
+        if value:
+            touch[name] = value
+    for name in ("gclid", "gbraid", "wbraid", "twclid"):
+        value = str(request.query_params.get(name) or "").strip()
+        if _CLICK_ID_RE.fullmatch(value):
+            touch[name] = value
+    if "gclid" in touch or "gbraid" in touch or "wbraid" in touch:
+        touch.setdefault("utm_source", "google")
+        touch.setdefault("utm_medium", "paid_search")
+    if "twclid" in touch:
+        touch.setdefault("utm_source", "x")
+        touch.setdefault("utm_medium", "paid_social")
+    touch.setdefault("utm_source", "direct")
+    touch.setdefault("utm_medium", "none")
+    touch["landing_path"] = request.url.path[:256]
+    referer_host = _external_referer_host(request)
+    if referer_host:
+        touch["referer_host"] = referer_host
+        if touch["utm_source"] == "direct":
+            touch["utm_source"] = referer_host
+            touch["utm_medium"] = "referral"
+    touch["captured_at"] = iso_now()
+    return touch
+
+
+def _validated_touch(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    touch: dict[str, str] = {}
+    for key, raw_value in value.items():
+        if key not in _TOUCH_FIELDS or not isinstance(raw_value, str):
+            continue
+        if key in {"gclid", "gbraid", "wbraid", "twclid"}:
+            if _CLICK_ID_RE.fullmatch(raw_value):
+                touch[key] = raw_value
+            continue
+        limit = 256 if key == "landing_path" else 128
+        safe = _safe_text(raw_value, limit)
+        if safe:
+            touch[key] = safe
+    return touch
+
+
+def _direct_context(request: Request) -> AttributionContext:
+    now = iso_now()
+    touch = {
+        "utm_source": "direct",
+        "utm_medium": "none",
+        "landing_path": request.url.path[:256],
+        "captured_at": now,
+    }
+    return AttributionContext(uuid.uuid4().hex, touch, touch, now)
+
+
+def _should_capture_request(request: Request) -> bool:
+    if request.method.upper() != "GET" or _privacy_signal_enabled(request):
+        return False
+    path = request.url.path
+    excluded = (
+        "/auth",
+        "/console",
+        "/internal",
+        "/v1",
+        "/static",
+        "/health",
+        "/openapi",
+    )
+    if path.startswith(excluded) or path.endswith("_oauth_callback"):
+        return False
+    user_agent = request.headers.get("user-agent", "").lower()
+    return not any(token in user_agent for token in ("bot", "crawler", "spider"))
+
+
+def _has_explicit_campaign_touch(request: Request) -> bool:
+    return any(
+        request.query_params.get(name)
+        for name in (
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+            "utm_term",
+            "utm_content",
+            "gclid",
+            "gbraid",
+            "wbraid",
+            "twclid",
+        )
+    )
+
+
+def _privacy_signal_enabled(request: Request) -> bool:
+    return request.headers.get("sec-gpc") == "1" or request.headers.get("dnt") == "1"
+
+
+def _external_referer_host(request: Request) -> str | None:
+    raw = request.headers.get("referer", "").strip()
+    if not raw:
+        return None
+    try:
+        host = urlsplit(raw).hostname or ""
+    except ValueError:
+        return None
+    request_host = (request.url.hostname or "").lower()
+    host = host.lower()
+    return host[:128] if host and host != request_host else None
+
+
+def _safe_text(value: str | None, limit: int) -> str:
+    if not value:
+        return ""
+    return "".join(character for character in value.strip() if character.isprintable())[:limit]
+
+
+def _cookie_signing_key(settings: Settings) -> bytes:
+    root = settings.internal_gateway_token or f"local:{settings.service_name}"
+    return hmac.new(
+        root.encode("utf-8"),
+        b"trustedrouter-attribution-cookie-v1",
+        hashlib.sha256,
+    ).digest()
+
+
+def _cookie_expired(created_at: str) -> bool:
+    try:
+        created = dt.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=dt.UTC)
+    age = (dt.datetime.now(dt.UTC) - created).total_seconds()
+    return age < 0 or age > ATTRIBUTION_COOKIE_MAX_AGE
+
+
+def _age_seconds(earlier: str, later: str) -> float:
+    try:
+        start = dt.datetime.fromisoformat(earlier.replace("Z", "+00:00"))
+        end = dt.datetime.fromisoformat(later.replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=dt.UTC)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=dt.UTC)
+    return max(0.0, (end - start).total_seconds())
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _usage_check_due(workspace_id: str) -> bool:
+    now = time.monotonic()
+    with _usage_check_lock:
+        check_after = _usage_check_after.get(workspace_id)
+        if check_after is not None and check_after > now:
+            _usage_check_after.move_to_end(workspace_id)
+            return False
+        _usage_check_after.pop(workspace_id, None)
+        return True
+
+
+def _defer_usage_check(workspace_id: str, seconds: int) -> None:
+    with _usage_check_lock:
+        _usage_check_after[workspace_id] = time.monotonic() + max(seconds, 1)
+        _usage_check_after.move_to_end(workspace_id)
+        while len(_usage_check_after) > _USAGE_CHECK_CACHE_MAX:
+            _usage_check_after.popitem(last=False)
+
+
+def _clear_usage_check(workspace_id: str) -> None:
+    with _usage_check_lock:
+        _usage_check_after.pop(workspace_id, None)

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -24,6 +24,7 @@ from trusted_router.catalog import validate_auto_model_order
 from trusted_router.config import Settings, get_settings
 from trusted_router.errors import error_response
 from trusted_router.middleware import register_http_middleware
+from trusted_router.routes.acquisition import register_acquisition_routes
 from trusted_router.routes.activity import register_activity_routes
 from trusted_router.routes.auth import register_auth_routes
 from trusted_router.routes.billing import register_billing_routes
@@ -154,6 +155,7 @@ def _make_api_router(settings: Settings) -> APIRouter:
 
     register_inference_routes(inference_router)
 
+    register_acquisition_routes(router)
     register_catalog_routes(router)
     register_auth_routes(router)
     register_byok_routes(router)

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -3,7 +3,8 @@
 Four middlewares register in order from outermost to innermost:
   1. request_id  — mints/accepts a per-request id, echoes in response
                    header, makes it available as request.state.request_id.
-  2. public_pageview — emits metadata-only public blog pageview events.
+  2. public_pageview — captures signed first-party attribution and emits
+                       metadata-only public pageview events.
   3. rate_limit  — enforces per-(key|ip|internal-token) windowed limits
                    via STORE.hit_rate_limit; logs structured 429s with
                    the request_id from (1).
@@ -26,6 +27,11 @@ from urllib.parse import parse_qs, urlsplit
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 
+from trusted_router.acquisition import (
+    pageview_attribution_fields,
+    prepare_request_attribution,
+    set_attribution_cookie,
+)
 from trusted_router.auth import get_authorization_bearer
 from trusted_router.config import Settings
 from trusted_router.errors import error_response
@@ -86,8 +92,11 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
+        attribution, attribution_changed = prepare_request_attribution(request, settings)
         start = time.perf_counter()
         response = await call_next(request)
+        if attribution is not None and attribution_changed:
+            set_attribution_cookie(response, attribution, settings)
         _log_public_page_view(request, response, latency_ms=(time.perf_counter() - start) * 1000)
         return response
 
@@ -299,19 +308,19 @@ def _log_public_page_view(request: Request, response: Response, *, latency_ms: f
     """Emit privacy-bounded public page analytics through the app logger.
 
     The Axiom integration subscribes to Python log records. We only log
-    metadata needed for blog traffic analytics and deliberately avoid raw IPs,
+    metadata needed for public-site analytics and deliberately avoid raw IPs,
     cookies, auth headers, full query strings, or user-agent strings.
     """
     if request.method.upper() != "GET":
         return
     path = request.url.path
-    if path != "/blog" and not path.startswith("/blog/"):
+    if not _is_public_html_response(path, response):
         return
     slug = path.removeprefix("/blog/") if path.startswith("/blog/") else ""
     extra: dict[str, object] = {
         "event": "public.page_view",
         "request_id": getattr(request.state, "request_id", None),
-        "page_kind": "blog_post" if slug else "blog_index",
+        "page_kind": _page_kind(path),
         "path": path,
         "blog_slug": slug or None,
         "status_code": response.status_code,
@@ -320,7 +329,39 @@ def _log_public_page_view(request: Request, response: Response, *, latency_ms: f
         "user_agent_family": _user_agent_family(request.headers.get("user-agent", "")),
     }
     extra.update(_utm_fields(request))
+    extra.update(pageview_attribution_fields(request))
     log.info("public.page_view", extra=extra)
+
+
+def _is_public_html_response(path: str, response: Response) -> bool:
+    excluded = (
+        "/auth",
+        "/console",
+        "/internal",
+        "/v1",
+        "/static",
+        "/health",
+        "/openapi",
+    )
+    if path.startswith(excluded) or path.endswith("_oauth_callback"):
+        return False
+    return "text/html" in response.headers.get("content-type", "").lower()
+
+
+def _page_kind(path: str) -> str:
+    if path == "/":
+        return "homepage"
+    if path == "/blog":
+        return "blog_index"
+    if path.startswith("/blog/"):
+        return "blog_post"
+    if path.startswith("/docs"):
+        return "docs"
+    if path.startswith("/models/"):
+        return "model"
+    if path.startswith("/providers/"):
+        return "provider"
+    return "marketing"
 
 
 def _referer_host(request: Request) -> str | None:

--- a/src/trusted_router/routes/acquisition.py
+++ b/src/trusted_router/routes/acquisition.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Request, Response
+from pydantic import BaseModel, ConfigDict
+
+from trusted_router.acquisition import log_browser_funnel_event
+
+
+class MarketingEventRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event: Literal["sign_in_opened"]
+
+
+def register_acquisition_routes(router: APIRouter) -> None:
+    @router.post("/analytics/events", status_code=204)
+    async def marketing_event(body: MarketingEventRequest, request: Request) -> Response:
+        log_browser_funnel_event(request, body.event)
+        return Response(status_code=204)

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -21,6 +21,7 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Request
 from starlette.concurrency import run_in_threadpool
 
+from trusted_router.acquisition import record_successful_api_call_safely
 from trusted_router.auth import SettingsDep, is_api_key_expired
 from trusted_router.byok_crypto import byok_cache_key, encrypted_secret_payload
 from trusted_router.catalog import (
@@ -1079,6 +1080,19 @@ def _settle_gateway_authorization(
     if success and selected_usage_type == UsageType.CREDITS:
         _schedule_auto_refill(authorization.workspace_id, settings, background_tasks)
     if success:
+        if background_tasks is not None:
+            background_tasks.add_task(
+                record_successful_api_call_safely,
+                authorization.workspace_id,
+                model=model.id,
+                provider=selected_endpoint.provider,
+            )
+        else:
+            record_successful_api_call_safely(
+                authorization.workspace_id,
+                model=model.id,
+                provider=selected_endpoint.provider,
+            )
         # Alert-mode budgets: email the owner when a window is crossed (never
         # blocks — the block happens at authorize for limit-mode keys). Off the
         # hot path; best-effort.

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -20,6 +20,7 @@ from typing import Any
 import stripe
 from fastapi import APIRouter, HTTPException, Request
 
+from trusted_router.acquisition import record_credit_purchase
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
 from trusted_router.money import MICRODOLLARS_PER_CENT
@@ -117,6 +118,12 @@ def register(router: APIRouter) -> None:
                 credited = STORE.credit_workspace_typed_direct(
                     workspace_id, amount_total * MICRODOLLARS_PER_CENT, event_id
                 )
+                if credited:
+                    record_credit_purchase(
+                        workspace_id,
+                        amount_microdollars=amount_total * MICRODOLLARS_PER_CENT,
+                        payment_method="stripe",
+                    )
                 # Capture the Stripe customer the first time they pay so
                 # auto-refill can use it later. The default payment method
                 # arrives separately in `setup_intent.succeeded` (or via the
@@ -208,6 +215,12 @@ def register(router: APIRouter) -> None:
                 credited = STORE.credit_workspace_typed_direct(
                     workspace_id, amount_microdollars, event_id
                 )
+                if credited:
+                    record_credit_purchase(
+                        workspace_id,
+                        amount_microdollars=amount_microdollars,
+                        payment_method="stripe_auto_refill",
+                    )
                 STORE.record_auto_refill_outcome(workspace_id, status="succeeded")
                 # Also persist the payment-method if Stripe surfaced one —
                 # first auto-refill after a Checkout that didn't include

--- a/src/trusted_router/routes/oauth.py
+++ b/src/trusted_router/routes/oauth.py
@@ -22,6 +22,7 @@ import secrets
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.responses import RedirectResponse
 
+from trusted_router.acquisition import record_signup_attribution
 from trusted_router.auth import SettingsDep, set_session_cookie
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
@@ -153,6 +154,11 @@ async def _handle_callback(
         if result is not None:
             user_id = result.user.id
             pending_reveal_raw_key = result.raw_key
+            record_signup_attribution(
+                request,
+                workspace_id=result.workspace.id,
+                signup_provider=provider.slug,
+            )
         else:
             concurrent = STORE.find_user_by_email(info.email)
             if concurrent is None:

--- a/src/trusted_router/routes/signup.py
+++ b/src/trusted_router/routes/signup.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from trusted_router.acquisition import record_signup_attribution
 from trusted_router.errors import api_error
 from trusted_router.schemas import SignupRequest
 from trusted_router.storage import STORE
@@ -11,7 +12,7 @@ from trusted_router.types import ErrorType
 
 def register_signup_routes(router: APIRouter) -> None:
     @router.post("/signup")
-    async def signup(body: SignupRequest) -> JSONResponse:
+    async def signup(body: SignupRequest, request: Request) -> JSONResponse:
         result = STORE.signup(email=str(body.email).lower(), workspace_name=body.name)
         if result is None:
             raise api_error(
@@ -19,6 +20,11 @@ def register_signup_routes(router: APIRouter) -> None:
                 "This email is already registered. Sign in with your saved management key.",
                 ErrorType.ALREADY_REGISTERED,
             )
+        record_signup_attribution(
+            request,
+            workspace_id=result.workspace.id,
+            signup_provider="email",
+        )
         return JSONResponse(
             {
                 "data": {

--- a/src/trusted_router/routes/wallet_oauth.py
+++ b/src/trusted_router/routes/wallet_oauth.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Form, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
+from trusted_router.acquisition import record_signup_attribution
 from trusted_router.auth import (
     SESSION_COOKIE_NAME,
     SettingsDep,
@@ -87,6 +88,7 @@ def register_wallet_oauth_routes(router: APIRouter) -> None:
 
     @router.post("/auth/wallet/verify")
     async def wallet_verify(
+        request: Request,
         body: WalletVerifyRequest,
         settings: SettingsDep,
     ) -> Response:
@@ -105,13 +107,20 @@ def register_wallet_oauth_routes(router: APIRouter) -> None:
         if recovered != body.address.strip().lower():
             raise api_error(400, "Signature does not match address", ErrorType.BAD_REQUEST)
 
-        user = STORE.find_user_by_wallet(body.address) or STORE.create_wallet_user(body.address)
+        existing_user = STORE.find_user_by_wallet(body.address)
+        user = existing_user or STORE.create_wallet_user(body.address)
         workspaces = STORE.list_workspaces_for_user(user.id)
         workspace = workspaces[0] if workspaces else STORE.create_workspace(
             user.id,
             "Personal Workspace",
             trial_credit_microdollars=0,
         )
+        if existing_user is None:
+            record_signup_attribution(
+                request,
+                workspace_id=workspace.id,
+                signup_provider="metamask",
+            )
 
         raw_token, _ = STORE.create_auth_session(
             user_id=user.id,

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 
+from trusted_router.acquisition import record_credit_purchase
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
 from trusted_router.money import (
@@ -150,6 +151,12 @@ def credit_paypal_capture(
         amount_microdollars,
         f"paypal_capture:{capture_id}",
     )
+    if credited:
+        record_credit_purchase(
+            workspace_id,
+            amount_microdollars=amount_microdollars,
+            payment_method="paypal",
+        )
     return PayPalCaptureResult(
         order_id=parsed["order_id"],
         capture_id=capture_id,

--- a/src/trusted_router/services/x402_billing.py
+++ b/src/trusted_router/services/x402_billing.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import stripe
 
+from trusted_router.acquisition import record_credit_purchase
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
 from trusted_router.money import (
@@ -168,6 +169,12 @@ def credit_x402_payment_intent(
         amount_microdollars,
         x402_event_id(payment_intent_id),
     )
+    if credited:
+        record_credit_purchase(
+            workspace_id,
+            amount_microdollars=amount_microdollars,
+            payment_method="stablecoin",
+        )
     return _x402_settle_payload(
         status=status,
         payment_intent_id=payment_intent_id,

--- a/src/trusted_router/static/dashboard.js
+++ b/src/trusted_router/static/dashboard.js
@@ -84,6 +84,17 @@ function openSigninModal() {
         dialog.showModal();
     }
 }
+function trackFunnelEvent(event) {
+    void fetch("/analytics/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ event }),
+        credentials: "same-origin",
+        keepalive: true,
+    }).catch(() => {
+        /* measurement is best-effort and must never interrupt sign-in */
+    });
+}
 function setSigninError(message) {
     const el = document.getElementById("signinError");
     if (!el)
@@ -213,6 +224,7 @@ function init() {
         const opener = target.closest('[data-action="open-signin"]');
         if (opener) {
             event.preventDefault();
+            trackFunnelEvent("sign_in_opened");
             openSigninModal();
             return;
         }

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -5,6 +5,7 @@ import threading
 import uuid
 from typing import Any, cast
 
+from trusted_router.storage_attribution import InMemoryAcquisitionAttribution
 from trusted_router.storage_auth_sessions import InMemoryAuthSessions
 from trusted_router.storage_broadcast import InMemoryBroadcastDestinations
 from trusted_router.storage_byok import InMemoryByok
@@ -13,6 +14,7 @@ from trusted_router.storage_email_blocks import InMemoryEmailBlocks
 from trusted_router.storage_generations import InMemoryGenerations
 from trusted_router.storage_keys import InMemoryApiKeys
 from trusted_router.storage_models import (
+    AcquisitionAttribution,
     ApiKey,
     AuthSession,
     BroadcastDeliveryJob,
@@ -74,6 +76,7 @@ class InMemoryStore:
             credit_money_by_workspace=self.credit_money,
             lock=self._lock,
         )
+        self.acquisition_store = InMemoryAcquisitionAttribution(lock=self._lock)
         self.generation_store = InMemoryGenerations(
             lock=self._lock,
             add_usage_to_key=self.api_keys.add_usage,
@@ -100,6 +103,7 @@ class InMemoryStore:
             self.credit_money.clear()
             self.stripe_events.clear()
             self.api_keys.reset()
+            self.acquisition_store.reset()
             self.generation_store.reset()
             self.synthetic_store.reset()
             self.byok_store.reset()
@@ -153,6 +157,40 @@ class InMemoryStore:
             raw_key=raw_key,
             api_key=api_key,
             trial_credit_microdollars=trial,
+        )
+
+    def create_acquisition_attribution(self, record: AcquisitionAttribution) -> bool:
+        return self.acquisition_store.create(record)
+
+    def get_acquisition_attribution(
+        self, workspace_id: str
+    ) -> AcquisitionAttribution | None:
+        return self.acquisition_store.get(workspace_id)
+
+    def claim_acquisition_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]:
+        return self.acquisition_store.claim_milestones(
+            workspace_id,
+            milestones,
+            occurred_at=occurred_at,
+        )
+
+    def record_acquisition_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None:
+        return self.acquisition_store.record_purchase(
+            workspace_id,
+            amount_microdollars=amount_microdollars,
+            occurred_at=occurred_at,
         )
 
     # Auth sessions delegate to storage_auth_sessions.InMemoryAuthSessions.

--- a/src/trusted_router/storage_attribution.py
+++ b/src/trusted_router/storage_attribution.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import threading
+
+from trusted_router.storage_models import AcquisitionAttribution, iso_now
+
+
+class InMemoryAcquisitionAttribution:
+    def __init__(self, *, lock: threading.RLock) -> None:
+        self._lock = lock
+        self.records: dict[str, AcquisitionAttribution] = {}
+
+    def reset(self) -> None:
+        self.records.clear()
+
+    def create(self, record: AcquisitionAttribution) -> bool:
+        with self._lock:
+            if record.workspace_id in self.records:
+                return False
+            self.records[record.workspace_id] = record
+            return True
+
+    def get(self, workspace_id: str) -> AcquisitionAttribution | None:
+        with self._lock:
+            return self.records.get(workspace_id)
+
+    def claim_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]:
+        with self._lock:
+            record = self.records.get(workspace_id)
+            if record is None:
+                return None, []
+            claimed: list[str] = []
+            for name in milestones:
+                if name not in record.milestones and name not in claimed:
+                    claimed.append(name)
+            for name in claimed:
+                record.milestones[name] = occurred_at
+            if claimed:
+                record.updated_at = iso_now()
+            return record, claimed
+
+    def record_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None:
+        with self._lock:
+            record = self.records.get(workspace_id)
+            if record is None:
+                return None
+            record.purchase_count += 1
+            record.purchase_microdollars += amount_microdollars
+            record.first_purchase_at = record.first_purchase_at or occurred_at
+            record.last_purchase_at = occurred_at
+            record.updated_at = iso_now()
+            return record

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from trusted_router.storage import (
+    AcquisitionAttribution,
     ApiKey,
     AuthSession,
     BroadcastDeliveryJob,
@@ -37,6 +38,7 @@ from trusted_router.storage import (
     Workspace,
     iso_now,
 )
+from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
 from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
 from trusted_router.storage_gcp_byok import SpannerByok
@@ -220,6 +222,7 @@ class SpannerBigtableStore:
             delete_entities_tx=self._delete_entities_tx,
         )
         self.api_keys = SpannerApiKeys(io)
+        self.acquisition_store = SpannerAcquisitionAttribution(io)
         self.generation_store = SpannerGenerations(
             io,
             bt_table=self._bt_table,
@@ -243,6 +246,40 @@ class SpannerBigtableStore:
 
     def reset(self) -> None:
         raise RuntimeError("refusing to reset production Spanner/Bigtable store")
+
+    def create_acquisition_attribution(self, record: AcquisitionAttribution) -> bool:
+        return self.acquisition_store.create(record)
+
+    def get_acquisition_attribution(
+        self, workspace_id: str
+    ) -> AcquisitionAttribution | None:
+        return self.acquisition_store.get(workspace_id)
+
+    def claim_acquisition_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]:
+        return self.acquisition_store.claim_milestones(
+            workspace_id,
+            milestones,
+            occurred_at=occurred_at,
+        )
+
+    def record_acquisition_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None:
+        return self.acquisition_store.record_purchase(
+            workspace_id,
+            amount_microdollars=amount_microdollars,
+            occurred_at=occurred_at,
+        )
 
     def ensure_user(self, user_id: str, email: str | None = None) -> User:
         normalized_email = _normalize_email(email or user_id)

--- a/src/trusted_router/storage_gcp_attribution.py
+++ b/src/trusted_router/storage_gcp_attribution.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
+from trusted_router.storage_models import AcquisitionAttribution, iso_now
+
+_KIND = "acquisition_attribution"
+
+
+class SpannerAcquisitionAttribution:
+    def __init__(self, io: SpannerIO) -> None:
+        self._io = io
+
+    def create(self, record: AcquisitionAttribution) -> bool:
+        def txn(transaction: Any) -> bool:
+            existing = self._io.read_entity_tx(
+                transaction,
+                _KIND,
+                record.workspace_id,
+                AcquisitionAttribution,
+            )
+            if existing is not None:
+                return False
+            self._io.write_entity_tx(transaction, _KIND, record.workspace_id, record)
+            return True
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def get(self, workspace_id: str) -> AcquisitionAttribution | None:
+        return self._io.read_entity(_KIND, workspace_id, AcquisitionAttribution)
+
+    def claim_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]:
+        def txn(
+            transaction: Any,
+        ) -> tuple[AcquisitionAttribution | None, list[str]]:
+            record = self._io.read_entity_tx(
+                transaction,
+                _KIND,
+                workspace_id,
+                AcquisitionAttribution,
+            )
+            if record is None:
+                return None, []
+            claimed: list[str] = []
+            for name in milestones:
+                if name not in record.milestones and name not in claimed:
+                    claimed.append(name)
+            for name in claimed:
+                record.milestones[name] = occurred_at
+            if claimed:
+                record.updated_at = iso_now()
+                self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
+            return record, claimed
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def record_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None:
+        def txn(transaction: Any) -> AcquisitionAttribution | None:
+            record = self._io.read_entity_tx(
+                transaction,
+                _KIND,
+                workspace_id,
+                AcquisitionAttribution,
+            )
+            if record is None:
+                return None
+            record.purchase_count += 1
+            record.purchase_microdollars += amount_microdollars
+            record.first_purchase_at = record.first_purchase_at or occurred_at
+            record.last_purchase_at = occurred_at
+            record.updated_at = iso_now()
+            self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
+            return record
+
+        return run_in_transaction_with_retry(self._io.database, txn)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -816,6 +816,29 @@ class SignupResult:
 
 
 @dataclass
+class AcquisitionAttribution:
+    """Privacy-bounded acquisition record for one workspace.
+
+    Click identifiers are retained here so paid conversions can eventually be
+    uploaded to the originating ad platform. They are never copied into logs,
+    public APIs, generation metadata, or the prompt path.
+    """
+
+    workspace_id: str
+    anonymous_id: str
+    first_touch: dict[str, str]
+    last_touch: dict[str, str]
+    signup_provider: str
+    signup_at: str = field(default_factory=iso_now)
+    milestones: dict[str, str] = field(default_factory=dict)
+    purchase_count: int = 0
+    purchase_microdollars: int = 0
+    first_purchase_at: str | None = None
+    last_purchase_at: str | None = None
+    updated_at: str = field(default_factory=iso_now)
+
+
+@dataclass
 class AuthSession:
     hash: str
     salt: str

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 from trusted_router.storage_models import (
+    AcquisitionAttribution,
     ApiKey,
     AuthSession,
     BroadcastDeliveryJob,
@@ -61,6 +62,24 @@ class Store(Protocol):
         email: str,
         workspace_name: str | None = ...,
     ) -> SignupResult | None: ...
+    def create_acquisition_attribution(self, record: AcquisitionAttribution) -> bool: ...
+    def get_acquisition_attribution(
+        self, workspace_id: str
+    ) -> AcquisitionAttribution | None: ...
+    def claim_acquisition_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]: ...
+    def record_acquisition_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None: ...
     def create_workspace(
         self,
         owner_user_id: str,

--- a/src/trusted_router/templates/public/privacy.html
+++ b/src/trusted_router/templates/public/privacy.html
@@ -1,7 +1,7 @@
 {% extends "public/_base.html" %}
 {% block body %}
 <section class="public-proof-strip">
-  <div><strong>Effective</strong><span>July 13, 2026</span></div>
+  <div><strong>Effective</strong><span>July 21, 2026</span></div>
   <div><strong>Controller</strong><span>{{ entity.name }}</span></div>
   <div><strong>Prompt storage</strong><span>Off by default</span></div>
   <div><strong>Contact</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
@@ -21,7 +21,7 @@
   <h3>Prompts and outputs</h3>
   <p>TrustedRouter does not store prompt or output content by default. Prompt traffic is designed to terminate inside the attested gateway. If a workspace explicitly enables a content-bearing Broadcast destination or another content feature, the selected content is sent to that destination under the workspace's configuration and the destination's terms. Downstream model providers process content according to the selected route and provider terms.</p>
   <h3>Website information</h3>
-  <p>We may collect IP address, browser and device information, referring page, coarse location derived from IP, cookie or session identifiers, and page interaction data needed to operate, secure, and improve the service.</p>
+  <p>We may collect IP address, browser and device information, referring page, coarse location derived from IP, cookie or session identifiers, and page interaction data needed to operate, secure, and improve the service. Our first-party campaign cookie is signed, HttpOnly, and limited to source, campaign, landing page, pseudonymous click identifiers, and an anonymous identifier. It does not contain prompts, outputs, API keys, BYOK credentials, email addresses, or payment details. TrustedRouter honors browser Global Privacy Control and Do Not Track signals by not creating or using this attribution cookie for that request.</p>
 
   <h2>How we use information</h2>
   <p>We use information to provide and secure the service, authenticate users, route requests, meter usage, process payments, prevent abuse, respond to support, maintain reliability, comply with law, and improve product performance. We do not use customer prompts or outputs to train our own models.</p>

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1064,6 +1064,7 @@ def make_fake_store(
     *, ready_barrier: threading.Barrier | None = None
 ) -> tuple[Any, FakeSpannerDatabase, FakeBigtableTable]:
     from trusted_router.storage_gcp import SpannerBigtableStore
+    from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
     from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
     from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
     from trusted_router.storage_gcp_byok import SpannerByok
@@ -1100,6 +1101,7 @@ def make_fake_store(
         delete_entities_tx=store._delete_entities_tx,
     )
     store.api_keys = SpannerApiKeys(io)
+    store.acquisition_store = SpannerAcquisitionAttribution(io)
     store.generation_store = SpannerGenerations(
         io,
         bt_table=bt,

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.acquisition import (
+    ATTRIBUTION_COOKIE_NAME,
+    AttributionContext,
+    decode_attribution_cookie,
+    encode_attribution_cookie,
+    record_successful_api_call,
+)
+from trusted_router.config import Settings
+from trusted_router.storage import STORE
+from trusted_router.storage_models import AcquisitionAttribution
+
+
+def _campaign_landing(client: TestClient, *, click_id: str = "google-click-123") -> None:
+    response = client.get(
+        "/openrouter-alternative"
+        "?utm_source=google&utm_medium=paid_search"
+        "&utm_campaign=router_launch&utm_content=privacy_a"
+        f"&gclid={click_id}"
+    )
+    assert response.status_code == 200
+
+
+def _signup(client: TestClient, email: str = "attributed@example.com") -> dict[str, object]:
+    response = client.post("/v1/signup", json={"email": email, "name": "Attributed"})
+    assert response.status_code == 201, response.text
+    payload = response.json()["data"]
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_cookie_round_trip_and_tamper_rejection() -> None:
+    settings = Settings(
+        internal_gateway_token="cookie-signing-root"  # noqa: S106 - test fixture secret.
+    )
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    touch = {
+        "utm_source": "google",
+        "utm_medium": "paid_search",
+        "utm_campaign": "launch",
+        "gclid": "click-123",
+        "landing_path": "/openrouter-alternative",
+        "captured_at": now,
+    }
+    context = AttributionContext("a" * 32, touch, touch, now)
+
+    encoded = encode_attribution_cookie(context, settings)
+    assert decode_attribution_cookie(encoded, settings) == context
+    assert decode_attribution_cookie(encoded + "tampered", settings) is None
+    assert decode_attribution_cookie(
+        encoded,
+        Settings(internal_gateway_token="rotated"),  # noqa: S106 - test fixture secret.
+    ) is None
+
+
+def test_expired_cookie_is_rejected() -> None:
+    settings = Settings(
+        internal_gateway_token="cookie-signing-root"  # noqa: S106 - test fixture secret.
+    )
+    old = (dt.datetime.now(dt.UTC) - dt.timedelta(days=91)).replace(microsecond=0)
+    created_at = old.isoformat().replace("+00:00", "Z")
+    touch = {
+        "utm_source": "x",
+        "utm_medium": "paid_social",
+        "landing_path": "/",
+        "captured_at": created_at,
+    }
+    encoded = encode_attribution_cookie(
+        AttributionContext("b" * 32, touch, touch, created_at), settings
+    )
+    assert decode_attribution_cookie(encoded, settings) is None
+
+
+def test_paid_landing_sets_signed_httponly_cookie(client: TestClient) -> None:
+    response = client.get(
+        "/?utm_source=x&utm_medium=paid_social&utm_campaign=privacy&twclid=tw-123"
+    )
+    assert response.status_code == 200
+    set_cookie = response.headers["set-cookie"]
+    assert f"{ATTRIBUTION_COOKIE_NAME}=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "SameSite=lax" in set_cookie
+    assert "tw-123" not in set_cookie
+
+    encoded = client.cookies.get(ATTRIBUTION_COOKIE_NAME)
+    context = decode_attribution_cookie(encoded, client.app.state.settings)
+    assert context is not None
+    assert context.last_touch["utm_source"] == "x"
+    assert context.last_touch["utm_medium"] == "paid_social"
+    assert context.last_touch["twclid"] == "tw-123"
+
+
+def test_first_touch_is_preserved_and_last_touch_updates(client: TestClient) -> None:
+    first = client.get("/?utm_source=x&utm_campaign=first&twclid=tw-first")
+    assert first.status_code == 200
+    second = client.get(
+        "/private-llm-api?utm_source=google&utm_campaign=second&gclid=g-second"
+    )
+    assert second.status_code == 200
+
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert context.first_touch["utm_source"] == "x"
+    assert context.first_touch["utm_campaign"] == "first"
+    assert context.last_touch["utm_source"] == "google"
+    assert context.last_touch["utm_campaign"] == "second"
+    assert context.last_touch["landing_path"] == "/private-llm-api"
+
+
+@pytest.mark.parametrize("header", ["sec-gpc", "dnt"])
+def test_privacy_signals_suppress_attribution_cookie(
+    client: TestClient, header: str
+) -> None:
+    response = client.get(
+        "/?utm_source=google&gclid=do-not-store",
+        headers={header: "1"},
+    )
+    assert response.status_code == 200
+    assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+
+def test_crawlers_do_not_receive_attribution_cookie(client: TestClient) -> None:
+    response = client.get(
+        "/?utm_source=google&gclid=bot-click",
+        headers={"user-agent": "Googlebot/2.1"},
+    )
+    assert response.status_code == 200
+    assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+
+def test_invalid_click_id_is_not_persisted(client: TestClient) -> None:
+    response = client.get("/?utm_source=google&gclid=bad%20click%0Avalue")
+    assert response.status_code == 200
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert "gclid" not in context.last_touch
+
+
+def test_signup_persists_attribution_and_emits_no_raw_click_id(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_click_id = "gclid-secret-987"
+    _campaign_landing(client, click_id=raw_click_id)
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+    payload = _signup(client)
+
+    workspace_id = str(payload["workspace_id"])
+    record = STORE.get_acquisition_attribution(workspace_id)
+    assert record is not None
+    assert record.first_touch["gclid"] == raw_click_id
+    assert record.last_touch["utm_campaign"] == "router_launch"
+    assert record.signup_provider == "email"
+    assert set(record.milestones) == {"signup_completed", "api_key_created"}
+    assert "acquisition.signup_completed" in caplog.text
+    assert "acquisition.api_key_created" in caplog.text
+    assert raw_click_id not in caplog.text
+    assert str(payload["key"]) not in caplog.text
+
+
+def test_attribution_failure_never_blocks_signup(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _campaign_landing(client)
+
+    def fail_write(_record: object) -> bool:
+        raise RuntimeError("spanner unavailable")
+
+    monkeypatch.setattr(STORE.target, "create_acquisition_attribution", fail_write)
+    caplog.set_level(logging.WARNING, logger="trusted_router.acquisition")
+    payload = _signup(client, "analytics-failure@example.com")
+    assert payload["workspace_id"]
+    assert "acquisition.signup_write_failed" in caplog.text
+    assert "spanner unavailable" not in caplog.text
+
+
+def test_signin_open_event_is_campaign_attributed_without_click_id_leak(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_click_id = "tw-private-123"
+    landing = client.get(
+        f"/?utm_source=x&utm_campaign=modal-test&twclid={raw_click_id}"
+    )
+    assert landing.status_code == 200
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+    response = client.post("/analytics/events", json={"event": "sign_in_opened"})
+    assert response.status_code == 204
+    assert "acquisition.sign_in_opened" in caplog.text
+    assert raw_click_id not in caplog.text
+
+
+def test_unknown_browser_funnel_event_is_rejected(client: TestClient) -> None:
+    response = client.post("/analytics/events", json={"event": "prompt_submitted"})
+    assert response.status_code == 400
+
+
+def test_successful_usage_milestones_are_once_only(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _campaign_landing(client)
+    payload = _signup(client)
+    workspace_id = str(payload["workspace_id"])
+    record = STORE.get_acquisition_attribution(workspace_id)
+    assert record is not None
+    record.signup_at = (
+        dt.datetime.now(dt.UTC) - dt.timedelta(days=8)
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+    record_successful_api_call(workspace_id, model="test/model", provider="test-provider")
+    record_successful_api_call(workspace_id, model="test/model", provider="test-provider")
+
+    record = STORE.get_acquisition_attribution(workspace_id)
+    assert record is not None
+    assert "first_successful_api_call" in record.milestones
+    assert "retained_api_usage_7d" in record.milestones
+    messages = [item.getMessage() for item in caplog.records]
+    assert messages.count("acquisition.first_successful_api_call") == 1
+    assert messages.count("acquisition.retained_api_usage_7d") == 1
+
+
+def test_stripe_purchase_attribution_follows_ledger_idempotency(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _campaign_landing(client)
+    payload = _signup(client)
+    workspace_id = str(payload["workspace_id"])
+    event = {
+        "id": "evt_attributed_purchase",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "amount_total": 2500,
+                "metadata": {"workspace_id": workspace_id},
+            }
+        },
+    }
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+    first = client.post("/v1/internal/stripe/webhook", json=event)
+    second = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert first.json()["data"]["credited"] is True
+    assert second.json()["data"]["credited"] is False
+    record = STORE.get_acquisition_attribution(workspace_id)
+    assert record is not None
+    assert record.purchase_count == 1
+    assert record.purchase_microdollars == 25_000_000
+    messages = [item.getMessage() for item in caplog.records]
+    assert messages.count("acquisition.credit_purchase_completed") == 1
+
+
+def test_public_pageviews_cover_marketing_but_not_console(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="trusted_router.middleware")
+    assert client.get("/private-llm-api?utm_source=google").status_code == 200
+    client.get("/console/api-keys", follow_redirects=False)
+    records = [item for item in caplog.records if item.getMessage() == "public.page_view"]
+    assert len(records) == 1
+    assert records[0].path == "/private-llm-api"
+    assert records[0].page_kind == "marketing"
+
+
+def test_record_signup_helper_uses_direct_fallback_without_cookie(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/v1/signup",
+        json={"email": "direct-route@example.com", "name": "Direct"},
+    )
+    assert response.status_code == 201
+    workspace_id = response.json()["data"]["workspace_id"]
+    record = STORE.get_acquisition_attribution(workspace_id)
+    assert record is not None
+    assert record.first_touch["utm_source"] == "direct"
+    assert record.first_touch["landing_path"] == "/v1/signup"
+
+
+def test_spanner_attribution_adapter_is_atomic_and_persistent() -> None:
+    store, _, _ = make_fake_store()
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    touch = {
+        "utm_source": "google",
+        "utm_medium": "paid_search",
+        "utm_campaign": "launch",
+        "gclid": "private-click-id",
+        "landing_path": "/private-llm-api",
+        "captured_at": now,
+    }
+    original = AcquisitionAttribution(
+        workspace_id="ws-attribution",
+        anonymous_id="c" * 32,
+        first_touch=touch,
+        last_touch=touch,
+        signup_provider="google",
+        signup_at=now,
+    )
+
+    assert store.create_acquisition_attribution(original) is True
+    assert store.create_acquisition_attribution(original) is False
+    stored = store.get_acquisition_attribution(original.workspace_id)
+    assert stored is not None
+    assert stored.first_touch["gclid"] == "private-click-id"
+
+    stored, claimed = store.claim_acquisition_milestones(
+        original.workspace_id,
+        ["first_successful_api_call", "first_successful_api_call"],
+        occurred_at=now,
+    )
+    assert stored is not None
+    assert claimed == ["first_successful_api_call"]
+    _, replay_claimed = store.claim_acquisition_milestones(
+        original.workspace_id,
+        ["first_successful_api_call"],
+        occurred_at=now,
+    )
+    assert replay_claimed == []
+
+    purchased = store.record_acquisition_purchase(
+        original.workspace_id,
+        amount_microdollars=12_345_678,
+        occurred_at=now,
+    )
+    assert purchased is not None
+    assert purchased.purchase_count == 1
+    assert purchased.purchase_microdollars == 12_345_678


### PR DESCRIPTION
## Summary
- capture signed first-party campaign attribution with GPC/DNT support
- persist signup, activation, retention, and credited-purchase milestones in Spanner
- emit privacy-bounded Axiom funnel events without raw click IDs or inference content
- document measurement policy and disclose the campaign cookie

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1726 passed, 33 skipped)
- `npx tsc`
- `npx eslint frontend/src`
- `npx stylelint "src/trusted_router/static/*.css"`