### PR TITLE
Isolate sustained throughput probes from uptime monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ Provider measurement uses two independent probe classes:
   TTFB, TTFT, and upstream API drift.
 - A sustained 512-token stream covers the 200 most important provider/model
   routes in deterministic rotation from `us-central1`. It measures output
-  tokens per second after the first token. Long-probe failures never count
+  tokens per second after the first token. It runs in a separate Cloud Run Job,
+  so slow streams cannot delay uptime probes. Long-probe failures never count
   against provider uptime or API-drift alerts.
 
 The current two-minute schedule gives each sustained route about 25 samples per

--- a/docs/design/provider-latency-probe.md
+++ b/docs/design/provider-latency-probe.md
@@ -43,8 +43,10 @@ chooses 200 routes: every active chat provider receives one slot, models used by
 TrustedRouter aliases and orchestration presets rank first, recent launches get
 a bounded bonus, and measured provider rank breaks ties.
 
-The US monitor runs one sustained route every two minutes with a 512-token cap.
-That is 3.6 samples per route per day, roughly 25 per week and 108 per 30 days.
+An isolated US throughput job runs one sustained route every two minutes with a
+512-token cap. That is 3.6 samples per route per day, roughly 25 per week and
+108 per 30 days. The ordinary US/EU monitor jobs never run this long probe, so
+slow streams cannot delay health, billing, fallback, TLS, or attestation checks.
 The probe requires final provider usage, discards response bytes, and persists
 only token counts, timing, route, finish reason, and calculated cost. These
 samples use `source="synthetic_throughput"` and contribute only throughput:
@@ -78,11 +80,12 @@ provider/model only. Probe content is "reply exactly PONG". No content is ever
 read by the probe or proxy. Consistent with the "0 prompt/output logs" promise.
 
 ## Cost
-Upstream tokens only; folds into the existing monitor job with no new service.
-The short random probe remains mostly `max_tokens=16`. The sustained set has a
-512-token cap and one US request per two-minute invocation. A deterministic CI
-test prices all 200 selected routes at their full cap and enforces a reviewed
-$75/month upper bound; the July 2026 catalog projects about $52/month.
+The short random probe remains mostly `max_tokens=16`. The sustained set runs
+in its own Cloud Run Job with a 512-token cap and one US request per two-minute
+invocation. A deterministic CI test prices all 200 selected routes at their
+full cap and enforces a reviewed $75/month upstream-token ceiling; the July
+2026 catalog projects about $52/month. The single small Cloud Run task adds a
+minor compute charge independent of provider token spend.
 
 ## Shipped in
 PRs #34 (probe + TTFB/source), #35 (drift), #36 (aggregation), #37 (/leaderboard),

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# Phase 5: deploy scheduled synthetic monitor jobs in each configured region.
-# Jobs run outside the prompt path and write privacy-safe samples to
-# /internal/synthetic/samples. Cloud Scheduler triggers each regional job
-# every two minutes via the Cloud Run Jobs API. Each pass includes real
-# provider and ledger probes; minute-granularity scheduling can overlap during
-# upstream slowness and create synthetic-only router-core failures.
+# Phase 5: deploy scheduled synthetic monitor jobs and an isolated sustained
+# throughput job. Jobs run outside the prompt path and write privacy-safe
+# samples to internal ingest endpoints. Short uptime probes must never wait on
+# the longer throughput benchmark.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
@@ -65,29 +63,6 @@ BASE_ENV_VARS=(
   # Cloud Run Job self-timeouts.
   "TR_SYNTHETIC_RUNS_PER_INVOCATION=1"
   "TR_SYNTHETIC_RUN_SPACING_SECONDS=0"
-  # Provider/model rotation probe — LAUNCHED (2026-06-04). Each pass takes
-  # TR_SYNTHETIC_ROTATION_PER_PASS random provider+model samples (two-stage),
-  # streams a tiny request, and records measured TTFB/TTFT into the benchmark
-  # store that feeds /leaderboard + the per-model/provider pages + API-drift
-  # detection. Most probes use max_tokens=16; reasoning-heavy models use a
-  # larger cap so hidden reasoning does not falsely look like provider
-  # downtime. To control spend: lower PER_PASS or set ENABLED to false. Watch
-  # the monitor workspace's credit burn (these spend prepaid credits on the
-  # synthetic-monitor key).
-  "TR_SYNTHETIC_ROTATION_ENABLED=true"
-  "TR_SYNTHETIC_ROTATION_PER_PASS=4"
-  # Sustained-output benchmark — one deterministic top-200 route per scheduler
-  # tick, from one region only. At the two-minute schedule this gives every
-  # selected provider/model route 3.6 samples/day (~25/week, ~108/month).
-  # Keeping it separate from the PONG probes preserves cheap, high-frequency
-  # uptime coverage. Long-probe failures never count against provider uptime.
-  "TR_SYNTHETIC_THROUGHPUT_ENABLED=true"
-  "TR_SYNTHETIC_THROUGHPUT_REGION=us-central1"
-  "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT=200"
-  "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
-  "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
-  "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
-  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
 )
@@ -100,13 +75,54 @@ fi
 ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/run.developer"
 ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager.secretAccessor"
 
+upsert_scheduler() {
+  local scheduler_name="$1"
+  local job_name="$2"
+  local region="$3"
+  local schedule="$4"
+  local run_uri="https://${region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"
+
+  if gc scheduler jobs describe "$scheduler_name" --location "$region" >/dev/null 2>&1; then
+    log "updating synthetic scheduler ${scheduler_name}"
+    if ! gc scheduler jobs update http "$scheduler_name" \
+      --location "$region" \
+      --schedule "$schedule" \
+      --uri "$run_uri" \
+      --http-method POST \
+      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --quiet >/dev/null; then
+      log "WARN: failed to update synthetic scheduler ${scheduler_name}; leaving existing schedule in place"
+    fi
+  else
+    log "creating synthetic scheduler ${scheduler_name}"
+    if ! gc scheduler jobs create http "$scheduler_name" \
+      --location "$region" \
+      --schedule "$schedule" \
+      --uri "$run_uri" \
+      --http-method POST \
+      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --quiet >/dev/null; then
+      log "WARN: failed to create synthetic scheduler ${scheduler_name}; deploy the job exists but is not scheduled"
+    fi
+  fi
+}
+
 SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
 IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
   scheduler_name="${job_name}-every-minute"
-  env_vars=("${BASE_ENV_VARS[@]}" "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}")
+  env_vars=(
+    "${BASE_ENV_VARS[@]}"
+    "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}"
+    # Short random provider/model probes feed uptime and TTFT. Sustained
+    # throughput is deliberately disabled in these health jobs.
+    "TR_SYNTHETIC_ROTATION_ENABLED=true"
+    "TR_SYNTHETIC_ROTATION_PER_PASS=4"
+    "TR_SYNTHETIC_THROUGHPUT_ENABLED=false"
+    "TR_SYNTHETIC_THROUGHPUT_ONLY=false"
+  )
   set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
   log "deploying synthetic Cloud Run job ${job_name} in ${monitor_region}"
@@ -127,31 +143,50 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   # concurrently via asyncio.gather + httpx. On 1 CPU / 512Mi (the
   # Cloud Run default) the parallel TLS handshakes serialize and
   # probe latency balloons from ~2s to ~12s, blowing past task-
-  # timeout. 2 CPU / 1Gi handles 6 passes × 4 region pairs × 2
-  # probe types per pass comfortably.
+  # timeout. 2 CPU / 1Gi keeps the concurrent regional probes bounded.
 
-  run_uri="https://${monitor_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"
-  if gc scheduler jobs describe "$scheduler_name" --location "$monitor_region" >/dev/null 2>&1; then
-    log "updating synthetic scheduler ${scheduler_name}"
-    if ! gc scheduler jobs update http "$scheduler_name" \
-      --location "$monitor_region" \
-      --schedule "*/2 * * * *" \
-      --uri "$run_uri" \
-      --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
-      --quiet >/dev/null; then
-      log "WARN: failed to update synthetic scheduler ${scheduler_name}; leaving existing schedule in place"
-    fi
-  else
-    log "creating synthetic scheduler ${scheduler_name}"
-    if ! gc scheduler jobs create http "$scheduler_name" \
-      --location "$monitor_region" \
-      --schedule "*/2 * * * *" \
-      --uri "$run_uri" \
-      --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
-      --quiet >/dev/null; then
-      log "WARN: failed to create synthetic scheduler ${scheduler_name}; deploy the job exists but is not scheduled"
-    fi
-  fi
+  upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/2 * * * *"
 done
+
+# Sustained-output benchmark: one deterministic top-200 route per tick. This
+# has a separate Cloud Run Job so a slow 512-token stream cannot delay or
+# overlap TLS, attestation, billing, fallback, or short provider probes.
+throughput_region="us-central1"
+throughput_job_name="trusted-router-throughput-${throughput_region}"
+throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
+throughput_env_vars=(
+  "${BASE_ENV_VARS[@]}"
+  "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
+  "TR_SYNTHETIC_ROTATION_ENABLED=false"
+  "TR_SYNTHETIC_ROTATION_PER_PASS=0"
+  "TR_SYNTHETIC_THROUGHPUT_ENABLED=true"
+  "TR_SYNTHETIC_THROUGHPUT_ONLY=true"
+  "TR_SYNTHETIC_THROUGHPUT_REGION=${throughput_region}"
+  "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT=200"
+  "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
+  "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
+  "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
+  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
+)
+throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
+
+log "deploying isolated throughput Cloud Run job ${throughput_job_name}"
+gc run jobs deploy "$throughput_job_name" \
+  --region "$throughput_region" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.synthetic.cli" \
+  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --set-env-vars "$throughput_set_env_vars" \
+  --update-secrets "$UPDATE_SECRETS" \
+  --max-retries 0 \
+  --task-timeout 180s \
+  --cpu 1 \
+  --memory 1Gi \
+  --quiet >/dev/null
+
+upsert_scheduler \
+  "$throughput_scheduler_name" \
+  "$throughput_job_name" \
+  "$throughput_region" \
+  "*/2 * * * *"

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -45,6 +45,13 @@ _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS = 90.0
 _DEFAULT_THROUGHPUT_INTERVAL_SECONDS = 120
 
 
+def _env_flag(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in ("1", "true", "yes", "on")
+
+
 async def _one_probe_pass(
     *,
     settings: Settings,
@@ -225,6 +232,7 @@ async def _throughput_pass(
                 model=model,
                 max_tokens=max_tokens,
                 minimum_output_tokens=minimum_output_tokens,
+                total_timeout_seconds=timeout_seconds,
             )
         ]
 
@@ -291,23 +299,14 @@ async def run() -> int:
             str(_DEFAULT_RUN_SPACING_SECONDS),
         )
     )
-    rotation_enabled = os.environ.get("TR_SYNTHETIC_ROTATION_ENABLED", "false").lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+    rotation_enabled = _env_flag("TR_SYNTHETIC_ROTATION_ENABLED")
     rotation_per_pass = max(
         0,
         int(os.environ.get("TR_SYNTHETIC_ROTATION_PER_PASS", str(_DEFAULT_ROTATION_PER_PASS))),
     )
     rotation_rng = random.Random()  # noqa: S311 - picks which model to probe, not cryptographic
-    throughput_enabled = os.environ.get("TR_SYNTHETIC_THROUGHPUT_ENABLED", "false").lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+    throughput_enabled = _env_flag("TR_SYNTHETIC_THROUGHPUT_ENABLED")
+    throughput_only = _env_flag("TR_SYNTHETIC_THROUGHPUT_ONLY")
     throughput_region = os.environ.get("TR_SYNTHETIC_THROUGHPUT_REGION", "us-central1")
     throughput_route_limit = max(
         0,
@@ -353,58 +352,94 @@ async def run() -> int:
     )
 
     all_samples: list[SyntheticProbeSample] = []
-    rotation_samples: list[ProviderBenchmarkSample] = []
-    pass_start_monotonic = time.monotonic()
-    for pass_idx in range(runs_per_invocation):
-        pass_samples, pass_rotation_samples = await _probe_and_rotation_pass(
-            settings=settings,
-            monitor_region=monitor_region,
-            control_plane=control_plane,
-            internal_token=internal_token,
-            api_key=api_key,
-            timeout=timeout,
-            rotation_enabled=rotation_enabled,
-            rotation_per_pass=rotation_per_pass,
-            rotation_rng=rotation_rng,
-            throughput_enabled=throughput_enabled,
-            throughput_region=throughput_region,
-            throughput_route_limit=throughput_route_limit,
-            throughput_max_tokens=throughput_max_tokens,
-            throughput_minimum_output_tokens=throughput_minimum_output_tokens,
-            throughput_timeout_seconds=throughput_timeout_seconds,
-            throughput_interval_seconds=throughput_interval_seconds,
+    benchmark_samples: list[ProviderBenchmarkSample] = []
+    if throughput_only:
+        if not throughput_enabled:
+            print(
+                "TR_SYNTHETIC_THROUGHPUT_ONLY requires TR_SYNTHETIC_THROUGHPUT_ENABLED",
+                file=sys.stderr,
+            )
+            return 2
+        if monitor_region != throughput_region:
+            print(
+                "throughput-only job must run in TR_SYNTHETIC_THROUGHPUT_REGION",
+                file=sys.stderr,
+            )
+            return 2
+        if not api_key:
+            print(
+                "TR_SYNTHETIC_MONITOR_API_KEY is required for throughput probes",
+                file=sys.stderr,
+            )
+            return 2
+        benchmark_samples.extend(
+            await _throughput_pass(
+                settings=settings,
+                monitor_region=monitor_region,
+                api_key=api_key,
+                route_limit=throughput_route_limit,
+                max_tokens=throughput_max_tokens,
+                minimum_output_tokens=throughput_minimum_output_tokens,
+                timeout_seconds=throughput_timeout_seconds,
+                interval_seconds=throughput_interval_seconds,
+            )
         )
-        all_samples.extend(pass_samples)
-        rotation_samples.extend(pass_rotation_samples)
-        # Sleep until the next probe pass should start, but only if
-        # there IS a next pass. Compensates for the time the probe
-        # itself took so the spacing is between pass-starts, not
-        # pass-ends.
-        if pass_idx + 1 < runs_per_invocation:
-            target = (pass_idx + 1) * run_spacing_seconds
-            elapsed = time.monotonic() - pass_start_monotonic
-            to_sleep = target - elapsed
-            if to_sleep > 0:
-                await asyncio.sleep(to_sleep)
+    else:
+        pass_start_monotonic = time.monotonic()
+        for pass_idx in range(runs_per_invocation):
+            pass_samples, pass_benchmark_samples = await _probe_and_rotation_pass(
+                settings=settings,
+                monitor_region=monitor_region,
+                control_plane=control_plane,
+                internal_token=internal_token,
+                api_key=api_key,
+                timeout=timeout,
+                rotation_enabled=rotation_enabled,
+                rotation_per_pass=rotation_per_pass,
+                rotation_rng=rotation_rng,
+                throughput_enabled=throughput_enabled,
+                throughput_region=throughput_region,
+                throughput_route_limit=throughput_route_limit,
+                throughput_max_tokens=throughput_max_tokens,
+                throughput_minimum_output_tokens=throughput_minimum_output_tokens,
+                throughput_timeout_seconds=throughput_timeout_seconds,
+                throughput_interval_seconds=throughput_interval_seconds,
+            )
+            all_samples.extend(pass_samples)
+            benchmark_samples.extend(pass_benchmark_samples)
+            # Sleep until the next probe pass should start, but only if
+            # there IS a next pass. Compensates for the time the probe
+            # itself took so the spacing is between pass-starts, not
+            # pass-ends.
+            if pass_idx + 1 < runs_per_invocation:
+                target = (pass_idx + 1) * run_spacing_seconds
+                elapsed = time.monotonic() - pass_start_monotonic
+                to_sleep = target - elapsed
+                if to_sleep > 0:
+                    await asyncio.sleep(to_sleep)
 
     ingest_url = os.environ.get(
         "TR_SYNTHETIC_INGEST_URL",
         f"{control_plane.rstrip('/')}/v1/internal/synthetic/samples",
     )
     if not internal_token:
-        for sample in all_samples:
-            print(sample.public_dict())
+        for probe_sample in all_samples:
+            print(probe_sample.public_dict())
+        for benchmark_sample in benchmark_samples:
+            print(asdict(benchmark_sample))
         print("TR_INTERNAL_GATEWAY_TOKEN is required to ingest samples", file=sys.stderr)
         return 2
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.post(
-            ingest_url,
-            headers={"x-trustedrouter-internal-token": internal_token},
-            json={"samples": [sample.public_dict() for sample in all_samples]},
-        )
-        print(response.text)
-        ok = response.status_code == 200
-        if rotation_samples:
+        ok = True
+        if all_samples:
+            response = await client.post(
+                ingest_url,
+                headers={"x-trustedrouter-internal-token": internal_token},
+                json={"samples": [sample.public_dict() for sample in all_samples]},
+            )
+            print(response.text)
+            ok = response.status_code == 200
+        if benchmark_samples:
             benchmark_url = os.environ.get(
                 "TR_SYNTHETIC_BENCHMARK_INGEST_URL",
                 f"{control_plane.rstrip('/')}/v1/internal/synthetic/benchmark",
@@ -412,19 +447,20 @@ async def run() -> int:
             bench_response = await client.post(
                 benchmark_url,
                 headers={"x-trustedrouter-internal-token": internal_token},
-                json={"samples": [asdict(sample) for sample in rotation_samples]},
+                json={"samples": [asdict(sample) for sample in benchmark_samples]},
             )
             print(bench_response.text)
             ok = ok and bench_response.status_code == 200
-            route_health_url = os.environ.get(
-                "TR_SYNTHETIC_ROUTE_HEALTH_URL",
-                f"{control_plane.rstrip('/')}/v1/internal/synthetic/route-health",
-            )
-            await _post_route_health_if_due(
-                client,
-                url=route_health_url,
-                internal_token=internal_token,
-            )
+            if not throughput_only:
+                route_health_url = os.environ.get(
+                    "TR_SYNTHETIC_ROUTE_HEALTH_URL",
+                    f"{control_plane.rstrip('/')}/v1/internal/synthetic/route-health",
+                )
+                await _post_route_health_if_due(
+                    client,
+                    url=route_health_url,
+                    internal_token=internal_token,
+                )
     return 0 if ok else 1
 
 

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1050,6 +1050,7 @@ async def provider_throughput_probe(
     model: str,
     max_tokens: int = 512,
     minimum_output_tokens: int = 128,
+    total_timeout_seconds: float | None = None,
     clock: Callable[[], float] = time.perf_counter,
 ) -> ProviderBenchmarkSample:
     """Measure sustained output speed after the first streamed token.
@@ -1084,30 +1085,31 @@ async def provider_throughput_probe(
     served_provider = provider
     served_model = model
     try:
-        async with client.stream(
-            "POST", url, json=body, headers=_auth_headers(api_key)
-        ) as response:
-            served_provider = response.headers.get("x-trustedrouter-provider") or provider
-            served_model = response.headers.get("x-trustedrouter-served-model") or model
-            if response.status_code != 200:
-                await response.aread()
-                error_type, error_status, message = _response_error(response)
-                return _rotation_error_sample(
-                    served_provider,
-                    served_model,
-                    region=monitor_region,
-                    elapsed_ms=_elapsed_ms_with_clock(started, clock),
-                    error_status=error_status,
-                    error_type=error_type,
-                    error_message=message,
-                    source="synthetic_throughput",
+        async with asyncio.timeout(total_timeout_seconds):
+            async with client.stream(
+                "POST", url, json=body, headers=_auth_headers(api_key)
+            ) as response:
+                served_provider = response.headers.get("x-trustedrouter-provider") or provider
+                served_model = response.headers.get("x-trustedrouter-served-model") or model
+                if response.status_code != 200:
+                    await response.aread()
+                    error_type, error_status, message = _response_error(response)
+                    return _rotation_error_sample(
+                        served_provider,
+                        served_model,
+                        region=monitor_region,
+                        elapsed_ms=_elapsed_ms_with_clock(started, clock),
+                        error_status=error_status,
+                        error_type=error_type,
+                        error_message=message,
+                        source="synthetic_throughput",
+                    )
+                observation = await _observe_provider_stream(
+                    response,
+                    started=started,
+                    clock=clock,
                 )
-            observation = await _observe_provider_stream(
-                response,
-                started=started,
-                clock=clock,
-            )
-    except (httpx.HTTPError, ValueError) as exc:
+    except (TimeoutError, httpx.HTTPError, ValueError) as exc:
         return _rotation_error_sample(
             served_provider,
             served_model,

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1836,7 +1836,11 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
 
     assert "TR_API_BASE_URL=https://api.trustedrouter.com/v1" in body
     assert "TR_API_BASE_URL=https://api.quillrouter.com/v1" not in body
-    assert '--schedule "*/2 * * * *"' in body
+    assert 'throughput_job_name="trusted-router-throughput-${throughput_region}"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=true"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=false"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_ENABLED=false"' in body
+    assert '"*/2 * * * *"' in body
 
 
 class _FakeCell:

--- a/tests/test_synthetic_throughput.py
+++ b/tests/test_synthetic_throughput.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from typing import Any
@@ -198,6 +199,38 @@ async def test_throughput_probe_errors_keep_separate_provenance() -> None:
 
 
 @pytest.mark.asyncio
+async def test_throughput_probe_has_a_total_wall_clock_deadline() -> None:
+    class _SlowStream(httpx.AsyncByteStream):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            await asyncio.sleep(1)
+            yield b'data: {"choices":[{"delta":{"content":"benchmark"}}]}\n\n'
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_SlowStream())
+
+    target = SyntheticTarget(
+        "throughput",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_throughput_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="slow-provider",
+            model="slow/model",
+            total_timeout_seconds=0.01,
+        )
+
+    assert sample.status == "error"
+    assert sample.source == "synthetic_throughput"
+    assert sample.error_type == "TimeoutError"
+    assert sample.error_status is None
+
+
+@pytest.mark.asyncio
 async def test_throughput_pass_runs_in_configured_region_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -246,6 +279,59 @@ async def test_throughput_pass_runs_in_configured_region_only(
     assert eu_samples == []
     assert eu_benchmarks == []
     assert calls == ["us-central1"]
+
+
+@pytest.mark.asyncio
+async def test_throughput_only_cli_skips_every_health_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    benchmark_posts: list[dict[str, Any]] = []
+
+    async def forbidden_probe(**_kwargs: Any) -> list[Any]:
+        raise AssertionError("throughput-only mode must not run health probes")
+
+    async def fake_throughput_pass(**_kwargs: Any) -> list[ProviderBenchmarkSample]:
+        return [_benchmark_sample()]
+
+    class _Response:
+        status_code = 200
+        text = '{"data":{"recorded":1}}'
+
+    class _Client:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> _Response:
+            assert url.endswith("/v1/internal/synthetic/benchmark")
+            benchmark_posts.append(kwargs["json"])
+            return _Response()
+
+    settings = Settings(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token="internal",  # noqa: S106 - test placeholder.
+        synthetic_monitor_api_key="sk-test",  # noqa: S106 - test placeholder.
+    )
+    monkeypatch.setattr(cli_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(cli_module, "_one_probe_pass", forbidden_probe)
+    monkeypatch.setattr(cli_module, "_rotation_pass", forbidden_probe)
+    monkeypatch.setattr(cli_module, "_throughput_pass", fake_throughput_pass)
+    monkeypatch.setattr(cli_module.httpx, "AsyncClient", _Client)
+    monkeypatch.setenv("TR_SYNTHETIC_MONITOR_REGION", "us-central1")
+    monkeypatch.setenv("TR_SYNTHETIC_ROTATION_ENABLED", "true")
+    monkeypatch.setenv("TR_SYNTHETIC_THROUGHPUT_ENABLED", "true")
+    monkeypatch.setenv("TR_SYNTHETIC_THROUGHPUT_ONLY", "true")
+    monkeypatch.setenv("TR_SYNTHETIC_THROUGHPUT_REGION", "us-central1")
+
+    assert await cli_module.run() == 0
+    assert len(benchmark_posts) == 1
+    assert benchmark_posts[0]["samples"][0]["source"] == "synthetic_throughput"
 
 
 def _benchmark_sample() -> ProviderBenchmarkSample:


### PR DESCRIPTION
## Summary
- run top-200 sustained throughput sampling in a dedicated US Cloud Run Job
- keep regional uptime, billing, fallback, TLS, and attestation jobs on short probes only
- enforce a 90-second total stream deadline and persist timeout metadata instead of hitting the task timeout
- share scheduler deployment logic and document the isolation/cost model

## Production evidence
The combined job reproduced the problem in production: execution `trusted-router-synthetic-us-central1-v898w` reached the five-minute task timeout. This patch removes sustained probes from that job.

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1876 passed, 33 skipped)
- `bash -n scripts/deploy/synthetic.sh`
- `git diff --check`