### PR TITLE
Add Baseten GLM 5.2 Fast route

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -114,6 +114,7 @@ _BASETEN_MODEL_IDS = {
     "deepseek-ai/DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro",
     "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
+    "zai-org/GLM-5.2-Fast": "z-ai/glm-5.2-fast",
     "moonshotai/Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
 }
 

--- a/scripts/pricing/providers/baseten.py
+++ b/scripts/pricing/providers/baseten.py
@@ -11,7 +11,8 @@ provider-native id, not a guessed lowercase slug.
 from __future__ import annotations
 
 import os
-from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -19,17 +20,26 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_TIMEOUT,
     PROVIDER_FETCH_TRANSPORT_RETRIES,
     PROVIDER_FETCH_UA,
-    ModelPrice,
     ProviderPricingResult,
     validate,
 )
-from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
+from scripts.pricing.manifest import write_discovered_chat_manifest
+from scripts.pricing.openai_catalog import discover_openai_chat_catalog
 
 SLUG = "baseten"
 URL = "https://inference.baseten.co/v1/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "baseten.json"
+)
 
 EXPECTED_MODELS = [
     "z-ai/glm-5.2",
+    "z-ai/glm-5.2-fast",
     "moonshotai/kimi-k2.7-code",
     "thinkingmachines/inkling-1m",
 ]
@@ -45,26 +55,18 @@ _NATIVE_TO_OR_ID = {
     "deepseek-ai/DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro",
     "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
+    "zai-org/GLM-5.2-Fast": "z-ai/glm-5.2-fast",
     "moonshotai/Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
     "thinkingmachines/inkling": "thinkingmachines/inkling-1m",
 }
 
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
-
-
-def _price_to_micro_per_m(value: object) -> int | None:
-    """Baseten returns dollars/token; TR stores microdollars/million tokens."""
-
-    try:
-        parsed = Decimal(str(value))
-    except (InvalidOperation, TypeError, ValueError):
-        return None
-    if parsed < 0:
-        return None
-    return int((parsed * Decimal("1000000000000")).to_integral_value(ROUND_HALF_UP))
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
     api_key = os.environ.get("BASETEN_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -80,34 +82,13 @@ def fetch() -> ProviderPricingResult:
         payload = response.json()
 
     rows = payload.get("data") if isinstance(payload, dict) else payload
-    if not isinstance(rows, list):
-        rows = []
-    prices: dict[str, ModelPrice] = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        native_id = row.get("id")
-        if not isinstance(native_id, str):
-            continue
-        or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
-        if or_id is None:
-            continue
-        remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
-        pricing = row.get("pricing")
-        if not isinstance(pricing, dict):
-            continue
-        prompt = _price_to_micro_per_m(pricing.get("prompt") or pricing.get("input"))
-        completion = _price_to_micro_per_m(pricing.get("completion") or pricing.get("output"))
-        if prompt is None or completion is None:
-            continue
-        cache_read = _price_to_micro_per_m(
-            pricing.get("input_cache_read") or pricing.get("cache_read")
-        )
-        prices[or_id] = ModelPrice(
-            prompt_micro_per_m=prompt,
-            completion_micro_per_m=completion,
-            prompt_cached_micro_per_m=cache_read,
-        )
+    source_rows = [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+    prices, discovered = discover_openai_chat_catalog(
+        source_rows,
+        explicit_map=_NATIVE_TO_OR_ID,
+        upstream_id_map=UPSTREAM_ID_MAP,
+    )
+    _DISCOVERED_MANIFEST_ROWS = discovered
 
     notes: list[str] = []
     errors = validate(prices, EXPECTED_MODELS)
@@ -121,4 +102,13 @@ def fetch() -> ProviderPricingResult:
         source="api",
         fetched_url=URL,
         notes=notes,
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=URL,
     )

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -92,6 +92,7 @@ _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS = frozenset(
         "cerebras",
         "cloudflare-workers-ai",
         "crusoe",
+        "baseten",
         "friendli",
         "google-ai-studio",
         "kimi",

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -2980,9 +2980,9 @@
           "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.000000627",
-            "completion": "0.000001344",
-            "input_cache_read": "0.00000006886"
+            "prompt": "0.00000139",
+            "completion": "0.00000279",
+            "input_cache_read": "0.000000301"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10099,9 +10099,9 @@
           "tr_provider_slug": "makora",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.000000328",
-            "completion": "0.0000013532",
-            "input_cache_read": "0.0000000646"
+            "prompt": "0.0000009701",
+            "completion": "0.000003865",
+            "input_cache_read": "0.00000019012"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -24073,9 +24073,9 @@
           "tr_provider_slug": "makora",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.00000044",
-            "completion": "0.0000015404",
-            "input_cache_read": "0.00000011"
+            "prompt": "0.00000094",
+            "completion": "0.0000028",
+            "input_cache_read": "0.00000018"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],

--- a/src/trusted_router/data/provider_models/baseten.json
+++ b/src/trusted_router/data/provider_models/baseten.json
@@ -1,130 +1,391 @@
 {
-  "_about": "Provider-native supplement for Baseten Model APIs. Verified against https://inference.baseten.co/v1/models on 2026-07-15.",
+  "_about": "Provider-native Baseten Model API routes, capabilities, context windows, and account-billable prices refreshed hourly from Baseten's authenticated /v1/models feed.",
   "provider": "baseten",
   "source": "https://inference.baseten.co/v1/models",
-  "generated_at": "2026-07-15T00:00:00Z",
+  "generated_at": "2026-07-24T06:26:04Z",
   "price_scale": "microdollars_per_million",
-  "model_count": 12,
+  "model_count": 13,
   "models": [
     {
       "id": "openai/gpt-oss-120b",
       "upstream_id": "openai/gpt-oss-120b",
-      "display_name": "GPT OSS 120B",
+      "display_name": "OpenAI GPT 120B",
       "context_length": 128072,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 100000,
       "output_token_price_per_m": 500000,
-      "cached_input_token_price_per_m": 100000
+      "cached_input_token_price_per_m": 100000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "reasoning",
+        "json_mode",
+        "structured_outputs",
+        "reasoning_effort"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
     },
     {
       "id": "z-ai/glm-4.7",
       "upstream_id": "zai-org/GLM-4.7",
       "display_name": "GLM 4.7",
       "context_length": 200000,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 600000,
       "output_token_price_per_m": 2200000,
-      "cached_input_token_price_per_m": 120000
+      "cached_input_token_price_per_m": 120000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "id": "moonshotai/kimi-k2.5",
       "upstream_id": "moonshotai/Kimi-K2.5",
       "display_name": "Kimi K2.5",
       "context_length": 262000,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 600000,
       "output_token_price_per_m": 3000000,
-      "cached_input_token_price_per_m": 120000
+      "cached_input_token_price_per_m": 120000,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "vision"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
     },
     {
       "id": "z-ai/glm-5",
       "upstream_id": "zai-org/GLM-5",
       "display_name": "GLM 5",
       "context_length": 202800,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 3150000,
-      "cached_input_token_price_per_m": 200000
+      "cached_input_token_price_per_m": 200000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "id": "nvidia/nemotron-120b-a12b",
       "upstream_id": "nvidia/Nemotron-120B-A12B",
-      "display_name": "Nemotron 120B A12B",
+      "display_name": "Nemotron Super",
       "context_length": 202800,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 300000,
       "output_token_price_per_m": 750000,
-      "cached_input_token_price_per_m": 60000
+      "cached_input_token_price_per_m": 60000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "id": "z-ai/glm-5.1",
       "upstream_id": "zai-org/GLM-5.1",
       "display_name": "GLM 5.1",
       "context_length": 202800,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 1300000,
       "output_token_price_per_m": 4300000,
-      "cached_input_token_price_per_m": 260000
+      "cached_input_token_price_per_m": 260000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "id": "moonshotai/kimi-k2.6",
       "upstream_id": "moonshotai/Kimi-K2.6",
       "display_name": "Kimi K2.6",
       "context_length": 262000,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
-      "cached_input_token_price_per_m": 160000
+      "cached_input_token_price_per_m": 160000,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
     },
     {
       "id": "deepseek/deepseek-v4-pro",
       "upstream_id": "deepseek-ai/DeepSeek-V4-Pro",
-      "display_name": "DeepSeek V4 Pro",
-      "context_length": 131000,
-      "endpoints": ["chat/completions"],
+      "display_name": "Deepseek V4 Pro",
+      "context_length": 262144,
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 1740000,
       "output_token_price_per_m": 3480000,
-      "cached_input_token_price_per_m": 145000
+      "cached_input_token_price_per_m": 145000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
     },
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "upstream_id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
-      "display_name": "NVIDIA Nemotron 3 Ultra 550B A55B",
+      "display_name": "Nemotron Ultra",
       "context_length": 202800,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 600000,
       "output_token_price_per_m": 2400000,
-      "cached_input_token_price_per_m": 120000
+      "cached_input_token_price_per_m": 120000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop",
+        "top_p",
+        "top_k"
+      ]
     },
     {
       "id": "z-ai/glm-5.2",
       "upstream_id": "zai-org/GLM-5.2",
       "display_name": "GLM 5.2",
-      "context_length": 262144,
-      "endpoints": ["chat/completions"],
+      "context_length": 524288,
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,
-      "cached_input_token_price_per_m": 260000
+      "cached_input_token_price_per_m": 140000,
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "stop"
+      ]
     },
     {
       "id": "moonshotai/kimi-k2.7-code",
       "upstream_id": "moonshotai/Kimi-K2.7-Code",
       "display_name": "Kimi K2.7 Code",
       "context_length": 262000,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
-      "cached_input_token_price_per_m": 160000
+      "cached_input_token_price_per_m": 160000,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
     },
     {
       "id": "thinkingmachines/inkling-1m",
       "upstream_id": "thinkingmachines/inkling",
-      "display_name": "Thinking Machines Inkling 1M",
+      "display_name": "Inkling",
       "context_length": 1048576,
-      "endpoints": ["chat/completions"],
+      "endpoints": [
+        "chat/completions"
+      ],
       "input_token_price_per_m": 1000000,
       "output_token_price_per_m": 4050000,
-      "cached_input_token_price_per_m": 170000
+      "cached_input_token_price_per_m": 170000,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ]
+    },
+    {
+      "display_name": "GLM 5.2 Fast",
+      "title": "zai-org/GLM-5.2-Fast",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "z-ai/glm-5.2-fast",
+      "upstream_id": "zai-org/GLM-5.2-Fast",
+      "context_length": 524288,
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "stop"
+      ],
+      "input_token_price_per_m": 2100000,
+      "output_token_price_per_m": 6600000,
+      "cached_input_token_price_per_m": 210000
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/makora.json
+++ b/src/trusted_router/data/provider_models/makora.json
@@ -3,7 +3,7 @@
   "provider": "makora",
   "source": "https://inference.makora.com/v1/models",
   "pricing_source": "https://inference.makora.com/v1/models",
-  "generated_at": "2026-07-22T00:02:00Z",
+  "generated_at": "2026-07-24T06:26:04Z",
   "price_scale": "microdollars_per_million",
   "model_count": 11,
   "models": [
@@ -57,9 +57,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 627000,
-      "output_token_price_per_m": 1344000,
-      "cached_input_token_price_per_m": 68860,
+      "input_token_price_per_m": 1390000,
+      "output_token_price_per_m": 2790000,
+      "cached_input_token_price_per_m": 301000,
       "input_modalities": [
         "text"
       ],
@@ -140,9 +140,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 440000,
-      "output_token_price_per_m": 1540400,
-      "cached_input_token_price_per_m": 110000,
+      "input_token_price_per_m": 940000,
+      "output_token_price_per_m": 2800000,
+      "cached_input_token_price_per_m": 180000,
       "input_modalities": [
         "text"
       ],
@@ -182,9 +182,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 328000,
-      "output_token_price_per_m": 1353200,
-      "cached_input_token_price_per_m": 64600,
+      "input_token_price_per_m": 970100,
+      "output_token_price_per_m": 3865000,
+      "cached_input_token_price_per_m": 190120,
       "input_modalities": [
         "text",
         "image"
@@ -366,9 +366,9 @@
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 1020000,
-      "output_token_price_per_m": 3400000,
-      "cached_input_token_price_per_m": 161500,
+      "input_token_price_per_m": 720000,
+      "output_token_price_per_m": 2380000,
+      "cached_input_token_price_per_m": 120000,
       "input_modalities": [
         "text"
       ],

--- a/tests/test_baseten_wafer_pricing.py
+++ b/tests/test_baseten_wafer_pricing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import baseten, wafer
 
 
@@ -22,10 +23,20 @@ def test_baseten_fetch_discovers_prices_without_float_drift(monkeypatch) -> None
         "data": [
             {
                 "id": "zai-org/GLM-5.2",
+                "context_length": 524288,
                 "pricing": {
                     "prompt": "0.0000014",
                     "completion": "0.0000044",
-                    "input_cache_read": "0.00000026",
+                    "input_cache_read": "0.00000014",
+                },
+            },
+            {
+                "id": "zai-org/GLM-5.2-Fast",
+                "context_length": 524288,
+                "pricing": {
+                    "prompt": "0.0000021",
+                    "completion": "0.0000066",
+                    "input_cache_read": "0.00000021",
                 },
             },
             {
@@ -64,19 +75,115 @@ def test_baseten_fetch_discovers_prices_without_float_drift(monkeypatch) -> None
 
     result = baseten.fetch()
     glm = result.prices["z-ai/glm-5.2"]
+    glm_fast = result.prices["z-ai/glm-5.2-fast"]
     kimi = result.prices["moonshotai/kimi-k2.7-code"]
     inkling = result.prices["thinkingmachines/inkling-1m"]
 
     assert glm.prompt_micro_per_m == 1_400_000
     assert glm.completion_micro_per_m == 4_400_000
-    assert glm.tiers[0].prompt_cached_micro_per_m == 260_000
+    assert glm.tiers[0].prompt_cached_micro_per_m == 140_000
+    assert glm_fast.prompt_micro_per_m == 2_100_000
+    assert glm_fast.completion_micro_per_m == 6_600_000
+    assert glm_fast.tiers[0].prompt_cached_micro_per_m == 210_000
     assert kimi.prompt_micro_per_m == 950_000
     assert kimi.completion_micro_per_m == 4_000_000
     assert inkling.prompt_micro_per_m == 1_000_000
     assert inkling.completion_micro_per_m == 4_050_000
     assert inkling.tiers[0].prompt_cached_micro_per_m == 170_000
     assert baseten.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "zai-org/GLM-5.2"
+    assert baseten.UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] == "zai-org/GLM-5.2-Fast"
     assert baseten.UPSTREAM_ID_MAP["thinkingmachines/inkling-1m"] == "thinkingmachines/inkling"
+
+
+def test_baseten_provider_appends_new_priced_models_to_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "baseten.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "baseten",
+                "source": baseten.URL,
+                "generated_at": "2026-01-01T00:00:00Z",
+                "model_count": 1,
+                "models": [
+                    {
+                        "id": "z-ai/glm-5.2",
+                        "upstream_id": "zai-org/GLM-5.2",
+                        "display_name": "GLM 5.2",
+                        "context_length": 262144,
+                        "endpoints": ["chat/completions"],
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(baseten, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        baseten,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "z-ai/glm-5.2": {
+                "id": "z-ai/glm-5.2",
+                "upstream_id": "zai-org/GLM-5.2",
+                "display_name": "GLM 5.2",
+                "context_length": 524288,
+                "endpoints": ["chat/completions"],
+            },
+            "z-ai/glm-5.2-fast": {
+                "id": "z-ai/glm-5.2-fast",
+                "upstream_id": "zai-org/GLM-5.2-Fast",
+                "display_name": "GLM 5.2 Fast",
+                "context_length": 524288,
+                "endpoints": ["chat/completions"],
+            },
+        },
+    )
+    result = ProviderPricingResult(
+        slug="baseten",
+        source="api",
+        fetched_url=baseten.URL,
+        prices={
+            "z-ai/glm-5.2": ModelPrice(
+                1_400_000,
+                4_400_000,
+                prompt_cached_micro_per_m=140_000,
+            ),
+            "z-ai/glm-5.2-fast": ModelPrice(
+                2_100_000,
+                6_600_000,
+                prompt_cached_micro_per_m=210_000,
+            ),
+        },
+    )
+
+    notes = baseten.write_provider_manifest(result)
+
+    assert notes == ["baseten: refreshed provider_models/baseten.json (2 priced rows, appended 1)"]
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert raw["model_count"] == 2
+    assert by_id["z-ai/glm-5.2"]["context_length"] == 524288
+    assert by_id["z-ai/glm-5.2"]["cached_input_token_price_per_m"] == 140_000
+    assert by_id["z-ai/glm-5.2-fast"] == {
+        "display_name": "GLM 5.2 Fast",
+        "title": "zai-org/GLM-5.2-Fast",
+        "model_type": "chat",
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "endpoints": ["chat/completions"],
+        "status": 1,
+        "id": "z-ai/glm-5.2-fast",
+        "upstream_id": "zai-org/GLM-5.2-Fast",
+        "context_length": 524288,
+        "input_token_price_per_m": 2_100_000,
+        "output_token_price_per_m": 6_600_000,
+        "cached_input_token_price_per_m": 210_000,
+    }
 
 
 def test_wafer_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # noqa: ANN001

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -102,6 +102,10 @@ def test_cerebras_discovery_uses_canonical_ids_and_ignores_unknown_models() -> N
     assert check_price_coverage._cerebras_model_id("unknown") is None
 
 
+def test_baseten_discovery_maps_glm_fast_native_id() -> None:
+    assert check_price_coverage._baseten_model_id("zai-org/GLM-5.2-Fast") == "z-ai/glm-5.2-fast"
+
+
 def test_novita_discovery_ignores_internal_aliases_but_catches_public_families() -> None:
     assert check_price_coverage._novita_model_id("ai_infer_test_1") is None
     assert check_price_coverage._novita_model_id("bunny") is None

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -656,6 +656,26 @@ def test_fireworks_catalog_exposes_glm_52_fast_router() -> None:
     }
 
 
+def test_baseten_catalog_exposes_glm_52_fast_router() -> None:
+    endpoints = endpoints_for_model("z-ai/glm-5.2-fast")
+    baseten = [endpoint for endpoint in endpoints if endpoint.provider == "baseten"]
+
+    assert {endpoint.usage_type for endpoint in baseten} == {"Credits", "BYOK"}
+    assert {endpoint.upstream_id for endpoint in baseten} == {
+        "zai-org/GLM-5.2-Fast"
+    }
+    assert {endpoint.prompt_price_microdollars_per_million_tokens for endpoint in baseten} == {
+        2_205_000
+    }
+    assert {endpoint.completion_price_microdollars_per_million_tokens for endpoint in baseten} == {
+        6_930_000
+    }
+    assert {
+        endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens
+        for endpoint in baseten
+    } == {220_500}
+
+
 def test_alibaba_catalog_is_staged_but_not_routable_until_entitled() -> None:
     from trusted_router.catalog import GATEWAY_PREPAID_PROVIDER_SLUGS, PROVIDERS
 


### PR DESCRIPTION
## Summary
- publish Baseten `zai-org/GLM-5.2-Fast` as `z-ai/glm-5.2-fast`
- persist authenticated Baseten model discovery into its authoritative provider manifest each hourly refresh
- lock exact upstream pricing, cached-input pricing, native ID, capabilities, and routing contracts
- accept independently verified current Makora price baselines so the spike watchdog no longer blocks on reviewed changes

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (`1853 passed, 33 skipped`)
- strict live coverage: Baseten discovery matched all 13 catalog IDs and all 5 GLM IDs
- direct Baseten non-streaming and streaming PONG, HTTP 200 with `[DONE]`

## Safety note
The strict live audit still flags an unrelated newly free Novita model (`inclusionai/ling-3.0-flash`) for explicit price review. It is not silently published by this PR.