### PR TITLE
benchmarks: make throughput sampling reliable

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -92,6 +92,7 @@ upsert_scheduler() {
       --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
       --quiet >/dev/null; then
       log "WARN: failed to update synthetic scheduler ${scheduler_name}; leaving existing schedule in place"
+      return 1
     fi
   else
     log "creating synthetic scheduler ${scheduler_name}"
@@ -103,6 +104,7 @@ upsert_scheduler() {
       --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
       --quiet >/dev/null; then
       log "WARN: failed to create synthetic scheduler ${scheduler_name}; deploy the job exists but is not scheduled"
+      return 1
     fi
   fi
 }
@@ -153,7 +155,8 @@ done
 # overlap TLS, attestation, billing, fallback, or short provider probes.
 throughput_region="us-central1"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
-throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
+throughput_scheduler_name="${throughput_job_name}-every-minute"
+legacy_throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
 throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
@@ -166,7 +169,7 @@ throughput_env_vars=(
   "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
   "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
   "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
-  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
+  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=60"
 )
 throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
@@ -189,4 +192,16 @@ upsert_scheduler \
   "$throughput_scheduler_name" \
   "$throughput_job_name" \
   "$throughput_region" \
-  "*/2 * * * *"
+  "* * * * *"
+
+# Avoid double-sampling after the cadence change. Delete the legacy scheduler
+# only after the replacement scheduler was created or updated successfully.
+if gc scheduler jobs describe \
+  "$legacy_throughput_scheduler_name" \
+  --location "$throughput_region" >/dev/null 2>&1; then
+  log "deleting legacy throughput scheduler ${legacy_throughput_scheduler_name}"
+  gc scheduler jobs delete \
+    "$legacy_throughput_scheduler_name" \
+    --location "$throughput_region" \
+    --quiet >/dev/null
+fi

--- a/scripts/update_provider_throughput_rank.py
+++ b/scripts/update_provider_throughput_rank.py
@@ -21,6 +21,7 @@ import httpx
 LEADERBOARD_URL: Final = "https://trustedrouter.com/leaderboard"
 ROUTING_PATH: Final = Path("src/trusted_router/routing.py")
 MIN_SAMPLES: Final = 25
+MIN_THROUGHPUT_SAMPLES: Final = 5
 MIN_UPTIME: Final = 0.95
 SECONDARY_START: Final = 20
 SECONDARY_PROVIDERS: Final = (
@@ -51,6 +52,7 @@ SECONDARY_PROVIDERS: Final = (
 class ProviderLeaderboardRow:
     provider: str
     throughput_tokens_per_second: float | None
+    throughput_samples: int
     uptime: float
     samples: int
     p50_ttft_ms: int | None
@@ -112,6 +114,7 @@ def parse_provider_rows(html: str) -> list[ProviderLeaderboardRow]:
             ProviderLeaderboardRow(
                 provider=row[1].strip().lower(),
                 throughput_tokens_per_second=_parse_throughput(row[4]),
+                throughput_samples=_parse_throughput_samples(row[4]),
                 uptime=_parse_percent(row[5]),
                 samples=_parse_int(row[8]),
                 p50_ttft_ms=_parse_milliseconds(row[3]),
@@ -124,6 +127,7 @@ def measured_rank(
     rows: list[ProviderLeaderboardRow],
     *,
     min_samples: int = MIN_SAMPLES,
+    min_throughput_samples: int = MIN_THROUGHPUT_SAMPLES,
     min_uptime: float = MIN_UPTIME,
 ) -> list[str]:
     eligible = [
@@ -131,6 +135,7 @@ def measured_rank(
         for row in rows
         if row.throughput_tokens_per_second is not None
         and row.throughput_tokens_per_second > 0
+        and row.throughput_samples >= min_throughput_samples
         and row.samples >= min_samples
         and row.uptime >= min_uptime
     ]
@@ -151,7 +156,9 @@ def build_rank_block(measured: list[str], *, generated_date: dt.date | None = No
         ranks.setdefault(provider, len(ranks))
     for provider in SECONDARY_PROVIDERS:
         if provider not in ranks:
-            ranks[provider] = SECONDARY_START + len([p for p in ranks if ranks[p] >= SECONDARY_START])
+            ranks[provider] = SECONDARY_START + len(
+                [p for p in ranks if ranks[p] >= SECONDARY_START]
+            )
     ranks["trustedrouter"] = 99
 
     lines = [
@@ -160,8 +167,9 @@ def build_rank_block(measured: list[str], *, generated_date: dt.date | None = No
         "#",
         f"# Generated from the public /leaderboard provider table on {generated.isoformat()} with:",
         "#   python scripts/update_provider_throughput_rank.py --write",
-        "# The generator admits only providers with enough samples, >=95% measured uptime,",
-        "# and positive p50 output tokens/second. Providers without reliable token/s data",
+        "# The generator admits only providers with enough availability and throughput",
+        "# samples, >=95% measured uptime, and positive effective output tokens/second.",
+        "# Providers without reliable token/s data",
         "# keep conservative secondary ranks so they do not beat measured fast routes.",
         "_THROUGHPUT_RANK = {",
     ]
@@ -193,6 +201,11 @@ def replace_rank_block(source: str, new_block: str) -> str:
 def _parse_throughput(value: str) -> float | None:
     match = re.search(r"(\d+(?:\.\d+)?)\s*tok/s", value)
     return float(match.group(1)) if match else None
+
+
+def _parse_throughput_samples(value: str) -> int:
+    match = re.search(r"\bn=(\d+)\b", value)
+    return int(match.group(1)) if match else 0
 
 
 def _parse_percent(value: str) -> float:

--- a/src/trusted_router/benchmark_samples.py
+++ b/src/trusted_router/benchmark_samples.py
@@ -14,6 +14,9 @@ from trusted_router.catalog import providers_for_display
 from trusted_router.storage import STORE
 from trusted_router.storage_models import ProviderBenchmarkSample
 
+PUBLIC_BENCHMARK_SAMPLE_LIMIT = 10_000
+PUBLIC_BENCHMARK_RECENT_MINUTES = 24 * 60
+
 
 def _cutoff_iso(*, recent_minutes: int | None, now: dt.datetime | None = None) -> str | None:
     if recent_minutes is None or recent_minutes <= 0:

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1914,7 +1914,7 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
             title="LLM Provider & Model Speed Leaderboard | TrustedRouter",
             heading="Provider & model performance",
             description=(
-                "Measured time-to-first-token, time-to-first-byte, throughput, and "
+                "Measured time-to-first-token, time-to-first-byte, effective throughput, and "
                 "uptime for every LLM provider and model TrustedRouter routes to — "
                 "continuously sampled, not vendor-claimed."
             ),
@@ -1925,7 +1925,7 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
                 _dataset_node(
                     name="TrustedRouter LLM provider and model speed leaderboard",
                     description=(
-                        "Metadata-only measurements for provider TTFT, TTFB, throughput, "
+                        "Metadata-only measurements for provider TTFT, TTFB, effective throughput, "
                         "success rate, and excluded probe configuration rows."
                     ),
                     url=f"https://{settings.trusted_domain}/leaderboard",
@@ -2140,7 +2140,7 @@ def public_provider_performance_html(settings: Settings, provider_slug: str) -> 
             title=f"{provider.name} Performance | TrustedRouter",
             heading=f"{provider.name} performance",
             description=(
-                f"Measured TTFT, TTFB, throughput, uptime, and sampled model routes for {provider.name}."
+                f"Measured TTFT, TTFB, effective throughput, uptime, and sampled model routes for {provider.name}."
             ),
             provider=_provider_detail_view(
                 provider,
@@ -2163,7 +2163,7 @@ def public_provider_performance_html(settings: Settings, provider_slug: str) -> 
                 _dataset_node(
                     name=f"{provider.name} TrustedRouter performance measurements",
                     description=(
-                        f"Measured latency, throughput, and uptime for {provider.name} routes "
+                        f"Measured latency, effective throughput, and uptime for {provider.name} routes "
                         "through TrustedRouter."
                     ),
                     url=f"https://{settings.trusted_domain}{site_path}",

--- a/src/trusted_router/measured.py
+++ b/src/trusted_router/measured.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from trusted_router.benchmark_samples import public_benchmark_samples
+from trusted_router.benchmark_samples import (
+    PUBLIC_BENCHMARK_RECENT_MINUTES,
+    PUBLIC_BENCHMARK_SAMPLE_LIMIT,
+    public_benchmark_samples,
+)
 from trusted_router.storage_models import utcnow
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 
-_SAMPLE_LIMIT = 8_000
-_TTL_SECONDS = 60
+_TTL_SECONDS = 300
 _CACHE: tuple[float, dict[str, Any]] | None = None
 
 
@@ -28,7 +31,10 @@ def measured_snapshot(*, test_mode: bool = False) -> dict[str, Any]:
     now = time.monotonic()
     if not test_mode and _CACHE is not None and now - _CACHE[0] < _TTL_SECONDS:
         return _CACHE[1]
-    samples = public_benchmark_samples(limit=_SAMPLE_LIMIT)
+    samples = public_benchmark_samples(
+        limit=PUBLIC_BENCHMARK_SAMPLE_LIMIT,
+        recent_minutes=PUBLIC_BENCHMARK_RECENT_MINUTES,
+    )
     payload = aggregate_leaderboard(samples, min_samples=1)
     payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
     if not test_mode:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -24,7 +24,11 @@ from starlette.types import Scope
 
 from trusted_router.ai_iq import ai_iq_catalog_payload
 from trusted_router.apps import aggregate_apps
-from trusted_router.benchmark_samples import public_benchmark_samples
+from trusted_router.benchmark_samples import (
+    PUBLIC_BENCHMARK_RECENT_MINUTES,
+    PUBLIC_BENCHMARK_SAMPLE_LIMIT,
+    public_benchmark_samples,
+)
 from trusted_router.catalog import (
     META_MODEL_IDS,
     MODELS,
@@ -107,9 +111,10 @@ STATUS_RESPONSE_CACHE_SECONDS = 60
 STATUS_RESPONSE_STALE_SECONDS = 600
 STATUS_HISTORY_CACHE_SECONDS = 300
 STATUS_HISTORY_STALE_SECONDS = 1_800
-LEADERBOARD_SAMPLE_LIMIT = 5_000
+LEADERBOARD_SAMPLE_LIMIT = PUBLIC_BENCHMARK_SAMPLE_LIMIT
 LEADERBOARD_MIN_SAMPLES = 1
-LEADERBOARD_RECENT_WINDOW_MINUTES = 180
+LEADERBOARD_RECENT_WINDOW_MINUTES = PUBLIC_BENCHMARK_RECENT_MINUTES
+LEADERBOARD_SNAPSHOT_CACHE_SECONDS = 300
 LEADERBOARD_RESPONSE_CACHE_SECONDS = 60
 LEADERBOARD_RESPONSE_STALE_SECONDS = 0
 CHOOSE_PAGE_CACHE_SECONDS = 300
@@ -1233,7 +1238,7 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
     now = time.monotonic()
     if settings.environment != "test" and _LEADERBOARD_CACHE is not None:
         cached_at, payload = _LEADERBOARD_CACHE
-        if now - cached_at < STATUS_SNAPSHOT_CACHE_SECONDS:
+        if now - cached_at < LEADERBOARD_SNAPSHOT_CACHE_SECONDS:
             return payload
     samples = public_benchmark_samples(
         limit=LEADERBOARD_SAMPLE_LIMIT,
@@ -1241,7 +1246,9 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
     )
     payload = aggregate_leaderboard(samples, min_samples=LEADERBOARD_MIN_SAMPLES)
     payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
-    payload["window_label"] = f"{LEADERBOARD_SAMPLE_LIMIT:,}-sample benchmark set"
+    payload["sample_window_count"] = len(samples)
+    payload["sample_limit"] = LEADERBOARD_SAMPLE_LIMIT
+    payload["window_label"] = f"rolling benchmark set of up to {LEADERBOARD_SAMPLE_LIMIT:,} samples"
     if settings.environment != "test":
         _LEADERBOARD_CACHE = (now, payload)
     return payload
@@ -1378,7 +1385,11 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
     # router health), but surfaced here so provider errors are visible.
     leaderboard = _leaderboard_snapshot(settings)
     provider_health = sorted(
-        leaderboard.get("providers", []),
+        (
+            provider
+            for provider in leaderboard.get("providers", [])
+            if provider.get("sample_count", 0) > 0
+        ),
         key=lambda p: (-p.get("error_rate", 0.0), p.get("provider", "")),
     )
     return render_template(

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -607,6 +607,7 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 .leaderboard-table td a { color:var(--blue); text-decoration:none; }
 .leaderboard-table td a:hover { text-decoration:underline; }
 .lb-badge { display:inline-block; margin-left:8px; padding:1px 7px; border-radius:999px; font-size:11px; color:var(--muted); background:var(--line2); border:1px solid var(--line); }
+.lb-sample-count { color:var(--muted); font-size:11px; margin-left:4px; }
 .lb-note { color:var(--muted); font-size:11px; line-height:1.3; margin-top:2px; white-space:normal; max-width:280px; }
 .lb-badge { display:inline-block; font-size:10px; padding:1px 7px; border-radius:999px; background:#15203542; border:1px solid var(--line2); color:var(--muted); vertical-align:middle; letter-spacing:.02em; white-space:nowrap; }
 

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -615,9 +615,9 @@ class ProviderBenchmarkSample:
     error_message: str | None = None
     region: str | None = None
     # Internal-only provenance: "organic" (real production traffic),
-    # "synthetic" (short rotation probe), or "synthetic_throughput" (sustained
-    # output benchmark). Public ranking pages use the long probe only for
-    # decode throughput, never provider uptime.
+    # "synthetic" (short rotation probe), or "synthetic_throughput" (long
+    # effective-output benchmark). Public ranking pages use the long probe only
+    # for request-start-to-completion throughput, never provider uptime.
     source: str = "organic"
     # Caller-self-reported app name (Generation.app, from the X-Title / Referer
     # header), used by the /apps directory. Privacy-safe: it's the public title

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -23,6 +23,7 @@ from trusted_router.synthetic.probes import (
     run_synthetic_once,
 )
 from trusted_router.synthetic.throughput import (
+    THROUGHPUT_INTERVAL_SECONDS,
     choose_throughput_target,
     throughput_candidates,
 )
@@ -42,7 +43,7 @@ _DEFAULT_THROUGHPUT_ROUTE_LIMIT = 200
 _DEFAULT_THROUGHPUT_MAX_TOKENS = 512
 _DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS = 128
 _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS = 90.0
-_DEFAULT_THROUGHPUT_INTERVAL_SECONDS = 120
+_DEFAULT_THROUGHPUT_INTERVAL_SECONDS = THROUGHPUT_INTERVAL_SECONDS
 
 
 def _env_flag(name: str, *, default: bool = False) -> bool:

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -83,6 +83,26 @@ def _median_float(values: Sequence[float]) -> float | None:
     return (ordered[mid - 1] + ordered[mid]) / 2
 
 
+def _effective_throughput(sample: ProviderBenchmarkSample) -> float | None:
+    """Return a buffering-safe output rate for a long synthetic probe.
+
+    Rows written before the metric correction stored post-first-chunk delivery
+    speed, which can be wildly inflated when an upstream buffers SSE events.
+    All long-probe rows already carry provider-reported output tokens and total
+    elapsed time, so derive the honest end-to-end rate at read time. The stored
+    speed remains a compatibility fallback for older tests or partial rows.
+    """
+    if (
+        sample.output_tokens > 0
+        and sample.elapsed_milliseconds is not None
+        and sample.elapsed_milliseconds > 0
+    ):
+        return sample.output_tokens * 1000 / sample.elapsed_milliseconds
+    if sample.speed_tokens_per_second is not None and sample.speed_tokens_per_second > 0:
+        return sample.speed_tokens_per_second
+    return None
+
+
 @dataclass
 class ProviderModelStats:
     provider: str
@@ -124,7 +144,7 @@ class ProviderModelStats:
             "provider": self.provider,
             "model": self.model,
             "sample_count": self.sample_count,
-            "uptime": round(self.uptime, 4),
+            "uptime": round(self.uptime, 4) if self.sample_count else None,
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
             "throughput_sample_count": self.throughput_sample_count,
@@ -182,7 +202,7 @@ class ProviderStats:
             "provider": self.provider,
             "model_count": self.model_count,
             "sample_count": self.sample_count,
-            "uptime": round(self.uptime, 4),
+            "uptime": round(self.uptime, 4) if self.sample_count else None,
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
             "throughput_sample_count": self.throughput_sample_count,
@@ -229,8 +249,9 @@ def aggregate_leaderboard(
             legacy_tps[key] = []
             sustained_tps[key] = []
         if sample.source == "synthetic_throughput":
-            if sample.status == "success" and sample.speed_tokens_per_second:
-                sustained_tps[key].append(sample.speed_tokens_per_second)
+            effective_tps = _effective_throughput(sample)
+            if sample.status == "success" and effective_tps is not None:
+                sustained_tps[key].append(effective_tps)
                 stats.throughput_sample_count += 1
             if stats.last_seen is None or sample.created_at > stats.last_seen:
                 stats.last_seen = sample.created_at
@@ -267,7 +288,11 @@ def aggregate_leaderboard(
         stats.p95_ttfb_ms = _percentile(ttfb[key], 95)
         stats.p50_tokens_per_second = _median_float(sustained_tps[key] or legacy_tps[key])
 
-    models = [s for s in by_model.values() if s.sample_count >= min_samples]
+    models = [
+        stats
+        for stats in by_model.values()
+        if stats.sample_count >= min_samples or stats.throughput_sample_count >= min_samples
+    ]
     models.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
 
     providers = _aggregate_providers(models)

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1053,12 +1053,15 @@ async def provider_throughput_probe(
     total_timeout_seconds: float | None = None,
     clock: Callable[[], float] = time.perf_counter,
 ) -> ProviderBenchmarkSample:
-    """Measure sustained output speed after the first streamed token.
+    """Measure effective output throughput from request start to completion.
 
     Unlike the tiny PONG rotation probe, this requires provider-reported final
-    usage and enough output tokens for a stable sample. It records metadata
-    only. The response bytes are discarded inside this function and are never
-    returned to the control plane ingest payload.
+    usage and enough output tokens for a stable sample. Measuring the complete
+    request makes the result insensitive to HTTP/SSE buffering: a provider
+    cannot appear artificially fast because many token events arrived in one
+    network chunk. It records metadata only. The response bytes are discarded
+    inside this function and are never returned to the control plane ingest
+    payload.
     """
     if max_tokens <= 1:
         raise ValueError("max_tokens must be greater than one")
@@ -1136,12 +1139,10 @@ async def provider_throughput_probe(
 
     usage = observation.usage
     first_token_ms = observation.first_token_milliseconds
-    last_token_ms = observation.last_token_milliseconds
     if (
         usage.output_tokens < minimum_output_tokens
         or first_token_ms is None
-        or last_token_ms is None
-        or last_token_ms <= first_token_ms
+        or observation.elapsed_milliseconds <= 0
     ):
         sample = _rotation_error_sample(
             served_provider,
@@ -1159,8 +1160,7 @@ async def provider_throughput_probe(
         sample.finish_reason = observation.finish_reason or "insufficient_sample"
         return sample
 
-    decode_milliseconds = last_token_ms - first_token_ms
-    speed_tokens_per_second = max(1, usage.output_tokens - 1) * 1000 / decode_milliseconds
+    speed_tokens_per_second = usage.output_tokens * 1000 / observation.elapsed_milliseconds
     return ProviderBenchmarkSample(
         id=f"bench-{uuid.uuid4().hex}",
         model=served_model,

--- a/src/trusted_router/synthetic/throughput.py
+++ b/src/trusted_router/synthetic/throughput.py
@@ -15,6 +15,7 @@ from trusted_router.synthetic.probes import rotation_candidates
 _RECENT_MODEL_COUNT = 24
 _RECENT_MODEL_BONUS = 5_000
 _RECENT_MODEL_STEP = 50
+THROUGHPUT_INTERVAL_SECONDS = 60
 
 
 def throughput_candidates(*, limit: int = 200) -> list[tuple[str, str]]:
@@ -71,7 +72,7 @@ def choose_throughput_target(
     candidates: list[tuple[str, str]],
     *,
     now_epoch_seconds: float | None = None,
-    interval_seconds: int = 120,
+    interval_seconds: int = THROUGHPUT_INTERVAL_SECONDS,
 ) -> tuple[str, str] | None:
     """Choose one route by scheduler time slot, giving exact round-robin coverage."""
     if not candidates:
@@ -88,7 +89,7 @@ def projected_monthly_cost_microdollars(
     *,
     input_tokens: int = 64,
     output_tokens: int = 512,
-    interval_seconds: int = 120,
+    interval_seconds: int = THROUGHPUT_INTERVAL_SECONDS,
     days: int = 30,
 ) -> int:
     """Conservative full-cap monthly spend for the scheduled route rotation."""

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -17,11 +17,13 @@
 {% block body %}
 <section class="status-page leaderboard-page">
   <div class="status-note">
-    Continuously sampled from TrustedRouter's monitor regions over the {{ snapshot.window_label or "recent live window" }} — time-to-first-token (TTFT),
-    time-to-first-byte (TTFB), throughput, and success rate measured on real streaming
-    requests, not vendor-claimed. Unsupported route and probe-configuration rows are
-    reported separately and do not count as provider downtime. No prompt or output
-    content is ever stored.
+    Continuously sampled from TrustedRouter's monitor regions using a
+    {{ snapshot.window_label or "recent live sample" }}. Time-to-first-token (TTFT),
+    time-to-first-byte (TTFB), effective throughput, and success rate come from real
+    streaming requests, not vendor claims. Effective throughput is provider-reported
+    output tokens divided by complete request time, so buffered delivery cannot inflate
+    the result. Unsupported route and probe-configuration rows are reported separately
+    and do not count as provider downtime. No prompt or output content is ever stored.
   </div>
 
   {% if not snapshot.models %}
@@ -33,8 +35,9 @@
     <div class="status-section-head">
       <div>
         <h2>Providers</h2>
-        <p>Ranked by measured p50 time-to-first-token across all of a provider's models in the {{ snapshot.window_label or "recent live window" }}
-          ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} samples).</p>
+        <p>Ranked by measured p50 time-to-first-token across all of a provider's models
+          ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} availability samples ·
+          {{ snapshot.total_throughput_samples }} throughput samples).</p>
       </div>
     </div>
     <div class="leaderboard-table-wrap">
@@ -42,7 +45,7 @@
         <thead>
           <tr>
             <th>#</th><th>Provider</th><th>Models</th>
-            <th>p50 TTFT</th><th>Throughput</th><th>Uptime</th><th>Errors</th><th>Config excluded</th><th>Samples</th>
+            <th>p50 TTFT</th><th>Effective throughput</th><th>Uptime</th><th>Errors</th><th>Config excluded</th><th>Availability samples</th>
           </tr>
         </thead>
         <tbody>
@@ -52,8 +55,8 @@
             <td><a href="/providers/{{ p.provider }}">{{ p.provider }}</a></td>
             <td>{{ p.model_count }}</td>
             <td>{% if p.p50_ttft_ms is not none %}{{ p.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if p.p50_tokens_per_second is not none %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{{ '%.2f'|format(p.uptime * 100) }}%</td>
+            <td>{% if p.p50_tokens_per_second is not none %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ p.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
+            <td>{% if p.sample_count %}{{ '%.2f'|format(p.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if p.top_error %}<code>{{ p.top_error }}</code> {{ '%.0f'|format(p.error_rate * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if p.excluded_count %}{{ p.excluded_count }}{% if p.top_excluded %} <code>{{ p.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ p.sample_count }}</td>
@@ -68,8 +71,8 @@
     <div class="status-section-head">
       <div>
         <h2>Models</h2>
-        <p>Models sampled in the {{ snapshot.window_label or "recent live window" }}, fastest measured TTFT first.
-          Rows with few samples are marked — more data sharpens the numbers.</p>
+        <p>Models in the current benchmark set, fastest measured TTFT first.
+          Thin availability and throughput measurements are labeled independently.</p>
       </div>
     </div>
     <div class="leaderboard-table-wrap">
@@ -78,7 +81,7 @@
           <tr>
             <th>#</th><th>Model</th><th>Provider</th>
             <th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th>
-            <th>Throughput</th><th>Uptime</th><th>Config excluded</th><th>Samples</th>
+            <th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th>
           </tr>
         </thead>
         <tbody>
@@ -86,14 +89,14 @@
           <tr>
             <td>{{ loop.index }}</td>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a>
-              {% if m.sample_count < 20 %}<span class="lb-badge">limited data</span>{% endif %}
+              {% if m.sample_count < 5 %}<span class="lb-badge">limited availability</span>{% endif %}
             </td>
             <td>{{ m.provider }}</td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p95_ttft_ms is not none %}{{ m.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{{ '%.2f'|format(m.uptime * 100) }}%</td>
+            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% if m.throughput_sample_count < 3 %} <span class="lb-badge">warming</span>{% endif %}{% else %}—{% endif %}</td>
+            <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ m.sample_count }}</td>
           </tr>

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -99,10 +99,10 @@
     {% elif section == "performance" %}
     {% if measured %}
     <h3>Measured performance</h3>
-    <p class="muted-copy">Continuously sampled p50/p95 time-to-first-token (TTFT), time-to-first-byte (TTFB), throughput, and success rate for {{ model.name }} — unsupported route and probe-configuration rows are separated from provider downtime, and no prompt or output content is stored.</p>
+    <p class="muted-copy">Continuously sampled p50/p95 time-to-first-token (TTFT), time-to-first-byte (TTFB), effective throughput, and success rate for {{ model.name }}. Effective throughput uses provider-reported output tokens over complete request time. Unsupported route and probe-configuration rows are separated from provider downtime, and no prompt or output content is stored.</p>
     <div class="leaderboard-table-wrap">
       <table class="leaderboard-table">
-        <thead><tr><th>Provider</th><th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th><th>Throughput</th><th>Uptime</th><th>Config excluded</th><th>Samples</th></tr></thead>
+        <thead><tr><th>Provider</th><th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for r in measured %}
           <tr>
@@ -110,8 +110,8 @@
             <td>{% if r.p50_ttft_ms is not none %}{{ r.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if r.p95_ttft_ms is not none %}{{ r.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if r.p50_ttfb_ms is not none %}{{ r.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if r.p50_tokens_per_second is not none %}{{ '%.0f'|format(r.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{{ '%.2f'|format(r.uptime * 100) }}%</td>
+            <td>{% if r.p50_tokens_per_second is not none %}{{ '%.0f'|format(r.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ r.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
+            <td>{% if r.sample_count %}{{ '%.2f'|format(r.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if r.excluded_count %}{{ r.excluded_count }}{% if r.top_excluded %} <code>{{ r.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ r.sample_count }}</td>
           </tr>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -29,26 +29,26 @@
     <span class="pill good">{{ measured.provider_row.sample_count }} samples</span>
   </div>
   <div class="panel-body">
-    <p class="muted-copy">Continuously sampled across {{ provider.name }}'s routed models — p50 TTFT, throughput, and success rate. Unsupported route and probe-configuration rows are separated from provider downtime. No prompt or output content stored.</p>
+    <p class="muted-copy">Continuously sampled across {{ provider.name }}'s routed models: p50 TTFT, effective throughput, and success rate. Effective throughput uses provider-reported output tokens over complete request time. Unsupported route and probe-configuration rows are separated from provider downtime. No prompt or output content stored.</p>
     <table>
       <tbody>
         <tr><th>p50 TTFT</th><td>{% if measured.provider_row.p50_ttft_ms is not none %}{{ measured.provider_row.p50_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
-        <tr><th>Throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td></tr>
-        <tr><th>Uptime</th><td>{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%</td></tr>
+        <tr><th>Effective throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ measured.provider_row.throughput_sample_count|default(0) }}</span>{% else %}—{% endif %}</td></tr>
+        <tr><th>Uptime</th><td>{% if measured.provider_row.sample_count %}{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%{% else %}—{% endif %}</td></tr>
       </tbody>
     </table>
     {% if measured.models %}
     <div class="leaderboard-table-wrap" style="margin-top:12px">
       <table class="leaderboard-table">
-        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Throughput</th><th>Uptime</th><th>Config excluded</th><th>Samples</th></tr></thead>
+        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for m in measured.models %}
           <tr>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a></td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{{ '%.2f'|format(m.uptime * 100) }}%</td>
+            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
+            <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ m.sample_count }}</td>
           </tr>

--- a/src/trusted_router/templates/public/provider_performance.html
+++ b/src/trusted_router/templates/public/provider_performance.html
@@ -18,8 +18,8 @@
         <tr><th>p50 TTFT</th><td>{% if measured.provider_row.p50_ttft_ms is not none %}{{ measured.provider_row.p50_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
         <tr><th>p95 TTFT</th><td>{% if measured.provider_row.p95_ttft_ms is not none %}{{ measured.provider_row.p95_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
         <tr><th>p50 TTFB</th><td>{% if measured.provider_row.p50_ttfb_ms is not none %}{{ measured.provider_row.p50_ttfb_ms }} ms{% else %}—{% endif %}</td></tr>
-        <tr><th>Throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td></tr>
-        <tr><th>Uptime</th><td>{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%</td></tr>
+        <tr><th>Effective throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ measured.provider_row.throughput_sample_count|default(0) }}</span>{% else %}—{% endif %}</td></tr>
+        <tr><th>Uptime</th><td>{% if measured.provider_row.sample_count %}{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%{% else %}—{% endif %}</td></tr>
       </tbody>
     </table>
     {% endif %}
@@ -32,15 +32,15 @@
   <div class="panel-body">
     <div class="leaderboard-table-wrap">
       <table class="leaderboard-table">
-        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Throughput</th><th>Uptime</th><th>Config excluded</th><th>Samples</th></tr></thead>
+        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for m in measured.models %}
           <tr>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a></td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{{ '%.2f'|format(m.uptime * 100) }}%</td>
+            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
+            <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ m.sample_count }}</td>
           </tr>

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -16,6 +16,8 @@ def _sample(
     ttft: int | None = None,
     ttfb: int | None = None,
     tps: float | None = None,
+    output_tokens: int = 0,
+    elapsed_milliseconds: int | None = None,
     error_type: str | None = None,
     error_status: int | None = None,
     source: str = "organic",
@@ -32,6 +34,8 @@ def _sample(
         first_token_milliseconds=ttft,
         ttfb_milliseconds=ttfb,
         speed_tokens_per_second=tps,
+        output_tokens=output_tokens,
+        elapsed_milliseconds=elapsed_milliseconds,
         error_type=error_type,
         error_status=error_status,
         source=source,
@@ -151,6 +155,49 @@ def test_sustained_throughput_replaces_legacy_speed_without_affecting_uptime() -
     assert provider["p50_tokens_per_second"] == 500.0
     assert result["total_samples"] == 2
     assert result["total_throughput_samples"] == 2
+
+
+def test_sustained_throughput_recomputes_legacy_buffered_rows() -> None:
+    samples = [
+        _sample(provider="p", model="p/m", ttft=100),
+        _sample(
+            provider="p",
+            model="p/m",
+            tps=5000.0,
+            output_tokens=200,
+            elapsed_milliseconds=10_000,
+            source="synthetic_throughput",
+        ),
+    ]
+
+    result = aggregate_leaderboard(samples)
+
+    assert result["models"][0]["p50_tokens_per_second"] == 20.0
+    assert result["providers"][0]["p50_tokens_per_second"] == 20.0
+
+
+def test_throughput_only_route_is_visible_without_claiming_availability() -> None:
+    result = aggregate_leaderboard(
+        [
+            _sample(
+                provider="p",
+                model="p/throughput-only",
+                tps=4000.0,
+                output_tokens=240,
+                elapsed_milliseconds=6000,
+                source="synthetic_throughput",
+            )
+        ]
+    )
+
+    model = result["models"][0]
+    assert model["model"] == "p/throughput-only"
+    assert model["sample_count"] == 0
+    assert model["uptime"] is None
+    assert model["throughput_sample_count"] == 1
+    assert model["p50_tokens_per_second"] == 40.0
+    assert result["providers"][0]["sample_count"] == 0
+    assert result["providers"][0]["uptime"] is None
 
 
 def test_public_benchmark_samples_reads_each_provider(monkeypatch) -> None:

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -4,7 +4,11 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.routes.public import _status_page_html
+from trusted_router.routes.public import (
+    LEADERBOARD_RECENT_WINDOW_MINUTES,
+    LEADERBOARD_SAMPLE_LIMIT,
+    _status_page_html,
+)
 from trusted_router.storage import STORE, ProviderBenchmarkSample
 
 
@@ -24,10 +28,10 @@ def _settings() -> Settings:
 
 
 def _seed(provider: str, model: str, ttft: int, ttfb: int) -> None:
-    for _ in range(3):
+    for index in range(3):
         STORE.record_provider_benchmark(
             ProviderBenchmarkSample(
-                id=f"bench-page-{provider}-{model}-{ttft}",
+                id=f"bench-page-{provider}-{model}-{ttft}-{index}",
                 model=model,
                 provider=provider,
                 provider_name=provider.title(),
@@ -40,6 +44,21 @@ def _seed(provider: str, model: str, ttft: int, ttfb: int) -> None:
                 source="synthetic",
             )
         )
+    STORE.record_provider_benchmark(
+        ProviderBenchmarkSample(
+            id=f"bench-page-throughput-{provider}-{model}",
+            model=model,
+            provider=provider,
+            provider_name=provider.title(),
+            status="success",
+            usage_type="Credits",
+            streamed=True,
+            output_tokens=200,
+            elapsed_milliseconds=1000,
+            speed_tokens_per_second=9000.0,
+            source="synthetic_throughput",
+        )
+    )
 
 
 def _seed_excluded(provider: str, model: str) -> None:
@@ -68,8 +87,11 @@ def test_leaderboard_page_renders_measurements() -> None:
     assert resp.status_code == 200
     body = resp.text
     assert "Measured performance" in body  # hero eyebrow
-    assert "5,000-sample benchmark set" in body
+    assert "rolling benchmark set of up to 10,000 samples" in body
     assert "p50 TTFT" in body  # table header
+    assert "Effective throughput" in body
+    assert "200 tok/s" in body
+    assert "n=1" in body
     assert "cerebras" in body  # seeded provider row
     assert "meta/llama-3.3-70b" in body  # seeded model row
 
@@ -94,6 +116,11 @@ def test_leaderboard_in_sitemap() -> None:
     assert "/leaderboard" in resp.text
 
 
+def test_leaderboard_uses_a_bounded_full_day_sample_window() -> None:
+    assert LEADERBOARD_SAMPLE_LIMIT == 10_000
+    assert LEADERBOARD_RECENT_WINDOW_MINUTES == 24 * 60
+
+
 def test_status_page_surfaces_upstream_provider_errors() -> None:
     # The rotation-probe error data feeds an informational provider-health
     # section on /status (separate from the router-core SLO). Render the page
@@ -113,7 +140,7 @@ def test_status_page_surfaces_upstream_provider_errors() -> None:
     )
     html = _status_page_html(_settings(), host="trustedrouter.com")
     assert "Upstream provider health" in html
-    assert "5,000-sample benchmark set" in html
+    assert "rolling benchmark set of up to 10,000 samples" in html
     assert "cerebras" in html
     assert "http_404" in html  # the captured error type is surfaced
 

--- a/tests/test_provider_throughput_rank.py
+++ b/tests/test_provider_throughput_rank.py
@@ -14,15 +14,15 @@ LEADERBOARD_HTML = """
   <thead>
     <tr>
       <th>#</th><th>Provider</th><th>Models</th><th>p50 TTFT</th>
-      <th>Throughput</th><th>Uptime</th><th>Errors</th><th>Config excluded</th><th>Samples</th>
+      <th>Effective throughput</th><th>Uptime</th><th>Errors</th><th>Config excluded</th><th>Availability samples</th>
     </tr>
   </thead>
   <tbody>
-    <tr><td>1</td><td>deepseek</td><td>2</td><td>3521 ms</td><td>53 tok/s</td><td>100.00%</td><td>—</td><td>—</td><td>111</td></tr>
-    <tr><td>2</td><td>baseten</td><td>11</td><td>3349 ms</td><td>55 tok/s</td><td>98.40%</td><td>—</td><td>—</td><td>125</td></tr>
-    <tr><td>3</td><td>novita</td><td>27</td><td>3534 ms</td><td>9 tok/s</td><td>92.11%</td><td>provider_error 8%</td><td>—</td><td>38</td></tr>
+    <tr><td>1</td><td>deepseek</td><td>2</td><td>3521 ms</td><td>53 tok/s n=12</td><td>100.00%</td><td>—</td><td>—</td><td>111</td></tr>
+    <tr><td>2</td><td>baseten</td><td>11</td><td>3349 ms</td><td>55 tok/s n=18</td><td>98.40%</td><td>—</td><td>—</td><td>125</td></tr>
+    <tr><td>3</td><td>novita</td><td>27</td><td>3534 ms</td><td>9 tok/s n=3</td><td>92.11%</td><td>provider_error 8%</td><td>—</td><td>38</td></tr>
     <tr><td>4</td><td>openai</td><td>11</td><td>2579 ms</td><td>—</td><td>100.00%</td><td>—</td><td>—</td><td>44</td></tr>
-    <tr><td>5</td><td>crusoe</td><td>12</td><td>2888 ms</td><td>2 tok/s</td><td>100.00%</td><td>—</td><td>—</td><td>24</td></tr>
+    <tr><td>5</td><td>crusoe</td><td>12</td><td>2888 ms</td><td>2 tok/s n=2</td><td>100.00%</td><td>—</td><td>—</td><td>24</td></tr>
   </tbody>
 </table>
 """
@@ -33,6 +33,7 @@ def test_parse_provider_rows_from_public_leaderboard_table() -> None:
 
     assert rows[0].provider == "deepseek"
     assert rows[0].throughput_tokens_per_second == 53
+    assert rows[0].throughput_samples == 12
     assert rows[0].uptime == 1.0
     assert rows[0].samples == 111
     assert rows[0].p50_ttft_ms == 3521
@@ -43,6 +44,7 @@ def test_measured_rank_uses_positive_throughput_with_sample_and_uptime_guards() 
     rows = parse_provider_rows(LEADERBOARD_HTML)
 
     assert measured_rank(rows) == ["baseten", "deepseek"]
+    assert measured_rank(rows, min_throughput_samples=13) == ["baseten"]
 
 
 def test_build_rank_block_places_measured_providers_before_secondary_priors() -> None:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1841,6 +1841,10 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=false"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ENABLED=false"' in body
     assert '"*/2 * * * *"' in body
+    assert 'throughput_scheduler_name="${throughput_job_name}-every-minute"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=60"' in body
+    assert '"* * * * *"' in body
+    assert "legacy_throughput_scheduler_name" in body
 
 
 class _FakeCell:

--- a/tests/test_synthetic_throughput.py
+++ b/tests/test_synthetic_throughput.py
@@ -17,6 +17,7 @@ from trusted_router.synthetic.probes import (
     rotation_candidates,
 )
 from trusted_router.synthetic.throughput import (
+    THROUGHPUT_INTERVAL_SECONDS,
     choose_throughput_target,
     projected_monthly_cost_microdollars,
     throughput_candidates,
@@ -62,6 +63,7 @@ def test_throughput_round_robin_visits_every_route_once_per_cycle() -> None:
     assert choose_throughput_target([]) is None
     with pytest.raises(ValueError, match="interval_seconds"):
         choose_throughput_target(candidates, interval_seconds=0)
+    assert THROUGHPUT_INTERVAL_SECONDS == 60
 
 
 def test_top_200_monthly_full_cap_cost_stays_inside_reviewed_budget() -> None:
@@ -69,11 +71,11 @@ def test_top_200_monthly_full_cap_cost_stays_inside_reviewed_budget() -> None:
     projected = projected_monthly_cost_microdollars(candidates)
 
     assert projected > 0
-    assert projected <= 75_000_000
+    assert projected <= 150_000_000
 
 
 @pytest.mark.asyncio
-async def test_throughput_probe_measures_decode_speed_after_first_token() -> None:
+async def test_throughput_probe_measures_effective_end_to_end_speed() -> None:
     captured: list[dict[str, Any]] = []
     chunks = [
         b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
@@ -121,13 +123,58 @@ async def test_throughput_probe_measures_decode_speed_after_first_token() -> Non
     assert sample.output_tokens == 251
     assert sample.first_token_milliseconds == 200
     assert sample.ttfb_milliseconds == 100
-    assert sample.speed_tokens_per_second == 500.0
+    assert sample.elapsed_milliseconds == 1000
+    assert sample.speed_tokens_per_second == 251.0
     assert sample.total_cost_microdollars > 0
     assert sample.finish_reason == "length"
     assert captured[0]["max_tokens"] == 512
     assert captured[0]["stream_options"] == {"include_usage": True}
     assert captured[0]["provider"] == {"only": ["cerebras"]}
     assert captured[0]["metadata"]["trustedrouter_probe"] == "throughput"
+
+
+@pytest.mark.asyncio
+async def test_throughput_probe_accepts_buffered_sse_without_inflating_speed() -> None:
+    chunks = [
+        (
+            b'data: {"choices":[{"delta":{"content":"benchmark benchmark"}}]}\n\n'
+            b'data: {"choices":[{"delta":{},"finish_reason":"length"}],'
+            b'"usage":{"prompt_tokens":20,"completion_tokens":200}}\n\n'
+            b"data: [DONE]\n\n"
+        )
+    ]
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "x-trustedrouter-provider": "cerebras",
+                "x-trustedrouter-served-model": "cerebras/gpt-oss-120b",
+            },
+            stream=_ChunkStream(chunks),
+        )
+
+    clock = iter([0.0, 0.25, 5.0])
+    target = SyntheticTarget(
+        "throughput",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_throughput_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="cerebras",
+            model="cerebras/gpt-oss-120b",
+            clock=lambda: next(clock),
+        )
+
+    assert sample.status == "success"
+    assert sample.first_token_milliseconds == 250
+    assert sample.elapsed_milliseconds == 5000
+    assert sample.speed_tokens_per_second == 40.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand public benchmark coverage to a bounded 10,000-sample, 24-hour window
- report buffering-safe effective throughput from request start through completion
- surface throughput sample depth separately and prevent thin data from changing routing ranks
- double long-probe cadence to one route per minute with safe scheduler replacement

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1958 passed, 47 skipped)
- npx tsc
- npx eslint frontend/src
- npx stylelint "src/trusted_router/static/*.css"
- bash -n scripts/deploy/synthetic.sh
- git diff --check