### PR TITLE
Prepare creator pilot Week 0

### DIFF
--- a/docs/marketing/creator-program/README.md
+++ b/docs/marketing/creator-program/README.md
@@ -1,0 +1,47 @@
+# TrustedRouter creator pilot
+
+This folder is the Week 0 operating pack for paid, honest developer tests of
+TrustedRouter. It is designed to make each placement measurable without
+turning creators into scripted endorsers.
+
+## Week 0 package
+
+- [Creator brief](creator-brief.md)
+- [Claims and disclosures](claims-and-disclosures.md)
+- [Four demo recipes](demo-recipes.md)
+- [Standard sponsorship agreement](standard-sponsorship-agreement.md)
+- [Tracking and provisioning](tracking-and-provisioning.md)
+- [Pilot manifest](creator-pilot-202607.json)
+- Public test page: https://trustedrouter.com/for-developers
+
+The first wave includes Theo as the tentpole prospect. Smaller creator and
+newsletter placements remain in the wave so the campaign can compare audience
+quality and activation cost instead of learning from one expensive placement.
+
+## Operating sequence
+
+1. Send a personalized pitch and the creator brief.
+2. Agree on the format, fixed fee, date, and factual test.
+3. Sign the agreement before issuing credentials.
+4. Provision only that creator's capped workspace and inference key.
+5. Deliver the private key outside email threads and public documents.
+6. Check disclosure and factual claims before publication. Do not request a
+   positive opinion or edit the creator's conclusion.
+7. Record views, clicks, successful API callers, retained usage, and purchases
+   at 48 hours, 7 days, and 30 days.
+
+No outreach is sent by this repository. No raw creator key belongs in Git,
+analytics, logs, an agreement, or a campaign URL.
+
+## Success event
+
+The primary event is the first successful API call from an attributed
+workspace. Signups, views, and clicks explain the funnel but are not the goal.
+The first-party attribution implementation records campaign touches through
+first use, seven-day retained use, and credited purchases.
+
+## Records to retain
+
+For each placement, retain the signed agreement, brief version, factual claims
+review, published URL, visible disclosure evidence, invoice, and the 48-hour,
+7-day, and 30-day performance snapshots.

--- a/docs/marketing/creator-program/claims-and-disclosures.md
+++ b/docs/marketing/creator-program/claims-and-disclosures.md
@@ -1,0 +1,62 @@
+# Creator claims and disclosures
+
+This sheet separates claims a creator can verify from claims TrustedRouter does
+not make. Verify time-sensitive catalog, pricing, and status statements on the
+linked live pages immediately before publication.
+
+## Supported factual claims
+
+- TrustedRouter exposes an OpenAI-compatible API. The quickstart runs through
+  the standard OpenAI client with a different base URL.
+- The hosted gateway and control-plane source are published at
+  https://github.com/Lore-Hex/quill-router.
+- The live prompt gateway publishes nonce-bound attestation evidence at
+  https://trust.trustedrouter.com.
+- TrustedRouter does not durably store prompt or output content by default.
+  It records operational metadata such as model, provider, tokens, latency,
+  status, cost, and region.
+- Downstream provider privacy posture is route specific and published at
+  https://trustedrouter.com/providers and on model pages.
+- The deployed catalog is available from https://trustedrouter.com/v1/models.
+  Use that endpoint instead of quoting a hard-coded model count.
+- Public router-core and provider-effective health are available from
+  https://status.trustedrouter.com.
+- Prepaid pricing is the provider route price plus 5 percent, with no required
+  monthly subscription. Verify current per-model prices before publication.
+
+## Claims that are not approved
+
+Do not say any of the following:
+
+- Every provider is end-to-end encrypted or zero data retention.
+- Attestation proves the source code has no bugs.
+- The provider cannot see a prompt unless that specific route documents an
+  end-to-end confidential-compute property.
+- TrustedRouter guarantees 100 percent privacy, security, uptime, or accuracy.
+- Every model is cheaper or faster than every alternative.
+- TrustedRouter is SOC 2 certified, ISO 27001 certified, HIPAA certified, or a
+  legal substitute for the customer's own compliance review.
+- A failover happened unless the observed response metadata or campaign test
+  evidence shows that it happened.
+
+## Required disclosure
+
+Use clear words such as `Sponsored by TrustedRouter` or `This video is
+sponsored by TrustedRouter`.
+
+- Video: say it aloud and show it on screen before or at the sponsored segment.
+- Description: put the disclosure with the sponsor link before text that a user
+  must expand.
+- Social post: put `Ad` or `Sponsored by TrustedRouter` in the post itself.
+- Live stream: repeat the disclosure periodically.
+- Newsletter: label the placement `Sponsored by TrustedRouter` at its start.
+
+Free API credits are also something of value and require disclosure even when
+there is no cash fee.
+
+The FTC says material connections must be obvious, disclosures must be hard to
+miss and use clear language, and creators cannot claim experience with a
+product they have not tried:
+https://www.ftc.gov/business-guidance/resources/disclosures-101-social-media-influencers
+
+This checklist supports campaign review. It is not legal advice.

--- a/docs/marketing/creator-program/creator-brief.md
+++ b/docs/marketing/creator-program/creator-brief.md
@@ -1,0 +1,44 @@
+# Creator brief: test TrustedRouter honestly
+
+## The assignment
+
+Use TrustedRouter before talking about it. Show one concrete developer task,
+report what happened, and keep your own opinion. The sponsorship pays for the
+work and distribution. It does not buy a positive conclusion.
+
+TrustedRouter is an OpenAI-compatible gateway for hundreds of model routes.
+The hosted prompt gateway is open source and hardware attested. TrustedRouter
+does not durably store prompt or output content by default. Downstream provider
+retention and confidential-compute properties differ by route and are listed
+separately.
+
+## Required deliverable
+
+- The format, placement, length, and publication date in the signed agreement.
+- A real API request made before recording.
+- One factual developer test from the [demo recipes](demo-recipes.md).
+- A clear sponsorship disclosure in the content and description.
+- A unique campaign URL supplied by TrustedRouter.
+- The published URL plus platform metrics at 48 hours, 7 days, and 30 days.
+
+## Editorial control
+
+The creator controls the opinion, wording, and conclusion. Lore Hex Corp may
+review a draft only to identify factual errors, unsupported security claims,
+credential exposure, or missing sponsorship disclosure. The creator does not
+have to accept stylistic edits or praise the product.
+
+## Useful test links
+
+- 60-second quickstart: https://trustedrouter.com/for-developers
+- Live models API: https://trustedrouter.com/v1/models
+- Verify the gateway: https://trust.trustedrouter.com
+- Provider posture: https://trustedrouter.com/providers
+- Public status: https://status.trustedrouter.com
+- Source: https://github.com/Lore-Hex/quill-router
+
+## Do not expose
+
+Never put an API key, BYOK credential, authorization header, private campaign
+document, customer prompt, or customer output on screen. Use synthetic prompts
+and redact terminal history before recording.

--- a/docs/marketing/creator-program/creator-pilot-202607.json
+++ b/docs/marketing/creator-program/creator-pilot-202607.json
@@ -1,0 +1,111 @@
+{
+  "campaign": "creator_pilot_202607",
+  "landing_path": "/for-developers",
+  "key_ttl_days": 90,
+  "creators": [
+    {
+      "slug": "theo_t3gg",
+      "display_name": "Theo, t3.gg",
+      "concept": "cost_per_completed_job",
+      "viewer_code": "THEO-TR",
+      "creator_credit_microdollars": 250000000,
+      "daily_limit_microdollars": 50000000
+    },
+    {
+      "slug": "cole_medin",
+      "display_name": "Cole Medin",
+      "concept": "agent_model_bakeoff",
+      "viewer_code": "COLE-TR",
+      "creator_credit_microdollars": 150000000,
+      "daily_limit_microdollars": 30000000
+    },
+    {
+      "slug": "ai_jason",
+      "display_name": "AI Jason",
+      "concept": "openai_base_url_eval",
+      "viewer_code": "JASON-TR",
+      "creator_credit_microdollars": 150000000,
+      "daily_limit_microdollars": 30000000
+    },
+    {
+      "slug": "indydevdan",
+      "display_name": "IndyDevDan",
+      "concept": "agent_provider_fallback",
+      "viewer_code": "INDY-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "sonny_sangha",
+      "display_name": "Sonny Sangha",
+      "concept": "build_one_agent",
+      "viewer_code": "SONNY-TR",
+      "creator_credit_microdollars": 150000000,
+      "daily_limit_microdollars": 30000000
+    },
+    {
+      "slug": "david_ondrej",
+      "display_name": "David Ondrej",
+      "concept": "open_model_comparison",
+      "viewer_code": "DAVID-TR",
+      "creator_credit_microdollars": 150000000,
+      "daily_limit_microdollars": 30000000
+    },
+    {
+      "slug": "tech_with_tim",
+      "display_name": "Tech With Tim",
+      "concept": "three_model_eval",
+      "viewer_code": "TIM-TR",
+      "creator_credit_microdollars": 150000000,
+      "daily_limit_microdollars": 30000000
+    },
+    {
+      "slug": "no_code_mba",
+      "display_name": "No Code MBA",
+      "concept": "one_api_many_models",
+      "viewer_code": "NOCODE-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "arielle_phoenix",
+      "display_name": "Arielle Phoenix",
+      "concept": "automation_model_routing",
+      "viewer_code": "ARIELLE-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "devops_ai_toolkit",
+      "display_name": "DevOps and AI Toolkit",
+      "concept": "attestation_and_rollover",
+      "viewer_code": "DEVOPS-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "pointer",
+      "display_name": "Pointer",
+      "concept": "provable_privacy",
+      "viewer_code": "POINTER-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "ai_weekly",
+      "display_name": "AI Weekly",
+      "concept": "hundreds_of_models",
+      "viewer_code": "AIWEEKLY-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    },
+    {
+      "slug": "thecodeman",
+      "display_name": "TheCodeMan",
+      "concept": "dotnet_openai_migration",
+      "viewer_code": "CODEMAN-TR",
+      "creator_credit_microdollars": 100000000,
+      "daily_limit_microdollars": 25000000
+    }
+  ]
+}

--- a/docs/marketing/creator-program/demo-recipes.md
+++ b/docs/marketing/creator-program/demo-recipes.md
@@ -1,0 +1,81 @@
+# Four TrustedRouter demo recipes
+
+Use synthetic prompts. Keep each first run small and capped. Record the model,
+selected provider, token count, cost, latency, request ID, and result without
+publishing credentials.
+
+## 1. One-line migration
+
+Start from an existing OpenAI client. Change only the key and base URL.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    base_url="https://api.trustedrouter.com/v1",
+)
+
+response = client.chat.completions.create(
+    model="trustedrouter/zdr",
+    messages=[{"role": "user", "content": "Reply with PONG only."}],
+    max_tokens=128,
+)
+print(response.choices[0].message.content)
+```
+
+Show the original and changed `base_url`. Do not show the key.
+
+## 2. Three-prompt model bakeoff
+
+Choose three representative prompts from the creator's normal workflow and
+three models from the live catalog. Include one strong open-weight model, one
+frontier model, and one cost-oriented route. Shuffle model labels before rating
+the answers. Score correctness, usefulness, latency, and actual request cost.
+
+Start here:
+
+```text
+GET https://trustedrouter.com/v1/models
+```
+
+Do not pick winners from one cherry-picked prompt. Publish the prompts, scoring
+rubric, token caps, and model versions when the content makes a performance
+claim.
+
+## 3. Fallback-ready request
+
+Send an ordered primary and fallback list. This demonstrates the request shape
+without pretending an outage occurred.
+
+```python
+response = client.chat.completions.create(
+    model="trustedrouter/zdr",
+    messages=[{"role": "user", "content": "Reply with ROUTED only."}],
+    max_tokens=128,
+    extra_body={
+        "models": ["trustedrouter/auto"],
+        "provider": {"allow_fallbacks": True},
+    },
+)
+```
+
+Use response and activity metadata to identify the route that served the call.
+A forced provider-failure demonstration must be coordinated with TrustedRouter
+in a sandbox window. Do not intentionally disrupt a production provider.
+
+## 4. Verify before sending
+
+Generate a fresh nonce, request live evidence, and compare it with the trust
+page instructions.
+
+```bash
+NONCE=$(openssl rand -hex 16)
+curl -s "https://api.trustedrouter.com/attestation?nonce=$NONCE" | jq .
+```
+
+Confirm the evidence includes the supplied nonce and the published workload
+identity. Explain the boundary accurately: the evidence identifies the running
+gateway image. It does not prove that the source is bug free or that every
+downstream provider is confidential.

--- a/docs/marketing/creator-program/standard-sponsorship-agreement.md
+++ b/docs/marketing/creator-program/standard-sponsorship-agreement.md
@@ -1,0 +1,90 @@
+# TrustedRouter creator sponsorship agreement
+
+Template for review and signature. Replace bracketed fields before use. This
+template is not a substitute for legal advice.
+
+## Parties and effective date
+
+This Creator Sponsorship Agreement is effective [DATE] between Lore Hex Corp,
+a Delaware corporation, 1111 Brickell Ave, Floor 10, Miami, Florida 33131
+(`Company`), and [CREATOR LEGAL NAME AND ADDRESS] (`Creator`). Joseph Perla,
+CEO, signs for Company.
+
+## Deliverable
+
+Creator will produce and publish [FORMAT AND DESCRIPTION] on [CHANNEL] by
+[DATE]. The sponsored segment will be at least [LENGTH] and will use the unique
+campaign URL supplied by Company. Creator will use the product before making
+statements about that experience.
+
+## Fee and test credits
+
+Company will pay Creator a fixed fee of [FEE] within [PAYMENT TERMS] after
+[INVOICE OR PUBLICATION CONDITION]. Company may provide capped API test credits
+with no cash value. Unused credits may expire after the campaign. Creator is
+responsible for taxes and expenses unless this agreement says otherwise.
+
+## Honest opinion and factual review
+
+Creator retains editorial control over opinions and conclusions. Company does
+not require a positive review. Creator will give Company a factual-review copy
+at least [REVIEW WINDOW] before publication. Company may identify factual
+errors, unsupported claims, exposed credentials, or missing disclosures, but
+may not require praise or suppress an honest conclusion.
+
+## Disclosure and accuracy
+
+Creator will clearly disclose `Sponsored by TrustedRouter` in the content and
+description, comply with applicable endorsement law and platform rules, and
+follow the signed claims sheet. Creator will not claim use that did not occur or
+make security, privacy, performance, compliance, or pricing claims without a
+reasonable factual basis.
+
+## Credentials and data
+
+Creator will protect API keys and other credentials, use synthetic or
+authorized data in demonstrations, and notify security@trustedrouter.com
+promptly if a credential is exposed. Creator may not share or resell campaign
+credits. Company may revoke a compromised or abused key.
+
+## Usage rights
+
+Creator owns the deliverable. Creator grants Company a non-exclusive,
+worldwide, royalty-free right for 12 months to link to, repost, and use excerpts
+of up to [EXCERPT LIMIT] in Company channels, with attribution. Paid media,
+material edits, whitelisting, and use of Creator's name or likeness outside the
+published deliverable require separate written approval.
+
+## Reporting
+
+Creator will provide available platform-reported views or opens, clicks,
+engagement, and audience comments at approximately 48 hours, 7 days, and 30
+days. Company may measure its own attributed signup, API-use, retention, and
+purchase events without receiving prompt or output content.
+
+## Cancellation and correction
+
+If Company cancels after work begins, Company will pay [KILL FEE]. If Creator
+misses the delivery date by more than [DAYS] without written agreement, Company
+may cancel and recover unearned prepaid fees. Creator will promptly correct a
+material factual error, missing legal disclosure, or exposed credential.
+
+## Independent contractor and general terms
+
+Creator is an independent contractor and cannot bind Company. Neither party
+assigns this agreement without written consent, except in a merger or sale of
+substantially all assets. This agreement is the complete agreement for the
+deliverable and may be changed only in writing. Delaware law governs, without
+regard to conflict-of-law rules. Electronic signatures and counterparts are
+valid.
+
+## Signatures
+
+Lore Hex Corp
+
+By: Joseph Perla, CEO
+
+Signature: ____________________  Date: __________
+Creator: [LEGAL NAME]
+
+Signature: ____________________  Date: __________

--- a/docs/marketing/creator-program/tracking-and-provisioning.md
+++ b/docs/marketing/creator-program/tracking-and-provisioning.md
@@ -1,0 +1,63 @@
+# Creator tracking and provisioning
+
+## Link convention
+
+Every placement gets one signed first-party attribution path:
+
+```text
+https://trustedrouter.com/for-developers
+  ?utm_source=creator
+  &utm_medium=sponsorship
+  &utm_campaign=creator_pilot_202607
+  &utm_content=<creator>_<concept>
+  &utm_term=<viewer_code>
+```
+
+The manifest contains unique creator slugs, concepts, and viewer codes. Viewer
+codes are attribution labels in this pilot. They do not redeem public credit and
+must not be advertised as coupons unless a separate redemption system is
+approved and tested.
+
+The primary conversion is `first_successful_api_call`. Also report sign-in
+opened, signup, key creation, seven-day retained API use, credit purchase, and
+30-day gross margin.
+
+## Provisioning safety
+
+Creator workspaces stay owned by the TrustedRouter operator until a partner is
+contracted. Each creator receives only a non-management inference key with:
+
+- a fixed lifetime spend limit equal to the funded credit;
+- an enforced daily limit;
+- a 90-day expiration;
+- campaign, creator, and purpose tags;
+- an idempotent funding event; and
+- no ability to list keys, mutate workspaces, configure BYOK, or call internal
+  management endpoints.
+
+Dry-run one creator:
+
+```bash
+uv run python scripts/provision_creator_pilot.py \
+  --owner-email joseph@jperla.com \
+  --creator theo_t3gg
+```
+
+Apply after the agreement is signed:
+
+```bash
+uv run python scripts/provision_creator_pilot.py \
+  --owner-email joseph@jperla.com \
+  --creator theo_t3gg \
+  --secrets-file /Users/jperla/claude/.trustedrouter_creator_pilot.private \
+  --apply
+```
+
+The private file must remain mode 0600 and outside Git. The script persists a
+recoverable raw key before committing its one-way hash, never prints raw keys,
+and reuses deterministic funding event IDs so retries cannot grant credit
+twice.
+
+Provision only accepted creators. Running the command without `--creator`
+targets every manifest entry and should be reserved for an explicitly approved
+batch.

--- a/scripts/provision_creator_pilot.py
+++ b/scripts/provision_creator_pilot.py
@@ -1,0 +1,412 @@
+"""Provision capped, inference-only workspaces for a creator pilot.
+
+The command is read-only unless ``--apply`` is supplied. New raw API keys are
+written to a local ``*.private`` JSON file with mode 0600 and are never printed.
+
+Example:
+  uv run python scripts/provision_creator_pilot.py \
+    --owner-email operator@example.com \
+    --creator theo_t3gg \
+    --secrets-file ~/.trustedrouter_creator_pilot.private \
+    --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.money import format_money_precise
+from trusted_router.security import new_api_key
+from trusted_router.storage import create_store
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = (
+    REPO_ROOT / "docs/marketing/creator-program/creator-pilot-202607.json"
+)
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+_CODE_RE = re.compile(r"^[A-Z0-9]+(?:-[A-Z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class CreatorSpec:
+    slug: str
+    display_name: str
+    concept: str
+    viewer_code: str
+    creator_credit_microdollars: int
+    daily_limit_microdollars: int
+
+    @property
+    def workspace_name(self) -> str:
+        return f"Creator Pilot: {self.display_name}"
+
+
+@dataclass(frozen=True)
+class PilotManifest:
+    campaign: str
+    landing_path: str
+    key_ttl_days: int
+    creators: tuple[CreatorSpec, ...]
+
+
+def load_manifest(path: Path) -> PilotManifest:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("manifest must be a JSON object")
+    campaign = _required_string(payload, "campaign")
+    landing_path = _required_string(payload, "landing_path")
+    if not landing_path.startswith("/") or landing_path.startswith("//"):
+        raise ValueError("landing_path must be an absolute site path")
+    key_ttl_days = _required_positive_int(payload, "key_ttl_days")
+    raw_creators = payload.get("creators")
+    if not isinstance(raw_creators, list) or not raw_creators:
+        raise ValueError("manifest creators must be a non-empty array")
+
+    creators: list[CreatorSpec] = []
+    slugs: set[str] = set()
+    codes: set[str] = set()
+    for index, raw in enumerate(raw_creators):
+        if not isinstance(raw, dict):
+            raise ValueError(f"creators[{index}] must be an object")
+        spec = CreatorSpec(
+            slug=_required_string(raw, "slug"),
+            display_name=_required_string(raw, "display_name"),
+            concept=_required_string(raw, "concept"),
+            viewer_code=_required_string(raw, "viewer_code"),
+            creator_credit_microdollars=_required_positive_int(
+                raw, "creator_credit_microdollars"
+            ),
+            daily_limit_microdollars=_required_positive_int(
+                raw, "daily_limit_microdollars"
+            ),
+        )
+        if not _SLUG_RE.fullmatch(spec.slug):
+            raise ValueError(f"invalid creator slug: {spec.slug}")
+        if not _SLUG_RE.fullmatch(spec.concept):
+            raise ValueError(f"invalid creator concept: {spec.concept}")
+        if not _CODE_RE.fullmatch(spec.viewer_code):
+            raise ValueError(f"invalid viewer code: {spec.viewer_code}")
+        if spec.daily_limit_microdollars > spec.creator_credit_microdollars:
+            raise ValueError(f"daily limit exceeds total credit for {spec.slug}")
+        if spec.slug in slugs or spec.viewer_code in codes:
+            raise ValueError("creator slugs and viewer codes must be unique")
+        slugs.add(spec.slug)
+        codes.add(spec.viewer_code)
+        creators.append(spec)
+    return PilotManifest(campaign, landing_path, key_ttl_days, tuple(creators))
+
+
+def tracking_url(manifest: PilotManifest, creator: CreatorSpec) -> str:
+    query = urlencode(
+        {
+            "utm_source": "creator",
+            "utm_medium": "sponsorship",
+            "utm_campaign": manifest.campaign,
+            "utm_content": f"{creator.slug}_{creator.concept}",
+            "utm_term": creator.viewer_code.lower(),
+        }
+    )
+    return f"https://trustedrouter.com{manifest.landing_path}?{query}"
+
+
+def provision_creator(
+    store: Any,
+    *,
+    owner_user: Any,
+    manifest: PilotManifest,
+    creator: CreatorSpec,
+    apply: bool,
+    raw_key: str | None = None,
+) -> dict[str, Any]:
+    matching = [
+        workspace
+        for workspace in store.list_workspaces_for_user(owner_user.id)
+        if workspace.name == creator.workspace_name
+        and workspace.owner_user_id == owner_user.id
+    ]
+    if len(matching) > 1:
+        raise ValueError(f"multiple workspaces match {creator.workspace_name}")
+    workspace = matching[0] if matching else None
+    existing_key = None
+    if workspace is not None:
+        keys = store.list_keys(workspace.id)
+        existing = [key for key in keys if key.name == _key_name(manifest)]
+        if len(existing) > 1:
+            raise ValueError(f"multiple pilot keys exist for {creator.slug}")
+        existing_key = existing[0] if existing else None
+
+    result: dict[str, Any] = {
+        "slug": creator.slug,
+        "display_name": creator.display_name,
+        "tracking_url": tracking_url(manifest, creator),
+        "viewer_code": creator.viewer_code,
+        "workspace_id": workspace.id if workspace else None,
+        "key_id": existing_key.hash if existing_key else None,
+        "credit_microdollars": creator.creator_credit_microdollars,
+        "created_workspace": False,
+        "created_key": False,
+        "credited": False,
+    }
+    if not apply:
+        return result
+
+    if workspace is None:
+        workspace = store.create_workspace(
+            owner_user.id,
+            creator.workspace_name,
+            trial_credit_microdollars=0,
+        )
+        result["workspace_id"] = workspace.id
+        result["created_workspace"] = True
+
+    event_id = f"{manifest.campaign}:{creator.slug}:creator_funding_v1"
+    result["credited"] = store.credit_workspace_typed_direct(
+        workspace.id,
+        creator.creator_credit_microdollars,
+        event_id,
+    )
+
+    keys = store.list_keys(workspace.id)
+    existing = [key for key in keys if key.name == _key_name(manifest)]
+    if len(existing) > 1:
+        raise ValueError(f"multiple pilot keys exist for {creator.slug}")
+    if existing:
+        result["key_id"] = existing[0].hash
+        return result
+
+    expires_at = (
+        dt.datetime.now(dt.UTC) + dt.timedelta(days=manifest.key_ttl_days)
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    raw_key, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name=_key_name(manifest),
+        creator_user_id=owner_user.id,
+        management=False,
+        raw_key=raw_key,
+        limit_microdollars=creator.creator_credit_microdollars,
+        limit_daily_microdollars=creator.daily_limit_microdollars,
+        limit_monthly_microdollars=creator.creator_credit_microdollars,
+        budget_alert_only=False,
+        expires_at=expires_at,
+        tags={
+            "campaign": manifest.campaign,
+            "creator": creator.slug,
+            "purpose": "sponsored_test",
+        },
+    )
+    result.update(
+        {
+            "key_id": api_key.hash,
+            "api_key": raw_key,
+            "created_key": True,
+            "expires_at": expires_at,
+        }
+    )
+    return result
+
+
+def _key_name(manifest: PilotManifest) -> str:
+    return f"Creator test: {manifest.campaign}"
+
+
+def _required_string(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
+
+
+def _required_positive_int(payload: dict[str, Any], name: str) -> int:
+    value = payload.get(name)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _load_secret_document(path: Path, campaign: str) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "campaign": campaign, "credentials": {}}
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise ValueError(f"secrets file must not be group/world accessible: {oct(mode)}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("campaign") != campaign:
+        raise ValueError("secrets file campaign does not match manifest")
+    credentials = payload.get("credentials")
+    if not isinstance(credentials, dict):
+        raise ValueError("secrets file credentials must be an object")
+    return payload
+
+
+def _write_secret_document(path: Path, payload: dict[str, Any]) -> None:
+    if path.suffix != ".private":
+        raise ValueError("secrets file must end in .private so git ignores it")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.chmod(temporary, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--owner-email", required=True)
+    parser.add_argument("--creator", action="append", default=[])
+    parser.add_argument("--secrets-file", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.apply and os.environ.get("TR_STORAGE_BACKEND") != "spanner-bigtable":
+        print("ERROR: --apply requires TR_STORAGE_BACKEND=spanner-bigtable", file=sys.stderr)
+        return 2
+    if args.apply and args.secrets_file is None:
+        print("ERROR: --apply requires --secrets-file", file=sys.stderr)
+        return 2
+    try:
+        manifest = load_manifest(args.manifest)
+        selected = set(args.creator)
+        unknown = selected - {creator.slug for creator in manifest.creators}
+        if unknown:
+            raise ValueError(f"unknown creator slug(s): {', '.join(sorted(unknown))}")
+        creators = [
+            creator for creator in manifest.creators if not selected or creator.slug in selected
+        ]
+        active_store = create_store(Settings()) if store is None else store
+        owner_user = active_store.find_user_by_email(args.owner_email)
+        if owner_user is None:
+            raise ValueError("owner email does not match an existing user")
+        secrets = (
+            _load_secret_document(args.secrets_file, manifest.campaign)
+            if args.apply
+            else None
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    total = sum(creator.creator_credit_microdollars for creator in creators)
+    print(
+        f"campaign={manifest.campaign} creators={len(creators)} "
+        f"maximum_funded={format_money_precise(total)}"
+    )
+    try:
+        for creator in creators:
+            prepared_raw_key = None
+            if args.apply:
+                assert args.secrets_file is not None and secrets is not None
+                credentials = secrets["credentials"]
+                credential = credentials.get(creator.slug)
+                if credential is not None and not isinstance(credential, dict):
+                    raise ValueError(f"invalid credential record for {creator.slug}")
+                prepared_raw_key = (
+                    str(credential.get("api_key"))
+                    if isinstance(credential, dict) and credential.get("api_key")
+                    else new_api_key()
+                )
+                if not isinstance(credential, dict):
+                    credentials[creator.slug] = {
+                        "workspace_id": None,
+                        "key_id": None,
+                        "api_key": prepared_raw_key,
+                        "expires_at": None,
+                        "state": "prepared",
+                    }
+                    # Persist the recoverable raw key before creating its
+                    # one-way hash in Spanner. A crash can then safely retry
+                    # with the exact same key instead of orphaning access.
+                    _write_secret_document(args.secrets_file, secrets)
+            result = provision_creator(
+                active_store,
+                owner_user=owner_user,
+                manifest=manifest,
+                creator=creator,
+                apply=args.apply,
+                raw_key=prepared_raw_key,
+            )
+            action = "existing" if result["workspace_id"] else "would-create"
+            if result["created_workspace"]:
+                action = "created"
+            funding = "would-credit"
+            if args.apply:
+                funding = "applied" if result["credited"] else "existing"
+            key_action = "would-create"
+            if args.apply:
+                key_action = "created" if result["created_key"] else "existing"
+            print(
+                f"{creator.slug}: workspace={action} "
+                f"funding={funding} key={key_action} "
+                f"credit={format_money_precise(creator.creator_credit_microdollars)}"
+            )
+            print(f"  {result['tracking_url']}")
+            result.pop("api_key", None)
+            if args.apply:
+                assert secrets is not None
+                credentials = secrets["credentials"]
+                credential = credentials[creator.slug]
+                assert isinstance(credential, dict)
+                stored_raw_key = str(credential["api_key"])
+                persisted_key = active_store.get_key_by_raw(stored_raw_key)
+                if persisted_key is None or persisted_key.hash != result["key_id"]:
+                    raise ValueError(
+                        f"private key material does not match pilot key for {creator.slug}"
+                    )
+                credentials[creator.slug] = {
+                    "workspace_id": result["workspace_id"],
+                    "key_id": result["key_id"],
+                    "api_key": stored_raw_key,
+                    "expires_at": result.get("expires_at") or credential.get("expires_at"),
+                    "state": "active",
+                }
+                _write_secret_document(args.secrets_file, secrets)
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.apply:
+        assert args.secrets_file is not None and secrets is not None
+        try:
+            _write_secret_document(args.secrets_file, secrets)
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        print(f"Raw keys written only to {args.secrets_file}")
+    else:
+        print("DRY-RUN: no workspace, credit, or key changes were made")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -153,6 +153,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/docs/migrate-from-openrouter",
     "/docs/tagging",
     "/docs/web-search",
+    "/for-developers",
     "/llms.txt",
     "/docs/llms.txt",
     "/docs/llms-full.txt",
@@ -1190,6 +1191,24 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "Point any OpenAI-compatible SDK at TrustedRouter with one base_url "
             "change. Guides, Python / TypeScript / Swift SDKs, and the "
             "OpenAI-compatible API reference."
+        ),
+    ),
+    "for-developers": PublicPage(
+        template="public/for_developers.html",
+        title="Try TrustedRouter in 60 Seconds",
+        description=(
+            "Run one OpenAI-compatible request, inspect the live model catalog, "
+            "and verify the attested gateway before moving real traffic."
+        ),
+        faq_items=(
+            (
+                "Does TrustedRouter store prompts or outputs?",
+                "TrustedRouter does not durably store prompt or output content by default. Operational metadata includes model, provider, token counts, latency, cost, status, and region. Downstream provider handling remains provider specific and is published on model and provider pages.",
+            ),
+            (
+                "What does gateway attestation prove?",
+                "A fresh nonce challenge lets you verify that the live prompt gateway is running the published workload image. It does not prove the code is bug free or make every downstream provider confidential.",
+            ),
         ),
     ),
     "apps": PublicPage(

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -568,6 +568,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def docs_hub() -> str:
         return public_page_html(settings, "docs")
 
+    @public_html_route("/for-developers")
+    async def for_developers() -> str:
+        return public_page_html(settings, "for-developers")
+
     @public_html_route("/apps")
     async def apps() -> str:
         return public_apps_html(settings, apps=_apps_snapshot(settings))

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -33,6 +33,7 @@
     <div class="footer-col">
       <h3>Developers</h3>
       <a href="/docs">Documentation</a>
+      <a href="/for-developers">60-second quickstart</a>
       <a href="/docs/migrate-from-openrouter">Migration guide</a>
       <a href="/docs/agent-setup#codex-skill">Agent skill</a>
       <a href="/docs/mcp">MCP server</a>

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -36,6 +36,7 @@ const r = await client.chat.completions.create({
 <section style="margin-top:48px">
   <h2 class="section-center">Guides</h2>
   <div class="marketing-grid three">
+    <a class="marketing-card card-as-link" href="/for-developers"><h3>60-second quickstart</h3><p>Make one request, inspect the catalog, and verify the live prompt path.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/agent-setup"><h3>Agent setup</h3><p>Point Codex, Claude Code, Hermes, Cursor, or any OpenAI-compatible client at TrustedRouter.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/mcp"><h3>MCP server</h3><p>Let agents inspect live models, pricing, provider posture, credits, docs, and quick test messages.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/agent-setup#codex-skill"><h3>Agent skill</h3><p>Help Codex, Claude Code, Hermes, and other agents choose models using speed, cost, AI IQ, privacy, context length, and prompt-cache fit.</p><span class="card-link">Open →</span></a>

--- a/src/trusted_router/templates/public/for_developers.html
+++ b/src/trusted_router/templates/public/for_developers.html
@@ -1,0 +1,93 @@
+{% extends "public/_base.html" %}
+
+{% block body %}
+<section class="public-proof-strip" aria-label="What to verify">
+  <div><strong>One request</strong><span>OpenAI SDK compatible.</span></div>
+  <div><strong>Live catalog</strong><span>Models, routes, and prices.</span></div>
+  <div><strong>Fresh evidence</strong><span>Challenge the gateway with your nonce.</span></div>
+  <div><strong>Public status</strong><span>Check the service before a test.</span></div>
+</section>
+
+<section class="marketing-split" aria-label="TrustedRouter quickstart">
+  <div class="marketing-copy">
+    <span class="eyebrow">60-second quickstart</span>
+    <h2>Change the base URL. Keep the client.</h2>
+    <ol class="plain-list">
+      <li>Create an API key and export it as <code>TRUSTEDROUTER_API_KEY</code>.</li>
+      <li>Install the OpenAI client: <code>pip install openai</code>.</li>
+      <li>Run the request at right. A successful response should contain <code>PONG</code>.</li>
+    </ol>
+    <div class="hero-actions">
+      <button class="btn primary" type="button" data-action="open-signin">Create key</button>
+      <a class="btn" href="/docs/migrate-from-openrouter">Migration guide <span aria-hidden="true">→</span></a>
+    </div>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Quickstart</span><span>Python</span></div>
+    <pre><code>import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    base_url="{{ api_base_url }}",
+)
+
+response = client.chat.completions.create(
+    model="trustedrouter/zdr",
+    messages=[{
+        "role": "user",
+        "content": "Reply with PONG only.",
+    }],
+    max_tokens=128,
+)
+
+print(response.choices[0].message.content)</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid three" aria-label="Developer test paths">
+  <a class="marketing-card card-as-link" href="/v1/models">
+    <span class="card-label">Catalog</span>
+    <h3>Inspect the live API.</h3>
+    <p>Use the deployed model list as the source of truth for model IDs, context, capabilities, and pricing.</p>
+    <span class="card-link">Open model JSON →</span>
+  </a>
+  <a class="marketing-card card-as-link" href="https://trust.trustedrouter.com">
+    <span class="card-label">Attestation</span>
+    <h3>Verify before sending data.</h3>
+    <p>Generate fresh nonce-bound evidence and compare the running image with the published open-source release.</p>
+    <span class="card-link">Verify gateway →</span>
+  </a>
+  <a class="marketing-card card-as-link" href="https://status.trustedrouter.com">
+    <span class="card-label">Operations</span>
+    <h3>Check status and latency.</h3>
+    <p>See router-core health separately from provider response health and regional measurements.</p>
+    <span class="card-link">Open status →</span>
+  </a>
+</section>
+
+<section class="marketing-split" aria-label="Test ideas">
+  <div class="marketing-copy">
+    <span class="eyebrow">Test it honestly</span>
+    <h2>Four useful experiments.</h2>
+    <ul class="check-list">
+      <li>Change only <code>base_url</code> in an existing OpenAI integration.</li>
+      <li>Run the same three prompts across an open model, a frontier model, and <code>trustedrouter/cheap</code>.</li>
+      <li>Use an ordered <code>models</code> list and leave provider fallback enabled.</li>
+      <li>Challenge the live gateway with your own nonce before the request.</li>
+    </ul>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">State the boundary</span>
+    <h2>What the proof does not claim.</h2>
+    <p>TrustedRouter attestation verifies the hosted gateway workload. It does not prove that the source has no bugs, and it does not make every downstream provider end-to-end encrypted.</p>
+    <p>Prompt and output content is not durably stored by TrustedRouter by default. Provider retention, training, jurisdiction, and confidential-compute posture remain provider specific.</p>
+    <div class="sdk-links">
+      <a class="pill" href="/providers">Provider posture</a>
+      <a class="pill" href="/models">Model routes</a>
+      <a class="pill" href="/leaderboard">Measured performance</a>
+      <a class="pill" href="https://github.com/Lore-Hex/quill-router">Source</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_creator_pilot.py
+++ b/tests/test_creator_pilot.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts import provision_creator_pilot
+from tests.fakes.spanner import make_fake_store
+from trusted_router.acquisition import (
+    ATTRIBUTION_COOKIE_NAME,
+    decode_attribution_cookie,
+)
+from trusted_router.typed_balance import live_credit_summary
+
+
+def _owner(store: Any, email: str = "operator@example.com") -> Any:
+    return store.ensure_user(email)
+
+
+def test_creator_quickstart_is_public_and_campaign_attributed(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/for-developers"
+        "?utm_source=creator&utm_medium=sponsorship"
+        "&utm_campaign=creator_pilot_202607"
+        "&utm_content=theo_t3gg_cost_per_completed_job"
+        "&utm_term=theo-tr"
+    )
+
+    assert response.status_code == 200
+    assert "Try TrustedRouter in 60 Seconds" in response.text
+    assert 'base_url="https://api.trustedrouter.com/v1"' in response.text
+    assert "max_tokens=128" in response.text
+    assert "https://trust.trustedrouter.com" in response.text
+    assert "https://status.trustedrouter.com" in response.text
+    assert 'href="/v1/models"' in response.text
+    assert "does not make every downstream provider end-to-end encrypted" in response.text
+
+    encoded = client.cookies.get(ATTRIBUTION_COOKIE_NAME)
+    context = decode_attribution_cookie(encoded, client.app.state.settings)
+    assert context is not None
+    assert context.last_touch["utm_source"] == "creator"
+    assert context.last_touch["utm_medium"] == "sponsorship"
+    assert context.last_touch["utm_campaign"] == "creator_pilot_202607"
+    assert context.last_touch["utm_term"] == "theo-tr"
+    assert context.last_touch["landing_path"] == "/for-developers"
+
+
+def test_creator_quickstart_is_in_core_sitemap(client: TestClient) -> None:
+    response = client.get("/sitemap-core.xml")
+
+    assert response.status_code == 200
+    assert "<loc>https://trustedrouter.com/for-developers</loc>" in response.text
+
+
+def test_manifest_is_valid_unique_and_integer_only() -> None:
+    manifest = provision_creator_pilot.load_manifest(
+        provision_creator_pilot.DEFAULT_MANIFEST
+    )
+
+    assert manifest.campaign == "creator_pilot_202607"
+    assert manifest.creators[0].slug == "theo_t3gg"
+    assert len(manifest.creators) == 13
+    assert len({creator.slug for creator in manifest.creators}) == 13
+    assert len({creator.viewer_code for creator in manifest.creators}) == 13
+    assert all(
+        isinstance(creator.creator_credit_microdollars, int)
+        for creator in manifest.creators
+    )
+
+
+def test_tracking_url_is_stable_and_contains_no_secret() -> None:
+    manifest = provision_creator_pilot.load_manifest(
+        provision_creator_pilot.DEFAULT_MANIFEST
+    )
+    theo = manifest.creators[0]
+
+    assert provision_creator_pilot.tracking_url(manifest, theo) == (
+        "https://trustedrouter.com/for-developers"
+        "?utm_source=creator&utm_medium=sponsorship"
+        "&utm_campaign=creator_pilot_202607"
+        "&utm_content=theo_t3gg_cost_per_completed_job"
+        "&utm_term=theo-tr"
+    )
+    assert "sk-tr-v1-" not in provision_creator_pilot.tracking_url(manifest, theo)
+
+
+def test_dry_run_does_not_create_workspace_credit_key_or_secret(
+    tmp_path: Path,
+) -> None:
+    store, _database, _ = make_fake_store()
+    owner = _owner(store)
+    before = list(store.list_workspaces_for_user(owner.id))
+    secret_path = tmp_path / "pilot.private"
+
+    result = provision_creator_pilot.main(
+        [
+            "--owner-email",
+            "operator@example.com",
+            "--creator",
+            "theo_t3gg",
+            "--secrets-file",
+            str(secret_path),
+        ],
+        store=store,
+    )
+
+    assert result == 0
+    assert store.list_workspaces_for_user(owner.id) == before
+    assert not secret_path.exists()
+
+
+def test_apply_is_idempotent_capped_non_management_and_keeps_raw_key_private(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+    store, _database, _ = make_fake_store()
+    owner = _owner(store)
+    secret_path = tmp_path / "pilot.private"
+    argv = [
+        "--owner-email",
+        "operator@example.com",
+        "--creator",
+        "theo_t3gg",
+        "--secrets-file",
+        str(secret_path),
+        "--apply",
+    ]
+
+    assert provision_creator_pilot.main(argv, store=store) == 0
+    first_output = capsys.readouterr().out
+    assert provision_creator_pilot.main(argv, store=store) == 0
+    second_output = capsys.readouterr().out
+
+    creator_workspaces = [
+        workspace
+        for workspace in store.list_workspaces_for_user(owner.id)
+        if workspace.name == "Creator Pilot: Theo, t3.gg"
+    ]
+    assert len(creator_workspaces) == 1
+    workspace = creator_workspaces[0]
+    keys = store.list_keys(workspace.id)
+    assert len(keys) == 1
+    key = keys[0]
+    assert key.management is False
+    assert key.limit_microdollars == 250_000_000
+    assert key.limit_daily_microdollars == 50_000_000
+    assert key.limit_monthly_microdollars == 250_000_000
+    assert key.budget_alert_only is False
+    assert key.expires_at is not None
+    assert key.tags == {
+        "campaign": "creator_pilot_202607",
+        "creator": "theo_t3gg",
+        "purpose": "sponsored_test",
+    }
+
+    balance = live_credit_summary(workspace.id, store=store)
+    assert balance is not None
+    assert balance["total_credits"] == 250_000_000
+
+    payload = json.loads(secret_path.read_text(encoding="utf-8"))
+    credential = payload["credentials"]["theo_t3gg"]
+    raw_key = credential["api_key"]
+    assert raw_key.startswith("sk-tr-v1-")
+    assert credential["key_id"] == key.hash
+    assert credential["state"] == "active"
+    assert store.get_key_by_raw(raw_key) == key
+    assert raw_key not in first_output
+    assert raw_key not in second_output
+    assert "funding=applied key=created" in first_output
+    assert "funding=existing key=existing" in second_output
+    assert stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+
+
+def test_apply_requires_private_suffix_before_mutating(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+    store, _database, _ = make_fake_store()
+    owner = _owner(store)
+
+    result = provision_creator_pilot.main(
+        [
+            "--owner-email",
+            "operator@example.com",
+            "--creator",
+            "theo_t3gg",
+            "--secrets-file",
+            str(tmp_path / "pilot.json"),
+            "--apply",
+        ],
+        store=store,
+    )
+
+    assert result == 1
+    assert all(
+        workspace.name != "Creator Pilot: Theo, t3.gg"
+        for workspace in store.list_workspaces_for_user(owner.id)
+    )
+
+
+def test_manifest_rejects_float_money(tmp_path: Path) -> None:
+    manifest = {
+        "campaign": "test",
+        "landing_path": "/for-developers",
+        "key_ttl_days": 30,
+        "creators": [
+            {
+                "slug": "creator",
+                "display_name": "Creator",
+                "concept": "test",
+                "viewer_code": "CREATOR-TR",
+                "creator_credit_microdollars": 1.5,
+                "daily_limit_microdollars": 1,
+            }
+        ],
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="positive integer"):
+        provision_creator_pilot.load_manifest(path)


### PR DESCRIPTION
## Summary
- add a public 60-second developer quickstart with first-party campaign attribution
- add creator brief, claims controls, demo recipes, sponsorship agreement, and Theo-first pilot manifest
- add idempotent capped creator workspace and inference-key provisioning

## Validation
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1829 passed, 33 skipped)
- final focused pytest pass after quickstart tuning (44 passed)
- npx tsc --noEmit
- npx eslint frontend/src
- npx stylelint "src/trusted_router/static/*.css"
- desktop and mobile visual inspection
- production creator-key auth, permission-boundary, and trustedrouter/zdr PONG smoke