### PR TITLE
Fix automatic Kimi K3 provider discovery

### DIFF
--- a/scripts/pricing/providers/makora.py
+++ b/scripts/pricing/providers/makora.py
@@ -216,9 +216,6 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
             updated.append(model_id)
         present_rows[model_id] = row
 
-    missing = sorted(set(EXPECTED_MODELS) - set(updated))
-    if missing:
-        raise RuntimeError(f"makora manifest did not update expected model(s): {missing}")
     if not updated:
         raise RuntimeError("makora manifest update touched no rows")
 

--- a/scripts/pricing/providers/nebius.py
+++ b/scripts/pricing/providers/nebius.py
@@ -18,6 +18,10 @@ from scripts.pricing.base import (
     ModelPrice,
     ProviderPricingResult,
 )
+from scripts.pricing.model_ids import (
+    mapped_or_canonical_model_id,
+    remember_upstream_id,
+)
 
 SLUG = "nebius"
 URL = "https://api.tokenfactory.nebius.com/v1/models?verbose=true"
@@ -44,7 +48,30 @@ _NATIVE_TO_CANONICAL = {
     # only for upstream requests so refreshes cannot create a duplicate model.
     "nvidia/Nemotron-3-Ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
     "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia/nemotron-3-ultra-550b-a55b",
+    "moonshotai/Kimi-K3": "moonshotai/kimi-k3",
 }
+UPSTREAM_ID_MAP: dict[str, str] = {}
+
+
+def _existing_native_ids() -> dict[str, str]:
+    """Preserve legacy public IDs while normalizing newly discovered models."""
+
+    if not MANIFEST_PATH.exists():
+        return {}
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    mapped: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        native_id = row.get("upstream_id") or model_id
+        if not isinstance(model_id, str) or not isinstance(native_id, str):
+            continue
+        mapped[native_id] = model_id
+    return mapped
 
 
 def _dollars_per_token_to_micro_per_m(value: object) -> int | None:
@@ -127,6 +154,8 @@ def fetch() -> ProviderPricingResult:
     rows = payload.get("data") if isinstance(payload, dict) else payload
     if not isinstance(rows, list):
         rows = []
+    canonical_by_native = _existing_native_ids()
+    canonical_by_native.update(_NATIVE_TO_CANONICAL)
     prices: dict[str, ModelPrice] = {}
     discovered: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -135,7 +164,10 @@ def fetch() -> ProviderPricingResult:
         upstream_id = row.get("id")
         if not isinstance(upstream_id, str):
             continue
-        model_id = _NATIVE_TO_CANONICAL.get(upstream_id, upstream_id)
+        model_id = mapped_or_canonical_model_id(upstream_id, canonical_by_native)
+        if model_id is None:
+            continue
+        remember_upstream_id(UPSTREAM_ID_MAP, model_id, upstream_id)
         architecture = row.get("architecture")
         architecture = architecture if isinstance(architecture, dict) else {}
         modality = str(architecture.get("modality") or "")
@@ -175,11 +207,25 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         for row in rows
         if isinstance(row, dict) and isinstance(row.get("id"), str)
     }
+    existing_by_upstream = {
+        row.get("upstream_id", row["id"]): row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
     updated: list[str] = []
     appended: list[str] = []
     for model_id, price in sorted(result.prices.items()):
         row = existing.get(model_id)
         discovered = _DISCOVERED_ROWS.get(model_id)
+        if row is None and discovered is not None:
+            upstream_id = discovered.get("upstream_id")
+            if isinstance(upstream_id, str):
+                row = existing_by_upstream.get(upstream_id)
+                if row is not None:
+                    old_id = row["id"]
+                    row["id"] = model_id
+                    existing.pop(old_id, None)
+                    existing[model_id] = row
         if row is None:
             if discovered is None:
                 continue

--- a/scripts/pricing/providers/novita.py
+++ b/scripts/pricing/providers/novita.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
 from scripts.pricing.base import (
+    ModelPrice,
     ProviderPricingResult,
     fetch_json,
     fetch_provider,
@@ -45,6 +47,7 @@ EXPECTED_MODELS = [
     "tencent/hy3",
 ]
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+_API_PRICE_SCALE_TO_MICRODOLLARS_PER_M = Decimal(100)
 
 
 def _positive_int(value: object) -> int | None:
@@ -113,7 +116,49 @@ def _new_required_price_ids(
     )
 
 
-def _live_model_rows() -> dict[str, dict[str, Any]]:
+def _api_price_per_m(value: object) -> int | None:
+    if isinstance(value, dict):
+        value = value.get("price_per_m")
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        scaled = Decimal(str(value)) * _API_PRICE_SCALE_TO_MICRODOLLARS_PER_M
+    except (InvalidOperation, ValueError):
+        return None
+    if scaled < 0 or scaled != scaled.to_integral_value():
+        return None
+    return int(scaled)
+
+
+def _source_price(source: dict[str, Any]) -> ModelPrice | None:
+    """Parse Novita's account-specific per-million-token price fields."""
+
+    pricing = source.get("pricing")
+    pricing = pricing if isinstance(pricing, dict) else {}
+    prompt = _api_price_per_m(
+        source.get("input_token_price_per_m", pricing.get("prompt"))
+    )
+    completion = _api_price_per_m(
+        source.get("output_token_price_per_m", pricing.get("completion"))
+    )
+    if prompt is None or completion is None:
+        return None
+    if prompt == 0 and completion == 0:
+        return None
+    cached = _api_price_per_m(
+        source.get(
+            "cached_input_token_price_per_m",
+            pricing.get("input_cache_read"),
+        )
+    )
+    return ModelPrice(
+        prompt_micro_per_m=prompt,
+        completion_micro_per_m=completion,
+        prompt_cached_micro_per_m=cached,
+    )
+
+
+def _live_catalog() -> tuple[dict[str, dict[str, Any]], dict[str, ModelPrice]]:
     api_key = os.environ.get("NOVITA_API_KEY")
     if not api_key:
         raise RuntimeError("novita: NOVITA_API_KEY is required")
@@ -127,6 +172,7 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
 
     existing_ids = _existing_native_ids()
     discovered: dict[str, dict[str, Any]] = {}
+    api_prices: dict[str, ModelPrice] = {}
     for source in source_rows:
         if not isinstance(source, dict):
             continue
@@ -170,27 +216,47 @@ def _live_model_rows() -> dict[str, dict[str, Any]]:
             if parsed is not None:
                 row[field] = parsed
         discovered[model_id] = row
+        price = _source_price(source)
+        if price is not None:
+            api_prices[model_id] = price
 
     if not discovered:
         raise RuntimeError("novita: /models returned no supported model ids")
+    return discovered, api_prices
+
+
+def _live_model_rows() -> dict[str, dict[str, Any]]:
+    """Return authenticated discovery rows for focused tests and tooling."""
+
+    discovered, _ = _live_catalog()
     return discovered
 
 
 def fetch() -> ProviderPricingResult:
     global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
 
-    discovered = _live_model_rows()
+    discovered, api_prices = _live_catalog()
     required_price_ids = _new_required_price_ids(discovered)
+    page_expected_models = [
+        model_id for model_id in EXPECTED_MODELS if model_id not in api_prices
+    ]
     result = fetch_provider(
         slug=SLUG,
         url=URL,
-        expected_models=EXPECTED_MODELS,
-        required_models=required_price_ids,
+        expected_models=page_expected_models,
+        required_models=required_price_ids - api_prices.keys(),
     )
     _DISCOVERED_MANIFEST_ROWS = discovered
-    result.prices = {
+    page_prices = {
         model_id: price for model_id, price in result.prices.items() if model_id in discovered
     }
+    api_fallback_ids = required_price_ids | (set(EXPECTED_MODELS) - set(page_prices))
+    api_fallback_prices = {
+        model_id: price
+        for model_id, price in api_prices.items()
+        if model_id in api_fallback_ids
+    }
+    result.prices = api_fallback_prices | page_prices
     errors = validate(result.prices, EXPECTED_MODELS)
     if errors:
         raise RuntimeError("; ".join(errors))
@@ -198,6 +264,11 @@ def fetch() -> ProviderPricingResult:
     result.notes.append(
         f"intersected official prices with {len(discovered)} authenticated live models"
     )
+    if api_fallback_prices:
+        result.notes.append(
+            "used authenticated API pricing for "
+            f"{len(api_fallback_prices)} newly discovered or required live models"
+        )
     return result
 
 

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -1,7 +1,7 @@
 {
   "provider": "nebius",
   "source": "https://api.tokenfactory.nebius.com/v1/models?verbose=true",
-  "generated_at": "2026-07-27T15:44:32Z",
+  "generated_at": "2026-07-27T17:25:23Z",
   "model_count": 39,
   "models": [
     {
@@ -969,7 +969,7 @@
       "status": 1
     },
     {
-      "id": "moonshotai/Kimi-K3",
+      "id": "moonshotai/kimi-k3",
       "upstream_id": "moonshotai/Kimi-K3",
       "display_name": "Kimi-K3",
       "title": "moonshotai/Kimi-K3",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -100,6 +100,20 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert "moonshotai/kimi-k3@novita/byok" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@gmi/prepaid" not in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@gmi/byok" in MODEL_ENDPOINTS
+    kimi_k3_routes = {
+        (endpoint.provider, endpoint.usage_type)
+        for endpoint in endpoints_for_model("moonshotai/kimi-k3")
+    }
+    assert {
+        ("kimi", "Credits"),
+        ("siliconflow", "Credits"),
+        ("baseten", "Credits"),
+        ("atlas-cloud", "Credits"),
+        ("novita", "Credits"),
+        ("nebius", "Credits"),
+        ("fireworks", "Credits"),
+        ("gmi", "BYOK"),
+    } <= kimi_k3_routes
     kimi_k3 = MODELS["moonshotai/kimi-k3"]
     assert kimi_k3.context_length == 1_048_576
     assert kimi_k3.prompt_price_microdollars_per_million_tokens == 3_150_000
@@ -109,6 +123,22 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert (
         MODEL_ENDPOINTS["moonshotai/kimi-k3@novita/prepaid"].upstream_id
         == "moonshotai/kimi-k3"
+    )
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k3@siliconflow/prepaid"].upstream_id
+        == "moonshotai/kimi-k3"
+    )
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k3@baseten/prepaid"].upstream_id
+        == "moonshotai/Kimi-K3"
+    )
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k3@nebius/prepaid"].upstream_id
+        == "moonshotai/Kimi-K3"
+    )
+    assert (
+        MODEL_ENDPOINTS["moonshotai/kimi-k3@fireworks/prepaid"].upstream_id
+        == "accounts/fireworks/models/kimi-k3"
     )
     assert (
         MODEL_ENDPOINTS["moonshotai/kimi-k2.7-code-highspeed@kimi/prepaid"].upstream_id

--- a/tests/test_makora_pricing.py
+++ b/tests/test_makora_pricing.py
@@ -286,6 +286,70 @@ def test_makora_provider_updates_supplemental_manifest(tmp_path: Path, monkeypat
     assert raw["generated_at"] != "2026-01-01T00:00:00Z"
 
 
+def test_makora_manifest_writer_allows_normal_upstream_retirement(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    current = "z-ai/glm-5.2"
+    retired = "qwen/qwen3.6-27b"
+    manifest_path = tmp_path / "makora.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "makora",
+                "models": [
+                    {
+                        "id": current,
+                        "upstream_id": "zai-org/GLM-5.2-FP8",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
+                    {
+                        "id": retired,
+                        "upstream_id": "unsloth/Qwen3.6-27B-NVFP4",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(makora, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(makora, "EXPECTED_MODELS", [current, retired])
+    monkeypatch.setattr(
+        makora,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            current: {
+                "id": current,
+                "upstream_id": "zai-org/GLM-5.2-FP8",
+                "status": 1,
+            }
+        },
+    )
+
+    notes = makora.write_provider_manifest(
+        ProviderPricingResult(
+            slug="makora",
+            prices={
+                current: ModelPrice(
+                    prompt_micro_per_m=1_000_000,
+                    completion_micro_per_m=2_000_000,
+                )
+            },
+            source="api",
+            fetched_url=makora.MODELS_URL,
+        )
+    )
+
+    assert notes == ["makora: refreshed provider_models/makora.json (1 priced rows)"]
+    rows = json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    by_id = {row["id"]: row for row in rows}
+    assert by_id[current]["input_token_price_per_m"] == 1_000_000
+    assert retired in by_id
+
+
 def test_provider_model_manifests_have_hourly_refresh_path() -> None:
     legacy_manual: set[str] = set()
     manifest_slugs = {

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -264,6 +264,14 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
                 "pricing": {"prompt": "0.0000006", "completion": "0.0000024"},
             },
             {
+                "id": "moonshotai/Kimi-K3",
+                "name": "Kimi K3",
+                "created": 1,
+                "context_length": 1048576,
+                "architecture": {"modality": "text->text"},
+                "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+            },
+            {
                 "id": "Qwen/Qwen3-Embedding-8B",
                 "name": "Qwen3-Embedding-8B",
                 "created": 1,
@@ -298,15 +306,26 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
     assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in result.prices
     assert nebius._DISCOVERED_ROWS[canonical]["id"] == canonical
     assert nebius._DISCOVERED_ROWS[canonical]["upstream_id"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
+    kimi = "moonshotai/kimi-k3"
+    assert result.prices[kimi].completion_micro_per_m == 15_000_000
+    assert "moonshotai/Kimi-K3" not in result.prices
+    assert nebius._DISCOVERED_ROWS[kimi]["upstream_id"] == "moonshotai/Kimi-K3"
+    assert nebius.UPSTREAM_ID_MAP[kimi] == "moonshotai/Kimi-K3"
     assert "Qwen/Qwen3-Embedding-8B" not in result.prices
 
     manifest = tmp_path / "nebius.json"
-    manifest.write_text('{"models": []}\n', encoding="utf-8")
+    manifest.write_text(
+        '{"models": [{"id": "moonshotai/Kimi-K3", '
+        '"upstream_id": "moonshotai/Kimi-K3"}]}\n',
+        encoding="utf-8",
+    )
     monkeypatch.setattr(nebius, "MANIFEST_PATH", manifest)
 
     nebius.write_provider_manifest(result)
 
     rows = json.loads(manifest.read_text(encoding="utf-8"))["models"]
-    ids = {row["id"] for row in rows}
+    ids = [row["id"] for row in rows]
     assert canonical in ids
     assert "nvidia/Nemotron-3-Ultra-550b-a55b" not in ids
+    assert ids.count(kimi) == 1
+    assert "moonshotai/Kimi-K3" not in ids

--- a/tests/test_novita_pricing.py
+++ b/tests/test_novita_pricing.py
@@ -183,6 +183,132 @@ def test_novita_live_discovery_preserves_existing_ids_and_normalizes_new_ids(
     assert kimi["input_modalities"] == ["text", "image", "video"]
 
 
+def test_novita_fetch_uses_authenticated_api_price_when_html_lags(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "novita.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "novita",
+                "price_scale_to_microdollars_per_million_tokens": 100,
+                "models": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(novita, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setenv("NOVITA_API_KEY", "secret")
+    monkeypatch.setattr(
+        novita,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {
+                    "id": "moonshotai/kimi-k3",
+                    "display_name": "Kimi K3",
+                    "context_size": 1_048_576,
+                    "endpoints": ["chat/completions"],
+                    "input_token_price_per_m": 30_000,
+                    "output_token_price_per_m": 150_000,
+                    "pricing": {
+                        "input_cache_read": {"price_per_m": 3_000},
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        novita,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="novita",
+            prices={},
+            source="html",
+            fetched_url=novita.URL,
+        ),
+    )
+    monkeypatch.setattr(novita, "EXPECTED_MODELS", ["moonshotai/kimi-k3"])
+
+    result = novita.fetch()
+
+    price = result.prices["moonshotai/kimi-k3"]
+    assert price.prompt_micro_per_m == 3_000_000
+    assert price.completion_micro_per_m == 15_000_000
+    assert price.tiers[0].prompt_cached_micro_per_m == 300_000
+    assert any("authenticated API pricing" in note for note in result.notes)
+
+    novita.write_provider_manifest(result)
+    row = json.loads(manifest_path.read_text(encoding="utf-8"))["models"][0]
+    assert row["input_token_price_per_m"] == 30_000
+    assert row["output_token_price_per_m"] == 150_000
+    assert row["cached_input_token_price_per_m"] == 3_000
+
+
+def test_novita_fetch_keeps_public_price_and_does_not_promote_old_dark_rows(
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    kimi = "moonshotai/kimi-k3"
+    old_dark = "example/old-dark-model"
+    discovered = {
+        kimi: {"id": kimi, "upstream_id": kimi, "status": 1},
+        old_dark: {"id": old_dark, "upstream_id": old_dark, "status": 1},
+    }
+    monkeypatch.setattr(
+        novita,
+        "_live_catalog",
+        lambda: (
+            discovered,
+            {
+                kimi: ModelPrice(
+                    prompt_micro_per_m=9_000_000,
+                    completion_micro_per_m=9_000_000,
+                ),
+                old_dark: ModelPrice(
+                    prompt_micro_per_m=100,
+                    completion_micro_per_m=100,
+                ),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        novita,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="novita",
+            prices={
+                kimi: ModelPrice(
+                    prompt_micro_per_m=3_000_000,
+                    completion_micro_per_m=15_000_000,
+                )
+            },
+            source="html",
+            fetched_url=novita.URL,
+        ),
+    )
+    monkeypatch.setattr(novita, "_new_required_price_ids", lambda _rows: frozenset())
+    monkeypatch.setattr(novita, "EXPECTED_MODELS", [kimi])
+
+    result = novita.fetch()
+
+    assert result.prices[kimi].prompt_micro_per_m == 3_000_000
+    assert result.prices[kimi].completion_micro_per_m == 15_000_000
+    assert old_dark not in result.prices
+
+
+def test_novita_api_price_rejects_all_zero_internal_rows() -> None:
+    assert (
+        novita._source_price(
+            {
+                "input_token_price_per_m": 0,
+                "output_token_price_per_m": 0,
+            }
+        )
+        is None
+    )
+
+
 def test_novita_manifest_writer_appends_live_priced_model(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- canonicalize newly discovered Nebius model IDs while preserving legacy public IDs
- migrate Nebius Kimi K3 to the shared canonical ID without duplicating the native route
- use Novita authenticated API pricing as a safe fallback for new/required models when its public HTML catalog lags
- keep public-page pricing authoritative and keep unrelated zero-priced/dark rows dark
- allow Makora models to retire through the existing tombstone policy instead of aborting the entire hourly refresh
- assert all currently routable Kimi K3 providers and exact native IDs

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (1,989 passed, 47 skipped before final focused Makora regression)
- focused pricing/routing tests pass
- direct Nebius `moonshotai/Kimi-K3` streaming canary: HTTP 200, PONG
- live Novita discovery: 137 models; K3 $3 input / $0.30 cached input / $15 output per million tokens
- live Makora fetch + manifest writer succeeds against a temporary manifest (6 current prices; retired rows reconcile safely)