### PR TITLE
Default API key budgets to hard limits

### DIFF
--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -102,9 +102,8 @@ def register(app: FastAPI) -> None:
             limit_daily_microdollars=daily_micro,
             limit_weekly_microdollars=weekly_micro,
             limit_monthly_microdollars=monthly_micro,
-            # The model/API default is alert (True); here 'omitted checkbox' = False.
-            # That's safe ONLY because the create template renders the box checked —
-            # a browser always sends 'on' unless the user unchecks it (codex/reviewer note).
+            # Omitted checkbox = the shared hard-limit default. Alert-only must be
+            # selected explicitly.
             budget_alert_only=_checkbox(budget_alert_only),
         )
         return _render_page(ctx, settings, created_key=raw)

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -97,8 +97,8 @@ class CreateKeyRequest(_Lenient):
     limit_daily: Decimal | None = None
     limit_weekly: Decimal | None = None
     limit_monthly: Decimal | None = None
-    # True = window budgets ALERT (email, don't block); False = hard-limit (429).
-    budget_alert_only: bool = True
+    # False = hard-limit (429, default); True = alert by email without blocking.
+    budget_alert_only: bool = False
     include_byok_in_limit: bool = True
     expires_at: str | None = None
     workspace_id: str | None = None

--- a/src/trusted_router/serialization.py
+++ b/src/trusted_router/serialization.py
@@ -82,7 +82,7 @@ def key_shape(key: ApiKey, *, window_usage: dict[str, int] | None = None) -> dic
         "limit_reset": key.limit_reset,
         "include_byok_in_limit": key.include_byok_in_limit,
         "tags": dict(key.tags),
-        # True (default) = window budgets ALERT (email, don't block); False = hard-limit.
+        # False (default) = hard-limit; True explicitly opts into email-only alerts.
         "budget_alert_only": key.budget_alert_only,
         **usage_breakdown,
         **byok_breakdown,

--- a/src/trusted_router/services/budget_alerts.py
+++ b/src/trusted_router/services/budget_alerts.py
@@ -1,6 +1,6 @@
 """Per-key budget ALERT emails.
 
-When a key is in alert mode (`budget_alert_only`, the default), crossing a
+When a key explicitly opts into alert mode (`budget_alert_only`), crossing a
 daily/weekly/monthly window budget does NOT block the request — it emails the
 workspace owner instead ("know when weird shit is happening" without stopping a
 working app). Called from the gateway settle path AFTER the window usage is

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -433,7 +433,7 @@ class InMemoryStore:
         limit_daily_microdollars: int | None = None,
         limit_weekly_microdollars: int | None = None,
         limit_monthly_microdollars: int | None = None,
-        budget_alert_only: bool = True,
+        budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
         return self.api_keys.create(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -693,7 +693,7 @@ class SpannerBigtableStore:
         limit_daily_microdollars: int | None = None,
         limit_weekly_microdollars: int | None = None,
         limit_monthly_microdollars: int | None = None,
-        budget_alert_only: bool = True,
+        budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
         return self.api_keys.create(

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -60,7 +60,7 @@ class SpannerApiKeys:
         limit_daily_microdollars: int | None = None,
         limit_weekly_microdollars: int | None = None,
         limit_monthly_microdollars: int | None = None,
-        budget_alert_only: bool = True,
+        budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
         raw = raw_key or new_api_key()

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -108,7 +108,7 @@ class InMemoryApiKeys:
         limit_daily_microdollars: int | None = None,
         limit_weekly_microdollars: int | None = None,
         limit_monthly_microdollars: int | None = None,
-        budget_alert_only: bool = True,
+        budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
         with self._lock:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -114,12 +114,11 @@ class ApiKey:
     limit_daily_microdollars: int | None = None
     limit_weekly_microdollars: int | None = None
     limit_monthly_microdollars: int | None = None
-    # When True (the default), the window budgets are ALERT thresholds: a crossed
-    # window emails the workspace owner but NEVER blocks the request (don't stop a
-    # working app). When False, the windows HARD-LIMIT (429). `budget_alerted`
-    # dedups the email — {window: window_start_iso} of the last alert per window,
-    # so at most one email per window (JSON-owned alert state, not a counter).
-    budget_alert_only: bool = True
+    # False (the default) makes window budgets HARD LIMITS (429). True explicitly
+    # opts into alert-only thresholds: crossing a window emails the workspace
+    # owner but does not block requests. `budget_alerted` dedups the email as
+    # {window: window_start_iso} (JSON-owned alert state, not a counter).
+    budget_alert_only: bool = False
     budget_alerted: dict[str, str] = field(default_factory=dict)
     include_byok_in_limit: bool = True
     usage_microdollars: int = 0

--- a/src/trusted_router/templates/console/api_keys.html
+++ b/src/trusted_router/templates/console/api_keys.html
@@ -11,8 +11,8 @@
     <label>Weekly limit (USD, optional)<input name="limit_weekly" type="text" inputmode="decimal" placeholder="e.g. {{ suggested.weekly }}"></label>
     <label>Monthly limit (USD, optional)<input name="limit_monthly" type="text" inputmode="decimal" placeholder="e.g. {{ suggested.monthly }}"></label>
   </div>
-  <label class="budget-action-check"><input type="checkbox" name="budget_alert_only" checked> <span>Alert only — email me when a budget is crossed, don’t block the app</span></label>
-  <p class="key-window-note">Optional — left blank, a key has no window limit. A balanced starting point is <strong>${{ suggested.daily }} / day</strong>, <strong>${{ suggested.weekly }} / week</strong>, <strong>${{ suggested.monthly }} / month</strong> (weekly ≈ half the monthly, daily ≈ a fifth of the weekly). Uncheck “Alert only” to hard-stop (429) at the budget instead. Windows reset at UTC midnight / Monday / the 1st; enforcement is approximate. Agents can read their remaining budget from <code>GET /v1/key</code>.</p>
+  <label class="budget-action-check"><input type="checkbox" name="budget_alert_only"> <span>Email alert only — notify me when a budget is crossed, but don’t block requests</span></label>
+  <p class="key-window-note">Optional — left blank, a key has no window limit. A balanced starting point is <strong>${{ suggested.daily }} / day</strong>, <strong>${{ suggested.weekly }} / week</strong>, <strong>${{ suggested.monthly }} / month</strong> (weekly ≈ half the monthly, daily ≈ a fifth of the weekly). Budgets hard-stop requests with 429 by default. Select “Email alert only” to notify without blocking. Windows reset at UTC midnight / Monday / the 1st; enforcement is approximate. Agents can read their remaining budget from <code>GET /v1/key</code>.</p>
   <button class="btn primary" type="submit">Create key</button>
 </form>
 {% endmacro %}
@@ -71,7 +71,7 @@
                 <label>{{ w.name|capitalize }}<input name="limit_{{ w.name }}" type="text" inputmode="decimal" placeholder="off" value="{{ w.input }}" aria-label="{{ w.name|capitalize }} limit for {{ k.name }}"></label>
                 {% endfor %}
               </div>
-              <label class="budget-action-check"><input type="checkbox" name="budget_alert_only" {% if k.budget_alert_only %}checked{% endif %} aria-label="Alert only for {{ k.name }}"> <span>Alert only (email, don’t block)</span></label>
+              <label class="budget-action-check"><input type="checkbox" name="budget_alert_only" {% if k.budget_alert_only %}checked{% endif %} aria-label="Email alert only for {{ k.name }}"> <span>Email alert only (don’t block)</span></label>
               <button class="btn" type="submit">Save</button>
             </form>
             <div class="key-budget-current">

--- a/tests/test_billing_budget_alert_mode.py
+++ b/tests/test_billing_budget_alert_mode.py
@@ -1,5 +1,5 @@
-"""Alert-vs-Limit budget mode: alert mode (default) never blocks — it emails the
-workspace owner when a window is crossed (once per window); limit mode 429s."""
+"""Alert-vs-limit budget mode: hard limits are the default; explicitly selected
+alert mode emails once per crossed window without blocking requests."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def _key(*, alert_only: bool, email: str = "owner@example.com"):
 
 def test_alert_mode_never_blocks_over_budget() -> None:
     STORE.reset()
-    _ws, key = _key(alert_only=True)  # the default
+    _ws, key = _key(alert_only=True)
     STORE.api_keys.add_usage(key.hash, 5_000, is_byok=False)  # way over $0.001 daily
     # Alert mode: authorize/reserve must NOT raise — the app keeps working.
     STORE.reserve_key_limit(key.hash, 500, usage_type="Credits")

--- a/tests/test_console_keys_manage.py
+++ b/tests/test_console_keys_manage.py
@@ -130,11 +130,15 @@ def test_member_cannot_disable_enable_or_delete(console: dict, client: TestClien
 
 def test_create_form_budget_alert_only_checkbox(console: dict) -> None:
     client, workspace = console["client"], console["workspace"]
-    # Rendered-checked "Alert only" box submits as 'on' -> alert mode.
+    page = client.get("/console/api-keys").text
+    assert '<input type="checkbox" name="budget_alert_only">' in page
+    assert '<input type="checkbox" name="budget_alert_only" checked>' not in page
+    assert "Budgets hard-stop requests with 429 by default" in page
+    # Alert-only mode requires an explicit checked value.
     client.post("/console/api-keys", data={"name": "alerted", "budget_alert_only": "on"})
     alerted = next(k for k in STORE.list_keys(workspace.id) if k.name == "alerted")
     assert alerted.budget_alert_only is True
-    # Unchecked (field omitted) -> hard limit.
+    # The normal omitted field creates a hard-limit key.
     client.post("/console/api-keys", data={"name": "hardlimit"})
     hard = next(k for k in STORE.list_keys(workspace.id) if k.name == "hardlimit")
     assert hard.budget_alert_only is False
@@ -152,7 +156,7 @@ def test_limit_form_toggles_alert_vs_limit(console: dict) -> None:
     )
     assert STORE.get_key_by_hash(key.hash).budget_alert_only is True
     # The checkbox renders on the page.
-    assert "Alert only" in client.get("/console/api-keys").text
+    assert "Email alert only" in client.get("/console/api-keys").text
 
 
 def test_budget_can_be_cleared_back_to_undefined(console: dict) -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.catalog import PROVIDER_JURISDICTION_US, PROVIDERS
+from trusted_router.spend_windows import KeyWindowLimitExceeded
 from trusted_router.storage import STORE
 
 
@@ -29,6 +30,40 @@ def test_key_create_list_and_one_time_reveal(
     credit_data = credits.json()["data"]
     assert isinstance(credit_data["total_credits_microdollars"], int)
     assert isinstance(credit_data["available_microdollars"], int)
+
+
+def test_api_key_budgets_default_to_hard_limit_and_alert_only_is_opt_in(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    hard_response = client.post(
+        "/v1/keys",
+        headers=user_headers,
+        json={"name": "hard by default", "limit_daily": "0.001"},
+    )
+    assert hard_response.status_code == 201, hard_response.text
+    hard = STORE.get_key_by_hash(hard_response.json()["data"]["hash"])
+    assert hard is not None
+    assert hard.budget_alert_only is False
+    STORE.api_keys.add_usage(hard.hash, 1_000, is_byok=False)
+    with pytest.raises(KeyWindowLimitExceeded):
+        STORE.reserve_key_limit(hard.hash, 1, usage_type="Credits")
+
+    alert_response = client.post(
+        "/v1/keys",
+        headers=user_headers,
+        json={
+            "name": "explicit email alert",
+            "limit_daily": "0.001",
+            "budget_alert_only": True,
+        },
+    )
+    assert alert_response.status_code == 201, alert_response.text
+    alert = STORE.get_key_by_hash(alert_response.json()["data"]["hash"])
+    assert alert is not None
+    assert alert.budget_alert_only is True
+    STORE.api_keys.add_usage(alert.hash, 1_000, is_byok=False)
+    STORE.reserve_key_limit(alert.hash, 1, usage_type="Credits")
 
 
 def test_inference_key_cannot_call_management_api(

--- a/tests/test_internal_chat_browser_key.py
+++ b/tests/test_internal_chat_browser_key.py
@@ -94,6 +94,7 @@ def test_issue_chat_browser_key_creates_scoped_key_and_sets_cookie() -> None:
     assert issued.creator_user_id == user_id
     assert issued.management is False  # browser keys must NEVER be mgmt
     assert issued.limit_microdollars == CHAT_BROWSER_KEY_LIMIT_MICRODOLLARS
+    assert issued.budget_alert_only is False
     assert issued.expires_at is not None
 
     # Cookie is set with the right attributes for the chat client

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -64,6 +64,7 @@ def test_oauth_code_exchange_creates_delegated_inference_key(
     assert api_key.limit_microdollars == 12_345_678
     assert api_key.limit_reset == "monthly"
     assert api_key.expires_at == "2099-01-01T00:00:00Z"
+    assert api_key.budget_alert_only is False
 
 
 def test_oauth_code_exchange_returns_signed_in_identity(

--- a/tests/test_storage_contracts.py
+++ b/tests/test_storage_contracts.py
@@ -23,6 +23,29 @@ def test_delete_key_removes_raw_lookup_path() -> None:
     assert store.delete_key(key.hash) is False
 
 
+def test_in_memory_keys_default_to_hard_budgets_and_allow_alert_opt_in() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("budget-default@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+
+    _, hard = store.create_api_key(
+        workspace_id=workspace.id,
+        name="hard",
+        creator_user_id=user.id,
+        limit_daily_microdollars=1_000,
+    )
+    _, alert = store.create_api_key(
+        workspace_id=workspace.id,
+        name="alert",
+        creator_user_id=user.id,
+        limit_daily_microdollars=1_000,
+        budget_alert_only=True,
+    )
+
+    assert hard.budget_alert_only is False
+    assert alert.budget_alert_only is True
+
+
 def test_set_user_email_resets_verified_when_address_changes() -> None:
     store = InMemoryStore()
     user = store.ensure_user("alice@example.com")

--- a/tests/test_storage_gcp_features.py
+++ b/tests/test_storage_gcp_features.py
@@ -40,6 +40,29 @@ def _seed_workspace_and_key(store) -> tuple[str, str]:
     return workspace.id, api_key.hash
 
 
+def test_gcp_keys_default_to_hard_budgets_and_allow_alert_opt_in() -> None:
+    store, _db, _ = make_fake_store()
+    user = store.ensure_user("gcp-budget-default@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+
+    _, hard = store.create_api_key(
+        workspace_id=workspace.id,
+        name="hard",
+        creator_user_id=user.id,
+        limit_daily_microdollars=1_000,
+    )
+    _, alert = store.create_api_key(
+        workspace_id=workspace.id,
+        name="alert",
+        creator_user_id=user.id,
+        limit_daily_microdollars=1_000,
+        budget_alert_only=True,
+    )
+
+    assert hard.budget_alert_only is False
+    assert alert.budget_alert_only is True
+
+
 # ── Auth sessions ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- make hard 429 enforcement the default for new API-key window budgets
- keep email-only alert behavior as an explicit opt-in
- apply the default consistently to management API, console, OAuth, browser keys, in-memory storage, and Spanner storage
- clarify the console copy and leave existing persisted key settings unchanged

## Validation
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1904 passed, 33 skipped)