### PR TITLE
Document fail-closed confidential and E2EE routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Migrate this project to TrustedRouter, a privacy-first LLM router
 Anthropic SDK), read the key from the TRUSTEDROUTER_API_KEY env var, and keep
 all my existing calls working.
 
-For maximum privacy, add the routing preference
-{"provider": {"data_collection": "deny"}} so only zero-retention providers
-are used.
+For a hard provider-side confidential-compute and end-to-end-encryption
+requirement, add {"provider": {"min_privacy": "confidential"}}. TrustedRouter
+fails closed when the selected model or provider cannot satisfy both controls.
 
 Then tell me to sign up at trustedrouter.com, add a card, and paste my sk-tr
 key into TRUSTEDROUTER_API_KEY.
@@ -37,11 +37,13 @@ key into TRUSTEDROUTER_API_KEY.
 
 Then:
 
-1. **Pick your privacy level or region** — start sensitive workloads with
-   `trustedrouter/zdr`, use `trustedrouter/e2e` for confidential + E2EE
-   routes, use `trustedrouter/eu` with
-   `https://api-europe-west4.quillrouter.com/v1` for EU-focused routing, or
-   set `{"provider": {"data_collection": "deny"}}` yourself.
+1. **Pick your privacy level or region** — use
+   `{"provider": {"min_privacy": "zdr"}}` for a hard zero-retention floor, or
+   `{"provider": {"min_privacy": "confidential"}}` for the stronger hard
+   confidential-compute + E2EE floor. The convenient `trustedrouter/zdr` and
+   `trustedrouter/e2e` (`trustedrouter/confidential`) aliases select those
+   pools. Use `trustedrouter/eu` with
+   `https://api-europe-west4.quillrouter.com/v1` for EU-focused routing.
 2. **Pick a model** — any of hundreds, or `trustedrouter/auto` for automatic
    fallback when provider breadth matters more than the strictest privacy
    filter.
@@ -272,8 +274,10 @@ the router-core error budget when fallback remains available.
   first, and `trustedrouter/e2e` forces confidential + E2EE routes with
   Tinfoil first. Chat requests also honor OpenRouter-style `models` and
   `provider` routing filters (`order`, `only`, `ignore`, `allow_fallbacks`,
-  `data_collection`, and `sort`) so clients can request explicit fallback
-  chains or provider preferences.
+  `min_privacy`, `data_collection`, and `sort`) so clients can request explicit
+  fallback chains or provider preferences. `min_privacy="confidential"` is a
+  hard provider-side confidential-compute + E2EE requirement and fails closed
+  rather than falling back to a weaker route.
 - Billing: prepaid credits and BYOK first; no subscription is required.
 - Trust: hosted open source, with the running API's source commit, image
   reference, image digest, and attestation policy published at

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -345,7 +345,7 @@ def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
         if key not in PRIVACY_TIER_ALIASES:
             raise api_error(
                 400,
-                "provider.min_privacy must be one of: any, no_store, zdr, confidential",
+                "provider.min_privacy must be one of: any, no_store, zdr, confidential (alias: e2ee)",
                 ErrorType.BAD_REQUEST,
             )
         min_privacy_rank = PRIVACY_TIER_ALIASES[key]

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -131,7 +131,7 @@
           <ul class="check-list">
             <li>Use <code>trustedrouter/auto</code> for healthy-provider rollover</li>
             <li>Use <code>trustedrouter/zdr</code> for zero-retention routing</li>
-            <li>Use <code>trustedrouter/e2e</code> for confidential provider routes</li>
+            <li>Use <code>trustedrouter/e2e</code> for confidential + E2EE provider routes</li>
             <li>Use <a href="/eu"><code>trustedrouter/eu</code></a> for Europe-focused routing</li>
             <li>Bring your own provider keys where needed</li>
           </ul>
@@ -150,7 +150,7 @@ response = client.chat.completions.create(
     model="trustedrouter/auto",
     messages=[{"role": "user", "content": "Hello"}],
     extra_body={
-        "provider": {"data_collection": "deny"}
+        "provider": {"min_privacy": "confidential"}
     },
 )</code></pre>
         </div>

--- a/src/trusted_router/templates/public/agent_setup.html
+++ b/src/trusted_router/templates/public/agent_setup.html
@@ -85,7 +85,7 @@ Run a PONG smoke test before editing app code.</code></pre>
     }
   }]
 }</code></pre>
-      <p class="muted">The advisor sees the same prompt context as the worker. Use <span class="mono">provider.data_collection = "deny"</span>, <span class="mono">trustedrouter/zdr</span>, <span class="mono">trustedrouter/e2e</span>, or EU routing when those privacy requirements matter. If the advisor is itself a Synth model such as <span class="mono">trustedrouter/zeus-1.0</span>, TrustedRouter decrements orchestration depth automatically.</p>
+      <p class="muted">The advisor sees the same prompt context as the worker. Use <span class="mono">provider.min_privacy = "zdr"</span> for a hard zero-retention floor or <span class="mono">provider.min_privacy = "confidential"</span> to require both provider-side confidential compute and E2EE. The <span class="mono">trustedrouter/zdr</span> and <span class="mono">trustedrouter/e2e</span> aliases select those pools. If the advisor is itself a Synth model such as <span class="mono">trustedrouter/zeus-1.0</span>, TrustedRouter decrements orchestration depth automatically.</p>
     </div>
   </div>
 

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -15,7 +15,8 @@
       <li>✓ Use <code>trustedrouter/openpatcher-g2</code> for a Kimi K3 worker with parallel Gemma 4 and Prometheus 2.0 advisors</li>
       <li>✓ Use <code>trustedrouter/plato-pro-2.0</code> for GLM 5.2 advised by Prometheus 2.0</li>
       <li>✓ Use <code>trustedrouter/iris-code-1.0</code>, <code>trustedrouter/prometheus-code-1.0</code>, or <code>trustedrouter/zeus-code-1.0</code> for code-tuned Synth presets</li>
-      <li>✓ Add <code>provider.data_collection = "deny"</code> for zero-retention routing</li>
+      <li>✓ Add <code>provider.min_privacy = "zdr"</code> for a hard zero-retention floor</li>
+      <li>✓ Add <code>provider.min_privacy = "confidential"</code> to require confidential compute + provider E2EE</li>
     </ul>
     <a class="btn" href="/docs/migrate-from-openrouter">Migration guide →</a>
   </div>
@@ -31,6 +32,29 @@ const r = await client.chat.completions.create({
   messages: [{ role: "user", content: "Hello" }]
 })</code></pre>
   </div>
+</section>
+
+<section style="margin-top:48px" id="privacy-filters">
+  <h2 class="section-center">Fail-closed privacy filters</h2>
+  <div class="marketing-grid two">
+    <div class="marketing-card">
+      <h3>Require zero retention</h3>
+      <pre><code>{
+  "model": "your/model",
+  "provider": {"min_privacy": "zdr"}
+}</code></pre>
+      <p>This is a hard minimum. If no endpoint for the selected model and provider filters has a tracked ZDR guarantee, the request fails before inference.</p>
+    </div>
+    <div class="marketing-card">
+      <h3>Require confidential + E2EE</h3>
+      <pre><code>{
+  "model": "your/model",
+  "provider": {"min_privacy": "confidential"}
+}</code></pre>
+      <p>This stronger hard minimum requires both provider-side confidential compute and end-to-end encryption. <code>e2ee</code> is an accepted value alias. Unsupported model/provider combinations fail closed.</p>
+    </div>
+  </div>
+  <p class="muted" style="margin-top:14px"><code>trustedrouter/e2e</code> and <code>trustedrouter/confidential</code> select the same confidential + E2EE pool. <code>provider.data_collection = "deny"</code> remains an OpenRouter-compatible routing preference; use <code>min_privacy</code> when the privacy floor must never be relaxed.</p>
 </section>
 
 <section style="margin-top:48px">

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -6,6 +6,7 @@
   <div><strong>trustedrouter/eu</strong><span>EU-focused routing target.</span></div>
   <div><strong>trustedrouter/zdr</strong><span>Zero-retention routing target.</span></div>
   <div><strong>trustedrouter/e2e</strong><span>Confidential + E2EE routes. Alias: trustedrouter/confidential.</span></div>
+  <div><strong>Hard privacy floor</strong><span>Use provider.min_privacy = "confidential" with any selected model.</span></div>
   <div><strong>Synth presets</strong><span>Iris, Prometheus, Zeus, and code variants.</span></div>
   <div><strong>Streaming</strong><span>No buffering in the prompt path.</span></div>
   <div><strong>Hundreds of models</strong><span>More provider routes are added as keys and pricing are verified.</span></div>

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -64,7 +64,7 @@
   <div class="marketing-card">
     <span class="card-label">Routing</span>
     <h3>Choose privacy posture explicitly.</h3>
-    <p>Use <span class="mono">trustedrouter/zdr</span> for zero-retention providers first, <span class="mono">trustedrouter/eu</span> for EU-focused provider selection, <span class="mono">trustedrouter/e2e</span> for confidential + E2EE routes, or provider routing filters for custom policy. Use <span class="mono">trustedrouter/auto</span> when breadth and health are the priority.</p>
+    <p>Use <span class="mono">trustedrouter/zdr</span> for the zero-retention pool, <span class="mono">trustedrouter/eu</span> for EU-focused provider selection, or <span class="mono">trustedrouter/e2e</span> for the confidential + E2EE pool. When selecting a model or provider directly, set <span class="mono">provider.min_privacy = "zdr"</span> or the stronger <span class="mono">provider.min_privacy = "confidential"</span>; these hard filters fail closed if no eligible endpoint remains. Use <span class="mono">trustedrouter/auto</span> when breadth and health are the priority.</p>
   </div>
 </section>
 {% endblock %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -424,10 +424,24 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "ATTESTED GATEWAY" in response.text  # attestation record
     assert "Get API key" in response.text  # primary CTA
     assert "Provider failover" in response.text  # hero proof row
-    assert "data_collection" in response.text  # privacy-level routing pref
+    assert 'min_privacy": "confidential"' in response.text
     assert 'href="/eu"' in response.text
     assert '/static/charter.css?v=' in response.text
     assert 'class="brand-mark"' in response.text
+
+
+def test_public_docs_explain_hard_confidential_e2ee_filter(client: TestClient) -> None:
+    docs = client.get("/docs")
+    providers = client.get("/providers")
+    agent_setup = client.get("/docs/agent-setup")
+
+    assert docs.status_code == providers.status_code == agent_setup.status_code == 200
+    assert '"min_privacy": "confidential"' in docs.text
+    assert "requires both provider-side confidential compute and end-to-end encryption" in docs.text
+    assert "Unsupported model/provider combinations fail closed" in docs.text
+    assert 'provider.min_privacy = "confidential"' in providers.text
+    assert "these hard filters fail closed" in providers.text
+    assert 'provider.min_privacy = "confidential"' in agent_setup.text
 
 
 def test_eu_host_renders_eu_landing_page(client: TestClient) -> None:

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -320,8 +320,42 @@ def test_min_privacy_parses_friendly_aliases() -> None:
     assert p.min_privacy_rank == PRIVACY_TIER_ZERO_RETENTION
     p2 = provider_route_preferences({"model": "x", "provider": {"min_privacy": "maximum"}})
     assert p2.min_privacy_rank == PRIVACY_TIER_CONFIDENTIAL
+    p3 = provider_route_preferences({"model": "x", "provider": {"min_privacy": "e2ee"}})
+    assert p3.min_privacy_rank == PRIVACY_TIER_CONFIDENTIAL
     # Default: no filter.
     assert provider_route_preferences({"model": "x"}).min_privacy_rank == 0
+
+
+def test_confidential_privacy_tier_requires_compute_and_e2ee() -> None:
+    from trusted_router.catalog import (
+        PRIVACY_TIER_CONFIDENTIAL,
+        PRIVACY_TIER_STANDARD,
+        Provider,
+        provider_privacy_tier,
+    )
+
+    confidential_compute_only = Provider(
+        slug="compute-only",
+        name="Compute only",
+        provider_confidential_compute=True,
+        provider_e2ee=False,
+    )
+    e2ee_only = Provider(
+        slug="e2ee-only",
+        name="E2EE only",
+        provider_confidential_compute=False,
+        provider_e2ee=True,
+    )
+    both = Provider(
+        slug="both",
+        name="Both",
+        provider_confidential_compute=True,
+        provider_e2ee=True,
+    )
+
+    assert provider_privacy_tier(confidential_compute_only) == PRIVACY_TIER_STANDARD
+    assert provider_privacy_tier(e2ee_only) == PRIVACY_TIER_STANDARD
+    assert provider_privacy_tier(both) == PRIVACY_TIER_CONFIDENTIAL
 
 
 def test_min_privacy_rejects_unknown_value() -> None:


### PR DESCRIPTION
## Summary
- document provider.min_privacy=confidential as the hard confidential-compute + provider-E2EE floor
- distinguish the stronger confidential tier from ZDR and from the soft data_collection preference
- add public docs, homepage examples, and regression coverage proving both controls are required

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1831 passed, 33 skipped)