### PR TITLE
Correct Venice privacy and TEE classifications

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -135,6 +135,7 @@ from trusted_router.catalog_ingest import (  # noqa: F401 - used by import-time 
 # keeps working for every existing caller.
 from trusted_router.catalog_privacy import (  # noqa: F401 - re-exported for back-compat
     endpoint_privacy_tier,
+    endpoint_stores_content,
     endpoint_zero_data_retention,
     endpoint_zero_data_retention_scope,
     model_provider_policy,
@@ -616,7 +617,7 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
                 "usage_type": endpoint.usage_type,
                 "upstream_id": endpoint.upstream_id,
                 "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
-                "stores_content": PROVIDERS[endpoint.provider].stores_content,
+                "stores_content": endpoint_stores_content(endpoint),
                 "provider_zero_data_retention": endpoint_zero_data_retention(endpoint),
                 "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
                 "privacy_tier": endpoint_privacy_tier(endpoint),

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -90,6 +90,30 @@ class ModelProviderPrivacyOverride:
     provider_policy_url: str | None = None
 
 
+# Audited 2026-07-27 against https://api.venice.ai/api/v1/models. Any new
+# Venice route defaults to Standard until its model-level privacy mode is
+# reviewed and added here.
+_VENICE_PRIVATE_MODEL_IDS = frozenset(
+    {
+        "qwen/qwen3-235b-a22b-thinking-2507",
+        "qwen/qwen3.5-9b",
+        "qwen/qwen3.6-27b",
+        "z-ai/glm-4.6",
+        "z-ai/glm-4.7",
+        "z-ai/glm-4.7-flash",
+        "z-ai/glm-5",
+        "z-ai/glm-5.1",
+        "z-ai/glm-5.2",
+    }
+)
+_VENICE_PRIVATE_POLICY = (
+    "Venice's live model catalog marks this exact route private. Venice describes "
+    "Private as contract-enforced zero data retention. This is policy-backed, not "
+    "hardware-verified: the route is not TEE or E2EE and is excluded from "
+    "trustedrouter/e2e."
+)
+
+
 _MODEL_PROVIDER_PRIVACY_OVERRIDES: dict[tuple[str, str], ModelProviderPrivacyOverride] = {
     (
         "anthropic/claude-fable-5",
@@ -117,6 +141,15 @@ _MODEL_PROVIDER_PRIVACY_OVERRIDES: dict[tuple[str, str], ModelProviderPrivacyOve
             "trustedrouter/zdr and provider.min_privacy=zdr routing."
         ),
     ),
+    **{
+        (model_id, "venice"): ModelProviderPrivacyOverride(
+            privacy_tier=PRIVACY_TIER_ZERO_RETENTION,
+            provider_zero_data_retention=True,
+            provider_policy=_VENICE_PRIVATE_POLICY,
+            provider_policy_url="https://venice.ai/privacy",
+        )
+        for model_id in _VENICE_PRIVATE_MODEL_IDS
+    },
 }
 
 
@@ -441,23 +474,27 @@ PROVIDERS: dict[str, Provider] = {
         provider_policy_url="https://tinfoil.sh/security-and-privacy-faq",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
-    # Venice.AI — privacy-focused LLM gateway. No-logs, no-censoring
-    # positioning. OpenAI-compatible at api.venice.ai/api/v1.
+    # Venice's privacy posture is model-specific. Its Private routes carry a
+    # policy-backed ZDR claim, while Anonymized routes may be retained by the
+    # downstream model provider. TEE/E2EE require distinct tee-* / e2ee-*
+    # models and a separate attestation/encryption protocol that the current
+    # TrustedRouter Venice adapter does not implement.
     "venice": Provider(
         slug="venice",
         name="Venice",
         supports_prepaid=True,
-        stores_content=False,
-        provider_zero_data_retention=True,
-        provider_confidential_compute=True,
-        provider_e2ee=True,
+        stores_content=True,
+        provider_zero_data_retention=False,
+        provider_confidential_compute=False,
+        provider_e2ee=False,
         provider_policy=(
-            "Tracked as confidential — Venice documents no logging or storage of "
-            "prompts/responses plus TEE-isolated, end-to-end-encrypted inference. "
-            "(Caveat: requests Venice proxies to external frontier models inherit "
-            "those providers' policies; TR routes Venice-native open models here.)"
+            "Mixed model-specific posture. TrustedRouter's current Venice routes do "
+            "not use Venice's tee-* or e2ee-* protocol and are not tracked as "
+            "confidential or E2EE. Exact routes marked Private in Venice's live "
+            "catalog qualify as contract-enforced ZDR through endpoint-specific "
+            "records; Anonymized routes do not."
         ),
-        provider_policy_url="https://docs.venice.ai/overview/privacy",
+        provider_policy_url="https://venice.ai/privacy",
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
     # Parasail — serverless inference platform. Hosts Llama, Qwen,
@@ -1677,7 +1714,7 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
     ),
 }
 
-_PROVIDER_DISPLAY_ORDER = ("tinfoil", "venice")
+_PROVIDER_DISPLAY_ORDER = ("tinfoil",)
 
 
 # Legacy compatibility aliases (advisor/synth primitives) — completes

--- a/src/trusted_router/catalog_privacy.py
+++ b/src/trusted_router/catalog_privacy.py
@@ -63,6 +63,11 @@ def endpoint_privacy_tier(endpoint: ModelEndpoint) -> int:
     return provider_privacy_tier(provider)
 
 
+def endpoint_stores_content(endpoint: ModelEndpoint) -> bool:
+    """Return the retention posture for this exact provider/model route."""
+    return endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE
+
+
 def endpoint_zero_data_retention(endpoint: ModelEndpoint) -> bool | None:
     """Return the ZDR guarantee that applies to this exact credential path."""
     override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -12,6 +12,7 @@ from trusted_router.catalog import (
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
     endpoint_privacy_tier,
+    endpoint_stores_content,
     endpoint_zero_data_retention,
     endpoint_zero_data_retention_scope,
     model_provider_policy,
@@ -171,7 +172,7 @@ def register_catalog_routes(router: APIRouter) -> None:
                     ],
                     "trustedrouter": {
                         "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
-                        "stores_content": PROVIDERS[endpoint.provider].stores_content,
+                        "stores_content": endpoint_stores_content(endpoint),
                         "provider_zero_data_retention": endpoint_zero_data_retention(endpoint),
                         "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
                         "privacy_tier": endpoint_privacy_tier(endpoint),

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -490,7 +490,7 @@ def _requested_model_ids(
                 "anthropic,openai,google-vertex,google-ai-studio,tinfoil,venice,phala"
             )
         elif stripped == E2E_MODEL_ID:
-            overrides["order"] = "tinfoil,venice,phala"
+            overrides["order"] = "tinfoil,phala"
         elif stripped == EU_MODEL_ID:
             provider_order = ",".join(EU_FOCUSED_PROVIDER_ORDER)
             overrides["order"] = provider_order

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -297,7 +297,7 @@ def zdr_candidate_models(limit: int = 12) -> list[Model]:
 def e2e_candidate_models(limit: int = 12) -> list[Model]:
     return _privacy_candidate_models(
         min_tier=PRIVACY_TIER_CONFIDENTIAL,
-        preferred_providers=("tinfoil", "venice", "phala", "gmi"),
+        preferred_providers=("tinfoil", "phala"),
         limit=limit,
     )
 

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -66,6 +66,8 @@ from trusted_router.catalog import (
     auto_candidate_models,
     canonical_orchestration_model_id,
     endpoint_privacy_tier,
+    endpoint_stores_content,
+    endpoint_zero_data_retention,
     endpoints_for_model,
     meta_candidate_models,
     model_eu_focused_provider_available,
@@ -1351,6 +1353,70 @@ def test_privacy_meta_models_force_endpoint_privacy_floor() -> None:
     assert all(
         provider_privacy_tier(PROVIDERS[endpoint.provider]) >= PRIVACY_TIER_CONFIDENTIAL
         for _model, endpoint in e2e_endpoints
+    )
+    assert "venice" not in {endpoint.provider for _model, endpoint in e2e_endpoints}
+
+
+def test_venice_privacy_is_model_specific_and_never_claims_tee() -> None:
+    provider = PROVIDERS["venice"]
+    assert provider.stores_content is True
+    assert provider.provider_zero_data_retention is False
+    assert provider.provider_confidential_compute is False
+    assert provider.provider_e2ee is False
+
+    private_models = {
+        "qwen/qwen3-235b-a22b-thinking-2507",
+        "qwen/qwen3.5-9b",
+        "qwen/qwen3.6-27b",
+        "z-ai/glm-4.6",
+        "z-ai/glm-4.7",
+        "z-ai/glm-4.7-flash",
+        "z-ai/glm-5",
+        "z-ai/glm-5.1",
+        "z-ai/glm-5.2",
+    }
+    anonymized_models = {
+        "qwen/qwen3.5-397b-a17b",
+        "z-ai/glm-5-turbo",
+        "z-ai/glm-5v-turbo",
+    }
+    endpoints = [
+        endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "venice"
+    ]
+    assert {endpoint.model_id for endpoint in endpoints} == private_models | anonymized_models
+
+    for endpoint in endpoints:
+        if endpoint.model_id in private_models:
+            assert endpoint_privacy_tier(endpoint) == PRIVACY_TIER_ZERO_RETENTION
+            assert endpoint_zero_data_retention(endpoint) is True
+            assert endpoint_stores_content(endpoint) is False
+        else:
+            assert endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD
+            assert endpoint_zero_data_retention(endpoint) is False
+            assert endpoint_stores_content(endpoint) is True
+
+    private_shape = model_to_openrouter_shape(MODELS["z-ai/glm-5.2"])
+    private_venice = [
+        endpoint
+        for endpoint in private_shape["trustedrouter"]["endpoints"]
+        if endpoint["provider"] == "venice"
+    ]
+    assert private_venice
+    assert all(endpoint["stores_content"] is False for endpoint in private_venice)
+    assert all(endpoint["provider_zero_data_retention"] is True for endpoint in private_venice)
+    assert all(endpoint["provider_confidential_compute"] is False for endpoint in private_venice)
+    assert all(endpoint["provider_e2ee"] is False for endpoint in private_venice)
+
+    anonymized_shape = model_to_openrouter_shape(MODELS["z-ai/glm-5-turbo"])
+    anonymized_venice = [
+        endpoint
+        for endpoint in anonymized_shape["trustedrouter"]["endpoints"]
+        if endpoint["provider"] == "venice"
+    ]
+    assert anonymized_venice
+    assert all(endpoint["stores_content"] is True for endpoint in anonymized_venice)
+    assert all(
+        endpoint["provider_zero_data_retention"] is False for endpoint in anonymized_venice
     )
 
 

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1063,7 +1063,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         not provider["provider_zero_data_retention"] or provider["stores_content"] is False
         for provider in providers
     )
-    assert [provider["id"] for provider in providers[:2]] == ["tinfoil", "venice"]
+    assert [provider["id"] for provider in providers[:2]] == ["tinfoil", "trustedrouter"]
     assert {
         "anthropic",
         "openai",
@@ -1090,10 +1090,12 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["together"]["provider_zero_data_retention"] is True
     assert provider_flags["nebius"]["provider_zero_data_retention"] is True
     assert provider_flags["parasail"]["provider_zero_data_retention"] is True
-    assert provider_flags["venice"]["provider_zero_data_retention"] is True
-    # Venice runs TEE + E2EE inference — it's confidential, not merely no-logs.
-    assert provider_flags["venice"]["provider_confidential_compute"] is True
-    assert provider_flags["venice"]["provider_e2ee"] is True
+    # Venice privacy is model-specific. Current TR routes use its ordinary
+    # OpenAI-compatible protocol, never the separate tee-* / e2ee-* protocol.
+    assert provider_flags["venice"]["provider_zero_data_retention"] is False
+    assert provider_flags["venice"]["stores_content"] is True
+    assert provider_flags["venice"]["provider_confidential_compute"] is False
+    assert provider_flags["venice"]["provider_e2ee"] is False
     # DeepInfra is normally memory-only, but reserves limited content logging
     # for debugging/security and therefore must not satisfy strict ZDR routing.
     assert provider_flags["deepinfra"]["provider_zero_data_retention"] is False
@@ -1121,7 +1123,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert providers_without_policy_source == []
     expected_policy_sources = {
         "tinfoil": "https://tinfoil.sh/security-and-privacy-faq",
-        "venice": "https://docs.venice.ai/overview/privacy",
+        "venice": "https://venice.ai/privacy",
         "anthropic": "https://platform.claude.com/docs/en/api/data-retention",
         "cerebras": "https://inference-docs.cerebras.ai/capabilities/prompt-caching",
         "together": "https://docs.together.ai/docs/privacy-and-security",
@@ -1155,8 +1157,8 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "phala",
         "tinfoil",
         "together",
-        "venice",
     }.issubset(zdr_providers)
+    assert "venice" not in zdr_providers
     assert "anthropic" not in zdr_providers
     assert "google-ai-studio" not in zdr_providers
     assert "google-vertex" not in zdr_providers

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -228,7 +228,7 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert providers_json.status_code == 200
     assert providers_json.headers["content-type"].startswith("application/json")
     provider_rows = providers_json.json()["data"]
-    assert [item["id"] for item in provider_rows[:2]] == ["tinfoil", "venice"]
+    assert [item["id"] for item in provider_rows[:2]] == ["tinfoil", "trustedrouter"]
     tinfoil = next(item for item in provider_rows if item["id"] == "tinfoil")
     assert tinfoil["provider_e2ee"] is True
     openai = next(item for item in provider_rows if item["id"] == "openai")


### PR DESCRIPTION
## Summary
- remove provider-wide TEE/E2EE/ZDR claims from Venice
- retain contractual ZDR only for Venice routes marked private by its live model catalog
- exclude Venice from trustedrouter/e2e and keep anonymized routes at standard privacy
- make endpoint stores_content metadata follow the exact route privacy tier

## Verification
- live Venice /models audit: 12 current TR routes, 0 TEE/E2EE; 9 private and 3 anonymized
- nonce-bound attestation checked separately on Venice e2ee-glm-5-2-p
- uv run pytest -q: 1991 passed, 47 skipped
- focused routing/API/security suite: 211 passed
- uv run ruff check .
- uv run mypy