### PR TITLE
Price Parasail Liberty output at $19/M

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -149,6 +149,7 @@ from trusted_router.catalog_registry import (  # noqa: F401 - built there, re-ex
 )
 from trusted_router.money import (
     microdollars_per_million_tokens_to_token_decimal,
+    microdollars_to_decimal,
 )
 from trusted_router.pricing import (  # noqa: F401 - re-exported for back-compat
     _CACHE_READ_PRICE_MULTIPLIER,
@@ -539,6 +540,8 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         "prompt": microdollars_per_million_tokens_to_token_decimal(prompt_min),
         "completion": microdollars_per_million_tokens_to_token_decimal(completion_min),
     }
+    if model.minimum_charge_microdollars:
+        pricing["minimum"] = microdollars_to_decimal(model.minimum_charge_microdollars)
     if is_meta and (prompt_max != prompt_min or completion_max != completion_min):
         pricing["prompt_max"] = microdollars_per_million_tokens_to_token_decimal(prompt_max)
         pricing["completion_max"] = microdollars_per_million_tokens_to_token_decimal(completion_max)
@@ -587,6 +590,7 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         "completion_price_microdollars_per_million_tokens": completion_min,
         "published_prompt_price_microdollars_per_million_tokens": pub_prompt_min,
         "published_completion_price_microdollars_per_million_tokens": pub_completion_min,
+        "minimum_charge_microdollars": model.minimum_charge_microdollars,
         # Uniform pricing means the customer pays the headline rate — no
         # secret 1¢/M discount layered on top. Field kept for OpenRouter
         # consumer compat, but always zero.

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -139,6 +139,7 @@ class Model:
     completion_price_microdollars_per_million_tokens: int = 0
     published_prompt_price_microdollars_per_million_tokens: int = 0
     published_completion_price_microdollars_per_million_tokens: int = 0
+    minimum_charge_microdollars: int = 0
     # Full tier list for context-conditional pricing. Defaults to a
     # single tier matching the headline rates above; the ingest path
     # populates multi-tier values when the snapshot carries them.

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -133,6 +133,11 @@ from trusted_router.catalog_ingest import (  # noqa: F401 - used by import-time 
     _is_provider_deprecated_model,
     _supplemental_provider_models_and_endpoints,
 )
+from trusted_router.partner_billing import (
+    PARASAIL_LIBERTY_2_0_INPUT_MICRODOLLARS_PER_MILLION,
+    PARASAIL_LIBERTY_2_0_MINIMUM_CHARGE_MICRODOLLARS,
+    PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION,
+)
 from trusted_router.pricing import (  # noqa: F401 - re-exported for back-compat
     _CACHE_READ_PRICE_MULTIPLIER,
     _CACHE_WRITE_PRICE_MULTIPLIER,
@@ -499,10 +504,21 @@ MODELS: dict[str, Model] = {
         supports_messages=False,
         prepaid_available=True,
         byok_available=False,
-        prompt_price_microdollars_per_million_tokens=2_000_000,
-        completion_price_microdollars_per_million_tokens=20_000_000,
-        published_prompt_price_microdollars_per_million_tokens=2_000_000,
-        published_completion_price_microdollars_per_million_tokens=20_000_000,
+        prompt_price_microdollars_per_million_tokens=(
+            PARASAIL_LIBERTY_2_0_INPUT_MICRODOLLARS_PER_MILLION
+        ),
+        completion_price_microdollars_per_million_tokens=(
+            PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION
+        ),
+        published_prompt_price_microdollars_per_million_tokens=(
+            PARASAIL_LIBERTY_2_0_INPUT_MICRODOLLARS_PER_MILLION
+        ),
+        published_completion_price_microdollars_per_million_tokens=(
+            PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION
+        ),
+        minimum_charge_microdollars=(
+            PARASAIL_LIBERTY_2_0_MINIMUM_CHARGE_MICRODOLLARS
+        ),
     ),
     LIBERTY_3_0_MODEL_ID: Model(
         id=LIBERTY_3_0_MODEL_ID,

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -50,7 +50,7 @@ from trusted_router.content.legal import (
     subprocessor_packet,
 )
 from trusted_router.measured import measured_for_model, measured_for_provider
-from trusted_router.money import MICRODOLLARS_PER_DOLLAR
+from trusted_router.money import MICRODOLLARS_PER_DOLLAR, format_money_precise
 from trusted_router.og import OG_DESCRIPTION, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, OG_TITLE
 from trusted_router.regions import configured_regions, region_map_payload
 
@@ -3024,6 +3024,11 @@ def _model_detail_view(
         "prompt_price": _price(model.prompt_price_microdollars_per_million_tokens),
         "completion_price": _price(
             model.completion_price_microdollars_per_million_tokens
+        ),
+        "minimum_charge": (
+            format_money_precise(model.minimum_charge_microdollars)
+            if model.minimum_charge_microdollars
+            else None
         ),
         "endpoints": endpoint_views,
         "endpoint_count": len(endpoint_views),

--- a/src/trusted_router/partner_billing.py
+++ b/src/trusted_router/partner_billing.py
@@ -13,7 +13,8 @@ PARASAIL_LIBERTY_2_0_IDEMPOTENCY_PREFIX = "partner:parasail-liberty-2.0:"
 PARTNER_OPERATOR_COST_SETTLE_FIELD = "_trustedrouter_operator_cost_microdollars"
 
 PARASAIL_LIBERTY_2_0_INPUT_MICRODOLLARS_PER_MILLION = 2_000_000
-PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION = 20_000_000
+PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION = 19_000_000
+PARASAIL_LIBERTY_2_0_MINIMUM_CHARGE_MICRODOLLARS = 1_000
 
 
 class PartnerBillingMode(StrEnum):
@@ -69,10 +70,11 @@ def partner_cost_microdollars(
 ) -> int:
     if mode == PartnerBillingMode.INTERNAL:
         return 0
-    return token_cost_microdollars(
+    token_cost = token_cost_microdollars(
         input_tokens,
         PARASAIL_LIBERTY_2_0_INPUT_MICRODOLLARS_PER_MILLION,
     ) + token_cost_microdollars(
         output_tokens,
         PARASAIL_LIBERTY_2_0_OUTPUT_MICRODOLLARS_PER_MILLION,
     )
+    return max(token_cost, PARASAIL_LIBERTY_2_0_MINIMUM_CHARGE_MICRODOLLARS)

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -63,6 +63,9 @@
         {% if model.fixed_price %}
         <tr><th>Input price</th><td>{{ model.prompt_price }} tokens</td></tr>
         <tr><th>Output price</th><td>{{ model.completion_price }} tokens</td></tr>
+        {% if model.minimum_charge %}
+        <tr><th>Minimum charge</th><td>{{ model.minimum_charge }} per successful request</td></tr>
+        {% endif %}
         {% endif %}
         <tr><th>Modes</th><td>
           {% if model.supports_chat %}<span class="pill">chat</span>{% endif %}

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -152,8 +152,10 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
         assert model.provider in PROVIDERS
         assert isinstance(model.prompt_price_microdollars_per_million_tokens, int)
         assert isinstance(model.completion_price_microdollars_per_million_tokens, int)
+        assert isinstance(model.minimum_charge_microdollars, int)
         assert model.prompt_price_microdollars_per_million_tokens >= 0
         assert model.completion_price_microdollars_per_million_tokens >= 0
+        assert model.minimum_charge_microdollars >= 0
         assert (
             model.prompt_price_microdollars_per_million_tokens
             <= model.published_prompt_price_microdollars_per_million_tokens
@@ -169,12 +171,14 @@ def test_parasail_liberty_catalog_publishes_fixed_credits_only_price() -> None:
     shape = model_to_openrouter_shape(model)
 
     assert shape["pricing"]["prompt"] == "0.000002"
-    assert shape["pricing"]["completion"] == "0.00002"
+    assert shape["pricing"]["completion"] == "0.000019"
+    assert shape["pricing"]["minimum"] == "0.001"
     assert shape["trustedrouter"]["prompt_price_microdollars_per_million_tokens"] == 2_000_000
     assert (
         shape["trustedrouter"]["completion_price_microdollars_per_million_tokens"]
-        == 20_000_000
+        == 19_000_000
     )
+    assert shape["trustedrouter"]["minimum_charge_microdollars"] == 1_000
     assert shape["trustedrouter"]["prepaid_available"] is True
     assert shape["trustedrouter"]["byok_available"] is False
     assert shape["trustedrouter"]["route_kind"] == "advisor_orchestration"

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -191,7 +191,7 @@ def test_parasail_liberty_uses_fixed_top_level_price_and_public_generation() -> 
     )
     assert authorize.status_code == 200, authorize.text
     auth_data = authorize.json()["data"]
-    assert auth_data["estimated_cost_microdollars"] == 4_000
+    assert auth_data["estimated_cost_microdollars"] == 3_900
     assert auth_data["requested_model"] == "parasail/liberty-2.0"
     assert auth_data["usage_type"] == "Credits"
     assert auth_data["route_candidates"]
@@ -210,7 +210,7 @@ def test_parasail_liberty_uses_fixed_top_level_price_and_public_generation() -> 
     )
     assert settle.status_code == 200, settle.text
     data = settle.json()["data"]
-    assert data["cost_microdollars"] == 13_808
+    assert data["cost_microdollars"] == 13_241
     assert data["model"] == "parasail/liberty-2.0"
     assert data["provider"] == "parasail"
 
@@ -218,7 +218,85 @@ def test_parasail_liberty_uses_fixed_top_level_price_and_public_generation() -> 
     assert generation is not None
     assert generation.model == "parasail/liberty-2.0"
     assert generation.provider == "parasail"
-    assert generation.total_cost_microdollars == 13_808
+    assert generation.total_cost_microdollars == 13_241
+
+
+def test_parasail_liberty_minimum_is_reserved_and_settled_exactly_once() -> None:
+    client, key = _client_and_key()
+    money = STORE.credit_money[key["workspace_id"]]
+    usage_before = money.total_usage_microdollars
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "parasail/liberty-2.0",
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+            "route_type": PARASAIL_LIBERTY_2_0_TOP_LEVEL_ROUTE,
+            "idempotency_key": "req-parasail-liberty-minimum",
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    auth_data = authorize.json()["data"]
+    assert auth_data["estimated_cost_microdollars"] == 1_000
+
+    settle_body = {
+        "authorization_id": auth_data["authorization_id"],
+        "actual_input_tokens": 8,
+        "actual_output_tokens": 3,
+        "route_type": PARASAIL_LIBERTY_2_0_TOP_LEVEL_ROUTE,
+        "request_id": "req-parasail-liberty-minimum",
+        "elapsed_seconds": 0.1,
+    }
+    settle = client.post("/v1/internal/gateway/settle", json=settle_body)
+    assert settle.status_code == 200, settle.text
+    assert settle.json()["data"]["cost_microdollars"] == 1_000
+    assert money.total_usage_microdollars == usage_before + 1_000
+
+    replay = client.post("/v1/internal/gateway/settle", json=settle_body)
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert money.total_usage_microdollars == usage_before + 1_000
+
+
+def test_parasail_liberty_failed_request_refunds_minimum_reservation() -> None:
+    client, key = _client_and_key()
+    money = STORE.credit_money[key["workspace_id"]]
+    usage_before = money.total_usage_microdollars
+
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "parasail/liberty-2.0",
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+            "route_type": PARASAIL_LIBERTY_2_0_TOP_LEVEL_ROUTE,
+            "idempotency_key": "req-parasail-liberty-minimum-refund",
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    auth_data = authorize.json()["data"]
+    assert auth_data["estimated_cost_microdollars"] == 1_000
+
+    refund = client.post(
+        "/v1/internal/gateway/refund",
+        json={
+            "authorization_id": auth_data["authorization_id"],
+            "actual_input_tokens": 1,
+            "actual_output_tokens": 0,
+            "route_type": PARASAIL_LIBERTY_2_0_TOP_LEVEL_ROUTE,
+            "request_id": "req-parasail-liberty-minimum-refund",
+            "elapsed_seconds": 0.1,
+            "error_status": 503,
+            "error_type": "provider_error",
+        },
+    )
+    assert refund.status_code == 200, refund.text
+    assert money.total_usage_microdollars == usage_before
+    assert money.reserved_microdollars == 0
+    assert not STORE.generation_store.generations
 
 
 def test_parasail_liberty_internal_calls_are_customer_cost_zero(

--- a/tests/test_partner_billing.py
+++ b/tests/test_partner_billing.py
@@ -19,7 +19,32 @@ def test_partner_top_level_cost_uses_exact_integer_token_rates() -> None:
             input_tokens=1_234_567,
             output_tokens=89_012,
         )
-        == 4_249_374
+        == 4_160_362
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_tokens", "output_tokens", "expected_microdollars"),
+    [
+        (0, 0, 1_000),
+        (1, 1, 1_000),
+        (400, 10, 1_000),
+        (405, 10, 1_000),
+        (406, 10, 1_002),
+    ],
+)
+def test_partner_top_level_cost_enforces_exact_request_minimum(
+    input_tokens: int,
+    output_tokens: int,
+    expected_microdollars: int,
+) -> None:
+    assert (
+        partner_cost_microdollars(
+            PartnerBillingMode.TOP_LEVEL,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        == expected_microdollars
     )
 
 

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -293,6 +293,17 @@ def test_public_model_detail_lists_distinct_serving_providers(client: TestClient
         assert f'title="{provider}"' in response.text
 
 
+def test_public_partner_model_discloses_fixed_price_and_minimum(
+    client: TestClient,
+) -> None:
+    response = client.get("/models/parasail/liberty-2.0")
+
+    assert response.status_code == 200
+    assert "$2/1M tokens" in response.text
+    assert "$19/1M tokens" in response.text
+    assert "$0.001 per successful request" in response.text
+
+
 def test_public_model_pages_never_claim_tr_stores_content(client: TestClient) -> None:
     catalog = client.get("/models")
     detail = client.get("/models/moonshotai/kimi-k2.6")


### PR DESCRIPTION
## Summary
- price `parasail/liberty-2.0` output at $19 per million tokens
- enforce a $0.001 minimum on successful top-level requests at both authorization and settlement
- disclose the minimum through `/v1/models` and the public model page
- keep internal orchestration fan-out at zero customer charge

## Verification
- `uv run pytest -q` (1901 passed, 33 skipped)
- `uv run mypy`
- `uv run ruff check .`
- targeted reserve, settle, idempotency, refund, catalog, and UI regressions