### PR TITLE
Fix Makora retirement routing contract

### DIFF
--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1558,14 +1558,16 @@ def test_makora_provider_models_present_and_routable() -> None:
         "z-ai/glm-5.2": "zai-org/GLM-5.2-FP8",
         "z-ai/glm-5.2-nvfp4": "zai-org/GLM-5.2-NVFP4",
         "moonshotai/kimi-k2.7-code": "moonshotai/Kimi-K2.7-Code",
-        "qwen/qwen3.6-35b-a3b": "unsloth/Qwen3.6-35B-A3B-NVFP4",
     }
     makora_model_ids = {
         endpoint.model_id
         for endpoint in MODEL_ENDPOINTS.values()
         if endpoint.provider == "makora" and str(endpoint.usage_type) == "Credits"
     }
-    assert len(makora_model_ids) >= 8
+    # The manifest deliberately keeps a missing upstream model routable for
+    # one refresh before tombstoning it. Require the current live lineup
+    # without freezing a minimum fleet size that breaks normal retirements.
+    assert set(expected) <= makora_model_ids
     assert "qwen/qwen3.6-27b" not in makora_model_ids
     assert "openai/gpt-oss-120b" not in makora_model_ids
     for model_id, upstream in expected.items():


### PR DESCRIPTION
## Summary
- require Makora current live six-model lineup instead of a brittle minimum provider count
- allow the existing one-refresh retirement grace period without failing hourly ingestion
- retain exact native ID and positive-price assertions for every required route

## Verification
- focused Makora routing and retirement tests
- Ruff
- mypy

This fixes the validation failure in hourly refresh run 30298873442 after Makora retired legacy routes.