### PR TITLE
Fix Ahrefs crawl health issues

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -77,6 +77,7 @@ MODEL_PERFORMANCE_INDEX_MIN_SAMPLES = 20
 PROVIDER_PERFORMANCE_INDEX_MIN_SAMPLES = 20
 MODEL_COMPARE_URL_LIMIT = 2_600
 MODEL_COMPARE_MODEL_LIMIT = 73
+MODEL_COMPARE_PAGE_SIZE = 100
 SEO_CORE_PATHS: tuple[str, ...] = (
     "/azure-openai-alternative",
     "/deepseek-api-privacy",
@@ -122,7 +123,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/legal/subprocessors",
     "/chat",
     "/synth",
-    "/fusion",
+    "/compare/models",
     "/compare/openrouter",
     "/compare/vercel-ai-gateway",
     "/compare/litellm",
@@ -144,11 +145,12 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/pricing",
     "/docs",
     "/apps",
+    "/resources",
+    "/careers",
     "/blog",
     "/docs/agent-setup",
     "/docs/evals",
     "/docs/synth",
-    "/docs/fusion",
     "/docs/mcp",
     "/docs/migrate-from-openrouter",
     "/docs/tagging",
@@ -909,15 +911,6 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "fallbacks to return one OpenAI-compatible answer."
         ),
     ),
-    "docs/fusion": PublicPage(
-        template="public/fusion.html",
-        og_card="synth.png",
-        title="TrustedRouter Synth",
-        description=(
-            "Run a panel of models inside the attested gateway, then use judge and final "
-            "fallbacks to return one OpenAI-compatible answer."
-        ),
-    ),
     "docs/x402": PublicPage(
         template="public/x402.html",
         title="x402 Stablecoin Funding For Agents",
@@ -1219,6 +1212,22 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "Apps routing through TrustedRouter can self-identify and appear "
             "here. Opt-in by construction and privacy-safe: names and counts "
             "only, never prompts or keys."
+        ),
+    ),
+    "resources": PublicPage(
+        template="public/resources.html",
+        title="Resources",
+        description=(
+            "Guides, comparisons, privacy references, model APIs, benchmarks, and "
+            "integration pages for building with TrustedRouter."
+        ),
+    ),
+    "careers": PublicPage(
+        template="public/careers.html",
+        title="Work on TrustedRouter",
+        description=(
+            "Work on attested AI routing, open model orchestration, evals, and "
+            "infrastructure developers can verify."
         ),
     ),
 }
@@ -2200,8 +2209,16 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                 f"Compare {left.name} and {right.name} by providers, context, price, "
                 "and TrustedRouter route support."
             ),
-            left=_model_detail_view(left, test_mode=test_mode),
-            right=_model_detail_view(right, test_mode=test_mode),
+            left=_model_detail_view(
+                left,
+                test_mode=test_mode,
+                include_section_links=False,
+            ),
+            right=_model_detail_view(
+                right,
+                test_mode=test_mode,
+                include_section_links=False,
+            ),
             comparison=_comparison_view(left, right),
             json_ld_blob=_json_ld_graph(
                 _breadcrumb_node(
@@ -2212,6 +2229,76 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                         (f"{left.name} vs {right.name}", site_path),
                     ),
                 )
+            ),
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
+def public_model_compare_index_html(settings: Settings, *, page: int = 1) -> str | None:
+    pairs = _model_comparison_pairs()
+    page_count = max(1, (len(pairs) + MODEL_COMPARE_PAGE_SIZE - 1) // MODEL_COMPARE_PAGE_SIZE)
+    if page < 1 or page > page_count:
+        return None
+    start = (page - 1) * MODEL_COMPARE_PAGE_SIZE
+    selected = pairs[start : start + MODEL_COMPARE_PAGE_SIZE]
+    rows = [
+        {
+            "href": f"/compare/models/{left.id}/vs/{right.id}",
+            "label": f"{left.name} vs {right.name}",
+            "left_id": left.id,
+            "right_id": right.id,
+            "left_routes": len(endpoints_for_model(left.id)),
+            "right_routes": len(endpoints_for_model(right.id)),
+        }
+        for left, right in selected
+    ]
+    site_path = "/compare/models" if page == 1 else f"/compare/models/page/{page}"
+    return (
+        _env()
+        .get_template("public/model_compare_index.html")
+        .render(
+            api_base_url=settings.api_base_url,
+            site_url=f"https://{settings.trusted_domain}{site_path}",
+            title=(
+                "Compare AI Models | TrustedRouter"
+                if page == 1
+                else f"Compare AI Models, Page {page} | TrustedRouter"
+            ),
+            heading="Compare AI models",
+            description=(
+                "Compare context, provider routes, pricing, privacy posture, and measured "
+                "performance across the TrustedRouter model catalog."
+            ),
+            comparisons=rows,
+            page=page,
+            page_count=page_count,
+            pages=[
+                {
+                    "number": number,
+                    "href": (
+                        "/compare/models" if number == 1 else f"/compare/models/page/{number}"
+                    ),
+                }
+                for number in range(1, page_count + 1)
+            ],
+            json_ld_blob=_json_ld_graph(
+                _breadcrumb_node(
+                    settings,
+                    (("Home", "/"), ("Models", "/models"), ("Compare models", site_path)),
+                ),
+                _item_list_node(
+                    name=f"TrustedRouter model comparisons, page {page}",
+                    items=[
+                        {
+                            "name": str(row["label"]),
+                            "url": f"https://{settings.trusted_domain}{row['href']}",
+                        }
+                        for row in rows
+                    ],
+                ),
             ),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -2365,8 +2452,12 @@ def sitemap_models_xml(settings: Settings) -> str:
 
 def sitemap_comparisons_xml(settings: Settings) -> str:
     domain = settings.trusted_domain
-    paths: list[tuple[str, str, str]] = []
-    for left, right in _model_comparison_pairs():
+    pairs = _model_comparison_pairs()
+    page_count = max(1, (len(pairs) + MODEL_COMPARE_PAGE_SIZE - 1) // MODEL_COMPARE_PAGE_SIZE)
+    paths: list[tuple[str, str, str]] = [
+        (f"/compare/models/page/{page}", "weekly", "0.4") for page in range(2, page_count + 1)
+    ]
+    for left, right in pairs:
         paths.append((f"/compare/models/{left.id}/vs/{right.id}", "weekly", "0.5"))
     return _sitemap_urlset(domain, paths)
 
@@ -2756,7 +2847,19 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         "eu_focused_provider_available": model_eu_focused_provider_available(model),
         "detail_href": f"/models/{model.id}",
         "benchmarks_href": (
-            f"/models/{model.id}/benchmarks" if model.id not in META_MODEL_IDS else None
+            f"/models/{model.id}/benchmarks"
+            if model.id not in META_MODEL_IDS and scores_for_model(model.id)
+            else None
+        ),
+        "providers_href": (
+            f"/models/{model.id}/providers"
+            if model.id not in META_MODEL_IDS and len(endpoints) >= 2
+            else None
+        ),
+        "pricing_href": (
+            f"/models/{model.id}/pricing"
+            if model.id not in META_MODEL_IDS and len(endpoints) >= 2
+            else None
         ),
     }
 
@@ -2853,6 +2956,7 @@ def _model_detail_view(
     *,
     active_section: str | None = None,
     test_mode: bool = False,
+    include_section_links: bool = True,
 ) -> dict[str, object]:
     provider = PROVIDERS[model.provider]
     is_meta = model.id in META_MODEL_IDS
@@ -2911,10 +3015,20 @@ def _model_detail_view(
         "endpoints": endpoint_views,
         "endpoint_count": len(endpoint_views),
         "providers": _endpoint_provider_views(endpoints, fallback_provider=model.provider),
+        "benchmarks_href": (
+            f"/models/{model.id}/benchmarks" if not is_meta and scores_for_model(model.id) else None
+        ),
+        "providers_href": (
+            f"/models/{model.id}/providers" if not is_meta and len(endpoints) >= 2 else None
+        ),
+        "pricing_href": (
+            f"/models/{model.id}/pricing" if not is_meta and len(endpoints) >= 2 else None
+        ),
         "section_links": _model_section_links(
             model.id,
             active_section=active_section,
-            include_sections=not is_meta,
+            include_sections=not is_meta and include_section_links,
+            test_mode=test_mode,
         ),
         "ai_iq": ai_iq,
         "is_meta": is_meta,
@@ -2945,6 +3059,7 @@ def _model_section_links(
     *,
     active_section: str | None,
     include_sections: bool = True,
+    test_mode: bool = False,
 ) -> list[dict[str, object]]:
     links: list[dict[str, object]] = [
         {
@@ -2955,7 +3070,13 @@ def _model_section_links(
     ]
     if not include_sections:
         return links
+    model = MODELS.get(model_id)
+    if model is None:
+        return links
+    measured = measured_for_model(model_id, test_mode=test_mode)
     for section in MODEL_SEO_SECTIONS:
+        if section != active_section and not _model_section_indexable(model, section, measured):
+            continue
         links.append(
             {
                 "label": MODEL_SEO_SECTION_LABELS[section],
@@ -3211,11 +3332,8 @@ def _privacy_summary(model: Model) -> str:
 def _provider_model_rows(provider_slug: str, *, test_mode: bool = False) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for model in _public_models_for_seo():
-        endpoints = [
-            endpoint
-            for endpoint in endpoints_for_model(model.id)
-            if endpoint.provider == provider_slug
-        ]
+        all_endpoints = endpoints_for_model(model.id)
+        endpoints = [endpoint for endpoint in all_endpoints if endpoint.provider == provider_slug]
         if not endpoints:
             continue
         rows.append(
@@ -3223,7 +3341,15 @@ def _provider_model_rows(provider_slug: str, *, test_mode: bool = False) -> list
                 "id": model.id,
                 "name": model.name,
                 "detail_href": f"/models/{model.id}",
-                "benchmarks_href": f"/models/{model.id}/benchmarks",
+                "benchmarks_href": (
+                    f"/models/{model.id}/benchmarks" if scores_for_model(model.id) else None
+                ),
+                "providers_href": (
+                    f"/models/{model.id}/providers" if len(all_endpoints) >= 2 else None
+                ),
+                "pricing_href": (
+                    f"/models/{model.id}/pricing" if len(all_endpoints) >= 2 else None
+                ),
                 "context_length": f"{model.context_length:,}",
                 "endpoint_count": len(endpoints),
                 "prompt_price": _endpoint_price_range(

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -1,20 +1,26 @@
 """HTTP middleware shared across the FastAPI app.
 
-Four middlewares register in order from outermost to innermost:
+HTTP middleware registers in order from outermost to innermost:
   1. request_id  — mints/accepts a per-request id, echoes in response
                    header, makes it available as request.state.request_id.
-  2. public_pageview — captures signed first-party attribution and emits
+  2. canonical_public_host — keeps marketing URLs off www/status aliases.
+  3. public_pageview — captures signed first-party attribution and emits
                        metadata-only public pageview events.
-  3. rate_limit  — enforces per-(key|ip|internal-token) windowed limits
+  4. rate_limit  — enforces per-(key|ip|internal-token) windowed limits
                    via STORE.hit_rate_limit; logs structured 429s with
                    the request_id from (1).
-  4. security_headers — sets HSTS so browsers remember to skip http://
+  5. security_headers — sets HSTS so browsers remember to skip http://
                         on subsequent visits.
+
+Starlette's GZipMiddleware wraps compressible responses larger than 1 KiB.
+It explicitly excludes ``text/event-stream``, so inference streaming remains
+unbuffered while catalog, documentation, and public SEO pages compress.
 
 Splitting these out of main.py keeps the app factory readable. The
 middleware here has no FastAPI dependencies beyond Request/Response;
 it could be reused by other ASGI services in the same project.
 """
+
 from __future__ import annotations
 
 import logging
@@ -25,7 +31,8 @@ from hashlib import sha256
 from urllib.parse import parse_qs, urlsplit
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
+from starlette.middleware.gzip import GZipMiddleware
 
 from trusted_router.acquisition import (
     pageview_attribution_fields,
@@ -47,6 +54,21 @@ OAUTH_KEY_EXCHANGE_CORS_HEADERS = {
     "Access-Control-Allow-Headers": "content-type",
     "Access-Control-Max-Age": "600",
 }
+STATUS_HOST_EXACT_PATHS = frozenset(
+    {
+        "/",
+        "/favicon.ico",
+        "/health",
+        "/healthz",
+        "/og.png",
+        "/robots.txt",
+        "/status",
+        "/status.json",
+        "/v1/health",
+        "/v1/healthz",
+    }
+)
+STATUS_HOST_PATH_PREFIXES = ("/static/", "/status/")
 
 
 def register_http_middleware(app: FastAPI, settings: Settings) -> None:
@@ -57,6 +79,8 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
     request_id to mint the id before pageview/rate-limit logs use it,
     so request_id is registered first.
     """
+
+    app.add_middleware(GZipMiddleware, minimum_size=1_000, compresslevel=6)
 
     @app.middleware("http")
     async def request_id_middleware(
@@ -74,11 +98,7 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         chars); else mints one. This means traces survive the LB hop
         without the LB being able to inject log-injection payloads."""
         upstream = request.headers.get("x-request-id", "").strip()
-        if (
-            upstream
-            and len(upstream) <= 64
-            and all(c.isalnum() or c in "-_" for c in upstream)
-        ):
+        if upstream and len(upstream) <= 64 and all(c.isalnum() or c in "-_" for c in upstream):
             request_id = upstream
         else:
             request_id = uuid.uuid4().hex
@@ -86,6 +106,33 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         response = await call_next(request)
         response.headers.setdefault("X-TrustedRouter-Request-Id", request_id)
         return response
+
+    @app.middleware("http")
+    async def canonical_public_host_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Keep crawlable pages on one host.
+
+        ``www`` is only an alias. The status hostname intentionally serves a
+        small status surface, but relative links in that page previously let
+        crawlers discover the entire marketing site under the status host.
+        Redirecting those escaped paths prevents duplicate pages and
+        status-host 404s without changing the status API or static assets.
+        """
+        hostname = request.headers.get("host", "").split(":", 1)[0].lower()
+        path = request.url.path
+        if hostname == f"www.{settings.trusted_domain}":
+            return RedirectResponse(
+                url=_canonical_public_url(settings, request),
+                status_code=308,
+            )
+        if hostname == f"status.{settings.trusted_domain}" and not _status_host_path(path):
+            return RedirectResponse(
+                url=_canonical_public_url(settings, request),
+                status_code=308,
+            )
+        return await call_next(request)
 
     @app.middleware("http")
     async def public_pageview_middleware(
@@ -215,6 +262,16 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
             "max-age=63072000; includeSubDomains",
         )
         return response
+
+
+def _status_host_path(path: str) -> bool:
+    return path in STATUS_HOST_EXACT_PATHS or path.startswith(STATUS_HOST_PATH_PREFIXES)
+
+
+def _canonical_public_url(settings: Settings, request: Request) -> str:
+    query = request.url.query
+    suffix = f"?{query}" if query else ""
+    return f"https://{settings.trusted_domain}{request.url.path}{suffix}"
 
 
 def _rate_limit_request(request: Request, settings: Settings) -> JSONResponse | None:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -54,6 +54,7 @@ from trusted_router.dashboard import (
     public_leaderboard_html,
     public_legal_html,
     public_model_compare_html,
+    public_model_compare_index_html,
     public_model_detail_html,
     public_model_not_found_html,
     public_model_section_html,
@@ -88,6 +89,14 @@ from trusted_router.trust import gcp_release, trust_html
 from trusted_router.views import render_template
 
 STATUS_SNAPSHOT_CACHE_SECONDS = 15
+LEGACY_MODEL_PAGE_REDIRECTS: dict[str, str] = {
+    "deepseek/deepseek-chat-v3.1": "/models/deepseek/deepseek-v3.1",
+    "google/gemini-3-pro-image": "/models/google/gemini-3.1-flash-image-preview",
+    # Muse Spark was removed after the only configured route failed every
+    # health probe. There is no like-for-like successor, so retain the old
+    # backlink by sending readers to the current open-weight catalog.
+    "meta/muse-spark-1.1": "/models?filter=open",
+}
 STATUS_RAW_SAMPLE_LIMIT_PER_DAY = 35_000
 STATUS_LIVE_SAMPLE_LIMIT = 500
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
@@ -355,8 +364,8 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         return public_page_html(settings, "docs/synth")
 
     @public_html_route("/docs/fusion")
-    async def fusion_docs() -> str:
-        return public_page_html(settings, "docs/synth")
+    async def fusion_docs() -> RedirectResponse:
+        return RedirectResponse(url="/docs/synth", status_code=301)
 
     @public_html_route("/docs/x402")
     async def x402_docs() -> str:
@@ -575,6 +584,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/apps")
     async def apps() -> str:
         return public_apps_html(settings, apps=_apps_snapshot(settings))
+
+    @public_html_route("/resources")
+    async def resources() -> str:
+        return public_page_html(settings, "resources")
+
+    @public_html_route("/careers")
+    async def careers() -> str:
+        return public_page_html(settings, "careers")
 
     @public_html_route("/blog")
     async def blog() -> str:
@@ -883,6 +900,24 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             )
         return HTMLResponse(body)
 
+    @public_html_route("/compare/models")
+    async def model_compare_index() -> HTMLResponse:
+        body = public_model_compare_index_html(settings)
+        assert body is not None
+        return HTMLResponse(body)
+
+    @public_html_route("/compare/models/page/{page}")
+    async def model_compare_index_page(page: int) -> Response:
+        if page == 1:
+            return RedirectResponse(url="/compare/models", status_code=301)
+        body = public_model_compare_index_html(settings, page=page)
+        if body is None:
+            return HTMLResponse(
+                public_model_not_found_html(settings, f"comparison page {page}"),
+                status_code=404,
+            )
+        return HTMLResponse(body)
+
     @public_html_route("/compare/models/{left_author}/{left_slug}/vs/{right_author}/{right_slug}")
     async def model_compare(
         left_author: str,
@@ -918,8 +953,8 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         return public_fusion_html(settings)
 
     @public_html_route("/fusion")
-    async def fusion() -> str:
-        return public_fusion_html(settings)
+    async def fusion() -> RedirectResponse:
+        return RedirectResponse(url="/synth", status_code=301)
 
     # Per-model detail page. Path captures `{author}/{slug}` (e.g.
     # `z-ai/glm-4.6`, `moonshotai/kimi-k2.6`) so the URL exactly mirrors
@@ -932,9 +967,17 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         methods=["GET", "HEAD"],
         response_class=HTMLResponse,
     )
-    async def model_detail(model_id: str) -> HTMLResponse:
+    async def model_detail(model_id: str) -> Response:
         cleaned = model_id.strip()
         maybe_base_model_id, separator, maybe_section = cleaned.rpartition("/")
+        legacy_model_id = (
+            maybe_base_model_id
+            if separator and maybe_section in MODEL_SEO_SECTIONS
+            else cleaned
+        )
+        legacy_target = LEGACY_MODEL_PAGE_REDIRECTS.get(legacy_model_id)
+        if legacy_target:
+            return RedirectResponse(url=legacy_target, status_code=301)
         if separator and maybe_section in MODEL_SEO_SECTIONS:
             body = public_model_section_html(settings, maybe_base_model_id, maybe_section)
             if body is None:

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -14,6 +14,7 @@
       <h3>Product</h3>
       <a href="/choose">Choose a model</a>
       <a href="/models">Models</a>
+      <a href="/compare/models">Model comparisons</a>
       <a href="/providers">Providers</a>
       <a href="/eu">EU routing</a>
       <a href="/synth">Synth</a>
@@ -45,6 +46,8 @@
     <div class="footer-col">
       <h3>Company</h3>
       <a href="/blog">Blog</a>
+      <a href="/resources">Resources</a>
+      <a href="/careers">Careers</a>
       <a href="/support">Support</a>
       <a href="/legal">Legal</a>
       <a href="/terms">Terms</a>

--- a/src/trusted_router/templates/public/careers.html
+++ b/src/trusted_router/templates/public/careers.html
@@ -1,0 +1,23 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="marketing-split">
+  <div class="marketing-copy">
+    <span class="eyebrow">Small team. Hard systems.</span>
+    <h2>Make AI infrastructure developers can inspect and verify.</h2>
+    <p>TrustedRouter works on confidential computing, model routing, provider reliability, open evals, and combination models. The code and the claims are public.</p>
+    <p>We are especially interested in engineers and researchers who have shipped distributed systems, security infrastructure, model serving, or rigorous evals.</p>
+    <a class="btn primary" href="mailto:careers@trustedrouter.com?subject=TrustedRouter%20application">Email careers@trustedrouter.com</a>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Send</h2></div>
+    <div class="panel-body">
+      <ul class="check-list">
+        <li>Work you built and can explain precisely</li>
+        <li>The hardest production failure you diagnosed</li>
+        <li>A short note on what you want to improve at TrustedRouter</li>
+        <li>GitHub, papers, benchmarks, or other evidence</li>
+      </ul>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/model_compare.html
+++ b/src/trusted_router/templates/public/model_compare.html
@@ -75,9 +75,9 @@
     <div class="panel-body">
       <ul class="link-list">
         <li><a href="/models/{{ left.id }}">Overview</a><span>{{ left.endpoint_count }} endpoints</span></li>
-        <li><a href="/models/{{ left.id }}/pricing">Pricing</a><span>Prompt and completion rates</span></li>
-        <li><a href="/models/{{ left.id }}/benchmarks">Benchmarks</a><span>TrustedRouter and external sources</span></li>
-        <li><a href="/models/{{ left.id }}/providers">Providers</a><span>All serving providers</span></li>
+        {% if left.pricing_href %}<li><a href="{{ left.pricing_href }}">Pricing</a><span>Prompt and completion rates</span></li>{% endif %}
+        {% if left.benchmarks_href %}<li><a href="{{ left.benchmarks_href }}">Benchmarks</a><span>TrustedRouter and external sources</span></li>{% endif %}
+        {% if left.providers_href %}<li><a href="{{ left.providers_href }}">Providers</a><span>All serving providers</span></li>{% endif %}
       </ul>
     </div>
   </div>
@@ -86,9 +86,9 @@
     <div class="panel-body">
       <ul class="link-list">
         <li><a href="/models/{{ right.id }}">Overview</a><span>{{ right.endpoint_count }} endpoints</span></li>
-        <li><a href="/models/{{ right.id }}/pricing">Pricing</a><span>Prompt and completion rates</span></li>
-        <li><a href="/models/{{ right.id }}/benchmarks">Benchmarks</a><span>TrustedRouter and external sources</span></li>
-        <li><a href="/models/{{ right.id }}/providers">Providers</a><span>All serving providers</span></li>
+        {% if right.pricing_href %}<li><a href="{{ right.pricing_href }}">Pricing</a><span>Prompt and completion rates</span></li>{% endif %}
+        {% if right.benchmarks_href %}<li><a href="{{ right.benchmarks_href }}">Benchmarks</a><span>TrustedRouter and external sources</span></li>{% endif %}
+        {% if right.providers_href %}<li><a href="{{ right.providers_href }}">Providers</a><span>All serving providers</span></li>{% endif %}
       </ul>
     </div>
   </div>

--- a/src/trusted_router/templates/public/model_compare_index.html
+++ b/src/trusted_router/templates/public/model_compare_index.html
@@ -1,0 +1,41 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="model-catalog">
+  <div class="model-catalog-head">
+    <div>
+      <span class="eyebrow">Model comparisons</span>
+      <h2>Pick two models. Compare the routes that actually serve them.</h2>
+    </div>
+    <p>Every comparison uses the current TrustedRouter catalog, prices, provider posture, and measured route data.</p>
+  </div>
+  <div class="model-table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Comparison</th>
+          <th>First model</th>
+          <th>Routes</th>
+          <th>Second model</th>
+          <th>Routes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for comparison in comparisons %}
+        <tr>
+          <td><a href="{{ comparison.href }}"><strong>{{ comparison.label }}</strong></a></td>
+          <td><a href="/models/{{ comparison.left_id }}"><code>{{ comparison.left_id }}</code></a></td>
+          <td>{{ comparison.left_routes }}</td>
+          <td><a href="/models/{{ comparison.right_id }}"><code>{{ comparison.right_id }}</code></a></td>
+          <td>{{ comparison.right_routes }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <nav class="model-filter-row" aria-label="Comparison pages">
+    {% for item in pages %}
+    <a class="pill {% if item.number == page %}good{% endif %}" href="{{ item.href }}"{% if item.number == page %} aria-current="page"{% endif %}>{{ item.number }}</a>
+    {% endfor %}
+  </nav>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -18,7 +18,7 @@
       <span class="eyebrow">Models</span>
       <h2>Route by model, provider, price, or privacy posture.</h2>
     </div>
-    <p>API JSON remains at <span class="mono">{{ api_base_url }}/models</span> with an API key.</p>
+    <p>API JSON remains at <span class="mono">{{ api_base_url }}/models</span> with an API key. <a href="/compare/models">Compare models</a>.</p>
   </div>
   <div class="model-filter-row" aria-label="Model filters">
     {% for item in model_filters %}
@@ -51,11 +51,11 @@
               {% if model.us_provider_available %}<span class="pill">US providers</span>{% endif %}
               {% if model.eu_focused_provider_available %}<span class="pill">EU-focused</span>{% endif %}
             </div>
-            {% if model.benchmarks_href %}
+            {% if model.benchmarks_href or model.providers_href or model.pricing_href %}
             <div class="mini-links">
-              <a href="{{ model.benchmarks_href }}">benchmarks</a>
-              <a href="{{ model.detail_href }}/providers">providers</a>
-              <a href="{{ model.detail_href }}/pricing">pricing</a>
+              {% if model.benchmarks_href %}<a href="{{ model.benchmarks_href }}">benchmarks</a>{% endif %}
+              {% if model.providers_href %}<a href="{{ model.providers_href }}">providers</a>{% endif %}
+              {% if model.pricing_href %}<a href="{{ model.pricing_href }}">pricing</a>{% endif %}
             </div>
             {% endif %}
           </td>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -57,7 +57,7 @@
       </table>
     </div>
     {% endif %}
-    <p class="muted-copy" style="margin-top:10px"><a href="/leaderboard">Full provider &amp; model leaderboard</a>.</p>
+    <p class="muted-copy" style="margin-top:10px"><a href="/providers/{{ provider.id }}/performance">{{ provider.name }} performance history</a> · <a href="/leaderboard">Full provider &amp; model leaderboard</a>.</p>
   </div>
 </section>
 {% endif %}
@@ -88,11 +88,13 @@
         <tr>
           <td>
             <a href="{{ model.detail_href }}"><code>{{ model.id }}</code></a><br>{{ model.name }}
+            {% if model.benchmarks_href or model.providers_href or model.pricing_href %}
             <div class="mini-links">
-              <a href="{{ model.benchmarks_href }}">benchmarks</a>
-              <a href="{{ model.detail_href }}/performance">performance</a>
-              <a href="{{ model.detail_href }}/api">api</a>
+              {% if model.benchmarks_href %}<a href="{{ model.benchmarks_href }}">benchmarks</a>{% endif %}
+              {% if model.providers_href %}<a href="{{ model.providers_href }}">providers</a>{% endif %}
+              {% if model.pricing_href %}<a href="{{ model.pricing_href }}">pricing</a>{% endif %}
             </div>
+            {% endif %}
           </td>
           <td>
             {% if model.ai_iq %}

--- a/src/trusted_router/templates/public/resources.html
+++ b/src/trusted_router/templates/public/resources.html
@@ -1,0 +1,84 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<section class="seo-two-col">
+  <div class="panel">
+    <div class="panel-head"><h2>Build</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/for-developers">60 second quickstart</a><span>First request and trust verification</span></li>
+        <li><a href="/apps">Apps</a><span>Products built on TrustedRouter</span></li>
+        <li><a href="/cline-api-provider">Cline API provider</a><span>Connect coding agents</span></li>
+        <li><a href="/sillytavern-api">SillyTavern API</a><span>OpenAI compatible setup</span></li>
+        <li><a href="/llm-document-processing">LLM document processing</a><span>Private document workflows</span></li>
+        <li><a href="/llm-failover">LLM failover</a><span>Provider rollover design</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Measure</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/benchmarks">Benchmarks</a><span>Model benchmark sources</span></li>
+        <li><a href="/rankings">Rankings</a><span>Practical model signals</span></li>
+        <li><a href="/leaderboard">Provider leaderboard</a><span>Live route measurements</span></li>
+        <li><a href="/compare/models">Model comparisons</a><span>Price, context, routes, and privacy</span></li>
+        <li><a href="/llm-provider-latency-benchmarks">Latency benchmarks</a><span>TTFT, TTFB, and throughput</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Privacy and compliance</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/private-llm-api">Private LLM API</a><span>Verifiable prompt path</span></li>
+        <li><a href="/confidential-computing-llm">Confidential computing</a><span>Hardware attestation</span></li>
+        <li><a href="/claude-api-privacy">Claude API privacy</a><span>Privacy boundaries for Claude routes</span></li>
+        <li><a href="/deepseek-api-privacy">DeepSeek API privacy</a><span>Hosting and provider boundaries</span></li>
+        <li><a href="/gdpr-compliant-llm-api">GDPR and LLM APIs</a><span>DPA and routing evidence</span></li>
+        <li><a href="/eu-ai-act-llm-compliance">EU AI Act</a><span>Evidence for deployers</span></li>
+        <li><a href="/llm-data-residency">LLM data residency</a><span>Region and attestation scope</span></li>
+        <li><a href="/llm-api-for-law-firms">LLM API for law firms</a><span>Privileged workflows</span></li>
+        <li><a href="/llm-api-for-financial-services">LLM API for financial services</a><span>Risk and procurement evidence</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Model APIs</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/glm-5-api">GLM 5 API</a><span>Routes, privacy, and migration</span></li>
+        <li><a href="/gpt-oss-120b-api">gpt-oss-120b API</a><span>Fast open weight inference</span></li>
+        <li><a href="/minimax-m3-api">MiniMax M3 API</a><span>Current routes and context</span></li>
+        <li><a href="/gemini-flash-alternative">Gemini Flash alternatives</a><span>Compare fast model routes</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Compare gateways</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/best-llm-router">Best LLM router</a><span>How to evaluate routing systems</span></li>
+        <li><a href="/aws-bedrock-alternative">AWS Bedrock alternative</a><span>Catalog and quota tradeoffs</span></li>
+        <li><a href="/azure-openai-alternative">Azure OpenAI alternative</a><span>Attested private inference</span></li>
+        <li><a href="/groq-alternative">Groq alternative</a><span>Fast routes with fallback</span></li>
+        <li><a href="/litellm-alternative">LiteLLM alternative</a><span>Hosted and self hosted tradeoffs</span></li>
+        <li><a href="/portkey-alternative">Portkey alternative</a><span>Observability and privacy posture</span></li>
+        <li><a href="/tinfoil-alternative">Tinfoil alternative</a><span>Confidential provider routes</span></li>
+        <li><a href="/vertex-ai-alternative">Vertex AI alternative</a><span>One API across providers</span></li>
+        <li><a href="/compare/litellm">TrustedRouter and LiteLLM</a><span>Deployment model comparison</span></li>
+        <li><a href="/compare/vercel-ai-gateway">TrustedRouter and Vercel AI Gateway</a><span>Gateway comparison</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="panel-head"><h2>Projects</h2></div>
+    <div class="panel-body">
+      <ul class="link-list">
+        <li><a href="/trustedos">TrustedOS</a><span>Infrastructure for AI clouds</span></li>
+        <li><a href="/synth">Synth</a><span>Combination models behind one API</span></li>
+        <li><a href="/blog">Blog</a><span>Research, launches, and eval results</span></li>
+      </ul>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_index.html
+++ b/src/trusted_router/templates/public/seo_index.html
@@ -45,10 +45,9 @@
           <td>{{ model.completion_price }}</td>
           <td>
             <div class="mini-links">
-              <a href="{{ model.detail_href }}/benchmarks">benchmarks</a>
-              <a href="{{ model.detail_href }}/performance">performance</a>
-              <a href="{{ model.detail_href }}/pricing">pricing</a>
-              <a href="{{ model.detail_href }}/api">api</a>
+              {% if model.benchmarks_href %}<a href="{{ model.benchmarks_href }}">benchmarks</a>{% endif %}
+              {% if model.providers_href %}<a href="{{ model.providers_href }}">providers</a>{% endif %}
+              {% if model.pricing_href %}<a href="{{ model.pricing_href }}">pricing</a>{% endif %}
             </div>
           </td>
         </tr>

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -16,9 +16,9 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         "/compare/litellm": "LiteLLM for your own infra",
         "/docs/migrate-from-openrouter": "Change base_url",
         "/docs/synth": "Run a panel of models inside the attested gateway.",
-        "/docs/fusion": "Run a panel of models inside the attested gateway.",
         "/synth": "Synthesize many models into one perfect frontier answer.",
-        "/fusion": "Synthesize many models into one perfect frontier answer.",
+        "/resources": "Guides, comparisons, privacy references",
+        "/careers": "Work on attested AI routing",
         "/blog": "TrustedRouter blog",
         "/blog/fusion-evals-open-source": "New SOTA: TrustedRouter Synth beats Fable and Frontier",
         "/security": "TrustedRouter does not store prompt or output content by default.",
@@ -27,7 +27,7 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         # The marker is a load-bearing headline from the page so a
         # silent template breakage gets caught here.
         "/openrouter-alternative": "An OpenRouter alternative built around verifiable privacy.",
-        "/private-llm-api": "A private LLM API where \"private\" means cryptographically verified.",
+        "/private-llm-api": 'A private LLM API where "private" means cryptographically verified.',
         "/hipaa-llm-api": "The LLM API whose privacy posture is verifiable",
         "/llm-zero-data-retention": "Zero data retention as a verifiable property",
         "/claude-api-privacy": "Call Claude through a prompt path you can verify.",
@@ -89,9 +89,7 @@ def test_revenue_pages_support_link_checkers(client: TestClient) -> None:
         "/compare/litellm",
         "/docs/migrate-from-openrouter",
         "/docs/synth",
-        "/docs/fusion",
         "/synth",
-        "/fusion",
         "/blog",
         "/blog/fusion-evals-open-source",
         "/security",
@@ -136,7 +134,9 @@ def test_agent_discovery_surfaces_model_advisor_skill(client: TestClient) -> Non
     for path in ["/docs", "/docs/agent-setup"]:
         response = client.get(path)
         assert "https://github.com/Lore-Hex/LLM-advisor" in response.text
-        assert "https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md" in response.text
+        assert (
+            "https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md" in response.text
+        )
 
     for path in ["/llms.txt", "/docs/llms.txt", "/docs/llms-full.txt"]:
         response = client.get(path)
@@ -222,8 +222,12 @@ def test_synth_playground_is_public_and_uses_browser_key_proxy(client: TestClien
     assert "z-ai/glm-5.2" in response.text
     assert client.head("/synth").status_code == 200
     assert client.get("/synth/", follow_redirects=False).status_code == 200
-    assert client.head("/fusion").status_code == 200
-    assert client.get("/fusion/", follow_redirects=False).status_code == 200
+    legacy = client.get("/fusion", follow_redirects=False)
+    assert legacy.status_code == 301
+    assert legacy.headers["location"] == "/synth"
+    legacy_slash = client.get("/fusion/", follow_redirects=False)
+    assert legacy_slash.status_code == 301
+    assert legacy_slash.headers["location"] == "/synth"
 
 
 def test_synth_docs_publish_current_gateway_shape(client: TestClient) -> None:
@@ -247,9 +251,14 @@ def test_synth_docs_publish_current_gateway_shape(client: TestClient) -> None:
     assert "google/gemma-4-31b-it" in response.text
     assert "deepseek/deepseek-v4-pro" in response.text
     assert "Final fallback can switch before the first byte" in response.text
-    assert "TrustedRouter stores billing and route metadata, not prompt/output content by default." in response.text
+    assert (
+        "TrustedRouter stores billing and route metadata, not prompt/output content by default."
+        in response.text
+    )
     assert "OpenAI compatible API" in response.text
-    assert client.get("/docs/fusion").status_code == 200
+    legacy = client.get("/docs/fusion", follow_redirects=False)
+    assert legacy.status_code == 301
+    assert legacy.headers["location"] == "/docs/synth"
 
 
 def test_homepage_and_nav_link_to_choose(client: TestClient) -> None:
@@ -318,8 +327,8 @@ def test_public_meta_model_detail_renders_orchestration_components(client: TestC
 
     assert response.status_code == 200
     assert "TrustedRouter Socrates 1.1" in response.text
-    assert "<span class=\"pill\">advisor</span>" in response.text
-    assert "<span class=\"pill\">named preset</span>" in response.text
+    assert '<span class="pill">advisor</span>' in response.text
+    assert '<span class="pill">named preset</span>' in response.text
     assert "Models used by this orchestration" in response.text
     assert "xiaomi/mimo-v2.5-pro-ultraspeed" in response.text
     assert "minimax/minimax-m3" in response.text
@@ -331,9 +340,9 @@ def test_public_meta_model_detail_renders_orchestration_components(client: TestC
 
     rolling = client.get("/models/trustedrouter/socrates")
     assert rolling.status_code == 200
-    assert "<span class=\"pill\">advisor</span>" in rolling.text
-    assert "<span class=\"pill\">rolling alias</span>" in rolling.text
-    assert "Canonical: <a href=\"/models/trustedrouter/socrates-1.1\"" in rolling.text
+    assert '<span class="pill">advisor</span>' in rolling.text
+    assert '<span class="pill">rolling alias</span>' in rolling.text
+    assert 'Canonical: <a href="/models/trustedrouter/socrates-1.1"' in rolling.text
 
 
 def test_public_k3_combo_pages_render_exact_graphs(
@@ -426,7 +435,7 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "Provider failover" in response.text  # hero proof row
     assert 'min_privacy": "confidential"' in response.text
     assert 'href="/eu"' in response.text
-    assert '/static/charter.css?v=' in response.text
+    assert "/static/charter.css?v=" in response.text
     assert 'class="brand-mark"' in response.text
 
 

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -4,8 +4,10 @@ import json
 import logging
 import re
 
+import pytest
 from fastapi.testclient import TestClient
 
+from trusted_router.dashboard import MODEL_COMPARE_PAGE_SIZE
 from trusted_router.routes.public import INDEXNOW_KEY
 
 
@@ -61,7 +63,11 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
         in core.text
     )
     assert "<loc>https://trustedrouter.com/docs/synth</loc>" in core.text
-    assert "<loc>https://trustedrouter.com/docs/fusion</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/docs/fusion</loc>" not in core.text
+    assert "<loc>https://trustedrouter.com/fusion</loc>" not in core.text
+    assert "<loc>https://trustedrouter.com/compare/models</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/resources</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/careers</loc>" in core.text
 
     models = client.get("/sitemap-models.xml")
     assert models.status_code == 200
@@ -88,9 +94,48 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
         "<loc>https://trustedrouter.com/compare/models/z-ai/glm-5.2/vs/moonshotai/kimi-k2.6</loc>"
         in comparisons.text
     )
+    assert "<loc>https://trustedrouter.com/compare/models/page/2</loc>" in comparisons.text
     combined = sitemap.text + core.text + models.text + providers.text + comparisons.text
     assert "trustedrouter/monitor" not in combined
     assert "openrouter.ai" not in combined
+
+
+def test_public_pages_are_gzip_compressed(client: TestClient) -> None:
+    response = client.get("/models", headers={"accept-encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.headers["content-encoding"] == "gzip"
+    assert "Accept-Encoding" in response.headers.get("vary", "")
+    assert "Hundreds of models" in response.text
+
+
+def test_public_host_aliases_redirect_to_the_canonical_marketing_host(
+    client: TestClient,
+) -> None:
+    www = client.get(
+        "/api/reference?group=models",
+        headers={"host": "www.trustedrouter.com"},
+        follow_redirects=False,
+    )
+    assert www.status_code == 308
+    assert www.headers["location"] == "https://trustedrouter.com/api/reference?group=models"
+
+    escaped_status_link = client.get(
+        "/providers/minimax",
+        headers={"host": "status.trustedrouter.com"},
+        follow_redirects=False,
+    )
+    assert escaped_status_link.status_code == 308
+    assert escaped_status_link.headers["location"] == (
+        "https://trustedrouter.com/providers/minimax"
+    )
+
+    status_json = client.get(
+        "/status.json",
+        headers={"host": "status.trustedrouter.com"},
+        follow_redirects=False,
+    )
+    assert status_json.status_code == 200
 
 
 def test_indexnow_key_file_is_public(client: TestClient) -> None:
@@ -478,9 +523,7 @@ def test_public_legal_dpa_baa_and_subprocessors_are_honest(client: TestClient) -
     system_names = {row["name"] for row in payload["system_subprocessors"]}
     model_names = {row["name"] for row in payload["model_provider_subprocessors"]}
     assert {"Google Cloud Platform", "Stripe", "Sentry"}.issubset(system_names)
-    assert {"Anthropic", "OpenAI", "Google AI Studio", "Google Vertex AI"}.issubset(
-        model_names
-    )
+    assert {"Anthropic", "OpenAI", "Google AI Studio", "Google Vertex AI"}.issubset(model_names)
     anthropic = next(
         row for row in payload["model_provider_subprocessors"] if row["id"] == "anthropic"
     )
@@ -551,6 +594,44 @@ def test_provider_detail_page_links_served_models(client: TestClient) -> None:
     assert "Policy source" in response.text
 
 
+def test_provider_detail_links_indexable_performance_page(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import dashboard
+
+    measured = {
+        "provider_row": {
+            "sample_count": 25,
+            "p50_ttft_ms": 125,
+            "p50_tokens_per_second": 80.0,
+            "uptime": 0.999,
+        },
+        "models": [],
+    }
+    monkeypatch.setattr(dashboard, "measured_for_provider", lambda *_args, **_kwargs: measured)
+
+    response = client.get("/providers/minimax")
+    assert response.status_code == 200
+    assert 'href="/providers/minimax/performance"' in response.text
+
+    sitemap = client.get("/sitemap-providers.xml")
+    assert "<loc>https://trustedrouter.com/providers/minimax/performance</loc>" in sitemap.text
+
+
+def test_model_overview_only_links_subpages_with_indexable_content(
+    client: TestClient,
+) -> None:
+    response = client.get("/models/minimax/minimax-m3")
+
+    assert response.status_code == 200
+    assert 'href="/models/minimax/minimax-m3/benchmarks"' in response.text
+    assert 'href="/models/minimax/minimax-m3/providers"' in response.text
+    assert 'href="/models/minimax/minimax-m3/pricing"' in response.text
+    assert 'href="/models/minimax/minimax-m3/uptime"' not in response.text
+    assert 'href="/models/minimax/minimax-m3/api"' not in response.text
+
+
 def test_model_seo_cluster_pages_are_public_and_not_openrouter_links(
     client: TestClient,
 ) -> None:
@@ -603,12 +684,104 @@ def test_model_comparison_pages_are_public(client: TestClient) -> None:
     assert "openrouter.ai" not in response.text.lower()
 
 
+def test_model_comparison_directory_links_every_sitemap_pair(client: TestClient) -> None:
+    sitemap = client.get("/sitemap-comparisons.xml")
+    sitemap_pairs = set(
+        re.findall(
+            r"<loc>https://trustedrouter\.com(/compare/models/[^<]+/vs/[^<]+)</loc>",
+            sitemap.text,
+        )
+    )
+    expected_page_count = (
+        len(sitemap_pairs) + MODEL_COMPARE_PAGE_SIZE - 1
+    ) // MODEL_COMPARE_PAGE_SIZE
+
+    first = client.get("/compare/models")
+    assert first.status_code == 200
+    assert "Compare AI models" in first.text
+    assert f'href="/compare/models/page/{expected_page_count}"' in first.text
+
+    linked_paths: set[str] = set()
+    for page in range(1, expected_page_count + 1):
+        path = "/compare/models" if page == 1 else f"/compare/models/page/{page}"
+        response = client.get(path)
+        assert response.status_code == 200, path
+        linked_paths.update(
+            re.findall(
+                r'href="(/compare/models/[^\"]+/vs/[^\"]+)"',
+                response.text,
+            )
+        )
+
+    assert len(sitemap_pairs) == 2_600
+    assert linked_paths == sitemap_pairs
+
+
+def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> None:
+    response = client.get("/resources")
+    assert response.status_code == 200
+    expected_paths = {
+        "/apps",
+        "/aws-bedrock-alternative",
+        "/azure-openai-alternative",
+        "/benchmarks",
+        "/best-llm-router",
+        "/claude-api-privacy",
+        "/cline-api-provider",
+        "/compare/litellm",
+        "/compare/vercel-ai-gateway",
+        "/confidential-computing-llm",
+        "/deepseek-api-privacy",
+        "/eu-ai-act-llm-compliance",
+        "/gdpr-compliant-llm-api",
+        "/gemini-flash-alternative",
+        "/glm-5-api",
+        "/gpt-oss-120b-api",
+        "/groq-alternative",
+        "/litellm-alternative",
+        "/llm-api-for-financial-services",
+        "/llm-api-for-law-firms",
+        "/llm-data-residency",
+        "/llm-document-processing",
+        "/llm-failover",
+        "/minimax-m3-api",
+        "/portkey-alternative",
+        "/private-llm-api",
+        "/rankings",
+        "/sillytavern-api",
+        "/tinfoil-alternative",
+        "/trustedos",
+        "/vertex-ai-alternative",
+    }
+    for path in expected_paths:
+        assert f'href="{path}"' in response.text, path
+
+    footer = client.get("/")
+    assert 'href="/resources"' in footer.text
+    assert 'href="/careers"' in footer.text
+
+
+def test_retired_model_pages_redirect_to_current_catalog_entries(client: TestClient) -> None:
+    redirects = {
+        "/models/deepseek/deepseek-chat-v3.1/performance": ("/models/deepseek/deepseek-v3.1"),
+        "/models/google/gemini-3-pro-image/performance": (
+            "/models/google/gemini-3.1-flash-image-preview"
+        ),
+        "/models/meta/muse-spark-1.1/performance": "/models?filter=open",
+    }
+    for path, target in redirects.items():
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 301, path
+        assert response.headers["location"] == target
+
+
 def test_benchmarks_and_rankings_pages_link_model_clusters(client: TestClient) -> None:
     for path in ["/benchmarks", "/rankings"]:
         response = client.get(path)
         assert response.status_code == 200
         assert "/models/minimax/minimax-m3/benchmarks" in response.text
-        assert "/models/minimax/minimax-m3/performance" in response.text
+        assert "/models/minimax/minimax-m3/api" not in response.text
+        assert "/models/minimax/minimax-m3/uptime" not in response.text
         assert "/providers/minimax" in response.text
         assert 'href="https://aiiq.org/models/minimax-m3/"' in response.text
         assert "openrouter.ai" not in response.text.lower()


### PR DESCRIPTION
## Summary
- add crawlable directories for all 2,600 model comparison pages and the 31 standalone SEO/resource pages
- link indexable provider performance pages and stop exposing intentionally noindex model tabs without content
- canonicalize www/status host aliases, gzip large public responses, and redirect retired aliases/model URLs
- add a real careers page for existing internal links

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1,839 passed, 33 skipped)
- desktop and mobile render checks for /compare/models and /resources