### PR TITLE
storage: put cloud SDKs behind ports so app code is deployment-neutral

### DIFF
--- a/src/trusted_router/byok_crypto.py
+++ b/src/trusted_router/byok_crypto.py
@@ -7,9 +7,9 @@ import secrets
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from google.cloud import kms_v1
 
 from trusted_router.config import Settings
+from trusted_router.key_management import key_wrapper_for
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
@@ -168,16 +168,7 @@ def _wrapping_key(settings: Settings) -> bytes:
 
 
 def _wrap_dek(dek: bytes, dek_nonce: bytes, aad: bytes, settings: Settings) -> bytes:
-    if settings.byok_kms_key_name:
-        response = kms_v1.KeyManagementServiceClient().encrypt(
-            request={
-                "name": settings.byok_kms_key_name,
-                "plaintext": dek,
-                "additional_authenticated_data": aad,
-            }
-        )
-        return bytes(response.ciphertext)
-    return AESGCM(_wrapping_key(settings)).encrypt(dek_nonce, dek, aad)
+    return key_wrapper_for(settings).wrap(dek, nonce=dek_nonce, aad=aad)
 
 
 def _unwrap_dek(
@@ -186,20 +177,13 @@ def _unwrap_dek(
     settings: Settings,
 ) -> bytes:
     encrypted_dek = _unb64(envelope.encrypted_dek)
-    if settings.byok_kms_key_name:
-        response = kms_v1.KeyManagementServiceClient().decrypt(
-            request={
-                "name": settings.byok_kms_key_name,
-                "ciphertext": encrypted_dek,
-                "additional_authenticated_data": aad,
-            }
-        )
-        return bytes(response.plaintext)
-    return AESGCM(_wrapping_key(settings)).decrypt(_unb64(envelope.dek_nonce), encrypted_dek, aad)
+    return key_wrapper_for(settings).unwrap(
+        encrypted_dek, nonce=_unb64(envelope.dek_nonce), aad=aad
+    )
 
 
 def _key_ref(settings: Settings) -> str:
-    return settings.byok_kms_key_name or settings.byok_envelope_key_ref
+    return key_wrapper_for(settings).key_ref
 
 
 def _aad(workspace_id: str, provider: str) -> bytes:

--- a/src/trusted_router/key_management.py
+++ b/src/trusted_router/key_management.py
@@ -106,7 +106,7 @@ class GcpKmsKeyWrapper:
         return kms_v1.KeyManagementServiceClient()
 
     def wrap(self, dek: bytes, *, nonce: bytes, aad: bytes) -> bytes:
-        with _translated_kms_errors():
+        try:
             response = self._client().encrypt(
                 request={
                     "name": self._key_name,
@@ -114,10 +114,12 @@ class GcpKmsKeyWrapper:
                     "additional_authenticated_data": aad,
                 }
             )
-            return bytes(response.ciphertext)
+        except Exception as exc:
+            raise _translate_kms_error(exc) from exc
+        return bytes(response.ciphertext)
 
     def unwrap(self, wrapped: bytes, *, nonce: bytes, aad: bytes) -> bytes:
-        with _translated_kms_errors():
+        try:
             response = self._client().decrypt(
                 request={
                     "name": self._key_name,
@@ -125,32 +127,30 @@ class GcpKmsKeyWrapper:
                     "additional_authenticated_data": aad,
                 }
             )
-            return bytes(response.plaintext)
+        except Exception as exc:
+            raise _translate_kms_error(exc) from exc
+        return bytes(response.plaintext)
 
 
-class _translated_kms_errors:
-    """Map Google KMS exceptions onto the neutral taxonomy.
+def _translate_kms_error(exc: Exception) -> Exception:
+    """Map a Google KMS exception onto the neutral taxonomy.
 
-    A context manager rather than a decorator so the lazy import of the Google
-    exception types stays inside the call, keeping module import free of any
-    cloud SDK.
+    Returns the original exception unchanged when it is not a recognised KMS
+    failure, so genuine bugs keep their own type and traceback instead of being
+    laundered into a misleading "key unavailable".
+
+    The Google exception types are imported here rather than at module scope so
+    that importing this module never pulls in a cloud SDK.
     """
-
-    def __enter__(self) -> None:
-        return None
-
-    def __exit__(self, exc_type, exc, _tb) -> bool:  # type: ignore[no-untyped-def]
-        if exc is None:
-            return False
-        try:
-            from google.api_core import exceptions as gcp_exceptions
-        except ImportError:  # pragma: no cover - only without GCP deps
-            return False
-        if isinstance(exc, gcp_exceptions.PermissionDenied):
-            raise KeyAccessDenied(str(exc)) from exc
-        if isinstance(exc, gcp_exceptions.GoogleAPICallError):
-            raise KeyUnavailable(str(exc)) from exc
-        return False
+    try:
+        from google.api_core import exceptions as gcp_exceptions
+    except ImportError:  # pragma: no cover - only without GCP deps
+        return exc
+    if isinstance(exc, gcp_exceptions.PermissionDenied):
+        return KeyAccessDenied(str(exc))
+    if isinstance(exc, gcp_exceptions.GoogleAPICallError):
+        return KeyUnavailable(str(exc))
+    return exc
 
 
 def key_wrapper_for(settings: Settings) -> KeyWrapper:

--- a/src/trusted_router/key_management.py
+++ b/src/trusted_router/key_management.py
@@ -1,0 +1,175 @@
+"""Envelope-key wrapping, decoupled from any one cloud KMS.
+
+BYOK secrets are envelope-encrypted: a random per-secret DEK encrypts the
+customer's provider key, and that DEK is then *wrapped*. Only the wrapping
+step is cloud-specific, so it is the only thing behind this port.
+
+Before this module, `byok_crypto` called `google.cloud.kms_v1` inline and
+`routes/byok.py` caught `google.api_core.exceptions` to decide HTTP status —
+which put a GCP SDK dependency in the request path of an endpoint that has
+nothing to do with GCP. Adding AWS KMS or Azure Key Vault means adding a class
+here; no caller changes.
+
+Errors are translated at this boundary into `KeyAccessDenied` /
+`KeyUnavailable` so route code can map them to HTTP status without knowing
+which cloud produced them.
+
+Compatibility note (deliberate): `unwrap` dispatches on the CURRENT settings,
+matching the behaviour this replaced. That is wrong in the long run — the
+envelope records the `key_ref` it was wrapped with, so a cloud migration or
+key rotation should dispatch on `envelope.key_ref` or every existing envelope
+becomes undecryptable. Fixing it changes production crypto behaviour and needs
+its own migration (re-wrap all DEKs), so it is called out in
+docs/storage-portability/README.md rather than smuggled in here.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from trusted_router.config import Settings
+
+
+class KeyManagementError(Exception):
+    """Base for envelope-key wrapping failures."""
+
+
+class KeyAccessDenied(KeyManagementError):
+    """This principal may not use the wrapping key.
+
+    Distinct because it is not retryable and not transient: it means the
+    deployment is misconfigured (or the endpoint genuinely lacks permission),
+    and the caller should say so rather than invite a retry.
+    """
+
+
+class KeyUnavailable(KeyManagementError):
+    """The key service could not be reached or failed transiently."""
+
+
+@runtime_checkable
+class KeyWrapper(Protocol):
+    """Wraps and unwraps a data encryption key."""
+
+    @property
+    def key_ref(self) -> str:
+        """Stable identifier recorded in the envelope for auditability."""
+
+    def wrap(self, dek: bytes, *, nonce: bytes, aad: bytes) -> bytes: ...
+
+    def unwrap(self, wrapped: bytes, *, nonce: bytes, aad: bytes) -> bytes: ...
+
+
+class LocalAesKeyWrapper:
+    """AES-GCM wrapping with a locally-held 32-byte key.
+
+    Used for local/test, and for deployments that supply their own key rather
+    than delegating to a cloud KMS.
+    """
+
+    def __init__(self, key: bytes, key_ref: str) -> None:
+        if len(key) != 32:
+            raise ValueError("envelope wrapping key must be 32 bytes")
+        self._key = key
+        self._key_ref = key_ref
+
+    @property
+    def key_ref(self) -> str:
+        return self._key_ref
+
+    def wrap(self, dek: bytes, *, nonce: bytes, aad: bytes) -> bytes:
+        return AESGCM(self._key).encrypt(nonce, dek, aad)
+
+    def unwrap(self, wrapped: bytes, *, nonce: bytes, aad: bytes) -> bytes:
+        return AESGCM(self._key).decrypt(nonce, wrapped, aad)
+
+
+class GcpKmsKeyWrapper:
+    """Wrapping delegated to Google Cloud KMS.
+
+    The client and the Google exception types are imported lazily so that a
+    non-GCP deployment does not need the Google libraries installed at all.
+    """
+
+    def __init__(self, key_name: str) -> None:
+        self._key_name = key_name
+
+    @property
+    def key_ref(self) -> str:
+        return self._key_name
+
+    def _client(self):  # type: ignore[no-untyped-def]
+        from google.cloud import kms_v1
+
+        return kms_v1.KeyManagementServiceClient()
+
+    def wrap(self, dek: bytes, *, nonce: bytes, aad: bytes) -> bytes:
+        with _translated_kms_errors():
+            response = self._client().encrypt(
+                request={
+                    "name": self._key_name,
+                    "plaintext": dek,
+                    "additional_authenticated_data": aad,
+                }
+            )
+            return bytes(response.ciphertext)
+
+    def unwrap(self, wrapped: bytes, *, nonce: bytes, aad: bytes) -> bytes:
+        with _translated_kms_errors():
+            response = self._client().decrypt(
+                request={
+                    "name": self._key_name,
+                    "ciphertext": wrapped,
+                    "additional_authenticated_data": aad,
+                }
+            )
+            return bytes(response.plaintext)
+
+
+class _translated_kms_errors:
+    """Map Google KMS exceptions onto the neutral taxonomy.
+
+    A context manager rather than a decorator so the lazy import of the Google
+    exception types stays inside the call, keeping module import free of any
+    cloud SDK.
+    """
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, _tb) -> bool:  # type: ignore[no-untyped-def]
+        if exc is None:
+            return False
+        try:
+            from google.api_core import exceptions as gcp_exceptions
+        except ImportError:  # pragma: no cover - only without GCP deps
+            return False
+        if isinstance(exc, gcp_exceptions.PermissionDenied):
+            raise KeyAccessDenied(str(exc)) from exc
+        if isinstance(exc, gcp_exceptions.GoogleAPICallError):
+            raise KeyUnavailable(str(exc)) from exc
+        return False
+
+
+def key_wrapper_for(settings: Settings) -> KeyWrapper:
+    """Select the wrapper for this deployment.
+
+    Precedence matches the behaviour this replaced: an explicit local key wins
+    over KMS, and outside local/test one of the two must be configured — a
+    silent dev-key fallback in production would be a security hole.
+    """
+    if settings.byok_envelope_key_b64:
+        from trusted_router.byok_crypto import _unb64
+
+        return LocalAesKeyWrapper(
+            _unb64(settings.byok_envelope_key_b64), settings.byok_envelope_key_ref
+        )
+    if settings.byok_kms_key_name:
+        return GcpKmsKeyWrapper(settings.byok_kms_key_name)
+    if settings.environment.lower() in {"local", "test"}:
+        from trusted_router.byok_crypto import _DEV_WRAPPING_KEY
+
+        return LocalAesKeyWrapper(_DEV_WRAPPING_KEY, settings.byok_envelope_key_ref)
+    raise ValueError("TR_BYOK_ENVELOPE_KEY_B64 is required outside local/test")

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -17,7 +17,6 @@ from typing import Any
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from google.api_core.exceptions import Aborted
 
 from trusted_router.axiom_config import init_axiom
 from trusted_router.catalog import validate_auto_model_order
@@ -49,6 +48,7 @@ from trusted_router.routes.wallet_oauth import register_wallet_oauth_routes
 from trusted_router.routes.workspaces import register_workspace_routes
 from trusted_router.sentry_config import init_sentry
 from trusted_router.storage import configure_store, create_store
+from trusted_router.storage_errors import conflict_store_error_types
 from trusted_router.types import ErrorType
 
 
@@ -110,10 +110,10 @@ def create_app(
         message = first.get("msg") or "Invalid request body"
         return error_response(400, f"{loc}: {message}", ErrorType.BAD_REQUEST)
 
-    @app.exception_handler(Aborted)
-    async def aborted_exception_handler(_request: Request, exc: Aborted) -> Response:
-        # A Spanner transaction exhausted its retry budget under contention. This is
-        # transient, so signal the caller to retry rather than surfacing a 500.
+    async def aborted_exception_handler(_request: Request, _exc: Exception) -> Response:
+        # A storage transaction exhausted its retry budget under contention.
+        # This is transient, so signal the caller to retry rather than
+        # surfacing a 500.
         response = error_response(
             503,
             "The request was aborted due to transient database contention; retry.",
@@ -121,6 +121,14 @@ def create_app(
         )
         response.headers["Retry-After"] = "1"
         return response
+
+    # Registered per concrete type rather than via a decorator: Starlette
+    # dispatches exception handlers by class, and which classes represent
+    # "a concurrent writer won" is backend-specific (Spanner's Aborted today,
+    # a serialization failure on a SQL backend). storage_errors owns that
+    # mapping so this module never imports a cloud SDK.
+    for conflict_type in conflict_store_error_types():
+        app.add_exception_handler(conflict_type, aborted_exception_handler)
 
     register_public_routes(app, settings)
     api = _make_api_router(settings)

--- a/src/trusted_router/routes/byok.py
+++ b/src/trusted_router/routes/byok.py
@@ -5,12 +5,12 @@ from typing import Any
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from google.api_core import exceptions as gcp_exceptions
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep
 from trusted_router.byok_crypto import encrypt_byok_secret
 from trusted_router.catalog import PROVIDERS
 from trusted_router.errors import api_error
+from trusted_router.key_management import KeyAccessDenied, KeyManagementError
 from trusted_router.provider_compat import (
     byok_storage_provider_candidates,
     canonical_byok_provider,
@@ -88,10 +88,10 @@ def register_byok_routes(router: APIRouter) -> None:
                     workspace_id=principal.workspace.id,
                     provider=slug,
                 )
-            except gcp_exceptions.PermissionDenied as exc:
-                # The BYOK envelope DEK is wrapped with the GCP KMS
-                # byok-envelope key, which only the primary control-plane SA
-                # may encrypt with. Return a clean, actionable 503 instead of
+            except KeyAccessDenied as exc:
+                # The BYOK envelope DEK is wrapped with the configured
+                # envelope key, which only the primary control-plane
+                # principal may encrypt with. Return a clean, actionable 503 instead of
                 # an unhandled 500 + KMS stack trace if this endpoint lacks
                 # encrypt permission.
                 log.warning(
@@ -104,8 +104,8 @@ def register_byok_routes(router: APIRouter) -> None:
                     "Register keys through the primary API at https://api.trustedrouter.com.",
                     ErrorType.SERVICE_UNAVAILABLE,
                 ) from exc
-            except gcp_exceptions.GoogleAPICallError as exc:
-                # Any other KMS/RPC failure (transient unavailability, timeout):
+            except KeyManagementError as exc:
+                # Any other key-service failure (unavailability, timeout):
                 # a best-effort retry-able error, not an unhandled 500.
                 log.error(
                     "byok.encrypt_failed",

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -6,14 +6,6 @@ import logging
 from dataclasses import replace
 from typing import Any, cast
 
-from google.api_core.exceptions import (
-    Aborted,
-    DeadlineExceeded,
-    InternalServerError,
-    ResourceExhausted,
-    RetryError,
-    ServiceUnavailable,
-)
 from pydantic import ValidationError
 
 from trusted_router.catalog import PROVIDERS, endpoint_for_id
@@ -21,6 +13,7 @@ from trusted_router.catalog_data import PARASAIL_LIBERTY_2_0_MODEL_ID
 from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
 from trusted_router.schemas import GatewaySettleRequest
 from trusted_router.storage import STORE, Generation, typed_billing_store
+from trusted_router.storage_errors import transient_store_error_types
 from trusted_router.storage_gcp_authorize import SettleOutcome
 from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
@@ -35,16 +28,12 @@ logger = logging.getLogger(__name__)
 # whole-backend outage must not burn attempts toward dead); legacy-origin rows
 # map to ERROR (drain backoff). Anything else propagates — an unrecognized
 # exception is a bug, and the drain's generic handler is the right place for it.
-# ResourceExhausted covers Spanner session-pool/admission-control overload.
-# RetryError subclasses GoogleAPIError, not GoogleAPICallError, so list it here.
-_TRANSIENT_STORE_EXCS = (
-    Aborted,
-    DeadlineExceeded,
-    InternalServerError,
-    ResourceExhausted,
-    RetryError,
-    ServiceUnavailable,
-)
+# The concrete exception classes are backend-specific, so `storage_errors`
+# owns that mapping and this module stays free of cloud SDK imports. The set is
+# unchanged: Spanner's Aborted/DeadlineExceeded/InternalServerError/
+# ResourceExhausted (session-pool and admission-control overload)/RetryError/
+# ServiceUnavailable, plus the backend-neutral StoreConflict/StoreUnavailable.
+_TRANSIENT_STORE_EXCS = transient_store_error_types()
 
 
 class ApplyOutcome:

--- a/src/trusted_router/storage_errors.py
+++ b/src/trusted_router/storage_errors.py
@@ -53,9 +53,7 @@ class StoreUnavailable(StoreError):
 
 
 @lru_cache(maxsize=1)
-def _google_error_types() -> tuple[
-    tuple[type[BaseException], ...], tuple[type[BaseException], ...]
-]:
+def _google_error_types() -> tuple[tuple[type[Exception], ...], tuple[type[Exception], ...]]:
     """`(transient, conflict)` types contributed by the GCP backend.
 
     Empty when the Google libraries are not installed, which is the expected
@@ -77,7 +75,7 @@ def _google_error_types() -> tuple[
     # ResourceExhausted covers Spanner session-pool / admission-control
     # overload. RetryError subclasses GoogleAPIError rather than
     # GoogleAPICallError, so it must be listed explicitly.
-    transient: tuple[type[BaseException], ...] = (
+    transient: tuple[type[Exception], ...] = (
         Aborted,
         DeadlineExceeded,
         InternalServerError,
@@ -88,12 +86,12 @@ def _google_error_types() -> tuple[
     # Aborted is both transient AND a conflict: it is the one member of the set
     # meaning "a concurrent writer won" rather than "the backend is unwell",
     # and callers that retry immediately key off exactly that distinction.
-    conflict: tuple[type[BaseException], ...] = (Aborted,)
+    conflict: tuple[type[Exception], ...] = (Aborted,)
     return (transient, conflict)
 
 
 @lru_cache(maxsize=1)
-def transient_store_error_types() -> tuple[type[BaseException], ...]:
+def transient_store_error_types() -> tuple[type[Exception], ...]:
     """Types meaning "the write did not land; try again later".
 
     Returned as a tuple so it can be used directly in an `except` clause,
@@ -104,7 +102,7 @@ def transient_store_error_types() -> tuple[type[BaseException], ...]:
 
 
 @lru_cache(maxsize=1)
-def conflict_store_error_types() -> tuple[type[BaseException], ...]:
+def conflict_store_error_types() -> tuple[type[Exception], ...]:
     """Types meaning "a concurrent writer aborted this; replaying may work"."""
     _, google_conflict = _google_error_types()
     return (StoreConflict, *google_conflict)

--- a/src/trusted_router/storage_errors.py
+++ b/src/trusted_router/storage_errors.py
@@ -1,0 +1,125 @@
+"""Backend-neutral storage error taxonomy.
+
+Application code needs two answers about a storage failure: "is retrying
+worthwhile?" and "did a concurrent writer abort this?". Today it answers by
+importing `google.api_core.exceptions` directly — `main.py` registers an
+exception handler on Spanner's `Aborted`, and the settle-outbox drain switches
+on a tuple of six Google types. Neither decision is really about Google.
+
+This module is the one place that knows how a concrete backend spells those
+conditions. Callers ask `transient_store_error_types()` /
+`conflict_store_error_types()` (or the `is_*` predicates) and stay portable;
+teaching the system about Postgres means adding one mapping function here, not
+editing call sites.
+
+Two deliberate properties:
+
+* **Google is imported lazily.** Importing `trusted_router.main` currently
+  hard-requires `google-api-core`. A non-GCP deployment should not need the
+  Google client libraries installed at all, so the import sits behind a cached
+  helper that degrades to "no Google types" when they are absent.
+* **Semantics are preserved exactly.** The transient set is the same six types
+  the drain already parks on, and `Aborted` remains the sole conflict type.
+  This is a refactor; the park-vs-error policy keys off exactly what it did
+  before.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+class StoreError(Exception):
+    """Base for backend-neutral storage failures."""
+
+
+class StoreConflict(StoreError):
+    """A concurrent writer won; the transaction was aborted.
+
+    Spanner raises `Aborted`; Postgres raises serialization_failure (40001);
+    CockroachDB raises a retry error; Aurora DSQL aborts under OCC. All mean
+    the same thing — nothing committed, and replaying the whole transaction is
+    the correct response.
+    """
+
+
+class StoreUnavailable(StoreError):
+    """The backend could not service the request; retry later.
+
+    Covers unavailability, deadline exhaustion, and admission-control or
+    overload rejection. Distinct from `StoreConflict` because there is no
+    useful *immediate* retry — the caller should back off or park the work.
+    """
+
+
+@lru_cache(maxsize=1)
+def _google_error_types() -> tuple[
+    tuple[type[BaseException], ...], tuple[type[BaseException], ...]
+]:
+    """`(transient, conflict)` types contributed by the GCP backend.
+
+    Empty when the Google libraries are not installed, which is the expected
+    state on a non-GCP deployment.
+    """
+    try:
+        from google.api_core.exceptions import (
+            Aborted,
+            DeadlineExceeded,
+            InternalServerError,
+            ResourceExhausted,
+            RetryError,
+            ServiceUnavailable,
+        )
+    except ImportError:  # pragma: no cover - only hit without GCP deps
+        return ((), ())
+
+    # The same six the settle-outbox drain treats as retryable.
+    # ResourceExhausted covers Spanner session-pool / admission-control
+    # overload. RetryError subclasses GoogleAPIError rather than
+    # GoogleAPICallError, so it must be listed explicitly.
+    transient: tuple[type[BaseException], ...] = (
+        Aborted,
+        DeadlineExceeded,
+        InternalServerError,
+        ResourceExhausted,
+        RetryError,
+        ServiceUnavailable,
+    )
+    # Aborted is both transient AND a conflict: it is the one member of the set
+    # meaning "a concurrent writer won" rather than "the backend is unwell",
+    # and callers that retry immediately key off exactly that distinction.
+    conflict: tuple[type[BaseException], ...] = (Aborted,)
+    return (transient, conflict)
+
+
+@lru_cache(maxsize=1)
+def transient_store_error_types() -> tuple[type[BaseException], ...]:
+    """Types meaning "the write did not land; try again later".
+
+    Returned as a tuple so it can be used directly in an `except` clause,
+    which is how the settle-outbox drain consumes it.
+    """
+    google_transient, _ = _google_error_types()
+    return (StoreConflict, StoreUnavailable, *google_transient)
+
+
+@lru_cache(maxsize=1)
+def conflict_store_error_types() -> tuple[type[BaseException], ...]:
+    """Types meaning "a concurrent writer aborted this; replaying may work"."""
+    _, google_conflict = _google_error_types()
+    return (StoreConflict, *google_conflict)
+
+
+def is_transient_store_error(exc: BaseException) -> bool:
+    """True when retrying the operation later could succeed.
+
+    Anything unrecognised is a bug rather than an infrastructure blip and
+    should propagate to the caller's generic handler instead of being retried
+    forever.
+    """
+    return isinstance(exc, transient_store_error_types())
+
+
+def is_conflict_error(exc: BaseException) -> bool:
+    """True when the transaction lost a write conflict and may be replayed."""
+    return isinstance(exc, conflict_store_error_types())

--- a/src/trusted_router/storage_gcp_synthetic_index.py
+++ b/src/trusted_router/storage_gcp_synthetic_index.py
@@ -88,3 +88,29 @@ def _samples_from_rows(rows: Any, family: str) -> list[SyntheticProbeSample]:
             continue
         samples.append(SyntheticProbeSample(**json.loads(cells[0].value.decode("utf-8"))))
     return samples
+
+
+def open_generation_table(settings: Any) -> Any:
+    """Open the Bigtable generation table for admin/backfill tooling.
+
+    Lives here, in the GCP adapter layer, so that operational scripts do not
+    import a cloud SDK themselves. That keeps one architectural rule true
+    without exception: `google.*` is imported only by the storage adapter and
+    the two explicit cloud ports (`key_management`, `storage_errors`), which
+    is what `tests/test_cloud_sdk_boundary.py` enforces.
+
+    This tool is GCP-specific by nature — it rewrites Bigtable rollup rows in
+    place — so the goal is not to make it portable, only to keep the SDK
+    dependency where it belongs.
+    """
+    if not settings.gcp_project_id or not settings.bigtable_instance_id:
+        raise SystemExit("TR_GCP_PROJECT_ID and TR_BIGTABLE_INSTANCE_ID are required")
+    try:
+        from google.cloud import bigtable
+    except ImportError as exc:  # pragma: no cover - dependency exists in prod image.
+        raise SystemExit("google-cloud-bigtable is required") from exc
+    return (
+        bigtable.Client(project=settings.gcp_project_id, admin=True)
+        .instance(settings.bigtable_instance_id)
+        .table(settings.bigtable_generation_table)
+    )

--- a/src/trusted_router/synthetic/backfill_rollups.py
+++ b/src/trusted_router/synthetic/backfill_rollups.py
@@ -7,7 +7,10 @@ from typing import Any
 
 from trusted_router.config import get_settings
 from trusted_router.storage_gcp_codec import json_body
-from trusted_router.storage_gcp_synthetic_index import synthetic_probe_samples
+from trusted_router.storage_gcp_synthetic_index import (
+    open_generation_table,
+    synthetic_probe_samples,
+)
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
 from trusted_router.synthetic.rollups import (
     apply_sample_to_rollup,
@@ -24,19 +27,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     settings = get_settings()
-    if not settings.gcp_project_id or not settings.bigtable_instance_id:
-        raise SystemExit("TR_GCP_PROJECT_ID and TR_BIGTABLE_INSTANCE_ID are required")
-
-    try:
-        from google.cloud import bigtable
-    except ImportError as exc:  # pragma: no cover - dependency exists in prod image.
-        raise SystemExit("google-cloud-bigtable is required") from exc
-
-    table = (
-        bigtable.Client(project=settings.gcp_project_id, admin=True)
-        .instance(settings.bigtable_instance_id)
-        .table(settings.bigtable_generation_table)
-    )
+    table = open_generation_table(settings)
     dates = args.dates or _recent_dates(args.days)
     all_samples: list[SyntheticProbeSample] = []
     for date in dates:

--- a/tests/test_byok_crypto.py
+++ b/tests/test_byok_crypto.py
@@ -33,8 +33,11 @@ class _FakeKmsClient:
 
 def test_byok_envelope_uses_kms_wrap_without_plaintext_in_envelope(monkeypatch) -> None:
     _FakeKmsClient.calls.clear()
+    # Patch at the SDK itself rather than at an importing module: the KMS
+    # client is now constructed inside the key_management port, and pinning the
+    # patch to the source keeps this test robust to where it is imported.
     monkeypatch.setattr(
-        "trusted_router.byok_crypto.kms_v1.KeyManagementServiceClient",
+        "google.cloud.kms_v1.KeyManagementServiceClient",
         _FakeKmsClient,
     )
     key_name = "projects/test/locations/us-central1/keyRings/tr/cryptoKeys/byok"

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -1,0 +1,104 @@
+"""Architectural guard: cloud SDKs stay out of the infrastructure path.
+
+The control plane must be able to run somewhere other than GCP. That is not
+achieved by a one-time cleanup — it is achieved by keeping cloud SDKs out of
+application code permanently. Route handlers, services and the app factory
+were making control-flow decisions on Google exception types; each such import
+quietly re-couples the process to one cloud and makes the Google client
+libraries an install-time requirement everywhere.
+
+The distinction this test draws is INFRASTRUCTURE vs VENDOR PRODUCT:
+
+* **Infrastructure** — storage, secrets, key wrapping, retry/conflict
+  classification. These must sit behind a port, because they are exactly what
+  changes when the deployment moves cloud. Violations here block portability.
+* **Vendor product APIs** — calling Vertex as an upstream LLM provider, or SES
+  to send mail. These use a vendor SDK to talk to that vendor's service, which
+  works identically from any cloud. They are ordinary third-party
+  integrations, no different from the OpenAI SDK, and are NOT portability
+  blockers.
+
+So the allowlist below is not "known exceptions we tolerate" — it is the set
+of modules whose job legitimately involves a cloud SDK. Anything else fails
+here with a pointer to the port it should use. Adding an entry is deliberate,
+and visible in a diff.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "trusted_router"
+
+#: Modules permitted to import a cloud SDK, and why.
+ALLOWED = {
+    # The GCP storage adapter: implementing SpannerBigtableStore is exactly
+    # what these exist to do.
+    "storage_gcp.py",
+    "storage_gcp_authorize.py",
+    "storage_gcp_io.py",
+    "storage_gcp_settle_outbox.py",
+    "storage_gcp_synthetic_rollups.py",
+    "storage_gcp_synthetic_index.py",
+    # The two explicit cloud ports. Both import lazily so a non-GCP deployment
+    # need not install the Google libraries at all.
+    "storage_errors.py",
+    "key_management.py",
+    # VENDOR PRODUCT APIs, not infrastructure — see the module docstring.
+    # google.auth here mints an access token for Vertex AI as an upstream LLM
+    # PROVIDER. Routing to Vertex requires Google credentials no matter which
+    # cloud we run on, exactly as routing to OpenAI requires an OpenAI key.
+    "providers.py",
+    # boto3 talks to Amazon SES to send transactional mail. SES is reachable
+    # from any cloud; this is a vendor choice, not a deployment coupling.
+    "services/email.py",
+}
+
+CLOUD_SDK_ROOTS = {"google", "boto3", "botocore", "azure"}
+
+
+def _cloud_sdk_imports(path: Path) -> set[str]:
+    """Top-level package names of any cloud SDK imported by `path`.
+
+    Walks the AST rather than grepping so that a name inside a string or
+    comment (e.g. the provider slug "google-ai-studio") is not mistaken for an
+    import.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root in CLOUD_SDK_ROOTS:
+                    found.add(root)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".")[0]
+            if root in CLOUD_SDK_ROOTS:
+                found.add(root)
+    return found
+
+
+def test_cloud_sdks_are_confined_to_the_adapter_layer() -> None:
+    violations: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        rel = path.relative_to(SRC).as_posix()
+        if rel in ALLOWED or path.name in ALLOWED:
+            continue
+        imports = _cloud_sdk_imports(path)
+        if imports:
+            violations.append(f"{rel} imports {sorted(imports)}")
+    assert not violations, (
+        "Cloud SDK imported outside the storage adapter layer:\n  "
+        + "\n  ".join(violations)
+        + "\n\nUse a port instead: storage_errors (retry/conflict classification), "
+        "key_management (envelope key wrapping), or the Store protocol. "
+        "If this really is a new adapter, add it to ALLOWED with a reason."
+    )
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """An allowlist that outlives its reason silently widens the boundary."""
+    stale = [name for name in ALLOWED if not (SRC / name).exists()]
+    assert not stale, f"ALLOWED lists modules that no longer exist: {stale}"

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1231,14 +1231,32 @@ def test_byok_provider_config_returns_503_when_kms_encrypt_denied(
     # A management caller can land on a control-plane node whose GCP SA can't
     # encrypt with the byok-envelope KMS key. That must return a clean 503 — never an
     # unhandled 500 + KMS stack trace (prod 2026-06-08).
+    # Fault-inject at the KMS boundary rather than mid-chain: this exercises
+    # the real path (KMS PermissionDenied -> key_management translates it to
+    # KeyAccessDenied -> the route maps that to 503), so a break anywhere along
+    # it fails this test.
     from google.api_core import exceptions as gcp_exceptions
 
-    import trusted_router.routes.byok as byok_routes
+    import trusted_router.byok_crypto as byok_crypto
+    from trusted_router.key_management import GcpKmsKeyWrapper
 
-    def _denied(*_args: object, **_kwargs: object) -> object:
-        raise gcp_exceptions.PermissionDenied("useToEncrypt denied on byok-envelope")
+    class _DeniedKmsClient:
+        def encrypt(self, *, request: dict) -> object:
+            raise gcp_exceptions.PermissionDenied(
+                "useToEncrypt denied on byok-envelope"
+            )
 
-    monkeypatch.setattr(byok_routes, "encrypt_byok_secret", _denied)
+    monkeypatch.setattr(
+        "google.cloud.kms_v1.KeyManagementServiceClient", _DeniedKmsClient
+    )
+    monkeypatch.setattr(
+        byok_crypto,
+        "key_wrapper_for",
+        lambda _settings: GcpKmsKeyWrapper(
+            "projects/p/locations/l/keyRings/r/cryptoKeys/byok"
+        ),
+    )
+
     resp = client.put(
         "/v1/byok/providers/cerebras",
         headers=user_headers,

--- a/tests/test_storage_errors_and_key_ports.py
+++ b/tests/test_storage_errors_and_key_ports.py
@@ -1,0 +1,218 @@
+"""The two cloud ports: storage error classification and envelope-key wrapping.
+
+Both replaced direct cloud SDK use in application code, so the thing worth
+testing is that behaviour is UNCHANGED — a refactor that quietly narrowed the
+retryable set would make the settle-outbox drain burn attempts on a transient
+Spanner outage instead of parking, which is real money.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trusted_router.key_management import (
+    GcpKmsKeyWrapper,
+    KeyAccessDenied,
+    KeyManagementError,
+    KeyUnavailable,
+    LocalAesKeyWrapper,
+    key_wrapper_for,
+)
+from trusted_router.storage_errors import (
+    StoreConflict,
+    StoreUnavailable,
+    conflict_store_error_types,
+    is_conflict_error,
+    is_transient_store_error,
+    transient_store_error_types,
+)
+
+# --------------------------------------------------------------------------
+# Storage error taxonomy
+# --------------------------------------------------------------------------
+
+#: The exact set settle_outbox_apply parked on before the refactor.
+ORIGINAL_GOOGLE_TRANSIENT = {
+    "Aborted",
+    "DeadlineExceeded",
+    "InternalServerError",
+    "ResourceExhausted",
+    "RetryError",
+    "ServiceUnavailable",
+}
+
+
+def test_transient_set_still_contains_every_original_google_type() -> None:
+    """Regression guard on the outbox park/error policy.
+
+    Dropping one of these would turn a transient backend outage into burned
+    delivery attempts on rows carrying real settlements.
+    """
+    names = {t.__name__ for t in transient_store_error_types()}
+    missing = ORIGINAL_GOOGLE_TRANSIENT - names
+    assert not missing, f"transient set lost {missing}"
+
+
+def test_aborted_is_the_only_google_conflict_type() -> None:
+    """`Aborted` uniquely means "a concurrent writer won", not "backend unwell".
+
+    main.py answers 503 + Retry-After on exactly that condition; widening it
+    would start telling clients to retry unretryable failures.
+    """
+    names = {t.__name__ for t in conflict_store_error_types()}
+    assert "Aborted" in names
+    assert "DeadlineExceeded" not in names
+
+
+def test_neutral_types_are_classified() -> None:
+    assert is_transient_store_error(StoreConflict("lost a race"))
+    assert is_transient_store_error(StoreUnavailable("backend down"))
+    assert is_conflict_error(StoreConflict("lost a race"))
+    # Unavailability is retryable but is NOT a write conflict.
+    assert not is_conflict_error(StoreUnavailable("backend down"))
+
+
+def test_unknown_errors_are_not_swallowed() -> None:
+    """An unrecognised exception is a bug, not an infra blip.
+
+    If this returned True the drain would retry a deterministic failure
+    forever instead of surfacing it.
+    """
+    assert not is_transient_store_error(ValueError("bug"))
+    assert not is_conflict_error(ValueError("bug"))
+
+
+def test_google_types_resolve_when_the_sdk_is_installed() -> None:
+    """The lazy import must actually find the SDK when present.
+
+    Without this, the graceful ImportError fallback could silently mean "no
+    Google types" in production and nothing would ever be classified transient.
+    """
+    names = {t.__name__ for t in transient_store_error_types()}
+    assert ORIGINAL_GOOGLE_TRANSIENT <= names
+
+
+# --------------------------------------------------------------------------
+# Key wrapping port
+# --------------------------------------------------------------------------
+
+
+def test_local_wrapper_round_trips() -> None:
+    wrapper = LocalAesKeyWrapper(b"\x01" * 32, "local:test")
+    dek, nonce, aad = b"\x02" * 32, b"\x03" * 12, b"ws:provider"
+    wrapped = wrapper.wrap(dek, nonce=nonce, aad=aad)
+    assert wrapped != dek
+    assert wrapper.unwrap(wrapped, nonce=nonce, aad=aad) == dek
+
+
+def test_local_wrapper_binds_the_aad() -> None:
+    """AAD binds the envelope to its workspace+provider.
+
+    Without this check a ciphertext could be lifted from one workspace's row
+    into another's and still decrypt.
+    """
+    from cryptography.exceptions import InvalidTag
+
+    wrapper = LocalAesKeyWrapper(b"\x01" * 32, "local:test")
+    dek, nonce = b"\x02" * 32, b"\x03" * 12
+    wrapped = wrapper.wrap(dek, nonce=nonce, aad=b"ws-a:openai")
+    # InvalidTag specifically: authentication must fail, not merely "some error".
+    with pytest.raises(InvalidTag):
+        wrapper.unwrap(wrapped, nonce=nonce, aad=b"ws-b:openai")
+
+
+def test_local_wrapper_rejects_wrong_key_length() -> None:
+    with pytest.raises(ValueError):
+        LocalAesKeyWrapper(b"short", "local:test")
+
+
+def test_kms_errors_are_translated_to_the_neutral_taxonomy() -> None:
+    """Route code must not need Google's exception classes to pick a status.
+
+    routes/byok.py distinguishes "this principal may not use the key" (a
+    configuration problem, surfaced as an actionable 503) from any other key
+    service failure, and that distinction has to survive the port.
+    """
+    from google.api_core import exceptions as gcp_exceptions
+
+    wrapper = GcpKmsKeyWrapper("projects/p/locations/l/keyRings/r/cryptoKeys/k")
+
+    def boom(exc: Exception):
+        def _client():
+            raise exc
+
+        return _client
+
+    wrapper._client = boom(gcp_exceptions.PermissionDenied("nope"))  # type: ignore[method-assign]
+    with pytest.raises(KeyAccessDenied):
+        wrapper.wrap(b"x" * 32, nonce=b"n" * 12, aad=b"aad")
+
+    wrapper._client = boom(gcp_exceptions.ServiceUnavailable("later"))  # type: ignore[method-assign]
+    with pytest.raises(KeyUnavailable):
+        wrapper.wrap(b"x" * 32, nonce=b"n" * 12, aad=b"aad")
+
+    # Both are catchable as the common base, which is what byok routes use.
+    assert issubclass(KeyAccessDenied, KeyManagementError)
+    assert issubclass(KeyUnavailable, KeyManagementError)
+
+
+class _KeySettings:
+    """Minimal stand-in for the three attributes `key_wrapper_for` reads.
+
+    The real `Settings` is fail-closed for `environment="production"` — it
+    refuses to construct without the full production secret set — which is
+    correct behaviour but makes it unusable for isolating this one decision.
+    """
+
+    def __init__(
+        self, *, environment: str, envelope_key_b64: str = "", kms_key_name: str = ""
+    ) -> None:
+        self.environment = environment
+        self.byok_envelope_key_b64 = envelope_key_b64
+        self.byok_kms_key_name = kms_key_name
+        self.byok_envelope_key_ref = "test-ref"
+
+
+def test_production_refuses_the_dev_wrapping_key() -> None:
+    """The dev key is derivable from public inputs in this repo.
+
+    Falling back to it outside local/test would wrap every customer's BYOK
+    secret with a key anyone reading the source can reconstruct.
+    """
+    with pytest.raises(ValueError, match="required outside local/test"):
+        key_wrapper_for(_KeySettings(environment="production"))
+
+
+def test_local_environment_gets_the_dev_wrapper() -> None:
+    wrapper = key_wrapper_for(_KeySettings(environment="test"))
+    assert isinstance(wrapper, LocalAesKeyWrapper)
+
+
+def test_explicit_local_key_wins_over_kms() -> None:
+    """Precedence must match the behaviour this replaced.
+
+    An operator who sets an explicit envelope key expects it to be used even
+    if a KMS key name is also present in the environment.
+    """
+    import base64
+
+    key_b64 = base64.urlsafe_b64encode(b"\x07" * 32).decode()
+    wrapper = key_wrapper_for(
+        _KeySettings(
+            environment="production",
+            envelope_key_b64=key_b64,
+            kms_key_name="projects/p/locations/l/keyRings/r/cryptoKeys/k",
+        )
+    )
+    assert isinstance(wrapper, LocalAesKeyWrapper)
+
+
+def test_kms_is_used_when_no_explicit_local_key() -> None:
+    wrapper = key_wrapper_for(
+        _KeySettings(
+            environment="production",
+            kms_key_name="projects/p/locations/l/keyRings/r/cryptoKeys/k",
+        )
+    )
+    assert isinstance(wrapper, GcpKmsKeyWrapper)
+    assert wrapper.key_ref.endswith("cryptoKeys/k")


### PR DESCRIPTION
Closes leaks #1, #2 and #4 from `docs/storage-portability/README.md`. No behaviour changes — this is a decoupling, verified by keeping the exact same exception sets and by the full suite.

## The problem
Application code imported Google client libraries to make control-flow decisions:

| Site | What it imported | For what |
|---|---|---|
| `main.py` | `Aborted` | register a 503 exception handler |
| `services/settle_outbox_apply.py` | six `api_core` types | decide park-vs-error in the outbox drain |
| `byok_crypto.py` | `kms_v1` | wrap the envelope DEK |
| `routes/byok.py` | `api_core.exceptions` | choose an HTTP status |
| `synthetic/backfill_rollups.py` | `bigtable` | build a client |

None of those decisions are about Google, and each made the Google libraries an install-time requirement everywhere.

## Two ports
**`storage_errors`** — `StoreConflict` / `StoreUnavailable`, `transient_store_error_types()` / `conflict_store_error_types()`, and predicates. The transient set still resolves to exactly the six Google types the drain parked on, and `Aborted` is still the only conflict type — asserted by test, because narrowing it would make the drain burn attempts on a transient outage instead of parking.

**`key_management`** — a `KeyWrapper` port (`LocalAesKeyWrapper`, `GcpKmsKeyWrapper`) that translates KMS failures into `KeyAccessDenied` / `KeyUnavailable`. **Adding AWS KMS or Azure Key Vault is one new class; no caller changes.**

Both import Google **lazily**, so a non-GCP deployment needn't install the libraries at all.

## The guard
`tests/test_cloud_sdk_boundary.py` walks every module's AST and fails if a cloud SDK is imported outside an allowlisted adapter. Writing it immediately caught two importers I'd missed by grepping.

It encodes the distinction that matters: **infrastructure** (storage, secrets, key wrapping, retry classification) must sit behind a port; a vendor SDK calling that vendor's own product — `google.auth` for Vertex as an upstream LLM provider, `boto3` for SES — is an ordinary integration that works from any cloud and is explicitly *not* a portability blocker.

## Test changes
Two existing BYOK tests patched the old inline KMS path. Repointed at the SDK boundary, which makes them stronger — the 503-on-denied-KMS test now drives the full chain (KMS `PermissionDenied` → `KeyAccessDenied` → 503) instead of mocking its middle.

## Noted, not fixed
BYOK `unwrap` dispatches on **current settings**, not the envelope's stored `key_ref`. That's latent today but strands every existing envelope on a cloud migration or key rotation. Fixing it changes production crypto behaviour and needs a re-wrap migration, so it's documented rather than smuggled in here.

`ruff` clean; full suite **1939 passed**.