### PR TITLE
Add privacy-bounded Google Ads conversions

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -17,13 +17,13 @@ days. Production sends it only over HTTPS. The cookie contains:
 
 The cookie and durable attribution record never contain prompts, outputs, raw
 API keys, BYOK keys, email addresses, payment credentials, request bodies, IP
-addresses, or full referring URLs. Click identifiers are retained only in the
-private Spanner record for future consented offline conversion uploads. Logs
-contain booleans indicating which click identifier was present, never its raw
-value. Public landing events also contain a server-keyed HMAC fingerprint of
-the click identifier. This lets reports deduplicate the same ad click across
-cookie churn without exposing an identifier that an analytics operator can
-reuse outside TrustedRouter.
+addresses, or full referring URLs. Click identifiers are retained only in
+private Spanner records and the metadata-only Google conversion rows described
+below. Logs contain booleans indicating which click identifier was present,
+never its raw value. Public landing events also contain a server-keyed HMAC
+fingerprint of the click identifier. This lets reports deduplicate the same ad
+click across cookie churn without exposing an identifier that an analytics
+operator can reuse outside TrustedRouter.
 
 Requests carrying `Sec-GPC: 1` or `DNT: 1` do not create or use attribution.
 Known crawler, link-preview, prefetch, and prerender requests do not receive
@@ -64,6 +64,40 @@ after signup.
 
 Attribution writes are failure-isolated. They cannot fail signup, inference,
 settlement, payment acknowledgement, or streaming.
+
+## Google Ads Data Manager
+
+Google Ads imports attributed outcomes from:
+
+```text
+GET /v1/internal/marketing/google-ads-conversions.csv
+```
+
+The HTTPS feed requires a dedicated HTTP Basic username and a 32-character or
+longer secret from Secret Manager. It is private, uncached, and excluded from
+indexing. The feed covers the last 90 days and fails with `503` rather than
+silently truncating if it reaches the configured row ceiling.
+
+Each Google-attributed milestone creates an idempotent, month-partitioned
+Spanner row:
+
+1. `TrustedRouter Signup`
+2. `TrustedRouter Activated API User`
+3. `TrustedRouter Retained API User 7d`
+4. `TrustedRouter Credit Purchase`
+
+The row contains only `gclid`, `gbraid`, or `wbraid`, the conversion action and
+timestamp, exact integer-derived USD value, currency, and a SHA-256 order ID
+derived from the random anonymous attribution ID. It contains no workspace ID,
+user ID, email, model/provider choice, API key, prompt, output, or request body.
+Google can use the order ID and its own click ID for deduplication without
+receiving a TrustedRouter account identifier.
+
+Signup and product-use rows are committed atomically with their attribution
+milestones. Purchase rows are created only after the payment ledger's
+idempotency check wins. A protected backfill endpoint reconstructs historic
+signup, activation, and retention rows; it deliberately does not synthesize
+historic individual purchases from aggregate totals.
 
 ## Campaign Conventions
 

--- a/docs/marketing/paid-acquisition-ahrefs-2026-07-21.md
+++ b/docs/marketing/paid-acquisition-ahrefs-2026-07-21.md
@@ -183,6 +183,14 @@ primary optimization event to `first_successful_api_call` or a credit purchase
 only after there is enough volume for the bidding system to learn. Report both
 CAC and activated CAC; signup CAC alone is easy to make look good.
 
+Implementation: Google Ads Data Manager pulls the authenticated,
+metadata-only CSV documented in
+[`first-party-attribution.md`](first-party-attribution.md). Keep
+`TrustedRouter Signup` as the only primary bidding conversion initially.
+Configure activation, seven-day retention, and purchase as secondary
+observation conversions until each has enough weekly volume for stable
+optimization.
+
 ## Raw Inputs
 
 The source CSVs were downloaded locally from Ahrefs on 2026-07-21:

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -28,6 +28,7 @@ SECRET_ENVS=(
   "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
   "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret:latest"
   "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
+  "TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD=trustedrouter-google-ads-conversion-feed-password:latest"
 )
 add_secret_env_if_exists() {
   local env_name="$1"

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -214,6 +214,14 @@ grant_tr_deploy_secret_access "trustedrouter-streamlake-api-key"
 ensure_secret_from_env_file "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token" "AXIOM_TOKEN" "AXIOM_API_KEY"
 require_secret_from_env_file "STRIPE_SECRET_KEY" "trustedrouter-stripe-secret-key" "STRIPE_KEY"
 require_secret_from_env_file "STRIPE_WEBHOOK_SECRET" "trustedrouter-stripe-webhook-secret"
+if ! gc secrets describe trustedrouter-google-ads-conversion-feed-password >/dev/null 2>&1; then
+  ensure_secret_value trustedrouter-google-ads-conversion-feed-password "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+  log "generated secret trustedrouter-google-ads-conversion-feed-password"
+fi
 
 # OAuth + SES secrets — independently optional. Push to Secret Manager only
 # when the local keys file (or env) supplies a value; production fail-closed

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -65,6 +65,13 @@ class Settings(BaseSettings):
     # error log lines we just enriched. DEBUG would flood; ERROR alone
     # would miss the request_id correlation in 429s.
     axiom_log_level: str = "INFO"
+    # Google Ads Data Manager pulls a metadata-only CSV over authenticated
+    # HTTPS. The password is optional so local/test installs stay simple; when
+    # absent the feed route is an intentional 404.
+    google_ads_conversion_feed_username: str = "trustedrouter-data-manager"
+    google_ads_conversion_feed_password: str | None = None
+    google_ads_conversion_feed_retention_days: int = 90
+    google_ads_conversion_feed_max_rows: int = 100_000
     enable_sentry_test_route: bool = False
     sentry_floodgate_enabled: bool = True
     sentry_floodgate_window_seconds: int = 60 * 60
@@ -232,6 +239,21 @@ class Settings(BaseSettings):
         environment = self.environment.lower()
         if self.signup_trial_credit_microdollars < 0:
             raise ValueError("TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS cannot be negative")
+        if not 1 <= self.google_ads_conversion_feed_retention_days <= 90:
+            raise ValueError(
+                "TR_GOOGLE_ADS_CONVERSION_FEED_RETENTION_DAYS must be between 1 and 90"
+            )
+        if self.google_ads_conversion_feed_max_rows < 1:
+            raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_MAX_ROWS must be positive")
+        if ":" in self.google_ads_conversion_feed_username:
+            raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_USERNAME cannot contain ':'")
+        if (
+            self.google_ads_conversion_feed_password is not None
+            and len(self.google_ads_conversion_feed_password) < 32
+        ):
+            raise ValueError(
+                "TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD must contain at least 32 characters"
+            )
         if self.x402_allow_mock_payments and environment not in {"local", "test"}:
             raise ValueError("TR_X402_ALLOW_MOCK_PAYMENTS is only allowed in local/test")
         if (
@@ -331,6 +353,8 @@ _LOCAL_KEY_FALLBACKS: tuple[str, ...] = (
     "paypal_webhook_id",
     "paypal_api_base_url",
     "sentry_dsn",
+    "google_ads_conversion_feed_username",
+    "google_ads_conversion_feed_password",
     "bootstrap_management_key",
     "byok_kms_key_name",
     "byok_envelope_key_b64",

--- a/src/trusted_router/google_ads_conversions.py
+++ b/src/trusted_router/google_ads_conversions.py
@@ -1,0 +1,162 @@
+"""Privacy-bounded Google Ads conversion records and CSV formatting.
+
+Google Ads receives only its own click identifier plus an event name, time,
+integer-derived value, currency, and an opaque order ID. Prompt/output data,
+emails, API keys, workspace IDs, and request bodies never enter this module.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import hashlib
+import io
+from decimal import Decimal
+
+from trusted_router.money import MICRODOLLARS_PER_DOLLAR
+from trusted_router.storage_models import AcquisitionAttribution, GoogleAdsConversion
+
+GOOGLE_ADS_SIGNUP_ACTION = "TrustedRouter Signup"
+GOOGLE_ADS_ACTIVATED_ACTION = "TrustedRouter Activated API User"
+GOOGLE_ADS_RETAINED_ACTION = "TrustedRouter Retained API User 7d"
+GOOGLE_ADS_PURCHASE_ACTION = "TrustedRouter Credit Purchase"
+
+GOOGLE_ADS_ACTION_BY_EVENT = {
+    "signup_completed": GOOGLE_ADS_SIGNUP_ACTION,
+    "first_successful_api_call": GOOGLE_ADS_ACTIVATED_ACTION,
+    "retained_api_usage_7d": GOOGLE_ADS_RETAINED_ACTION,
+    "credit_purchase_completed": GOOGLE_ADS_PURCHASE_ACTION,
+}
+
+GOOGLE_ADS_CSV_COLUMNS = (
+    "conversion_action",
+    "gclid",
+    "gbraid",
+    "wbraid",
+    "conversion_datetime",
+    "conversion_value",
+    "currency_code",
+    "order_id",
+)
+
+_CLICK_ID_FIELDS = ("gclid", "gbraid", "wbraid")
+_ENTITY_KIND_PREFIX = "google_ads_conversion_"
+
+
+def build_google_ads_conversion(
+    record: AcquisitionAttribution,
+    event: str,
+    *,
+    occurred_at: str,
+    value_microdollars: int = 0,
+    ordinal: int = 0,
+) -> GoogleAdsConversion | None:
+    """Create a deterministic conversion for a Google-attributed account."""
+    action = GOOGLE_ADS_ACTION_BY_EVENT.get(event)
+    if action is None:
+        return None
+    touch = _google_touch(record)
+    if touch is None:
+        return None
+    if value_microdollars < 0:
+        raise ValueError("Google Ads conversion value cannot be negative")
+    seed = "\0".join(
+        (
+            record.anonymous_id,
+            event,
+            occurred_at,
+            str(ordinal),
+        )
+    )
+    order_id = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return GoogleAdsConversion(
+        order_id=order_id,
+        conversion_action=action,
+        occurred_at=occurred_at,
+        gclid=touch.get("gclid"),
+        gbraid=touch.get("gbraid"),
+        wbraid=touch.get("wbraid"),
+        value_microdollars=value_microdollars,
+    )
+
+
+def google_ads_conversion_kind(occurred_at: str) -> str:
+    timestamp = parse_utc_timestamp(occurred_at)
+    return f"{_ENTITY_KIND_PREFIX}{timestamp:%Y%m}"
+
+
+def google_ads_conversion_entity_id(conversion: GoogleAdsConversion) -> str:
+    timestamp = parse_utc_timestamp(conversion.occurred_at)
+    return f"{timestamp:%Y%m%dT%H%M%SZ}#{conversion.order_id}"
+
+
+def google_ads_conversion_kinds_since(
+    since: dt.datetime,
+    *,
+    now: dt.datetime | None = None,
+) -> list[str]:
+    """Return month-partitioned entity kinds covering ``since`` through now."""
+    start = _as_utc(since).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = _as_utc(now or dt.datetime.now(dt.UTC)).replace(
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+    kinds: list[str] = []
+    cursor = start
+    while cursor <= end:
+        kinds.append(f"{_ENTITY_KIND_PREFIX}{cursor:%Y%m}")
+        if cursor.month == 12:
+            cursor = cursor.replace(year=cursor.year + 1, month=1)
+        else:
+            cursor = cursor.replace(month=cursor.month + 1)
+    return kinds
+
+
+def google_ads_conversions_csv(conversions: list[GoogleAdsConversion]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        output,
+        fieldnames=GOOGLE_ADS_CSV_COLUMNS,
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    for conversion in conversions:
+        writer.writerow(
+            {
+                "conversion_action": conversion.conversion_action,
+                "gclid": conversion.gclid or "",
+                "gbraid": conversion.gbraid or "",
+                "wbraid": conversion.wbraid or "",
+                "conversion_datetime": conversion.occurred_at,
+                "conversion_value": _microdollars_decimal(conversion.value_microdollars),
+                "currency_code": conversion.currency_code,
+                "order_id": conversion.order_id,
+            }
+        )
+    return output.getvalue()
+
+
+def parse_utc_timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return _as_utc(parsed)
+
+
+def _as_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _google_touch(record: AcquisitionAttribution) -> dict[str, str] | None:
+    for touch in (record.last_touch, record.first_touch):
+        if any(touch.get(field) for field in _CLICK_ID_FIELDS):
+            return touch
+    return None
+
+
+def _microdollars_decimal(value: int) -> str:
+    amount = Decimal(value) / Decimal(MICRODOLLARS_PER_DOLLAR)
+    return f"{amount:.6f}"

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -89,7 +89,14 @@ def create_app(
             return JSONResponse(
                 exc.detail, status_code=exc.status_code, headers=exc.headers
             )
-        return error_response(exc.status_code, str(exc.detail), ErrorType.HTTP_ERROR)
+        response = error_response(
+            exc.status_code,
+            str(exc.detail),
+            ErrorType.HTTP_ERROR,
+        )
+        if exc.headers:
+            response.headers.update(exc.headers)
+        return response
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(

--- a/src/trusted_router/routes/internal/__init__.py
+++ b/src/trusted_router/routes/internal/__init__.py
@@ -11,6 +11,7 @@ from . import broadcast_queue as broadcast_queue
 from . import chat_browser_key as chat_browser_key
 from . import fetch_image as fetch_image
 from . import gateway as gateway
+from . import google_ads as google_ads
 from . import paypal as paypal
 from . import reconcile as reconcile
 from . import sentry as sentry
@@ -23,6 +24,7 @@ def register_internal_routes(router: APIRouter) -> None:
     paypal.register(router)
     broadcast_queue.register(router)
     gateway.register(router)
+    google_ads.register(router)
     fetch_image.register(router)
     reconcile.register(router)
     synthetic.register(router)

--- a/src/trusted_router/routes/internal/google_ads.py
+++ b/src/trusted_router/routes/internal/google_ads.py
@@ -1,0 +1,97 @@
+"""Authenticated Google Ads Data Manager conversion feed.
+
+The CSV is intentionally narrower than the private attribution record. It
+contains only Google click IDs and conversion metadata, never TrustedRouter
+account identifiers or inference content.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import datetime as dt
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from trusted_router.auth import SettingsDep
+from trusted_router.config import Settings
+from trusted_router.errors import api_error
+from trusted_router.google_ads_conversions import google_ads_conversions_csv
+from trusted_router.routes.internal._shared import require_internal_gateway
+from trusted_router.security import constant_time_equal
+from trusted_router.storage import STORE
+from trusted_router.types import ErrorType
+
+
+def register(router: APIRouter) -> None:
+    @router.get("/internal/marketing/google-ads-conversions.csv")
+    async def google_ads_conversion_feed(
+        request: Request,
+        settings: SettingsDep,
+    ) -> Response:
+        _require_feed_auth(request, settings)
+        now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+        since = now - dt.timedelta(days=settings.google_ads_conversion_feed_retention_days)
+        max_rows = settings.google_ads_conversion_feed_max_rows
+        conversions = STORE.list_google_ads_conversions(
+            since=since.isoformat().replace("+00:00", "Z"),
+            limit=max_rows + 1,
+        )
+        if len(conversions) > max_rows:
+            raise api_error(
+                503,
+                "Google Ads conversion feed exceeded its configured row limit",
+                ErrorType.SERVICE_UNAVAILABLE,
+            )
+        return Response(
+            google_ads_conversions_csv(conversions),
+            media_type="text/csv",
+            headers={
+                "Cache-Control": "private, no-store",
+                "X-Robots-Tag": "noindex, nofollow",
+            },
+        )
+
+    @router.post("/internal/marketing/google-ads-conversions/backfill")
+    async def backfill_google_ads_conversions(
+        request: Request,
+        settings: SettingsDep,
+        limit: int = Query(default=10_000, ge=1, le=100_000),
+    ) -> dict[str, object]:
+        require_internal_gateway(request, settings)
+        created = STORE.backfill_google_ads_conversions(limit=limit)
+        return {"data": {"created": created, "scanned_limit": limit}}
+
+
+def _require_feed_auth(request: Request, settings: Settings) -> None:
+    expected_password = settings.google_ads_conversion_feed_password
+    if not expected_password:
+        raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+    supplied_username, supplied_password = _basic_credentials(
+        request.headers.get("authorization", "")
+    )
+    valid_username = constant_time_equal(
+        supplied_username,
+        settings.google_ads_conversion_feed_username,
+    )
+    valid_password = constant_time_equal(supplied_password, expected_password)
+    if not (valid_username and valid_password):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid Google Ads Data Manager credentials",
+            headers={"WWW-Authenticate": 'Basic realm="TrustedRouter conversions"'},
+        )
+
+
+def _basic_credentials(header: str) -> tuple[str, str]:
+    if not header.lower().startswith("basic "):
+        return "", ""
+    encoded = header.split(" ", 1)[1].strip()
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return "", ""
+    if ":" not in decoded:
+        return "", ""
+    username, password = decoded.split(":", 1)
+    return username, password

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -28,6 +28,7 @@ from trusted_router.storage_models import (
     EncryptedSecretEnvelope,
     GatewayAuthorization,
     Generation,
+    GoogleAdsConversion,
     Member,
     OAuthAuthorizationCode,
     ProviderBenchmarkSample,
@@ -208,6 +209,20 @@ class InMemoryStore:
             amount_microdollars=amount_microdollars,
             occurred_at=occurred_at,
         )
+
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]:
+        return self.acquisition_store.list_google_ads_conversions(
+            since=since,
+            limit=limit,
+        )
+
+    def backfill_google_ads_conversions(self, *, limit: int) -> int:
+        return self.acquisition_store.backfill_google_ads_conversions(limit=limit)
 
     # Auth sessions delegate to storage_auth_sessions.InMemoryAuthSessions.
     def create_auth_session(

--- a/src/trusted_router/storage_attribution.py
+++ b/src/trusted_router/storage_attribution.py
@@ -1,23 +1,36 @@
 from __future__ import annotations
 
+import datetime as dt
 import threading
 
-from trusted_router.storage_models import AcquisitionAttribution, iso_now
+from trusted_router.google_ads_conversions import build_google_ads_conversion
+from trusted_router.storage_models import (
+    AcquisitionAttribution,
+    GoogleAdsConversion,
+    iso_now,
+)
 
 
 class InMemoryAcquisitionAttribution:
     def __init__(self, *, lock: threading.RLock) -> None:
         self._lock = lock
         self.records: dict[str, AcquisitionAttribution] = {}
+        self.google_ads_conversions: dict[str, GoogleAdsConversion] = {}
 
     def reset(self) -> None:
         self.records.clear()
+        self.google_ads_conversions.clear()
 
     def create(self, record: AcquisitionAttribution) -> bool:
         with self._lock:
             if record.workspace_id in self.records:
                 return False
             self.records[record.workspace_id] = record
+            self._record_google_conversion(
+                record,
+                "signup_completed",
+                occurred_at=record.signup_at,
+            )
             return True
 
     def get(self, workspace_id: str) -> AcquisitionAttribution | None:
@@ -41,6 +54,11 @@ class InMemoryAcquisitionAttribution:
                     claimed.append(name)
             for name in claimed:
                 record.milestones[name] = occurred_at
+                self._record_google_conversion(
+                    record,
+                    name,
+                    occurred_at=occurred_at,
+                )
             if claimed:
                 record.updated_at = iso_now()
             return record, claimed
@@ -61,4 +79,85 @@ class InMemoryAcquisitionAttribution:
             record.first_purchase_at = record.first_purchase_at or occurred_at
             record.last_purchase_at = occurred_at
             record.updated_at = iso_now()
+            self._record_google_conversion(
+                record,
+                "credit_purchase_completed",
+                occurred_at=occurred_at,
+                value_microdollars=amount_microdollars,
+                ordinal=record.purchase_count,
+            )
             return record
+
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]:
+        since_at = dt.datetime.fromisoformat(since.replace("Z", "+00:00"))
+        with self._lock:
+            rows = [
+                conversion
+                for conversion in self.google_ads_conversions.values()
+                if dt.datetime.fromisoformat(conversion.occurred_at.replace("Z", "+00:00"))
+                >= since_at
+            ]
+            rows.sort(key=lambda item: (item.occurred_at, item.order_id))
+            return rows[:limit]
+
+    def backfill_google_ads_conversions(self, *, limit: int) -> int:
+        """Backfill deterministic non-purchase events from existing records.
+
+        Historic individual purchases cannot be reconstructed from the
+        aggregate attribution row without risking duplicate or invented
+        conversions, so purchase export starts when this pipeline is deployed.
+        """
+        created = 0
+        with self._lock:
+            records = sorted(
+                self.records.values(),
+                key=lambda item: (item.signup_at, item.workspace_id),
+            )[:limit]
+            for record in records:
+                events = [("signup_completed", record.signup_at)]
+                events.extend(
+                    (name, occurred_at)
+                    for name, occurred_at in record.milestones.items()
+                    if name
+                    in {
+                        "first_successful_api_call",
+                        "retained_api_usage_7d",
+                    }
+                )
+                for event, occurred_at in events:
+                    conversion = build_google_ads_conversion(
+                        record,
+                        event,
+                        occurred_at=occurred_at,
+                    )
+                    if (
+                        conversion is not None
+                        and conversion.order_id not in self.google_ads_conversions
+                    ):
+                        self.google_ads_conversions[conversion.order_id] = conversion
+                        created += 1
+        return created
+
+    def _record_google_conversion(
+        self,
+        record: AcquisitionAttribution,
+        event: str,
+        *,
+        occurred_at: str,
+        value_microdollars: int = 0,
+        ordinal: int = 0,
+    ) -> None:
+        conversion = build_google_ads_conversion(
+            record,
+            event,
+            occurred_at=occurred_at,
+            value_microdollars=value_microdollars,
+            ordinal=ordinal,
+        )
+        if conversion is not None:
+            self.google_ads_conversions.setdefault(conversion.order_id, conversion)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -25,6 +25,7 @@ from trusted_router.storage import (
     EncryptedSecretEnvelope,
     GatewayAuthorization,
     Generation,
+    GoogleAdsConversion,
     Member,
     OAuthAuthorizationCode,
     ProviderBenchmarkSample,
@@ -281,6 +282,20 @@ class SpannerBigtableStore:
             amount_microdollars=amount_microdollars,
             occurred_at=occurred_at,
         )
+
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]:
+        return self.acquisition_store.list_google_ads_conversions(
+            since=since,
+            limit=limit,
+        )
+
+    def backfill_google_ads_conversions(self, *, limit: int) -> int:
+        return self.acquisition_store.backfill_google_ads_conversions(limit=limit)
 
     def ensure_user(
         self,

--- a/src/trusted_router/storage_gcp_attribution.py
+++ b/src/trusted_router/storage_gcp_attribution.py
@@ -2,8 +2,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from trusted_router.google_ads_conversions import (
+    build_google_ads_conversion,
+    google_ads_conversion_entity_id,
+    google_ads_conversion_kind,
+    google_ads_conversion_kinds_since,
+    parse_utc_timestamp,
+)
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
-from trusted_router.storage_models import AcquisitionAttribution, iso_now
+from trusted_router.storage_models import (
+    AcquisitionAttribution,
+    GoogleAdsConversion,
+    iso_now,
+)
 
 _KIND = "acquisition_attribution"
 
@@ -23,6 +34,12 @@ class SpannerAcquisitionAttribution:
             if existing is not None:
                 return False
             self._io.write_entity_tx(transaction, _KIND, record.workspace_id, record)
+            self._write_google_conversion_tx(
+                transaction,
+                record,
+                "signup_completed",
+                occurred_at=record.signup_at,
+            )
             return True
 
         return run_in_transaction_with_retry(self._io.database, txn)
@@ -54,6 +71,12 @@ class SpannerAcquisitionAttribution:
                     claimed.append(name)
             for name in claimed:
                 record.milestones[name] = occurred_at
+                self._write_google_conversion_tx(
+                    transaction,
+                    record,
+                    name,
+                    occurred_at=occurred_at,
+                )
             if claimed:
                 record.updated_at = iso_now()
                 self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
@@ -83,6 +106,129 @@ class SpannerAcquisitionAttribution:
             record.last_purchase_at = occurred_at
             record.updated_at = iso_now()
             self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
+            self._write_google_conversion_tx(
+                transaction,
+                record,
+                "credit_purchase_completed",
+                occurred_at=occurred_at,
+                value_microdollars=amount_microdollars,
+                ordinal=record.purchase_count,
+            )
             return record
 
         return run_in_transaction_with_retry(self._io.database, txn)
+
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]:
+        since_at = parse_utc_timestamp(since)
+        rows: list[GoogleAdsConversion] = []
+        for kind in google_ads_conversion_kinds_since(since_at):
+            remaining = limit - len(rows)
+            if remaining <= 0:
+                break
+            rows.extend(
+                self._io.list_entities(
+                    kind,
+                    cls=GoogleAdsConversion,
+                    limit=remaining,
+                )
+            )
+        rows = [
+            conversion
+            for conversion in rows
+            if parse_utc_timestamp(conversion.occurred_at) >= since_at
+        ]
+        rows.sort(key=lambda item: (item.occurred_at, item.order_id))
+        return rows[:limit]
+
+    def backfill_google_ads_conversions(self, *, limit: int) -> int:
+        records = self._io.list_entities(
+            _KIND,
+            cls=AcquisitionAttribution,
+            limit=limit,
+        )
+        created = 0
+        for candidate in records:
+            workspace_id = candidate.workspace_id
+
+            def txn(
+                transaction: Any,
+                workspace_id: str = workspace_id,
+            ) -> int:
+                record = self._io.read_entity_tx(
+                    transaction,
+                    _KIND,
+                    workspace_id,
+                    AcquisitionAttribution,
+                )
+                if record is None:
+                    return 0
+                events = [("signup_completed", record.signup_at)]
+                events.extend(
+                    (name, occurred_at)
+                    for name, occurred_at in record.milestones.items()
+                    if name
+                    in {
+                        "first_successful_api_call",
+                        "retained_api_usage_7d",
+                    }
+                )
+                inserted = 0
+                for event, occurred_at in events:
+                    conversion = build_google_ads_conversion(
+                        record,
+                        event,
+                        occurred_at=occurred_at,
+                    )
+                    if conversion is None:
+                        continue
+                    kind = google_ads_conversion_kind(conversion.occurred_at)
+                    entity_id = google_ads_conversion_entity_id(conversion)
+                    existing = self._io.read_entity_tx(
+                        transaction,
+                        kind,
+                        entity_id,
+                        GoogleAdsConversion,
+                    )
+                    if existing is None:
+                        self._io.write_entity_tx(
+                            transaction,
+                            kind,
+                            entity_id,
+                            conversion,
+                        )
+                        inserted += 1
+                return inserted
+
+            created += run_in_transaction_with_retry(self._io.database, txn)
+        return created
+
+    def _write_google_conversion_tx(
+        self,
+        transaction: Any,
+        record: AcquisitionAttribution,
+        event: str,
+        *,
+        occurred_at: str,
+        value_microdollars: int = 0,
+        ordinal: int = 0,
+    ) -> None:
+        conversion = build_google_ads_conversion(
+            record,
+            event,
+            occurred_at=occurred_at,
+            value_microdollars=value_microdollars,
+            ordinal=ordinal,
+        )
+        if conversion is None:
+            return
+        self._io.write_entity_tx(
+            transaction,
+            google_ads_conversion_kind(conversion.occurred_at),
+            google_ads_conversion_entity_id(conversion),
+            conversion,
+        )

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -843,6 +843,27 @@ class AcquisitionAttribution:
 
 
 @dataclass
+class GoogleAdsConversion:
+    """Metadata-only conversion row consumed by Google Ads Data Manager.
+
+    The row deliberately carries no TrustedRouter account, workspace, email,
+    or inference identifier. ``order_id`` is derived from the attribution's
+    random anonymous ID and the event, so Google can deduplicate imports
+    without receiving a product identifier.
+    """
+
+    order_id: str
+    conversion_action: str
+    occurred_at: str
+    gclid: str | None = None
+    gbraid: str | None = None
+    wbraid: str | None = None
+    value_microdollars: int = 0
+    currency_code: str = "USD"
+    created_at: str = field(default_factory=iso_now)
+
+
+@dataclass
 class AuthSession:
     hash: str
     salt: str

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -25,6 +25,7 @@ from trusted_router.storage_models import (
     EncryptedSecretEnvelope,
     GatewayAuthorization,
     Generation,
+    GoogleAdsConversion,
     Member,
     OAuthAuthorizationCode,
     ProviderBenchmarkSample,
@@ -87,6 +88,13 @@ class Store(Protocol):
         amount_microdollars: int,
         occurred_at: str,
     ) -> AcquisitionAttribution | None: ...
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]: ...
+    def backfill_google_ads_conversions(self, *, limit: int) -> int: ...
     def create_workspace(
         self,
         owner_user_id: str,

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import base64
+import csv
 import datetime as dt
+import io
 import logging
 
 import pytest
@@ -17,6 +20,9 @@ from trusted_router.acquisition import (
 from trusted_router.config import Settings
 from trusted_router.storage import STORE
 from trusted_router.storage_models import AcquisitionAttribution
+
+_FEED_USERNAME = "trustedrouter-data-manager"
+_FEED_PASSWORD = "test-google-ads-feed-password-at-least-32-characters"  # noqa: S105
 
 
 def _campaign_landing(client: TestClient, *, click_id: str = "google-click-123") -> None:
@@ -35,6 +41,15 @@ def _signup(client: TestClient, email: str = "attributed@example.com") -> dict[s
     payload = response.json()["data"]
     assert isinstance(payload, dict)
     return payload
+
+
+def _feed_headers(
+    *,
+    username: str = _FEED_USERNAME,
+    password: str = _FEED_PASSWORD,
+) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"authorization": f"Basic {token}"}
 
 
 def test_cookie_round_trip_and_tamper_rejection() -> None:
@@ -169,6 +184,28 @@ def test_invalid_click_id_is_not_persisted(client: TestClient) -> None:
     assert "gclid" not in context.last_touch
 
 
+@pytest.mark.parametrize("click_field", ["gbraid", "wbraid"])
+def test_google_browser_click_ids_are_exportable(
+    client: TestClient,
+    click_field: str,
+) -> None:
+    click_id = f"{click_field}-private-123"
+    landing = client.get(
+        f"/?utm_source=google&utm_medium=paid_search&{click_field}={click_id}"
+    )
+    assert landing.status_code == 200
+    _signup(client, f"{click_field}@example.com")
+
+    conversions = STORE.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )
+
+    assert len(conversions) == 1
+    assert getattr(conversions[0], click_field) == click_id
+    assert conversions[0].gclid is None
+
+
 def test_signup_persists_attribution_and_emits_no_raw_click_id(
     client: TestClient,
     caplog: pytest.LogCaptureFixture,
@@ -189,6 +226,15 @@ def test_signup_persists_attribution_and_emits_no_raw_click_id(
     assert "acquisition.api_key_created" in caplog.text
     assert raw_click_id not in caplog.text
     assert str(payload["key"]) not in caplog.text
+
+    conversions = STORE.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )
+    assert len(conversions) == 1
+    assert conversions[0].conversion_action == "TrustedRouter Signup"
+    assert conversions[0].gclid == raw_click_id
+    assert conversions[0].value_microdollars == 0
 
 
 def test_attribution_failure_never_blocks_signup(
@@ -287,6 +333,14 @@ def test_successful_usage_milestones_are_once_only(
     messages = [item.getMessage() for item in caplog.records]
     assert messages.count("acquisition.first_successful_api_call") == 1
     assert messages.count("acquisition.retained_api_usage_7d") == 1
+    conversions = STORE.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )
+    actions = [item.conversion_action for item in conversions]
+    assert actions.count("TrustedRouter Signup") == 1
+    assert actions.count("TrustedRouter Activated API User") == 1
+    assert actions.count("TrustedRouter Retained API User 7d") == 1
 
 
 def test_stripe_purchase_attribution_follows_ledger_idempotency(
@@ -318,6 +372,16 @@ def test_stripe_purchase_attribution_follows_ledger_idempotency(
     assert record.purchase_microdollars == 25_000_000
     messages = [item.getMessage() for item in caplog.records]
     assert messages.count("acquisition.credit_purchase_completed") == 1
+    purchases = [
+        item
+        for item in STORE.list_google_ads_conversions(
+            since="2000-01-01T00:00:00Z",
+            limit=10,
+        )
+        if item.conversion_action == "TrustedRouter Credit Purchase"
+    ]
+    assert len(purchases) == 1
+    assert purchases[0].value_microdollars == 25_000_000
 
 
 def test_public_pageviews_cover_marketing_but_not_console(
@@ -371,6 +435,176 @@ def test_record_signup_helper_uses_direct_fallback_without_cookie(
     assert record is not None
     assert record.first_touch["utm_source"] == "direct"
     assert record.first_touch["landing_path"] == "/v1/signup"
+    assert (
+        STORE.list_google_ads_conversions(
+            since="2000-01-01T00:00:00Z",
+            limit=10,
+        )
+        == []
+    )
+
+
+def test_google_ads_feed_is_disabled_without_secret(client: TestClient) -> None:
+    response = client.get("/v1/internal/marketing/google-ads-conversions.csv")
+    assert response.status_code == 404
+
+
+def test_google_ads_feed_requires_valid_basic_auth(client: TestClient) -> None:
+    client.app.state.settings.google_ads_conversion_feed_password = _FEED_PASSWORD
+    missing = client.get("/v1/internal/marketing/google-ads-conversions.csv")
+    invalid = client.get(
+        "/v1/internal/marketing/google-ads-conversions.csv",
+        headers=_feed_headers(password="x" * 40),
+    )
+    assert missing.status_code == 401
+    assert missing.headers["www-authenticate"].startswith("Basic ")
+    assert invalid.status_code == 401
+
+
+def test_google_ads_feed_is_metadata_only_and_exact(client: TestClient) -> None:
+    raw_click_id = "gclid-feed-private-123"
+    _campaign_landing(client, click_id=raw_click_id)
+    payload = _signup(client, "never-export@example.com")
+    workspace_id = str(payload["workspace_id"])
+    record_successful_api_call(
+        workspace_id,
+        model="private/model",
+        provider="private-provider",
+    )
+    client.app.state.settings.google_ads_conversion_feed_password = _FEED_PASSWORD
+
+    response = client.get(
+        "/v1/internal/marketing/google-ads-conversions.csv",
+        headers=_feed_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["x-robots-tag"] == "noindex, nofollow"
+    rows = list(csv.DictReader(io.StringIO(response.text)))
+    assert {row["conversion_action"] for row in rows} == {
+        "TrustedRouter Signup",
+        "TrustedRouter Activated API User",
+    }
+    assert all(row["gclid"] == raw_click_id for row in rows)
+    assert all(row["conversion_value"] == "0.000000" for row in rows)
+    assert all(row["currency_code"] == "USD" for row in rows)
+    assert all(len(row["order_id"]) == 64 for row in rows)
+    assert workspace_id not in response.text
+    assert "never-export@example.com" not in response.text
+    assert str(payload["key"]) not in response.text
+    assert "private/model" not in response.text
+    assert "private-provider" not in response.text
+    assert "prompt" not in response.text.lower()
+    assert "output" not in response.text.lower()
+
+
+def test_google_ads_feed_preserves_microdollar_purchase_value(
+    client: TestClient,
+) -> None:
+    _campaign_landing(client)
+    payload = _signup(client)
+    occurred_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+    STORE.record_acquisition_purchase(
+        str(payload["workspace_id"]),
+        amount_microdollars=1_234_567,
+        occurred_at=occurred_at,
+    )
+    client.app.state.settings.google_ads_conversion_feed_password = _FEED_PASSWORD
+
+    response = client.get(
+        "/v1/internal/marketing/google-ads-conversions.csv",
+        headers=_feed_headers(),
+    )
+
+    purchases = [
+        row
+        for row in csv.DictReader(io.StringIO(response.text))
+        if row["conversion_action"] == "TrustedRouter Credit Purchase"
+    ]
+    assert len(purchases) == 1
+    assert purchases[0]["conversion_value"] == "1.234567"
+
+
+def test_google_ads_feed_fails_loudly_instead_of_truncating(
+    client: TestClient,
+) -> None:
+    _campaign_landing(client)
+    payload = _signup(client)
+    record_successful_api_call(
+        str(payload["workspace_id"]),
+        model="test/model",
+        provider="test-provider",
+    )
+    settings = client.app.state.settings
+    settings.google_ads_conversion_feed_password = _FEED_PASSWORD
+    settings.google_ads_conversion_feed_max_rows = 1
+
+    response = client.get(
+        "/v1/internal/marketing/google-ads-conversions.csv",
+        headers=_feed_headers(),
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["type"] == "service_unavailable"
+
+
+def test_google_ads_backfill_is_idempotent(client: TestClient) -> None:
+    _campaign_landing(client)
+    _signup(client)
+    attribution_store = STORE.in_memory_target.acquisition_store
+    attribution_store.google_ads_conversions.clear()
+
+    first = client.post("/v1/internal/marketing/google-ads-conversions/backfill")
+    second = client.post("/v1/internal/marketing/google-ads-conversions/backfill")
+
+    assert first.status_code == 200
+    assert first.json()["data"]["created"] == 1
+    assert second.status_code == 200
+    assert second.json()["data"]["created"] == 0
+    assert len(attribution_store.google_ads_conversions) == 1
+
+
+def test_google_ads_feed_excludes_events_older_than_retention(
+    client: TestClient,
+) -> None:
+    _campaign_landing(client)
+    payload = _signup(client)
+    attribution_store = STORE.in_memory_target.acquisition_store
+    conversion = next(iter(attribution_store.google_ads_conversions.values()))
+    conversion.occurred_at = (
+        dt.datetime.now(dt.UTC) - dt.timedelta(days=91)
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    client.app.state.settings.google_ads_conversion_feed_password = _FEED_PASSWORD
+
+    response = client.get(
+        "/v1/internal/marketing/google-ads-conversions.csv",
+        headers=_feed_headers(),
+    )
+
+    assert response.status_code == 200
+    assert list(csv.DictReader(io.StringIO(response.text))) == []
+    assert payload["workspace_id"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("google_ads_conversion_feed_retention_days", 0),
+        ("google_ads_conversion_feed_retention_days", 91),
+        ("google_ads_conversion_feed_max_rows", 0),
+        ("google_ads_conversion_feed_username", "invalid:name"),
+        ("google_ads_conversion_feed_password", "too-short"),
+    ],
+)
+def test_google_ads_feed_config_rejects_unsafe_values(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError):
+        Settings(**{field: value})
 
 
 def test_spanner_attribution_adapter_is_atomic_and_persistent() -> None:
@@ -421,3 +655,19 @@ def test_spanner_attribution_adapter_is_atomic_and_persistent() -> None:
     assert purchased is not None
     assert purchased.purchase_count == 1
     assert purchased.purchase_microdollars == 12_345_678
+    conversions = store.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )
+    actions = [item.conversion_action for item in conversions]
+    assert sorted(actions) == sorted(
+        [
+            "TrustedRouter Signup",
+            "TrustedRouter Activated API User",
+            "TrustedRouter Credit Purchase",
+        ]
+    )
+    purchase = next(
+        item for item in conversions if item.conversion_action == "TrustedRouter Credit Purchase"
+    )
+    assert purchase.value_microdollars == 12_345_678


### PR DESCRIPTION
## Summary
- add an authenticated Google Ads Data Manager CSV feed
- persist signup, activation, retention, and purchase conversions idempotently in Spanner
- keep emails, workspace IDs, API keys, prompts, outputs, and request bodies out of Google
- wire Secret Manager deployment and historic non-purchase backfill
- preserve WWW-Authenticate headers in FastAPI errors

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1895 passed, 33 skipped)
- bash -n scripts/deploy/secrets.sh scripts/deploy/rollout.sh