### PR TITLE
storage: behavioural conformance suite + ClickHouse analytics proof

### DIFF
--- a/clickhouse/001_provider_benchmark_samples.sql
+++ b/clickhouse/001_provider_benchmark_samples.sql
@@ -1,0 +1,85 @@
+-- TrustedRouter analytics schema, increment 1: provider benchmark samples.
+--
+-- This is the leaderboard / route-health dataset that currently lives in
+-- Bigtable as `benchmark_*#...` rows, one JSON blob per row in column family
+-- `m`. Every aggregate over it today is computed by scanning rows and
+-- json.loads-ing each one in Python (storage_gcp_benchmark_index.py,
+-- synthetic/backfill_rollups.py). That is the workload this schema removes.
+--
+-- Design notes:
+--
+-- * ReplacingMergeTree keyed on the full sort key makes ingestion IDEMPOTENT.
+--   Backfill from Bigtable can be re-run, and the dual-write path can retry,
+--   without double-counting. This is the property that makes the migration
+--   safe to attempt more than once.
+-- * The sort key leads with (provider, model) because every operational query
+--   is scoped to one route; `created_at` after it gives the newest-first range
+--   scan that the Bigtable reverse-timestamp row key provides today.
+-- * LowCardinality on the dimension columns: provider/model/status are a few
+--   hundred distinct values over millions of rows, so this is a large win on
+--   both storage and GROUP BY speed.
+-- * TTL replaces the Bigtable GC policy. Set deliberately long here; the
+--   rollup views below retain aggregates after raw rows expire.
+
+CREATE TABLE IF NOT EXISTS provider_benchmark_samples
+(
+    id                       String,
+    created_at               DateTime64(3, 'UTC'),
+    provider                 LowCardinality(String),
+    model                    LowCardinality(String),
+    provider_name            LowCardinality(String),
+    status                   LowCardinality(String),
+    usage_type               LowCardinality(String),
+    source                   LowCardinality(String),
+    streamed                 UInt8,
+
+    input_tokens             UInt32,
+    output_tokens            UInt32,
+    total_cost_microdollars  Int64,
+
+    speed_tokens_per_second  Nullable(Float32),
+    elapsed_milliseconds     Nullable(UInt32),
+    first_token_milliseconds Nullable(UInt32),
+    ttfb_milliseconds        Nullable(UInt32),
+
+    finish_reason            LowCardinality(Nullable(String)),
+    error_type               LowCardinality(Nullable(String)),
+    error_status             Nullable(UInt16),
+    error_message            Nullable(String),
+    region                   LowCardinality(Nullable(String)),
+    app                      String
+)
+ENGINE = ReplacingMergeTree(created_at)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (provider, model, created_at, id)
+TTL toDateTime(created_at) + INTERVAL 400 DAY;
+
+
+-- Hourly route health, maintained incrementally.
+--
+-- This is the direct replacement for the hand-rolled rollup machinery
+-- (storage_gcp_synthetic_rollups.py + synthetic/backfill_rollups.py +
+-- `synthetic_rollup#` row keys). AggregatingMergeTree keeps the partial
+-- aggregate states up to date as rows arrive; nothing has to be backfilled
+-- on a schedule, and there is no rollup job to fail silently.
+--
+-- Aggregate STATES are stored (not finalised numbers) so they can be merged
+-- across any window at read time: the same view answers "last 48h" and
+-- "last 90 days" without storing either.
+CREATE MATERIALIZED VIEW IF NOT EXISTS route_health_hourly
+ENGINE = AggregatingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (provider, model, hour)
+AS
+SELECT
+    provider,
+    model,
+    toStartOfHour(created_at)                        AS hour,
+    countState()                                     AS samples_state,
+    countIfState(status = 'error')                   AS failures_state,
+    countIfState(status = 'success')                 AS successes_state,
+    quantileState(0.95)(elapsed_milliseconds)        AS p95_elapsed_state,
+    sumState(toInt64(input_tokens + output_tokens))  AS tokens_state
+FROM provider_benchmark_samples
+WHERE source = 'synthetic'
+GROUP BY provider, model, hour;

--- a/clickhouse/001_provider_benchmark_samples.sql
+++ b/clickhouse/001_provider_benchmark_samples.sql
@@ -55,17 +55,38 @@ ORDER BY (provider, model, created_at, id)
 TTL toDateTime(created_at) + INTERVAL 400 DAY;
 
 
--- Hourly route health, maintained incrementally.
+-- Hourly route-health aggregates, maintained incrementally.
 --
--- This is the direct replacement for the hand-rolled rollup machinery
--- (storage_gcp_synthetic_rollups.py + synthetic/backfill_rollups.py +
--- `synthetic_rollup#` row keys). AggregatingMergeTree keeps the partial
--- aggregate states up to date as rows arrive; nothing has to be backfilled
--- on a schedule, and there is no rollup job to fail silently.
+-- Scope: this covers the ProviderBenchmarkSample dataset (provider/model)
+-- only. It is NOT a replacement for synthetic/backfill_rollups.py, which
+-- rolls up a DIFFERENT dataset — SyntheticProbeSample, keyed by
+-- component/target/probe_type/region. Retiring that job is separate work.
+--
+-- The WHERE clause deliberately mirrors synthetic/route_health.py: synthetic
+-- source only, only `error`/`success` statuses (so `unsupported` is excluded
+-- from BOTH numerator and denominator), and transient failures dropped
+-- entirely rather than counted. Without those exclusions this view is not
+-- route health at all — on a 30.8k-row sample the unfiltered numbers are
+-- 30832 samples / 1176 failures, against the correct 28214 / 59. A 20x
+-- overstatement of failures is precisely the kind of plausible-looking wrong
+-- answer that survives code review.
+--
+-- ifNull() on the transient predicate is load-bearing for the same reason it
+-- is in the query path: `NULL IN (...)` is NULL, not false, and a NULL here
+-- would silently drop rows from the aggregate.
 --
 -- Aggregate STATES are stored (not finalised numbers) so they can be merged
 -- across any window at read time: the same view answers "last 48h" and
 -- "last 90 days" without storing either.
+--
+-- !! IDEMPOTENCY WARNING !!
+-- The source table's ReplacingMergeTree does NOT protect this view.
+-- Materialized views run per INSERT BLOCK, before any replacement happens,
+-- so re-inserting the same rows adds duplicate aggregate states here even
+-- though the source table later collapses them. Re-running a backfill
+-- therefore inflates this view permanently. Ingestion must either be
+-- append-once, or use insert_deduplication_token, or the view must be
+-- rebuilt (DROP + re-populate) alongside any source reload.
 CREATE MATERIALIZED VIEW IF NOT EXISTS route_health_hourly
 ENGINE = AggregatingMergeTree()
 PARTITION BY toYYYYMM(hour)
@@ -82,4 +103,9 @@ SELECT
     sumState(toInt64(input_tokens + output_tokens))  AS tokens_state
 FROM provider_benchmark_samples
 WHERE source = 'synthetic'
+  AND status IN ('error', 'success')
+  AND NOT (status = 'error' AND (
+        ifNull(error_status, 0) IN (429,500,502,503,504,529)
+     OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
+                                   'ConnectError','ReadError','WriteError','RemoteProtocolError')))
 GROUP BY provider, model, hour;

--- a/clickhouse/prove_leaderboard.py
+++ b/clickhouse/prove_leaderboard.py
@@ -1,0 +1,241 @@
+"""Proof: the leaderboard/route-health aggregates that TrustedRouter computes
+by scanning Bigtable and json.loads-ing every row in Python can be computed in
+ClickHouse SQL, and the numbers are identical.
+
+Method
+------
+1. Read real ProviderBenchmarkSample rows out of production Bigtable
+   (read-only, the same prefix scan the app uses).
+2. Compute route health in Python EXACTLY the way
+   `synthetic/route_health.py` does today: filter to synthetic, drop
+   `unsupported`, drop transient failures, then failures/samples per route.
+   This is the baseline — the current production answer.
+3. Load the same rows into ClickHouse.
+4. Compute the same thing in one SQL statement.
+5. Assert the two agree, route by route.
+
+A match means the columnar engine reproduces production semantics, so the
+Python scan layer can be retired rather than reimplemented.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+from collections import defaultdict
+
+import httpx
+from google.cloud import bigtable
+from google.cloud.bigtable.row_set import RowSet
+
+PROJECT = "quill-cloud-proxy"
+INSTANCE = "trusted-router-logs"
+TABLE = "trustedrouter-generations"
+FAMILY = "m"
+SCAN_LIMIT = int(os.environ.get("SCAN_LIMIT", "40000"))
+
+CH_URL = os.environ.get("CH_URL", "http://localhost:18123/")
+CH_AUTH = (os.environ.get("CH_USER", "tr"), os.environ.get("CH_PASSWORD", "tr"))
+
+# Mirrors synthetic/route_health.py exactly.
+TRANSIENT_TYPES = {
+    "ReadTimeout", "ConnectTimeout", "WriteTimeout", "PoolTimeout",
+    "ConnectError", "ReadError", "WriteError", "RemoteProtocolError",
+}
+TRANSIENT_STATUSES = {429, 500, 502, 503, 504, 529}
+
+
+def ch(query: str, body: bytes | None = None) -> str:
+    """Run a ClickHouse statement over the HTTP interface.
+
+    With `body`, the query goes in the querystring and the body carries rows
+    (that is the shape ClickHouse wants for `INSERT ... FORMAT JSONEachRow`).
+    Without it, the statement itself is the body.
+    """
+    if body is not None:
+        response = httpx.post(
+            CH_URL, params={"query": query}, content=body, auth=CH_AUTH, timeout=300
+        )
+    else:
+        response = httpx.post(CH_URL, content=query.encode(), auth=CH_AUTH, timeout=300)
+    response.raise_for_status()
+    return response.text
+
+
+def fetch_bigtable_samples() -> list[dict]:
+    client = bigtable.Client(project=PROJECT, admin=False)
+    table = client.instance(INSTANCE).table(TABLE)
+    rs = RowSet()
+    rs.add_row_range_with_prefix("benchmark_recent#")
+    rows = []
+    for i, row in enumerate(table.read_rows(row_set=rs)):
+        if i >= SCAN_LIMIT:
+            break
+        cells = row.cells.get(FAMILY, {}).get(b"body", [])
+        if not cells:
+            continue
+        try:
+            rows.append(json.loads(cells[0].value.decode("utf-8")))
+        except ValueError:
+            continue
+    return rows
+
+
+def python_route_health(samples: list[dict]) -> dict[tuple[str, str], tuple[int, int]]:
+    """The current production computation: scan, parse, loop in Python."""
+    acc: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    for b in samples:
+        if b.get("source") != "synthetic":
+            continue
+        status = b.get("status")
+        if status == "unsupported" or status not in {"error", "success"}:
+            continue
+        if status == "error" and (
+            b.get("error_status") in TRANSIENT_STATUSES
+            or b.get("error_type") in TRANSIENT_TYPES
+        ):
+            continue
+        key = (b.get("provider"), b.get("model"))
+        acc[key][0] += 1
+        if status == "error":
+            acc[key][1] += 1
+    return {k: (v[0], v[1]) for k, v in acc.items()}
+
+
+def to_ch_row(b: dict) -> dict:
+    created = b.get("created_at", "")
+    try:
+        t = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=dt.UTC)
+        created_fmt = t.astimezone(dt.UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    except ValueError:
+        return {}
+    return {
+        "id": str(b.get("id", "")),
+        "created_at": created_fmt,
+        "provider": str(b.get("provider") or ""),
+        "model": str(b.get("model") or ""),
+        "provider_name": str(b.get("provider_name") or ""),
+        "status": str(b.get("status") or ""),
+        "usage_type": str(b.get("usage_type") or ""),
+        "source": str(b.get("source") or ""),
+        "streamed": 1 if b.get("streamed") else 0,
+        "input_tokens": int(b.get("input_tokens") or 0),
+        "output_tokens": int(b.get("output_tokens") or 0),
+        "total_cost_microdollars": int(b.get("total_cost_microdollars") or 0),
+        "speed_tokens_per_second": b.get("speed_tokens_per_second"),
+        "elapsed_milliseconds": b.get("elapsed_milliseconds"),
+        "first_token_milliseconds": b.get("first_token_milliseconds"),
+        "ttfb_milliseconds": b.get("ttfb_milliseconds"),
+        "finish_reason": b.get("finish_reason"),
+        "error_type": b.get("error_type"),
+        "error_status": b.get("error_status"),
+        "error_message": b.get("error_message"),
+        "region": b.get("region"),
+        "app": str(b.get("app") or ""),
+    }
+
+
+SQL_ROUTE_HEALTH = """
+SELECT provider, model,
+       count()                       AS samples,
+       countIf(status = 'error')     AS failures
+FROM provider_benchmark_samples
+WHERE source = 'synthetic'
+  AND status IN ('error', 'success')
+  -- ifNull() is load-bearing. error_status/error_type are Nullable, and in
+  -- SQL's three-valued logic `NULL IN (...)` is NULL, not false. That NULL
+  -- propagates through OR/AND, survives NOT, and WHERE then DROPS the row —
+  -- silently under-counting failures on exactly the routes whose errors carry
+  -- no HTTP status (empty_stream, client-side aborts). Python's
+  -- `None in {...}` is plainly False, so the two disagree unless NULLs are
+  -- flattened first. This cost 6 routes on the first run of this proof.
+  AND NOT (status = 'error' AND (
+        ifNull(error_status, 0) IN (429,500,502,503,504,529)
+     OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
+                       'ConnectError','ReadError','WriteError','RemoteProtocolError')))
+GROUP BY provider, model
+FORMAT JSONEachRow
+"""
+
+
+def main() -> int:
+    print(f"Scanning Bigtable (limit {SCAN_LIMIT})...")
+    samples = fetch_bigtable_samples()
+    print(f"  fetched {len(samples)} rows")
+    if not samples:
+        print("no rows; aborting")
+        return 1
+
+    print("Computing route health the CURRENT way (Python scan + json parse)...")
+    baseline = python_route_health(samples)
+    print(f"  {len(baseline)} routes")
+
+    print("Loading into ClickHouse...")
+    ch("TRUNCATE TABLE provider_benchmark_samples")
+    payload = "\n".join(
+        json.dumps(r) for r in (to_ch_row(b) for b in samples) if r
+    ).encode()
+    ch("INSERT INTO provider_benchmark_samples FORMAT JSONEachRow", payload)
+    loaded = ch("SELECT count() FROM provider_benchmark_samples").strip()
+    print(f"  loaded {loaded} rows")
+
+    print("Computing the SAME thing in SQL...")
+    out = ch(SQL_ROUTE_HEALTH)
+    sql_result = {}
+    for line in out.strip().splitlines():
+        r = json.loads(line)
+        sql_result[(r["provider"], r["model"])] = (int(r["samples"]), int(r["failures"]))
+    print(f"  {len(sql_result)} routes")
+
+    print("\nComparing...")
+    mismatches = []
+    for key in sorted(set(baseline) | set(sql_result), key=lambda k: (k[0] or "", k[1] or "")):
+        py = baseline.get(key)
+        sq = sql_result.get(key)
+        if py != sq:
+            mismatches.append((key, py, sq))
+
+    if mismatches:
+        print(f"MISMATCH on {len(mismatches)} route(s):")
+        for key, py, sq in mismatches[:20]:
+            print(f"  {key[0]}/{key[1]}: python={py} sql={sq}")
+        return 1
+
+    print(f"EXACT MATCH on all {len(baseline)} routes.")
+    print("\nTop failing routes (from SQL, one query, no Python loop):")
+    top = ch("""
+        SELECT provider, model,
+               count() AS samples,
+               round(100 * countIf(status='error') / count(), 1) AS failure_pct,
+               round(quantile(0.95)(elapsed_milliseconds)) AS p95_ms
+        FROM provider_benchmark_samples
+        WHERE source='synthetic' AND status IN ('error','success')
+        GROUP BY provider, model
+        HAVING samples >= 6
+        ORDER BY failure_pct DESC, samples DESC
+        LIMIT 12
+        FORMAT PrettyCompactMonoBlock
+    """)
+    print(top)
+
+    print("Materialized view (rollups maintained incrementally, no backfill job):")
+    print(ch("""
+        SELECT provider, model,
+               countMerge(samples_state)   AS samples,
+               countIfMerge(failures_state) AS failures,
+               round(quantileMerge(0.95)(p95_elapsed_state)) AS p95_ms
+        FROM route_health_hourly
+        GROUP BY provider, model
+        ORDER BY samples DESC
+        LIMIT 8
+        FORMAT PrettyCompactMonoBlock
+    """))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clickhouse/prove_leaderboard.py
+++ b/clickhouse/prove_leaderboard.py
@@ -253,7 +253,10 @@ def sql_route_health(cutoff: dt.datetime) -> dict[tuple[str, str], tuple[int, in
     row_number() reproduces "newest N per route", and is computed BEFORE the
     status/transient filters so the truncation matches production's ordering.
     """
-    query = f"""
+    # Values are bound server-side via ClickHouse `{name:Type}` placeholders —
+    # nothing is spliced into SQL text. The transient predicate is a fixed
+    # fragment shared with the schema, not caller input.
+    query = """
     WITH ranked AS (
         SELECT provider, model, status, source, created_at, error_status, error_type,
                row_number() OVER (PARTITION BY provider, model ORDER BY created_at DESC) AS rn
@@ -263,16 +266,23 @@ def sql_route_health(cutoff: dt.datetime) -> dict[tuple[str, str], tuple[int, in
            count()                   AS samples,
            countIf(status = 'error') AS failures
     FROM ranked
-    WHERE rn <= {SAMPLES_PER_ROUTE_LIMIT}
+    WHERE rn <= {route_limit:UInt32}
       AND source = 'synthetic'
-      AND created_at >= toDateTime64('{cutoff.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+      AND created_at >= {cutoff:DateTime64(3, 'UTC')}
       AND status IN ('error', 'success')
-      AND NOT (status = 'error' AND {SQL_TRANSIENT})
+      AND NOT (status = 'error' AND (
+            ifNull(error_status, 0) IN (429,500,502,503,504,529)
+         OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
+                                       'ConnectError','ReadError','WriteError','RemoteProtocolError')))
     GROUP BY provider, model
     FORMAT JSONEachRow
     """
+    params = {
+        "route_limit": str(SAMPLES_PER_ROUTE_LIMIT),
+        "cutoff": cutoff.strftime("%Y-%m-%d %H:%M:%S"),
+    }
     result: dict[tuple[str, str], tuple[int, int]] = {}
-    for line in ch(query).strip().splitlines():
+    for line in ch(query, params=params).strip().splitlines():
         r = json.loads(line)
         result[(r["provider"], r["model"])] = (int(r["samples"]), int(r["failures"]))
     return result
@@ -329,7 +339,8 @@ def main() -> int:
     if not args.no_load:
         print("Loading into ClickHouse (local proof table)...")
         load(rows)
-        print(f"  loaded {ch('SELECT count() FROM provider_benchmark_samples').strip()} rows")
+        loaded = ch("SELECT count() FROM provider_benchmark_samples").strip()
+        print(f"  loaded {loaded} rows")
 
     print("Evaluating route health the CURRENT way (Python)...")
     baseline = python_route_health(rows, cutoff)

--- a/clickhouse/prove_leaderboard.py
+++ b/clickhouse/prove_leaderboard.py
@@ -1,25 +1,43 @@
-"""Proof: the leaderboard/route-health aggregates that TrustedRouter computes
-by scanning Bigtable and json.loads-ing every row in Python can be computed in
-ClickHouse SQL, and the numbers are identical.
+"""Differential proof: route-health evaluation in ClickHouse SQL agrees with
+the Python implementation that runs in production today.
 
-Method
+What this DOES prove
+--------------------
+Given an identical set of input rows, the SQL translation of
+`synthetic/route_health.py` produces the same per-route sample/failure counts
+and the same set of FLAGGED routes as the Python original — including the
+48-hour cutoff, the newest-N-per-route window, the synthetic-only filter, the
+`unsupported` exclusion, the transient-failure exclusion, and the
+min-samples / failure-rate thresholds.
+
+That is the risky part of the migration: the predicate and aggregation logic.
+It is where the NULL-handling bug (see below) lived.
+
+What this does NOT prove
+------------------------
+* It does not exercise the full public leaderboard aggregator
+  (`synthetic/leaderboard.py`), which additionally blends organic traffic,
+  computes exact nearest-rank percentiles, and ranks providers. ClickHouse's
+  `quantile()` is approximate and has NOT been reconciled against that exact
+  implementation.
+* It compares two computations over the SAME slice of rows. It is not a test
+  of the ingestion path.
+
+To keep the first point honest, the script ASSERTS that the scanned slice
+fully covers the evaluation window (see `assert_window_covered`) — otherwise
+both sides could agree perfectly on a biased sample while disagreeing with
+production.
+
+Safety
 ------
-1. Read real ProviderBenchmarkSample rows out of production Bigtable
-   (read-only, the same prefix scan the app uses).
-2. Compute route health in Python EXACTLY the way
-   `synthetic/route_health.py` does today: filter to synthetic, drop
-   `unsupported`, drop transient failures, then failures/samples per route.
-   This is the baseline — the current production answer.
-3. Load the same rows into ClickHouse.
-4. Compute the same thing in one SQL statement.
-5. Assert the two agree, route by route.
-
-A match means the columnar engine reproduces production semantics, so the
-Python scan layer can be retired rather than reimplemented.
+`--load` TRUNCATEs the local analytics table and rebuilds the materialized
+view. This script is a LOCAL PROOF HARNESS. Do not point it at a production
+ClickHouse: use `--no-load` to compare against already-present data.
 """
 
 from __future__ import annotations
 
+import argparse
 import datetime as dt
 import json
 import os
@@ -34,206 +52,314 @@ PROJECT = "quill-cloud-proxy"
 INSTANCE = "trusted-router-logs"
 TABLE = "trustedrouter-generations"
 FAMILY = "m"
-SCAN_LIMIT = int(os.environ.get("SCAN_LIMIT", "40000"))
 
 CH_URL = os.environ.get("CH_URL", "http://localhost:18123/")
 CH_AUTH = (os.environ.get("CH_USER", "tr"), os.environ.get("CH_PASSWORD", "tr"))
 
-# Mirrors synthetic/route_health.py exactly.
+# These mirror synthetic/route_health.py exactly.
 TRANSIENT_TYPES = {
     "ReadTimeout", "ConnectTimeout", "WriteTimeout", "PoolTimeout",
     "ConnectError", "ReadError", "WriteError", "RemoteProtocolError",
 }
 TRANSIENT_STATUSES = {429, 500, 502, 503, 504, 529}
+SAMPLES_PER_ROUTE_LIMIT = 48
+WINDOW_HOURS = 48
+MIN_SAMPLES = 6
+FAILURE_THRESHOLD = 0.95
+
+SQL_TRANSIENT = """(
+        ifNull(error_status, 0) IN (429,500,502,503,504,529)
+     OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
+                                   'ConnectError','ReadError','WriteError','RemoteProtocolError'))"""
 
 
-def ch(query: str, body: bytes | None = None) -> str:
+def ch(query: str, body: bytes | None = None, params: dict[str, str] | None = None) -> str:
     """Run a ClickHouse statement over the HTTP interface.
 
-    With `body`, the query goes in the querystring and the body carries rows
-    (that is the shape ClickHouse wants for `INSERT ... FORMAT JSONEachRow`).
-    Without it, the statement itself is the body.
+    `params` are bound SERVER-SIDE via ClickHouse's `{name:Type}` placeholders
+    (sent as `param_<name>`), so no value is ever spliced into SQL text.
     """
+    query_params: dict[str, str] = {}
+    if params:
+        query_params.update({f"param_{k}": v for k, v in params.items()})
     if body is not None:
+        query_params["query"] = query
         response = httpx.post(
-            CH_URL, params={"query": query}, content=body, auth=CH_AUTH, timeout=300
+            CH_URL, params=query_params, content=body, auth=CH_AUTH, timeout=300
         )
     else:
-        response = httpx.post(CH_URL, content=query.encode(), auth=CH_AUTH, timeout=300)
+        response = httpx.post(
+            CH_URL, params=query_params or None, content=query.encode(), auth=CH_AUTH, timeout=300
+        )
     response.raise_for_status()
     return response.text
 
 
-def fetch_bigtable_samples() -> list[dict]:
+# --------------------------------------------------------------------------
+# Normalisation — SHARED by both sides.
+# --------------------------------------------------------------------------
+
+
+def normalise(raw: dict) -> dict | None:
+    """Coerce one Bigtable JSON blob into the canonical shape.
+
+    Both the Python baseline and the ClickHouse load consume the output of
+    this function, so a coercion cannot make the two sides disagree by
+    construction. That matters: `error_status` arrives as an int today but a
+    historical string `"429"` would be non-transient to Python's `in {...}`
+    and transient to ClickHouse's UInt16 column — an invisible divergence if
+    each side did its own parsing.
+
+    Returns None for rows that cannot be placed in time; production route
+    health skips those too (`_parse_created_at` returning None).
+    """
+    created = raw.get("created_at") or ""
+    try:
+        parsed = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    parsed = parsed.astimezone(dt.UTC)
+
+    error_status = raw.get("error_status")
+    if isinstance(error_status, str):
+        error_status = int(error_status) if error_status.isdigit() else None
+    elif error_status is not None:
+        error_status = int(error_status)
+
+    provider = raw.get("provider")
+    model = raw.get("model")
+    if not provider or not model:
+        # Ungrouped rows would land in an empty-string bucket on one side and
+        # a None bucket on the other. Production keys routes by real ids.
+        return None
+
+    return {
+        "id": str(raw.get("id") or ""),
+        "created_at": parsed,
+        "provider": str(provider),
+        "model": str(model),
+        "provider_name": str(raw.get("provider_name") or ""),
+        "status": str(raw.get("status") or ""),
+        "usage_type": str(raw.get("usage_type") or ""),
+        "source": str(raw.get("source") or ""),
+        "streamed": 1 if raw.get("streamed") else 0,
+        "input_tokens": int(raw.get("input_tokens") or 0),
+        "output_tokens": int(raw.get("output_tokens") or 0),
+        "total_cost_microdollars": int(raw.get("total_cost_microdollars") or 0),
+        "speed_tokens_per_second": raw.get("speed_tokens_per_second"),
+        "elapsed_milliseconds": raw.get("elapsed_milliseconds"),
+        "first_token_milliseconds": raw.get("first_token_milliseconds"),
+        "ttfb_milliseconds": raw.get("ttfb_milliseconds"),
+        "finish_reason": raw.get("finish_reason"),
+        "error_type": raw.get("error_type"),
+        "error_status": error_status,
+        "error_message": raw.get("error_message"),
+        "region": raw.get("region"),
+        "app": str(raw.get("app") or ""),
+    }
+
+
+def fetch_bigtable_samples(limit: int) -> list[dict]:
     client = bigtable.Client(project=PROJECT, admin=False)
     table = client.instance(INSTANCE).table(TABLE)
     rs = RowSet()
     rs.add_row_range_with_prefix("benchmark_recent#")
-    rows = []
+    rows: list[dict] = []
     for i, row in enumerate(table.read_rows(row_set=rs)):
-        if i >= SCAN_LIMIT:
+        if i >= limit:
             break
         cells = row.cells.get(FAMILY, {}).get(b"body", [])
         if not cells:
             continue
         try:
-            rows.append(json.loads(cells[0].value.decode("utf-8")))
+            raw = json.loads(cells[0].value.decode("utf-8"))
         except ValueError:
             continue
+        record = normalise(raw)
+        if record is not None:
+            rows.append(record)
     return rows
 
 
-def python_route_health(samples: list[dict]) -> dict[tuple[str, str], tuple[int, int]]:
-    """The current production computation: scan, parse, loop in Python."""
-    acc: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
-    for b in samples:
-        if b.get("source") != "synthetic":
-            continue
-        status = b.get("status")
-        if status == "unsupported" or status not in {"error", "success"}:
-            continue
-        if status == "error" and (
-            b.get("error_status") in TRANSIENT_STATUSES
-            or b.get("error_type") in TRANSIENT_TYPES
-        ):
-            continue
-        key = (b.get("provider"), b.get("model"))
-        acc[key][0] += 1
-        if status == "error":
-            acc[key][1] += 1
-    return {k: (v[0], v[1]) for k, v in acc.items()}
+def assert_window_covered(rows: list[dict], cutoff: dt.datetime) -> None:
+    """The scanned slice must extend back past the evaluation window.
+
+    The Bigtable scan is newest-first ACROSS ALL ROUTES, so a slice that stops
+    inside the window would truncate busy routes and leave sparse ones intact
+    — a biased sample. Both sides would still agree (they read the same
+    slice), so the comparison would look perfect while diverging from what
+    production, which reads per-route, actually sees. Checking coverage is
+    what makes the agreement meaningful.
+    """
+    oldest = min(r["created_at"] for r in rows)
+    if oldest > cutoff:
+        raise SystemExit(
+            f"scan does not cover the {WINDOW_HOURS}h window: oldest row {oldest.isoformat()} "
+            f"is newer than cutoff {cutoff.isoformat()}. Increase --limit."
+        )
+    print(
+        f"  window coverage OK: oldest row {oldest.isoformat()} "
+        f"predates the {WINDOW_HOURS}h cutoff"
+    )
 
 
-def to_ch_row(b: dict) -> dict:
-    created = b.get("created_at", "")
-    try:
-        t = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
-        if t.tzinfo is None:
-            t = t.replace(tzinfo=dt.UTC)
-        created_fmt = t.astimezone(dt.UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-    except ValueError:
-        return {}
+def python_route_health(
+    rows: list[dict], cutoff: dt.datetime
+) -> dict[tuple[str, str], tuple[int, int]]:
+    """Reproduce synthetic/route_health.py evaluate_route_health().
+
+    Order of operations is load-bearing and mirrors production: the store
+    returns the newest `SAMPLES_PER_ROUTE_LIMIT` rows for a route across ALL
+    sources, and only then does the Python loop apply the synthetic / status /
+    transient filters. Filtering before truncating would consider older rows
+    production never sees.
+    """
+    by_route: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for r in rows:
+        by_route[(r["provider"], r["model"])].append(r)
+
+    out: dict[tuple[str, str], tuple[int, int]] = {}
+    for route, route_rows in by_route.items():
+        route_rows.sort(key=lambda r: r["created_at"], reverse=True)
+        newest = route_rows[:SAMPLES_PER_ROUTE_LIMIT]
+
+        samples = failures = 0
+        for r in newest:
+            if r["source"] != "synthetic":
+                continue
+            if r["created_at"] < cutoff:
+                continue
+            status = r["status"]
+            if status == "unsupported" or status not in {"error", "success"}:
+                continue
+            if status == "error" and (
+                r["error_status"] in TRANSIENT_STATUSES
+                or r["error_type"] in TRANSIENT_TYPES
+            ):
+                continue
+            samples += 1
+            if status == "error":
+                failures += 1
+        if samples:
+            out[route] = (samples, failures)
+    return out
+
+
+def sql_route_health(cutoff: dt.datetime) -> dict[tuple[str, str], tuple[int, int]]:
+    """Same evaluation, expressed once in SQL.
+
+    row_number() reproduces "newest N per route", and is computed BEFORE the
+    status/transient filters so the truncation matches production's ordering.
+    """
+    query = f"""
+    WITH ranked AS (
+        SELECT provider, model, status, source, created_at, error_status, error_type,
+               row_number() OVER (PARTITION BY provider, model ORDER BY created_at DESC) AS rn
+        FROM provider_benchmark_samples
+    )
+    SELECT provider, model,
+           count()                   AS samples,
+           countIf(status = 'error') AS failures
+    FROM ranked
+    WHERE rn <= {SAMPLES_PER_ROUTE_LIMIT}
+      AND source = 'synthetic'
+      AND created_at >= toDateTime64('{cutoff.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+      AND status IN ('error', 'success')
+      AND NOT (status = 'error' AND {SQL_TRANSIENT})
+    GROUP BY provider, model
+    FORMAT JSONEachRow
+    """
+    result: dict[tuple[str, str], tuple[int, int]] = {}
+    for line in ch(query).strip().splitlines():
+        r = json.loads(line)
+        result[(r["provider"], r["model"])] = (int(r["samples"]), int(r["failures"]))
+    return result
+
+
+def flagged(health: dict[tuple[str, str], tuple[int, int]]) -> set[tuple[str, str]]:
+    """Production's actual output: which routes raise an alert."""
     return {
-        "id": str(b.get("id", "")),
-        "created_at": created_fmt,
-        "provider": str(b.get("provider") or ""),
-        "model": str(b.get("model") or ""),
-        "provider_name": str(b.get("provider_name") or ""),
-        "status": str(b.get("status") or ""),
-        "usage_type": str(b.get("usage_type") or ""),
-        "source": str(b.get("source") or ""),
-        "streamed": 1 if b.get("streamed") else 0,
-        "input_tokens": int(b.get("input_tokens") or 0),
-        "output_tokens": int(b.get("output_tokens") or 0),
-        "total_cost_microdollars": int(b.get("total_cost_microdollars") or 0),
-        "speed_tokens_per_second": b.get("speed_tokens_per_second"),
-        "elapsed_milliseconds": b.get("elapsed_milliseconds"),
-        "first_token_milliseconds": b.get("first_token_milliseconds"),
-        "ttfb_milliseconds": b.get("ttfb_milliseconds"),
-        "finish_reason": b.get("finish_reason"),
-        "error_type": b.get("error_type"),
-        "error_status": b.get("error_status"),
-        "error_message": b.get("error_message"),
-        "region": b.get("region"),
-        "app": str(b.get("app") or ""),
+        route
+        for route, (samples, failures) in health.items()
+        if samples >= MIN_SAMPLES and failures / samples >= FAILURE_THRESHOLD
     }
 
 
-SQL_ROUTE_HEALTH = """
-SELECT provider, model,
-       count()                       AS samples,
-       countIf(status = 'error')     AS failures
-FROM provider_benchmark_samples
-WHERE source = 'synthetic'
-  AND status IN ('error', 'success')
-  -- ifNull() is load-bearing. error_status/error_type are Nullable, and in
-  -- SQL's three-valued logic `NULL IN (...)` is NULL, not false. That NULL
-  -- propagates through OR/AND, survives NOT, and WHERE then DROPS the row —
-  -- silently under-counting failures on exactly the routes whose errors carry
-  -- no HTTP status (empty_stream, client-side aborts). Python's
-  -- `None in {...}` is plainly False, so the two disagree unless NULLs are
-  -- flattened first. This cost 6 routes on the first run of this proof.
-  AND NOT (status = 'error' AND (
-        ifNull(error_status, 0) IN (429,500,502,503,504,529)
-     OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
-                       'ConnectError','ReadError','WriteError','RemoteProtocolError')))
-GROUP BY provider, model
-FORMAT JSONEachRow
-"""
+def load(rows: list[dict]) -> None:
+    """Reload the LOCAL proof table.
+
+    The materialized view is dropped and recreated rather than left in place:
+    an MV runs per INSERT BLOCK and does NOT inherit the source table's
+    ReplacingMergeTree collapsing, so reloading without rebuilding it silently
+    doubles every aggregate. Verified the hard way — three loader runs against
+    30,832 source rows left 92,500 samples in the view.
+    """
+    ch("TRUNCATE TABLE provider_benchmark_samples")
+    ch("DROP TABLE IF EXISTS route_health_hourly")
+    payload = "\n".join(
+        json.dumps({**r, "created_at": r["created_at"].strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]})
+        for r in rows
+    ).encode()
+    ch("INSERT INTO provider_benchmark_samples FORMAT JSONEachRow", payload)
 
 
 def main() -> int:
-    print(f"Scanning Bigtable (limit {SCAN_LIMIT})...")
-    samples = fetch_bigtable_samples()
-    print(f"  fetched {len(samples)} rows")
-    if not samples:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=int(os.environ.get("SCAN_LIMIT", "40000")))
+    parser.add_argument(
+        "--no-load",
+        action="store_true",
+        help="compare against data already in ClickHouse (does not truncate)",
+    )
+    args = parser.parse_args()
+
+    print(f"Scanning Bigtable (limit {args.limit})...")
+    rows = fetch_bigtable_samples(args.limit)
+    print(f"  {len(rows)} usable rows")
+    if not rows:
         print("no rows; aborting")
         return 1
 
-    print("Computing route health the CURRENT way (Python scan + json parse)...")
-    baseline = python_route_health(samples)
-    print(f"  {len(baseline)} routes")
+    newest = max(r["created_at"] for r in rows)
+    cutoff = newest - dt.timedelta(hours=WINDOW_HOURS)
+    assert_window_covered(rows, cutoff)
 
-    print("Loading into ClickHouse...")
-    ch("TRUNCATE TABLE provider_benchmark_samples")
-    payload = "\n".join(
-        json.dumps(r) for r in (to_ch_row(b) for b in samples) if r
-    ).encode()
-    ch("INSERT INTO provider_benchmark_samples FORMAT JSONEachRow", payload)
-    loaded = ch("SELECT count() FROM provider_benchmark_samples").strip()
-    print(f"  loaded {loaded} rows")
+    if not args.no_load:
+        print("Loading into ClickHouse (local proof table)...")
+        load(rows)
+        print(f"  loaded {ch('SELECT count() FROM provider_benchmark_samples').strip()} rows")
 
-    print("Computing the SAME thing in SQL...")
-    out = ch(SQL_ROUTE_HEALTH)
-    sql_result = {}
-    for line in out.strip().splitlines():
-        r = json.loads(line)
-        sql_result[(r["provider"], r["model"])] = (int(r["samples"]), int(r["failures"]))
-    print(f"  {len(sql_result)} routes")
+    print("Evaluating route health the CURRENT way (Python)...")
+    baseline = python_route_health(rows, cutoff)
+    print(f"  {len(baseline)} routes, {len(flagged(baseline))} flagged")
 
-    print("\nComparing...")
-    mismatches = []
-    for key in sorted(set(baseline) | set(sql_result), key=lambda k: (k[0] or "", k[1] or "")):
-        py = baseline.get(key)
-        sq = sql_result.get(key)
-        if py != sq:
-            mismatches.append((key, py, sq))
+    print("Evaluating the SAME rules in SQL...")
+    sql_result = sql_route_health(cutoff)
+    print(f"  {len(sql_result)} routes, {len(flagged(sql_result))} flagged")
 
+    mismatches = [
+        (route, baseline.get(route), sql_result.get(route))
+        for route in sorted(set(baseline) | set(sql_result))
+        if baseline.get(route) != sql_result.get(route)
+    ]
     if mismatches:
-        print(f"MISMATCH on {len(mismatches)} route(s):")
-        for key, py, sq in mismatches[:20]:
-            print(f"  {key[0]}/{key[1]}: python={py} sql={sq}")
+        print(f"\nMISMATCH on {len(mismatches)} route(s):")
+        for route, py, sq in mismatches[:20]:
+            print(f"  {route[0]}/{route[1]}: python={py} sql={sq}")
         return 1
 
-    print(f"EXACT MATCH on all {len(baseline)} routes.")
-    print("\nTop failing routes (from SQL, one query, no Python loop):")
-    top = ch("""
-        SELECT provider, model,
-               count() AS samples,
-               round(100 * countIf(status='error') / count(), 1) AS failure_pct,
-               round(quantile(0.95)(elapsed_milliseconds)) AS p95_ms
-        FROM provider_benchmark_samples
-        WHERE source='synthetic' AND status IN ('error','success')
-        GROUP BY provider, model
-        HAVING samples >= 6
-        ORDER BY failure_pct DESC, samples DESC
-        LIMIT 12
-        FORMAT PrettyCompactMonoBlock
-    """)
-    print(top)
+    py_flagged, sql_flagged = flagged(baseline), flagged(sql_result)
+    if py_flagged != sql_flagged:
+        print(f"\nFLAGGED SET MISMATCH: only-python={py_flagged ^ sql_flagged}")
+        return 1
 
-    print("Materialized view (rollups maintained incrementally, no backfill job):")
-    print(ch("""
-        SELECT provider, model,
-               countMerge(samples_state)   AS samples,
-               countIfMerge(failures_state) AS failures,
-               round(quantileMerge(0.95)(p95_elapsed_state)) AS p95_ms
-        FROM route_health_hourly
-        GROUP BY provider, model
-        ORDER BY samples DESC
-        LIMIT 8
-        FORMAT PrettyCompactMonoBlock
-    """))
+    print(f"\nEXACT MATCH: {len(baseline)} routes, identical counts.")
+    print(f"Identical flagged set ({len(py_flagged)} routes would alert):")
+    for provider, model in sorted(py_flagged):
+        samples, failures = baseline[(provider, model)]
+        print(f"  {provider}/{model}: {failures}/{samples}")
     return 0
 
 

--- a/docs/storage-portability/README.md
+++ b/docs/storage-portability/README.md
@@ -1,0 +1,283 @@
+# Storage portability: running TrustedRouter outside GCP
+
+Handoff document. Goal: run the control plane end-to-end on AWS (then Azure)
+without a risky rewrite of the billing core.
+
+Status as of 2026-07-26:
+
+| Phase | State |
+|---|---|
+| 0. Behavioural storage conformance suite | **landed (this branch)** |
+| 1. ClickHouse analytics — local proof on real data | **done, exact match** |
+| 2. ClickHouse in parallel on GCP (dual-write + verify) | next |
+| 3. AWS test cluster (ClickHouse + remote Spanner) | after phase 2 |
+| 4. Leak closures (#1 exceptions, #2 KMS, #4 backfill script) | designed, not landed |
+| 5. Azure | later |
+| — Postgres/`PostgresStore` port | **deliberately NOT on the path** |
+
+---
+
+## The architecture decision
+
+The naive plan is "replace Spanner and Bigtable with cloud-native equivalents
+on each cloud." That is three ports of the hardest, most dangerous code we
+own (reserve/settle billing), once per cloud.
+
+**We are not doing that.** Instead:
+
+* **Spanner stays the system of record — even when compute runs on AWS.**
+  Spanner is reachable over its API from anywhere and is multi-region HA
+  across zones. The control plane on AWS talks to the same Spanner instance
+  that GCP does. No billing port, no dual-writing money, no migration of the
+  thing that must never be wrong.
+* **Only analytics becomes portable**, via ClickHouse — which runs identically
+  on GCP, AWS, Azure, and self-hosted/appliance.
+
+This buys multi-cloud *compute* now and defers multi-cloud *data* until there
+is a concrete reason to pay for it.
+
+### What this trades away (know these before phase 3)
+
+1. **Cross-cloud latency on the hot path.** Every inference request does an
+   authorize (Spanner write) and a settle (Spanner write). From AWS these
+   become cross-cloud round trips. Budget for tens of ms each way and
+   **measure it in the phase-3 test cluster before committing** — pair the AWS
+   region with the nearest Spanner region (e.g. `us-east-1` ↔ `nam6`).
+   If the added TTFB is unacceptable, that measurement — not a guess — is what
+   justifies starting the Postgres port.
+2. **A hard GCP dependency remains.** This is multi-cloud compute, not
+   provider independence. A GCP outage or account action still takes the
+   control plane down wherever it runs.
+3. **Egress cost** on every Spanner round trip from AWS.
+
+None of these are blockers; they are the things to measure rather than assume.
+
+---
+
+## Why Bigtable was the wrong home for analytics
+
+Bigtable is a wide-column **operational** store — LSM-tree sorted map, built
+for point reads and range scans. It is not a columnar analytics warehouse;
+"column family" is not "column store". The GCP analytics warehouse is
+BigQuery, and this repo contains **zero** BigQuery usage.
+
+Worse, our schema forecloses even the partial benefit Bigtable offers. Bigtable
+puts column families in separate locality groups, so a field-per-qualifier
+layout would give some projection pushdown. We write **one column family
+(`m`), one cell, containing a JSON blob**. So every analytic read is: scan
+rows → `json.loads` each one in Python → aggregate in app memory.
+
+Evidence in-tree:
+
+* `storage_gcp_benchmark_index.py`, `storage_gcp_activity_index.py`,
+  `storage_gcp_synthetic_rollups.py` — `json.loads` per row.
+* `usage_series` implemented **five times** across storage modules.
+* ~245 lines of hand-rolled pre-aggregation
+  (`storage_gcp_synthetic_rollups.py` + `synthetic/backfill_rollups.py` +
+  `synthetic_rollup#` row keys) — that machinery exists *because* the store
+  cannot aggregate.
+
+Bigtable remains a fine fit for the operational half (newest-N lookups for
+route health, the activity feed). The split is the point: keep it for that,
+stop using it as a warehouse.
+
+---
+
+## Phase 1 result (done): ClickHouse reproduces production exactly
+
+`clickhouse/prove_leaderboard.py` is a differential test, not a demo:
+
+1. Read real `ProviderBenchmarkSample` rows from production Bigtable (read-only).
+2. Compute route health in Python **exactly as `synthetic/route_health.py`
+   does today** — the current production answer.
+3. Load the same rows into ClickHouse.
+4. Compute the same thing in one SQL statement.
+5. Assert agreement route by route.
+
+Result on **40,000 real rows / 525 routes: EXACT MATCH.**
+
+Run it:
+
+```bash
+docker run -d --name tr-clickhouse -p 18123:8123 -p 19000:9000 \
+  -e CLICKHOUSE_DB=tr -e CLICKHOUSE_USER=tr -e CLICKHOUSE_PASSWORD=tr \
+  clickhouse/clickhouse-server:latest
+
+# apply schema (strip -- comments before splitting on ';' — the prose
+# contains semicolons)
+# then:
+export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/tr-ops-local.json
+SCAN_LIMIT=40000 uv run --with google-cloud-bigtable \
+  python clickhouse/prove_leaderboard.py
+```
+
+### The bug this proof caught — read this before writing any porting SQL
+
+First run mismatched on 6 of 525 routes. SQL reported **0 failures** where
+Python found some, and dropped exactly as many rows as Python counted as
+failures.
+
+Cause: `error_status` / `error_type` are `Nullable`. In SQL's three-valued
+logic `NULL IN (...)` is **NULL, not false**. That NULL propagates through
+`OR` and `AND`, survives `NOT`, and `WHERE NULL` **drops the row**. Python's
+`None in {...}` is plainly `False`.
+
+So the naive translation silently under-counted failures on exactly the routes
+whose errors carry no HTTP status (`empty_stream`, client-side aborts) — the
+dead routes we most need to detect. Fix: flatten NULLs first
+(`ifNull(error_status, 0)`, `ifNull(error_type, '')`).
+
+**Generalise:** any Python→SQL port of predicate logic must be differentially
+tested against the Python original on real data. Reviewing the SQL by eye
+would not have caught this; the aggregate was plausible and wrong.
+
+### What ClickHouse deletes
+
+`route_health_hourly` (an `AggregatingMergeTree` materialized view) maintains
+rollups incrementally as rows arrive. It replaces the entire hand-rolled
+rollup layer — `storage_gcp_synthetic_rollups.py` and
+`synthetic/backfill_rollups.py` — including the scheduled backfill job that
+can fail silently. Aggregate *states* are stored, so one view answers "last
+48h" and "last 90 days" without storing either.
+
+It also makes questions cheap that were previously scripts. The same run
+immediately surfaced that **every `google-ai-studio` Gemini route is at 100%
+failure**, and confirmed `atlas-cloud/openai/gpt-5.1-codex-max` (previously
+left unquarantined for lack of evidence) is dead at 11/11.
+
+---
+
+## Phase 0 (landed): the behavioural conformance suite
+
+`tests/conformance/` — the acceptance test any storage backend must pass.
+
+The pre-existing `tests/test_store_protocol_conformance.py` checks that both
+backends declare the same method *names and signatures*. It cannot see
+behaviour, so a backend that double-credits on retry, or lets a verification
+token be redeemed twice, passes it happily.
+
+The new suite pins semantics instead, talking **only to the `Store` protocol**:
+exactly-once credit (both directions — no double-credit *and* no
+over-dedupe), single-use wallet challenges / verification tokens / OAuth
+codes, purpose-scoping, all three API-key lookup paths agreeing plus
+revocation, session lifecycle, read-your-writes, and index newest-first /
+limit / route-filter semantics.
+
+Adding a backend = one entry in `conformance/conftest.BACKENDS`. Tests do not
+change.
+
+```bash
+uv run pytest -q tests/conformance/     # 15 passed, 15 skipped
+```
+
+The 15 skips are the `spanner-emulator` backend, which is registered and skips
+cleanly until emulator schema provisioning lands. **A skipped backend proves
+nothing** — wiring the Spanner/Bigtable emulators is the next increment here,
+and it is what turns this from an executable spec into actual cross-backend
+enforcement.
+
+### Known divergence this exposed
+
+`InMemoryStore` deliberately does **not** implement `TypedBillingStore`, and
+the Spanner store's legacy `reserve()` raises `RuntimeError`. The two backends
+run **genuinely different money code paths today**, and nothing pins which
+semantics are correct. Any new backend has to pick one. This is why the
+typed-billing contract (leak #3) is explicitly *not* being touched yet.
+
+---
+
+## Phase 2 (next): ClickHouse in parallel on GCP
+
+Goal: ClickHouse running alongside the live stack, continuously verified,
+before anything depends on it.
+
+1. **Stand up ClickHouse on GCP.** ClickHouse Cloud on GCP, or self-managed on
+   GCE. Single node is fine at current volume.
+2. **Dual-write.** Where `record_provider_benchmark` / `add_generation` write
+   Bigtable, also enqueue to ClickHouse. Use `async_insert` or a buffer —
+   **one synchronous row per generation is a ClickHouse anti-pattern.**
+   Dual-write must be best-effort: a ClickHouse failure must never fail an
+   inference request.
+3. **Backfill** history from Bigtable (idempotent — `ReplacingMergeTree` keyed
+   on the sort key means re-running is safe).
+4. **Verify continuously.** Run `prove_leaderboard.py`'s comparison as a
+   scheduled job against live data. Divergence is a page.
+5. **Flip reads** for the leaderboard only — lowest-risk surface: public,
+   non-money, self-verifying against Bigtable.
+6. Then flip `usage_series` / activity aggregates, and delete the rollup layer.
+
+Verification gate for each step: the differential comparison stays exact.
+Rollback: flip reads back to Bigtable; dual-write keeps both populated.
+
+## Phase 3: AWS test cluster
+
+Control plane on AWS + ClickHouse on AWS + **Spanner still in GCP**.
+
+Must-measure before committing:
+
+* Added p50/p95 latency on authorize and settle from AWS → Spanner.
+* Egress cost per million requests.
+* Behaviour under a cross-cloud network partition — specifically whether the
+  settle-outbox drains correctly when Spanner is briefly unreachable
+  (`storage_errors.is_transient_store_error` is what should be classifying
+  that; see leak #1).
+
+## Phase 4: leak closures (designed, not landed)
+
+1. **GCP exceptions in app code** — `google.api_core.exceptions` is imported
+   in `main.py`, `routes/byok.py`, `services/settle_outbox_apply.py` to make
+   control-flow decisions. `src/trusted_router/storage_errors.py` (written,
+   not yet wired) provides `StoreError`/`StoreConflict`/`StoreUnavailable` +
+   `is_transient_store_error()` / `is_conflict_error()`, preserving the exact
+   six-type transient set the outbox parks on, with Google imported **lazily**
+   so a non-GCP deployment need not install the Google libraries at all.
+2. **KMS** — `byok_crypto.py` calls `kms_v1` directly. `_wrap_dek` /
+   `_unwrap_dek` already branch on `settings.byok_kms_key_name`, so a
+   `KeyWrapper` port (`LocalAes` / `GcpKms` / `AwsKms` / `AzureKeyVault`)
+   drops in cleanly.
+   **Latent bug found:** decrypt dispatches on *current settings*, not on the
+   envelope's stored `key_ref`. Switching clouds would strand every existing
+   envelope. The port should dispatch on `envelope.key_ref`. This changes
+   production crypto behaviour and deserves its own careful PR.
+4. **`synthetic/backfill_rollups.py`** imports Bigtable directly. Largely moot
+   once phase 2 lands — ClickHouse's materialized view replaces the script.
+
+(#3, the typed-billing neutral contract, is intentionally deferred — see
+"Known divergence" above.)
+
+---
+
+## Reference: what we actually use
+
+**Spanner** — `run_in_transaction` ×55, `snapshot()` ×21, `execute_update`
+×19, `commit_timestamp` ×8, `PENDING_COMMIT_TIMESTAMP` ×4. Multi-row ACID
+transactions, serializable, SQL DML, server-side commit timestamps.
+**No interleaved tables** — which is the single least-portable Spanner
+feature, so a future port is more tractable than expected.
+
+**Bigtable** — ~16 row-key families, all lexicographic prefix scans shaped
+`<prefix>#<dims>#<reverse_ts>#<id>`, single column family `m`, single JSON
+cell, append-only. This maps almost 1:1 onto DynamoDB (PK = `prefix#dims`,
+SK = `reverse_ts#id`) or Cosmos NoSQL **if** we ever need the operational half
+ported — but phase 2 removes the analytics reason to.
+
+**KMS** — envelope encryption of customer BYOK keys.
+
+**The seam is good.** `store_protocol.Store` is 102 methods in domain language
+(`create_workspace`, `reserve_key_limit`) with no GCP vocabulary leaking, two
+implementations already satisfy it, and `storage.create_store()` is a
+config-driven factory (`TR_STORAGE_BACKEND`). The hard architectural work was
+already done; what was missing is behavioural enforcement (phase 0) and an
+analytics engine (phase 1).
+
+## If someone later needs the Postgres port
+
+Target the **PostgreSQL wire protocol**, not a specific product: one adapter
+then covers CockroachDB (neutral + self-host), Aurora DSQL (AWS), Cosmos DB
+for PostgreSQL / Azure SQL (Azure), and plain Postgres for local dev — which
+would also replace `InMemoryStore` as a higher-fidelity test backend.
+
+Caveat: wire-compatible is not behaviour-compatible (DSQL has no foreign keys
+and a reduced PG surface; CockroachDB diverges on sequences and retry
+semantics). Expect a thin dialect layer. **The conformance suite from phase 0
+is the acceptance test** — write the backend against it.

--- a/docs/storage-portability/README.md
+++ b/docs/storage-portability/README.md
@@ -94,7 +94,30 @@ stop using it as a warehouse.
 4. Compute the same thing in one SQL statement.
 5. Assert agreement route by route.
 
-Result on **40,000 real rows / 525 routes: EXACT MATCH.**
+Result on **40,000 real rows / 500 routes: EXACT MATCH**, including an
+identical flagged set (the routes that would actually alert).
+
+### What it proves, precisely
+
+It proves that **given the same input rows**, the SQL translation of
+`evaluate_route_health` matches the Python original — same per-route counts,
+same flagged set — under the real rules: 48-hour cutoff, newest-48-per-route,
+synthetic-only, `unsupported` excluded, transient failures excluded,
+`min_samples=6`, `failure_rate>=0.95`. That is the risky part of the port, and
+it is where the NULL bug below lived.
+
+It does **not** prove:
+
+* the full public leaderboard aggregator (`synthetic/leaderboard.py`), which
+  also blends organic traffic, computes exact nearest-rank percentiles and
+  ranks providers. ClickHouse's `quantile()` is *approximate* and has not been
+  reconciled against that exact implementation. Do not swap it in blind.
+* anything about the ingestion path — both sides read one slice.
+
+Because both sides read the same slice, a biased slice would let them agree
+while diverging from production (which reads per-route). The script therefore
+**asserts** that the scan reaches back past the 48h cutoff before comparing;
+if it doesn't, it exits rather than reporting a meaningless match.
 
 Run it:
 
@@ -107,9 +130,13 @@ docker run -d --name tr-clickhouse -p 18123:8123 -p 19000:9000 \
 # contains semicolons)
 # then:
 export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/tr-ops-local.json
-SCAN_LIMIT=40000 uv run --with google-cloud-bigtable \
-  python clickhouse/prove_leaderboard.py
+uv run --with google-cloud-bigtable python clickhouse/prove_leaderboard.py
 ```
+
+> **This is a local proof harness, not a monitor.** By default it TRUNCATEs
+> the analytics table and rebuilds the materialized view. Never point it at a
+> production ClickHouse. Use `--no-load` to compare against data already
+> present.
 
 ### The bug this proof caught — read this before writing any porting SQL
 
@@ -131,14 +158,33 @@ dead routes we most need to detect. Fix: flatten NULLs first
 tested against the Python original on real data. Reviewing the SQL by eye
 would not have caught this; the aggregate was plausible and wrong.
 
-### What ClickHouse deletes
+### What ClickHouse replaces — and what it does NOT
 
 `route_health_hourly` (an `AggregatingMergeTree` materialized view) maintains
-rollups incrementally as rows arrive. It replaces the entire hand-rolled
-rollup layer — `storage_gcp_synthetic_rollups.py` and
-`synthetic/backfill_rollups.py` — including the scheduled backfill job that
-can fail silently. Aggregate *states* are stored, so one view answers "last
-48h" and "last 90 days" without storing either.
+per-route rollups incrementally as rows arrive, with no scheduled job to fail
+silently. Aggregate *states* are stored, so one view answers "last 48h" and
+"last 90 days" without storing either.
+
+Scope, precisely: it covers the **ProviderBenchmarkSample** dataset
+(provider/model). It is **not** a replacement for
+`synthetic/backfill_rollups.py`, which rolls up a *different* dataset —
+`SyntheticProbeSample`, keyed by component/target/probe_type/region. Retiring
+that job is separate work. (An earlier draft of this document claimed
+otherwise; it was wrong.)
+
+Two traps found the hard way, both now encoded in the schema comments:
+
+1. **The view must repeat route-health's exclusions.** Counting every
+   synthetic row and every error is *not* route health: on a 30.8k-row sample
+   that yields 30832 samples / 1176 failures against the correct 28214 / 59 —
+   a **20x overstatement of failures** that looks entirely plausible.
+2. **`ReplacingMergeTree` does not make ingestion idempotent for the view.**
+   Materialized views run per INSERT BLOCK, before any source-table
+   replacement, so re-running a backfill permanently inflates the aggregates
+   even though the source table collapses its duplicates. Measured: three
+   loads of 30,832 rows left **92,500** samples in the view. Ingestion must be
+   append-once, use `insert_deduplication_token`, or rebuild the view
+   alongside any source reload.
 
 It also makes questions cheap that were previously scripts. The same run
 immediately surfaced that **every `google-ai-studio` Gemini route is at 100%
@@ -198,10 +244,15 @@ before anything depends on it.
    **one synchronous row per generation is a ClickHouse anti-pattern.**
    Dual-write must be best-effort: a ClickHouse failure must never fail an
    inference request.
-3. **Backfill** history from Bigtable (idempotent — `ReplacingMergeTree` keyed
-   on the sort key means re-running is safe).
-4. **Verify continuously.** Run `prove_leaderboard.py`'s comparison as a
-   scheduled job against live data. Divergence is a page.
+3. **Backfill** history from Bigtable. Re-running is safe for the *source
+   table* (`ReplacingMergeTree` collapses duplicates on the sort key) but
+   **not** for the materialized view — see the trap above. Either backfill
+   once, carry an `insert_deduplication_token`, or rebuild the view after any
+   reload.
+4. **Verify continuously** with a comparison job — the *logic* of
+   `prove_leaderboard.py`, but read-only. Do **not** schedule that script
+   itself against production: it truncates by default. Extract the comparison
+   into a job that only reads both stores and alerts on divergence.
 5. **Flip reads** for the leaderboard only — lowest-risk surface: public,
    non-money, self-verifying against Bigtable.
 6. Then flip `usage_series` / activity aggregates, and delete the rollup layer.

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -22,12 +22,24 @@ Backend availability
 emulators today, a Postgres container later) are opt-in: their factory calls
 `pytest.skip()` when the server isn't reachable, so the suite stays green on a
 laptop and gains real cross-backend enforcement in CI. A backend that is
-skipped proves nothing — see `test_backend_coverage.py`.
+skipped proves nothing, which is why `test_memory_backend_is_always_runnable`
+deliberately does NOT depend on the parametrized `store` fixture — a guard
+that can itself be skipped guards nothing.
+
+Test isolation
+--------------
+`InMemoryStore` is constructed fresh per test, so it is isolated for free.
+Server-backed backends are NOT: `SpannerBigtableStore.reset()` explicitly
+refuses to wipe a real database. Tests therefore must not reuse fixed
+identifiers across tests — every id is namespaced with the per-test `unique`
+fixture below, so a shared emulator database stays order-independent and
+uncontaminated between runs.
 """
 
 from __future__ import annotations
 
 import os
+import uuid
 from collections.abc import Callable, Iterator
 from typing import Any
 
@@ -109,7 +121,35 @@ def store(request: pytest.FixtureRequest) -> Iterator[Store]:
 
 
 @pytest.fixture
-def workspace_id(store: Store) -> str:
+def unique() -> str:
+    """A per-test identifier namespace.
+
+    Server-backed backends share one database across the whole run and cannot
+    be reset (see "Test isolation" above), so every id a test invents must be
+    unique or tests contaminate each other — e.g. one test consuming event
+    `evt-A` would make the next test's "this event is new" assertion fail
+    purely because of ordering.
+    """
+    return uuid.uuid4().hex[:12]
+
+
+@pytest.fixture
+def user_id(store: Store, unique: str) -> str:
+    """A REAL user, created through the store.
+
+    Tests must not invent dangling foreign keys. Spanner's generic entity
+    table happens to accept a fabricated `user_id`, but a backend with
+    referential integrity (any SQL port with an FK, which is the likely shape
+    of a Postgres backend) would correctly reject it — and would then fail
+    this suite for being correct. Accepting orphaned rows is not a contract we
+    want to freeze in.
+    """
+    user = store.ensure_user(f"conformance-user-{unique}", f"conf-{unique}@example.com")
+    return str(user.id)
+
+
+@pytest.fixture
+def workspace_id(store: Store, user_id: str, unique: str) -> str:
     """A workspace with an explicit ZERO starter credit.
 
     Explicit is load-bearing twice over. The repo-root `auto_credit_test_
@@ -118,8 +158,7 @@ def workspace_id(store: Store) -> str:
     fixture instead of the backend. And a backend-neutral test must not depend
     on any backend's default granting policy.
     """
-    user = store.ensure_user("conformance-user", "conformance@example.com")
-    ws = store.create_workspace(user.id, "conformance", trial_credit_microdollars=0)
+    ws = store.create_workspace(user_id, f"conformance-{unique}", trial_credit_microdollars=0)
     return str(ws.id)
 
 

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -1,0 +1,155 @@
+"""Backend registry for the storage conformance suite.
+
+Every test in this package talks to the `Store` Protocol and nothing else —
+no backend-specific imports, no GCP types, no SQL. That is the whole point:
+a new backend becomes conformant by being added to `BACKENDS` below and
+passing this suite unchanged.
+
+Why this exists
+---------------
+`tests/test_store_protocol_conformance.py` checks that both backends declare
+the same method *names* and signatures. It cannot see behaviour, so a backend
+whose `credit_workspace_once` double-credits on retry, or whose
+`consume_verification_token` allows a token to be redeemed twice, passes it
+happily. Those are exactly the divergences that cost money or leak access.
+
+This suite pins the *semantics* instead, so they are an executable contract
+rather than tribal knowledge living in one implementation.
+
+Backend availability
+--------------------
+`memory` always runs. Backends that need a live server (the Spanner/Bigtable
+emulators today, a Postgres container later) are opt-in: their factory calls
+`pytest.skip()` when the server isn't reachable, so the suite stays green on a
+laptop and gains real cross-backend enforcement in CI. A backend that is
+skipped proves nothing — see `test_backend_coverage.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+
+from trusted_router.store_protocol import Store
+
+# --------------------------------------------------------------------------
+# Backend factories
+# --------------------------------------------------------------------------
+
+
+def _memory_store() -> Store:
+    from trusted_router.storage import InMemoryStore
+
+    return InMemoryStore()
+
+
+def _spanner_emulator_store() -> Store:
+    """`SpannerBigtableStore` pointed at the Google emulators.
+
+    `SpannerBigtableStore.__init__` eagerly opens clients, and the Google
+    client libraries route to a local emulator when SPANNER_EMULATOR_HOST /
+    BIGTABLE_EMULATOR_HOST are exported. Both are required: this store spans
+    two services and a half-configured one fails in a confusing way partway
+    through a test rather than skipping cleanly here.
+
+    Schema provisioning against the emulator is deliberately NOT done here —
+    it is the next increment. Until then this backend skips, and the suite
+    documents the gap instead of pretending to cover it.
+    """
+    spanner_host = os.environ.get("SPANNER_EMULATOR_HOST")
+    bigtable_host = os.environ.get("BIGTABLE_EMULATOR_HOST")
+    if not (spanner_host and bigtable_host):
+        pytest.skip(
+            "Spanner/Bigtable emulators not configured "
+            "(export SPANNER_EMULATOR_HOST and BIGTABLE_EMULATOR_HOST)"
+        )
+    if not os.environ.get("TR_CONFORMANCE_EMULATOR_SCHEMA"):
+        pytest.skip(
+            "emulator schema provisioning not implemented yet "
+            "(set TR_CONFORMANCE_EMULATOR_SCHEMA=1 once it lands)"
+        )
+    from trusted_router.storage_gcp import SpannerBigtableStore
+
+    return SpannerBigtableStore(
+        project_id=os.environ.get("TR_CONFORMANCE_PROJECT", "tr-conformance"),
+        spanner_instance_id=os.environ.get("TR_CONFORMANCE_SPANNER_INSTANCE", "tr-test"),
+        spanner_database_id=os.environ.get("TR_CONFORMANCE_SPANNER_DB", "tr-test"),
+        bigtable_instance_id=os.environ.get("TR_CONFORMANCE_BIGTABLE_INSTANCE", "tr-test"),
+        generation_table=os.environ.get(
+            "TR_CONFORMANCE_BIGTABLE_TABLE", "trustedrouter-generations"
+        ),
+    )
+
+
+#: Add a backend here and it must pass every test in this package.
+BACKENDS: dict[str, Callable[[], Store]] = {
+    "memory": _memory_store,
+    "spanner-emulator": _spanner_emulator_store,
+}
+
+
+@pytest.fixture(params=sorted(BACKENDS), ids=lambda name: f"backend={name}")
+def store(request: pytest.FixtureRequest) -> Iterator[Store]:
+    """A live store for each registered backend.
+
+    The factory may `pytest.skip()` when its server isn't available; that is
+    reported per-backend so a skipped backend is visible rather than silently
+    counted as a pass.
+    """
+    backend = BACKENDS[request.param]()
+    yield backend
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_id(store: Store) -> str:
+    """A workspace with an explicit ZERO starter credit.
+
+    Explicit is load-bearing twice over. The repo-root `auto_credit_test_
+    workspaces` autouse fixture grants $10 to any workspace created without an
+    explicit amount, which would make credit assertions here measure the
+    fixture instead of the backend. And a backend-neutral test must not depend
+    on any backend's default granting policy.
+    """
+    user = store.ensure_user("conformance-user", "conformance@example.com")
+    ws = store.create_workspace(user.id, "conformance", trial_credit_microdollars=0)
+    return str(ws.id)
+
+
+def make_benchmark_sample(
+    *,
+    sample_id: str,
+    provider: str,
+    model: str,
+    status: str = "success",
+    created_at: str | None = None,
+) -> Any:
+    """A minimal `ProviderBenchmarkSample`.
+
+    Only the fields the index contract depends on are set; everything else
+    keeps its dataclass default so this helper doesn't quietly encode
+    assumptions about unrelated columns.
+    """
+    from trusted_router.storage_models import ProviderBenchmarkSample
+    from trusted_router.types import UsageType
+
+    kwargs: dict[str, Any] = {
+        "id": sample_id,
+        "model": model,
+        "provider": provider,
+        "provider_name": provider,
+        "status": status,
+        "usage_type": UsageType.CREDITS,
+        "streamed": True,
+        "source": "synthetic",
+    }
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    return ProviderBenchmarkSample(**kwargs)

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -1,0 +1,257 @@
+"""Behavioural contract every storage backend must satisfy.
+
+Each test names one property and the failure it prevents. They are written
+against the `Store` Protocol only, so a new backend (Postgres, DSQL,
+CockroachDB) is validated by registering it in `conftest.BACKENDS` — no test
+changes.
+
+The properties chosen here are the ones where a backend can diverge *silently*
+and expensively: exactly-once credit, single-use secrets, and index ordering.
+An implementation that is more permissive than the contract (double-crediting
+on retry, letting a token be redeemed twice) passes the existing structural
+conformance test and fails these.
+"""
+
+from __future__ import annotations
+
+from trusted_router.store_protocol import Store
+
+from .conftest import make_benchmark_sample
+
+# --------------------------------------------------------------------------
+# Exactly-once money
+# --------------------------------------------------------------------------
+
+
+def test_credit_workspace_once_is_idempotent_per_event(
+    store: Store, workspace_id: str
+) -> None:
+    """Re-applying the same credit event MUST NOT credit twice.
+
+    This is the retry path for Stripe webhooks and top-ups: the same event_id
+    is delivered again after a timeout. A backend that returns True twice has
+    given the customer free money. The boolean is the contract — True means
+    "applied now", False means "already applied".
+    """
+    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is True
+    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is False
+
+
+def test_credit_workspace_once_distinguishes_events(
+    store: Store, workspace_id: str
+) -> None:
+    """Idempotency is keyed on the event, not the amount or workspace.
+
+    Guards the opposite error from the test above: a backend that dedupes too
+    aggressively (e.g. keys on workspace+amount) would silently swallow a
+    second, legitimate top-up of the same size.
+    """
+    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is True
+    assert store.credit_workspace_once(workspace_id, 5_000, "evt-B") is True
+
+
+def test_record_sns_message_once_is_idempotent(store: Store) -> None:
+    """SNS redelivers; bounce/complaint processing must run once.
+
+    Without this, one bounce notification replayed by SNS can suppress an
+    address twice or double-count a complaint.
+    """
+    assert store.record_sns_message_once("msg-1") is True
+    assert store.record_sns_message_once("msg-1") is False
+    assert store.record_sns_message_once("msg-2") is True
+
+
+# --------------------------------------------------------------------------
+# Single-use secrets
+# --------------------------------------------------------------------------
+
+
+def test_wallet_challenge_is_single_use(store: Store) -> None:
+    """A SIWE nonce must be redeemable exactly once.
+
+    Replayable nonces are a signature-replay authentication bypass, so
+    "consume" has to be an atomic take, not a read.
+    """
+    raw_nonce, _challenge = store.create_wallet_challenge(
+        address="0xabc", message="sign this", ttl_seconds=300
+    )
+    assert store.consume_wallet_challenge(raw_nonce) is not None
+    assert store.consume_wallet_challenge(raw_nonce) is None
+
+
+def test_unknown_wallet_challenge_returns_none(store: Store) -> None:
+    """An unissued nonce must not authenticate anything."""
+    assert store.consume_wallet_challenge("never-issued") is None
+
+
+def test_verification_token_is_single_use(store: Store) -> None:
+    """Email-verification links land in inboxes and get clicked twice."""
+    raw_token, _token = store.create_verification_token(
+        user_id="u1", purpose="verify_email", ttl_seconds=300
+    )
+    assert store.consume_verification_token(raw_token, purpose="verify_email") is not None
+    assert store.consume_verification_token(raw_token, purpose="verify_email") is None
+
+
+def test_verification_token_is_scoped_to_its_purpose(store: Store) -> None:
+    """A token minted for one purpose must not satisfy another.
+
+    Otherwise a low-value token (email verification) could be redeemed on a
+    high-value flow (password reset) — privilege escalation via token reuse.
+    """
+    raw_token, _token = store.create_verification_token(
+        user_id="u1", purpose="verify_email", ttl_seconds=300
+    )
+    assert store.consume_verification_token(raw_token, purpose="password_reset") is None
+
+
+def test_oauth_authorization_code_is_single_use(store: Store, workspace_id: str) -> None:
+    """OAuth codes are single-use by RFC 6749; replay must fail."""
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace_id,
+        user_id=None,
+        callback_url="https://example.com/cb",
+        key_label="conformance",
+        ttl_seconds=300,
+        app_id=1,
+    )
+    assert store.consume_oauth_authorization_code(raw_code) is not None
+    assert store.consume_oauth_authorization_code(raw_code) is None
+
+
+# --------------------------------------------------------------------------
+# Read-your-writes and lifecycle
+# --------------------------------------------------------------------------
+
+
+def test_workspace_is_readable_immediately_after_creation(
+    store: Store, workspace_id: str
+) -> None:
+    """No backend may require a settling delay for its own write.
+
+    Route code creates a workspace and immediately reads it back in the same
+    request. An eventually-consistent backend would 404 intermittently.
+    """
+    fetched = store.get_workspace(workspace_id)
+    assert fetched is not None
+    assert str(fetched.id) == workspace_id
+
+
+def test_api_key_lookups_agree_and_delete_revokes(
+    store: Store, workspace_id: str
+) -> None:
+    """Every key lookup path must resolve to the same key, and delete must
+    actually revoke it.
+
+    `get_key_by_raw` and `get_key_by_hash` are separate code paths (and on the
+    typed backend, separate tables). If they disagree, authentication and
+    revocation disagree — a deleted key that still authenticates is the worst
+    case.
+    """
+    raw_key, created = store.create_api_key(
+        workspace_id=workspace_id, name="conformance", creator_user_id=None
+    )
+    by_raw = store.get_key_by_raw(raw_key)
+    by_hash = store.get_key_by_hash(created.hash)
+    by_lookup = store.get_key_by_lookup_hash(created.lookup_hash)
+    assert by_raw is not None
+    assert by_hash is not None
+    assert by_lookup is not None
+    assert by_raw.hash == by_hash.hash == by_lookup.hash == created.hash
+
+    assert store.delete_key(created.hash) is True
+    assert store.get_key_by_raw(raw_key) is None
+    assert store.get_key_by_hash(created.hash) is None
+    assert store.get_key_by_lookup_hash(created.lookup_hash) is None
+
+
+def test_auth_session_lifecycle(store: Store) -> None:
+    """Create -> read -> delete -> gone. Logout must actually invalidate."""
+    raw_token, _session = store.create_auth_session(
+        user_id="u1", provider="google", label="conformance", ttl_seconds=300
+    )
+    assert store.get_auth_session_by_raw(raw_token) is not None
+    assert store.delete_auth_session_by_raw(raw_token) is True
+    assert store.get_auth_session_by_raw(raw_token) is None
+
+
+# --------------------------------------------------------------------------
+# Index / scan semantics
+# --------------------------------------------------------------------------
+
+
+def test_benchmark_samples_return_newest_first(store: Store) -> None:
+    """The index contract is reverse-chronological order.
+
+    Route-health and the leaderboard both read "the newest N samples" and
+    treat element 0 as current state. On Bigtable this ordering is a property
+    of the reverse-timestamp row key; on SQL it must come from an explicit
+    ORDER BY. A backend that returns insertion order breaks freshness logic
+    without any error.
+    """
+    for idx, created_at in enumerate(
+        ["2026-01-01T00:00:00+00:00", "2026-01-02T00:00:00+00:00", "2026-01-03T00:00:00+00:00"]
+    ):
+        store.record_provider_benchmark(
+            make_benchmark_sample(
+                sample_id=f"s{idx}",
+                provider="acme",
+                model="acme/m1",
+                created_at=created_at,
+            )
+        )
+    samples = store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=10)
+    assert len(samples) == 3
+    timestamps = [s.created_at for s in samples]
+    assert timestamps == sorted(timestamps, reverse=True), (
+        f"expected newest-first, got {timestamps}"
+    )
+
+
+def test_benchmark_samples_respect_limit(store: Store) -> None:
+    """`limit` must cap the result set.
+
+    Route-health sizes its statistical window with this argument; a backend
+    that ignores it silently changes the alert threshold.
+    """
+    for idx in range(5):
+        store.record_provider_benchmark(
+            make_benchmark_sample(
+                sample_id=f"s{idx}",
+                provider="acme",
+                model="acme/m1",
+                created_at=f"2026-01-0{idx + 1}T00:00:00+00:00",
+            )
+        )
+    assert len(store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=2)) == 2
+
+
+def test_benchmark_samples_filter_by_route(store: Store) -> None:
+    """Provider/model filtering must not leak other routes' samples.
+
+    A leak here silently mixes another model's health into a route's failure
+    rate — which is exactly how a false alert (or a missed one) is born.
+    """
+    store.record_provider_benchmark(
+        make_benchmark_sample(sample_id="a", provider="acme", model="acme/m1")
+    )
+    store.record_provider_benchmark(
+        make_benchmark_sample(sample_id="b", provider="other", model="other/m2")
+    )
+    samples = store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=10)
+    assert [s.id for s in samples] == ["a"]
+
+
+# --------------------------------------------------------------------------
+# Coverage guard
+# --------------------------------------------------------------------------
+
+
+def test_at_least_one_backend_actually_ran(store: Store) -> None:
+    """Tripwire: a suite where every backend skipped proves nothing.
+
+    `memory` has no external dependency, so it must always run. If this is
+    ever reported as skipped, the harness itself is broken and every other
+    result in this package is meaningless.
+    """
+    assert store is not None

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -10,13 +10,30 @@ and expensively: exactly-once credit, single-use secrets, and index ordering.
 An implementation that is more permissive than the contract (double-crediting
 on retry, letting a token be redeemed twice) passes the existing structural
 conformance test and fails these.
+
+Known limits of this suite — read before trusting it
+----------------------------------------------------
+* **Sequential, not concurrent.** "Single use" is really a claim about an
+  atomic take, and these tests exercise it one caller at a time. A backend
+  that implements consume as a non-atomic read-then-write would pass here and
+  still double-redeem under two concurrent callers. Concurrent conformance
+  needs real backends (an emulator or container), so it lands with that
+  wiring rather than being faked against the in-memory store.
+* **Credit is asserted through its return contract, not a balance.** The
+  `Store` protocol exposes no backend-neutral balance read: `CreditAccount`
+  became metadata-only, and the money snapshot lives on backend-specific
+  methods (`credit_money_snapshot`, `typed_credit_snapshot`). So a backend
+  that returns `(True, False)` while crediting the wrong amount would pass.
+  Closing that hole means putting a neutral money read on the protocol — a
+  real portability gap, tracked in docs/storage-portability/README.md rather
+  than papered over here.
 """
 
 from __future__ import annotations
 
 from trusted_router.store_protocol import Store
 
-from .conftest import make_benchmark_sample
+from .conftest import BACKENDS, make_benchmark_sample
 
 # --------------------------------------------------------------------------
 # Exactly-once money
@@ -24,7 +41,7 @@ from .conftest import make_benchmark_sample
 
 
 def test_credit_workspace_once_is_idempotent_per_event(
-    store: Store, workspace_id: str
+    store: Store, workspace_id: str, unique: str
 ) -> None:
     """Re-applying the same credit event MUST NOT credit twice.
 
@@ -33,32 +50,35 @@ def test_credit_workspace_once_is_idempotent_per_event(
     given the customer free money. The boolean is the contract — True means
     "applied now", False means "already applied".
     """
-    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is True
-    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is False
+    event = f"evt-{unique}-A"
+    assert store.credit_workspace_once(workspace_id, 5_000, event) is True
+    assert store.credit_workspace_once(workspace_id, 5_000, event) is False
 
 
 def test_credit_workspace_once_distinguishes_events(
-    store: Store, workspace_id: str
+    store: Store, workspace_id: str, unique: str
 ) -> None:
     """Idempotency is keyed on the event, not the amount or workspace.
 
     Guards the opposite error from the test above: a backend that dedupes too
     aggressively (e.g. keys on workspace+amount) would silently swallow a
-    second, legitimate top-up of the same size.
+    second, legitimate top-up of the same size. The third call proves a
+    rejected duplicate did not poison the dedupe state for later events.
     """
-    assert store.credit_workspace_once(workspace_id, 5_000, "evt-A") is True
-    assert store.credit_workspace_once(workspace_id, 5_000, "evt-B") is True
+    assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-A") is True
+    assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-A") is False
+    assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-B") is True
 
 
-def test_record_sns_message_once_is_idempotent(store: Store) -> None:
+def test_record_sns_message_once_is_idempotent(store: Store, unique: str) -> None:
     """SNS redelivers; bounce/complaint processing must run once.
 
     Without this, one bounce notification replayed by SNS can suppress an
     address twice or double-count a complaint.
     """
-    assert store.record_sns_message_once("msg-1") is True
-    assert store.record_sns_message_once("msg-1") is False
-    assert store.record_sns_message_once("msg-2") is True
+    assert store.record_sns_message_once(f"msg-{unique}-1") is True
+    assert store.record_sns_message_once(f"msg-{unique}-1") is False
+    assert store.record_sns_message_once(f"msg-{unique}-2") is True
 
 
 # --------------------------------------------------------------------------
@@ -69,8 +89,7 @@ def test_record_sns_message_once_is_idempotent(store: Store) -> None:
 def test_wallet_challenge_is_single_use(store: Store) -> None:
     """A SIWE nonce must be redeemable exactly once.
 
-    Replayable nonces are a signature-replay authentication bypass, so
-    "consume" has to be an atomic take, not a read.
+    Replayable nonces are a signature-replay authentication bypass.
     """
     raw_nonce, _challenge = store.create_wallet_challenge(
         address="0xabc", message="sign this", ttl_seconds=300
@@ -79,30 +98,36 @@ def test_wallet_challenge_is_single_use(store: Store) -> None:
     assert store.consume_wallet_challenge(raw_nonce) is None
 
 
-def test_unknown_wallet_challenge_returns_none(store: Store) -> None:
+def test_unknown_wallet_challenge_returns_none(store: Store, unique: str) -> None:
     """An unissued nonce must not authenticate anything."""
-    assert store.consume_wallet_challenge("never-issued") is None
+    assert store.consume_wallet_challenge(f"never-issued-{unique}") is None
 
 
-def test_verification_token_is_single_use(store: Store) -> None:
+def test_verification_token_is_single_use(store: Store, user_id: str) -> None:
     """Email-verification links land in inboxes and get clicked twice."""
     raw_token, _token = store.create_verification_token(
-        user_id="u1", purpose="verify_email", ttl_seconds=300
+        user_id=user_id, purpose="verify_email", ttl_seconds=300
     )
     assert store.consume_verification_token(raw_token, purpose="verify_email") is not None
     assert store.consume_verification_token(raw_token, purpose="verify_email") is None
 
 
-def test_verification_token_is_scoped_to_its_purpose(store: Store) -> None:
-    """A token minted for one purpose must not satisfy another.
+def test_verification_token_is_scoped_to_its_purpose(store: Store, user_id: str) -> None:
+    """A token minted for one purpose must not satisfy another, and a failed
+    attempt must not burn it.
 
     Otherwise a low-value token (email verification) could be redeemed on a
     high-value flow (password reset) — privilege escalation via token reuse.
+    The second half matters just as much: a backend that consumes the token
+    *while* rejecting the wrong purpose turns any attacker who guesses a token
+    into a denial-of-service on the legitimate user's verification link.
     """
     raw_token, _token = store.create_verification_token(
-        user_id="u1", purpose="verify_email", ttl_seconds=300
+        user_id=user_id, purpose="verify_email", ttl_seconds=300
     )
     assert store.consume_verification_token(raw_token, purpose="password_reset") is None
+    # Still redeemable for what it was actually minted for.
+    assert store.consume_verification_token(raw_token, purpose="verify_email") is not None
 
 
 def test_oauth_authorization_code_is_single_use(store: Store, workspace_id: str) -> None:
@@ -143,10 +168,9 @@ def test_api_key_lookups_agree_and_delete_revokes(
     """Every key lookup path must resolve to the same key, and delete must
     actually revoke it.
 
-    `get_key_by_raw` and `get_key_by_hash` are separate code paths (and on the
-    typed backend, separate tables). If they disagree, authentication and
-    revocation disagree — a deleted key that still authenticates is the worst
-    case.
+    The three lookups are separate code paths (and on the typed backend,
+    separate tables). If they disagree, authentication and revocation
+    disagree — a deleted key that still authenticates is the worst case.
     """
     raw_key, created = store.create_api_key(
         workspace_id=workspace_id, name="conformance", creator_user_id=None
@@ -165,10 +189,10 @@ def test_api_key_lookups_agree_and_delete_revokes(
     assert store.get_key_by_lookup_hash(created.lookup_hash) is None
 
 
-def test_auth_session_lifecycle(store: Store) -> None:
+def test_auth_session_lifecycle(store: Store, user_id: str) -> None:
     """Create -> read -> delete -> gone. Logout must actually invalidate."""
     raw_token, _session = store.create_auth_session(
-        user_id="u1", provider="google", label="conformance", ttl_seconds=300
+        user_id=user_id, provider="google", label="conformance", ttl_seconds=300
     )
     assert store.get_auth_session_by_raw(raw_token) is not None
     assert store.delete_auth_session_by_raw(raw_token) is True
@@ -180,7 +204,7 @@ def test_auth_session_lifecycle(store: Store) -> None:
 # --------------------------------------------------------------------------
 
 
-def test_benchmark_samples_return_newest_first(store: Store) -> None:
+def test_benchmark_samples_return_newest_first(store: Store, unique: str) -> None:
     """The index contract is reverse-chronological order.
 
     Route-health and the leaderboard both read "the newest N samples" and
@@ -189,18 +213,19 @@ def test_benchmark_samples_return_newest_first(store: Store) -> None:
     ORDER BY. A backend that returns insertion order breaks freshness logic
     without any error.
     """
+    provider, model = f"acme-{unique}", f"acme-{unique}/m1"
     for idx, created_at in enumerate(
         ["2026-01-01T00:00:00+00:00", "2026-01-02T00:00:00+00:00", "2026-01-03T00:00:00+00:00"]
     ):
         store.record_provider_benchmark(
             make_benchmark_sample(
-                sample_id=f"s{idx}",
-                provider="acme",
-                model="acme/m1",
+                sample_id=f"{unique}-s{idx}",
+                provider=provider,
+                model=model,
                 created_at=created_at,
             )
         )
-    samples = store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=10)
+    samples = store.provider_benchmark_samples(provider=provider, model=model, limit=10)
     assert len(samples) == 3
     timestamps = [s.created_at for s in samples]
     assert timestamps == sorted(timestamps, reverse=True), (
@@ -208,38 +233,42 @@ def test_benchmark_samples_return_newest_first(store: Store) -> None:
     )
 
 
-def test_benchmark_samples_respect_limit(store: Store) -> None:
+def test_benchmark_samples_respect_limit(store: Store, unique: str) -> None:
     """`limit` must cap the result set.
 
     Route-health sizes its statistical window with this argument; a backend
     that ignores it silently changes the alert threshold.
     """
+    provider, model = f"acme-{unique}", f"acme-{unique}/m1"
     for idx in range(5):
         store.record_provider_benchmark(
             make_benchmark_sample(
-                sample_id=f"s{idx}",
-                provider="acme",
-                model="acme/m1",
+                sample_id=f"{unique}-s{idx}",
+                provider=provider,
+                model=model,
                 created_at=f"2026-01-0{idx + 1}T00:00:00+00:00",
             )
         )
-    assert len(store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=2)) == 2
+    assert len(store.provider_benchmark_samples(provider=provider, model=model, limit=2)) == 2
 
 
-def test_benchmark_samples_filter_by_route(store: Store) -> None:
+def test_benchmark_samples_filter_by_route(store: Store, unique: str) -> None:
     """Provider/model filtering must not leak other routes' samples.
 
     A leak here silently mixes another model's health into a route's failure
     rate — which is exactly how a false alert (or a missed one) is born.
     """
+    provider, model = f"acme-{unique}", f"acme-{unique}/m1"
     store.record_provider_benchmark(
-        make_benchmark_sample(sample_id="a", provider="acme", model="acme/m1")
+        make_benchmark_sample(sample_id=f"{unique}-a", provider=provider, model=model)
     )
     store.record_provider_benchmark(
-        make_benchmark_sample(sample_id="b", provider="other", model="other/m2")
+        make_benchmark_sample(
+            sample_id=f"{unique}-b", provider=f"other-{unique}", model=f"other-{unique}/m2"
+        )
     )
-    samples = store.provider_benchmark_samples(provider="acme", model="acme/m1", limit=10)
-    assert [s.id for s in samples] == ["a"]
+    samples = store.provider_benchmark_samples(provider=provider, model=model, limit=10)
+    assert [s.id for s in samples] == [f"{unique}-a"]
 
 
 # --------------------------------------------------------------------------
@@ -247,11 +276,14 @@ def test_benchmark_samples_filter_by_route(store: Store) -> None:
 # --------------------------------------------------------------------------
 
 
-def test_at_least_one_backend_actually_ran(store: Store) -> None:
+def test_memory_backend_is_always_runnable() -> None:
     """Tripwire: a suite where every backend skipped proves nothing.
 
-    `memory` has no external dependency, so it must always run. If this is
-    ever reported as skipped, the harness itself is broken and every other
-    result in this package is meaningless.
+    This deliberately does NOT take the `store` fixture. A guard that depends
+    on the parametrized fixture is itself skipped when every backend skips,
+    so pytest would exit 0 having exercised no backend at all — the guard
+    would be part of the illusion it exists to prevent.
     """
-    assert store is not None
+    assert "memory" in BACKENDS
+    store = BACKENDS["memory"]()
+    assert isinstance(store, Store)


### PR DESCRIPTION
Groundwork for running the control plane outside GCP. No production code paths change — this adds a test suite, a proof harness, and a plan.

## 1. Behavioural conformance suite (`tests/conformance/`)
`test_store_protocol_conformance.py` checks both backends declare the same method *names and signatures*. It cannot see behaviour, so a backend that double-credits on retry, or lets a verification token be redeemed twice, passes it happily.

This suite pins the semantics, talking **only** to the `Store` protocol: exactly-once credit (both directions), single-use wallet challenges / verification tokens / OAuth codes, purpose scoping, all three API-key lookup paths agreeing plus revocation, session lifecycle, read-your-writes, and index newest-first / limit / route-filter semantics.

Adding a backend is one entry in `conformance/conftest.BACKENDS`; the tests don't change. The `spanner-emulator` backend is registered and skips cleanly until emulator provisioning lands — the next increment, and what turns this from an executable spec into cross-backend enforcement.

**Surfaced:** `InMemoryStore` deliberately does not implement `TypedBillingStore`, and Spanner's legacy `reserve()` raises. The two backends run genuinely different money code today, and nothing pins which is correct.

## 2. ClickHouse analytics proof (`clickhouse/`)
Bigtable is an operational wide-column store, not a columnar warehouse, and we keep one JSON blob in one column family — so every leaderboard aggregate is a row scan plus a `json.loads` per row in Python.

`prove_leaderboard.py` is a differential test: read real samples from Bigtable, evaluate route health exactly as `synthetic/route_health.py` does (48h cutoff, newest-48-per-route, exclusions, min-samples/threshold), compute the same in SQL, and compare counts **and the flagged set**.

**Result: 40,000 real rows / 500 routes — exact match, identical flagged set.**

It also asserts the scan reaches past the cutoff, so a biased slice can't produce a meaningless agreement.

### Bugs this caught
- **NULL propagation.** `error_status` is `Nullable`; `NULL IN (...)` is NULL, not false, so it survived `NOT` and `WHERE` dropped the row — under-counting failures on exactly the routes whose errors carry no HTTP status. Fixed with `ifNull()`.
- **The materialized view wasn't route health.** Missing the unsupported/transient exclusions: 30832/1176 vs the correct 28214/59 — a **20x** overstatement of failures.
- **`ReplacingMergeTree` doesn't cover materialized views.** MVs run per INSERT BLOCK, so re-ingestion permanently inflates them. Measured: three loads of 30,832 rows left **92,500** view samples.

## 3. Handoff doc (`docs/storage-portability/README.md`)
The architecture: **keep Spanner as the system of record even from AWS** (multi-region HA — no billing port on the critical path), make only analytics portable. Includes what that trades away (cross-cloud latency on authorize/settle is to be *measured* in the AWS phase, not assumed), the phased plan with verification gates, and the leak designs.

## Review
Reviewed adversarially by codex; every finding confirmed against live data before fixing (see the second commit). Remaining known limits are documented in the suite rather than implied away.

`ruff` clean; full suite **1919 passed**.