### PR TITLE
docs: analytics ingestion design (v2, after adversarial review) + ClickHouse node scripts

### DIFF
--- a/clickhouse/backfill_benchmark_samples.py
+++ b/clickhouse/backfill_benchmark_samples.py
@@ -1,0 +1,176 @@
+"""Backfill ProviderBenchmarkSample rows from Bigtable into ClickHouse.
+
+Runs ON the ClickHouse node: the VM has cloud-platform scope so it can read
+Bigtable directly, and ClickHouse is on localhost — so this needs no tunnel and
+no inbound path to the database.
+
+Scope (deliberately narrow, per docs/storage-portability/analytics-ingestion.md):
+
+* This is the HISTORICAL/RECONCILIATION source. It is NOT the live CDC
+  mechanism — the Bigtable row key is derived from `created_at`, not commit
+  time, so a high-water-mark cursor over it would permanently miss rows that
+  commit late. Live ingestion needs a durable outbox or Change Streams.
+* Ingestion is AT-LEAST-ONCE. Re-running re-inserts rows. The table is
+  ReplacingMergeTree, which collapses on merge, so `FINAL` (or a GROUP BY) is
+  required for exact counts until a merge happens. There is deliberately no
+  AggregatingMergeTree view attached: an MV would double-count on every replay
+  because it processes each inserted block before replacement.
+
+Verification prints per-day counts from BOTH sides so a mismatch is visible
+immediately rather than after a cutover.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+from collections import Counter
+
+from google.cloud import bigtable
+from google.cloud.bigtable.row_set import RowSet
+
+PROJECT = "quill-cloud-proxy"
+INSTANCE = "trusted-router-logs"
+TABLE = "trustedrouter-generations"
+FAMILY = "m"
+CH_DB = "tr"
+CH_TABLE = "provider_benchmark_samples"
+
+
+def ch(sql: str, stdin: bytes | None = None) -> str:
+    """Run a query through clickhouse-client on localhost."""
+    password = os.environ["CH_PASSWORD"]
+    cmd = [
+        "clickhouse-client", "--user", "tr", "--password", password,
+        "--database", CH_DB, "--query", sql,
+    ]
+    result = subprocess.run(cmd, input=stdin, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"clickhouse error: {result.stderr.decode()[:400]}")
+    return result.stdout.decode()
+
+
+def normalise(raw: dict) -> dict | None:
+    """Canonical row shape. Shared coercions matter: a historical string
+    "429" must become the same UInt16 the query path compares against, or the
+    two disagree by construction."""
+    created = raw.get("created_at") or ""
+    try:
+        parsed = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    parsed = parsed.astimezone(dt.UTC)
+
+    status_code = raw.get("error_status")
+    if isinstance(status_code, str):
+        status_code = int(status_code) if status_code.isdigit() else None
+    elif status_code is not None:
+        status_code = int(status_code)
+
+    provider, model = raw.get("provider"), raw.get("model")
+    if not provider or not model:
+        return None
+
+    return {
+        "id": str(raw.get("id") or ""),
+        "created_at": parsed.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+        "provider": str(provider),
+        "model": str(model),
+        "provider_name": str(raw.get("provider_name") or ""),
+        "status": str(raw.get("status") or ""),
+        "usage_type": str(raw.get("usage_type") or ""),
+        "source": str(raw.get("source") or ""),
+        "streamed": 1 if raw.get("streamed") else 0,
+        "input_tokens": int(raw.get("input_tokens") or 0),
+        "output_tokens": int(raw.get("output_tokens") or 0),
+        "total_cost_microdollars": int(raw.get("total_cost_microdollars") or 0),
+        "speed_tokens_per_second": raw.get("speed_tokens_per_second"),
+        "elapsed_milliseconds": raw.get("elapsed_milliseconds"),
+        "first_token_milliseconds": raw.get("first_token_milliseconds"),
+        "ttfb_milliseconds": raw.get("ttfb_milliseconds"),
+        "finish_reason": raw.get("finish_reason"),
+        "error_type": raw.get("error_type"),
+        "error_status": status_code,
+        "error_message": raw.get("error_message"),
+        "region": raw.get("region"),
+        "app": str(raw.get("app") or ""),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=200_000)
+    parser.add_argument("--batch", type=int, default=20_000)
+    args = parser.parse_args()
+
+    client = bigtable.Client(project=PROJECT, admin=False)
+    table = client.instance(INSTANCE).table(TABLE)
+    rs = RowSet()
+    rs.add_row_range_with_prefix("benchmark_recent#")
+
+    source_days: Counter[str] = Counter()
+    batch: list[dict] = []
+    read = written = skipped = 0
+
+    def flush() -> None:
+        nonlocal batch
+        if not batch:
+            return
+        payload = "\n".join(json.dumps(r) for r in batch).encode()
+        ch(f"INSERT INTO {CH_TABLE} FORMAT JSONEachRow", stdin=payload)
+        batch = []
+
+    print(f"scanning Bigtable (limit {args.limit})...", flush=True)
+    for index, row in enumerate(table.read_rows(row_set=rs)):
+        if index >= args.limit:
+            break
+        cells = row.cells.get(FAMILY, {}).get(b"body", [])
+        if not cells:
+            continue
+        try:
+            raw = json.loads(cells[0].value.decode("utf-8"))
+        except ValueError:
+            continue
+        read += 1
+        record = normalise(raw)
+        if record is None:
+            skipped += 1
+            continue
+        source_days[record["created_at"][:10]] += 1
+        batch.append(record)
+        written += 1
+        if len(batch) >= args.batch:
+            flush()
+            print(f"  {written} rows...", flush=True)
+    flush()
+
+    print(f"\nread={read} written={written} skipped_unparseable={skipped}")
+
+    # Verification: per-day counts from BOTH sides. FINAL because
+    # ReplacingMergeTree only collapses on merge, so a re-run would otherwise
+    # read high until merges catch up.
+    print("\nday          bigtable   clickhouse   delta")
+    ch_rows = ch(
+        f"SELECT toDate(created_at) AS d, count() FROM {CH_TABLE} FINAL "
+        "GROUP BY d ORDER BY d DESC FORMAT TSV"
+    )
+    ch_days = {line.split("\t")[0]: int(line.split("\t")[1])
+               for line in ch_rows.strip().splitlines() if "\t" in line}
+    mismatches = 0
+    for day in sorted(set(source_days) | set(ch_days), reverse=True)[:14]:
+        src, dst = source_days.get(day, 0), ch_days.get(day, 0)
+        flag = "" if src == dst else "  <-- MISMATCH"
+        if src != dst:
+            mismatches += 1
+        print(f"{day}   {src:>8}   {dst:>10}   {dst - src:>5}{flag}")
+    print(f"\n{'OK: every scanned day matches' if not mismatches else f'{mismatches} day(s) differ'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/backfill_benchmark_samples.py
+++ b/clickhouse/backfill_benchmark_samples.py
@@ -47,7 +47,9 @@ def ch(sql: str, stdin: bytes | None = None) -> str:
         "clickhouse-client", "--user", "tr", "--password", password,
         "--database", CH_DB, "--query", sql,
     ]
-    result = subprocess.run(cmd, input=stdin, capture_output=True, check=False)
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, callers pass literal SQL
+        cmd, input=stdin, capture_output=True, check=False
+    )
     if result.returncode != 0:
         raise SystemExit(f"clickhouse error: {result.stderr.decode()[:400]}")
     return result.stdout.decode()
@@ -156,7 +158,7 @@ def main() -> int:
     # read high until merges catch up.
     print("\nday          bigtable   clickhouse   delta")
     ch_rows = ch(
-        f"SELECT toDate(created_at) AS d, count() FROM {CH_TABLE} FINAL "
+        f"SELECT toDate(created_at) AS d, count() FROM {CH_TABLE} FINAL "  # noqa: S608 - module constant
         "GROUP BY d ORDER BY d DESC FORMAT TSV"
     )
     ch_days = {line.split("\t")[0]: int(line.split("\t")[1])

--- a/docs/storage-portability/analytics-ingestion.md
+++ b/docs/storage-portability/analytics-ingestion.md
@@ -1,0 +1,318 @@
+# Analytics ingestion: design for 1T → 100T tokens/month
+
+Companion to `README.md`. One question: **how analytics rows get from the
+control plane into ClickHouse** at 1T tokens/month within ~2 months and 100T
+soon after.
+
+> **Revision history.** v1 of this document proposed a Bigtable high-water-mark
+> replay feeding an additive materialized view, justified by a
+> `parts/s = N/T` argument. An adversarial review found that design cannot
+> survive a crash, a late write, or a replay. Three of its load-bearing claims
+> were factually wrong against this repo. v2 (below) is the corrected design;
+> §2 records the errors deliberately, because each one is a trap the next
+> person will otherwise re-enter.
+
+---
+
+## 1. Measured facts
+
+### Token distribution per organic generation
+
+| p25 | p50 | p75 | p99 | mean |
+|---|---|---|---|---|
+| 421 | 4,104 | 464,756 | 987,811 | 197,673 |
+
+Violently bimodal — small chat-shaped requests plus a heavy long-context tail.
+The mean is dominated by the tail and is useless for capacity planning.
+
+**Row rate cannot be derived from a token total.** At 100T tokens/month:
+
+| assumed tokens/generation | generations/month | rows/sec |
+|---|---|---|
+| 197,673 (mean) | 506 M | ~195 |
+| 4,104 (median) | 24.4 B | ~9,400 |
+| 421 (p25) | 237 B | ~91,000 |
+
+A **450× band**, decided by future traffic mix. Design for row rate, treat it
+as unknown within two orders of magnitude, and **instrument it** so the real
+number is observed rather than predicted.
+
+### Volume today
+
+synthetic ~240 rows/hour, synthetic_throughput ~29, organic ~11. Trivial. The
+problems below are structural and appear at any volume.
+
+### Storage
+
+**54.3 compressed bytes/row** over 20k real rows. Treat *compressed bytes per
+row* as the decision-relevant metric — not a compression ratio (see §5).
+
+### Write path
+
+`ProviderBenchmarkSample` (32 fields) is written for **every real generation**
+(`gateway.py:1211`, `inference_quota.py:137`) plus synthetic probes.
+`Generation` (63 fields) is not mirrored.
+
+### Writer topology
+
+Cloud Run `containerConcurrency=2`, `maxScale=100`, 4 regions ⇒ up to **400
+writer processes**. Concurrency is 2 deliberately — each in-flight request can
+consume 50–200 MB (`scripts/deploy/_lib.sh:33`) — so "just raise concurrency"
+is a mitigation, not a design.
+
+---
+
+## 2. Why the in-process sink (PR #291) is wrong — corrected
+
+PR #291 is merged but **disabled**, and must stay that way. Two of the
+original three arguments hold; the headline one did not.
+
+### 2a. Sound: Cloud Run does not reliably run background work
+
+Cloud Run allocates CPU **during request processing**. A worker thread waking
+on a timer gets little or no CPU between requests, and an instance is quietest
+exactly when it is about to be scaled down. In-process background buffering is
+structurally wrong on this runtime.
+
+### 2b. Sound: `wait_for_async_insert=0` moves the loss window into the server
+
+ClickHouse acks once rows are in its async-insert buffer, and that buffer has
+no WAL. A restart drops rows that already returned 200. ClickHouse's own
+guidance is `wait_for_async_insert=1` for reliable ingestion.
+
+### 2c. **Wrong: `parts/s = N/T`**
+
+v1 claimed 400 writers × 2s flush ⇒ 200 parts/s, therefore breakage "even at 1
+row/second". That is not right, and the error is worth naming:
+
+* The formula assumes every writer emits a **non-empty** insert every `T`. One
+  row/second in total cannot produce 200 non-empty insert blocks/second.
+* The sink does not flush on a fixed period anyway — it blocks for the first
+  row, then drains what is present (`analytics_sink.py:147`), so under sparse
+  traffic it tends toward one insert per row.
+* `async_insert` exists precisely to coalesce compatible inserts from hundreds
+  of clients, and the sink does send identical query text and settings.
+* The positive-feedback story ("inserts delay → threads pile up → autoscale →
+  more writers") is wrong for this code specifically: the request path does a
+  non-blocking `put_nowait` and drops on pressure (`analytics_sink.py:121`).
+  Only the sink's own worker ever blocks.
+
+A better model is `parts/s ≈ flushes per node × insert shapes × partitions
+touched × shards`, with size/time/queued thresholds making row and byte rate
+matter too.
+
+**Durable staging is still the answer — but justified by durability, crash
+recovery, and request-path isolation, not by that formula.** I repeated a
+striking claim without checking it against the code in front of me; the
+correction is the reason this section exists.
+
+---
+
+## 3. The decision that comes first: what loss is acceptable?
+
+**This is a product decision and it selects the architecture.** It cannot be
+deferred.
+
+The current code already answers it one way: `record_benchmark` catches every
+exception and logs (`storage_gcp_generations.py:128`) — Bigtable analytics
+writes are **best-effort, and lost rows are not repairable**. So:
+
+> **Bigtable is not a durable log of every generation.** It is an index of the
+> rows that happened to land. v1 called Source A "no data loss by
+> construction". That was false.
+
+Two coherent positions:
+
+* **(A) Bounded loss is fine** (analytics, not billing). Then a best-effort
+  source is acceptable, the SLO is stated explicitly (e.g. "<0.1% of rows,
+  measured"), and reconciliation detects drift.
+* **(B) Every generation must appear.** Then a **real durable outbox** is
+  required at the point of settle — the same pattern already used for
+  settlement (`storage_gcp_settle_outbox.py`) — and Bigtable's best-effort
+  index cannot be the source.
+
+**Recommendation: (A) now with a measured SLO, (B) if analytics ever becomes
+customer-facing billing evidence.** Do not build (B)'s machinery while the
+requirement is (A) — but do not claim (B)'s guarantees while running (A),
+which is what v1 did.
+
+---
+
+## 4. Ingestion architecture (v2)
+
+Principle retained from v1: **a small number of logical writers** feed
+ClickHouse, not 400 app processes. Everything else changes.
+
+### 4a. Ingestion is AT-LEAST-ONCE, and the schema must survive that
+
+v1's idempotency argument was false in two ways:
+
+* **IDs are random, not deterministic**: `id=f"bench-{uuid.uuid4().hex}"`
+  (`storage_models.py:637`, `:673`). A replayed row gets a *new* id, so
+  `ReplacingMergeTree` cannot collapse it at all.
+* **`ReplacingMergeTree` dedups only on merge.** Queries before merge see
+  duplicates unless they use `FINAL`.
+* **`insert_deduplication_token` is a finite window**, not historical replay
+  protection — and non-replicated tables need
+  `non_replicated_deduplication_window`, which the schema does not set.
+
+Required:
+
+1. A **stable `event_id`** derived from the generation (not a fresh uuid4),
+   plus `source_commit_version` for ordering repeats. This needs a small
+   change at the write site or a deterministic derivation from
+   (generation_id, provider, model, created_at).
+2. **Checkpoint only after durable ClickHouse acknowledgement** — and accept
+   that a crash between ack and checkpoint replays, which is why (1) matters.
+3. Large synchronous inserts, or `async_insert=1` with
+   **`wait_for_async_insert=1`**.
+
+### 4b. Remove the additive materialized view (for now)
+
+`route_health_hourly` is an `AggregatingMergeTree` MV. **MVs run per inserted
+block and do not inherit `ReplacingMergeTree` collapsing** — the schema file
+already says so (`001_provider_benchmark_samples.sql:82`) and the proof
+measured it (three loads of 30,832 rows → 92,500 aggregate samples). v1
+nonetheless asserted the MV "survives unchanged". It does not: **any replay
+permanently inflates it.**
+
+So: serve shadow queries from canonical raw (with `FINAL` at today's
+volumes), and build rollups later by **recomputing closed hourly partitions
+from raw**, with a lateness window — replacing, never accumulating.
+
+### 4c. Sources: split historical from live
+
+**Historical / reconciliation — Bigtable range scan.** Keep this; it is the
+right tool for backfill and for periodic drift detection, and the work is not
+wasted.
+
+**Live — NOT a `created_at` high-water mark.** v1's cursor is broken: the row
+key is `reverse_time_key(created_at)` (`storage_gcp_codec.py:45`), derived
+from **event time, not Bigtable commit time**. A row whose `created_at`
+precedes the checkpoint but which commits after it sorts *behind* the
+already-consumed range and is **missed forever**. Long generations, retries,
+clock skew and the planned eventually-consistent multi-cluster `route-any`
+profile (`config.py:184`) all make this real.
+
+Options, in order of preference:
+
+1. **Durable outbox at settle** (position B) — correct by construction, reuses
+   an established pattern in this codebase.
+2. **Bigtable Change Streams** — carries server commit timestamps,
+   continuation tokens, updates and partition watermarks; designed for exactly
+   this.
+3. **Range scan with a large explicit overlap window** — acceptable only as a
+   temporary low-volume shadow, only with deduplication on canonical raw, and
+   only with the maximum-lateness assumption written down.
+
+**Object-storage staging remains the portable target**, but v1 hand-waved it.
+Object stores have no shared append: it needs unique immutable object names,
+schema version, checksum, atomic finalize, a manifest or notification, a
+processed-object ledger, and retention. `gcs()`/`s3()` do not track what was
+processed. And objects must be produced by a durable regional collector — not
+from Cloud Run process memory, which reintroduces §2a.
+
+---
+
+## 5. Schema — measure, do not prescribe
+
+v1 asserted several changes as conclusions. They are hypotheses.
+
+* **Daily partitioning is not a parts fix.** Today's traffic lands in one
+  current partition either way. Daily may be right for *retention
+  granularity*, but a mixed-date backfill creates a part per partition per
+  insert — so it needs partition-aligned backfill batches and measured part
+  counts.
+* **`id → UUID` is not a drop-in.** Production ids are `bench-` + 32 hex
+  (`storage_models.py:637`), not 36-char UUIDs. Specify the transformation,
+  validate historically, and decide whether the external id is retained.
+* **"10× compression" is the wrong target.** Converting strings to native
+  types lowers the *uncompressed* denominator and can make the ratio look
+  worse while improving storage. Target **compressed bytes/row**, bytes
+  scanned per query, and CPU.
+* **Do not move `error_message` out yet.** Route-health displays the newest
+  error message (`route_health.py:95`); splitting it breaks that, and absent
+  nullable values already compress cheaply. Keep it with truncation + ZSTD
+  until column-level measurement justifies otherwise.
+* **Codecs are candidates, not conclusions.** Benchmark `Delta` vs
+  `DoubleDelta` vs `T64` vs plain ZSTD on real data.
+* **Two access paths, both explicit.** `(provider, model, created_at, id)` is
+  right for newest-per-route; a global recent-time scan needs a time-first
+  projection or a separately rebuilt rollup.
+* **Sharding/replication is unspecified** and must not stay that way past
+  stage 3: hashing by route helps locality but skews hot routes; hashing by
+  event id balances writes but fans route queries across shards.
+
+---
+
+## 6. Prove the real consumers before any cutover
+
+v1's stage 2 ("flip the leaderboard, then usage_series") is unsupported.
+
+* **`route_health_hourly` does not reproduce route health.** Production takes
+  the newest 48 rows per route *across all sources* and filters after
+  (`route_health.py:73`); the MV filters first and has no newest-N operation.
+  It also cannot supply the newest error message. The differential proof
+  validates the *raw-table SQL* (which does use `row_number()` correctly) and
+  **never validates the MV**.
+* **The public leaderboard is materially unproven** — provider-balanced capped
+  sampling (`benchmark_samples.py:51`), organic/synthetic exclusions, exact
+  nearest-rank percentiles, sustained-throughput fallback
+  (`leaderboard.py:251`), top errors, last-seen, weighted provider
+  aggregation.
+* **`usage_series`/activity cannot be served from this dataset at all**:
+  `ProviderBenchmarkSample` deliberately omits workspace identity
+  (`storage_models.py:588`). That needs a separate `Generation` pipeline.
+
+Each consumer gets its own differential proof before its own cutover.
+
+---
+
+## 7. Staged plan
+
+| Stage | Do | Move on when |
+|---|---|---|
+| **0** | Decide the loss SLO (§3). ClickHouse node up (**done** — `tr-clickhouse-1`, internal-only). Backfill history via Bigtable range scan. Canonical raw only, **no additive MV**. | backfill matches source counts per time bucket |
+| **1** | Live shadow via the chosen source (§4c). Continuous **row-set** verification. No reads from ClickHouse. | verification stable 7 days, lag within SLO |
+| **2** | Per-consumer: build the query, differentially prove it, then flip that one consumer. Route-health first (smallest surface), leaderboard second. | each proof passes on live data |
+| **3** | Instrument real rows/s. Revisit sizing, replication, sharding, and self-host-vs-managed **with numbers**. | rows/s > 5,000 sustained or storage > 1 TB/month |
+| **4** | Swap the source to object storage as part of the AWS move. | AWS cluster work begins |
+
+**Replication/backup must not lag a read cutover** — v1 had stage 2 flipping
+reads before stage 3 even considered replication. If a consumer reads from
+ClickHouse, ClickHouse needs a restore story and a Bigtable read fallback.
+
+---
+
+## 8. Verification
+
+The failure mode of an analytics migration is *plausible wrong numbers*, not
+an outage.
+
+* **Row-set comparison**, not just aggregate agreement: counts plus id/checksum
+  sets per time bucket. Aggregates can agree while rows are wrong.
+* **Wall-clock cutoffs.** The proof currently derives its window from
+  `newest_ingested_row - 48h` (`prove_leaderboard.py:359`), which silently
+  shifts the window backward and can *hide* ingestion lag. Use wall clock.
+* The comparison runs as a **read-only** job. `prove_leaderboard.py` truncates
+  by default — it is a local harness; extract the comparison, never schedule
+  the script.
+* Dashboard `system.part_log` parts/s and `system.asynchronous_insert_log`
+  shape counts from day one.
+* Alert on ingester lag, checkpoint age, and DLQ depth.
+
+Operational gaps to close before stage 2: durable checkpoint store, leader
+lease (what happens when two runs overlap), batch ids, retry caps, poison-row
+isolation and a DLQ (ClickHouse rejects an **entire** async insert if one row
+fails to parse), and backfill/live handoff.
+
+---
+
+## 9. What survives from PR #291
+
+* **Delete**: `ClickHouseAnalyticsSink` and the `_StoreProxy` fan-out.
+* **Keep**: `_row_from_sample` encoding and `_optional_int` normalisation — the
+  latter prevents a `"429"`-vs-`429` divergence between the Python and SQL
+  paths. They move to the ingester.
+* **Keep**: the ClickHouse schema (minus the additive MV), the differential
+  proof harness, and the route-health exclusion predicate.

--- a/scripts/deploy/clickhouse_node.sh
+++ b/scripts/deploy/clickhouse_node.sh
@@ -52,6 +52,27 @@ else
     --description "ClickHouse HTTP+native, VPC-internal only"
 fi
 
+# ------------------------------------------------------------------- egress
+# The node has NO external IP, so without Cloud NAT it cannot reach
+# deb.debian.org and the ClickHouse install fails with "Network is
+# unreachable". NAT gives egress only — no inbound path is created, so the
+# security posture is unchanged.
+if gcloud compute routers describe tr-nat-router --region "${ZONE%-*}" --project "$PROJECT" >/dev/null 2>&1; then
+  log "cloud router exists"
+else
+  log "creating cloud router"
+  gcloud compute routers create tr-nat-router --network default \
+    --region "${ZONE%-*}" --project "$PROJECT"
+fi
+if gcloud compute routers nats describe tr-nat --router tr-nat-router --region "${ZONE%-*}" --project "$PROJECT" >/dev/null 2>&1; then
+  log "cloud NAT exists"
+else
+  log "creating cloud NAT (egress only)"
+  gcloud compute routers nats create tr-nat --router tr-nat-router \
+    --region "${ZONE%-*}" --project "$PROJECT" \
+    --auto-allocate-nat-external-ips --nat-all-subnet-ip-ranges
+fi
+
 # ---------------------------------------------------------------- startup
 # The startup script lives in its own file rather than a heredoc inside $( ):
 # bash parses quotes inside command substitution, so a single apostrophe in a

--- a/scripts/deploy/clickhouse_node.sh
+++ b/scripts/deploy/clickhouse_node.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Provision the analytics ClickHouse node.
+#
+# Stage 0 of docs/storage-portability/analytics-ingestion.md: a single
+# internal-only node. Deliberately small — today's volume is ~280 rows/hour and
+# the row rate at scale is unknown within 450x, so sizing now would be guessing.
+# Stage 3 revisits this with measured numbers.
+#
+# NETWORKING: no public IP. Under the Bigtable-replay ingestion design only the
+# ingester talks to ClickHouse, and the ingester runs on this same host, so
+# nothing needs to reach it from outside the VPC. That is a security property
+# worth keeping: do not add an external IP to "make testing easier" — use
+# `gcloud compute ssh --tunnel-through-iap` instead.
+#
+# Idempotent: re-running skips resources that already exist.
+set -euo pipefail
+
+PROJECT="${PROJECT:-quill-cloud-proxy}"
+ZONE="${ZONE:-us-central1-a}"          # colocated with Bigtable/Spanner to keep the ingest scan local
+NAME="${NAME:-tr-clickhouse-1}"
+MACHINE="${MACHINE:-e2-standard-4}"    # 4 vCPU / 16 GB
+DISK_GB="${DISK_GB:-200}"
+DISK_TYPE="${DISK_TYPE:-pd-ssd}"
+SECRET="${SECRET:-trustedrouter-clickhouse-password}"
+
+log() { printf '\n=== %s\n' "$*"; }
+
+log "project=$PROJECT zone=$ZONE name=$NAME machine=$MACHINE disk=${DISK_GB}GB"
+
+# ---------------------------------------------------------------- password
+if gcloud secrets describe "$SECRET" --project "$PROJECT" >/dev/null 2>&1; then
+  log "secret $SECRET already exists — reusing"
+else
+  log "creating secret $SECRET"
+  # Generated here and never echoed; the VM reads it from Secret Manager at boot.
+  python3 -c "import secrets;print(secrets.token_urlsafe(32),end='')" \
+    | gcloud secrets create "$SECRET" --project "$PROJECT" --data-file=- --replication-policy=automatic
+fi
+
+# ---------------------------------------------------------------- firewall
+# Internal-only: the VPC's own ranges may reach the native + HTTP ports. No
+# 0.0.0.0/0 rule anywhere in this script, by design.
+if gcloud compute firewall-rules describe tr-clickhouse-internal --project "$PROJECT" >/dev/null 2>&1; then
+  log "firewall rule exists"
+else
+  log "creating internal-only firewall rule"
+  gcloud compute firewall-rules create tr-clickhouse-internal \
+    --project "$PROJECT" --network default \
+    --allow tcp:8123,tcp:9000 \
+    --source-ranges 10.128.0.0/9 \
+    --target-tags tr-clickhouse \
+    --description "ClickHouse HTTP+native, VPC-internal only"
+fi
+
+# ---------------------------------------------------------------- startup
+# The startup script lives in its own file rather than a heredoc inside $( ):
+# bash parses quotes inside command substitution, so a single apostrophe in a
+# comment there silently breaks the whole script (it did).
+STARTUP_FILE="$(dirname "$0")/clickhouse_startup.sh"
+
+if gcloud compute instances describe "$NAME" --zone "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
+  log "instance $NAME already exists — skipping create"
+else
+  log "creating instance (no external IP)"
+  PASSWORD=$(gcloud secrets versions access latest --secret "$SECRET" --project "$PROJECT")
+  gcloud compute instances create "$NAME" \
+    --project "$PROJECT" --zone "$ZONE" \
+    --machine-type "$MACHINE" \
+    --image-family debian-12 --image-project debian-cloud \
+    --boot-disk-size "${DISK_GB}GB" --boot-disk-type "$DISK_TYPE" \
+    --tags tr-clickhouse \
+    --no-address \
+    --scopes https://www.googleapis.com/auth/cloud-platform \
+    --metadata-from-file startup-script="$STARTUP_FILE" \
+    --metadata ch-password="$PASSWORD"
+fi
+
+log "done. tail provisioning with:"
+echo "  gcloud compute ssh $NAME --zone $ZONE --project $PROJECT --tunnel-through-iap --command 'sudo tail -f /var/log/tr-clickhouse-startup.log'"

--- a/scripts/deploy/clickhouse_startup.sh
+++ b/scripts/deploy/clickhouse_startup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec > >(tee /var/log/tr-clickhouse-startup.log) 2>&1
+
+if [ -f /var/lib/tr-clickhouse-provisioned ]; then
+  echo "already provisioned"; exit 0
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y apt-transport-https ca-certificates dirmngr gnupg curl
+
+GPG_KEY=8919F6BD2B48D754
+mkdir -p /usr/share/keyrings
+curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' \
+  | gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" \
+  > /etc/apt/sources.list.d/clickhouse.list
+apt-get update -y
+
+PASSWORD=$(curl -fsSL -H 'Metadata-Flavor: Google' \
+  "http://metadata.google.internal/computeMetadata/v1/instance/attributes/ch-password")
+debconf-set-selections <<< "clickhouse-server clickhouse-server/default-password password ${PASSWORD}"
+apt-get install -y clickhouse-server clickhouse-client
+
+# Listen on the VPC interface only — never 0.0.0.0. The firewall is the second
+# layer, not the only one.
+cat > /etc/clickhouse-server/config.d/tr-listen.xml <<'XML'
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <!-- Bound to the instance private NIC; there is no external IP on this
+         VM and the firewall restricts source ranges to the VPC. -->
+</clickhouse>
+XML
+
+# Ingest tuning for the single-ingester design: one writer means we can afford
+# a low part rate, which is the whole point of the architecture.
+cat > /etc/clickhouse-server/config.d/tr-merge.xml <<'XML'
+<clickhouse>
+    <merge_tree>
+        <!-- Defaults are 150/300; raised modestly because backfill inserts
+             large batches from ONE writer rather than many small ones from
+             hundreds. Still low enough to surface a runaway ingester. -->
+        <parts_to_delay_insert>300</parts_to_delay_insert>
+        <parts_to_throw_insert>600</parts_to_throw_insert>
+    </merge_tree>
+</clickhouse>
+XML
+
+cat > /etc/clickhouse-server/users.d/tr-user.xml <<XML
+<clickhouse>
+    <users>
+        <tr>
+            <password>${PASSWORD}</password>
+            <networks><ip>10.0.0.0/8</ip></networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </tr>
+    </users>
+</clickhouse>
+XML
+chmod 640 /etc/clickhouse-server/users.d/tr-user.xml
+chown clickhouse:clickhouse /etc/clickhouse-server/users.d/tr-user.xml
+
+systemctl enable clickhouse-server
+systemctl restart clickhouse-server
+
+for _ in $(seq 1 60); do
+  if clickhouse-client --user tr --password "${PASSWORD}" --query 'SELECT 1' >/dev/null 2>&1; then
+    clickhouse-client --user tr --password "${PASSWORD}" --query 'CREATE DATABASE IF NOT EXISTS tr'
+    echo "clickhouse ready"
+    touch /var/lib/tr-clickhouse-provisioned
+    exit 0
+  fi
+  sleep 2
+done
+echo "clickhouse did not become ready" >&2
+exit 1

--- a/scripts/deploy/clickhouse_startup.sh
+++ b/scripts/deploy/clickhouse_startup.sh
@@ -52,7 +52,15 @@ cat > /etc/clickhouse-server/users.d/tr-user.xml <<XML
     <users>
         <tr>
             <password>${PASSWORD}</password>
-            <networks><ip>10.0.0.0/8</ip></networks>
+            <networks>
+                <ip>10.0.0.0/8</ip>
+                <!-- Loopback is required, not optional: the ingester runs on
+                     this host and the readiness check below connects over
+                     127.0.0.1, which is NOT inside the VPC range. Omitting it
+                     leaves the server healthy but the user unable to log in. -->
+                <ip>127.0.0.1</ip>
+                <ip>::1</ip>
+            </networks>
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>


### PR DESCRIPTION
Design doc + provisioning scripts. No application code changes.

## v1 was wrong; this is the correction
I wrote a v1 of this design, had codex review it, and it came back **redesign**. Three load-bearing claims were factually wrong against this repo — each verified against the source before rewriting:

| v1 claim | Reality |
|---|---|
| "deterministic ids ⇒ replay is idempotent" | `id=f"bench-{uuid.uuid4().hex}"` (`storage_models.py:637`) — **random**. A replayed row gets a new id and can't be collapsed. |
| "the materialized view survives unchanged" | An MV runs per inserted block and does **not** inherit `ReplacingMergeTree` collapsing. The schema file said so and the proof had *measured* it (3 loads of 30,832 rows → 92,500 aggregate samples). v1 asserted the opposite anyway. |
| "no data loss by construction" | `record_benchmark` catches every exception and logs (`storage_gcp_generations.py:128`). Bigtable is a **best-effort index**, not a durable log. |

Plus a fourth: the live cursor. The row key is `reverse_time_key(created_at)` (`storage_gcp_codec.py:45`) — **event time, not commit time** — so a row that commits after the checkpoint but has an earlier `created_at` sorts behind the consumed range and is **missed forever**.

I also over-claimed `parts/s = N/T`. It assumes every writer emits a non-empty insert every `T`; one row/sec cannot produce 200 insert blocks/sec. And the positive-feedback story doesn't apply to this code — the request path uses non-blocking `put_nowait`. Durable staging is still right, but justified by **durability and request-path isolation**, not that formula. I'd repeated a striking claim without checking it against the code in front of me.

## What v2 changes
- **The loss SLO is now decision #1**, because it selects the architecture — rather than an assumed property.
- **Ingestion is at-least-once**: stable `event_id`, checkpoint-after-ack, `wait_for_async_insert=1`.
- **The additive MV is removed**; rollups get rebuilt from canonical raw by replacing closed partitions.
- **Range scan demoted** to backfill/reconciliation; live needs a durable outbox or Bigtable Change Streams.
- **Schema guidance demoted to hypotheses** — daily partitioning isn't a parts fix, `id` isn't a UUID (`bench-`+32hex), target *compressed bytes/row* not a ratio, and `error_message` stays because route-health shows the newest error.
- **Per-consumer proofs before per-consumer cutover.** `usage_series` can't be served from this dataset at all — `ProviderBenchmarkSample` omits workspace identity by design.

## Also included
`scripts/deploy/clickhouse_node.sh` + `clickhouse_startup.sh` — one internal-only node (**no external IP**), password in Secret Manager, VPC-only firewall. Under this design only the ingester reaches ClickHouse, so nothing needs access from the 400 app instances.

PR #291 stays **disabled** and is slated for deletion; §9 lists what survives from it.