### PR TITLE
Add Anthropic Claude Opus 5

### DIFF
--- a/scripts/pricing/parsers/anthropic.py
+++ b/scripts/pricing/parsers/anthropic.py
@@ -13,21 +13,11 @@
 """Anthropic pricing-page parser."""
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
+
 from bs4 import BeautifulSoup
 
-# Display name on anthropic.com → OR-canonical id. Extended over time.
-_NAME_TO_OR_ID = {
-    "Opus 4.7": "anthropic/claude-opus-4.7",
-    "Sonnet 4.6": "anthropic/claude-sonnet-4.6",
-    "Haiku 4.5": "anthropic/claude-haiku-4.5",
-    "Opus 4.6": "anthropic/claude-opus-4.6",
-    "Sonnet 4.5": "anthropic/claude-sonnet-4.5",
-    "Opus 4.5": "anthropic/claude-opus-4.5",
-    "Opus 4.1": "anthropic/claude-opus-4.1",
-    "Sonnet 4": "anthropic/claude-sonnet-4",
-    "Opus 4": "anthropic/claude-opus-4",
-    "Haiku 4": "anthropic/claude-haiku-4",
-}
+_MODEL_FAMILIES = {"Fable", "Opus", "Sonnet", "Haiku"}
 
 
 def parse(html: str) -> dict:
@@ -35,9 +25,14 @@ def parse(html: str) -> dict:
     out: dict = {}
     for heading in soup.select("h3.card_pricing_title_text"):
         name = heading.get_text(strip=True)
-        or_id = _NAME_TO_OR_ID.get(name)
-        if or_id is None:
+        parts = name.split()
+        if (
+            len(parts) != 2
+            or parts[0] not in _MODEL_FAMILIES
+            or not parts[1].replace(".", "", 1).isdigit()
+        ):
             continue
+        or_id = f"anthropic/claude-{parts[0].lower()}-{parts[1]}"
         # The card container is two levels up from the heading.
         card = heading.parent.parent if heading.parent else None
         if card is None:
@@ -47,12 +42,20 @@ def parse(html: str) -> dict:
         if len(spans) < 2:
             continue
         try:
-            prompt_usd = float(spans[0].get("data-value") or spans[0].text)
-            completion_usd = float(spans[1].get("data-value") or spans[1].text)
-        except (TypeError, ValueError):
+            prompt_usd = Decimal(spans[0].get("data-value") or spans[0].text)
+            completion_usd = Decimal(spans[1].get("data-value") or spans[1].text)
+            cache_read_usd = (
+                Decimal(spans[3].get("data-value") or spans[3].text)
+                if len(spans) >= 4
+                else None
+            )
+        except (InvalidOperation, TypeError, ValueError):
             continue
-        out[or_id] = {
-            "prompt_micro_per_m": int(round(prompt_usd * 1_000_000)),
-            "completion_micro_per_m": int(round(completion_usd * 1_000_000)),
+        row = {
+            "prompt_micro_per_m": int(prompt_usd * 1_000_000),
+            "completion_micro_per_m": int(completion_usd * 1_000_000),
         }
+        if cache_read_usd is not None:
+            row["prompt_cached_micro_per_m"] = int(cache_read_usd * 1_000_000)
+        out[or_id] = row
     return out

--- a/scripts/pricing/providers/anthropic.py
+++ b/scripts/pricing/providers/anthropic.py
@@ -1,23 +1,254 @@
-"""Anthropic — human-only provider config.
+"""Anthropic first-party model discovery and pricing.
 
-Hardcoded URL and the set of model IDs we expect to find on Anthropic's
-pricing page (drift detector). The LLM never reads or writes this file.
+The authenticated Models API is authoritative for account availability and
+capabilities. Anthropic's public pricing page is authoritative for token
+prices. Keeping both in one provider adapter lets the hourly refresh publish a
+new Claude release without waiting for a downstream catalog.
 """
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from scripts.pricing.base import ProviderPricingResult, fetch_json, fetch_provider
+from scripts.pricing.manifest import write_discovered_chat_manifest
 
 SLUG = "anthropic"
 URL = "https://www.anthropic.com/pricing"
+MODELS_URL = "https://api.anthropic.com/v1/models?limit=1000"
+API_KEY_ENV = "ANTHROPIC_API_KEY"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "anthropic.json"
+)
 # Model IDs we expect Anthropic to publish on its pricing page. Listed
 # in OpenRouter canonical form (`anthropic/<slug>`) — parsers translate
 # whatever the page says into these IDs.
 EXPECTED_MODELS = [
+    "anthropic/claude-opus-5",
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-fable-5",
+    "anthropic/claude-opus-4.8",
     "anthropic/claude-opus-4.7",
     "anthropic/claude-sonnet-4.6",
     "anthropic/claude-haiku-4.5",
 ]
 
+_DISPLAY_NAME_RE = re.compile(
+    r"^Claude (?P<family>Fable|Opus|Sonnet|Haiku) "
+    r"(?P<version>[0-9]+(?:\.[0-9]+)?)$"
+)
+_CANONICAL_ID_RE = re.compile(
+    r"^anthropic/claude-(?P<family>fable|opus|sonnet|haiku)-"
+    r"(?P<version>[0-9]+(?:\.[0-9]+)?)$"
+)
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+_DISCOVERY_SOURCE_URL = URL
+
+
+def _canonical_model_id(display_name: str) -> str | None:
+    match = _DISPLAY_NAME_RE.fullmatch(display_name.strip())
+    if match is None:
+        return None
+    return (
+        f"anthropic/claude-{match.group('family').lower()}-"
+        f"{match.group('version')}"
+    )
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _capability_supported(capabilities: dict[str, Any], name: str) -> bool:
+    capability = capabilities.get(name)
+    return isinstance(capability, dict) and capability.get("supported") is True
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    api_key = os.environ.get(API_KEY_ENV, "").strip()
+    if not api_key:
+        raise RuntimeError(f"{API_KEY_ENV} is required for Anthropic model discovery")
+
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        raise RuntimeError("Anthropic Models API returned no data list")
+    if payload.get("has_more") is True:
+        raise RuntimeError("Anthropic Models API exceeded the 1000-model discovery page")
+
+    discovered: dict[str, dict[str, Any]] = {}
+    for raw in data:
+        if not isinstance(raw, dict):
+            continue
+        native_id = raw.get("id")
+        display_name = raw.get("display_name")
+        if not isinstance(native_id, str) or not isinstance(display_name, str):
+            continue
+        model_id = _canonical_model_id(display_name)
+        context_length = _positive_int(raw.get("max_input_tokens"))
+        max_output_tokens = _positive_int(raw.get("max_tokens"))
+        if model_id is None or context_length is None or max_output_tokens is None:
+            continue
+
+        capabilities = raw.get("capabilities")
+        capabilities = capabilities if isinstance(capabilities, dict) else {}
+        features = ["function-calling"]
+        if _capability_supported(capabilities, "structured_outputs"):
+            features.append("structured-outputs")
+        if _capability_supported(capabilities, "thinking"):
+            features.append("reasoning")
+
+        input_modalities = ["text"]
+        if _capability_supported(capabilities, "image_input"):
+            input_modalities.append("image")
+
+        discovered[model_id] = {
+            "id": model_id,
+            "display_name": display_name,
+            "title": native_id,
+            "context_length": context_length,
+            "max_output_tokens": max_output_tokens,
+            "model_type": "chat",
+            "features": features,
+            "input_modalities": input_modalities,
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "upstream_id": native_id,
+            "created_at": raw.get("created_at"),
+            "status": 1,
+        }
+    if not discovered:
+        raise RuntimeError("Anthropic Models API returned no supported Claude models")
+    return discovered
+
+
+def _known_manifest_model_ids() -> frozenset[str]:
+    return frozenset(_manifest_rows_by_id())
+
+
+def _manifest_rows_by_id() -> dict[str, dict[str, Any]]:
+    try:
+        raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    return {
+        model_id: dict(row)
+        for row in rows
+        if isinstance(row, dict)
+        and isinstance((model_id := row.get("id")), str)
+        and model_id
+    }
+
+
+def _family_and_version(model_id: str) -> tuple[str, tuple[int, int]] | None:
+    match = _CANONICAL_ID_RE.fullmatch(model_id)
+    if match is None:
+        return None
+    parts = tuple(int(part) for part in match.group("version").split("."))
+    return match.group("family"), (parts[0], parts[1] if len(parts) > 1 else 0)
+
+
+def _public_pricing_model_rows(
+    prices: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Build conservative discovery rows when no Models API key is present.
+
+    The public pricing cards expose every current Claude family and price. An
+    existing authenticated row keeps its exact capabilities and token limits.
+    A brand-new row uses the stable dateless Claude ID convention and
+    conservative generation defaults until a keyed refresh enriches it.
+    """
+
+    existing = _manifest_rows_by_id()
+    newest_existing: dict[str, tuple[int, int]] = {}
+    for model_id in existing:
+        parsed = _family_and_version(model_id)
+        if parsed is None:
+            continue
+        family, version = parsed
+        newest_existing[family] = max(newest_existing.get(family, ()), version)
+
+    discovered: dict[str, dict[str, Any]] = {}
+    for model_id in prices:
+        parsed = _family_and_version(model_id)
+        if parsed is None:
+            continue
+        if model_id in existing:
+            discovered[model_id] = existing[model_id]
+            continue
+        family_slug, version_parts = parsed
+        if version_parts <= newest_existing.get(family_slug, ()):
+            continue
+
+        slug = model_id.removeprefix("anthropic/")
+        parts = slug.split("-")
+        if len(parts) < 3:
+            continue
+        family = parts[1].title()
+        version = ".".join(parts[2:])
+        major_text = parts[2].split(".", 1)[0]
+        major = int(major_text) if major_text.isdigit() else 0
+        discovered[model_id] = {
+            "id": model_id,
+            "display_name": f"Claude {family} {version}",
+            "title": slug.replace(".", "-"),
+            "context_length": 1_000_000 if major >= 5 else 200_000,
+            "max_output_tokens": 128_000 if major >= 5 else 64_000,
+            "model_type": "chat",
+            "features": ["function-calling"],
+            "input_modalities": ["text", "image"],
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "upstream_id": slug.replace(".", "-"),
+            "status": 1,
+        }
+    return discovered
+
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(slug=SLUG, url=URL, expected_models=EXPECTED_MODELS)
+    global _DISCOVERED_MANIFEST_ROWS, _DISCOVERY_SOURCE_URL  # noqa: PLW0603
+
+    has_api_key = bool(os.environ.get(API_KEY_ENV, "").strip())
+    discovered = _live_model_rows() if has_api_key else {}
+    required = frozenset(discovered) - _known_manifest_model_ids()
+    result = fetch_provider(
+        slug=SLUG,
+        url=URL,
+        expected_models=EXPECTED_MODELS,
+        required_models=required,
+    )
+    if not discovered:
+        discovered = _public_pricing_model_rows(result.prices)
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    _DISCOVERY_SOURCE_URL = MODELS_URL if has_api_key else URL
+    source = "account" if has_api_key else "public pricing"
+    result.notes.append(f"discovered {len(discovered)} Anthropic {source} models")
+    return result
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=_DISCOVERY_SOURCE_URL,
+    )

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -725,7 +725,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                 context_length=context_length,
                 upstream_id=upstream_id,
                 supports_chat=True,
-                supports_messages=False,
+                supports_messages=publisher == "anthropic",
                 # Availability comes from the explicit provider-native
                 # endpoints below. Do not let _build_endpoints synthesize
                 # publisher-direct routes for supplemental-only models

--- a/src/trusted_router/data/provider_models/anthropic.json
+++ b/src/trusted_router/data/provider_models/anthropic.json
@@ -1,53 +1,300 @@
 {
-  "_about": "Provider-native supplement for Anthropic-direct models released after the OpenRouter snapshot. The attested gateway maps the dotted catalog id -> Anthropic's dashed id algorithmically (internal/llm/anthropic.go mapModelID: strip 'anthropic/' prefix, then ReplaceAll('.', '-')), so adding a Claude model here usually needs no enclave change. Pricing fields are PROVIDER COST in microdollars/M; the loader applies x1.05 to get the customer price. Claude Sonnet 5 is listed at Anthropic's introductory price through 2026-08-31. Claude Fable 5 is listed but has a catalog-level privacy override because it is not tracked as ZDR.",
+  "_about": "Hourly provider-native Anthropic catalog. Availability, exact upstream IDs, context limits, output limits, and capabilities come from Anthropic's authenticated Models API. Token and cache-read prices come from Anthropic's public pricing page. Pricing fields are provider cost in microdollars/M; the runtime applies the standard customer markup. Anthropic remains non-ZDR in TrustedRouter until its contracted ZDR start date is separately activated.",
   "models": [
     {
       "id": "anthropic/claude-sonnet-5",
       "display_name": "Claude Sonnet 5",
-      "title": "anthropic/claude-sonnet-5",
-      "context_length": 1048576,
-      "max_output_tokens": 64000,
+      "title": "claude-sonnet-5",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
       "input_token_price_per_m": 2000000,
       "output_token_price_per_m": 10000000,
       "model_type": "chat",
-      "features": ["function-calling"],
-      "input_modalities": ["text", "image"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
-      "upstream_id": "anthropic/claude-sonnet-5",
-      "status": 1
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "upstream_id": "claude-sonnet-5",
+      "status": 1,
+      "created_at": "2026-06-29T00:00:00Z",
+      "cached_input_token_price_per_m": 200000
     },
     {
       "id": "anthropic/claude-opus-4.8",
       "display_name": "Claude Opus 4.8",
-      "title": "anthropic/claude-opus-4.8",
-      "context_length": 200000,
-      "max_output_tokens": 64000,
-      "input_token_price_per_m": 4500000,
-      "output_token_price_per_m": 22500000,
+      "title": "claude-opus-4-8",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "input_token_price_per_m": 5000000,
+      "output_token_price_per_m": 25000000,
       "model_type": "chat",
-      "features": ["function-calling"],
-      "input_modalities": ["text", "image"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
-      "upstream_id": "anthropic/claude-opus-4.8",
-      "status": 1
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "upstream_id": "claude-opus-4-8",
+      "status": 1,
+      "created_at": "2026-05-28T00:00:00Z",
+      "cached_input_token_price_per_m": 500000
     },
     {
       "id": "anthropic/claude-fable-5",
       "display_name": "Claude Fable 5",
-      "title": "anthropic/claude-fable-5",
+      "title": "claude-fable-5",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "input_token_price_per_m": 10000000,
+      "output_token_price_per_m": 50000000,
+      "model_type": "chat",
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "upstream_id": "claude-fable-5",
+      "status": 1,
+      "created_at": "2026-06-07T00:00:00Z",
+      "cached_input_token_price_per_m": 1000000
+    },
+    {
+      "display_name": "Claude Haiku 4.5",
+      "title": "claude-haiku-4-5-20251001",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-haiku-4.5",
       "context_length": 200000,
       "max_output_tokens": 64000,
-      "input_token_price_per_m": 9000000,
-      "output_token_price_per_m": 45000000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-haiku-4-5-20251001",
+      "created_at": "2025-10-15T00:00:00Z",
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 5000000,
+      "cached_input_token_price_per_m": 100000
+    },
+    {
+      "display_name": "Claude Opus 4.5",
+      "title": "claude-opus-4-5-20251101",
       "model_type": "chat",
-      "features": ["function-calling"],
-      "input_modalities": ["text", "image"],
-      "output_modalities": ["text"],
-      "endpoints": ["chat/completions"],
-      "upstream_id": "anthropic/claude-fable-5",
-      "status": 1
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-opus-4.5",
+      "context_length": 200000,
+      "max_output_tokens": 64000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-opus-4-5-20251101",
+      "created_at": "2025-11-24T00:00:00Z",
+      "input_token_price_per_m": 5000000,
+      "output_token_price_per_m": 25000000,
+      "cached_input_token_price_per_m": 500000
+    },
+    {
+      "display_name": "Claude Opus 4.6",
+      "title": "claude-opus-4-6",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-opus-4.6",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-opus-4-6",
+      "created_at": "2026-02-04T00:00:00Z",
+      "input_token_price_per_m": 5000000,
+      "output_token_price_per_m": 25000000,
+      "cached_input_token_price_per_m": 500000
+    },
+    {
+      "display_name": "Claude Opus 4.7",
+      "title": "claude-opus-4-7",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-opus-4.7",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-opus-4-7",
+      "created_at": "2026-04-14T00:00:00Z",
+      "input_token_price_per_m": 5000000,
+      "output_token_price_per_m": 25000000,
+      "cached_input_token_price_per_m": 500000
+    },
+    {
+      "display_name": "Claude Opus 5",
+      "title": "claude-opus-5",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-opus-5",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-opus-5",
+      "created_at": "2026-07-24T00:00:00Z",
+      "input_token_price_per_m": 5000000,
+      "output_token_price_per_m": 25000000,
+      "cached_input_token_price_per_m": 500000
+    },
+    {
+      "display_name": "Claude Sonnet 4.5",
+      "title": "claude-sonnet-4-5-20250929",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-sonnet-4.5",
+      "context_length": 1000000,
+      "max_output_tokens": 64000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-sonnet-4-5-20250929",
+      "created_at": "2025-09-29T00:00:00Z",
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000
+    },
+    {
+      "display_name": "Claude Sonnet 4.6",
+      "title": "claude-sonnet-4-6",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "anthropic/claude-sonnet-4.6",
+      "context_length": 1000000,
+      "max_output_tokens": 128000,
+      "features": [
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "upstream_id": "claude-sonnet-4-6",
+      "created_at": "2026-02-17T00:00:00Z",
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000
     }
-  ]
+  ],
+  "provider": "anthropic",
+  "source": "https://api.anthropic.com/v1/models?limit=1000",
+  "generated_at": "2026-07-25T00:15:15Z",
+  "price_scale": "microdollars_per_million",
+  "model_count": 10
 }

--- a/tests/test_anthropic_model_discovery.py
+++ b/tests/test_anthropic_model_discovery.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.parsers import anthropic as anthropic_parser
+from scripts.pricing.providers import anthropic
+from trusted_router.catalog import (
+    MODELS,
+    endpoint_zero_data_retention,
+    endpoints_for_model,
+)
+
+
+def _opus_5_api_row() -> dict[str, object]:
+    return {
+        "type": "model",
+        "id": "claude-opus-5",
+        "display_name": "Claude Opus 5",
+        "created_at": "2026-07-24T00:00:00Z",
+        "max_input_tokens": 1_000_000,
+        "max_tokens": 128_000,
+        "capabilities": {
+            "image_input": {"supported": True},
+            "structured_outputs": {"supported": True},
+            "thinking": {"supported": True, "types": {"adaptive": {"supported": True}}},
+        },
+    }
+
+
+def test_anthropic_parser_discovers_future_claude_names_and_cache_price() -> None:
+    html = """
+    <div class="card">
+      <div><h3 class="card_pricing_title_text">Opus 6</h3></div>
+      <span class="tokens_main_val_number" data-value="5"></span>
+      <span class="tokens_main_val_number" data-value="25"></span>
+      <span class="tokens_main_val_number" data-value="6.25"></span>
+      <span class="tokens_main_val_number" data-value="0.50"></span>
+    </div>
+    """
+
+    assert anthropic_parser.parse(html)["anthropic/claude-opus-6"] == {
+        "prompt_micro_per_m": 5_000_000,
+        "completion_micro_per_m": 25_000_000,
+        "prompt_cached_micro_per_m": 500_000,
+    }
+
+
+def test_anthropic_models_api_row_preserves_native_id_and_capabilities(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        anthropic,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [_opus_5_api_row()],
+            "has_more": False,
+        },
+    )
+
+    rows = anthropic._live_model_rows()
+
+    assert rows == {
+        "anthropic/claude-opus-5": {
+            "id": "anthropic/claude-opus-5",
+            "display_name": "Claude Opus 5",
+            "title": "claude-opus-5",
+            "context_length": 1_000_000,
+            "max_output_tokens": 128_000,
+            "model_type": "chat",
+            "features": ["function-calling", "structured-outputs", "reasoning"],
+            "input_modalities": ["text", "image"],
+            "output_modalities": ["text"],
+            "endpoints": ["chat/completions"],
+            "upstream_id": "claude-opus-5",
+            "created_at": "2026-07-24T00:00:00Z",
+            "status": 1,
+        }
+    }
+
+
+def test_anthropic_fetch_requires_price_for_newly_discovered_model(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(
+        anthropic,
+        "_live_model_rows",
+        lambda: {
+            "anthropic/claude-opus-5": {
+                "id": "anthropic/claude-opus-5",
+                "upstream_id": "claude-opus-5",
+            }
+        },
+    )
+    monkeypatch.setattr(anthropic, "_known_manifest_model_ids", frozenset)
+
+    def fake_fetch_provider(**kwargs):
+        captured.update(kwargs)
+        return ProviderPricingResult(
+            slug="anthropic",
+            prices={
+                "anthropic/claude-opus-5": ModelPrice(
+                    5_000_000,
+                    25_000_000,
+                    prompt_cached_micro_per_m=500_000,
+                )
+            },
+            source="deterministic",
+        )
+
+    monkeypatch.setattr(anthropic, "fetch_provider", fake_fetch_provider)
+
+    result = anthropic.fetch()
+
+    assert captured["required_models"] == frozenset({"anthropic/claude-opus-5"})
+    assert result.notes == ["discovered 1 Anthropic account models"]
+
+
+def test_anthropic_fetch_discovers_new_model_without_secret_access(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(anthropic, "_manifest_rows_by_id", dict)
+
+    def fake_fetch_provider(**_kwargs):
+        return ProviderPricingResult(
+            slug="anthropic",
+            prices={"anthropic/claude-opus-6": ModelPrice(5_000_000, 25_000_000)},
+            source="deterministic",
+        )
+
+    monkeypatch.setattr(anthropic, "fetch_provider", fake_fetch_provider)
+
+    result = anthropic.fetch()
+    discovered = anthropic._DISCOVERED_MANIFEST_ROWS["anthropic/claude-opus-6"]
+
+    assert result.notes == ["discovered 1 Anthropic public pricing models"]
+    assert discovered["upstream_id"] == "claude-opus-6"
+    assert discovered["context_length"] == 1_000_000
+    assert discovered["max_output_tokens"] == 128_000
+
+
+def test_anthropic_public_discovery_does_not_resurrect_legacy_models(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        anthropic,
+        "_manifest_rows_by_id",
+        lambda: {
+            "anthropic/claude-opus-5": {
+                "id": "anthropic/claude-opus-5",
+                "upstream_id": "claude-opus-5",
+            }
+        },
+    )
+
+    rows = anthropic._public_pricing_model_rows(
+        {
+            "anthropic/claude-opus-4.1": ModelPrice(15_000_000, 75_000_000),
+            "anthropic/claude-opus-5": ModelPrice(5_000_000, 25_000_000),
+            "anthropic/claude-opus-6": ModelPrice(5_000_000, 25_000_000),
+        }
+    )
+
+    assert set(rows) == {
+        "anthropic/claude-opus-5",
+        "anthropic/claude-opus-6",
+    }
+
+
+def test_anthropic_manifest_writer_publishes_discovered_opus_5(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    manifest = tmp_path / "anthropic.json"
+    manifest.write_text('{"models":[]}\n', encoding="utf-8")
+    monkeypatch.setattr(anthropic, "MANIFEST_PATH", manifest)
+    monkeypatch.setattr(
+        anthropic,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "anthropic/claude-opus-5": {
+                "id": "anthropic/claude-opus-5",
+                "display_name": "Claude Opus 5",
+                "title": "claude-opus-5",
+                "context_length": 1_000_000,
+                "max_output_tokens": 128_000,
+                "model_type": "chat",
+                "features": ["function-calling", "structured-outputs", "reasoning"],
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["text"],
+                "endpoints": ["chat/completions"],
+                "upstream_id": "claude-opus-5",
+                "status": 1,
+            }
+        },
+    )
+    result = ProviderPricingResult(
+        slug="anthropic",
+        prices={
+            "anthropic/claude-opus-5": ModelPrice(
+                5_000_000,
+                25_000_000,
+                prompt_cached_micro_per_m=500_000,
+            )
+        },
+        source="deterministic",
+    )
+
+    anthropic.write_provider_manifest(result)
+    row = json.loads(manifest.read_text(encoding="utf-8"))["models"][0]
+
+    assert row["id"] == "anthropic/claude-opus-5"
+    assert row["upstream_id"] == "claude-opus-5"
+    assert row["input_token_price_per_m"] == 5_000_000
+    assert row["output_token_price_per_m"] == 25_000_000
+    assert row["cached_input_token_price_per_m"] == 500_000
+
+
+def test_opus_5_catalog_is_routable_for_chat_and_messages_but_not_zdr() -> None:
+    model = MODELS["anthropic/claude-opus-5"]
+    endpoints = endpoints_for_model(model.id)
+    anthropic_endpoints = [
+        endpoint for endpoint in endpoints if endpoint.provider == "anthropic"
+    ]
+
+    assert model.context_length == 1_000_000
+    assert model.supports_chat is True
+    assert model.supports_messages is True
+    assert {endpoint.usage_type for endpoint in anthropic_endpoints} == {
+        "Credits",
+        "BYOK",
+    }
+    assert {endpoint.upstream_id for endpoint in anthropic_endpoints} == {
+        "claude-opus-5"
+    }
+    assert {
+        (
+            endpoint.prompt_price_microdollars_per_million_tokens,
+            endpoint.completion_price_microdollars_per_million_tokens,
+        )
+        for endpoint in anthropic_endpoints
+    } == {(5_250_000, 26_250_000)}
+    assert all(
+        endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens
+        == 525_000
+        for endpoint in anthropic_endpoints
+    )
+    assert not any(endpoint_zero_data_retention(endpoint) for endpoint in endpoints)


### PR DESCRIPTION
## Summary
- publish `anthropic/claude-opus-5` with Anthropic-native ID, 1M context, 128k output, vision, structured output, reasoning, cache pricing, Chat and Messages support
- add optional authenticated Anthropic Models API discovery and generic public pricing discovery for future Claude releases
- prevent public pricing discovery from resurrecting retired Claude versions

## Verification
- direct Anthropic `claude-opus-5` smoke: exact `PONG`
- authenticated and no-secret live discovery smokes
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1865 passed, 33 skipped)