### PR TITLE
Billing: add ACH bank checkout with delayed settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,10 +472,18 @@ wires the current GCP trust metadata into the trust page.
 `POST /v1/billing/checkout` creates a Stripe Checkout session when
 `TR_STRIPE_SECRET_KEY` is configured and otherwise returns a deterministic local
 mock response. Stripe webhooks credit workspaces idempotently using the
-workspace ID in Checkout metadata. `POST /v1/billing/portal` follows the same
+workspace ID in Checkout metadata. Card payments settle immediately. ACH
+payments use `{"payment_method":"ach"}` and are credited only after Stripe sends
+`checkout.session.async_payment_succeeded`; Checkout completion while the debit
+is processing never grants credits. `POST /v1/billing/portal` follows the same
 Stripe-or-mock pattern for billing management.
 
 For stablecoin checkout, send `{"payment_method":"stablecoin"}`. When
 `TR_STABLECOIN_CHECKOUT_ENABLED=true`, the Checkout session is created with
 Stripe's `crypto` payment method and still credits the workspace from the signed
 `checkout.session.completed` webhook.
+
+ACH uses Stripe Checkout's `us_bank_account` payment method. The default
+processing schedule is 0.8% capped at $5 and can be overridden with
+`TR_STRIPE_ACH_FEE_BASIS_POINTS`, `TR_STRIPE_ACH_FEE_FIXED_CENTS`, and
+`TR_STRIPE_ACH_FEE_MAX_CENTS`. Saved-card auto refill remains card-only.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -107,6 +107,9 @@ class Settings(BaseSettings):
     stripe_card_fee_fixed_cents: int = 30
     stripe_stablecoin_fee_basis_points: int = 150
     stripe_stablecoin_fee_fixed_cents: int = 0
+    stripe_ach_fee_basis_points: int = 80
+    stripe_ach_fee_fixed_cents: int = 0
+    stripe_ach_fee_max_cents: int = 500
     paypal_client_id: str | None = None
     paypal_client_secret: str | None = None
     paypal_webhook_id: str | None = None
@@ -260,6 +263,7 @@ class Settings(BaseSettings):
                 "TR_STRIPE_STABLECOIN_FEE_BASIS_POINTS",
                 self.stripe_stablecoin_fee_basis_points,
             ),
+            ("TR_STRIPE_ACH_FEE_BASIS_POINTS", self.stripe_ach_fee_basis_points),
         ):
             if not 0 <= value < 10_000:
                 raise ValueError(f"{name} must be between 0 and 9999")
@@ -269,6 +273,8 @@ class Settings(BaseSettings):
                 "TR_STRIPE_STABLECOIN_FEE_FIXED_CENTS",
                 self.stripe_stablecoin_fee_fixed_cents,
             ),
+            ("TR_STRIPE_ACH_FEE_FIXED_CENTS", self.stripe_ach_fee_fixed_cents),
+            ("TR_STRIPE_ACH_FEE_MAX_CENTS", self.stripe_ach_fee_max_cents),
         ):
             if value < 0:
                 raise ValueError(f"{name} cannot be negative")

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -59,6 +59,7 @@ def register_billing_routes(router: APIRouter) -> None:
         workspace_id = body.workspace_id or principal.workspace.id
         if workspace_id != principal.workspace.id:
             raise api_error(403, "Forbidden", ErrorType.FORBIDDEN)
+        account = STORE.get_credit_account(workspace_id)
         return JSONResponse(
             {
                 "data": (
@@ -73,6 +74,7 @@ def register_billing_routes(router: APIRouter) -> None:
                         body=body,
                         workspace_id=workspace_id,
                         customer_email=_checkout_customer_email(principal),
+                        customer_id=account.stripe_customer_id if account else None,
                         settings=settings,
                     )
                 )

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -114,6 +114,7 @@ def register(app: FastAPI) -> None:
             )
         except ValidationError:
             return RedirectResponse(url="/console/credits?error=invalid_checkout", status_code=303)
+        credit = STORE.get_credit_account(ctx.workspace.id)
         try:
             data = (
                 create_paypal_checkout_session(
@@ -127,6 +128,7 @@ def register(app: FastAPI) -> None:
                     body=body,
                     workspace_id=ctx.workspace.id,
                     customer_email=ctx.user.email if ctx.user.email and "@" in ctx.user.email else None,
+                    customer_id=credit.stripe_customer_id if credit else None,
                     settings=settings,
                 )
             )

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -1,6 +1,8 @@
-"""/internal/stripe/webhook — handles four Stripe event types:
+"""/internal/stripe/webhook handles Stripe billing events:
 
-* checkout.session.completed (payment, prepaid credit add)
+* checkout.session.completed (immediate payment or delayed-payment pending state)
+* checkout.session.async_payment_succeeded (delayed prepaid credit add)
+* checkout.session.async_payment_failed (delayed payment failure)
 * checkout.session.completed mode=setup (saved-card capture)
 * setup_intent.succeeded (saved-card capture from PaymentIntent flow)
 * payment_intent.succeeded (auto-refill credit add)
@@ -71,14 +73,18 @@ def register(router: APIRouter) -> None:
         event_id = str(event.get("id") or uuid.uuid4())
         event_type = event.get("type")
 
-        if event_type == "checkout.session.completed":
+        if event_type in {
+            "checkout.session.completed",
+            "checkout.session.async_payment_succeeded",
+            "checkout.session.async_payment_failed",
+        }:
             obj = event.get("data", {}).get("object", {})
             metadata = obj.get("metadata") or {}
             workspace_id = metadata.get("workspace_id")
             amount_total = int(obj.get("amount_total") or 0)
             customer_id = obj.get("customer")
             if workspace_id and STORE.get_credit_account(workspace_id) is not None:
-                if obj.get("mode") == "setup":
+                if event_type == "checkout.session.completed" and obj.get("mode") == "setup":
                     if isinstance(customer_id, str):
                         STORE.set_stripe_customer(workspace_id, customer_id=customer_id)
                     return {
@@ -88,25 +94,55 @@ def register(router: APIRouter) -> None:
                             "trial_credit_granted_microdollars": 0,
                         }
                     }
+                if event_type == "checkout.session.async_payment_failed":
+                    return {
+                        "data": {
+                            "credited": False,
+                            "payment_failed": True,
+                            "event_id": event_id,
+                            "trial_credit_granted_microdollars": 0,
+                        }
+                    }
+                if (
+                    event_type == "checkout.session.completed"
+                    and obj.get("payment_status") != "paid"
+                ):
+                    return {
+                        "data": {
+                            "credited": False,
+                            "payment_pending": True,
+                            "payment_status": obj.get("payment_status") or "unpaid",
+                            "event_id": event_id,
+                            "trial_credit_granted_microdollars": 0,
+                        }
+                    }
                 amount_microdollars = _checkout_credit_amount_microdollars(
                     metadata=metadata,
                     amount_total_cents=amount_total,
                 )
+                payment_method = str(metadata.get("payment_method") or "stripe")
+                credit_event_id = _checkout_credit_event_id(
+                    event_id=event_id,
+                    checkout_session=obj,
+                    payment_method=payment_method,
+                )
                 credited = STORE.credit_workspace_typed_direct(
-                    workspace_id, amount_microdollars, event_id
+                    workspace_id, amount_microdollars, credit_event_id
                 )
                 if credited:
                     record_credit_purchase(
                         workspace_id,
                         amount_microdollars=amount_microdollars,
-                        payment_method="stripe",
+                        payment_method=(
+                            "stripe_ach" if payment_method == "ach" else "stripe"
+                        ),
                     )
                 # Capture the Stripe customer the first time they pay so
                 # auto-refill can use it later. The default payment method
                 # arrives separately in `setup_intent.succeeded` (or via the
                 # PaymentIntent's `payment_method` if Checkout was set up
                 # with `setup_future_usage`).
-                if isinstance(customer_id, str):
+                if isinstance(customer_id, str) and payment_method != "ach":
                     STORE.set_stripe_customer(workspace_id, customer_id=customer_id)
                 return {
                     "data": {
@@ -206,7 +242,11 @@ def register(router: APIRouter) -> None:
                         payment_method_id=payment_method,
                     )
                 return {"data": {"credited": credited, "event_id": event_id, "auto_refill": True}}
-            if isinstance(workspace_id, str) and STORE.get_credit_account(workspace_id) is not None:
+            if (
+                metadata.get("payment_method") in {None, "auto", "card"}
+                and isinstance(workspace_id, str)
+                and STORE.get_credit_account(workspace_id) is not None
+            ):
                 payment_method = obj.get("payment_method")
                 customer_id = obj.get("customer")
                 if isinstance(payment_method, str) and isinstance(customer_id, str):
@@ -274,6 +314,26 @@ def register(router: APIRouter) -> None:
                 }
 
         return {"data": {"ignored": True, "event_id": event_id}}
+
+
+def _checkout_credit_event_id(
+    *,
+    event_id: str,
+    checkout_session: dict[str, Any],
+    payment_method: str,
+) -> str:
+    """Deduplicate ACH fulfillment across completed and async events.
+
+    Card events historically used the Stripe event id, so that key remains
+    unchanged. ACH is new and can safely key fulfillment to the PaymentIntent
+    or Checkout Session instead.
+    """
+    if payment_method != "ach":
+        return event_id
+    payment_id = checkout_session.get("payment_intent") or checkout_session.get("id")
+    if isinstance(payment_id, str) and payment_id:
+        return f"stripe_checkout:{payment_id}"
+    return event_id
 
 
 def _checkout_credit_amount_microdollars(

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -44,7 +44,16 @@ class CheckoutRequest(_Lenient):
     workspace_id: str | None = None
     success_url: str | None = None
     cancel_url: str | None = None
-    payment_method: Literal["auto", "stablecoin", "crypto", "usdc", "paypal"] = "auto"
+    payment_method: Literal[
+        "auto",
+        "ach",
+        "bank",
+        "us_bank_account",
+        "stablecoin",
+        "crypto",
+        "usdc",
+        "paypal",
+    ] = "auto"
 
     @field_validator("amount")
     @classmethod

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -19,6 +19,7 @@ def create_checkout_session(
     body: CheckoutRequest,
     workspace_id: str,
     customer_email: str | None,
+    customer_id: str | None,
     settings: Settings,
 ) -> dict[str, Any]:
     workspace = STORE.get_workspace(workspace_id)
@@ -30,22 +31,30 @@ def create_checkout_session(
     amount_cents = dollars_to_cents(body.amount)
     amount_microdollars = amount_cents * 10_000
     stablecoin_requested = body.payment_method in {"stablecoin", "crypto", "usdc"}
+    ach_requested = body.payment_method in {"ach", "bank", "us_bank_account"}
     if stablecoin_requested and not settings.stablecoin_checkout_enabled:
         raise api_error(400, "Stablecoin checkout is not enabled", ErrorType.BAD_REQUEST)
+    if ach_requested:
+        fee_basis_points = settings.stripe_ach_fee_basis_points
+        fee_fixed_cents = settings.stripe_ach_fee_fixed_cents
+        fee_max_cents: int | None = settings.stripe_ach_fee_max_cents
+        payment_method = "ach"
+    elif stablecoin_requested:
+        fee_basis_points = settings.stripe_stablecoin_fee_basis_points
+        fee_fixed_cents = settings.stripe_stablecoin_fee_fixed_cents
+        fee_max_cents = None
+        payment_method = "stablecoin"
+    else:
+        fee_basis_points = settings.stripe_card_fee_basis_points
+        fee_fixed_cents = settings.stripe_card_fee_fixed_cents
+        fee_max_cents = None
+        payment_method = "card"
     fee = stripe_processing_fee(
         credit_amount_cents=amount_cents,
-        variable_basis_points=(
-            settings.stripe_stablecoin_fee_basis_points
-            if stablecoin_requested
-            else settings.stripe_card_fee_basis_points
-        ),
-        fixed_fee_cents=(
-            settings.stripe_stablecoin_fee_fixed_cents
-            if stablecoin_requested
-            else settings.stripe_card_fee_fixed_cents
-        ),
+        variable_basis_points=fee_basis_points,
+        fixed_fee_cents=fee_fixed_cents,
+        max_fee_cents=fee_max_cents,
     )
-    payment_method = "stablecoin" if stablecoin_requested else "card"
     payment_metadata = fee.metadata(
         workspace_id=workspace_id,
         payment_method=payment_method,
@@ -65,16 +74,33 @@ def create_checkout_session(
             if customer_email:
                 session_args["customer_email"] = customer_email
         else:
-            # Capture the customer + payment method on the card path so
-            # auto-refill can charge off-session later. Crypto checkouts
-            # don't support `setup_future_usage`, so we only set this on
-            # the card path.
-            session_args["customer_creation"] = "always"
-            session_args["payment_intent_data"] = {
-                "setup_future_usage": "off_session",
-                "metadata": payment_metadata,
-            }
+            if customer_id:
+                session_args["customer"] = customer_id
+            else:
+                session_args["customer_creation"] = "always"
+                if customer_email:
+                    session_args["customer_email"] = customer_email
+            if ach_requested:
+                session_args["payment_method_types"] = ["us_bank_account"]
+                session_args["payment_method_options"] = {
+                    "us_bank_account": {"verification_method": "automatic"}
+                }
+                # ACH is a one-time top-up. Saved-card auto refill remains
+                # card-only because bank debits settle asynchronously.
+                session_args["payment_intent_data"] = {"metadata": payment_metadata}
+            else:
+                session_args["payment_intent_data"] = {
+                    "setup_future_usage": "off_session",
+                    "metadata": payment_metadata,
+                }
         session = stripe.checkout.Session.create(**session_args)
+        mode = (
+            "stripe_stablecoin"
+            if stablecoin_requested
+            else "stripe_ach"
+            if ach_requested
+            else "stripe"
+        )
         return {
             "id": session["id"],
             "url": session["url"],
@@ -82,9 +108,16 @@ def create_checkout_session(
             **money_pair("amount", amount_microdollars),
             **money_pair("processing_fee", fee.processing_fee_microdollars),
             **money_pair("total", fee.charge_amount_microdollars),
-            "mode": "stripe_stablecoin" if stablecoin_requested else "stripe",
+            "mode": mode,
         }
 
+    mock_mode = (
+        "mock_stablecoin"
+        if stablecoin_requested
+        else "mock_ach"
+        if ach_requested
+        else "mock"
+    )
     return {
         "id": f"cs_test_{uuid.uuid4().hex}",
         "url": f"https://{settings.trusted_domain}/billing/mock-checkout",
@@ -92,7 +125,7 @@ def create_checkout_session(
         **money_pair("amount", amount_microdollars),
         **money_pair("processing_fee", fee.processing_fee_microdollars),
         **money_pair("total", fee.charge_amount_microdollars),
-        "mode": "mock_stablecoin" if stablecoin_requested else "mock",
+        "mode": mock_mode,
     }
 
 
@@ -266,7 +299,7 @@ def list_workspace_payments(
     Why PaymentIntent search (not checkout.Session): Stripe's Search API
     is only enabled on certain resources — PaymentIntent yes, Charge yes,
     checkout.Session NO. Our `create_checkout_session()` stamps
-    `payment_intent_data.metadata.workspace_id` on every card-mode
+    `payment_intent_data.metadata.workspace_id` on every Stripe
     checkout, so the resulting PaymentIntent IS searchable by workspace.
 
     Returns up to `limit` rows newest-first, each with the shape:
@@ -279,8 +312,11 @@ def list_workspace_payments(
           "currency": "usd",
           "status": "succeeded" | "processing" | "requires_payment_method" | ...,
           "receipt_url": str | None,
+          "payment_method_type": "card" | "ach" | "stablecoin" | None,
           "card_brand": "visa" | "mastercard" | ... | None,
           "card_last4": "4242" | None,
+          "bank_name": str | None,
+          "bank_last4": "6789" | None,
         }
 
     Failures (Stripe API down, missing key) return an empty list rather
@@ -321,25 +357,32 @@ def list_workspace_payments(
             charge = None
         card_brand: str | None = None
         card_last4: str | None = None
+        bank_name: str | None = None
+        bank_last4: str | None = None
         receipt_url: str | None = None
         if isinstance(charge, dict):
             receipt_url = charge.get("receipt_url")
             pmd = charge.get("payment_method_details") or {}
             card = pmd.get("card") if isinstance(pmd, dict) else None
+            bank = pmd.get("us_bank_account") if isinstance(pmd, dict) else None
             if isinstance(card, dict):
                 card_brand = card.get("brand")
                 card_last4 = card.get("last4")
+            if isinstance(bank, dict):
+                bank_name = bank.get("bank_name")
+                bank_last4 = bank.get("last4")
+        metadata = pi_data.get("metadata")
         # PaymentIntent.amount is in cents already.
         out.append({
             "payment_intent": pi_data.get("id"),
             "created_at": pi_data.get("created"),
             "amount_cents": int(pi_data.get("amount") or 0),
             "credit_amount_cents": _metadata_microdollars_to_cents(
-                pi_data.get("metadata"),
+                metadata,
                 key="credit_amount_microdollars",
             ),
             "processing_fee_cents": _metadata_int(
-                pi_data.get("metadata"),
+                metadata,
                 key="processing_fee_cents",
             ),
             "currency": pi_data.get("currency") or "usd",
@@ -351,8 +394,13 @@ def list_workspace_payments(
                 "paid" if pi_data.get("status") == "succeeded" else pi_data.get("status")
             ),
             "receipt_url": receipt_url,
+            "payment_method_type": (
+                metadata.get("payment_method") if isinstance(metadata, dict) else None
+            ),
             "card_brand": card_brand,
             "card_last4": card_last4,
+            "bank_name": bank_name,
+            "bank_last4": bank_last4,
         })
     return out
 

--- a/src/trusted_router/services/stripe_fees.py
+++ b/src/trusted_router/services/stripe_fees.py
@@ -20,6 +20,7 @@ class StripeProcessingFee:
     charge_amount_cents: int
     variable_basis_points: int
     fixed_fee_cents: int
+    max_fee_cents: int | None = None
 
     @property
     def credit_amount_microdollars(self) -> int:
@@ -38,7 +39,10 @@ class StripeProcessingFee:
             self.charge_amount_cents * self.variable_basis_points,
             10_000,
         )
-        return variable + self.fixed_fee_cents
+        cost = variable + self.fixed_fee_cents
+        if self.max_fee_cents is not None:
+            return min(cost, self.max_fee_cents)
+        return cost
 
     def checkout_line_items(self) -> list[dict[str, Any]]:
         items = [
@@ -88,7 +92,7 @@ class StripeProcessingFee:
         workspace_id: str,
         payment_method: str,
     ) -> dict[str, str]:
-        return {
+        metadata = {
             "workspace_id": workspace_id,
             "payment_method": payment_method,
             "credit_amount_microdollars": str(self.credit_amount_microdollars),
@@ -97,6 +101,9 @@ class StripeProcessingFee:
             "fee_variable_basis_points": str(self.variable_basis_points),
             "fee_fixed_cents": str(self.fixed_fee_cents),
         }
+        if self.max_fee_cents is not None:
+            metadata["fee_max_cents"] = str(self.max_fee_cents)
+        return metadata
 
 
 def stripe_processing_fee(
@@ -104,6 +111,7 @@ def stripe_processing_fee(
     credit_amount_cents: int,
     variable_basis_points: int,
     fixed_fee_cents: int,
+    max_fee_cents: int | None = None,
 ) -> StripeProcessingFee:
     """Gross up a USD-cent principal so it survives the configured fee.
 
@@ -118,12 +126,21 @@ def stripe_processing_fee(
         raise ValueError("variable_basis_points must be between 0 and 9999")
     if fixed_fee_cents < 0:
         raise ValueError("fixed_fee_cents cannot be negative")
+    if max_fee_cents is not None and max_fee_cents < 0:
+        raise ValueError("max_fee_cents cannot be negative")
 
     denominator = 10_000 - variable_basis_points
-    charge_amount_cents = _ceil_div(
+    uncapped_charge_amount_cents = _ceil_div(
         (credit_amount_cents + fixed_fee_cents) * 10_000,
         denominator,
     )
+    if (
+        max_fee_cents is not None
+        and uncapped_charge_amount_cents - credit_amount_cents > max_fee_cents
+    ):
+        charge_amount_cents = credit_amount_cents + max_fee_cents
+    else:
+        charge_amount_cents = uncapped_charge_amount_cents
     processing_fee_cents = charge_amount_cents - credit_amount_cents
     return StripeProcessingFee(
         credit_amount_cents=credit_amount_cents,
@@ -131,6 +148,7 @@ def stripe_processing_fee(
         charge_amount_cents=charge_amount_cents,
         variable_basis_points=variable_basis_points,
         fixed_fee_cents=fixed_fee_cents,
+        max_fee_cents=max_fee_cents,
     )
 
 

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -16,6 +16,7 @@
         <label>Payment method
           <select name="payment_method">
             <option value="auto">Stripe card</option>
+            <option value="ach">Bank account (ACH)</option>
             <option value="stablecoin">Stripe USDC / stablecoin</option>
             {% if paypal_enabled %}
             <option value="paypal">PayPal</option>
@@ -26,7 +27,8 @@
       <button class="btn primary" type="submit">Continue to checkout</button>
       <p class="form-help">
         Stripe shows your credits and the payment processing fee as separate
-        line items before you pay. Only the credit amount is added to your balance.
+        line items before you pay. ACH costs 0.8%, capped at $5, and can take
+        up to four business days. Bank-funded credits appear only after settlement.
       </p>
     </form>
   </div>
@@ -41,7 +43,8 @@
   </div>
   <div class="panel-body">
     <p style="color:var(--muted);font-size:14px;margin:0 0 14px">
-      Save a Stripe card for auto refill. Credit purchases can use Stripe, PayPal, or USDC checkout above.
+      Save a Stripe card for auto refill. One-time credit purchases can use a
+      card, ACH bank account, PayPal, or USDC above.
       {% if payment_method_pending %}
       <br><strong>Stripe setup is pending. Auto-refill will unlock after Stripe confirms the card.</strong>
       {% endif %}
@@ -165,8 +168,14 @@
             {% endif %}
           </td>
           <td style="padding:10px 6px">
-            {% if p.card_brand and p.card_last4 %}
+            {% if p.bank_last4 %}
+              <span>{{ p.bank_name or 'Bank account' }}</span> ····{{ p.bank_last4 }}
+            {% elif p.card_brand and p.card_last4 %}
               <span style="text-transform:capitalize">{{ p.card_brand }}</span> ····{{ p.card_last4 }}
+            {% elif p.payment_method_type == 'ach' %}
+              <span>Bank account (ACH)</span>
+            {% elif p.payment_method_type == 'stablecoin' %}
+              <span>Stablecoin</span>
             {% else %}
               <span style="color:var(--muted)">none</span>
             {% endif %}
@@ -174,6 +183,8 @@
           <td style="padding:10px 6px">
             {% if p.payment_status == 'paid' %}
               <span class="pill good">paid</span>
+            {% elif p.payment_status == 'processing' %}
+              <span class="pill warn">processing</span>
             {% elif p.payment_status == 'unpaid' %}
               <span class="pill warn">unpaid</span>
             {% elif p.status == 'expired' %}
@@ -198,7 +209,8 @@
     </p>
     {% else %}
     <p style="color:var(--muted);font-size:14px;margin:0">
-      No payments yet. Your purchases will show up here within a few seconds of Stripe completing the charge.
+      No payments yet. Card payments appear after completion; ACH credits appear
+      after Stripe confirms bank settlement.
     </p>
     {% endif %}
   </div>

--- a/src/trusted_router/templates/public/pricing.html
+++ b/src/trusted_router/templates/public/pricing.html
@@ -30,7 +30,7 @@
       <li>Per-model prices are published on the <a href="/models">models page</a></li>
       <li>Prepaid credits, BYOK, and usage-based billing all supported</li>
       <li>Metadata-only billing records — no prompt or output bodies stored</li>
-      <li>Stripe and stablecoin checkout for prepaid credits</li>
+      <li>Card, ACH bank, PayPal, and stablecoin checkout for prepaid credits</li>
     </ul>
     <button class="btn primary" type="button" data-action="open-signin">Get an API key</button>
   </div>

--- a/src/trusted_router/templates/public/privacy.html
+++ b/src/trusted_router/templates/public/privacy.html
@@ -15,7 +15,7 @@
   <h3>Account and contact information</h3>
   <p>We may collect your email address, authentication identifiers, wallet address when you use wallet sign-in, workspace and organization membership, support communications, and preferences.</p>
   <h3>Billing information</h3>
-  <p>Payment processors handle payment-card, PayPal, and supported stablecoin payment details. TrustedRouter receives transaction identifiers, payment status, amounts, and limited payment-method metadata needed for billing, fraud prevention, refunds, and accounting.</p>
+  <p>Payment processors handle payment-card, bank-account, PayPal, and supported stablecoin payment details. TrustedRouter receives transaction identifiers, payment status, amounts, and limited payment-method metadata needed for billing, fraud prevention, refunds, and accounting.</p>
   <h3>API and service metadata</h3>
   <p>We collect operational metadata such as request and generation identifiers, selected model and provider, token counts, latency, status, cost, region, API-key hash and display hint, rate-limit state, and security events. Raw API keys are shown once and stored only as protected hashes. BYOK provider credentials are encrypted.</p>
   <h3>Prompts and outputs</h3>

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -356,6 +356,7 @@ def test_stripe_purchase_attribution_follows_ledger_idempotency(
         "data": {
             "object": {
                 "amount_total": 2500,
+                "payment_status": "paid",
                 "metadata": {"workspace_id": workspace_id},
             }
         },

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -36,6 +36,7 @@ def test_stripe_webhook_route_is_idempotent(user_headers: dict[str, str], client
         "data": {
             "object": {
                 "amount_total": 1200,
+                "payment_status": "paid",
                 "metadata": {"workspace_id": workspace_id},
             }
         },
@@ -1015,6 +1016,8 @@ def test_credits_page_renders_payment_history_section(monkeypatch) -> None:
     assert resp.status_code == 200, resp.text[:300]
     assert "Payment history" in resp.text
     assert "No payments yet" in resp.text
+    assert "Bank account (ACH)" in resp.text
+    assert "credits appear" in resp.text
 
 
 def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
@@ -1052,6 +1055,22 @@ def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
             "card_brand": "mastercard",
             "card_last4": "8888",
         },
+        {
+            "payment_intent": "pi_ach_processing",
+            "created_at": 1779550000,
+            "amount_cents": 2_521,
+            "credit_amount_cents": 2_500,
+            "processing_fee_cents": 21,
+            "currency": "usd",
+            "status": "processing",
+            "payment_status": "processing",
+            "receipt_url": None,
+            "payment_method_type": "ach",
+            "bank_name": "Test Bank",
+            "bank_last4": "6789",
+            "card_brand": None,
+            "card_last4": None,
+        },
     ]
     monkeypatch.setattr(
         credits_module,
@@ -1073,6 +1092,9 @@ def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
     assert "4242" in resp.text
     assert "mastercard" in resp.text.lower()
     assert "8888" in resp.text
+    assert "Test Bank" in resp.text
+    assert "6789" in resp.text
+    assert ">processing<" in resp.text or 'pill warn">processing' in resp.text
     # Receipt links rendered
     assert "https://pay.stripe.com/receipts/test-receipt" in resp.text
     # `paid` status pill

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -139,6 +139,7 @@ def test_stripe_checkout_webhook_routes_topup_through_typed_direct(
                 "object": {
                     "mode": "payment",
                     "amount_total": 123,
+                    "payment_status": "paid",
                     "customer": "cus_test",
                     "metadata": {"workspace_id": workspace_id},
                 }

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -178,7 +178,13 @@ def test_stripe_webhook_signature_is_required_when_secret_configured(monkeypatch
     event = {
         "id": "evt_signed",
         "type": "checkout.session.completed",
-        "data": {"object": {"amount_total": 321, "metadata": {"workspace_id": workspace_id}}},
+        "data": {
+            "object": {
+                "amount_total": 321,
+                "payment_status": "paid",
+                "metadata": {"workspace_id": workspace_id},
+            }
+        },
     }
     raw_event = json.dumps(event, separators=(",", ":")).encode()
     captured: dict[str, object] = {}

--- a/tests/test_stripe_processing_fees.py
+++ b/tests/test_stripe_processing_fees.py
@@ -40,6 +40,28 @@ def test_stablecoin_fee_grosses_up_principal_without_fixed_fee() -> None:
     assert fee.estimated_processor_cost_cents() <= fee.processing_fee_cents
 
 
+def test_ach_fee_is_integer_only_and_caps_at_five_dollars() -> None:
+    small = stripe_processing_fee(
+        credit_amount_cents=2_500,
+        variable_basis_points=80,
+        fixed_fee_cents=0,
+        max_fee_cents=500,
+    )
+    large = stripe_processing_fee(
+        credit_amount_cents=100_000,
+        variable_basis_points=80,
+        fixed_fee_cents=0,
+        max_fee_cents=500,
+    )
+
+    assert small.processing_fee_cents == 21
+    assert small.charge_amount_cents == 2_521
+    assert small.estimated_processor_cost_cents() == 21
+    assert large.processing_fee_cents == 500
+    assert large.charge_amount_cents == 100_500
+    assert large.estimated_processor_cost_cents() == 500
+
+
 @given(
     credit_amount_cents=st.integers(min_value=100, max_value=1_000_000),
     variable_basis_points=st.integers(min_value=0, max_value=900),
@@ -152,6 +174,239 @@ def test_stablecoin_checkout_uses_stablecoin_fee_schedule(
     assert response.json()["data"]["total_microdollars"] == 25_390_000
 
 
+def test_ach_checkout_uses_bank_account_and_capped_fee_schedule(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_ach"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_ach", "url": "https://checkout.stripe.test/ach"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 25, "payment_method": "ach"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert captured["payment_method_types"] == ["us_bank_account"]
+    assert captured["payment_method_options"] == {
+        "us_bank_account": {"verification_method": "automatic"}
+    }
+    assert captured["customer_creation"] == "always"
+    assert captured["payment_intent_data"] == {"metadata": captured["metadata"]}
+    assert "setup_future_usage" not in captured["payment_intent_data"]
+    assert [item["price_data"]["unit_amount"] for item in captured["line_items"]] == [
+        2_500,
+        21,
+    ]
+    assert captured["metadata"]["payment_method"] == "ach"
+    assert captured["metadata"]["fee_max_cents"] == "500"
+    assert response.json()["data"]["mode"] == "stripe_ach"
+    assert response.json()["data"]["amount_microdollars"] == 25_000_000
+    assert response.json()["data"]["processing_fee_microdollars"] == 210_000
+    assert response.json()["data"]["total_microdollars"] == 25_210_000
+
+
+def test_ach_checkout_reuses_existing_stripe_customer(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_ach"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_ach_existing", "url": "https://checkout.stripe.test/ach"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        workspace_id = local_client.get(
+            "/v1/workspaces", headers=user_headers
+        ).json()["data"][0]["id"]
+        from trusted_router.storage import STORE
+
+        STORE.set_stripe_customer(
+            workspace_id,
+            customer_id="cus_existing",
+            payment_method_id="pm_existing_card",
+        )
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 1000, "payment_method": "bank"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert captured["customer"] == "cus_existing"
+    assert "customer_creation" not in captured
+    assert [item["price_data"]["unit_amount"] for item in captured["line_items"]] == [
+        100_000,
+        500,
+    ]
+
+
+def test_ach_checkout_completion_waits_for_async_success_and_credits_once(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+    session = {
+        "id": "cs_ach_delayed",
+        "mode": "payment",
+        "payment_intent": "pi_ach_delayed",
+        "payment_status": "unpaid",
+        "amount_total": 2_521,
+        "customer": "cus_ach_new",
+        "metadata": {
+            "workspace_id": workspace_id,
+            "payment_method": "ach",
+            "credit_amount_microdollars": "25000000",
+            "processing_fee_cents": "21",
+            "charge_amount_cents": "2521",
+            "fee_variable_basis_points": "80",
+            "fee_fixed_cents": "0",
+            "fee_max_cents": "500",
+        },
+    }
+
+    pending = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_completed",
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        },
+    )
+    after_pending = live_credit_summary(workspace_id)
+    assert pending.status_code == 200, pending.text
+    assert pending.json()["data"]["payment_pending"] is True
+    assert pending.json()["data"]["credited"] is False
+    assert after_pending == before
+
+    session["payment_status"] = "paid"
+    first = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_async_succeeded_1",
+            "type": "checkout.session.async_payment_succeeded",
+            "data": {"object": session},
+        },
+    )
+    replay_with_distinct_event = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_async_succeeded_2",
+            "type": "checkout.session.async_payment_succeeded",
+            "data": {"object": session},
+        },
+    )
+    completed_after_success = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_completed_paid",
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        },
+    )
+
+    assert first.status_code == 200, first.text
+    assert first.json()["data"]["credited"] is True
+    assert replay_with_distinct_event.json()["data"]["credited"] is False
+    assert completed_after_success.json()["data"]["credited"] is False
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] - before["total_credits"] == 25_000_000
+
+
+def test_ach_async_failure_never_credits_or_replaces_saved_card(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    from trusted_router.storage import STORE
+
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    STORE.set_stripe_customer(
+        workspace_id,
+        customer_id="cus_saved_card",
+        payment_method_id="pm_saved_card",
+    )
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+
+    failed = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_async_failed",
+            "type": "checkout.session.async_payment_failed",
+            "data": {
+                "object": {
+                    "id": "cs_ach_failed",
+                    "mode": "payment",
+                    "payment_intent": "pi_ach_failed",
+                    "payment_status": "unpaid",
+                    "amount_total": 2_521,
+                    "customer": "cus_ach_other",
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "payment_method": "ach",
+                    },
+                }
+            },
+        },
+    )
+    payment_intent = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_ach_payment_intent_succeeded",
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "id": "pi_ach_failed",
+                    "customer": "cus_ach_other",
+                    "payment_method": "pm_ach_other",
+                    "metadata": {
+                        "workspace_id": workspace_id,
+                        "payment_method": "ach",
+                    },
+                }
+            },
+        },
+    )
+
+    assert failed.status_code == 200, failed.text
+    assert failed.json()["data"]["payment_failed"] is True
+    assert failed.json()["data"]["credited"] is False
+    assert payment_intent.json()["data"]["ignored"] is True
+    after = live_credit_summary(workspace_id)
+    assert after == before
+    account = STORE.get_credit_account(workspace_id)
+    assert account is not None
+    assert account.stripe_customer_id == "cus_saved_card"
+    assert account.stripe_payment_method_id == "pm_saved_card"
+
+
 def test_checkout_webhook_credits_only_requested_principal_when_total_includes_fee(
     client: TestClient,
     user_headers: dict[str, str],
@@ -167,6 +422,7 @@ def test_checkout_webhook_credits_only_requested_principal_when_total_includes_f
             "object": {
                 "mode": "payment",
                 "amount_total": 2_606,
+                "payment_status": "paid",
                 "customer": "cus_fee",
                 "metadata": {
                     "workspace_id": workspace_id,
@@ -207,6 +463,7 @@ def test_checkout_webhook_rejects_principal_larger_than_total_charge(
                 "object": {
                     "mode": "payment",
                     "amount_total": 1_000,
+                    "payment_status": "paid",
                     "metadata": {
                         "workspace_id": workspace_id,
                         "credit_amount_microdollars": "11000000",


### PR DESCRIPTION
## Summary
- add one-time Stripe ACH bank checkout with a 0.8% processing schedule capped at $5
- credit ACH purchases only after `checkout.session.async_payment_succeeded` and deduplicate by PaymentIntent/session
- preserve saved-card auto refill and show bank payment status/details in the console
- document the API mode and production webhook requirements

## Production Stripe configuration
- enabled `us_bank_account` on the direct Default payment-method configuration
- subscribed the active TrustedRouter webhook to `checkout.session.async_payment_succeeded` and `checkout.session.async_payment_failed`
- created and immediately expired a live no-charge ACH Checkout session successfully

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1982 passed, 47 skipped)
- `npx tsc --noEmit`
- `npx eslint frontend/src`
- `npx stylelint "src/trusted_router/static/*.css"`
- `npx playwright test` (13 passed)