### PR TITLE
Add Fireworks Kimi K3 route

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -85,6 +85,7 @@ def _novita_model_id(native_id: str) -> str | None:
 
 
 _FIREWORKS_MODEL_IDS = {
+    "accounts/fireworks/models/kimi-k3": "moonshotai/kimi-k3",
     "accounts/fireworks/models/kimi-k2p6": "moonshotai/kimi-k2.6",
     "accounts/fireworks/models/kimi-k2p5": "moonshotai/kimi-k2.5",
     "accounts/fireworks/models/kimi-k2p7-code": "moonshotai/kimi-k2.7-code",

--- a/scripts/pricing/parsers/fireworks.py
+++ b/scripts/pricing/parsers/fireworks.py
@@ -5,6 +5,7 @@ import re
 from decimal import Decimal
 
 MODEL_LABELS = {
+    "Kimi K3": "moonshotai/kimi-k3",
     "Kimi K2.7 Code": "moonshotai/kimi-k2.7-code",
     "Kimi K2.6": "moonshotai/kimi-k2.6",
     "Kimi K2.5": "moonshotai/kimi-k2.5",

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -38,6 +38,7 @@ MANIFEST_PATH = (
 )
 
 EXPECTED_MODELS = [
+    "moonshotai/kimi-k3",
     "moonshotai/kimi-k2.6",
     "deepseek/deepseek-v4-pro",
     "z-ai/glm-5.2",
@@ -46,6 +47,7 @@ EXPECTED_MODELS = [
 ]
 
 _NATIVE_TO_CANONICAL = {
+    "accounts/fireworks/models/kimi-k3": "moonshotai/kimi-k3",
     "accounts/fireworks/models/kimi-k2p6": "moonshotai/kimi-k2.6",
     "accounts/fireworks/models/kimi-k2p7-code": "moonshotai/kimi-k2.7-code",
     "accounts/fireworks/models/deepseek-v4-pro": "deepseek/deepseek-v4-pro",
@@ -61,6 +63,10 @@ UPSTREAM_ID_MAP = {canonical: native for native, canonical in _NATIVE_TO_CANONIC
 # Fast is an account router rather than a row in /v1/models. It remains an
 # explicit, separately smoke-tested route and is not subject to model pruning.
 UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] = "accounts/fireworks/routers/glm-5p2-fast"
+# Fireworks can publish and serve a launch model before its authenticated
+# /v1/models response catches up. Keep only explicitly verified exceptions,
+# and only while the first-party pricing page still contains the model.
+VERIFIED_PRICED_LAUNCH_MODELS = frozenset({"moonshotai/kimi-k3"})
 _DISCOVERED_LIVE_MODEL_IDS: set[str] = set()
 
 
@@ -100,10 +106,14 @@ def fetch() -> ProviderPricingResult:
         url=URL,
         expected_models=EXPECTED_MODELS,
     )
-    _DISCOVERED_LIVE_MODEL_IDS = live_model_ids
-    docs_only = sorted(set(result.prices) - live_model_ids)
+    verified_launch_ids = VERIFIED_PRICED_LAUNCH_MODELS.intersection(result.prices)
+    routable_model_ids = live_model_ids | verified_launch_ids
+    _DISCOVERED_LIVE_MODEL_IDS = routable_model_ids
+    docs_only = sorted(set(result.prices) - routable_model_ids)
     result.prices = {
-        model_id: price for model_id, price in result.prices.items() if model_id in live_model_ids
+        model_id: price
+        for model_id, price in result.prices.items()
+        if model_id in routable_model_ids
     }
     errors = validate(result.prices, EXPECTED_MODELS)
     if errors:
@@ -111,6 +121,12 @@ def fetch() -> ProviderPricingResult:
     if docs_only:
         result.notes.append(
             "official pricing rows not enabled for this Fireworks account: " + ", ".join(docs_only)
+        )
+    launch_ids_missing_from_catalog = sorted(verified_launch_ids - live_model_ids)
+    if launch_ids_missing_from_catalog:
+        result.notes.append(
+            "verified launch models served before /v1/models catalog update: "
+            + ", ".join(launch_ids_missing_from_catalog)
         )
     return result
 

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -1,11 +1,40 @@
 {
-  "_about": "Provider-native supplement for the Fireworks AI serverless models enabled on the TrustedRouter Fireworks account. Verified against https://api.fireworks.ai/inference/v1/models and direct chat completions. Fireworks uses full accounts/fireworks/models/... upstream IDs, so the enclave preserves upstream_id verbatim for this provider.",
+  "_about": "Provider-native supplement for the Fireworks AI serverless models enabled on the TrustedRouter Fireworks account. Verified against https://api.fireworks.ai/inference/v1/models, Fireworks' first-party pricing page, and direct chat completions. Kimi K3 is a verified launch route served before the account model-list feed caught up. Fireworks uses full accounts/fireworks/models/... upstream IDs, so the enclave preserves upstream_id verbatim for this provider.",
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-27T15:44:32Z",
-  "model_count": 6,
+  "generated_at": "2026-07-27T16:11:23Z",
+  "model_count": 7,
   "models": [
+    {
+      "id": "moonshotai/kimi-k3",
+      "upstream_id": "accounts/fireworks/models/kimi-k3",
+      "display_name": "Kimi K3 on Fireworks",
+      "title": "accounts/fireworks/models/kimi-k3",
+      "context_length": 1048576,
+      "max_output_tokens": 65536,
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000,
+      "model_type": "chat",
+      "features": [
+        "reasoning",
+        "function-calling",
+        "serverless",
+        "vision"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1
+    },
     {
       "id": "moonshotai/kimi-k2.6",
       "upstream_id": "accounts/fireworks/models/kimi-k2p6",

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -106,6 +106,13 @@ def test_baseten_discovery_maps_glm_fast_native_id() -> None:
     assert check_price_coverage._baseten_model_id("zai-org/GLM-5.2-Fast") == "z-ai/glm-5.2-fast"
 
 
+def test_fireworks_discovery_maps_kimi_k3_native_id() -> None:
+    assert (
+        check_price_coverage._fireworks_model_id("accounts/fireworks/models/kimi-k3")
+        == "moonshotai/kimi-k3"
+    )
+
+
 def test_novita_discovery_ignores_internal_aliases_but_catches_public_families() -> None:
     assert check_price_coverage._novita_model_id("ai_infer_test_1") is None
     assert check_price_coverage._novita_model_id("bunny") is None

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.parsers import fireworks as fireworks_parser
 from scripts.pricing.providers import fireworks
 
 
@@ -30,7 +31,9 @@ def test_fireworks_fetch_intersects_prices_with_operator_catalog(
         ),
     )
     live_rows = [
-        {"id": fireworks.UPSTREAM_ID_MAP[model_id]} for model_id in fireworks.EXPECTED_MODELS
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]}
+        for model_id in fireworks.EXPECTED_MODELS
+        if model_id not in fireworks.VERIFIED_PRICED_LAUNCH_MODELS
     ]
     monkeypatch.setattr(
         fireworks,
@@ -42,6 +45,48 @@ def test_fireworks_fetch_intersects_prices_with_operator_catalog(
 
     assert set(result.prices) == set(fireworks.EXPECTED_MODELS)
     assert any("kimi-k2.7-code" in note for note in result.notes)
+
+
+def test_fireworks_parser_reads_kimi_k3_standard_pricing() -> None:
+    parsed = fireworks_parser.parse(
+        "| [Kimi K3](https://app.fireworks.ai/models/fireworks/kimi-k3) "
+        "| $3.00 / $0.30 / $15.00 | $3.75 / $0.375 / $18.75 |"
+    )
+
+    assert parsed["moonshotai/kimi-k3"] == {
+        "prompt_micro_per_m": 3_000_000,
+        "prompt_cached_micro_per_m": 300_000,
+        "completion_micro_per_m": 15_000_000,
+    }
+
+
+def test_fireworks_fetch_keeps_verified_launch_model_while_catalog_lags(
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    priced_ids = {*fireworks.EXPECTED_MODELS, "moonshotai/kimi-k3"}
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="fireworks",
+            prices={model_id: _price() for model_id in priced_ids},
+            source="deterministic",
+        ),
+    )
+    live_rows = [
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]} for model_id in fireworks.EXPECTED_MODELS
+    ]
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_json",
+        lambda *_args, **_kwargs: {"data": live_rows},
+    )
+
+    result = fireworks.fetch()
+
+    assert "moonshotai/kimi-k3" in result.prices
+    assert "moonshotai/kimi-k3" in fireworks._DISCOVERED_LIVE_MODEL_IDS
 
 
 def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
@@ -72,6 +117,12 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
                         "input_token_price_per_m": 1,
                         "output_token_price_per_m": 1,
                     },
+                    {
+                        "id": "moonshotai/kimi-k3",
+                        "upstream_id": "accounts/fireworks/models/kimi-k3",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
                 ],
             }
         )
@@ -82,11 +133,18 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
     monkeypatch.setattr(
         fireworks,
         "_DISCOVERED_LIVE_MODEL_IDS",
-        {"moonshotai/kimi-k2.6"},
+        {"moonshotai/kimi-k2.6", "moonshotai/kimi-k3"},
     )
     result = ProviderPricingResult(
         slug="fireworks",
-        prices={"moonshotai/kimi-k2.6": _price()},
+        prices={
+            "moonshotai/kimi-k2.6": _price(),
+            "moonshotai/kimi-k3": ModelPrice(
+                prompt_micro_per_m=3_000_000,
+                completion_micro_per_m=15_000_000,
+                prompt_cached_micro_per_m=300_000,
+            ),
+        },
         source="deterministic",
     )
 
@@ -94,8 +152,14 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
 
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
     by_id = {row["id"]: row for row in raw["models"]}
-    assert set(by_id) == {"moonshotai/kimi-k2.6", "z-ai/glm-5.2-fast"}
+    assert set(by_id) == {
+        "moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k3",
+        "z-ai/glm-5.2-fast",
+    }
     assert by_id["moonshotai/kimi-k2.6"]["input_token_price_per_m"] == 1_000_000
+    assert by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 3_000_000
+    assert by_id["moonshotai/kimi-k3"]["cached_input_token_price_per_m"] == 300_000
     assert notes == [
-        "fireworks: refreshed provider_models/fireworks.json (1 priced rows, removed 1 unavailable)"
+        "fireworks: refreshed provider_models/fireworks.json (2 priced rows, removed 1 unavailable)"
     ]

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -643,6 +643,26 @@ def test_fireworks_catalog_exposes_provider_specific_endpoints() -> None:
     }
 
 
+def test_fireworks_catalog_exposes_kimi_k3_with_cached_pricing() -> None:
+    endpoints = endpoints_for_model("moonshotai/kimi-k3")
+    fireworks = [endpoint for endpoint in endpoints if endpoint.provider == "fireworks"]
+
+    assert {endpoint.usage_type for endpoint in fireworks} == {"Credits", "BYOK"}
+    assert {endpoint.upstream_id for endpoint in fireworks} == {
+        "accounts/fireworks/models/kimi-k3"
+    }
+    assert {endpoint.prompt_price_microdollars_per_million_tokens for endpoint in fireworks} == {
+        3_150_000
+    }
+    assert {endpoint.completion_price_microdollars_per_million_tokens for endpoint in fireworks} == {
+        15_750_000
+    }
+    assert {
+        endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens
+        for endpoint in fireworks
+    } == {315_000}
+
+
 def test_fireworks_catalog_exposes_glm_52_fast_router() -> None:
     endpoints = endpoints_for_model("z-ai/glm-5.2-fast")
     fireworks = [endpoint for endpoint in endpoints if endpoint.provider == "fireworks"]


### PR DESCRIPTION
## Summary
- add Fireworks Kimi K3 at the verified upstream ID with first-party standard and cached pricing
- retain narrowly allowlisted launch models when Fireworks pricing and direct inference are live before its authenticated model-list feed catches up
- add parser, discovery, pruning, catalog, BYOK, and billing-price regression coverage

## Verification
- regression tests failed against the previous implementation
- direct Fireworks chat completion: HTTP 200 for accounts/fireworks/models/kimi-k3
- live authenticated pricing refresh: 3.00 input, 0.30 cached input, 15.00 output per million
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 1986 passed, 47 skipped