### PR TITLE
Add sustained top-200 throughput probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,21 @@ Workers should run from `us-central1` and `europe-west4`, using a dedicated
 auto-refill. Raw samples are append-only Bigtable rows; public status pages
 read compact rollups exposed at `/status`, `/status.json`, and
 `/status/history?window=5m|24h|daily`. Synthetic generations use the
-`TrustedRouter Synthetic` app label and are excluded from public provider
-benchmark/ranking samples so uptime probes do not pollute customer analytics.
+`TrustedRouter Synthetic` app label and are excluded from customer/app
+analytics.
+
+Provider measurement uses two independent probe classes:
+
+- Short PONG probes randomly cover the full active catalog and measure uptime,
+  TTFB, TTFT, and upstream API drift.
+- A sustained 512-token stream covers the 200 most important provider/model
+  routes in deterministic rotation from `us-central1`. It measures output
+  tokens per second after the first token. Long-probe failures never count
+  against provider uptime or API-drift alerts.
+
+The current two-minute schedule gives each sustained route about 25 samples per
+week and 108 per 30 days. CI calculates a full-cap spend estimate from the live
+catalog and fails if it exceeds the reviewed monthly ceiling.
 
 Status separates three SLO classes instead of blending them:
 

--- a/docs/design/provider-latency-probe.md
+++ b/docs/design/provider-latency-probe.md
@@ -22,8 +22,8 @@ Every production inference already writes a privacy-safe `ProviderBenchmarkSampl
 tenant identifiers, no prompt/output. It carries `first_token_milliseconds`
 (TTFT), `ttfb_milliseconds` (TTFB), `elapsed_milliseconds`, `status`,
 `speed_tokens_per_second`, `error_type/status`, region, and an internal
-`source` field (`organic` | `synthetic`). Indexed in Bigtable by provider and
-provider#model.
+`source` field (`organic` | `synthetic` | `synthetic_throughput`). Indexed in
+Bigtable by provider and provider#model.
 
 ### Synthetic rotation probe (coverage + drift)
 `provider_rotation_probe()` (`synthetic/probes.py`) is "just a synthetic user":
@@ -36,10 +36,25 @@ to `POST /internal/synthetic/benchmark` — deliberately separate from the
 `/status` router-health SLO. Dark-launched behind `TR_SYNTHETIC_ROTATION_ENABLED`
 (+ `TR_SYNTHETIC_ROTATION_PER_PASS`).
 
+### Sustained throughput probe
+`provider_throughput_probe()` measures real post-first-token decode speed rather
+than dividing token count by total request latency. A deterministic selector
+chooses 200 routes: every active chat provider receives one slot, models used by
+TrustedRouter aliases and orchestration presets rank first, recent launches get
+a bounded bonus, and measured provider rank breaks ties.
+
+The US monitor runs one sustained route every two minutes with a 512-token cap.
+That is 3.6 samples per route per day, roughly 25 per week and 108 per 30 days.
+The probe requires final provider usage, discards response bytes, and persists
+only token counts, timing, route, finish reason, and calculated cost. These
+samples use `source="synthetic_throughput"` and contribute only throughput:
+they cannot change uptime, TTFT, API drift, route-health alerts, or app usage.
+
 ### Aggregation + surfaces
-`synthetic/leaderboard.py` aggregates samples (organic + synthetic combined;
-`source` not surfaced publicly) into per-model and per-provider stats. Surfaced,
-all behind short caches (no per-view store scan):
+`synthetic/leaderboard.py` aggregates organic and short synthetic samples for
+availability/latency. When sustained samples exist for a route, their median
+replaces the older end-to-end token-rate estimate. `source` is not surfaced
+publicly. All pages remain behind short caches (no per-view store scan):
 - **`/leaderboard`** — ranked providers + models by measured TTFT/TTFB/throughput/uptime.
 - **`/models/{id}/performance`** — per-provider measured table for that model.
 - **`/providers/{slug}`** — provider aggregate + per-model table.
@@ -63,9 +78,11 @@ provider/model only. Probe content is "reply exactly PONG". No content is ever
 read by the probe or proxy. Consistent with the "0 prompt/output logs" promise.
 
 ## Cost
-Upstream tokens only; folds into the existing per-minute monitor job (no new
-infra). Two-stage random over prepaid endpoints, `max_tokens=16` → ~$10–30/mo at
-the launch cadence. Dark-launch flag lets us watch real spend before ramping.
+Upstream tokens only; folds into the existing monitor job with no new service.
+The short random probe remains mostly `max_tokens=16`. The sustained set has a
+512-token cap and one US request per two-minute invocation. A deterministic CI
+test prices all 200 selected routes at their full cap and enforces a reviewed
+$75/month upper bound; the July 2026 catalog projects about $52/month.
 
 ## Shipped in
 PRs #34 (probe + TTFB/source), #35 (drift), #36 (aggregation), #37 (/leaderboard),

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -76,6 +76,18 @@ BASE_ENV_VARS=(
   # synthetic-monitor key).
   "TR_SYNTHETIC_ROTATION_ENABLED=true"
   "TR_SYNTHETIC_ROTATION_PER_PASS=4"
+  # Sustained-output benchmark — one deterministic top-200 route per scheduler
+  # tick, from one region only. At the two-minute schedule this gives every
+  # selected provider/model route 3.6 samples/day (~25/week, ~108/month).
+  # Keeping it separate from the PONG probes preserves cheap, high-frequency
+  # uptime coverage. Long-probe failures never count against provider uptime.
+  "TR_SYNTHETIC_THROUGHPUT_ENABLED=true"
+  "TR_SYNTHETIC_THROUGHPUT_REGION=us-central1"
+  "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT=200"
+  "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
+  "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
+  "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
+  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )

--- a/src/trusted_router/apps.py
+++ b/src/trusted_router/apps.py
@@ -7,6 +7,7 @@ entirely. We surface the app name + request/token counts only — never a
 workspace, key, or any prompt content. Built from the same recent benchmark
 sample set as the performance leaderboard (cached, no per-view live reads).
 """
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -30,7 +31,7 @@ def aggregate_apps(
     direct_tokens = 0
 
     for sample in samples:
-        if sample.source == "synthetic":
+        if sample.source != "organic":
             continue
         name = (sample.app or "").strip()
         folded = name.casefold()
@@ -53,8 +54,7 @@ def aggregate_apps(
         key=lambda name: (-requests[name], name),
     )
     apps = [
-        {"name": name, "requests": requests[name], "tokens": tokens[name]}
-        for name in ordered_names
+        {"name": name, "requests": requests[name], "tokens": tokens[name]} for name in ordered_names
     ]
 
     return {

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -610,10 +610,10 @@ class ProviderBenchmarkSample:
     # string, never tenant content.
     error_message: str | None = None
     region: str | None = None
-    # Internal-only provenance: "organic" (real production traffic) or
-    # "synthetic" (rotation-probe sample). Lets internal queries separate the
-    # two; public ranking pages intentionally combine them without surfacing
-    # this field.
+    # Internal-only provenance: "organic" (real production traffic),
+    # "synthetic" (short rotation probe), or "synthetic_throughput" (sustained
+    # output benchmark). Public ranking pages use the long probe only for
+    # decode throughput, never provider uptime.
     source: str = "organic"
     # Caller-self-reported app name (Generation.app, from the X-Title / Referer
     # header), used by the /apps directory. Privacy-safe: it's the public title

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -18,8 +18,13 @@ from trusted_router.synthetic.probes import (
     gateway_billing_probe,
     gateway_fallback_probe,
     provider_rotation_probe,
+    provider_throughput_probe,
     rotation_candidates,
     run_synthetic_once,
+)
+from trusted_router.synthetic.throughput import (
+    choose_throughput_target,
+    throughput_candidates,
 )
 
 # Inside-a-single-cron-invocation cadence. Cloud Scheduler is minute-granularity
@@ -33,11 +38,20 @@ _DEFAULT_RUN_SPACING_SECONDS = 30.0
 # take per pass. Dark-launched: only runs when TR_SYNTHETIC_ROTATION_ENABLED is
 # truthy, so we can watch real token spend for ~24h before ramping.
 _DEFAULT_ROTATION_PER_PASS = 4
+_DEFAULT_THROUGHPUT_ROUTE_LIMIT = 200
+_DEFAULT_THROUGHPUT_MAX_TOKENS = 512
+_DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS = 128
+_DEFAULT_THROUGHPUT_TIMEOUT_SECONDS = 90.0
+_DEFAULT_THROUGHPUT_INTERVAL_SECONDS = 120
 
 
 async def _one_probe_pass(
-    *, settings: Settings, monitor_region: str, control_plane: str,
-    internal_token: str | None, api_key: str | None,
+    *,
+    settings: Settings,
+    monitor_region: str,
+    control_plane: str,
+    internal_token: str | None,
+    api_key: str | None,
     timeout: httpx.Timeout,
 ) -> list[SyntheticProbeSample]:
     synthetic_task = asyncio.create_task(
@@ -90,6 +104,13 @@ async def _probe_and_rotation_pass(
     rotation_enabled: bool,
     rotation_per_pass: int,
     rotation_rng: random.Random,
+    throughput_enabled: bool = False,
+    throughput_region: str = "us-central1",
+    throughput_route_limit: int = _DEFAULT_THROUGHPUT_ROUTE_LIMIT,
+    throughput_max_tokens: int = _DEFAULT_THROUGHPUT_MAX_TOKENS,
+    throughput_minimum_output_tokens: int = _DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS,
+    throughput_timeout_seconds: float = _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS,
+    throughput_interval_seconds: int = _DEFAULT_THROUGHPUT_INTERVAL_SECONDS,
 ) -> tuple[list[SyntheticProbeSample], list[ProviderBenchmarkSample]]:
     probe_task = asyncio.create_task(
         _one_probe_pass(
@@ -101,25 +122,53 @@ async def _probe_and_rotation_pass(
             timeout=timeout,
         )
     )
+    benchmark_tasks: list[asyncio.Task[list[ProviderBenchmarkSample]]] = []
     if rotation_enabled and api_key:
-        rotation_task = asyncio.create_task(
-            _rotation_pass(
-                settings=settings,
-                monitor_region=monitor_region,
-                api_key=api_key,
-                timeout=timeout,
-                count=rotation_per_pass,
-                rng=rotation_rng,
+        benchmark_tasks.append(
+            asyncio.create_task(
+                _rotation_pass(
+                    settings=settings,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    timeout=timeout,
+                    count=rotation_per_pass,
+                    rng=rotation_rng,
+                )
             )
         )
-        probe_samples, rotation_samples = await asyncio.gather(probe_task, rotation_task)
-        return probe_samples, rotation_samples
-    return await probe_task, []
+    if throughput_enabled and api_key and monitor_region == throughput_region:
+        benchmark_tasks.append(
+            asyncio.create_task(
+                _throughput_pass(
+                    settings=settings,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    route_limit=throughput_route_limit,
+                    max_tokens=throughput_max_tokens,
+                    minimum_output_tokens=throughput_minimum_output_tokens,
+                    timeout_seconds=throughput_timeout_seconds,
+                    interval_seconds=throughput_interval_seconds,
+                )
+            )
+        )
+    if not benchmark_tasks:
+        return await probe_task, []
+    probe_samples, benchmark_groups = await asyncio.gather(
+        probe_task,
+        asyncio.gather(*benchmark_tasks),
+    )
+    benchmark_samples = [sample for group in benchmark_groups for sample in group]
+    return probe_samples, benchmark_samples
 
 
 async def _rotation_pass(
-    *, settings: Settings, monitor_region: str, api_key: str,
-    timeout: httpx.Timeout, count: int, rng: random.Random,
+    *,
+    settings: Settings,
+    monitor_region: str,
+    api_key: str,
+    timeout: httpx.Timeout,
+    count: int,
+    rng: random.Random,
 ) -> list[ProviderBenchmarkSample]:
     pool = rotation_candidates()
     target = SyntheticTarget("rotation", settings.api_base_url, monitor_region)
@@ -143,6 +192,41 @@ async def _rotation_pass(
         if not probes:
             return []
         return list(await asyncio.gather(*probes))
+
+
+async def _throughput_pass(
+    *,
+    settings: Settings,
+    monitor_region: str,
+    api_key: str,
+    route_limit: int,
+    max_tokens: int,
+    minimum_output_tokens: int,
+    timeout_seconds: float,
+    interval_seconds: int,
+) -> list[ProviderBenchmarkSample]:
+    candidates = throughput_candidates(limit=route_limit)
+    picked = choose_throughput_target(
+        candidates,
+        interval_seconds=interval_seconds,
+    )
+    if picked is None:
+        return []
+    provider, model = picked
+    target = SyntheticTarget("throughput", settings.api_base_url, monitor_region)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_seconds)) as client:
+        return [
+            await provider_throughput_probe(
+                client,
+                target,
+                monitor_region=monitor_region,
+                api_key=api_key,
+                provider=provider,
+                model=model,
+                max_tokens=max_tokens,
+                minimum_output_tokens=minimum_output_tokens,
+            )
+        ]
 
 
 async def _post_route_health(
@@ -218,6 +302,55 @@ async def run() -> int:
         int(os.environ.get("TR_SYNTHETIC_ROTATION_PER_PASS", str(_DEFAULT_ROTATION_PER_PASS))),
     )
     rotation_rng = random.Random()  # noqa: S311 - picks which model to probe, not cryptographic
+    throughput_enabled = os.environ.get("TR_SYNTHETIC_THROUGHPUT_ENABLED", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    throughput_region = os.environ.get("TR_SYNTHETIC_THROUGHPUT_REGION", "us-central1")
+    throughput_route_limit = max(
+        0,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT",
+                str(_DEFAULT_THROUGHPUT_ROUTE_LIMIT),
+            )
+        ),
+    )
+    throughput_max_tokens = max(
+        2,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS",
+                str(_DEFAULT_THROUGHPUT_MAX_TOKENS),
+            )
+        ),
+    )
+    throughput_minimum_output_tokens = max(
+        2,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS",
+                str(_DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS),
+            )
+        ),
+    )
+    throughput_timeout_seconds = float(
+        os.environ.get(
+            "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS",
+            str(_DEFAULT_THROUGHPUT_TIMEOUT_SECONDS),
+        )
+    )
+    throughput_interval_seconds = max(
+        1,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS",
+                str(_DEFAULT_THROUGHPUT_INTERVAL_SECONDS),
+            )
+        ),
+    )
 
     all_samples: list[SyntheticProbeSample] = []
     rotation_samples: list[ProviderBenchmarkSample] = []
@@ -233,6 +366,13 @@ async def run() -> int:
             rotation_enabled=rotation_enabled,
             rotation_per_pass=rotation_per_pass,
             rotation_rng=rotation_rng,
+            throughput_enabled=throughput_enabled,
+            throughput_region=throughput_region,
+            throughput_route_limit=throughput_route_limit,
+            throughput_max_tokens=throughput_max_tokens,
+            throughput_minimum_output_tokens=throughput_minimum_output_tokens,
+            throughput_timeout_seconds=throughput_timeout_seconds,
+            throughput_interval_seconds=throughput_interval_seconds,
         )
         all_samples.extend(pass_samples)
         rotation_samples.extend(pass_rotation_samples)

--- a/src/trusted_router/synthetic/drift.py
+++ b/src/trusted_router/synthetic/drift.py
@@ -73,6 +73,10 @@ def aggregate(samples: Iterable[ProviderBenchmarkSample]) -> dict[str, ModelStat
     grouped: dict[str, ModelStats] = {}
     ttfts: dict[str, list[int]] = {}
     for sample in samples:
+        if sample.source == "synthetic_throughput":
+            # Sustained-output probes test performance, not API compatibility.
+            # Their longer timeout/error profile must not create drift alerts.
+            continue
         key = _model_key(sample.provider, sample.model)
         stats = grouped.get(key)
         if stats is None:

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -91,6 +91,7 @@ class ProviderModelStats:
     success_count: int = 0
     error_count: int = 0
     excluded_count: int = 0
+    throughput_sample_count: int = 0
     p50_ttft_ms: int | None = None
     p95_ttft_ms: int | None = None
     p50_ttfb_ms: int | None = None
@@ -126,6 +127,7 @@ class ProviderModelStats:
             "uptime": round(self.uptime, 4),
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
+            "throughput_sample_count": self.throughput_sample_count,
             "top_error": self.top_error,
             "top_excluded": self.top_excluded,
             "errors": dict(self.errors),
@@ -151,6 +153,7 @@ class ProviderStats:
     success_count: int = 0
     error_count: int = 0
     excluded_count: int = 0
+    throughput_sample_count: int = 0
     p50_ttft_ms: int | None = None
     p50_tokens_per_second: float | None = None
     errors: Counter[str] = field(default_factory=Counter)
@@ -182,6 +185,7 @@ class ProviderStats:
             "uptime": round(self.uptime, 4),
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
+            "throughput_sample_count": self.throughput_sample_count,
             "top_error": self.top_error,
             "top_excluded": self.top_excluded,
             "errors": dict(self.errors),
@@ -211,7 +215,8 @@ def aggregate_leaderboard(
     by_model: dict[tuple[str, str], ProviderModelStats] = {}
     ttft: dict[tuple[str, str], list[int]] = {}
     ttfb: dict[tuple[str, str], list[int]] = {}
-    tps: dict[tuple[str, str], list[float]] = {}
+    legacy_tps: dict[tuple[str, str], list[float]] = {}
+    sustained_tps: dict[tuple[str, str], list[float]] = {}
 
     for sample in samples:
         key = (sample.provider, sample.model)
@@ -221,7 +226,18 @@ def aggregate_leaderboard(
             by_model[key] = stats
             ttft[key] = []
             ttfb[key] = []
-            tps[key] = []
+            legacy_tps[key] = []
+            sustained_tps[key] = []
+        if sample.source == "synthetic_throughput":
+            if sample.status == "success" and sample.speed_tokens_per_second:
+                sustained_tps[key].append(sample.speed_tokens_per_second)
+                stats.throughput_sample_count += 1
+            if stats.last_seen is None or sample.created_at > stats.last_seen:
+                stats.last_seen = sample.created_at
+            # Long probes are intentionally excluded from availability and
+            # TTFT. The short PONG probe already measures both without making a
+            # slow 512-token completion look like provider downtime.
+            continue
         label = sample.error_type or (
             f"http_{sample.error_status}" if sample.error_status else "error"
         )
@@ -240,7 +256,7 @@ def aggregate_leaderboard(
         if sample.ttfb_milliseconds is not None:
             ttfb[key].append(sample.ttfb_milliseconds)
         if sample.speed_tokens_per_second:
-            tps[key].append(sample.speed_tokens_per_second)
+            legacy_tps[key].append(sample.speed_tokens_per_second)
         if stats.last_seen is None or sample.created_at > stats.last_seen:
             stats.last_seen = sample.created_at
 
@@ -249,7 +265,7 @@ def aggregate_leaderboard(
         stats.p95_ttft_ms = _percentile(ttft[key], 95)
         stats.p50_ttfb_ms = _percentile(ttfb[key], 50)
         stats.p95_ttfb_ms = _percentile(ttfb[key], 95)
-        stats.p50_tokens_per_second = _median_float(tps[key])
+        stats.p50_tokens_per_second = _median_float(sustained_tps[key] or legacy_tps[key])
 
     models = [s for s in by_model.values() if s.sample_count >= min_samples]
     models.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
@@ -261,6 +277,7 @@ def aggregate_leaderboard(
         "model_count": len(models),
         "provider_count": len(providers),
         "total_samples": sum(s.sample_count for s in models),
+        "total_throughput_samples": sum(s.throughput_sample_count for s in models),
         "excluded_samples": sum(s.excluded_count for s in by_model.values()),
     }
 
@@ -281,13 +298,15 @@ def _aggregate_providers(model_stats: list[ProviderModelStats]) -> list[Provider
         agg.success_count += stats.success_count
         agg.error_count += stats.error_count
         agg.excluded_count += stats.excluded_count
+        agg.throughput_sample_count += stats.throughput_sample_count
         agg.errors.update(stats.errors)
         agg.excluded_reasons.update(stats.excluded_reasons)
         # Weight each model's p50 by its sample count for the provider median.
         if stats.p50_ttft_ms is not None:
             ttft[stats.provider].extend([stats.p50_ttft_ms] * stats.sample_count)
         if stats.p50_tokens_per_second is not None:
-            tps[stats.provider].extend([stats.p50_tokens_per_second] * stats.sample_count)
+            weight = stats.throughput_sample_count or stats.sample_count
+            tps[stats.provider].extend([stats.p50_tokens_per_second] * weight)
     providers = list(by_provider.values())
     for agg in providers:
         agg.p50_ttft_ms = _percentile(ttft[agg.provider], 50)

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -7,7 +7,9 @@ import random
 import secrets
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Any
 from urllib.parse import urljoin
 
@@ -76,9 +78,7 @@ def configured_targets(settings: Settings) -> list[SyntheticTarget]:
                     control_plane_url,
                 )
             continue
-        targets.append(
-            SyntheticTarget(name, api_base_url, name, control_plane_url)
-        )
+        targets.append(SyntheticTarget(name, api_base_url, name, control_plane_url))
     return targets
 
 
@@ -677,17 +677,42 @@ def _provider_display_name(provider: str) -> str:
     return entry.name if entry is not None else provider
 
 
-def _sse_line_has_content(line: str) -> bool:
-    """True if an SSE `data:` line carries a visible content/reasoning delta."""
+@dataclass
+class _StreamUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+
+
+@dataclass
+class _StreamObservation:
+    ttfb_milliseconds: int | None = None
+    first_token_milliseconds: int | None = None
+    last_token_milliseconds: int | None = None
+    elapsed_milliseconds: int = 0
+    finish_reason: str | None = None
+    stream_error: tuple[str, int | None, str | None] | None = None
+    usage: _StreamUsage = dataclass_field(default_factory=_StreamUsage)
+
+
+def _sse_line_payload(line: str) -> dict[str, Any] | None:
     line = line.strip()
     if not line.startswith("data:"):
-        return False
+        return None
     payload = line[len("data:") :].strip()
     if not payload or payload == "[DONE]":
-        return False
+        return None
     try:
         data = json.loads(payload)
     except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _sse_line_has_content(line: str) -> bool:
+    """True if an SSE `data:` line carries a visible content/reasoning delta."""
+    data = _sse_line_payload(line)
+    if data is None:
         return False
     for choice in data.get("choices") or []:
         delta = choice.get("delta") or {}
@@ -716,15 +741,8 @@ def _sse_line_has_content(line: str) -> bool:
 
 def _sse_line_error(line: str) -> tuple[str, int | None, str | None] | None:
     """Return an OpenAI-style SSE error if the data line carries one."""
-    line = line.strip()
-    if not line.startswith("data:"):
-        return None
-    payload = line[len("data:") :].strip()
-    if not payload or payload == "[DONE]":
-        return None
-    try:
-        data = json.loads(payload)
-    except ValueError:
+    data = _sse_line_payload(line)
+    if data is None:
         return None
     error = data.get("error")
     if not isinstance(error, dict):
@@ -742,21 +760,89 @@ def _sse_line_error(line: str) -> tuple[str, int | None, str | None] | None:
 
 def _sse_line_finish_reason(line: str) -> str | None:
     """Return the first choice finish reason from an SSE data line, if any."""
-    line = line.strip()
-    if not line.startswith("data:"):
-        return None
-    payload = line[len("data:") :].strip()
-    if not payload or payload == "[DONE]":
-        return None
-    try:
-        data = json.loads(payload)
-    except ValueError:
+    data = _sse_line_payload(line)
+    if data is None:
         return None
     for choice in data.get("choices") or []:
         reason = choice.get("finish_reason")
         if reason:
             return str(reason)
     return None
+
+
+def _sse_line_usage(line: str) -> _StreamUsage | None:
+    data = _sse_line_payload(line)
+    if data is None:
+        return None
+    usage = data.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    completion_details = usage.get("completion_tokens_details")
+    if not isinstance(completion_details, dict):
+        completion_details = {}
+    return _StreamUsage(
+        input_tokens=_first_int(usage, "prompt_tokens", "input_tokens"),
+        output_tokens=_first_int(usage, "completion_tokens", "output_tokens"),
+        reasoning_tokens=_first_int(completion_details, "reasoning_tokens"),
+    )
+
+
+def _first_int(values: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = values.get(key)
+        if value is None:
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+async def _observe_provider_stream(
+    response: httpx.Response,
+    *,
+    started: float,
+    clock: Callable[[], float] = time.perf_counter,
+) -> _StreamObservation:
+    observation = _StreamObservation()
+    tail = ""
+
+    def observe_line(line: str, now_milliseconds: int) -> None:
+        finish_reason = _sse_line_finish_reason(line)
+        if finish_reason is not None:
+            observation.finish_reason = finish_reason
+        stream_error = _sse_line_error(line)
+        if stream_error is not None:
+            observation.stream_error = stream_error
+            return
+        if _sse_line_has_content(line):
+            if observation.first_token_milliseconds is None:
+                observation.first_token_milliseconds = now_milliseconds
+            observation.last_token_milliseconds = now_milliseconds
+        usage = _sse_line_usage(line)
+        if usage is not None:
+            observation.usage = usage
+
+    async for chunk in response.aiter_bytes():
+        if not chunk:
+            continue
+        now_milliseconds = _elapsed_ms_with_clock(started, clock)
+        if observation.ttfb_milliseconds is None:
+            observation.ttfb_milliseconds = now_milliseconds
+        tail += chunk.decode("utf-8", "ignore")
+        lines = tail.split("\n")
+        tail = lines.pop()
+        for line in lines:
+            observe_line(line, now_milliseconds)
+            if observation.stream_error is not None:
+                break
+        if observation.stream_error is not None:
+            break
+    if tail and observation.stream_error is None:
+        observe_line(tail, _elapsed_ms_with_clock(started, clock))
+    observation.elapsed_milliseconds = _elapsed_ms_with_clock(started, clock)
+    return observation
 
 
 def _response_error(response: httpx.Response) -> tuple[str, int | None, str | None]:
@@ -876,8 +962,6 @@ async def provider_rotation_probe(
     if not _rotation_omits_temperature(provider, model):
         body["temperature"] = 0
     started = time.perf_counter()
-    ttfb_ms: int | None = None
-    ttft_ms: int | None = None
     served_provider = provider
     served_model = model
     try:
@@ -898,37 +982,14 @@ async def provider_rotation_probe(
                     error_type=error_type,
                     error_message=message,
                 )
-            tail = ""
-            finish_reason: str | None = None
-            stream_error: tuple[str, int | None, str | None] | None = None
-            async for chunk in response.aiter_bytes():
-                if not chunk:
-                    continue
-                now = _elapsed_ms(started)
-                if ttfb_ms is None:
-                    ttfb_ms = now
-                tail += chunk.decode("utf-8", "ignore")
-                lines = tail.split("\n")
-                tail = lines.pop()
-                for line in lines:
-                    line_finish_reason = _sse_line_finish_reason(line)
-                    if line_finish_reason is not None:
-                        finish_reason = line_finish_reason
-                    stream_error = _sse_line_error(line)
-                    if stream_error is not None:
-                        break
-                    if ttft_ms is None and _sse_line_has_content(line):
-                        ttft_ms = now
-                if stream_error is not None:
-                    break
-            elapsed_ms = _elapsed_ms(started)
-            if stream_error is not None:
-                error_type, status, message = stream_error
+            observation = await _observe_provider_stream(response, started=started)
+            if observation.stream_error is not None:
+                error_type, status, message = observation.stream_error
                 return _rotation_error_sample(
                     served_provider,
                     served_model,
                     region=monitor_region,
-                    elapsed_ms=elapsed_ms,
+                    elapsed_ms=observation.elapsed_milliseconds,
                     error_status=status or 502,
                     error_type=error_type,
                     error_message=message,
@@ -943,13 +1004,15 @@ async def provider_rotation_probe(
             error_type=exc.__class__.__name__,
             error_message=str(exc),
         )
-    if ttft_ms is None:
-        error_type = "probe_config_error" if finish_reason == "length" else "empty_stream"
+    if observation.first_token_milliseconds is None:
+        error_type = (
+            "probe_config_error" if observation.finish_reason == "length" else "empty_stream"
+        )
         return _rotation_error_sample(
             served_provider,
             served_model,
             region=monitor_region,
-            elapsed_ms=elapsed_ms,
+            elapsed_ms=observation.elapsed_milliseconds,
             error_status=None,
             error_type=error_type,
         )
@@ -961,12 +1024,187 @@ async def provider_rotation_probe(
         status="success",
         usage_type=UsageType.CREDITS,
         streamed=True,
-        elapsed_milliseconds=elapsed_ms,
-        first_token_milliseconds=ttft_ms,
-        ttfb_milliseconds=ttfb_ms,
-        finish_reason=finish_reason or "stop",
+        elapsed_milliseconds=observation.elapsed_milliseconds,
+        first_token_milliseconds=observation.first_token_milliseconds,
+        ttfb_milliseconds=observation.ttfb_milliseconds,
+        finish_reason=observation.finish_reason or "stop",
         region=monitor_region,
         source="synthetic",
+    )
+
+
+_THROUGHPUT_PROMPT = (
+    "Continue writing the lowercase word benchmark separated by single spaces "
+    "until the response token limit stops you. Do not count, explain, use "
+    "punctuation, or stop early."
+)
+
+
+async def provider_throughput_probe(
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    api_key: str,
+    provider: str,
+    model: str,
+    max_tokens: int = 512,
+    minimum_output_tokens: int = 128,
+    clock: Callable[[], float] = time.perf_counter,
+) -> ProviderBenchmarkSample:
+    """Measure sustained output speed after the first streamed token.
+
+    Unlike the tiny PONG rotation probe, this requires provider-reported final
+    usage and enough output tokens for a stable sample. It records metadata
+    only. The response bytes are discarded inside this function and are never
+    returned to the control plane ingest payload.
+    """
+    if max_tokens <= 1:
+        raise ValueError("max_tokens must be greater than one")
+    if minimum_output_tokens <= 1 or minimum_output_tokens > max_tokens:
+        raise ValueError("minimum_output_tokens must be between 2 and max_tokens")
+
+    url = _api_url(target.api_base_url, "/chat/completions")
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": _THROUGHPUT_PROMPT}],
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "provider": {"only": [provider]},
+        "metadata": {
+            "trustedrouter_synthetic": "true",
+            "trustedrouter_probe": "throughput",
+        },
+    }
+    if not _rotation_omits_temperature(provider, model):
+        body["temperature"] = 0
+
+    started = clock()
+    served_provider = provider
+    served_model = model
+    try:
+        async with client.stream(
+            "POST", url, json=body, headers=_auth_headers(api_key)
+        ) as response:
+            served_provider = response.headers.get("x-trustedrouter-provider") or provider
+            served_model = response.headers.get("x-trustedrouter-served-model") or model
+            if response.status_code != 200:
+                await response.aread()
+                error_type, error_status, message = _response_error(response)
+                return _rotation_error_sample(
+                    served_provider,
+                    served_model,
+                    region=monitor_region,
+                    elapsed_ms=_elapsed_ms_with_clock(started, clock),
+                    error_status=error_status,
+                    error_type=error_type,
+                    error_message=message,
+                    source="synthetic_throughput",
+                )
+            observation = await _observe_provider_stream(
+                response,
+                started=started,
+                clock=clock,
+            )
+    except (httpx.HTTPError, ValueError) as exc:
+        return _rotation_error_sample(
+            served_provider,
+            served_model,
+            region=monitor_region,
+            elapsed_ms=_elapsed_ms_with_clock(started, clock),
+            error_status=None,
+            error_type=exc.__class__.__name__,
+            error_message=str(exc),
+            source="synthetic_throughput",
+        )
+
+    if observation.stream_error is not None:
+        error_type, status, message = observation.stream_error
+        return _rotation_error_sample(
+            served_provider,
+            served_model,
+            region=monitor_region,
+            elapsed_ms=observation.elapsed_milliseconds,
+            error_status=status or 502,
+            error_type=error_type,
+            error_message=message,
+            source="synthetic_throughput",
+        )
+
+    usage = observation.usage
+    first_token_ms = observation.first_token_milliseconds
+    last_token_ms = observation.last_token_milliseconds
+    if (
+        usage.output_tokens < minimum_output_tokens
+        or first_token_ms is None
+        or last_token_ms is None
+        or last_token_ms <= first_token_ms
+    ):
+        sample = _rotation_error_sample(
+            served_provider,
+            served_model,
+            region=monitor_region,
+            elapsed_ms=observation.elapsed_milliseconds,
+            error_status=None,
+            error_type="insufficient_throughput_sample",
+            source="synthetic_throughput",
+        )
+        sample.input_tokens = usage.input_tokens
+        sample.output_tokens = usage.output_tokens
+        sample.first_token_milliseconds = first_token_ms
+        sample.ttfb_milliseconds = observation.ttfb_milliseconds
+        sample.finish_reason = observation.finish_reason or "insufficient_sample"
+        return sample
+
+    decode_milliseconds = last_token_ms - first_token_ms
+    speed_tokens_per_second = max(1, usage.output_tokens - 1) * 1000 / decode_milliseconds
+    return ProviderBenchmarkSample(
+        id=f"bench-{uuid.uuid4().hex}",
+        model=served_model,
+        provider=served_provider,
+        provider_name=_provider_display_name(served_provider),
+        status="success",
+        usage_type=UsageType.CREDITS,
+        streamed=True,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        total_cost_microdollars=_benchmark_route_cost_microdollars(
+            served_provider,
+            served_model,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+        ),
+        speed_tokens_per_second=round(speed_tokens_per_second, 3),
+        elapsed_milliseconds=observation.elapsed_milliseconds,
+        first_token_milliseconds=first_token_ms,
+        ttfb_milliseconds=observation.ttfb_milliseconds,
+        finish_reason=observation.finish_reason or "stop",
+        region=monitor_region,
+        source="synthetic_throughput",
+    )
+
+
+def _benchmark_route_cost_microdollars(
+    provider: str,
+    model: str,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+) -> int:
+    from trusted_router.money import token_cost_microdollars
+    from trusted_router.synthetic.throughput import credits_endpoint_prices
+
+    prices = credits_endpoint_prices(provider, model)
+    if prices is None:
+        return 0
+    prompt_price, completion_price = prices
+    return token_cost_microdollars(
+        input_tokens,
+        prompt_price,
+    ) + token_cost_microdollars(
+        output_tokens,
+        completion_price,
     )
 
 
@@ -974,10 +1212,7 @@ def _rotation_max_tokens(provider: str, model: str) -> int:
     provider_l = provider.lower()
     model_l = model.lower()
     if provider_l == "openai" and (
-        "/o1" in model_l
-        or "/o3" in model_l
-        or "/o4" in model_l
-        or "/gpt-5" in model_l
+        "/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l
     ):
         return 512
     if "gemini-2.5" in model_l or "gemini-3" in model_l:
@@ -1015,12 +1250,7 @@ def _rotation_omits_temperature(provider: str, model: str) -> bool:
         (provider_l == "kimi" and "kimi-k2." in model_l)
         or (
             provider_l == "openai"
-            and (
-                "/o1" in model_l
-                or "/o3" in model_l
-                or "/o4" in model_l
-                or "/gpt-5" in model_l
-            )
+            and ("/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l)
         )
         or (
             provider_l == "anthropic"
@@ -1038,6 +1268,7 @@ def _rotation_error_sample(
     error_status: int | None,
     error_type: str,
     error_message: str | None = None,
+    source: str = "synthetic",
 ) -> ProviderBenchmarkSample:
     status = "unsupported" if _rotation_error_excluded_from_uptime(error_type) else "error"
     truncated_error_message = None
@@ -1059,7 +1290,7 @@ def _rotation_error_sample(
         error_status=error_status,
         error_message=truncated_error_message,
         region=region,
-        source="synthetic",
+        source=source,
     )
 
 
@@ -1068,6 +1299,7 @@ def _rotation_error_excluded_from_uptime(error_type: str | None) -> bool:
         "unsupported_route",
         "probe_config_error",
         "provider_auth_config",
+        "insufficient_throughput_sample",
     }
 
 
@@ -1302,3 +1534,10 @@ def _evidence_str(evidence: dict[str, str | bool | None], key: str) -> str | Non
 
 def _elapsed_ms(started: float) -> int:
     return max(1, int(round((time.perf_counter() - started) * 1000)))
+
+
+def _elapsed_ms_with_clock(
+    started: float,
+    clock: Callable[[], float],
+) -> int:
+    return max(1, int(round((clock() - started) * 1000)))

--- a/src/trusted_router/synthetic/throughput.py
+++ b/src/trusted_router/synthetic/throughput.py
@@ -1,0 +1,212 @@
+"""Deterministic route selection and spend bounds for sustained benchmarks."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import time
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from trusted_router.synthetic.probes import rotation_candidates
+
+_RECENT_MODEL_COUNT = 24
+_RECENT_MODEL_BONUS = 5_000
+_RECENT_MODEL_STEP = 50
+
+
+def throughput_candidates(*, limit: int = 200) -> list[tuple[str, str]]:
+    """Return the deterministic high-value provider/model throughput set.
+
+    A route is important when it participates in a public TrustedRouter alias
+    or named orchestration model, is a recent catalog launch, or is the best
+    available representative for a provider. Every active chat provider is
+    represented before the remaining highest-scored routes fill the budget.
+    """
+    if limit <= 0:
+        return []
+
+    from trusted_router.routing import _THROUGHPUT_RANK
+
+    pool = rotation_candidates()
+    routes = [(provider, model) for provider, models in pool.items() for model in models]
+    if not routes:
+        return []
+
+    importance = _model_importance(routes)
+    releases = _model_release_epochs()
+    prices = {route: credits_endpoint_prices(*route) or (2**63 - 1, 2**63 - 1) for route in routes}
+
+    def route_key(route: tuple[str, str]) -> tuple[int, int, int, int, int, str, str]:
+        provider, model = route
+        prompt_price, completion_price = prices[route]
+        return (
+            -importance.get(model, 0),
+            -releases.get(model, 0),
+            _THROUGHPUT_RANK.get(provider, 80),
+            completion_price,
+            prompt_price,
+            model,
+            provider,
+        )
+
+    selected: list[tuple[str, str]] = []
+    # Preserve provider breadth even when one popular model has many hosts.
+    for provider in sorted(pool):
+        provider_routes = [(provider, model) for model in pool[provider]]
+        if provider_routes:
+            selected.append(min(provider_routes, key=route_key))
+
+    for route in sorted(routes, key=route_key):
+        if route not in selected:
+            selected.append(route)
+        if len(selected) >= limit:
+            break
+    return selected[:limit]
+
+
+def choose_throughput_target(
+    candidates: list[tuple[str, str]],
+    *,
+    now_epoch_seconds: float | None = None,
+    interval_seconds: int = 120,
+) -> tuple[str, str] | None:
+    """Choose one route by scheduler time slot, giving exact round-robin coverage."""
+    if not candidates:
+        return None
+    if interval_seconds <= 0:
+        raise ValueError("interval_seconds must be positive")
+    now = time.time() if now_epoch_seconds is None else now_epoch_seconds
+    slot = int(now // interval_seconds)
+    return candidates[slot % len(candidates)]
+
+
+def projected_monthly_cost_microdollars(
+    candidates: list[tuple[str, str]],
+    *,
+    input_tokens: int = 64,
+    output_tokens: int = 512,
+    interval_seconds: int = 120,
+    days: int = 30,
+) -> int:
+    """Conservative full-cap monthly spend for the scheduled route rotation."""
+    if not candidates or days <= 0:
+        return 0
+    if interval_seconds <= 0:
+        raise ValueError("interval_seconds must be positive")
+
+    from trusted_router.money import token_cost_microdollars
+
+    cycle_cost = 0
+    for provider, model in candidates:
+        prices = credits_endpoint_prices(provider, model)
+        if prices is None:
+            continue
+        prompt_price, completion_price = prices
+        cycle_cost += token_cost_microdollars(input_tokens, prompt_price)
+        cycle_cost += token_cost_microdollars(output_tokens, completion_price)
+
+    invocations = days * 24 * 60 * 60 // interval_seconds
+    cycles = (invocations + len(candidates) - 1) // len(candidates)
+    return cycle_cost * cycles
+
+
+def _model_importance(routes: list[tuple[str, str]]) -> dict[str, int]:
+    from trusted_router.catalog import META_MODEL_IDS, meta_candidate_models
+
+    scores: defaultdict[str, int] = defaultdict(int)
+
+    def concrete_models(model_id: str, seen: frozenset[str]) -> list[str]:
+        if model_id in seen:
+            return []
+        next_seen = frozenset((*seen, model_id))
+        concrete: list[str] = []
+        for model in meta_candidate_models(model_id):
+            if model.id in META_MODEL_IDS:
+                concrete.extend(concrete_models(model.id, next_seen))
+            else:
+                concrete.append(model.id)
+        return list(dict.fromkeys(concrete))
+
+    for alias in sorted(META_MODEL_IDS):
+        for index, model_id in enumerate(concrete_models(alias, frozenset())):
+            scores[model_id] += 1_000 + max(0, 100 - index)
+
+    active_models = {model for _, model in routes}
+    recent_models = sorted(
+        active_models,
+        key=lambda model: (-_model_release_epochs().get(model, 0), model),
+    )[:_RECENT_MODEL_COUNT]
+    for index, model_id in enumerate(recent_models):
+        scores[model_id] += _RECENT_MODEL_BONUS - index * _RECENT_MODEL_STEP
+    return dict(scores)
+
+
+def credits_endpoint_prices(provider: str, model: str) -> tuple[int, int] | None:
+    from trusted_router.catalog import MODEL_ENDPOINTS, effective_endpoint
+
+    endpoints = [
+        effective_endpoint(endpoint)
+        for endpoint in MODEL_ENDPOINTS.values()
+        if endpoint.provider == provider
+        and endpoint.model_id == model
+        and endpoint.usage_type == "Credits"
+    ]
+    if not endpoints:
+        return None
+    endpoint = min(
+        endpoints,
+        key=lambda item: (
+            item.completion_price_microdollars_per_million_tokens,
+            item.prompt_price_microdollars_per_million_tokens,
+            item.id,
+        ),
+    )
+    return (
+        endpoint.prompt_price_microdollars_per_million_tokens,
+        endpoint.completion_price_microdollars_per_million_tokens,
+    )
+
+
+@lru_cache(maxsize=1)
+def _model_release_epochs() -> dict[str, int]:
+    """Read optional release timestamps from catalog snapshot/manifests."""
+    data_root = Path(__file__).resolve().parents[1] / "data"
+    paths = [
+        data_root / "openrouter_snapshot.json",
+        *sorted((data_root / "provider_models").glob("*.json")),
+    ]
+    releases: dict[str, int] = {}
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        for row in payload.get("models") or []:
+            if not isinstance(row, dict):
+                continue
+            model_id = str(row.get("id") or "")
+            if not model_id:
+                continue
+            epoch = _release_epoch(row.get("created") or row.get("created_at"))
+            if epoch > releases.get(model_id, 0):
+                releases[model_id] = epoch
+    return releases
+
+
+def _release_epoch(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        pass
+    if not value:
+        return 0
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return int(parsed.timestamp())

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -37,6 +37,7 @@ def test_aggregate_ranks_named_apps_and_buckets_direct() -> None:
         _s("TrustedRouter Gateway"),  # default -> Direct
         _s("TrustedRouter Synthetic"),  # monitor name -> excluded
         _s("Probe", source="synthetic"),  # synthetic source -> excluded
+        _s("Throughput", source="synthetic_throughput"),
     ]
     result = aggregate_apps(samples)
     assert [a["name"] for a in result["apps"]] == ["Acme Chat", "Beta Bot"]

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -18,6 +18,7 @@ def _sample(
     tps: float | None = None,
     error_type: str | None = None,
     error_status: int | None = None,
+    source: str = "organic",
     created_at: str = "2026-06-04T00:00:00Z",
 ) -> ProviderBenchmarkSample:
     return ProviderBenchmarkSample(
@@ -33,6 +34,7 @@ def _sample(
         speed_tokens_per_second=tps,
         error_type=error_type,
         error_status=error_status,
+        source=source,
         created_at=created_at,
     )
 
@@ -102,6 +104,53 @@ def test_empty_samples_produce_empty_leaderboard() -> None:
     assert result["models"] == []
     assert result["providers"] == []
     assert result["total_samples"] == 0
+
+
+def test_sustained_throughput_replaces_legacy_speed_without_affecting_uptime() -> None:
+    samples = [
+        _sample(provider="p", model="p/m", ttft=100, tps=10.0),
+        _sample(
+            provider="p",
+            model="p/m",
+            status="error",
+            error_type="provider_error",
+            error_status=502,
+        ),
+        _sample(
+            provider="p",
+            model="p/m",
+            tps=400.0,
+            source="synthetic_throughput",
+        ),
+        _sample(
+            provider="p",
+            model="p/m",
+            tps=600.0,
+            source="synthetic_throughput",
+        ),
+        _sample(
+            provider="p",
+            model="p/m",
+            status="error",
+            error_type="ReadTimeout",
+            source="synthetic_throughput",
+        ),
+    ]
+
+    result = aggregate_leaderboard(samples)
+    model = result["models"][0]
+    provider = result["providers"][0]
+
+    assert model["sample_count"] == 2
+    assert model["throughput_sample_count"] == 2
+    assert model["uptime"] == 0.5
+    assert model["p50_tokens_per_second"] == 500.0
+    assert provider["sample_count"] == 2
+    assert provider["throughput_sample_count"] == 2
+    assert provider["uptime"] == 0.5
+    assert provider["p50_tokens_per_second"] == 500.0
+    assert result["total_samples"] == 2
+    assert result["total_throughput_samples"] == 2
 
 
 def test_public_benchmark_samples_reads_each_provider(monkeypatch) -> None:
@@ -346,12 +395,27 @@ def test_aggregate_still_counts_real_provider_downtime() -> None:
     # still count against uptime (not silently excluded by the config filter).
     samples = [
         _sample(provider="parasail", model="x/y", ttft=100),
-        _sample(provider="parasail", model="x/y", status="error",
-                error_type="rate_limited", error_status=429),
-        _sample(provider="parasail", model="x/y", status="error",
-                error_type="ttfb_exceeded", error_status=None),
-        _sample(provider="parasail", model="x/y", status="error",
-                error_type="provider_error", error_status=500),
+        _sample(
+            provider="parasail",
+            model="x/y",
+            status="error",
+            error_type="rate_limited",
+            error_status=429,
+        ),
+        _sample(
+            provider="parasail",
+            model="x/y",
+            status="error",
+            error_type="ttfb_exceeded",
+            error_status=None,
+        ),
+        _sample(
+            provider="parasail",
+            model="x/y",
+            status="error",
+            error_type="provider_error",
+            error_status=500,
+        ),
     ]
     result = aggregate_leaderboard(samples)
     model = result["models"][0]

--- a/tests/test_provider_drift.py
+++ b/tests/test_provider_drift.py
@@ -16,6 +16,7 @@ def _sample(
     ttft: int | None = 100,
     error_type: str | None = None,
     error_status: int | None = None,
+    source: str = "synthetic",
 ) -> ProviderBenchmarkSample:
     return ProviderBenchmarkSample(
         id="b",
@@ -28,7 +29,7 @@ def _sample(
         first_token_milliseconds=ttft,
         error_type=error_type,
         error_status=error_status,
-        source="synthetic",
+        source=source,
     )
 
 
@@ -47,9 +48,26 @@ def test_aggregate_counts_errors_and_median_ttft() -> None:
     assert stats.error_types == ["http_500"]
 
 
+def test_aggregate_ignores_sustained_throughput_samples() -> None:
+    assert (
+        aggregate(
+            [
+                _sample(
+                    status="error",
+                    error_status=504,
+                    source="synthetic_throughput",
+                )
+            ]
+        )
+        == {}
+    )
+
+
 def test_detect_drift_flags_error_spike() -> None:
     current = aggregate([_sample(status="error", error_status=503) for _ in range(10)])
-    baseline = {"openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}}
+    baseline = {
+        "openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}
+    }
     findings = detect_drift(current, baseline)
     kinds = {f.kind for f in findings}
     assert "error_spike" in kinds
@@ -74,7 +92,9 @@ def test_detect_drift_flags_new_model_appearance() -> None:
 def test_detect_drift_respects_min_samples() -> None:
     # Only 3 samples — below the default min_samples=5 — so no judgment.
     current = aggregate([_sample(status="error", error_status=500) for _ in range(3)])
-    baseline = {"openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}}
+    baseline = {
+        "openai/openai/gpt-5.4-nano": {"error_rate": 0.0, "error_types": [], "p50_ttft_ms": 100}
+    }
     assert detect_drift(current, baseline) == []
 
 

--- a/tests/test_synthetic_throughput.py
+++ b/tests/test_synthetic_throughput.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic import cli as cli_module
+from trusted_router.synthetic.probes import (
+    SyntheticTarget,
+    provider_throughput_probe,
+    rotation_candidates,
+)
+from trusted_router.synthetic.throughput import (
+    choose_throughput_target,
+    projected_monthly_cost_microdollars,
+    throughput_candidates,
+)
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def test_top_200_throughput_routes_are_deterministic_and_provider_complete() -> None:
+    first = throughput_candidates(limit=200)
+    second = throughput_candidates(limit=200)
+    pool = rotation_candidates()
+
+    assert first == second
+    assert len(first) == 200
+    assert len(first) == len(set(first))
+    assert {provider for provider, _ in first} == set(pool)
+    assert ("anthropic", "anthropic/claude-opus-5") in first
+    assert any(model == "moonshotai/kimi-k3" for _, model in first)
+    assert any(model == "z-ai/glm-5.2" for _, model in first)
+    assert any(model == "google/gemini-3.6-flash" for _, model in first)
+    assert all(model in pool[provider] for provider, model in first)
+
+
+def test_throughput_round_robin_visits_every_route_once_per_cycle() -> None:
+    candidates = [("a", "a/1"), ("b", "b/1"), ("c", "c/1")]
+    picks = [
+        choose_throughput_target(
+            candidates,
+            now_epoch_seconds=float(slot * 120),
+            interval_seconds=120,
+        )
+        for slot in range(6)
+    ]
+    assert picks == [*candidates, *candidates]
+    assert choose_throughput_target([]) is None
+    with pytest.raises(ValueError, match="interval_seconds"):
+        choose_throughput_target(candidates, interval_seconds=0)
+
+
+def test_top_200_monthly_full_cap_cost_stays_inside_reviewed_budget() -> None:
+    candidates = throughput_candidates(limit=200)
+    projected = projected_monthly_cost_microdollars(candidates)
+
+    assert projected > 0
+    assert projected <= 75_000_000
+
+
+@pytest.mark.asyncio
+async def test_throughput_probe_measures_decode_speed_after_first_token() -> None:
+    captured: list[dict[str, Any]] = []
+    chunks = [
+        b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+        b'data: {"choices":[{"delta":{"content":"benchmark "}}]}\n\n',
+        b'data: {"choices":[{"delta":{"content":"benchmark "}}]}\n\n',
+        (
+            b'data: {"choices":[{"delta":{},"finish_reason":"length"}],'
+            b'"usage":{"prompt_tokens":19,"completion_tokens":251,'
+            b'"total_tokens":270}}\n\n'
+        ),
+        b"data: [DONE]\n\n",
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            headers={
+                "x-trustedrouter-provider": "cerebras",
+                "x-trustedrouter-served-model": "cerebras/gpt-oss-120b",
+            },
+            stream=_ChunkStream(chunks),
+        )
+
+    clock = iter([0.0, 0.1, 0.2, 0.7, 0.8, 0.9, 1.0])
+    target = SyntheticTarget(
+        "throughput",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_throughput_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="cerebras",
+            model="cerebras/gpt-oss-120b",
+            clock=lambda: next(clock),
+        )
+
+    assert sample.status == "success"
+    assert sample.source == "synthetic_throughput"
+    assert sample.input_tokens == 19
+    assert sample.output_tokens == 251
+    assert sample.first_token_milliseconds == 200
+    assert sample.ttfb_milliseconds == 100
+    assert sample.speed_tokens_per_second == 500.0
+    assert sample.total_cost_microdollars > 0
+    assert sample.finish_reason == "length"
+    assert captured[0]["max_tokens"] == 512
+    assert captured[0]["stream_options"] == {"include_usage": True}
+    assert captured[0]["provider"] == {"only": ["cerebras"]}
+    assert captured[0]["metadata"]["trustedrouter_probe"] == "throughput"
+
+
+@pytest.mark.asyncio
+async def test_throughput_probe_rejects_short_noisy_samples() -> None:
+    chunks = [
+        b'data: {"choices":[{"delta":{"content":"benchmark "}}]}\n\n',
+        b'data: {"choices":[{"delta":{"content":"benchmark "}}]}\n\n',
+        (
+            b'data: {"choices":[{"finish_reason":"stop"}],'
+            b'"usage":{"prompt_tokens":12,"completion_tokens":64}}\n\n'
+        ),
+    ]
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_ChunkStream(chunks))
+
+    clock = iter([0.0, 0.1, 0.4, 0.5, 0.6])
+    target = SyntheticTarget(
+        "throughput",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_throughput_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="cerebras",
+            model="cerebras/gpt-oss-120b",
+            clock=lambda: next(clock),
+        )
+
+    assert sample.status == "unsupported"
+    assert sample.source == "synthetic_throughput"
+    assert sample.error_type == "insufficient_throughput_sample"
+    assert sample.input_tokens == 12
+    assert sample.output_tokens == 64
+    assert sample.speed_tokens_per_second is None
+
+
+@pytest.mark.asyncio
+async def test_throughput_probe_errors_keep_separate_provenance() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            json={"error": {"type": "rate_limit", "message": "capacity", "status": 429}},
+        )
+
+    target = SyntheticTarget(
+        "throughput",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_throughput_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="cerebras",
+            model="cerebras/gpt-oss-120b",
+        )
+
+    assert sample.status == "error"
+    assert sample.source == "synthetic_throughput"
+    assert sample.error_type == "rate_limit"
+    assert sample.error_status == 429
+
+
+@pytest.mark.asyncio
+async def test_throughput_pass_runs_in_configured_region_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fake_probe_pass(**_kwargs: Any) -> list[Any]:
+        return []
+
+    async def fake_throughput_pass(**kwargs: Any) -> list[ProviderBenchmarkSample]:
+        calls.append(str(kwargs["monitor_region"]))
+        return [_benchmark_sample()]
+
+    monkeypatch.setattr(cli_module, "_one_probe_pass", fake_probe_pass)
+    monkeypatch.setattr(cli_module, "_throughput_pass", fake_throughput_pass)
+    settings = Settings(environment="test", sentry_dsn=None)
+
+    us_samples, us_benchmarks = await cli_module._probe_and_rotation_pass(
+        settings=settings,
+        monitor_region="us-central1",
+        control_plane="https://trustedrouter.com",
+        internal_token=None,
+        api_key="sk-test",  # noqa: S106 - test placeholder.
+        timeout=httpx.Timeout(1),
+        rotation_enabled=False,
+        rotation_per_pass=0,
+        rotation_rng=__import__("random").Random(0),  # noqa: S311
+        throughput_enabled=True,
+        throughput_region="us-central1",
+    )
+    eu_samples, eu_benchmarks = await cli_module._probe_and_rotation_pass(
+        settings=settings,
+        monitor_region="europe-west4",
+        control_plane="https://trustedrouter.com",
+        internal_token=None,
+        api_key="sk-test",  # noqa: S106 - test placeholder.
+        timeout=httpx.Timeout(1),
+        rotation_enabled=False,
+        rotation_per_pass=0,
+        rotation_rng=__import__("random").Random(0),  # noqa: S311
+        throughput_enabled=True,
+        throughput_region="us-central1",
+    )
+
+    assert us_samples == []
+    assert len(us_benchmarks) == 1
+    assert eu_samples == []
+    assert eu_benchmarks == []
+    assert calls == ["us-central1"]
+
+
+def _benchmark_sample() -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample(
+        id="bench-throughput-test",
+        model="cerebras/gpt-oss-120b",
+        provider="cerebras",
+        provider_name="Cerebras",
+        status="success",
+        usage_type="Credits",
+        streamed=True,
+        speed_tokens_per_second=500.0,
+        source="synthetic_throughput",
+    )


### PR DESCRIPTION
## Summary
- add a deterministic sustained-output benchmark for the 200 highest-value provider/model routes
- measure post-first-token decode throughput from streamed provider usage while keeping long-probe failures out of uptime and drift
- run one US probe every two minutes, covering all 35 active providers at a conservative full-cap cost of $52.43/month
- expose throughput sample counts and prefer sustained measurements on the leaderboard

## Verification
- `ruff check .`
- `mypy`
- `pytest -q` (1874 passed, 33 skipped)
- `bash -n scripts/deploy/synthetic.sh`
- deterministic 200-route manifest and <= $75/month CI cost guard

`[skip ci]` intentionally not used: this changes production monitoring.