### PR TITLE
billing: pass Stripe processing fees through to credit purchases

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -100,6 +100,13 @@ class Settings(BaseSettings):
     internal_gateway_token: str | None = None
     stripe_webhook_secret: str | None = None
     stripe_secret_key: str | None = None
+    # Standard US Stripe processing schedules. These are grossed up against
+    # the complete charge so the requested credit principal remains intact.
+    # They are explicit config because negotiated Stripe pricing can differ.
+    stripe_card_fee_basis_points: int = 290
+    stripe_card_fee_fixed_cents: int = 30
+    stripe_stablecoin_fee_basis_points: int = 150
+    stripe_stablecoin_fee_fixed_cents: int = 0
     paypal_client_id: str | None = None
     paypal_client_secret: str | None = None
     paypal_webhook_id: str | None = None
@@ -247,6 +254,24 @@ class Settings(BaseSettings):
         environment = self.environment.lower()
         if self.signup_trial_credit_microdollars < 0:
             raise ValueError("TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS cannot be negative")
+        for name, value in (
+            ("TR_STRIPE_CARD_FEE_BASIS_POINTS", self.stripe_card_fee_basis_points),
+            (
+                "TR_STRIPE_STABLECOIN_FEE_BASIS_POINTS",
+                self.stripe_stablecoin_fee_basis_points,
+            ),
+        ):
+            if not 0 <= value < 10_000:
+                raise ValueError(f"{name} must be between 0 and 9999")
+        for name, value in (
+            ("TR_STRIPE_CARD_FEE_FIXED_CENTS", self.stripe_card_fee_fixed_cents),
+            (
+                "TR_STRIPE_STABLECOIN_FEE_FIXED_CENTS",
+                self.stripe_stablecoin_fee_fixed_cents,
+            ),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} cannot be negative")
         if not 1 <= self.google_ads_conversion_feed_retention_days <= 90:
             raise ValueError(
                 "TR_GOOGLE_ADS_CONVERSION_FEED_RETENTION_DAYS must be between 1 and 90"

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -73,7 +73,8 @@ def register(router: APIRouter) -> None:
 
         if event_type == "checkout.session.completed":
             obj = event.get("data", {}).get("object", {})
-            workspace_id = obj.get("metadata", {}).get("workspace_id")
+            metadata = obj.get("metadata") or {}
+            workspace_id = metadata.get("workspace_id")
             amount_total = int(obj.get("amount_total") or 0)
             customer_id = obj.get("customer")
             if workspace_id and STORE.get_credit_account(workspace_id) is not None:
@@ -87,13 +88,17 @@ def register(router: APIRouter) -> None:
                             "trial_credit_granted_microdollars": 0,
                         }
                     }
+                amount_microdollars = _checkout_credit_amount_microdollars(
+                    metadata=metadata,
+                    amount_total_cents=amount_total,
+                )
                 credited = STORE.credit_workspace_typed_direct(
-                    workspace_id, amount_total * MICRODOLLARS_PER_CENT, event_id
+                    workspace_id, amount_microdollars, event_id
                 )
                 if credited:
                     record_credit_purchase(
                         workspace_id,
-                        amount_microdollars=amount_total * MICRODOLLARS_PER_CENT,
+                        amount_microdollars=amount_microdollars,
                         payment_method="stripe",
                     )
                 # Capture the Stripe customer the first time they pay so
@@ -106,6 +111,7 @@ def register(router: APIRouter) -> None:
                 return {
                     "data": {
                         "credited": credited,
+                        "credited_microdollars": amount_microdollars,
                         "event_id": event_id,
                         # Kept for response compatibility. Starter credit is
                         # granted atomically at account creation, never here.
@@ -175,7 +181,10 @@ def register(router: APIRouter) -> None:
                 and isinstance(workspace_id, str)
                 and isinstance(amount_microdollars_raw, str)
             ):
-                amount_microdollars = int(amount_microdollars_raw)
+                amount_microdollars = _auto_refill_credit_amount_microdollars(
+                    metadata=metadata,
+                    payment_intent_amount_cents=obj.get("amount"),
+                )
                 credited = STORE.credit_workspace_typed_direct(
                     workspace_id, amount_microdollars, event_id
                 )
@@ -265,3 +274,88 @@ def register(router: APIRouter) -> None:
                 }
 
         return {"data": {"ignored": True, "event_id": event_id}}
+
+
+def _checkout_credit_amount_microdollars(
+    *,
+    metadata: dict[str, Any],
+    amount_total_cents: int,
+) -> int:
+    """Return credit principal, excluding the separately charged fee.
+
+    Sessions created before fee pass-through have no principal metadata and
+    retain the legacy amount_total behavior. New sessions fail closed if the
+    signed Stripe event contains malformed or impossible principal metadata.
+    """
+    raw = metadata.get("credit_amount_microdollars")
+    if raw is None:
+        return amount_total_cents * MICRODOLLARS_PER_CENT
+    processing_fee_raw = metadata.get("processing_fee_cents")
+    charge_amount_raw = metadata.get("charge_amount_cents")
+    if (
+        not isinstance(raw, str)
+        or not isinstance(processing_fee_raw, str)
+        or not isinstance(charge_amount_raw, str)
+    ):
+        raise api_error(400, "Invalid Stripe credit amount", ErrorType.BAD_REQUEST)
+    try:
+        amount_microdollars = int(raw)
+        processing_fee_cents = int(processing_fee_raw)
+        charge_amount_cents = int(charge_amount_raw)
+    except ValueError as exc:
+        raise api_error(400, "Invalid Stripe credit amount", ErrorType.BAD_REQUEST) from exc
+    if (
+        amount_microdollars <= 0
+        or amount_microdollars % MICRODOLLARS_PER_CENT
+        or processing_fee_cents < 0
+        or charge_amount_cents != amount_total_cents
+        or amount_microdollars // MICRODOLLARS_PER_CENT + processing_fee_cents
+        != amount_total_cents
+    ):
+        raise api_error(400, "Invalid Stripe credit amount", ErrorType.BAD_REQUEST)
+    return amount_microdollars
+
+
+def _auto_refill_credit_amount_microdollars(
+    *,
+    metadata: dict[str, Any],
+    payment_intent_amount_cents: Any,
+) -> int:
+    raw = metadata.get("amount_microdollars")
+    if not isinstance(raw, str):
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST)
+    try:
+        amount_microdollars = int(raw)
+    except ValueError as exc:
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST) from exc
+    if amount_microdollars <= 0 or amount_microdollars % MICRODOLLARS_PER_CENT:
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST)
+
+    charge_amount_raw = metadata.get("charge_amount_cents")
+    if charge_amount_raw is None:
+        # Legacy PaymentIntents predate explicit fee metadata.
+        return amount_microdollars
+    processing_fee_raw = metadata.get("processing_fee_cents")
+    credit_amount_raw = metadata.get("credit_amount_microdollars")
+    if (
+        not isinstance(charge_amount_raw, str)
+        or not isinstance(processing_fee_raw, str)
+        or not isinstance(credit_amount_raw, str)
+        or not isinstance(payment_intent_amount_cents, int)
+    ):
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST)
+    try:
+        charge_amount_cents = int(charge_amount_raw)
+        processing_fee_cents = int(processing_fee_raw)
+        credit_amount_microdollars = int(credit_amount_raw)
+    except ValueError as exc:
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST) from exc
+    if (
+        processing_fee_cents < 0
+        or credit_amount_microdollars != amount_microdollars
+        or charge_amount_cents != payment_intent_amount_cents
+        or amount_microdollars // MICRODOLLARS_PER_CENT + processing_fee_cents
+        != charge_amount_cents
+    ):
+        raise api_error(400, "Invalid Stripe refill amount", ErrorType.BAD_REQUEST)
+    return amount_microdollars

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -54,6 +54,8 @@ class CheckoutRequest(_Lenient):
             raise ValueError("amount must be at least 1")
         if microdollars > MAX_CHECKOUT_DOLLARS * MICRODOLLARS_PER_DOLLAR:
             raise ValueError(f"amount must be at most {MAX_CHECKOUT_DOLLARS}")
+        if microdollars % MICRODOLLARS_PER_CENT != 0:
+            raise ValueError("amount must be exactly representable in cents")
         return Decimal(str(value))
 
 

--- a/src/trusted_router/services/auto_refill.py
+++ b/src/trusted_router/services/auto_refill.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from trusted_router.config import Settings
+from trusted_router.services.stripe_fees import stripe_processing_fee
 from trusted_router.storage import STORE
 from trusted_router.storage_models import CreditAccount
 from trusted_router.typed_balance import live_credit_summary
@@ -94,25 +96,42 @@ def maybe_charge_after_settle(
         return AutoRefillOutcome(fired=False, reason="stripe_not_installed")
 
     stripe.api_key = settings.stripe_secret_key
-    cents = max(50, account.auto_refill_amount_microdollars // 10_000)
+    credit_amount_cents = max(50, account.auto_refill_amount_microdollars // 10_000)
+    fee = stripe_processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=settings.stripe_card_fee_basis_points,
+        fixed_fee_cents=settings.stripe_card_fee_fixed_cents,
+    )
     idempotency_key = (
-        f"auto-refill:{workspace_id}:{cents}:"
+        f"auto-refill:{workspace_id}:{fee.charge_amount_cents}:"
         f"{datetime.now(UTC).strftime('%Y%m%d%H%M')}"
+    )
+    metadata = fee.metadata(
+        workspace_id=workspace_id,
+        payment_method="card",
+    )
+    metadata.update(
+        {
+            "auto_refill": "true",
+            # Preserve the configured ledger principal even if a legacy
+            # account somehow contains a sub-cent value.
+            "amount_microdollars": str(account.auto_refill_amount_microdollars),
+        }
     )
     try:
         intent = stripe.PaymentIntent.create(
-            amount=cents,
+            amount=fee.charge_amount_cents,
             currency="usd",
             customer=account.stripe_customer_id,
             payment_method=account.stripe_payment_method_id,
             off_session=True,
             confirm=True,
             description="TrustedRouter auto-refill",
-            metadata={
-                "workspace_id": workspace_id,
-                "auto_refill": "true",
-                "amount_microdollars": str(account.auto_refill_amount_microdollars),
-            },
+            amount_details=cast(
+                Any,
+                {"line_items": fee.payment_intent_line_items()},
+            ),
+            metadata=metadata,
             idempotency_key=idempotency_key,
         )
     except stripe.CardError as exc:

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -7,8 +7,9 @@ import stripe
 
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
-from trusted_router.money import dollars_to_cents, dollars_to_microdollars, money_pair
+from trusted_router.money import dollars_to_cents, money_pair
 from trusted_router.schemas import CheckoutRequest
+from trusted_router.services.stripe_fees import stripe_processing_fee
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
 
@@ -20,7 +21,6 @@ def create_checkout_session(
     customer_email: str | None,
     settings: Settings,
 ) -> dict[str, Any]:
-    amount_microdollars = dollars_to_microdollars(body.amount)
     workspace = STORE.get_workspace(workspace_id)
     if workspace is None:
         raise api_error(404, "Workspace not found", ErrorType.NOT_FOUND)
@@ -28,32 +28,40 @@ def create_checkout_session(
     success_url = body.success_url or f"https://{settings.trusted_domain}/billing/success"
     cancel_url = body.cancel_url or f"https://{settings.trusted_domain}/billing"
     amount_cents = dollars_to_cents(body.amount)
+    amount_microdollars = amount_cents * 10_000
     stablecoin_requested = body.payment_method in {"stablecoin", "crypto", "usdc"}
     if stablecoin_requested and not settings.stablecoin_checkout_enabled:
         raise api_error(400, "Stablecoin checkout is not enabled", ErrorType.BAD_REQUEST)
+    fee = stripe_processing_fee(
+        credit_amount_cents=amount_cents,
+        variable_basis_points=(
+            settings.stripe_stablecoin_fee_basis_points
+            if stablecoin_requested
+            else settings.stripe_card_fee_basis_points
+        ),
+        fixed_fee_cents=(
+            settings.stripe_stablecoin_fee_fixed_cents
+            if stablecoin_requested
+            else settings.stripe_card_fee_fixed_cents
+        ),
+    )
+    payment_method = "stablecoin" if stablecoin_requested else "card"
+    payment_metadata = fee.metadata(
+        workspace_id=workspace_id,
+        payment_method=payment_method,
+    )
     if settings.stripe_secret_key:
         stripe.api_key = settings.stripe_secret_key
         session_args: dict[str, Any] = {
             "mode": "payment",
             "success_url": success_url,
             "cancel_url": cancel_url,
-            "line_items": [
-                {
-                    "price_data": {
-                        "currency": "usd",
-                        "product_data": {"name": "TrustedRouter credits"},
-                        "unit_amount": amount_cents,
-                    },
-                    "quantity": 1,
-                }
-            ],
-            "metadata": {
-                "workspace_id": workspace_id,
-                "payment_method": "stablecoin" if stablecoin_requested else "auto",
-            },
+            "line_items": fee.checkout_line_items(),
+            "metadata": payment_metadata,
         }
         if stablecoin_requested:
             session_args["payment_method_types"] = ["crypto"]
+            session_args["payment_intent_data"] = {"metadata": payment_metadata}
             if customer_email:
                 session_args["customer_email"] = customer_email
         else:
@@ -64,7 +72,7 @@ def create_checkout_session(
             session_args["customer_creation"] = "always"
             session_args["payment_intent_data"] = {
                 "setup_future_usage": "off_session",
-                "metadata": {"workspace_id": workspace_id},
+                "metadata": payment_metadata,
             }
         session = stripe.checkout.Session.create(**session_args)
         return {
@@ -72,6 +80,8 @@ def create_checkout_session(
             "url": session["url"],
             "workspace_id": workspace_id,
             **money_pair("amount", amount_microdollars),
+            **money_pair("processing_fee", fee.processing_fee_microdollars),
+            **money_pair("total", fee.charge_amount_microdollars),
             "mode": "stripe_stablecoin" if stablecoin_requested else "stripe",
         }
 
@@ -80,6 +90,8 @@ def create_checkout_session(
         "url": f"https://{settings.trusted_domain}/billing/mock-checkout",
         "workspace_id": workspace_id,
         **money_pair("amount", amount_microdollars),
+        **money_pair("processing_fee", fee.processing_fee_microdollars),
+        **money_pair("total", fee.charge_amount_microdollars),
         "mode": "mock_stablecoin" if stablecoin_requested else "mock",
     }
 
@@ -262,6 +274,8 @@ def list_workspace_payments(
           "payment_intent": "pi_...",
           "created_at": <unix ts>,
           "amount_cents": int,
+          "credit_amount_cents": int | None,
+          "processing_fee_cents": int | None,
           "currency": "usd",
           "status": "succeeded" | "processing" | "requires_payment_method" | ...,
           "receipt_url": str | None,
@@ -320,6 +334,14 @@ def list_workspace_payments(
             "payment_intent": pi_data.get("id"),
             "created_at": pi_data.get("created"),
             "amount_cents": int(pi_data.get("amount") or 0),
+            "credit_amount_cents": _metadata_microdollars_to_cents(
+                pi_data.get("metadata"),
+                key="credit_amount_microdollars",
+            ),
+            "processing_fee_cents": _metadata_int(
+                pi_data.get("metadata"),
+                key="processing_fee_cents",
+            ),
             "currency": pi_data.get("currency") or "usd",
             "status": pi_data.get("status"),
             # Display-shaped synonym so the template doesn't need to know
@@ -333,3 +355,23 @@ def list_workspace_payments(
             "card_last4": card_last4,
         })
     return out
+
+
+def _metadata_int(metadata: Any, *, key: str) -> int | None:
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get(key)
+    if not isinstance(raw, str):
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _metadata_microdollars_to_cents(metadata: Any, *, key: str) -> int | None:
+    value = _metadata_int(metadata, key=key)
+    if value is None or value % 10_000:
+        return None
+    return value // 10_000

--- a/src/trusted_router/services/stripe_fees.py
+++ b/src/trusted_router/services/stripe_fees.py
@@ -1,0 +1,138 @@
+"""Integer-only Stripe processing-fee calculation and line-item shaping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from trusted_router.money import MICRODOLLARS_PER_CENT
+
+CREDITS_LINE_ITEM_NAME = "TrustedRouter credits"
+PROCESSING_FEE_LINE_ITEM_NAME = "Payment processing fee"
+
+
+@dataclass(frozen=True)
+class StripeProcessingFee:
+    """A charge whose net principal remains the requested credit amount."""
+
+    credit_amount_cents: int
+    processing_fee_cents: int
+    charge_amount_cents: int
+    variable_basis_points: int
+    fixed_fee_cents: int
+
+    @property
+    def credit_amount_microdollars(self) -> int:
+        return self.credit_amount_cents * MICRODOLLARS_PER_CENT
+
+    @property
+    def processing_fee_microdollars(self) -> int:
+        return self.processing_fee_cents * MICRODOLLARS_PER_CENT
+
+    @property
+    def charge_amount_microdollars(self) -> int:
+        return self.charge_amount_cents * MICRODOLLARS_PER_CENT
+
+    def estimated_processor_cost_cents(self) -> int:
+        variable = _ceil_div(
+            self.charge_amount_cents * self.variable_basis_points,
+            10_000,
+        )
+        return variable + self.fixed_fee_cents
+
+    def checkout_line_items(self) -> list[dict[str, Any]]:
+        items = [
+            {
+                "price_data": {
+                    "currency": "usd",
+                    "product_data": {"name": CREDITS_LINE_ITEM_NAME},
+                    "unit_amount": self.credit_amount_cents,
+                },
+                "quantity": 1,
+            }
+        ]
+        if self.processing_fee_cents:
+            items.append(
+                {
+                    "price_data": {
+                        "currency": "usd",
+                        "product_data": {"name": PROCESSING_FEE_LINE_ITEM_NAME},
+                        "unit_amount": self.processing_fee_cents,
+                    },
+                    "quantity": 1,
+                }
+            )
+        return items
+
+    def payment_intent_line_items(self) -> list[dict[str, Any]]:
+        items = [
+            {
+                "product_name": CREDITS_LINE_ITEM_NAME,
+                "quantity": 1,
+                "unit_cost": self.credit_amount_cents,
+            }
+        ]
+        if self.processing_fee_cents:
+            items.append(
+                {
+                    "product_name": PROCESSING_FEE_LINE_ITEM_NAME,
+                    "quantity": 1,
+                    "unit_cost": self.processing_fee_cents,
+                }
+            )
+        return items
+
+    def metadata(
+        self,
+        *,
+        workspace_id: str,
+        payment_method: str,
+    ) -> dict[str, str]:
+        return {
+            "workspace_id": workspace_id,
+            "payment_method": payment_method,
+            "credit_amount_microdollars": str(self.credit_amount_microdollars),
+            "processing_fee_cents": str(self.processing_fee_cents),
+            "charge_amount_cents": str(self.charge_amount_cents),
+            "fee_variable_basis_points": str(self.variable_basis_points),
+            "fee_fixed_cents": str(self.fixed_fee_cents),
+        }
+
+
+def stripe_processing_fee(
+    *,
+    credit_amount_cents: int,
+    variable_basis_points: int,
+    fixed_fee_cents: int,
+) -> StripeProcessingFee:
+    """Gross up a USD-cent principal so it survives the configured fee.
+
+    If the processor charges ``rate * total + fixed``, the total required
+    to preserve ``principal`` is ``ceil((principal + fixed) / (1-rate))``.
+    All operations stay integer-only and round in the customer's favor only
+    when doing so still covers the configured processing cost.
+    """
+    if credit_amount_cents <= 0:
+        raise ValueError("credit_amount_cents must be positive")
+    if not 0 <= variable_basis_points < 10_000:
+        raise ValueError("variable_basis_points must be between 0 and 9999")
+    if fixed_fee_cents < 0:
+        raise ValueError("fixed_fee_cents cannot be negative")
+
+    denominator = 10_000 - variable_basis_points
+    charge_amount_cents = _ceil_div(
+        (credit_amount_cents + fixed_fee_cents) * 10_000,
+        denominator,
+    )
+    processing_fee_cents = charge_amount_cents - credit_amount_cents
+    return StripeProcessingFee(
+        credit_amount_cents=credit_amount_cents,
+        processing_fee_cents=processing_fee_cents,
+        charge_amount_cents=charge_amount_cents,
+        variable_basis_points=variable_basis_points,
+        fixed_fee_cents=fixed_fee_cents,
+    )
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -24,6 +24,10 @@
         </label>
       </div>
       <button class="btn primary" type="submit">Continue to checkout</button>
+      <p class="form-help">
+        Stripe shows your credits and the payment processing fee as separate
+        line items before you pay. Only the credit amount is added to your balance.
+      </p>
     </form>
   </div>
 </section>
@@ -95,8 +99,9 @@
   <div class="panel-body">
     <p style="color:var(--muted);font-size:14px;margin:0 0 14px">
       When your available balance drops below the threshold, we'll charge
-      your saved card and add the refill amount automatically. Disabling
-      stops future charges but keeps your saved payment method.
+      your saved card for the refill amount plus a separate payment processing
+      fee, then add only the refill amount to your balance. Disabling stops
+      future charges but keeps your saved payment method.
       {% if payment_method_pending %}
       <br><strong>Stripe is still confirming your payment method.</strong>
       {% elif not has_payment_method %}
@@ -152,6 +157,12 @@
           <td style="padding:10px 6px;font-variant-numeric:tabular-nums">
             ${{ '%.2f'|format((p.amount_cents or 0) / 100) }}
             <span style="color:var(--muted);font-size:11px">{{ (p.currency or 'usd')|upper }}</span>
+            {% if p.get('credit_amount_cents') is not none and p.get('processing_fee_cents') is not none %}
+            <span style="display:block;color:var(--muted);font-size:11px">
+              ${{ '%.2f'|format(p.credit_amount_cents / 100) }} credits
+              + ${{ '%.2f'|format(p.processing_fee_cents / 100) }} fee
+            </span>
+            {% endif %}
           </td>
           <td style="padding:10px 6px">
             {% if p.card_brand and p.card_last4 %}

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -30,7 +30,13 @@ def test_stablecoin_checkout_uses_stripe_crypto_payment_method(monkeypatch) -> N
     assert data["mode"] == "stripe_stablecoin"
     assert captured["payment_method_types"] == ["crypto"]
     assert captured["customer_email"] == "alice@example.com"
-    assert captured["metadata"] == {"workspace_id": data["workspace_id"], "payment_method": "stablecoin"}
+    metadata = captured["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["workspace_id"] == data["workspace_id"]
+    assert metadata["payment_method"] == "stablecoin"
+    assert metadata["credit_amount_microdollars"] == "25000000"
+    assert metadata["processing_fee_cents"] == "39"
+    assert metadata["charge_amount_cents"] == "2539"
 
 
 def test_trustedrouter_auto_rolls_over_to_next_provider(

--- a/tests/test_auto_refill.py
+++ b/tests/test_auto_refill.py
@@ -146,8 +146,9 @@ def test_auto_refill_fires_below_threshold(
     assert outcome.payment_intent_id == "pi_test_abc"
     create.assert_called_once()
     kwargs = create.call_args.kwargs
-    # Convert microdollars to cents: $20 → 2000 cents.
-    assert kwargs["amount"] == 2000
+    # The user receives $20.00 in credits. The card charge separately
+    # includes the grossed-up 2.9% + 30c payment processing fee.
+    assert kwargs["amount"] == 2091
     assert kwargs["currency"] == "usd"
     assert kwargs["customer"] == "cus_test_123"
     assert kwargs["payment_method"] == "pm_test_456"
@@ -155,6 +156,21 @@ def test_auto_refill_fires_below_threshold(
     assert kwargs["confirm"] is True
     assert kwargs["metadata"]["workspace_id"] == configured_workspace
     assert kwargs["metadata"]["auto_refill"] == "true"
+    assert kwargs["metadata"]["amount_microdollars"] == "20000000"
+    assert kwargs["metadata"]["processing_fee_cents"] == "91"
+    assert kwargs["metadata"]["charge_amount_cents"] == "2091"
+    assert kwargs["amount_details"]["line_items"] == [
+        {
+            "product_name": "TrustedRouter credits",
+            "quantity": 1,
+            "unit_cost": 2000,
+        },
+        {
+            "product_name": "Payment processing fee",
+            "quantity": 1,
+            "unit_cost": 91,
+        },
+    ]
     assert "auto-refill" in kwargs.get("idempotency_key", "")
 
     # Status should be pending until the webhook lands.

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1031,7 +1031,9 @@ def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
         {
             "payment_intent": "pi_3TaPnB",
             "created_at": 1779582083,  # 2026-05-24 01:01 UTC
-            "amount_cents": 100,
+            "amount_cents": 134,
+            "credit_amount_cents": 100,
+            "processing_fee_cents": 34,
             "currency": "usd",
             "status": "succeeded",
             "payment_status": "paid",
@@ -1063,6 +1065,8 @@ def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
     assert "Payment history" in resp.text
     # Amount formatted as dollars
     assert "$1.00" in resp.text
+    assert "$0.34 fee" in resp.text
+    assert "$1.34" in resp.text
     assert "$5.00" in resp.text
     # Card brand + last4 displayed
     assert "visa" in resp.text.lower()

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -1225,10 +1225,11 @@ def test_console_checkout_redirects_to_stripe_stablecoin_session(monkeypatch) ->
     assert resp.headers["location"] == "https://checkout.stripe.test/session"
     assert captured["payment_method_types"] == ["crypto"]
     assert captured["customer_email"] == "checkout@example.com"
-    assert captured["metadata"] == {
-        "workspace_id": workspace.id,
-        "payment_method": "stablecoin",
-    }
+    assert captured["metadata"]["workspace_id"] == workspace.id
+    assert captured["metadata"]["payment_method"] == "stablecoin"
+    assert captured["metadata"]["credit_amount_microdollars"] == "25000000"
+    assert captured["metadata"]["processing_fee_cents"] == "39"
+    assert captured["metadata"]["charge_amount_cents"] == "2539"
     assert captured["success_url"].endswith("/console/credits?checkout=success")
     assert captured["cancel_url"].endswith("/console/credits?checkout=cancel")
 

--- a/tests/test_stripe_processing_fees.py
+++ b/tests/test_stripe_processing_fees.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.schemas import CheckoutRequest
+from trusted_router.services.stripe_fees import stripe_processing_fee
+from trusted_router.typed_balance import live_credit_summary
+
+
+def test_card_fee_grosses_up_principal_without_float_math() -> None:
+    fee = stripe_processing_fee(
+        credit_amount_cents=2_500,
+        variable_basis_points=290,
+        fixed_fee_cents=30,
+    )
+
+    assert fee.credit_amount_cents == 2_500
+    assert fee.processing_fee_cents == 106
+    assert fee.charge_amount_cents == 2_606
+    assert fee.estimated_processor_cost_cents() <= fee.processing_fee_cents
+
+
+def test_stablecoin_fee_grosses_up_principal_without_fixed_fee() -> None:
+    fee = stripe_processing_fee(
+        credit_amount_cents=2_500,
+        variable_basis_points=150,
+        fixed_fee_cents=0,
+    )
+
+    assert fee.processing_fee_cents == 39
+    assert fee.charge_amount_cents == 2_539
+    assert fee.estimated_processor_cost_cents() <= fee.processing_fee_cents
+
+
+@given(
+    credit_amount_cents=st.integers(min_value=100, max_value=1_000_000),
+    variable_basis_points=st.integers(min_value=0, max_value=900),
+    fixed_fee_cents=st.integers(min_value=0, max_value=100),
+)
+def test_processing_fee_is_minimal_and_always_preserves_principal(
+    credit_amount_cents: int,
+    variable_basis_points: int,
+    fixed_fee_cents: int,
+) -> None:
+    fee = stripe_processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=variable_basis_points,
+        fixed_fee_cents=fixed_fee_cents,
+    )
+
+    net_cents = fee.charge_amount_cents - fee.estimated_processor_cost_cents()
+    assert net_cents >= credit_amount_cents
+    if fee.charge_amount_cents > credit_amount_cents:
+        lower_charge = fee.charge_amount_cents - 1
+        lower_cost = (
+            lower_charge * variable_basis_points + 9_999
+        ) // 10_000 + fixed_fee_cents
+        assert lower_charge - lower_cost < credit_amount_cents
+
+
+def test_checkout_rejects_subcent_credit_amount() -> None:
+    with pytest.raises(ValidationError, match="exactly representable in cents"):
+        CheckoutRequest(amount="25.000001")
+
+
+def test_card_checkout_uses_separate_credit_and_processing_fee_line_items(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_checkout"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_fee", "url": "https://checkout.stripe.test/fee"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 25, "payment_method": "auto"},
+        )
+
+    assert response.status_code == 201, response.text
+    line_items = captured["line_items"]
+    assert [item["price_data"]["product_data"]["name"] for item in line_items] == [
+        "TrustedRouter credits",
+        "Payment processing fee",
+    ]
+    assert [item["price_data"]["unit_amount"] for item in line_items] == [2_500, 106]
+    assert captured["metadata"]["credit_amount_microdollars"] == "25000000"
+    assert captured["metadata"]["processing_fee_cents"] == "106"
+    assert captured["metadata"]["charge_amount_cents"] == "2606"
+    assert captured["payment_intent_data"]["metadata"] == captured["metadata"]
+
+    data = response.json()["data"]
+    assert data["amount_microdollars"] == 25_000_000
+    assert data["processing_fee_microdollars"] == 1_060_000
+    assert data["total_microdollars"] == 26_060_000
+
+
+def test_stablecoin_checkout_uses_stablecoin_fee_schedule(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_stablecoin"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_stablecoin_fee", "url": "https://checkout.stripe.test/stablecoin"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 25, "payment_method": "stablecoin"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert captured["payment_method_types"] == ["crypto"]
+    assert [item["price_data"]["unit_amount"] for item in captured["line_items"]] == [
+        2_500,
+        39,
+    ]
+    assert captured["metadata"]["processing_fee_cents"] == "39"
+    assert captured["payment_intent_data"]["metadata"] == captured["metadata"]
+    assert response.json()["data"]["total_microdollars"] == 25_390_000
+
+
+def test_checkout_webhook_credits_only_requested_principal_when_total_includes_fee(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+
+    event = {
+        "id": "evt_checkout_with_processing_fee",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "mode": "payment",
+                "amount_total": 2_606,
+                "customer": "cus_fee",
+                "metadata": {
+                    "workspace_id": workspace_id,
+                    "credit_amount_microdollars": "25000000",
+                    "processing_fee_cents": "106",
+                    "charge_amount_cents": "2606",
+                },
+            }
+        },
+    }
+
+    first = client.post("/v1/internal/stripe/webhook", json=event)
+    second = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["data"]["credited"] is True
+    assert first.json()["data"]["credited_microdollars"] == 25_000_000
+    assert second.json()["data"]["credited"] is False
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] - before["total_credits"] == 25_000_000
+
+
+def test_checkout_webhook_rejects_principal_larger_than_total_charge(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_checkout_invalid_principal",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "mode": "payment",
+                    "amount_total": 1_000,
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "credit_amount_microdollars": "11000000",
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] == before["total_credits"]
+
+
+def test_auto_refill_webhook_validates_charge_but_credits_only_principal(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_refill_with_processing_fee",
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "id": "pi_refill_with_processing_fee",
+                    "amount": 2_091,
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "payment_method": "card",
+                        "auto_refill": "true",
+                        "amount_microdollars": "20000000",
+                        "credit_amount_microdollars": "20000000",
+                        "processing_fee_cents": "91",
+                        "charge_amount_cents": "2091",
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["credited"] is True
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] - before["total_credits"] == 20_000_000
+
+
+def test_auto_refill_webhook_rejects_fee_metadata_mismatch(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_refill_bad_processing_fee",
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "id": "pi_refill_bad_processing_fee",
+                    "amount": 2_091,
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "payment_method": "card",
+                        "auto_refill": "true",
+                        "amount_microdollars": "20000000",
+                        "credit_amount_microdollars": "20000000",
+                        "processing_fee_cents": "90",
+                        "charge_amount_cents": "2091",
+                    },
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] == before["total_credits"]


### PR DESCRIPTION
## Summary
- gross up Stripe card and stablecoin charges with integer-only fee math
- show credits and payment processing fee as separate Stripe line items
- credit only the requested principal and fail closed on inconsistent webhook metadata
- apply the same policy to auto-refill and expose the split in payment history

## Defaults
- card: 2.9% + 30 cents
- stablecoin: 1.5%
- configurable through TR_STRIPE_* fee settings

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (1977 passed, 47 skipped)
- npm run typecheck
- npm run lint
- npm run lint:css
- git diff --check