### PR TITLE
Schedule Baseten July 24 model retirements

### DIFF
--- a/scripts/pricing/providers/baseten.py
+++ b/scripts/pricing/providers/baseten.py
@@ -25,6 +25,7 @@ from scripts.pricing.base import (
 )
 from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.openai_catalog import discover_openai_chat_catalog
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "baseten"
 URL = "https://inference.baseten.co/v1/models"
@@ -88,6 +89,24 @@ def fetch() -> ProviderPricingResult:
         explicit_map=_NATIVE_TO_OR_ID,
         upstream_id_map=UPSTREAM_ID_MAP,
     )
+    prices = {
+        model_id: price
+        for model_id, price in prices.items()
+        if not provider_model_retired(
+            SLUG,
+            model_id,
+            str(discovered.get(model_id, {}).get("upstream_id") or ""),
+        )
+    }
+    discovered = {
+        model_id: row
+        for model_id, row in discovered.items()
+        if not provider_model_retired(
+            SLUG,
+            model_id,
+            str(row.get("upstream_id") or ""),
+        )
+    }
     _DISCOVERED_MANIFEST_ROWS = discovered
 
     notes: list[str] = []

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 
 PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
 TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
+BASETEN_JULY_2026_RETIREMENT_AT = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 
@@ -31,6 +32,30 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Baseten announced that these Model API routes become inactive at
+    # 2026-07-24 17:00 PT, which is 2026-07-25 00:00 UTC. Dedicated
+    # deployments and other providers serving the same checkpoints are
+    # unaffected.
+    _Retirement(
+        provider="baseten",
+        model_ids=frozenset(
+            {
+                "z-ai/glm-5",
+                "z-ai/glm-5.1",
+                "moonshotai/kimi-k2.5",
+                "nvidia/nemotron-120b-a12b",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "zai-org/GLM-5",
+                "zai-org/GLM-5.1",
+                "moonshotai/Kimi-K2.5",
+                "nvidia/Nemotron-120B-A12B",
+            }
+        ),
+        effective_at=BASETEN_JULY_2026_RETIREMENT_AT,
+    ),
     # Parasail announced that these three serverless routes retire on
     # 2026-08-04. The notice did not specify a time zone, so use 00:00 UTC as
     # the conservative cutover. Other providers serving the same checkpoints

--- a/tests/test_baseten_july_2026_lifecycle.py
+++ b/tests/test_baseten_july_2026_lifecycle.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import baseten
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
+_RETIRING = {
+    "z-ai/glm-5": "zai-org/GLM-5",
+    "z-ai/glm-5.1": "zai-org/GLM-5.1",
+    "moonshotai/kimi-k2.5": "moonshotai/Kimi-K2.5",
+    "nvidia/nemotron-120b-a12b": "nvidia/Nemotron-120B-A12B",
+}
+_SUCCESSORS = {
+    "z-ai/glm-5.2": "zai-org/GLM-5.2",
+    "z-ai/glm-5.2-fast": "zai-org/GLM-5.2-Fast",
+    "moonshotai/kimi-k2.6": "moonshotai/Kimi-K2.6",
+    "moonshotai/kimi-k2.7-code": "moonshotai/Kimi-K2.7-Code",
+    "nvidia/nemotron-3-ultra-550b-a55b": (
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
+    ),
+}
+
+
+def test_baseten_routes_retire_at_announced_instant() -> None:
+    for model_id, upstream_id in _RETIRING.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "baseten",
+            model_id,
+            upstream_id,
+            at=_CUTOFF - timedelta(microseconds=1),
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "baseten",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+    for model_id, upstream_id in _SUCCESSORS.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "baseten",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+
+def test_baseten_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    for model_id in _RETIRING:
+        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+        assert "baseten" not in providers
+        if model_id == "nvidia/nemotron-120b-a12b":
+            assert not providers
+        else:
+            assert providers
+
+    for model_id in _SUCCESSORS:
+        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+        assert "baseten" in providers
+
+
+def test_hourly_refresh_cannot_restore_retired_baseten_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prices = {
+        model_id: ModelPrice(1_000_000, 3_000_000)
+        for model_id in {*_RETIRING, *_SUCCESSORS}
+    }
+    result = ProviderPricingResult(
+        slug="baseten",
+        prices=prices,
+        source="api",
+        fetched_url=baseten.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"baseten": result})
+    for model_id in _RETIRING:
+        assert "baseten" in before[model_id]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"baseten": result})
+    for model_id in _RETIRING:
+        assert model_id not in after
+    for model_id in _SUCCESSORS:
+        assert "baseten" in after[model_id]
+
+
+def test_baseten_parser_filters_retired_rows_from_stale_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": upstream_id,
+                "pricing": {"input": "0.000001", "output": "0.000003"},
+            }
+            for upstream_id in {*_RETIRING.values(), *_SUCCESSORS.values()}
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(baseten.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = baseten.fetch()
+    assert set(_RETIRING).issubset(before.prices)
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = baseten.fetch()
+    assert set(_RETIRING).isdisjoint(after.prices)
+    assert set(_RETIRING).isdisjoint(baseten._DISCOVERED_MANIFEST_ROWS)
+    assert set(_SUCCESSORS).issubset(after.prices)
+
+
+def test_baseten_native_mappings_match_announced_routes() -> None:
+    for model_id, upstream_id in _RETIRING.items():
+        assert baseten.UPSTREAM_ID_MAP[model_id] == upstream_id
+    for model_id, upstream_id in _SUCCESSORS.items():
+        assert baseten.UPSTREAM_ID_MAP[model_id] == upstream_id


### PR DESCRIPTION
Summary:
- Retire Baseten GLM 5, GLM 5.1, Kimi K2.5, and Nemotron 120B exactly at 2026-07-25 00:00 UTC, July 24 5 PM PT.
- Keep retirement provider scoped so routes from other providers remain available.
- Filter retired rows from Baseten discovery so a stale live feed cannot restore them.
- Leave GLM 5.2, GLM 5.2 Fast, Kimi K2.6, Kimi K2.7 Code, and Nemotron 3 Ultra untouched.

Verification:
- Full pytest: 1858 passed, 33 skipped.
- Mypy passed.
- Ruff passed.
- Authenticated Baseten model catalog inspection confirmed the exact four upstream IDs remain live before cutoff.