### PR TITLE
Schedule Friendli Qwen3 235B serverless retirement

### DIFF
--- a/scripts/pricing/providers/friendli.py
+++ b/scripts/pricing/providers/friendli.py
@@ -36,6 +36,7 @@ from scripts.pricing.base import (
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
 from scripts.pricing.openai_catalog import dollars_per_token_to_micro_per_m
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "friendli"
 URL = "https://api.friendli.ai/serverless/v1/models"
@@ -140,6 +141,8 @@ def fetch() -> ProviderPricingResult:
             continue
         or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
         if or_id is None:
+            continue
+        if provider_model_retired(SLUG, or_id, native_id):
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
         manifest_rows[or_id] = _discovered_manifest_row(or_id, native_id, row)

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 
 PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
 TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
+FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 
 
 @dataclass(frozen=True)
@@ -29,6 +30,15 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Friendli announced that Qwen3-235B-A22B-Instruct-2507 retires from its
+    # serverless Model API at 2026-08-05 00:00 UTC. Dedicated endpoints are
+    # unaffected; TrustedRouter uses Friendli's serverless endpoint.
+    _Retirement(
+        provider="friendli",
+        model_ids=frozenset({"qwen/qwen3-235b-a22b-2507"}),
+        upstream_ids=frozenset({"Qwen/Qwen3-235B-A22B-Instruct-2507"}),
+        effective_at=FRIENDLI_QWEN3_235B_RETIREMENT_AT,
+    ),
     # Together announced that its serverless MiniMax M2.7 route retires on
     # 2026-07-27 and named MiniMax M3 as the replacement. The announcement did
     # not include a time zone, so use 00:00 UTC as the conservative cutover.

--- a/tests/test_friendli_august_2026_lifecycle.py
+++ b/tests/test_friendli_august_2026_lifecycle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import friendli
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
+_QWEN = "qwen/qwen3-235b-a22b-2507"
+_QWEN_UPSTREAM = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+_GLM = "z-ai/glm-5.2"
+
+
+def test_friendli_qwen_retires_at_announced_instant() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "friendli",
+        _QWEN,
+        _QWEN_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "friendli",
+        _QWEN,
+        _QWEN_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "friendli",
+        _GLM,
+        "zai-org/GLM-5.2",
+        at=_CUTOFF,
+    )
+
+
+def test_friendli_qwen_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    providers = {endpoint.provider for endpoint in endpoints_for_model(_QWEN)}
+
+    assert "friendli" not in providers
+    assert {"atlas-cloud", "crusoe"}.issubset(providers)
+
+
+def test_hourly_refresh_cannot_restore_retired_friendli_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="friendli",
+        prices={
+            _QWEN: ModelPrice(200_000, 800_000),
+            _GLM: ModelPrice(1_400_000, 4_400_000),
+        },
+        source="api",
+        fetched_url=friendli.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"friendli": result})
+    assert "friendli" in before[_QWEN]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"friendli": result})
+    assert _QWEN not in after
+    assert "friendli" in after[_GLM]
+
+
+def test_friendli_parser_drops_retired_model_even_if_feed_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": _QWEN_UPSTREAM,
+                "pricing": {"input": "0.0000002", "output": "0.0000008"},
+            },
+            {
+                "id": "zai-org/GLM-5.2",
+                "pricing": {"input": "0.0000014", "output": "0.0000044"},
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(friendli.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = friendli.fetch()
+    assert _QWEN in before.prices
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = friendli.fetch()
+    assert _QWEN not in after.prices
+    assert _QWEN not in friendli._DISCOVERED_MANIFEST_ROWS
+    assert _GLM in after.prices
+
+
+def test_friendli_qwen_native_mapping_matches_announced_route() -> None:
+    assert friendli.UPSTREAM_ID_MAP[_QWEN] == _QWEN_UPSTREAM


### PR DESCRIPTION
## Summary
- keep Friendli Qwen3-235B-A22B-Instruct-2507 live until 2026-08-05 00:00 UTC
- remove only the Friendli serverless route at the announced cutoff
- prevent catalog refresh and stale Friendli model feeds from restoring the retired route

## Verification
- uv run ruff check src/trusted_router/provider_lifecycle.py scripts/pricing/providers/friendli.py tests/test_friendli_august_2026_lifecycle.py
- uv run mypy
- uv run pytest -q: 1821 passed, 33 skipped