### PR TITLE
Fix duplicate page canonicalization

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -2209,18 +2209,13 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
 
 
 def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -> str | None:
-    left = MODELS.get(left_id)
-    right = MODELS.get(right_id)
-    if (
-        left is None
-        or right is None
-        or left.id in META_MODEL_IDS
-        or right.id in META_MODEL_IDS
-        or left.id == right.id
-    ):
+    pair = _canonical_model_comparison_pair(left_id, right_id)
+    if pair is None:
         return None
+    left, right = pair
     test_mode = settings.environment == "test"
-    site_path = f"/compare/models/{left.id}/vs/{right.id}"
+    site_path = canonical_model_comparison_path(left.id, right.id)
+    assert site_path is not None
     return (
         _env()
         .get_template("public/model_compare.html")
@@ -3272,7 +3267,38 @@ def _model_comparison_pairs() -> list[tuple[Model, Model]]:
             model.id.lower(),
         ),
     )[:MODEL_COMPARE_MODEL_LIMIT]
-    return list(combinations(candidates, 2))[:MODEL_COMPARE_URL_LIMIT]
+    pairs = [
+        tuple(sorted(pair, key=lambda model: model.id.casefold()))
+        for pair in combinations(candidates, 2)
+    ]
+    return cast(list[tuple[Model, Model]], pairs[:MODEL_COMPARE_URL_LIMIT])
+
+
+def _canonical_model_comparison_pair(
+    left_id: str,
+    right_id: str,
+) -> tuple[Model, Model] | None:
+    left = MODELS.get(left_id)
+    right = MODELS.get(right_id)
+    if (
+        left is None
+        or right is None
+        or left.id in META_MODEL_IDS
+        or right.id in META_MODEL_IDS
+        or left.id == right.id
+    ):
+        return None
+    ordered = sorted((left, right), key=lambda model: model.id.casefold())
+    return ordered[0], ordered[1]
+
+
+def canonical_model_comparison_path(left_id: str, right_id: str) -> str | None:
+    """Return the one stable URL for an unordered pair of model ids."""
+    pair = _canonical_model_comparison_pair(left_id, right_id)
+    if pair is None:
+        return None
+    left, right = pair
+    return f"/compare/models/{left.id}/vs/{right.id}"
 
 
 def _seo_model_rows(*, test_mode: bool = False) -> list[dict[str, object]]:

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -77,7 +77,9 @@ def create_app(
     app = FastAPI(
         title="TrustedRouter",
         version="0.1.0",
-        docs_url="/api/reference",
+        docs_url=None,
+        redoc_url=None,
+        swagger_ui_oauth2_redirect_url=None,
     )
     app.state.settings = settings
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import html
 import json
 import logging
 import re
@@ -11,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from fastapi import BackgroundTasks, FastAPI, Query, Request
+from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import (
     FileResponse,
     HTMLResponse,
@@ -40,6 +42,7 @@ from trusted_router.config import Settings
 from trusted_router.dashboard import (
     MODEL_SEO_SECTIONS,
     STATIC_DIR,
+    canonical_model_comparison_path,
     dashboard_html,
     docs_llms_full_txt,
     docs_llms_txt,
@@ -307,6 +310,47 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             return func
 
         return decorator
+
+    @app.api_route(
+        "/api/reference",
+        methods=["GET", "HEAD"],
+        response_class=HTMLResponse,
+        include_in_schema=False,
+    )
+    @app.api_route(
+        "/api/reference/",
+        methods=["GET", "HEAD"],
+        response_class=HTMLResponse,
+        include_in_schema=False,
+    )
+    async def api_reference() -> HTMLResponse:
+        response = get_swagger_ui_html(
+            openapi_url=app.openapi_url or "/openapi.json",
+            title=f"{app.title} API reference",
+        )
+        canonical = html.escape(
+            f"https://{settings.trusted_domain}/api/reference",
+            quote=True,
+        )
+        body = bytes(response.body).decode().replace(
+            "</head>",
+            f'<link rel="canonical" href="{canonical}">\n</head>',
+            1,
+        )
+        return HTMLResponse(body)
+
+    @app.api_route(
+        "/redoc",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    @app.api_route(
+        "/docs/oauth2-redirect",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    async def legacy_api_reference() -> RedirectResponse:
+        return RedirectResponse(url="/api/reference", status_code=301)
 
     @public_html_route("/", include_slash=False)
     async def dashboard(request: Request, background_tasks: BackgroundTasks) -> Any:
@@ -933,9 +977,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         left_slug: str,
         right_author: str,
         right_slug: str,
-    ) -> HTMLResponse:
+    ) -> Response:
         left_id = f"{left_author.strip()}/{left_slug.strip()}"
         right_id = f"{right_author.strip()}/{right_slug.strip()}"
+        canonical_path = canonical_model_comparison_path(left_id, right_id)
+        if canonical_path is not None:
+            requested_path = f"/compare/models/{left_id}/vs/{right_id}"
+            if requested_path != canonical_path:
+                return RedirectResponse(url=canonical_path, status_code=301)
         body = public_model_compare_html(settings, left_id, right_id)
         if body is None:
             return HTMLResponse(

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -66,6 +66,7 @@ def trust_html(settings: Settings) -> str:
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TrustedRouter Trust</title>
+  <link rel="canonical" href="https://trust.trustedrouter.com/">
   <style>
     :root {{
       color-scheme: light;

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -95,7 +95,7 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
     comparisons = client.get("/sitemap-comparisons.xml")
     assert comparisons.status_code == 200
     assert (
-        "<loc>https://trustedrouter.com/compare/models/z-ai/glm-5.2/vs/moonshotai/kimi-k2.6</loc>"
+        "<loc>https://trustedrouter.com/compare/models/moonshotai/kimi-k2.6/vs/z-ai/glm-5.2</loc>"
         in comparisons.text
     )
     assert "<loc>https://trustedrouter.com/compare/models/page/2</loc>" in comparisons.text
@@ -140,6 +140,44 @@ def test_public_host_aliases_redirect_to_the_canonical_marketing_host(
         follow_redirects=False,
     )
     assert status_json.status_code == 200
+
+
+def test_api_reference_declares_one_query_independent_canonical(
+    client: TestClient,
+) -> None:
+    response = client.get("/api/reference?group=models&utm_source=test")
+
+    assert response.status_code == 200
+    assert response.text.count('rel="canonical"') == 1
+    assert (
+        '<link rel="canonical" href="https://trustedrouter.com/api/reference">'
+        in response.text
+    )
+
+
+def test_duplicate_api_reference_surfaces_redirect_to_canonical(
+    client: TestClient,
+) -> None:
+    for path in ["/redoc", "/docs/oauth2-redirect"]:
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 301
+        assert response.headers["location"] == "/api/reference"
+
+
+def test_trust_page_declares_dedicated_trust_host_as_canonical(
+    client: TestClient,
+) -> None:
+    for path, headers in [
+        ("/trust", {}),
+        ("/", {"host": "trust.trustedrouter.com"}),
+    ]:
+        response = client.get(path, headers=headers)
+        assert response.status_code == 200
+        assert response.text.count('rel="canonical"') == 1
+        assert (
+            '<link rel="canonical" href="https://trust.trustedrouter.com/">'
+            in response.text
+        )
 
 
 def test_indexnow_key_file_is_public(client: TestClient) -> None:
@@ -722,6 +760,25 @@ def test_model_comparison_pages_are_public(client: TestClient) -> None:
     assert "openrouter.ai" not in response.text.lower()
 
 
+def test_reversed_model_comparison_redirects_to_stable_canonical(
+    client: TestClient,
+) -> None:
+    canonical_path = "/compare/models/moonshotai/kimi-k2.6/vs/z-ai/glm-5.1"
+    canonical = client.get(canonical_path, follow_redirects=False)
+    assert canonical.status_code == 200
+    assert (
+        f'<link rel="canonical" href="https://trustedrouter.com{canonical_path}">'
+        in canonical.text
+    )
+
+    reversed_page = client.get(
+        "/compare/models/z-ai/glm-5.1/vs/moonshotai/kimi-k2.6",
+        follow_redirects=False,
+    )
+    assert reversed_page.status_code == 301
+    assert reversed_page.headers["location"] == canonical_path
+
+
 def test_model_comparison_directory_links_every_sitemap_pair(client: TestClient) -> None:
     sitemap = client.get("/sitemap-comparisons.xml")
     sitemap_pairs = set(
@@ -753,6 +810,11 @@ def test_model_comparison_directory_links_every_sitemap_pair(client: TestClient)
 
     assert len(sitemap_pairs) == 2_600
     assert linked_paths == sitemap_pairs
+    assert all(
+        left.casefold() < right.casefold()
+        for pair in sitemap_pairs
+        for left, right in [pair.removeprefix("/compare/models/").split("/vs/", 1)]
+    )
 
 
 def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add a canonical URL to the public Swagger API reference and redirect duplicate ReDoc/OAuth helper surfaces
- declare `trust.trustedrouter.com` as the canonical trust-page host
- canonicalize model comparison pairs with stable model-id ordering and permanently redirect reversed URLs
- enforce canonical pair ordering in sitemap coverage tests

## Verification
- `mypy`
- `ruff check`
- `pytest -q` (1,996 passed, 47 skipped)
- local internal-link crawl: 3,731 pages, zero HTML pages missing a canonical