### PR TITLE
Add provider onboarding page

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -105,6 +105,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/choose",
     "/models",
     "/providers",
+    "/providers/apply",
     "/benchmarks",
     "/rankings",
     "/leaderboard",
@@ -1201,6 +1202,29 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             (
                 "What does gateway attestation prove?",
                 "A fresh nonce challenge lets you verify that the live prompt gateway is running the published workload image. It does not prove the code is bug free or make every downstream provider confidential.",
+            ),
+        ),
+    ),
+    "providers/apply": PublicPage(
+        template="public/provider_apply.html",
+        title="List Your Models on TrustedRouter",
+        description=(
+            "Give TrustedRouter a dedicated API key, an inference API base URL, "
+            "a machine-readable model catalog, and a pricing API. We will validate, "
+            "list, monitor, and keep your routes current automatically."
+        ),
+        faq_items=(
+            (
+                "What API format works best?",
+                "An OpenAI-compatible HTTPS API is the fastest path. Include the inference base URL, authentication format, supported request types, streaming behavior, and any model-specific capability differences.",
+            ),
+            (
+                "Why do you require model and pricing APIs?",
+                "TrustedRouter refreshes provider catalogs automatically. Machine-readable model availability and pricing let us add launches, update prices, and remove retired routes without relying on stale web pages or manual email updates.",
+            ),
+            (
+                "What kind of API key should we send?",
+                "Create a dedicated, revocable production key scoped only to inference and model discovery. Do not send an account password, owner credential, billing credential, or unrestricted administrative key.",
             ),
         ),
     ),
@@ -2513,6 +2537,7 @@ def llms_txt(settings: Settings) -> str:
         f"- Homepage: https://{domain}/",
         f"- Models: https://{domain}/models",
         f"- Providers: https://{domain}/providers",
+        f"- Provider onboarding: https://{domain}/providers/apply",
         f"- EU routing: https://{domain}/eu",
         f"- TrustedOS for AI clouds: https://{domain}/trustedos",
         f"- Benchmarks: https://{domain}/benchmarks",
@@ -2631,6 +2656,7 @@ def docs_llms_txt(settings: Settings) -> str:
             f"- Model catalog: https://{domain}/models",
             f"- Canonical live model API (public, no API key): https://{domain}/v1/models",
             f"- Provider transparency: https://{domain}/providers",
+            f"- Provider onboarding: https://{domain}/providers/apply",
             f"- EU routing: https://{domain}/eu",
             f"- TrustedOS for AI clouds: https://{domain}/trustedos",
             "- Public status: https://status.trustedrouter.com/",

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -581,6 +581,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def for_developers() -> str:
         return public_page_html(settings, "for-developers")
 
+    @public_html_route("/providers/apply")
+    async def provider_apply() -> str:
+        return public_page_html(settings, "providers/apply")
+
     @public_html_route("/apps")
     async def apps() -> str:
         return public_apps_html(settings, apps=_apps_snapshot(settings))

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -16,6 +16,7 @@
       <a href="/models">Models</a>
       <a href="/compare/models">Model comparisons</a>
       <a href="/providers">Providers</a>
+      <a href="/providers/apply">List your models</a>
       <a href="/eu">EU routing</a>
       <a href="/synth">Synth</a>
       <a href="/pricing">Pricing</a>

--- a/src/trusted_router/templates/public/provider_apply.html
+++ b/src/trusted_router/templates/public/provider_apply.html
@@ -1,0 +1,126 @@
+{% extends "public/_base.html" %}
+
+{% block hero %}
+<section class="public-hero marketing-hero">
+  <div>
+    <div class="kicker">For inference providers</div>
+    <h1>List your models on TrustedRouter.</h1>
+    <p class="lead">Give us stable machine interfaces once. We will validate your routes, publish your models, monitor availability, and keep pricing current.</p>
+    <div class="hero-actions">
+      <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">Email providers@trustedrouter.com</a>
+      <a class="btn" href="#integration-contract">View requirements <span aria-hidden="true">↓</span></a>
+    </div>
+  </div>
+  <div class="public-hero-metrics" aria-label="Provider integration requirements">
+    <div><strong>1</strong><span>dedicated API key</span></div>
+    <div><strong>3</strong><span>machine-readable URLs</span></div>
+    <div><strong>Hourly</strong><span>catalog refresh</span></div>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section class="public-proof-strip" aria-label="Provider onboarding flow">
+  <div><strong>Connect</strong><span>Send a restricted key and API base URL.</span></div>
+  <div><strong>Discover</strong><span>Expose live models through a catalog endpoint.</span></div>
+  <div><strong>Price</strong><span>Publish exact rates through a pricing API.</span></div>
+  <div><strong>Verify</strong><span>We test, monitor, and list working routes.</span></div>
+</section>
+
+<section class="marketing-split" id="integration-contract" aria-label="Provider integration contract">
+  <div class="marketing-copy">
+    <span class="eyebrow">Send one email</span>
+    <h2>Everything needed to connect.</h2>
+    <p>Email <a href="mailto:providers@trustedrouter.com">providers@trustedrouter.com</a> from your company domain. Include a technical contact who can answer routing and pricing questions.</p>
+    <ul class="check-list">
+      <li><strong>Dedicated API key.</strong> A revocable production key scoped to inference and model discovery.</li>
+      <li><strong>Inference API URL.</strong> The HTTPS base URL used to call your models, plus authentication and API documentation.</li>
+      <li><strong>Models API URL.</strong> A machine-readable endpoint such as <code>GET /v1/models</code> with stable model IDs and current availability.</li>
+      <li><strong>Pricing API URL.</strong> A machine-readable endpoint with exact input, output, cache, and other billable rates.</li>
+    </ul>
+    <p class="small-copy">Never send an account password, owner credential, billing credential, or unrestricted administrative key.</p>
+  </div>
+  <div class="copy-terminal" aria-label="Provider onboarding email template">
+    <div class="code-head"><span>Email checklist</span><span>providers@trustedrouter.com</span></div>
+    <pre><code>Company:
+Technical contact:
+
+API base URL:
+API documentation:
+Authentication format:
+Dedicated API key:
+
+Models API URL:
+Pricing API URL:
+
+Supported features:
+Regions:
+Retention policy URL:
+Confidential compute URL:
+Deprecation feed or contact:</code></pre>
+  </div>
+</section>
+
+<section class="model-catalog" aria-labelledby="machine-readable-heading">
+  <div class="model-catalog-head">
+    <div>
+      <span class="eyebrow">Machine readable by design</span>
+      <h2 id="machine-readable-heading">Make launches and price changes automatic.</h2>
+    </div>
+    <p>Web pricing pages are useful for people. TrustedRouter also needs structured sources that software can ingest without guessing.</p>
+  </div>
+  <div class="marketing-grid three">
+    <div class="marketing-card">
+      <span class="card-label">Inference</span>
+      <h3>A stable API base URL.</h3>
+      <p>OpenAI compatibility is preferred. Document chat, Responses, streaming, tools, vision, embeddings, timeouts, and rate-limit behavior where supported.</p>
+      <code>https://api.provider.com/v1</code>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Catalog</span>
+      <h3>A live models endpoint.</h3>
+      <p>Return stable model IDs, availability, context length, maximum output, modalities, and capabilities. Include pagination when needed.</p>
+      <code>GET /v1/models</code>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Pricing</span>
+      <h3>An exact pricing endpoint.</h3>
+      <p>Return currency, units, input and output rates, cache read and write rates, minimum charges, tiers, and effective timestamps as exact decimals.</p>
+      <code>GET /v1/pricing</code>
+    </div>
+  </div>
+</section>
+
+<section class="marketing-split" aria-label="What TrustedRouter does next">
+  <div class="marketing-copy">
+    <span class="eyebrow">After the email</span>
+    <h2>We verify before we list.</h2>
+    <ol class="plain-list">
+      <li>Validate authentication and retrieve the live model catalog.</li>
+      <li>Match model IDs to exact prices and supported capabilities.</li>
+      <li>Run non-streaming and streaming probes against representative models.</li>
+      <li>Publish provider and model pages only for callable routes.</li>
+      <li>Refresh availability and pricing automatically as your APIs change.</li>
+    </ol>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">Also include</span>
+    <h2>Help developers choose your routes.</h2>
+    <ul class="check-list">
+      <li>Data retention, training, and zero-retention policy links</li>
+      <li>Confidential-compute or attestation documentation</li>
+      <li>Serving regions and data-residency constraints</li>
+      <li>Rate limits, capacity tiers, and expected error contracts</li>
+      <li>A machine-readable deprecation feed, or an operations contact</li>
+    </ul>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel-head"><h2>Ready to connect?</h2></div>
+  <div class="panel-body">
+    <p>Send the integration details and dedicated key to <a href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">providers@trustedrouter.com</a>.</p>
+    <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">Start provider integration</a>
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -13,7 +13,10 @@
       <span class="eyebrow">Provider transparency</span>
       <h2>Trusted gateway first, then explicit provider claims.</h2>
     </div>
-    <p>Zero data retention, confidential compute, and encrypted provider routes are shown only when explicitly tracked. Unknown stays unknown.</p>
+    <div>
+      <p>Zero data retention, confidential compute, and encrypted provider routes are shown only when explicitly tracked. Unknown stays unknown.</p>
+      <a class="btn" href="/providers/apply">List your models <span aria-hidden="true">→</span></a>
+    </div>
   </div>
   <div class="model-table-wrap">
     <table>

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_provider_onboarding_page_has_machine_readable_requirements(
+    client: TestClient,
+) -> None:
+    response = client.get("/providers/apply")
+
+    assert response.status_code == 200
+    assert "List your models on TrustedRouter." in response.text
+    assert "providers@trustedrouter.com" in response.text
+    assert "Dedicated API key." in response.text
+    assert "Inference API URL." in response.text
+    assert "Models API URL." in response.text
+    assert "Pricing API URL." in response.text
+    assert "GET /v1/models" in response.text
+    assert "GET /v1/pricing" in response.text
+    assert "unrestricted administrative key" in response.text
+    assert (
+        'href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D"'
+        in response.text
+    )
+    assert '<link rel="canonical" href="https://trustedrouter.com/providers/apply">' in response.text
+
+
+def test_provider_onboarding_page_is_discoverable(client: TestClient) -> None:
+    providers = client.get("/providers")
+    footer = client.get("/")
+    sitemap = client.get("/sitemap-core.xml")
+    llms = client.get("/llms.txt")
+
+    assert providers.status_code == footer.status_code == sitemap.status_code == llms.status_code == 200
+    assert 'href="/providers/apply"' in providers.text
+    assert 'href="/providers/apply"' in footer.text
+    assert "<loc>https://trustedrouter.com/providers/apply</loc>" in sitemap.text
+    assert "Provider onboarding: https://trustedrouter.com/providers/apply" in llms.text
+
+
+def test_provider_onboarding_page_supports_head(client: TestClient) -> None:
+    response = client.head("/providers/apply")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")


### PR DESCRIPTION
## Summary
- add `/providers/apply` with a clear provider integration checklist
- require a dedicated API key, inference base URL, live `/models`, and machine-readable pricing API
- link onboarding from the provider directory, footer, sitemap, and llms.txt

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1923 passed, 33 skipped)
- desktop and 390px mobile visual QA with no horizontal overflow