### PR TITLE
catalog: quarantine atlas-cloud openai/gpt-5.1-codex-max (completes #251)

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -215,6 +215,11 @@ _PROVIDER_DEPRECATED_UPSTREAM_MODELS: dict[str, frozenset[str]] = {
             "gpt-5.2-chat",
             "openai/gpt-5.2-codex",
             "gpt-5.2-codex",
+            # Confirmed 2026-07-26: 11/11 synthetic failures, HTTP 400
+            # "router not found" — same phantom as its siblings. It was held
+            # back from the original sweep because it had no samples yet.
+            "openai/gpt-5.1-codex-max",
+            "gpt-5.1-codex-max",
             "openai/gpt-5.3-codex",
             "gpt-5.3-codex",
             "openai/o1",


### PR DESCRIPTION
## What
Quarantines the last atlas-cloud `openai/*` phantom, completing the #251 sweep.

## Why
#251 quarantined 23 atlas-cloud `openai/*` routes returning HTTP 400 `router not found`. `openai/gpt-5.1-codex-max` was deliberately **left in** at the time because it had zero synthetic samples — quarantining it would have been a guess rather than a finding.

It now has evidence: **11 samples, 11 failures, 0 successes**, all `upstream http 400: model[openai/gpt-5.1-codex-max] router not found`.

## Scope
Provider-scoped, unchanged in character from #251: atlas-cloud's open-weight catalog and the six `openai/*` models it actually serves stay routable. Verified post-change: atlas-cloud openai endpoints **7 → 6**, `codex-max` absent.

`ruff` clean; catalog contract + prepaid display suites pass (104 tests).