### PR TITLE
docs: each cloud is a separate deployment (identity federates, credits do not)

### DIFF
--- a/docs/storage-portability/README.md
+++ b/docs/storage-portability/README.md
@@ -22,6 +22,14 @@ with no deployment risk, and it is what lets a non-GCP process start at all.
 
 ## The architecture decision
 
+> **SUPERSEDED 2026-07-27 by [`multi-cloud-separation.md`](multi-cloud-separation.md).**
+> Each cloud is now a **standalone deployment with its own database**: identity
+> federates across clouds, credits and API keys do not. The shared-Spanner plan
+> below is kept because its *analysis* is still what makes the new decision
+> legible — the tradeoffs in "What this trades away" are exactly the costs that
+> separation avoids, and the phased delivery still applies. Read the new
+> document first; treat the bullets immediately below as history.
+
 The naive plan is "replace Spanner and Bigtable with cloud-native equivalents
 on each cloud." That is three ports of the hardest, most dangerous code we
 own (reserve/settle billing), once per cloud.

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -142,6 +142,28 @@ to a single logical partition, which is weaker than what reserve/settle needs.
 **These are recommendations, not conclusions.** Each is validated the same way:
 implement the `Store`, run the conformance suite, and only then argue about it.
 
+### The unlock: both are Postgres
+
+Aurora DSQL and Cosmos DB for PostgreSQL both speak the Postgres wire protocol.
+So this is **not two backends — it is one**.
+
+Write a single `PostgresStore`. Develop and test it against plain Postgres in a
+container, which costs nothing, runs in CI as a service container, and gives the
+conformance suite a *third real backend* to pin behaviour against — the thing
+that catches divergence, including in the money code. Then deploy that same
+implementation on Aurora DSQL for AWS and on Citus for Azure.
+
+This turns "port the hardest code in the system, twice, against two cloud
+databases we cannot run locally" into "write one SQL backend, test it locally,
+deploy it twice." It is the difference between a tractable project and a
+research project, and it is the reason to prefer these two managed services
+over their more obvious cloud-native alternatives.
+
+Where they diverge from stock Postgres — DSQL's optimistic concurrency and its
+restrictions on some DDL, Citus requiring a distribution column on every
+distributed table — those differences are narrow, known up front, and are the
+first thing the conformance suite should be pointed at once a cluster exists.
+
 ---
 
 ## 6. Open questions

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -1,0 +1,160 @@
+# Each cloud is a separate TrustedRouter
+
+**Status:** decided 2026-07-27. **Supersedes** the 2026-07-26 decision recorded
+in `README.md` that "Spanner stays the system of record even when compute runs
+on AWS/Azure."
+
+---
+
+## 1. Decision
+
+A TrustedRouter deployment on AWS is a **standalone deployment**: its own
+database, its own credits, its own API keys, its own analytics. Same for Azure.
+They are not front-ends onto a GCP database.
+
+Exactly one thing crosses cloud boundaries: **identity**. Everything else is
+cloud-local.
+
+| | Federates across clouds | Cloud-local |
+|---|---|---|
+| Who you are (email, OAuth subject, verified identity) | ✅ | |
+| Credit balance | | ✅ |
+| API keys | | ✅ |
+| Workspaces, members, roles | | ✅ |
+| Usage history, generations, analytics | | ✅ |
+| Provider routing + catalog | | ✅ |
+
+An API key issued on AWS authenticates only on AWS. Credit bought on GCP is
+spendable only on GCP.
+
+---
+
+## 2. Why identity federates and money does not
+
+This asymmetry looks arbitrary. It isn't — the two things are different kinds
+of object.
+
+**Identity is an assertion.** "This is joseph@example.com, signed by an issuer
+you trust." Verifying it requires a public key and nothing else. Every cloud
+can verify the same assertion independently, concurrently, while partitioned
+from every other cloud, and they cannot disagree — because there is no shared
+mutable state to disagree about.
+
+**A credit balance is a mutable quantity with a conservation law.** If two
+clouds can both spend from one balance, they must agree on ordering or the
+balance is spent twice. There are only three ways to get that agreement:
+
+1. **One authoritative store.** Then the clouds are not separate: every AWS
+   request round-trips to GCP, GCP's outages become AWS's outages, and the
+   cross-cloud hop lands on the *hot path* of authorize+settle. This is
+   precisely the design being superseded.
+2. **Cross-cloud consensus (2PC or similar).** Availability becomes the AND of
+   both clouds — strictly worse than either alone. Latency becomes the max.
+   Failure modes become the union. You pay for multi-cloud and receive less
+   reliability than single-cloud.
+3. **Partition the money.** Each cloud owns a disjoint slice. No coordination
+   on the hot path. Correct under partition, because there is nothing to
+   coordinate.
+
+Only (3) preserves the reason for having separate clouds at all.
+
+The analogy is exact: one passport, separate accounts at separate institutions.
+Nobody expects a balance at one bank to be spendable at another because it is
+the same person.
+
+### If credit must move between clouds
+
+It moves as an **explicit, asynchronous, idempotent transfer** with a
+settlement record on both sides — debit here, credit there, reconciled, with a
+visible in-flight state. Never a shared balance, never a synchronous
+cross-cloud debit. This is the same shape as the settle outbox already in the
+codebase (`storage_gcp_settle_outbox.py`), and it should reuse that thinking.
+
+Not in scope now. Recorded so that "just let credits work everywhere" is
+recognised as a request for a money-movement feature, not a config change.
+
+---
+
+## 3. The product consequence, which is not optional
+
+**Separateness must be visible.** A user who tops up on GCP and then gets a 402
+from their AWS key will file a support ticket every single time unless:
+
+* the console shows balances **per cloud**, never one merged number;
+* the 402 body names the cloud and the balance it checked;
+* API keys are visibly scoped to the cloud that issued them.
+
+A hidden partition is a permanent support tax. An explicit one is a feature —
+it is what data residency and cloud sovereignty actually mean, and it is
+sellable.
+
+---
+
+## 4. What this changes in the plan
+
+**Promoted to critical path.** The `Store` protocol and the behavioural
+conformance suite (`tests/conformance/`, PR #288) were a nice refactor when
+Spanner was universal. Now they are the mechanism: a new cloud is a new `Store`
+implementation that passes the conformance suite. Everything the suite does not
+pin is a place where two clouds can silently diverge in behaviour — and one of
+those behaviours is money.
+
+Known gap, now urgent: `InMemoryStore` does not implement `TypedBillingStore`
+and Spanner's legacy `reserve()` raises, so the two existing backends run
+genuinely different money code and nothing pins which is right. A third and
+fourth backend make that unacceptable.
+
+**Demoted.** The cross-cloud Workload Identity Federation path (this branch)
+was built to let AWS compute reach GCP Spanner. Under separation, no data path
+needs it. It is kept because it is keyless, narrowly scoped, and still the
+right way to do cross-cloud *operations* (bootstrap, image pull, ops tooling)
+without a long-lived key — but nothing new should be built on top of it.
+
+**Unchanged.** ClickHouse as the analytics backend, one per cloud — that is
+already how it is built (self-hosted node, no managed dependency). Per-cloud
+attestation (Confidential Space / Nitro / SEV-SNP) matters *more*, since each
+cloud is now a standalone product surface rather than a failover target.
+
+---
+
+## 5. Database per cloud
+
+The system of record needs: strong consistency, distributed transactions
+spanning a workspace's rows, conditional writes for the credit invariants, and
+secondary-index lookups. That is what Spanner gives us today.
+
+| Cloud | System of record | Why |
+|---|---|---|
+| GCP | Spanner *(today)* | — |
+| AWS | **Aurora DSQL** | The genuine Spanner analogue: distributed SQL, strong consistency, active-active, no failover step. Keeps the reserve/settle logic recognisably the same code rather than a rewrite. |
+| Azure | **Cosmos DB for PostgreSQL** (Citus) | Distributed Postgres with transactions inside a distribution key. Our money code is per-workspace, so distributing by workspace id puts every transaction on one node. |
+
+Rejected: **DynamoDB** as the system of record. It is the Bigtable analogue,
+not the Spanner analogue — `TransactWriteItems` caps at 100 items and there is
+no cross-partition SQL. It would force the billing logic to be rewritten in a
+different idiom, which is the one thing worth avoiding when the logic in
+question is money. Reasonable for the *operational* half (newest-N generation
+lookups) if that is ever split out.
+
+Rejected for Azure: **Cosmos DB (SQL API)** — transactional batches are limited
+to a single logical partition, which is weaker than what reserve/settle needs.
+
+**These are recommendations, not conclusions.** Each is validated the same way:
+implement the `Store`, run the conformance suite, and only then argue about it.
+
+---
+
+## 6. Open questions
+
+1. **Which issuer federates identity?** Today OAuth is Google and GitHub
+   directly (`oauth_provider.py`). Under separation each cloud can verify those
+   assertions independently with no shared state — which is the cheap and
+   correct answer. A TrustedRouter-owned issuer would be needed only for
+   email/password accounts, which need a home.
+2. **Does a single account see all its clouds?** Listing "GCP: $X, AWS: $Y"
+   requires reading N clouds from one console. That is a read-only fan-out and
+   is safe; it must not become a write path.
+3. **What is the canonical hostname per cloud?** `aws.trustedrouter.com` vs a
+   region-style selector. Affects key scoping and the 402 message.
+4. **Signup credit per cloud?** Granting the trial credit once per cloud
+   multiplies the giveaway by the number of clouds.

--- a/scripts/deploy/wif_setup.sh
+++ b/scripts/deploy/wif_setup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Provision keyless cross-cloud access to GCP for the AWS and Azure test
+# networks, via Workload Identity Federation.
+#
+# SCOPE — read docs/storage-portability/multi-cloud-separation.md first.
+#
+# Each cloud is a standalone deployment with its own database, so NO DATA PATH
+# crosses clouds. This script is not part of one. It exists so that a workload
+# on AWS or Azure can reach GCP for *operational* reasons — pulling the shared
+# container image, bootstrap, ops tooling — without a long-lived key.
+#
+# The alternative is a service-account key JSON mirrored into each cloud's
+# secret store. That is the single worst artifact in a multi-cloud setup — it
+# never expires, it is copyable, and every new cloud multiplies it. So even for
+# a narrow ops path it is worth not having.
+#
+# Do not extend this to carry application data between clouds. That is the
+# design that was superseded.
+#
+# The answer here is federation. Each cloud already gives its own workloads a
+# verifiable identity (an AWS instance role, an Azure managed identity). GCP
+# STS accepts that identity directly and hands back a short-lived token. The
+# configuration that makes it work is not a secret: it names a pool, a
+# provider, and a service account to impersonate, and points the SDK at the
+# LOCAL cloud's metadata for proof. So it travels as a plain env var — see
+# scripts/entrypoint.sh, which refuses anything carrying key material.
+#
+# Net effect: zero long-lived Google credentials on any other cloud, and one
+# identical mechanism per cloud rather than one bespoke story each.
+#
+# Usage:
+#   bash scripts/deploy/wif_setup.sh                    # dry-run, prints plan
+#   bash scripts/deploy/wif_setup.sh --apply            # create AWS provider
+#   bash scripts/deploy/wif_setup.sh --apply --azure-tenant <TENANT_ID>
+#   bash scripts/deploy/wif_setup.sh --emit-config aws  # print the JSON config
+#   bash scripts/deploy/wif_setup.sh --emit-config azure
+#
+# Idempotent: every create is check-then-create.
+set -euo pipefail
+
+PROJECT="${PROJECT:-quill-cloud-proxy}"
+POOL="${POOL:-multicloud}"
+SA_NAME="${SA_NAME:-tr-multicloud}"
+SPANNER_INSTANCE="${SPANNER_INSTANCE:-trusted-router-nam6}"
+SPANNER_DATABASE="${SPANNER_DATABASE:-trusted-router}"
+BIGTABLE_INSTANCE="${BIGTABLE_INSTANCE:-trusted-router-logs}"
+AWS_ACCOUNT="${AWS_ACCOUNT:-330422590279}"
+# The AWS role the test-network instance runs as. WIF is scoped to exactly
+# this role, so an unrelated principal in the same account cannot impersonate
+# the service account.
+AWS_ROLE_NAME="${AWS_ROLE_NAME:-tr-test-network}"
+AZURE_TENANT="${AZURE_TENANT:-}"
+# Azure hands out tokens per audience. Default to the well-known exchange
+# audience; override if a dedicated App Registration is used instead.
+AZURE_AUDIENCE="${AZURE_AUDIENCE:-api://AzureADTokenExchange}"
+AZURE_PRINCIPAL="${AZURE_PRINCIPAL:-}"   # managed identity object id (the `sub` claim)
+
+APPLY=0
+EMIT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --azure-tenant) AZURE_TENANT="$2"; shift 2 ;;
+    --azure-principal) AZURE_PRINCIPAL="$2"; shift 2 ;;
+    --emit-config) EMIT="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+say() { echo "[wif] $*" >&2; }
+run() {
+  if [ "$APPLY" = "1" ]; then "$@"; else echo "  [dry-run] $*" >&2; fi
+}
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+POOL_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}"
+
+# ─── config emission ───────────────────────────────────────────────────────
+# Printed, never written to a secret store. These files contain no key
+# material; that is the entire point.
+emit_config() {
+  local cloud="$1"
+  local impersonation="https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${SA_EMAIL}:generateAccessToken"
+  case "$cloud" in
+    aws)
+      cat <<JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/${POOL_RESOURCE}/providers/aws-workloads",
+  "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
+  "service_account_impersonation_url": "${impersonation}",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "environment_id": "aws1",
+    "region_url": "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+    "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+    "regional_cred_verification_url": "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+    "imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
+  }
+}
+JSON
+      ;;
+    azure)
+      # Azure's instance metadata endpoint mints an OIDC token for the VM's
+      # managed identity. Same shape as AWS: proof comes from the local cloud.
+      cat <<JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/${POOL_RESOURCE}/providers/azure-workloads",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "service_account_impersonation_url": "${impersonation}",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "url": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=${AZURE_AUDIENCE}",
+    "headers": {"Metadata": "True"},
+    "format": {"type": "json", "subject_token_field_name": "access_token"}
+  }
+}
+JSON
+      ;;
+    *) echo "unknown cloud: $cloud (want aws|azure)" >&2; exit 2 ;;
+  esac
+}
+
+if [ -n "$EMIT" ]; then
+  emit_config "$EMIT"
+  exit 0
+fi
+
+say "project=$PROJECT (#$PROJECT_NUMBER) pool=$POOL sa=$SA_EMAIL apply=$APPLY"
+
+# ─── service account ───────────────────────────────────────────────────────
+# Deliberately NOT the Cloud Run runtime SA. A test network on another cloud
+# should not be able to do everything production can; it gets the two roles it
+# needs to read and write the system of record, and nothing else. Notably no
+# secretmanager.secretAccessor: nothing on a test network reads secrets yet,
+# and the role can be added when something does.
+if gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" >/dev/null 2>&1; then
+  say "service account exists"
+else
+  say "creating service account $SA_EMAIL"
+  run gcloud iam service-accounts create "$SA_NAME" --project "$PROJECT" \
+    --display-name "TrustedRouter multi-cloud (federated)" \
+    --description "Impersonated by AWS/Azure test networks via Workload Identity Federation. No keys."
+fi
+
+# Scoped to the specific database and instance rather than granted
+# project-wide. A project-level roles/spanner.databaseUser reaches EVERY
+# database in the project, including any future one; a test network on
+# another cloud has no business with that.
+say "granting spanner.databaseUser on ${SPANNER_INSTANCE}/${SPANNER_DATABASE}"
+run gcloud spanner databases add-iam-policy-binding "$SPANNER_DATABASE" \
+  --instance="$SPANNER_INSTANCE" --project "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" --role roles/spanner.databaseUser --quiet
+
+say "granting bigtable.user on ${BIGTABLE_INSTANCE}"
+run gcloud bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE" --project "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" --role roles/bigtable.user --quiet
+
+# ─── pool ──────────────────────────────────────────────────────────────────
+if gcloud iam workload-identity-pools describe "$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+  say "pool exists"
+else
+  say "creating pool $POOL"
+  run gcloud iam workload-identity-pools create "$POOL" --location=global --project "$PROJECT" \
+    --display-name "Multi-cloud test networks" \
+    --description "AWS and Azure workloads federating into GCP. No key material."
+fi
+
+# ─── AWS provider ──────────────────────────────────────────────────────────
+# GCP verifies a signed sts:GetCallerIdentity request, so the trust is in the
+# AWS account, and the attribute mapping narrows it to one role.
+if gcloud iam workload-identity-pools providers describe aws-workloads \
+     --workload-identity-pool="$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+  say "aws provider exists"
+else
+  say "creating aws provider (account $AWS_ACCOUNT)"
+  run gcloud iam workload-identity-pools providers create-aws aws-workloads \
+    --workload-identity-pool="$POOL" --location=global --project "$PROJECT" \
+    --account-id="$AWS_ACCOUNT" \
+    --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.extract('assumed-role/{role}/')"
+fi
+
+say "binding AWS role $AWS_ROLE_NAME to $SA_EMAIL"
+run gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" --project "$PROJECT" \
+  --role roles/iam.workloadIdentityUser \
+  --member "principalSet://iam.googleapis.com/${POOL_RESOURCE}/attribute.aws_role/${AWS_ROLE_NAME}" \
+  --quiet
+
+# ─── Azure provider ────────────────────────────────────────────────────────
+if [ -z "$AZURE_TENANT" ]; then
+  say "skipping Azure provider (pass --azure-tenant <TENANT_ID> to create it)"
+else
+  if gcloud iam workload-identity-pools providers describe azure-workloads \
+       --workload-identity-pool="$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+    say "azure provider exists"
+  else
+    say "creating azure provider (tenant $AZURE_TENANT)"
+    run gcloud iam workload-identity-pools providers create-oidc azure-workloads \
+      --workload-identity-pool="$POOL" --location=global --project "$PROJECT" \
+      --issuer-uri="https://sts.windows.net/${AZURE_TENANT}/" \
+      --allowed-audiences="$AZURE_AUDIENCE" \
+      --attribute-mapping="google.subject=assertion.sub"
+  fi
+
+  if [ -z "$AZURE_PRINCIPAL" ]; then
+    say "NOTE: no --azure-principal given, so nothing is bound yet."
+    say "      Pass the managed identity's object id (the token's 'sub' claim)."
+  else
+    say "binding Azure principal $AZURE_PRINCIPAL to $SA_EMAIL"
+    run gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" --project "$PROJECT" \
+      --role roles/iam.workloadIdentityUser \
+      --member "principal://iam.googleapis.com/${POOL_RESOURCE}/subject/${AZURE_PRINCIPAL}" \
+      --quiet
+  fi
+fi
+
+say "done."
+say ""
+say "Credential config for a deployment (no secrets — pass as a plain env var):"
+say "  bash $0 --emit-config aws"
+say "  bash $0 --emit-config azure"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 # Container entrypoint for trusted-router.
 #
-# Production hosting is GCP-only. The GCP SDK's default ADC chain finds the
-# runtime service account from the metadata server, so there is no cross-cloud
-# external credential unwrap path here.
+# On GCP the SDK's default ADC chain finds the runtime service account from the
+# metadata server, and everything below is skipped.
+#
+# Off GCP, a container that needs to reach a Google API has no metadata server
+# to ask. It proves its identity with Workload Identity Federation instead, and
+# the important property is that a WIF configuration is *not a secret*: it names
+# a pool, a provider and a service account to impersonate, and points the SDK at
+# the **local** cloud's instance metadata for the proof. No key material is
+# involved, so it travels as a plain environment variable and needs no secret
+# store.
+#
+# Note the narrow scope. Each cloud runs its own database (see
+# docs/storage-portability/multi-cloud-separation.md), so this is for
+# operational access — shared image registry, bootstrap, ops tooling — not for
+# application data. Same image, same entrypoint, no long-lived Google
+# credentials on any cloud.
 
 set -euo pipefail
 
-# Exec uvicorn (or whatever CMD the image specifies). Using exec replaces
-# this shell so signals reach uvicorn directly.
+if [ -n "${TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG:-}" ]; then
+  # Guard the seam. This path exists to REMOVE long-lived keys, so refuse to
+  # materialise a service-account key through it — otherwise the keyless
+  # design quietly degrades back into a key file the first time someone is in
+  # a hurry.
+  case "$TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG" in
+    *'"private_key"'*|*'"service_account"'*)
+      echo "entrypoint: refusing a credential config that carries key material." >&2
+      echo "entrypoint: this variable takes a keyless external_account (Workload" >&2
+      echo "entrypoint: Identity Federation) config only." >&2
+      exit 1
+      ;;
+  esac
+
+  config_path="${TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH:-/tmp/gcp-external-credential.json}"
+  (umask 077 && printf '%s' "$TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG" > "$config_path")
+  export GOOGLE_APPLICATION_CREDENTIALS="$config_path"
+fi
+
+# exec replaces this shell so signals reach uvicorn directly.
 exec "$@"

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,21 +1,23 @@
 """The container entrypoint is the only cross-cloud credential seam.
 
-It runs on AWS and Azure test networks where there is no GCP metadata server,
-so a mistake here is a deployment that either cannot reach Spanner at all or —
-worse — reaches it with a long-lived key that the whole Workload Identity
-Federation design exists to eliminate. Shell is untested by default in this
-repo, so these tests execute the real script.
+It runs on AWS and Azure, where there is no GCP metadata server, so a mistake
+here is a deployment that either cannot reach Google APIs at all or — worse —
+reaches them with a long-lived key that the whole Workload Identity Federation
+design exists to eliminate. Shell is untested by default in this repo, so these
+tests execute the real script.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
 
 ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+BASH = shutil.which("bash") or "/bin/bash"
 
 # A realistic keyless config: it names the pool/provider/service account and
 # points at the *local* cloud's metadata for proof. No key material.
@@ -23,7 +25,7 @@ AWS_WIF_CONFIG = {
     "type": "external_account",
     "audience": (
         "//iam.googleapis.com/projects/44325983244/locations/global/"
-        "workloadIdentityPools/multicloud/providers/aws"
+        "workloadIdentityPools/multicloud/providers/aws-workloads"
     ),
     "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
     "token_url": "https://sts.googleapis.com/v1/token",
@@ -39,8 +41,8 @@ AWS_WIF_CONFIG = {
 def _run(env: dict[str, str], *argv: str) -> subprocess.CompletedProcess[str]:
     """Run the entrypoint with a harmless command in place of uvicorn."""
     child_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env}
-    return subprocess.run(  # noqa: S603,S607 - test-owned argv, bash resolved from PATH
-        ["bash", str(ENTRYPOINT), *argv],
+    return subprocess.run(  # noqa: S603 - test-owned argv, no shell
+        [BASH, str(ENTRYPOINT), *argv],
         env=child_env,
         capture_output=True,
         text=True,

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,116 @@
+"""The container entrypoint is the only cross-cloud credential seam.
+
+It runs on AWS and Azure test networks where there is no GCP metadata server,
+so a mistake here is a deployment that either cannot reach Spanner at all or —
+worse — reaches it with a long-lived key that the whole Workload Identity
+Federation design exists to eliminate. Shell is untested by default in this
+repo, so these tests execute the real script.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+
+# A realistic keyless config: it names the pool/provider/service account and
+# points at the *local* cloud's metadata for proof. No key material.
+AWS_WIF_CONFIG = {
+    "type": "external_account",
+    "audience": (
+        "//iam.googleapis.com/projects/44325983244/locations/global/"
+        "workloadIdentityPools/multicloud/providers/aws"
+    ),
+    "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
+    "token_url": "https://sts.googleapis.com/v1/token",
+    "credential_source": {
+        "environment_id": "aws1",
+        "regional_cred_verification_url": (
+            "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15"
+        ),
+    },
+}
+
+
+def _run(env: dict[str, str], *argv: str) -> subprocess.CompletedProcess[str]:
+    """Run the entrypoint with a harmless command in place of uvicorn."""
+    child_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env}
+    return subprocess.run(  # noqa: S603,S607 - test-owned argv, bash resolved from PATH
+        ["bash", str(ENTRYPOINT), *argv],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_exec_passes_through_without_credential_config() -> None:
+    """On GCP nothing is set and the entrypoint must stay out of the way."""
+    result = _run({}, "printenv")
+    assert result.returncode == 0, result.stderr
+    exported = dict(
+        line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+    )
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in exported
+
+
+def test_materialises_keyless_config_and_points_adc_at_it(tmp_path: Path) -> None:
+    target = tmp_path / "cred.json"
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": json.dumps(AWS_WIF_CONFIG),
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "printenv",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(target)
+    # Round-trips exactly: a truncated or shell-mangled config fails at token
+    # exchange time, in a deployed container, with an opaque error.
+    assert json.loads(target.read_text()) == AWS_WIF_CONFIG
+
+
+def test_config_file_is_not_world_readable(tmp_path: Path) -> None:
+    """Not key material, but it names an impersonation target — don't leak it
+    to every other process in the container."""
+    target = tmp_path / "cred.json"
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": json.dumps(AWS_WIF_CONFIG),
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "true",
+    )
+    assert result.returncode == 0, result.stderr
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert not mode & (stat.S_IRGRP | stat.S_IROTH), oct(mode)
+
+
+def test_refuses_a_service_account_key(tmp_path: Path) -> None:
+    """The whole point of this seam is to remove long-lived keys. If someone
+    pastes a key JSON in, fail loudly rather than silently accepting it."""
+    target = tmp_path / "cred.json"
+    key_json = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "quill-cloud-proxy",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----\n",
+            "client_email": "tr@quill-cloud-proxy.iam.gserviceaccount.com",
+        }
+    )
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": key_json,
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "printenv",
+    )
+    assert result.returncode == 1
+    assert "key material" in result.stderr
+    # And it must not have been written to disk on the way to failing.
+    assert not target.exists()


### PR DESCRIPTION
Supersedes the "Spanner stays the system of record even when compute runs on AWS/Azure" decision from 2026-07-26.

## The decision

A TrustedRouter deployment on AWS is standalone: its own database, credits, API keys, analytics. Same for Azure. Exactly one thing crosses cloud boundaries — **identity**.

## Why the asymmetry isn't arbitrary

**Identity is an assertion.** Verifying "this is joseph@example.com, signed by an issuer you trust" needs a public key and nothing else. Every cloud verifies it independently, concurrently, while partitioned, and they cannot disagree — there is no shared mutable state to disagree about.

**A credit balance is a mutable quantity with a conservation law.** Two clouds spending from one balance must agree on ordering or it is spent twice. Three ways to get that agreement:

1. One authoritative store → not separate clouds; a cross-cloud hop lands on the authorize+settle hot path and GCP's outages become AWS's outages. This is what is being superseded.
2. Cross-cloud consensus → availability becomes the AND of both clouds, latency the max, failure modes the union. You pay for multi-cloud and get less reliability than single-cloud.
3. Partition the money → no hot-path coordination, correct under partition.

Only (3) preserves the reason for separate clouds.

## Consequences

- **Promoted to critical path:** the `Store` protocol + conformance suite (#288). A new cloud is a new `Store` that passes the suite. Anything the suite doesn't pin is where two clouds silently diverge — and one of those behaviours is money.
- **Demoted:** cross-cloud WIF. No data path needs it. Kept for operational access (shared image registry, bootstrap) because keyless beats a mirrored SA key even there.
- **Unchanged:** ClickHouse per cloud — already built that way.
- **Product requirement, not optional:** per-cloud balances in the console and a 402 body that names the cloud. A hidden partition is a permanent support tax; an explicit one is what cloud sovereignty means.

## Database recommendations (to be validated by the conformance suite, not by argument)

| Cloud | System of record | Why |
|---|---|---|
| AWS | Aurora DSQL | The genuine Spanner analogue — distributed SQL, strong consistency, active-active. Keeps reserve/settle as recognisably the same code. |
| Azure | Cosmos DB for PostgreSQL (Citus) | Distributed Postgres with transactions inside a distribution key; money code is per-workspace, so distribute by workspace id. |

DynamoDB rejected as system of record: it is the Bigtable analogue, `TransactWriteItems` caps at 100 items, and it would force a rewrite of the billing logic in a different idiom — the one thing worth avoiding when the logic is money.

## Also in this PR

The keyless credential seam, scoped to operations:

- `scripts/entrypoint.sh` materialises an `external_account` WIF config from a plain env var, and **refuses** any config carrying key material so the seam cannot degrade back into a mirrored SA key.
- `scripts/deploy/wif_setup.sh` provisions the GCP side, scoped per-database/per-instance rather than project-wide.
- `tests/test_entrypoint.py` executes the real shell script — pass-through when unset, exact JSON round-trip, 0600 mode, key rejection.

GCP side is already provisioned: pool `multicloud`, provider `aws-workloads`, SA `tr-multicloud` with database-scoped Spanner + instance-scoped Bigtable.