### PR TITLE
Fix funded Cloudflare AI Gateway routing

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -160,7 +160,8 @@ jobs:
             echo "::add-mask::${KEY}"
             echo "${env}=${KEY}" >> "$GITHUB_ENV"
           done
-          echo "CLOUDFLARE_WORKERS_AI_ACCOUNT_ID=96781cbfaebf2b28d851b9c677dd2e81" >> "$GITHUB_ENV"
+          echo "CLOUDFLARE_WORKERS_AI_ACCOUNT_ID=2698c706fd4793c818af14adad4e1a39" >> "$GITHUB_ENV"
+          echo "TR_CLOUDFLARE_WORKERS_AI_ROUTABLE=1" >> "$GITHUB_ENV"
 
       - name: Snapshot existing pricing file
         run: cp src/trusted_router/data/openrouter_snapshot.json /tmp/before.json

--- a/scripts/pricing/manifest.py
+++ b/scripts/pricing/manifest.py
@@ -121,6 +121,13 @@ def write_discovered_chat_manifest(
         else:
             row = dict(existing)
         row.update(discovered)
+        if discovered.get("routable") is True:
+            # An explicit healthy signal from the provider adapter supersedes
+            # machine-owned holds such as account-unfunded. Without removing
+            # the stale reason, a funded account remains disabled forever even
+            # after the adapter sets routable=true.
+            row.pop("routable_reason", None)
+            row.pop("unresolved_since", None)
 
         price = result.prices.get(model_id)
         if price is not None:

--- a/scripts/pricing/providers/cloudflare_workers_ai.py
+++ b/scripts/pricing/providers/cloudflare_workers_ai.py
@@ -178,10 +178,6 @@ def fetch() -> ProviderPricingResult:
     account_enabled = os.environ.get("TR_CLOUDFLARE_WORKERS_AI_ROUTABLE") == "1"
     discovered = {model_id: dict(row) for model_id, row in _EARLY_ACCESS_MODELS.items()}
     prices = dict(_EARLY_ACCESS_PRICES)
-    if not account_enabled:
-        for row in discovered.values():
-            row["routable"] = False
-            row["routable_reason"] = "account-unfunded"
     for source in source_rows:
         if not isinstance(source, dict):
             continue
@@ -202,9 +198,6 @@ def fetch() -> ProviderPricingResult:
             "upstream_id": native_id,
             "display_name": str(source.get("name") or model_id),
         }
-        if not account_enabled:
-            row["routable"] = False
-            row["routable_reason"] = "account-unfunded"
         context = _positive_int(
             properties.get("context_window")
             or properties.get("context_length")
@@ -216,6 +209,16 @@ def fetch() -> ProviderPricingResult:
         price = _model_price(properties)
         if price is not None:
             prices[model_id] = price
+
+    for model_id, row in discovered.items():
+        if account_enabled and model_id in prices:
+            row["routable"] = True
+            row.pop("routable_reason", None)
+        else:
+            row["routable"] = False
+            row["routable_reason"] = (
+                "awaiting-price" if account_enabled else "account-unfunded"
+            )
 
     for model_id, row in _EARLY_ACCESS_MODELS.items():
         remember_upstream_id(UPSTREAM_ID_MAP, model_id, str(row["upstream_id"]))

--- a/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
+++ b/src/trusted_router/data/provider_models/cloudflare-workers-ai.json
@@ -1,7 +1,7 @@
 {
   "provider": "cloudflare-workers-ai",
-  "source": "https://api.cloudflare.com/client/v4/accounts/96781cbfaebf2b28d851b9c677dd2e81/ai/models/search?per_page=100",
-  "generated_at": "2026-07-27T21:13:41Z",
+  "source": "https://api.cloudflare.com/client/v4/accounts/2698c706fd4793c818af14adad4e1a39/ai/models/search?per_page=100",
+  "generated_at": "2026-07-27T22:24:50Z",
   "price_scale": "microdollars_per_million",
   "model_count": 27,
   "models": [
@@ -21,8 +21,7 @@
       "status": 1,
       "id": "aisingapore/gemma-sea-lion-v4-27b-it",
       "upstream_id": "@cf/aisingapore/gemma-sea-lion-v4-27b-it",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 128000,
       "input_token_price_per_m": 351000,
       "output_token_price_per_m": 555000
@@ -43,8 +42,7 @@
       "status": 1,
       "id": "deepseek/deepseek-r1-distill-qwen-32b",
       "upstream_id": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 80000,
       "input_token_price_per_m": 497000,
       "output_token_price_per_m": 4881000
@@ -66,7 +64,7 @@
       "id": "google/gemma-2b-it-lora",
       "upstream_id": "@cf/google/gemma-2b-it-lora",
       "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable_reason": "awaiting-price",
       "context_length": 8192
     },
     {
@@ -85,8 +83,7 @@
       "status": 1,
       "id": "google/gemma-4-26b-a4b-it",
       "upstream_id": "@cf/google/gemma-4-26b-a4b-it",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 256000,
       "input_token_price_per_m": 100000,
       "output_token_price_per_m": 300000
@@ -108,7 +105,7 @@
       "id": "google/gemma-7b-it-lora",
       "upstream_id": "@cf/google/gemma-7b-it-lora",
       "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable_reason": "awaiting-price",
       "context_length": 3500
     },
     {
@@ -127,8 +124,7 @@
       "status": 1,
       "id": "ibm-granite/granite-4.0-h-micro",
       "upstream_id": "@cf/ibm-granite/granite-4.0-h-micro",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 131000,
       "input_token_price_per_m": 17000,
       "output_token_price_per_m": 112000
@@ -150,7 +146,7 @@
       "id": "meta-llama/llama-2-7b-chat-hf-lora",
       "upstream_id": "@cf/meta-llama/llama-2-7b-chat-hf-lora",
       "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable_reason": "awaiting-price",
       "context_length": 8192
     },
     {
@@ -169,8 +165,7 @@
       "status": 1,
       "id": "meta-llama/llama-3.1-8b-instruct-fp8",
       "upstream_id": "@cf/meta/llama-3.1-8b-instruct-fp8",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 32000,
       "input_token_price_per_m": 152000,
       "output_token_price_per_m": 287000
@@ -191,8 +186,7 @@
       "status": 1,
       "id": "meta-llama/llama-3.2-11b-vision-instruct",
       "upstream_id": "@cf/meta/llama-3.2-11b-vision-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 128000,
       "input_token_price_per_m": 48500,
       "output_token_price_per_m": 676000
@@ -213,8 +207,7 @@
       "status": 1,
       "id": "meta-llama/llama-3.2-1b-instruct",
       "upstream_id": "@cf/meta/llama-3.2-1b-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 60000,
       "input_token_price_per_m": 27000,
       "output_token_price_per_m": 201000
@@ -235,8 +228,7 @@
       "status": 1,
       "id": "meta-llama/llama-3.2-3b-instruct",
       "upstream_id": "@cf/meta/llama-3.2-3b-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 80000,
       "input_token_price_per_m": 50900,
       "output_token_price_per_m": 335000
@@ -257,8 +249,7 @@
       "status": 1,
       "id": "meta-llama/llama-3.3-70b-instruct-fp8-fast",
       "upstream_id": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 24000,
       "input_token_price_per_m": 293000,
       "output_token_price_per_m": 2253000
@@ -279,8 +270,7 @@
       "status": 1,
       "id": "meta-llama/llama-4-scout-17b-16e-instruct",
       "upstream_id": "@cf/meta/llama-4-scout-17b-16e-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 131000,
       "input_token_price_per_m": 270000,
       "output_token_price_per_m": 850000
@@ -301,8 +291,7 @@
       "status": 1,
       "id": "meta-llama/llama-guard-3-8b",
       "upstream_id": "@cf/meta/llama-guard-3-8b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 131072,
       "input_token_price_per_m": 484000,
       "output_token_price_per_m": 30000
@@ -324,7 +313,7 @@
       "id": "mistralai/mistral-7b-instruct-v0.2-lora",
       "upstream_id": "@cf/mistral/mistral-7b-instruct-v0.2-lora",
       "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable_reason": "awaiting-price",
       "context_length": 15000
     },
     {
@@ -343,8 +332,7 @@
       "status": 1,
       "id": "mistralai/mistral-small-3.1-24b-instruct",
       "upstream_id": "@cf/mistralai/mistral-small-3.1-24b-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 128000,
       "input_token_price_per_m": 351000,
       "output_token_price_per_m": 555000
@@ -365,8 +353,7 @@
       "status": 1,
       "id": "moonshotai/kimi-k2.6",
       "upstream_id": "@cf/moonshotai/kimi-k2.6",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 262144,
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
@@ -388,8 +375,7 @@
       "status": 1,
       "id": "moonshotai/kimi-k2.7-code",
       "upstream_id": "@cf/moonshotai/kimi-k2.7-code",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 262144,
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
@@ -419,8 +405,7 @@
         "tools",
         "vision"
       ],
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "input_token_price_per_m": 3000000,
       "output_token_price_per_m": 15000000,
       "cached_input_token_price_per_m": 300000
@@ -441,8 +426,7 @@
       "status": 1,
       "id": "nvidia/nemotron-3-120b-a12b",
       "upstream_id": "@cf/nvidia/nemotron-3-120b-a12b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 256000,
       "input_token_price_per_m": 500000,
       "output_token_price_per_m": 1500000
@@ -463,8 +447,7 @@
       "status": 1,
       "id": "openai/gpt-oss-120b",
       "upstream_id": "@cf/openai/gpt-oss-120b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 128000,
       "input_token_price_per_m": 350000,
       "output_token_price_per_m": 750000
@@ -485,8 +468,7 @@
       "status": 1,
       "id": "openai/gpt-oss-20b",
       "upstream_id": "@cf/openai/gpt-oss-20b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 128000,
       "input_token_price_per_m": 200000,
       "output_token_price_per_m": 300000
@@ -507,8 +489,7 @@
       "status": 1,
       "id": "qwen/qwen2.5-coder-32b-instruct",
       "upstream_id": "@cf/qwen/qwen2.5-coder-32b-instruct",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 32768,
       "input_token_price_per_m": 660000,
       "output_token_price_per_m": 1000000
@@ -529,8 +510,7 @@
       "status": 1,
       "id": "qwen/qwen3-30b-a3b-fp8",
       "upstream_id": "@cf/qwen/qwen3-30b-a3b-fp8",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 32768,
       "input_token_price_per_m": 50900,
       "output_token_price_per_m": 335000
@@ -551,8 +531,7 @@
       "status": 1,
       "id": "qwen/qwq-32b",
       "upstream_id": "@cf/qwen/qwq-32b",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 24000,
       "input_token_price_per_m": 660000,
       "output_token_price_per_m": 1000000
@@ -573,8 +552,7 @@
       "status": 1,
       "id": "z-ai/glm-4.7-flash",
       "upstream_id": "@cf/zai-org/glm-4.7-flash",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 131072,
       "input_token_price_per_m": 60500,
       "output_token_price_per_m": 400000
@@ -595,8 +573,7 @@
       "status": 1,
       "id": "z-ai/glm-5.2",
       "upstream_id": "@cf/zai-org/glm-5.2",
-      "routable": false,
-      "routable_reason": "account-unfunded",
+      "routable": true,
       "context_length": 262144,
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -57,6 +57,14 @@ def test_hourly_kimi_discovery_has_narrow_secret_access_wiring() -> None:
     assert "no project-wide Secret" in workflow
 
 
+def test_hourly_cloudflare_discovery_uses_funded_account() -> None:
+    workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text()
+
+    assert "CLOUDFLARE_WORKERS_AI_ACCOUNT_ID=2698c706fd4793c818af14adad4e1a39" in workflow
+    assert "TR_CLOUDFLARE_WORKERS_AI_ROUTABLE=1" in workflow
+    assert "96781cbfaebf2b28d851b9c677dd2e81" not in workflow
+
+
 def test_every_authenticated_discovery_feed_is_wired_to_narrow_secret_access() -> None:
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
     workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text(

--- a/tests/test_new_provider_catalogs.py
+++ b/tests/test_new_provider_catalogs.py
@@ -65,14 +65,15 @@ def test_cloudflare_pricing_parses_input_cache_and_output_units() -> None:
     )
 
 
-def test_cloudflare_committed_manifest_is_fail_closed_until_funded() -> None:
+def test_cloudflare_committed_manifest_exposes_only_funded_priced_routes() -> None:
     manifest = json.loads(cloudflare_workers_ai.MANIFEST_PATH.read_text(encoding="utf-8"))
     rows = manifest["models"]
 
     assert rows
-    assert all(row.get("routable") is False for row in rows)
+    assert any(row.get("routable") is True for row in rows)
     assert all(
-        row.get("routable_reason") in {"account-unfunded", "awaiting-price"}
+        row.get("routable") is True
+        or row.get("routable_reason") == "awaiting-price"
         for row in rows
     )
     assert all(
@@ -83,6 +84,7 @@ def test_cloudflare_committed_manifest_is_fail_closed_until_funded() -> None:
     kimi_k3 = next(row for row in rows if row["id"] == "moonshotai/kimi-k3")
     assert kimi_k3["upstream_id"] == "moonshotai/kimi-k3"
     assert kimi_k3["context_length"] == 1_048_576
+    assert kimi_k3["routable"] is True
 
 
 def test_discovered_writer_never_routes_a_new_unpriced_model(tmp_path: Path) -> None:
@@ -133,7 +135,22 @@ def test_new_provider_manifests_create_only_eligible_routes() -> None:
 
     assert any(endpoint.provider == "chutes" for endpoint in endpoints)
     assert any(endpoint.provider == "digitalocean" for endpoint in endpoints)
-    assert not any(endpoint.provider == "cloudflare-workers-ai" for endpoint in endpoints)
+    cloudflare = [
+        endpoint
+        for endpoint in endpoints
+        if endpoint.provider == "cloudflare-workers-ai"
+    ]
+    assert cloudflare
+    assert any(
+        endpoint.model_id == "moonshotai/kimi-k3"
+        and endpoint.upstream_id == "moonshotai/kimi-k3"
+        for endpoint in cloudflare
+    )
+    assert all(
+        endpoint.prompt_price_microdollars_per_million_tokens > 0
+        and endpoint.completion_price_microdollars_per_million_tokens > 0
+        for endpoint in cloudflare
+    )
 
 
 def test_chutes_manifest_contains_only_confidential_compute_rows() -> None:


### PR DESCRIPTION
## Summary
- move hourly Cloudflare discovery to the funded production account
- recover machine-owned account-unfunded manifest holds after funding
- publish only priced Cloudflare routes and keep unpriced rows blocked
- add regression coverage for account wiring and route eligibility

## Verification
- direct Cloudflare moonshotai/kimi-k3 canary: HTTP 200, PONG
- focused catalog and deployment suite: 136 passed
- targeted ruff checks pass