### PR TITLE
Handle Tinfoil Kimi K2.6 retirement

### DIFF
--- a/scripts/pricing/providers/tinfoil.py
+++ b/scripts/pricing/providers/tinfoil.py
@@ -25,7 +25,6 @@ SLUG = "tinfoil"
 URL = "https://inference.tinfoil.sh/v1/models"
 
 EXPECTED_MODELS = [
-    "moonshotai/kimi-k2.6",
     "z-ai/glm-5.2",
     "google/gemma-4-31b-it",
 ]
@@ -37,6 +36,10 @@ EXPECTED_MODELS = [
 _NATIVE_TO_OR_ID = {
     "kimi-k2-6": "moonshotai/kimi-k2.6",
     "kimi-k2-7-code": "moonshotai/kimi-k2.7-code",
+    # Kimi K3 is announced but not live on Tinfoil yet. Mapping its expected
+    # native ID makes the hourly feed discover it automatically without
+    # treating it as required or advertising it before the provider does.
+    "kimi-k3": "moonshotai/kimi-k3",
     "glm-5-1": "z-ai/glm-5.1",
     "glm-5-2": "z-ai/glm-5.2",
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
 TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
 BASETEN_JULY_2026_RETIREMENT_AT = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
+TINFOIL_KIMI_K26_RETIREMENT_AT = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 
@@ -55,6 +56,17 @@ _RETIREMENTS = (
             }
         ),
         effective_at=BASETEN_JULY_2026_RETIREMENT_AT,
+    ),
+    # Tinfoil announced that Kimi K2.6 retires on 2026-08-03 and that Kimi K3
+    # is still being prepared. The notice did not specify a time zone, so use
+    # 00:00 UTC as the conservative cutover. Other K2.6 providers are
+    # unaffected, and Tinfoil K3 must not be advertised until its live model
+    # feed publishes the route.
+    _Retirement(
+        provider="tinfoil",
+        model_ids=frozenset({"moonshotai/kimi-k2.6"}),
+        upstream_ids=frozenset({"kimi-k2-6"}),
+        effective_at=TINFOIL_KIMI_K26_RETIREMENT_AT,
     ),
     # Parasail announced that these three serverless routes retire on
     # 2026-08-04. The notice did not specify a time zone, so use 00:00 UTC as

--- a/tests/test_tinfoil_august_2026_lifecycle.py
+++ b/tests/test_tinfoil_august_2026_lifecycle.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import tinfoil
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
+_K26 = "moonshotai/kimi-k2.6"
+_K26_UPSTREAM = "kimi-k2-6"
+_K3 = "moonshotai/kimi-k3"
+_K3_UPSTREAM = "kimi-k3"
+
+
+def test_tinfoil_kimi_k26_retires_at_announced_date() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "tinfoil",
+        _K26,
+        _K26_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "tinfoil",
+        _K26,
+        _K26_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "tinfoil",
+        _K3,
+        _K3_UPSTREAM,
+        at=_CUTOFF,
+    )
+
+
+def test_tinfoil_kimi_k26_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    providers = {endpoint.provider for endpoint in endpoints_for_model(_K26)}
+
+    assert "tinfoil" not in providers
+    assert providers
+
+
+def test_hourly_refresh_cannot_restore_retired_tinfoil_kimi_k26(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="tinfoil",
+        prices={
+            _K26: ModelPrice(1_500_000, 5_250_000),
+            _K3: ModelPrice(3_000_000, 15_000_000),
+        },
+        source="api",
+        fetched_url=tinfoil.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"tinfoil": result})
+    assert "tinfoil" in before[_K26]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"tinfoil": result})
+    assert _K26 not in after
+    assert "tinfoil" in after[_K3]
+
+
+def test_tinfoil_feed_discovers_kimi_k3_only_when_published(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tinfoil, "UPSTREAM_ID_MAP", dict(tinfoil.UPSTREAM_ID_MAP))
+    payload = {
+        "data": [
+            {
+                "id": "glm-5-2",
+                "pricing": {
+                    "inputTokenPricePer1M": 1.5,
+                    "outputTokenPricePer1M": 5.25,
+                },
+            },
+            {
+                "id": "gemma4-31b",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.4,
+                    "outputTokenPricePer1M": 1.0,
+                },
+            },
+            {
+                "id": _K3_UPSTREAM,
+                "pricing": {
+                    "inputTokenPricePer1M": 3.0,
+                    "outputTokenPricePer1M": 15.0,
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(tinfoil, "fetch_json", lambda _url: payload)
+
+    result = tinfoil.fetch()
+
+    assert result.prices[_K3].prompt_micro_per_m == 3_000_000
+    assert result.prices[_K3].completion_micro_per_m == 15_000_000
+    assert tinfoil.UPSTREAM_ID_MAP[_K3] == _K3_UPSTREAM
+
+
+def test_tinfoil_feed_does_not_advertise_kimi_k3_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": "glm-5-2",
+                "pricing": {
+                    "inputTokenPricePer1M": 1.5,
+                    "outputTokenPricePer1M": 5.25,
+                },
+            },
+            {
+                "id": "gemma4-31b",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.4,
+                    "outputTokenPricePer1M": 1.0,
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(tinfoil, "fetch_json", lambda _url: payload)
+
+    result = tinfoil.fetch()
+
+    assert _K3 not in result.prices
+    assert _K3 not in tinfoil.EXPECTED_MODELS


### PR DESCRIPTION
Summary:
- retire only Tinfoil Kimi K2.6 at the announced August 3 cutoff
- stop treating K2.6 as required in Tinfoil live catalog
- map the future kimi-k3 native ID so hourly discovery adds it only after Tinfoil publishes it
- cover provider scoping, stale-refresh suppression, and feed-gated K3 discovery

Verification:
- Ruff passed
- mypy passed
- pytest: 1997 passed, 47 skipped
- live Tinfoil model-feed parser check passed