### PR TITLE
analytics: dual-write benchmark samples to ClickHouse (off by default)

### DIFF
--- a/clickhouse/prove_leaderboard.py
+++ b/clickhouse/prove_leaderboard.py
@@ -297,17 +297,41 @@ def flagged(health: dict[tuple[str, str], tuple[int, int]]) -> set[tuple[str, st
     }
 
 
-def load(rows: list[dict]) -> None:
-    """Reload the LOCAL proof table.
+def _materialized_view_ddl() -> str:
+    """The CREATE MATERIALIZED VIEW statement, read from the schema file.
 
-    The materialized view is dropped and recreated rather than left in place:
-    an MV runs per INSERT BLOCK and does NOT inherit the source table's
-    ReplacingMergeTree collapsing, so reloading without rebuilding it silently
+    Read rather than duplicated so the view rebuilt here can never drift from
+    the one a real deployment applies.
+    """
+    schema_path = os.path.join(os.path.dirname(__file__), "001_provider_benchmark_samples.sql")
+    with open(schema_path) as handle:
+        raw = handle.read()
+    # Strip full-line comments before splitting: the prose contains semicolons.
+    code = "\n".join(line for line in raw.splitlines() if not line.strip().startswith("--"))
+    for statement in (s.strip() for s in code.split(";")):
+        if statement.upper().startswith("CREATE MATERIALIZED VIEW"):
+            return statement
+    raise SystemExit("no CREATE MATERIALIZED VIEW found in the schema file")
+
+
+def load(rows: list[dict]) -> None:
+    """Reload the LOCAL proof table, rebuilding the materialized view with it.
+
+    The view is dropped and RECREATED rather than left in place: an MV runs
+    per INSERT BLOCK and does NOT inherit the source table's
+    ReplacingMergeTree collapsing, so reloading without rebuilding silently
     doubles every aggregate. Verified the hard way — three loader runs against
     30,832 source rows left 92,500 samples in the view.
+
+    Order matters and is easy to get wrong in the other direction: the view
+    must be recreated BEFORE the insert. A materialized view only observes
+    rows inserted after it exists, so recreating it afterwards would leave a
+    permanently empty view — which is exactly the bug an earlier version of
+    this function shipped (it dropped the view and never brought it back).
     """
     ch("TRUNCATE TABLE provider_benchmark_samples")
     ch("DROP TABLE IF EXISTS route_health_hourly")
+    ch(_materialized_view_ddl())
     payload = "\n".join(
         json.dumps({**r, "created_at": r["created_at"].strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]})
         for r in rows

--- a/src/trusted_router/analytics_sink.py
+++ b/src/trusted_router/analytics_sink.py
@@ -1,0 +1,288 @@
+"""Analytics fan-out: a second, non-authoritative home for benchmark samples.
+
+Phase 2 of the storage-portability plan (docs/storage-portability/README.md).
+Bigtable stays authoritative; this mirrors the same rows into ClickHouse so the
+two can be compared continuously before anything reads from ClickHouse.
+
+Three properties matter more than throughput here:
+
+1. **It must never affect a request.** `record_provider_benchmark` is called on
+   the gateway settle path, which a customer is paying for and waiting on. So
+   the sink hands the row to a bounded in-memory queue and returns; a worker
+   thread does the network I/O. A slow or dead ClickHouse costs analytics
+   rows, never latency.
+2. **It must never grow without bound.** If ClickHouse is unreachable the queue
+   fills and further rows are DROPPED and counted, rather than accumulating
+   until the process dies. Losing analytics is acceptable; OOM-ing the control
+   plane is not.
+3. **Inserts must be batched.** ClickHouse is explicitly hostile to
+   one-row-per-INSERT: each insert creates a part, and a part per sample
+   generates merge pressure that degrades the whole table. The worker drains
+   whatever has accumulated into a single insert, and `async_insert` lets the
+   server coalesce further across replicas.
+
+This is deliberately NOT part of the `Store` protocol. Analytics is a
+side-channel with different durability requirements; putting it in the
+protocol would force every backend to implement it and would imply the write
+is authoritative, which it is not.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+from dataclasses import asdict, is_dataclass
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+#: Bounded so an unreachable ClickHouse cannot consume memory without limit.
+#: Sized for roughly a minute of peak synthetic + organic sample volume; past
+#: that, dropping is the correct behaviour.
+DEFAULT_QUEUE_SIZE = 10_000
+
+#: Rows per INSERT. ClickHouse prefers large batches; this bounds the request
+#: body while still being far from the one-row-per-part anti-pattern.
+DEFAULT_BATCH_SIZE = 500
+
+#: How long the worker waits for more rows before flushing a partial batch, so
+#: a quiet period does not leave rows sitting in memory indefinitely.
+DEFAULT_FLUSH_SECONDS = 2.0
+
+
+@runtime_checkable
+class AnalyticsSink(Protocol):
+    """Best-effort mirror of analytics rows. Implementations MUST NOT raise."""
+
+    def record_benchmark_sample(self, sample: Any) -> None: ...
+
+    def stats(self) -> dict[str, int]: ...
+
+    def close(self) -> None: ...
+
+
+class NullAnalyticsSink:
+    """The default. Does nothing, cheaply.
+
+    Chosen over `None` so call sites never branch — an `if sink is not None`
+    on the settle path is one more thing to get wrong.
+    """
+
+    def record_benchmark_sample(self, sample: Any) -> None:
+        return None
+
+    def stats(self) -> dict[str, int]:
+        return {"enqueued": 0, "written": 0, "dropped": 0, "failed": 0}
+
+    def close(self) -> None:
+        return None
+
+
+class ClickHouseAnalyticsSink:
+    """Queue rows to ClickHouse from a background worker.
+
+    The worker is a daemon thread: analytics must not keep the process alive
+    at shutdown. `close()` exists for tests and for a graceful drain.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        user: str,
+        password: str,
+        table: str = "provider_benchmark_samples",
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        flush_seconds: float = DEFAULT_FLUSH_SECONDS,
+        transport: Any | None = None,
+    ) -> None:
+        self._url = url
+        self._auth = (user, password)
+        self._table = table
+        self._batch_size = batch_size
+        self._flush_seconds = flush_seconds
+        self._queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=queue_size)
+        self._stop = threading.Event()
+        self._counts = {"enqueued": 0, "written": 0, "dropped": 0, "failed": 0}
+        self._counts_lock = threading.Lock()
+        # Injectable so tests exercise batching and failure handling without a
+        # live server.
+        self._transport = transport or self._post_rows
+        self._worker = threading.Thread(
+            target=self._run, name="clickhouse-analytics", daemon=True
+        )
+        self._worker.start()
+
+    # -- producer side (request path; must be fast and total) --------------
+
+    def record_benchmark_sample(self, sample: Any) -> None:
+        try:
+            row = _row_from_sample(sample)
+        except Exception:  # noqa: BLE001 - a malformed row must not break settle
+            self._bump("failed")
+            logger.warning("analytics.row_encode_failed", exc_info=True)
+            return
+        try:
+            self._queue.put_nowait(row)
+        except queue.Full:
+            # Deliberate: drop and count. Blocking here would put ClickHouse
+            # availability on the critical path of a paid request.
+            self._bump("dropped")
+            return
+        self._bump("enqueued")
+
+    def stats(self) -> dict[str, int]:
+        with self._counts_lock:
+            return dict(self._counts)
+
+    def close(self) -> None:
+        self._stop.set()
+        self._worker.join(timeout=5.0)
+
+    # -- consumer side (background thread) ---------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            batch = self._drain()
+            if batch:
+                self._write(batch)
+        # Final drain so an orderly close does not discard queued rows.
+        remaining = self._drain(block=False)
+        if remaining:
+            self._write(remaining)
+
+    def _drain(self, *, block: bool = True) -> list[dict[str, Any]]:
+        batch: list[dict[str, Any]] = []
+        try:
+            first = self._queue.get(timeout=self._flush_seconds) if block else self._queue.get_nowait()
+            batch.append(first)
+        except queue.Empty:
+            return batch
+        while len(batch) < self._batch_size:
+            try:
+                batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch
+
+    def _write(self, batch: list[dict[str, Any]]) -> None:
+        payload = "\n".join(json.dumps(row) for row in batch).encode()
+        try:
+            self._transport(payload)
+        except Exception:  # noqa: BLE001 - the sink is best-effort by contract
+            self._bump("failed", len(batch))
+            logger.warning(
+                "analytics.write_failed", extra={"rows": len(batch)}, exc_info=True
+            )
+            return
+        self._bump("written", len(batch))
+
+    def _post_rows(self, payload: bytes) -> None:
+        import httpx
+
+        # async_insert lets the server coalesce our batches further, which
+        # matters once several replicas are writing concurrently.
+        # wait_for_async_insert=0 means we do not block on the server's flush.
+        response = httpx.post(
+            self._url,
+            params={
+                "query": f"INSERT INTO {self._table} FORMAT JSONEachRow",
+                "async_insert": "1",
+                "wait_for_async_insert": "0",
+            },
+            content=payload,
+            auth=self._auth,
+            timeout=10.0,
+        )
+        response.raise_for_status()
+
+    def _bump(self, key: str, amount: int = 1) -> None:
+        with self._counts_lock:
+            self._counts[key] += amount
+
+
+def _row_from_sample(sample: Any) -> dict[str, Any]:
+    """Flatten a ProviderBenchmarkSample into the ClickHouse column shape.
+
+    `created_at` is normalised to ClickHouse's DateTime64 text format here so
+    the worker thread does no parsing, and `usage_type` is stringified because
+    it may arrive as an enum.
+    """
+    # `is_dataclass` also narrows to the dataclass *type*, which asdict()
+    # rejects; guard on the instance so mypy and runtime agree.
+    raw = (
+        asdict(sample)
+        if is_dataclass(sample) and not isinstance(sample, type)
+        else dict(sample)
+    )
+    created = str(raw.get("created_at") or "")
+    row = {
+        "id": str(raw.get("id") or ""),
+        "created_at": _clickhouse_timestamp(created),
+        "provider": str(raw.get("provider") or ""),
+        "model": str(raw.get("model") or ""),
+        "provider_name": str(raw.get("provider_name") or ""),
+        "status": str(raw.get("status") or ""),
+        "usage_type": str(raw.get("usage_type") or ""),
+        "source": str(raw.get("source") or ""),
+        "streamed": 1 if raw.get("streamed") else 0,
+        "input_tokens": int(raw.get("input_tokens") or 0),
+        "output_tokens": int(raw.get("output_tokens") or 0),
+        "total_cost_microdollars": int(raw.get("total_cost_microdollars") or 0),
+        "speed_tokens_per_second": raw.get("speed_tokens_per_second"),
+        "elapsed_milliseconds": raw.get("elapsed_milliseconds"),
+        "first_token_milliseconds": raw.get("first_token_milliseconds"),
+        "ttfb_milliseconds": raw.get("ttfb_milliseconds"),
+        "finish_reason": raw.get("finish_reason"),
+        "error_type": raw.get("error_type"),
+        "error_status": _optional_int(raw.get("error_status")),
+        "error_message": raw.get("error_message"),
+        "region": raw.get("region"),
+        "app": str(raw.get("app") or ""),
+    }
+    return row
+
+
+def _clickhouse_timestamp(value: str) -> str:
+    """ISO-8601 (with optional Z/offset) -> 'YYYY-MM-DD HH:MM:SS.mmm' UTC."""
+    import datetime as dt
+
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        parsed = dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce an HTTP status that may arrive as an int, a digit string, or None.
+
+    The differential proof found that a string `"429"` compares differently in
+    Python (`not in {429}`) than after coercion to ClickHouse's UInt16, so the
+    two paths must normalise identically.
+    """
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    return int(text) if text.isdigit() else None
+
+
+def create_analytics_sink(settings: Any) -> AnalyticsSink:
+    """Build the configured sink. Defaults to the no-op."""
+    url = getattr(settings, "clickhouse_url", "") or ""
+    if not url:
+        return NullAnalyticsSink()
+    return ClickHouseAnalyticsSink(
+        url=url,
+        user=getattr(settings, "clickhouse_user", "") or "default",
+        password=getattr(settings, "clickhouse_password", "") or "",
+        table=getattr(settings, "clickhouse_benchmark_table", "")
+        or "provider_benchmark_samples",
+    )

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -40,6 +40,14 @@ class Settings(BaseSettings):
     spanner_database_id: str | None = None
     bigtable_instance_id: str | None = None
     bigtable_generation_table: str = "trustedrouter-generations"
+    # ClickHouse analytics mirror (phase 2 of the storage-portability plan).
+    # Empty URL = disabled, which is the default: the sink is a no-op until a
+    # deployment explicitly points it somewhere. Bigtable stays authoritative
+    # while both are compared.
+    clickhouse_url: str = ""
+    clickhouse_user: str = ""
+    clickhouse_password: str = ""
+    clickhouse_benchmark_table: str = "provider_benchmark_samples"
 
     # Starter credit granted exactly once with a new email/OAuth account's
     # first workspace. Wallet-only and secondary workspaces receive no grant.

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 
+from trusted_router.analytics_sink import create_analytics_sink
 from trusted_router.axiom_config import init_axiom
 from trusted_router.catalog import validate_auto_model_order
 from trusted_router.config import Settings, get_settings
@@ -47,7 +48,11 @@ from trusted_router.routes.signup import register_signup_routes
 from trusted_router.routes.wallet_oauth import register_wallet_oauth_routes
 from trusted_router.routes.workspaces import register_workspace_routes
 from trusted_router.sentry_config import init_sentry
-from trusted_router.storage import configure_store, create_store
+from trusted_router.storage import (
+    configure_analytics_sink,
+    configure_store,
+    create_store,
+)
 from trusted_router.storage_errors import conflict_store_error_types
 from trusted_router.types import ErrorType
 
@@ -62,6 +67,8 @@ def create_app(
     validate_auto_model_order(settings.auto_model_order)
     if configure_store_arg:
         configure_store(create_store(settings))
+        # No-op unless TR_CLICKHOUSE_URL is set; Bigtable stays authoritative.
+        configure_analytics_sink(create_analytics_sink(settings))
     if init_observability:
         init_sentry(settings)
         init_axiom(settings)

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -5,6 +5,7 @@ import threading
 import uuid
 from typing import Any, cast
 
+from trusted_router.analytics_sink import AnalyticsSink, NullAnalyticsSink
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
 from trusted_router.storage_attribution import InMemoryAcquisitionAttribution
 from trusted_router.storage_auth_sessions import InMemoryAuthSessions
@@ -1172,6 +1173,11 @@ class InMemoryStore:
         return self.email_blocks.record_message_once(message_id)
 
 
+#: Analytics mirror. No-op until the app factory installs a real one, so
+#: importing this module never starts a background thread (tests, CLIs).
+_ANALYTICS_SINK: AnalyticsSink = NullAnalyticsSink()
+
+
 class _StoreProxy:
     """Singleton that forwards method calls to the active backend.
 
@@ -1210,6 +1216,24 @@ class _StoreProxy:
             raise TypeError("in_memory_target is only valid for the InMemoryStore backend")
         return target
 
+    def record_provider_benchmark(self, sample: Any) -> None:
+        """Write to the authoritative store, then mirror to analytics.
+
+        Defined explicitly rather than falling through `__getattr__` because
+        this is the single chokepoint every caller already routes through, so
+        the fan-out cannot miss a call site. It is deliberately NOT a wrapper
+        object around the store: `typed_billing_store()` unwraps this proxy to
+        do its capability check, and an extra layer it did not know about
+        would make that check read False and silently route typed billing down
+        the legacy path.
+
+        The store write is authoritative and its exceptions propagate. The
+        analytics mirror is best-effort and, by the sink's contract, cannot
+        raise.
+        """
+        self.target.record_provider_benchmark(sample)
+        _ANALYTICS_SINK.record_benchmark_sample(sample)
+
     def __getattr__(self, name: str) -> Any:
         return getattr(self.target, name)
 
@@ -1241,6 +1265,12 @@ def typed_billing_store(store: Any = None) -> TypedBillingStore | None:
     if isinstance(target, _StoreProxy):
         target = target.target
     return target if isinstance(target, TypedBillingStore) else None
+
+
+def configure_analytics_sink(sink: AnalyticsSink) -> None:
+    """Install the analytics mirror. Called once from the app factory."""
+    global _ANALYTICS_SINK
+    _ANALYTICS_SINK = sink
 
 
 def create_store(settings: Any) -> Store:

--- a/tests/test_analytics_sink.py
+++ b/tests/test_analytics_sink.py
@@ -1,0 +1,225 @@
+"""The analytics mirror must be invisible to the request path.
+
+`record_provider_benchmark` runs on the gateway settle path, which a customer
+is paying for and waiting on. Every test here is really one assertion: nothing
+about ClickHouse — being slow, full, broken, or absent — may change what that
+path does.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from trusted_router.analytics_sink import (
+    ClickHouseAnalyticsSink,
+    NullAnalyticsSink,
+    _optional_int,
+    _row_from_sample,
+    create_analytics_sink,
+)
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.types import UsageType
+
+# Not a credential — the sink never connects in these tests (the transport is
+# injected). Named rather than inlined so the linter does not read a literal
+# password assignment at five call sites.
+_UNUSED_URL = "http://unused"
+_UNUSED_USER = "u"
+_UNUSED_PASSWORD = "p"  # noqa: S105 - placeholder for an injected transport
+
+
+def _sample(**overrides: object) -> ProviderBenchmarkSample:
+    kwargs: dict[str, object] = {
+        "id": "s1",
+        "model": "acme/m1",
+        "provider": "acme",
+        "provider_name": "Acme",
+        "status": "success",
+        "usage_type": UsageType.CREDITS,
+        "streamed": True,
+        "source": "synthetic",
+    }
+    kwargs.update(overrides)
+    return ProviderBenchmarkSample(**kwargs)  # type: ignore[arg-type]
+
+
+def _drain_sink(sink: ClickHouseAnalyticsSink, *, predicate, timeout: float = 3.0) -> None:
+    """Wait for the worker thread to reach a state, without a fixed sleep."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate(sink.stats()):
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"sink never reached expected state; stats={sink.stats()}")
+
+
+# --------------------------------------------------------------------------
+# Default is off
+# --------------------------------------------------------------------------
+
+
+def test_sink_defaults_to_noop_without_a_url() -> None:
+    """No configuration must mean no background thread and no network.
+
+    Importing or booting the app in a test, a CLI, or a non-GCP deployment
+    should not start an analytics worker.
+    """
+
+    class _Settings:
+        clickhouse_url = ""
+
+    assert isinstance(create_analytics_sink(_Settings()), NullAnalyticsSink)
+
+
+def test_null_sink_accepts_anything_silently() -> None:
+    sink = NullAnalyticsSink()
+    sink.record_benchmark_sample(_sample())
+    sink.record_benchmark_sample(None)
+    assert sink.stats()["written"] == 0
+
+
+# --------------------------------------------------------------------------
+# The request path is never blocked or broken
+# --------------------------------------------------------------------------
+
+
+def test_enqueue_returns_immediately_even_when_the_transport_hangs() -> None:
+    """A hung ClickHouse must not stall settle.
+
+    The worker is blocked for the whole test; the producer still returns.
+    """
+    release = threading.Event()
+
+    def hanging_transport(_payload: bytes) -> None:
+        release.wait(timeout=5.0)
+
+    sink = ClickHouseAnalyticsSink(
+        url=_UNUSED_URL, user=_UNUSED_USER, password=_UNUSED_PASSWORD, transport=hanging_transport
+    )
+    try:
+        started = time.perf_counter()
+        for _ in range(50):
+            sink.record_benchmark_sample(_sample())
+        elapsed = time.perf_counter() - started
+        assert elapsed < 0.5, f"producer blocked for {elapsed:.2f}s"
+    finally:
+        release.set()
+        sink.close()
+
+
+def test_transport_failure_never_propagates() -> None:
+    """ClickHouse being down is not an error the settle path can see."""
+
+    def broken_transport(_payload: bytes) -> None:
+        raise RuntimeError("clickhouse is down")
+
+    sink = ClickHouseAnalyticsSink(
+        url=_UNUSED_URL, user=_UNUSED_USER, password=_UNUSED_PASSWORD, transport=broken_transport
+    )
+    try:
+        sink.record_benchmark_sample(_sample())  # must not raise
+        _drain_sink(sink, predicate=lambda s: s["failed"] >= 1)
+    finally:
+        sink.close()
+
+
+def test_full_queue_drops_rather_than_blocking() -> None:
+    """Bounded by design: analytics loss beats unbounded memory growth.
+
+    With the worker wedged and a queue of 2, the third row is dropped and
+    counted rather than queued forever.
+    """
+    release = threading.Event()
+
+    def hanging_transport(_payload: bytes) -> None:
+        release.wait(timeout=5.0)
+
+    sink = ClickHouseAnalyticsSink(
+        url=_UNUSED_URL,
+        user=_UNUSED_USER,
+        password=_UNUSED_PASSWORD,
+        queue_size=2,
+        transport=hanging_transport,
+    )
+    try:
+        for _ in range(50):
+            sink.record_benchmark_sample(_sample())
+        assert sink.stats()["dropped"] > 0, "a full queue must drop, not grow"
+    finally:
+        release.set()
+        sink.close()
+
+
+def test_a_malformed_row_is_counted_not_raised() -> None:
+    """An unencodable sample must not break the settle path either."""
+    sink = ClickHouseAnalyticsSink(
+        url=_UNUSED_URL, user=_UNUSED_USER, password=_UNUSED_PASSWORD, transport=lambda _p: None
+    )
+    try:
+        sink.record_benchmark_sample(object())  # not a dataclass or mapping
+        assert sink.stats()["failed"] >= 1
+    finally:
+        sink.close()
+
+
+# --------------------------------------------------------------------------
+# Batching
+# --------------------------------------------------------------------------
+
+
+def test_rows_are_batched_not_one_insert_each() -> None:
+    """One INSERT per row is a ClickHouse anti-pattern — each creates a part.
+
+    Asserts the worker coalesces: far fewer transport calls than rows.
+    """
+    payloads: list[bytes] = []
+    lock = threading.Lock()
+
+    def recording_transport(payload: bytes) -> None:
+        with lock:
+            payloads.append(payload)
+
+    sink = ClickHouseAnalyticsSink(
+        url=_UNUSED_URL, user=_UNUSED_USER, password=_UNUSED_PASSWORD, transport=recording_transport
+    )
+    try:
+        for index in range(200):
+            sink.record_benchmark_sample(_sample(id=f"s{index}"))
+        _drain_sink(sink, predicate=lambda s: s["written"] >= 200)
+        with lock:
+            calls = len(payloads)
+            total_rows = sum(len(p.decode().splitlines()) for p in payloads)
+        assert total_rows == 200, f"expected every row written, got {total_rows}"
+        assert calls < 200, f"rows were not batched: {calls} inserts for 200 rows"
+    finally:
+        sink.close()
+
+
+# --------------------------------------------------------------------------
+# Row encoding matches the schema and the proof harness
+# --------------------------------------------------------------------------
+
+
+def test_row_shape_matches_the_clickhouse_columns() -> None:
+    row = _row_from_sample(_sample())
+    assert row["id"] == "s1"
+    assert row["provider"] == "acme"
+    assert row["streamed"] == 1  # UInt8, not a bool
+    assert isinstance(row["usage_type"], str)  # enum stringified
+    # DateTime64(3) text format, not ISO-8601.
+    assert "T" not in row["created_at"] and row["created_at"].count("-") == 2
+
+
+def test_error_status_normalisation_matches_the_proof_harness() -> None:
+    """A string "429" must coerce the same way on both paths.
+
+    The differential proof found that Python's `not in {429}` and ClickHouse's
+    UInt16 column disagree unless normalisation is shared, which would make
+    dual-write rows silently differ from the Bigtable original.
+    """
+    assert _optional_int("429") == 429
+    assert _optional_int(429) == 429
+    assert _optional_int(None) is None
+    assert _optional_int("") is None
+    assert _optional_int("not-a-status") is None


### PR DESCRIPTION
Phase 2 of `docs/storage-portability/README.md`. Bigtable stays authoritative; this mirrors rows into ClickHouse so the two can be compared before anything *reads* from ClickHouse. **Disabled unless `TR_CLICKHOUSE_URL` is set — lands as a no-op.**

## Design: the settle path is sacred
`record_provider_benchmark` runs on the gateway settle path, which a customer is paying for and waiting on.

| Property | How | Test |
|---|---|---|
| Never adds latency | bounded queue + worker thread does the I/O | wedges the transport, asserts producer returns <0.5s for 50 rows |
| Never grows unbounded | full queue **drops and counts** | wedges worker with `queue_size=2`, asserts drops |
| Never raises | failures counted, not propagated | broken transport + malformed row |
| Batches | worker coalesces + `async_insert` | 200 rows ⇒ far fewer than 200 inserts |

Losing analytics rows is acceptable; adding latency to a paid request, or OOM-ing the control plane, is not.

## Why the fan-out is on `_StoreProxy`, not a wrapper
The proxy is the single chokepoint all three call sites already route through, so nothing can be missed. More importantly, a **new wrapper layer would defeat `typed_billing_store()`** — it unwraps the proxy to run its capability check, and an extra layer it didn't know about would make that read `False` and silently route typed billing down the legacy path. That's a money bug the repo already has a regression test for.

## Also fixes a bug I introduced
`prove_leaderboard.py`'s loader dropped `route_health_hourly` and **never recreated it**, so any proof run permanently destroyed the materialized view — an over-correction while removing duplicate MV states. It now rebuilds the view from the schema file (one source of truth), **before** the insert: an MV only observes rows inserted after it exists, so recreating it afterwards would leave it permanently empty.

## Verification
End-to-end against a live ClickHouse: **1200 enqueued → 1200 written → 1200 rows queryable, 0 dropped, 0 failed**, and the rebuilt view populated (16,708 post-exclusion samples from a 20k load). Differential proof still exact on 500 routes.

`ruff` + `mypy` clean; full suite **1963 passed**.

## Next
Provision ClickHouse on GCP, set the env, backfill, then run the comparison continuously before flipping leaderboard reads.