### PR TITLE
Measure engaged paid traffic accurately

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -20,10 +20,14 @@ API keys, BYOK keys, email addresses, payment credentials, request bodies, IP
 addresses, or full referring URLs. Click identifiers are retained only in the
 private Spanner record for future consented offline conversion uploads. Logs
 contain booleans indicating which click identifier was present, never its raw
-value.
+value. Public landing events also contain a server-keyed HMAC fingerprint of
+the click identifier. This lets reports deduplicate the same ad click across
+cookie churn without exposing an identifier that an analytics operator can
+reuse outside TrustedRouter.
 
 Requests carrying `Sec-GPC: 1` or `DNT: 1` do not create or use attribution.
-Known crawler user agents do not receive attribution cookies.
+Known crawler, link-preview, prefetch, and prerender requests do not receive
+attribution cookies.
 
 ## Durable Record
 
@@ -37,12 +41,19 @@ record.
 
 Structured metadata-only events are shipped through the existing Axiom logger:
 
-1. `acquisition.sign_in_opened`
-2. `acquisition.signup_completed`
-3. `acquisition.api_key_created`
-4. `acquisition.first_successful_api_call`
-5. `acquisition.credit_purchase_completed`
-6. `acquisition.retained_api_usage_7d`
+1. `acquisition.landing_engaged`
+2. `acquisition.sign_in_opened`
+3. `acquisition.signup_completed`
+4. `acquisition.api_key_created`
+5. `acquisition.first_successful_api_call`
+6. `acquisition.credit_purchase_completed`
+7. `acquisition.retained_api_usage_7d`
+
+`public.page_view` is a server-request metric and is deliberately labeled
+`measurement_tier=server_request`. Paid-landing reports should use
+`acquisition.landing_engaged`, which is emitted only after JavaScript has seen
+the document remain visible for 1.5 seconds. Compare unique click fingerprints,
+not raw server pageviews, with ad-platform clicks.
 
 Workspace and anonymous identifiers are SHA-256 fingerprints in logs. Purchase
 amounts remain integer microdollars. Stripe, PayPal, and stablecoin events are

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -91,7 +91,9 @@ function openSigninModal(): void {
   }
 }
 
-function trackFunnelEvent(event: "sign_in_opened"): void {
+type MarketingFunnelEvent = "landing_engaged" | "sign_in_opened";
+
+function trackFunnelEvent(event: MarketingFunnelEvent): void {
   void fetch("/analytics/events", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -101,6 +103,22 @@ function trackFunnelEvent(event: "sign_in_opened"): void {
   }).catch(() => {
     /* measurement is best-effort and must never interrupt sign-in */
   });
+}
+
+function trackEngagedLanding(): void {
+  let sent = false;
+  const sendWhenVisible = (): void => {
+    if (sent || document.visibilityState !== "visible") return;
+    sent = true;
+    document.removeEventListener("visibilitychange", sendWhenVisible);
+    trackFunnelEvent("landing_engaged");
+  };
+  window.setTimeout(() => {
+    sendWhenVisible();
+    if (!sent) {
+      document.addEventListener("visibilitychange", sendWhenVisible);
+    }
+  }, 1500);
 }
 
 function setSigninError(message: string): void {
@@ -220,6 +238,7 @@ function applyAuthAwareChrome(): void {
 function init(): void {
   applyAuthAwareChrome();
   applyStoredTheme();
+  trackEngagedLanding();
 
   document.addEventListener("click", (event) => {
     const target = event.target as HTMLElement | null;

--- a/src/trusted_router/acquisition.py
+++ b/src/trusted_router/acquisition.py
@@ -36,6 +36,16 @@ _COOKIE_VERSION = 1
 _MAX_COOKIE_BYTES = 3_800
 _ANONYMOUS_ID_RE = re.compile(r"^[a-f0-9]{32}$")
 _CLICK_ID_RE = re.compile(r"^[A-Za-z0-9._~-]{1,256}$")
+_CLICK_ID_FIELDS = ("gclid", "gbraid", "wbraid", "twclid")
+_AUTOMATED_USER_AGENT_TOKENS = (
+    "bot",
+    "crawler",
+    "spider",
+    "facebookexternalhit",
+    "preview",
+    "slack-imgproxy",
+)
+_AUTOMATED_PURPOSE_TOKENS = ("prefetch", "prerender", "preview")
 _TOUCH_FIELDS = frozenset(
     {
         "utm_source",
@@ -323,6 +333,7 @@ def log_browser_funnel_event(request: Request, event: str) -> None:
             "event": f"acquisition.{event}",
             "anonymous_fingerprint": _fingerprint(context.anonymous_id),
             **_safe_touch_log_fields(touch),
+            **_click_id_log_fields(request, touch),
         },
     )
 
@@ -334,6 +345,7 @@ def pageview_attribution_fields(request: Request) -> dict[str, object]:
     return {
         "anonymous_fingerprint": _fingerprint(context.anonymous_id),
         **_safe_touch_log_fields(context.last_touch),
+        **_click_id_log_fields(request, context.last_touch),
     }
 
 
@@ -381,7 +393,7 @@ def _touch_from_request(request: Request) -> dict[str, str]:
         value = _safe_text(request.query_params.get(name), 128)
         if value:
             touch[name] = value
-    for name in ("gclid", "gbraid", "wbraid", "twclid"):
+    for name in _CLICK_ID_FIELDS:
         value = str(request.query_params.get(name) or "").strip()
         if _CLICK_ID_RE.fullmatch(value):
             touch[name] = value
@@ -434,7 +446,11 @@ def _direct_context(request: Request) -> AttributionContext:
 
 
 def _should_capture_request(request: Request) -> bool:
-    if request.method.upper() != "GET" or _privacy_signal_enabled(request):
+    if (
+        request.method.upper() != "GET"
+        or _privacy_signal_enabled(request)
+        or acquisition_request_is_automated(request)
+    ):
         return False
     path = request.url.path
     excluded = (
@@ -448,8 +464,18 @@ def _should_capture_request(request: Request) -> bool:
     )
     if path.startswith(excluded) or path.endswith("_oauth_callback"):
         return False
+    return True
+
+
+def acquisition_request_is_automated(request: Request) -> bool:
     user_agent = request.headers.get("user-agent", "").lower()
-    return not any(token in user_agent for token in ("bot", "crawler", "spider"))
+    if any(token in user_agent for token in _AUTOMATED_USER_AGENT_TOKENS):
+        return True
+    purpose = " ".join(
+        request.headers.get(name, "").lower()
+        for name in ("purpose", "sec-purpose", "x-purpose")
+    )
+    return any(token in purpose for token in _AUTOMATED_PURPOSE_TOKENS)
 
 
 def _has_explicit_campaign_touch(request: Request) -> bool:
@@ -499,6 +525,27 @@ def _cookie_signing_key(settings: Settings) -> bytes:
         b"trustedrouter-attribution-cookie-v1",
         hashlib.sha256,
     ).digest()
+
+
+def _click_id_log_fields(request: Request, touch: dict[str, str]) -> dict[str, str]:
+    settings = getattr(request.app.state, "settings", None)
+    if not isinstance(settings, Settings):
+        return {}
+    key = hmac.new(
+        _cookie_signing_key(settings),
+        b"trustedrouter-attribution-click-fingerprint-v1",
+        hashlib.sha256,
+    ).digest()
+    fields: dict[str, str] = {}
+    for name in _CLICK_ID_FIELDS:
+        value = touch.get(name)
+        if value:
+            fields[f"{name}_fingerprint"] = hmac.new(
+                key,
+                f"{name}:{value}".encode(),
+                hashlib.sha256,
+            ).hexdigest()
+    return fields
 
 
 def _cookie_expired(created_at: str) -> bool:

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -35,6 +35,7 @@ from fastapi.responses import JSONResponse, RedirectResponse, Response
 from starlette.middleware.gzip import GZipMiddleware
 
 from trusted_router.acquisition import (
+    acquisition_request_is_automated,
     pageview_attribution_fields,
     prepare_request_attribution,
     set_attribution_cookie,
@@ -384,6 +385,8 @@ def _log_public_page_view(request: Request, response: Response, *, latency_ms: f
         "latency_ms": round(latency_ms, 2),
         "referer_host": _referer_host(request),
         "user_agent_family": _user_agent_family(request.headers.get("user-agent", "")),
+        "automated_request": acquisition_request_is_automated(request),
+        "measurement_tier": "server_request",
     }
     extra.update(_utm_fields(request))
     extra.update(pageview_attribution_fields(request))

--- a/src/trusted_router/routes/acquisition.py
+++ b/src/trusted_router/routes/acquisition.py
@@ -11,7 +11,7 @@ from trusted_router.acquisition import log_browser_funnel_event
 class MarketingEventRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    event: Literal["sign_in_opened"]
+    event: Literal["landing_engaged", "sign_in_opened"]
 
 
 def register_acquisition_routes(router: APIRouter) -> None:

--- a/src/trusted_router/static/dashboard.js
+++ b/src/trusted_router/static/dashboard.js
@@ -95,6 +95,22 @@ function trackFunnelEvent(event) {
         /* measurement is best-effort and must never interrupt sign-in */
     });
 }
+function trackEngagedLanding() {
+    let sent = false;
+    const sendWhenVisible = () => {
+        if (sent || document.visibilityState !== "visible")
+            return;
+        sent = true;
+        document.removeEventListener("visibilitychange", sendWhenVisible);
+        trackFunnelEvent("landing_engaged");
+    };
+    window.setTimeout(() => {
+        sendWhenVisible();
+        if (!sent) {
+            document.addEventListener("visibilitychange", sendWhenVisible);
+        }
+    }, 1500);
+}
 function setSigninError(message) {
     const el = document.getElementById("signinError");
     if (!el)
@@ -211,6 +227,7 @@ function applyAuthAwareChrome() {
 function init() {
     applyAuthAwareChrome();
     applyStoredTheme();
+    trackEngagedLanding();
     document.addEventListener("click", (event) => {
         const target = event.target;
         if (!target)

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -138,6 +138,27 @@ def test_crawlers_do_not_receive_attribution_cookie(client: TestClient) -> None:
     assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
 
 
+@pytest.mark.parametrize(
+    ("header", "value"),
+    [
+        ("purpose", "prefetch"),
+        ("sec-purpose", "prefetch;prerender"),
+        ("x-purpose", "preview"),
+    ],
+)
+def test_prefetches_do_not_receive_attribution_cookie(
+    client: TestClient,
+    header: str,
+    value: str,
+) -> None:
+    response = client.get(
+        "/?utm_source=x&twclid=preview-click",
+        headers={header: value, "user-agent": "Mozilla/5.0 Chrome/146.0"},
+    )
+    assert response.status_code == 200
+    assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+
 def test_invalid_click_id_is_not_persisted(client: TestClient) -> None:
     response = client.get("/?utm_source=google&gclid=bad%20click%0Avalue")
     assert response.status_code == 200
@@ -201,6 +222,38 @@ def test_signin_open_event_is_campaign_attributed_without_click_id_leak(
     response = client.post("/analytics/events", json={"event": "sign_in_opened"})
     assert response.status_code == 204
     assert "acquisition.sign_in_opened" in caplog.text
+    assert raw_click_id not in caplog.text
+
+
+def test_engaged_landing_has_stable_click_fingerprint_without_raw_id(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_click_id = "tw-private-engaged-123"
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+
+    assert client.get(f"/?utm_source=x&twclid={raw_click_id}").status_code == 200
+    first = client.post("/analytics/events", json={"event": "landing_engaged"})
+    assert first.status_code == 204
+    first_record = next(
+        item
+        for item in caplog.records
+        if item.getMessage() == "acquisition.landing_engaged"
+    )
+
+    caplog.clear()
+    client.cookies.clear()
+    assert client.get(f"/?utm_source=x&twclid={raw_click_id}").status_code == 200
+    second = client.post("/analytics/events", json={"event": "landing_engaged"})
+    assert second.status_code == 204
+    second_record = next(
+        item
+        for item in caplog.records
+        if item.getMessage() == "acquisition.landing_engaged"
+    )
+
+    assert first_record.twclid_fingerprint == second_record.twclid_fingerprint
+    assert first_record.anonymous_fingerprint != second_record.anonymous_fingerprint
     assert raw_click_id not in caplog.text
 
 
@@ -278,6 +331,31 @@ def test_public_pageviews_cover_marketing_but_not_console(
     assert len(records) == 1
     assert records[0].path == "/private-llm-api"
     assert records[0].page_kind == "marketing"
+    assert records[0].automated_request is False
+    assert records[0].measurement_tier == "server_request"
+
+
+def test_prefetch_pageview_is_classified_and_has_no_attribution(
+    client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_click_id = "tw-prefetch-do-not-attribute"
+    caplog.set_level(logging.INFO, logger="trusted_router.middleware")
+    response = client.get(
+        f"/?utm_source=x&twclid={raw_click_id}",
+        headers={
+            "purpose": "prefetch",
+            "user-agent": "Mozilla/5.0 Chrome/146.0",
+        },
+    )
+    assert response.status_code == 200
+    record = next(
+        item for item in caplog.records if item.getMessage() == "public.page_view"
+    )
+    assert record.automated_request is True
+    assert not hasattr(record, "anonymous_fingerprint")
+    assert not hasattr(record, "twclid_fingerprint")
+    assert raw_click_id not in caplog.text
 
 
 def test_record_signup_helper_uses_direct_fallback_without_cookie(

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -258,6 +258,9 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert "/v1/auth/wallet/challenge" in js.text
     assert "/v1/auth/wallet/verify" in js.text
     assert "eth_requestAccounts" in js.text
+    assert 'trackFunnelEvent("landing_engaged")' in js.text
+    assert 'document.visibilityState !== "visible"' in js.text
+    assert 'fetch("/analytics/events"' in js.text
     assert "alert(" not in js.text
 
     css = client.get("/static/dashboard.css")


### PR DESCRIPTION
## Summary
- distinguish server requests from visible engaged landings
- exclude crawler, preview, prefetch, and prerender traffic from attribution cookies
- add keyed click fingerprints for privacy-preserving deduplication across cookie churn
- document the reporting contract and protect the compiled frontend signal with tests

## Validation
- `uv run pytest -q`: 1881 passed, 33 skipped
- `uv run mypy`
- `uv run ruff check ...`
- `npm run typecheck`
- `npm run lint`
- `npm run lint:css`
- generated dashboard asset is current

## Campaign decision
No budget increase in this change. X Conversion Diagnostics currently reports no Pixel or CAPI events, so first-party activation and purchase milestones remain the decision source.
