### PR TITLE
Standardize provider onboarding contract

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -52,6 +52,7 @@ from trusted_router.content.legal import (
 from trusted_router.measured import measured_for_model, measured_for_provider
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR, format_money_precise
 from trusted_router.og import OG_DESCRIPTION, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, OG_TITLE
+from trusted_router.provider_contract import PROVIDER_CATALOG_EXAMPLE
 from trusted_router.regions import configured_regions, region_map_payload
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -1209,9 +1210,9 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         template="public/provider_apply.html",
         title="List Your Models on TrustedRouter",
         description=(
-            "Give TrustedRouter a dedicated API key, an inference API base URL, "
-            "a machine-readable model catalog, and a pricing API. We will validate, "
-            "list, monitor, and keep your routes current automatically."
+            "Give TrustedRouter a dedicated API key and one OpenAI-compatible API "
+            "base URL implementing our exact model catalog contract. We will "
+            "validate, list, monitor, and keep your routes current automatically."
         ),
         faq_items=(
             (
@@ -1220,7 +1221,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             ),
             (
                 "Why do you require model and pricing APIs?",
-                "TrustedRouter refreshes provider catalogs automatically. Machine-readable model availability and pricing let us add launches, update prices, and remove retired routes without relying on stale web pages or manual email updates.",
+                "TrustedRouter refreshes provider catalogs automatically. The canonical GET /v1/models response includes availability, capabilities, pricing, and lifecycle in one document, so a separate pricing API is not required.",
             ),
             (
                 "What kind of API key should we send?",
@@ -1570,6 +1571,10 @@ def public_page_html(settings: Settings, page_key: str, *, site_url: str | None 
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
             static_version=_static_version(settings),
+            provider_catalog_example_json=json.dumps(
+                PROVIDER_CATALOG_EXAMPLE,
+                indent=2,
+            ),
         )
     )
 

--- a/src/trusted_router/provider_contract.py
+++ b/src/trusted_router/provider_contract.py
@@ -1,0 +1,211 @@
+"""Canonical provider onboarding contract published on the provider apply page."""
+
+from __future__ import annotations
+
+from typing import Final
+
+PROVIDER_CATALOG_SCHEMA_URL: Final = (
+    "https://trustedrouter.com/providers/apply/catalog.schema.json"
+)
+
+PROVIDER_CATALOG_EXAMPLE: Final[dict[str, object]] = {
+    "object": "list",
+    "data": [
+        {
+            "id": "acme/atlas-70b",
+            "object": "model",
+            "owned_by": "acme",
+            "name": "Atlas 70B",
+            "type": "chat",
+            "context_length": 131072,
+            "max_output_tokens": 16384,
+            "endpoints": ["chat/completions"],
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+            "capabilities": {
+                "streaming": True,
+                "tools": True,
+                "structured_output": True,
+                "reasoning": False,
+                "prompt_caching": False,
+            },
+            "pricing": {
+                "currency": "USD",
+                "unit": "per_1m_tokens",
+                "input": "0.50",
+                "output": "1.50",
+                "cached_input": None,
+                "cache_write": None,
+                "minimum_request": "0",
+            },
+            "lifecycle": {
+                "status": "active",
+                "deprecation_at": None,
+                "retirement_at": None,
+                "replacement_model_id": None,
+            },
+        }
+    ],
+}
+
+_DECIMAL_PATTERN = r"^(0|[1-9][0-9]*)(\.[0-9]+)?$"
+_NULLABLE_DECIMAL: Final[dict[str, object]] = {
+    "type": ["string", "null"],
+    "pattern": _DECIMAL_PATTERN,
+}
+_NULLABLE_TIMESTAMP: Final[dict[str, object]] = {
+    "type": ["string", "null"],
+    "format": "date-time",
+}
+_NULLABLE_MODEL_ID: Final[dict[str, object]] = {
+    "type": ["string", "null"],
+    "pattern": r"^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+}
+
+PROVIDER_CATALOG_SCHEMA: Final[dict[str, object]] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": PROVIDER_CATALOG_SCHEMA_URL,
+    "title": "TrustedRouter provider catalog v1",
+    "description": (
+        "The canonical model, capability, price, and lifecycle response for "
+        "TrustedRouter provider onboarding."
+    ),
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["object", "data"],
+    "properties": {
+        "object": {"const": "list"},
+        "data": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/model"},
+        },
+    },
+    "$defs": {
+        "model": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "id",
+                "object",
+                "owned_by",
+                "name",
+                "type",
+                "context_length",
+                "max_output_tokens",
+                "endpoints",
+                "input_modalities",
+                "output_modalities",
+                "capabilities",
+                "pricing",
+                "lifecycle",
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "pattern": r"^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+                },
+                "object": {"const": "model"},
+                "owned_by": {
+                    "type": "string",
+                    "pattern": r"^[a-z0-9][a-z0-9._-]*$",
+                },
+                "name": {"type": "string", "minLength": 1},
+                "type": {"const": "chat"},
+                "context_length": {"type": "integer", "minimum": 1},
+                "max_output_tokens": {"type": "integer", "minimum": 1},
+                "endpoints": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "items": {
+                        "enum": [
+                            "chat/completions",
+                            "responses",
+                        ]
+                    },
+                },
+                "input_modalities": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "items": {
+                        "enum": ["text", "image", "audio", "video", "file"]
+                    },
+                },
+                "output_modalities": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "items": {"enum": ["text", "image", "audio"]},
+                },
+                "capabilities": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "streaming",
+                        "tools",
+                        "structured_output",
+                        "reasoning",
+                        "prompt_caching",
+                    ],
+                    "properties": {
+                        "streaming": {"type": "boolean"},
+                        "tools": {"type": "boolean"},
+                        "structured_output": {"type": "boolean"},
+                        "reasoning": {"type": "boolean"},
+                        "prompt_caching": {"type": "boolean"},
+                    },
+                },
+                "pricing": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "currency",
+                        "unit",
+                        "input",
+                        "output",
+                        "cached_input",
+                        "cache_write",
+                        "minimum_request",
+                    ],
+                    "properties": {
+                        "currency": {"const": "USD"},
+                        "unit": {"const": "per_1m_tokens"},
+                        "input": {
+                            "type": "string",
+                            "pattern": _DECIMAL_PATTERN,
+                        },
+                        "output": {
+                            "type": "string",
+                            "pattern": _DECIMAL_PATTERN,
+                        },
+                        "cached_input": _NULLABLE_DECIMAL,
+                        "cache_write": _NULLABLE_DECIMAL,
+                        "minimum_request": {
+                            "type": "string",
+                            "pattern": _DECIMAL_PATTERN,
+                        },
+                    },
+                },
+                "lifecycle": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "status",
+                        "deprecation_at",
+                        "retirement_at",
+                        "replacement_model_id",
+                    ],
+                    "properties": {
+                        "status": {
+                            "enum": ["active", "deprecated", "retired"]
+                        },
+                        "deprecation_at": _NULLABLE_TIMESTAMP,
+                        "retirement_at": _NULLABLE_TIMESTAMP,
+                        "replacement_model_id": _NULLABLE_MODEL_ID,
+                    },
+                },
+            },
+        }
+    },
+}

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -86,6 +86,7 @@ from trusted_router.dashboard import (
     subprocessors_json,
 )
 from trusted_router.og import OG_PNG_PATH
+from trusted_router.provider_contract import PROVIDER_CATALOG_SCHEMA
 from trusted_router.services.email import EmailMessage, get_email_service
 from trusted_router.storage import STORE
 from trusted_router.storage_custom_models import normalize_custom_model_id
@@ -633,6 +634,19 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/providers/apply")
     async def provider_apply() -> str:
         return public_page_html(settings, "providers/apply")
+
+    @app.get(
+        "/providers/apply/catalog.schema.json",
+        include_in_schema=False,
+    )
+    async def provider_catalog_schema() -> JSONResponse:
+        return JSONResponse(
+            PROVIDER_CATALOG_SCHEMA,
+            media_type="application/schema+json",
+            headers={
+                "cache-control": "public, max-age=3600, stale-while-revalidate=86400"
+            },
+        )
 
     @public_html_route("/apps")
     async def apps() -> str:

--- a/src/trusted_router/templates/public/provider_apply.html
+++ b/src/trusted_router/templates/public/provider_apply.html
@@ -13,7 +13,7 @@
   </div>
   <div class="public-hero-metrics" aria-label="Provider integration requirements">
     <div><strong>1</strong><span>dedicated API key</span></div>
-    <div><strong>3</strong><span>machine-readable URLs</span></div>
+    <div><strong>1</strong><span>canonical catalog endpoint</span></div>
     <div><strong>Hourly</strong><span>catalog refresh</span></div>
   </div>
 </section>
@@ -22,8 +22,8 @@
 {% block body %}
 <section class="public-proof-strip" aria-label="Provider onboarding flow">
   <div><strong>Connect</strong><span>Send a restricted key and API base URL.</span></div>
-  <div><strong>Discover</strong><span>Expose live models through a catalog endpoint.</span></div>
-  <div><strong>Price</strong><span>Publish exact rates through a pricing API.</span></div>
+  <div><strong>Implement</strong><span>Copy the canonical catalog response exactly.</span></div>
+  <div><strong>Publish</strong><span>Expose models, prices, and lifecycle together.</span></div>
   <div><strong>Verify</strong><span>We test, monitor, and list working routes.</span></div>
 </section>
 
@@ -34,9 +34,10 @@
     <p>Email <a href="mailto:providers@trustedrouter.com">providers@trustedrouter.com</a> from your company domain. Include a technical contact who can answer routing and pricing questions.</p>
     <ul class="check-list">
       <li><strong>Dedicated API key.</strong> A revocable production key scoped to inference and model discovery.</li>
-      <li><strong>Inference API URL.</strong> The HTTPS base URL used to call your models, plus authentication and API documentation.</li>
-      <li><strong>Models API URL.</strong> A machine-readable endpoint such as <code>GET /v1/models</code> with stable model IDs and current availability.</li>
-      <li><strong>Pricing API URL.</strong> A machine-readable endpoint with exact input, output, cache, and other billable rates.</li>
+      <li><strong>OpenAI-compatible base URL.</strong> One HTTPS base such as <code>https://api.provider.com/v1</code>.</li>
+      <li><strong>Bearer authentication.</strong> Accept <code>Authorization: Bearer PROVIDER_API_KEY</code> for discovery and inference.</li>
+      <li><strong>Canonical catalog.</strong> Serve the exact response below from <code>GET /v1/models</code>.</li>
+      <li><strong>Chat inference.</strong> Serve OpenAI-compatible requests from <code>POST /v1/chat/completions</code>.</li>
     </ul>
     <p class="small-copy">Never send an account password, owner credential, billing credential, or unrestricted administrative key.</p>
   </div>
@@ -47,17 +48,68 @@ Technical contact:
 
 API base URL:
 API documentation:
-Authentication format:
 Dedicated API key:
 
-Models API URL:
-Pricing API URL:
-
-Supported features:
 Regions:
 Retention policy URL:
 Confidential compute URL:
 Deprecation feed or contact:</code></pre>
+  </div>
+</section>
+
+<section class="marketing-split" aria-labelledby="canonical-contract-heading">
+  <div class="marketing-copy">
+    <span class="eyebrow">Canonical contract v1</span>
+    <h2 id="canonical-contract-heading">Copy this output exactly.</h2>
+    <p>Do not design a custom catalog or pricing format. Return one unpaginated JSON document from <code>GET /v1/models</code>. Put availability, capabilities, prices, and lifecycle in each model row.</p>
+    <ul class="check-list">
+      <li><strong>Use exact decimal strings.</strong> Every price is USD per one million tokens. Use <code>"0.50"</code>, never a JSON float.</li>
+      <li><strong>Use <code>null</code> when a cache rate does not apply.</strong> Do not omit required fields.</li>
+      <li><strong>Use lowercase stable IDs.</strong> The format is <code>provider/model-name</code>. Never recycle an ID for a different model.</li>
+      <li><strong>Use UTC timestamps.</strong> Lifecycle timestamps use RFC 3339, for example <code>2026-08-05T00:00:00Z</code>.</li>
+      <li><strong>Use one row per billable tier.</strong> If rates or capabilities differ, publish a distinct stable model ID for that tier.</li>
+    </ul>
+    <p><a href="/providers/apply/catalog.schema.json">Download the JSON Schema</a> and validate the response before emailing us.</p>
+  </div>
+  <div class="copy-terminal" aria-label="Canonical provider catalog response">
+    <div class="code-head"><span>GET /v1/models</span><span>application/json</span></div>
+    <pre><code>{{ provider_catalog_example_json }}</code></pre>
+  </div>
+</section>
+
+<section class="marketing-split" aria-labelledby="validation-heading">
+  <div class="copy-terminal" aria-label="Provider contract validation requests">
+    <div class="code-head"><span>Two required requests</span><span>curl</span></div>
+    <pre><code>export PROVIDER_API_BASE="https://api.provider.com/v1"
+export PROVIDER_API_KEY="replace-me"
+
+curl --fail --silent --show-error \
+  "$PROVIDER_API_BASE/models" \
+  -H "Authorization: Bearer $PROVIDER_API_KEY"
+
+curl --fail --silent --show-error \
+  "$PROVIDER_API_BASE/chat/completions" \
+  -H "Authorization: Bearer $PROVIDER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "acme/atlas-70b",
+    "messages": [{"role": "user", "content": "Reply PONG"}],
+    "max_tokens": 8,
+    "stream": false
+  }'</code></pre>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">Acceptance check</span>
+    <h2 id="validation-heading">These two calls must work.</h2>
+    <p>The catalog request must match the published schema. The chat request must return a normal OpenAI chat completion with nonzero token usage.</p>
+    <ul class="check-list">
+      <li>HTTP <code>200</code> with <code>Content-Type: application/json</code></li>
+      <li><code>choices[0].message.content</code> contains <code>PONG</code></li>
+      <li><code>usage.prompt_tokens</code>, <code>usage.completion_tokens</code>, and <code>usage.total_tokens</code> are integers</li>
+      <li>The response <code>model</code> identifies the model that actually ran</li>
+    </ul>
+    <p class="small-copy">If your API cannot implement this contract, email the same address with the incompatibility. Do not invent a second format.</p>
+    <p class="small-copy">Contract v1 covers chat-capable models. Include embeddings, image generation, audio, or other APIs in the email and we will map them separately.</p>
   </div>
 </section>
 
@@ -79,14 +131,14 @@ Deprecation feed or contact:</code></pre>
     <div class="marketing-card">
       <span class="card-label">Catalog</span>
       <h3>A live models endpoint.</h3>
-      <p>Return stable model IDs, availability, context length, maximum output, modalities, and capabilities. Include pagination when needed.</p>
+      <p>Return the canonical unpaginated response above. TrustedRouter reads every model from the single document.</p>
       <code>GET /v1/models</code>
     </div>
     <div class="marketing-card">
       <span class="card-label">Pricing</span>
-      <h3>An exact pricing endpoint.</h3>
-      <p>Return currency, units, input and output rates, cache read and write rates, minimum charges, tiers, and effective timestamps as exact decimals.</p>
-      <code>GET /v1/pricing</code>
+      <h3>Prices live with each model.</h3>
+      <p>Publish input, output, cache, and minimum request rates in each model row. No separate pricing endpoint is required.</p>
+      <code>pricing.unit = "per_1m_tokens"</code>
     </div>
   </div>
 </section>

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from trusted_router.provider_contract import (
+    PROVIDER_CATALOG_EXAMPLE,
+    PROVIDER_CATALOG_SCHEMA_URL,
+)
+
 
 def test_provider_onboarding_page_has_machine_readable_requirements(
     client: TestClient,
@@ -12,17 +17,44 @@ def test_provider_onboarding_page_has_machine_readable_requirements(
     assert "List your models on TrustedRouter." in response.text
     assert "providers@trustedrouter.com" in response.text
     assert "Dedicated API key." in response.text
-    assert "Inference API URL." in response.text
-    assert "Models API URL." in response.text
-    assert "Pricing API URL." in response.text
+    assert "OpenAI-compatible base URL." in response.text
+    assert "Canonical catalog." in response.text
+    assert "Copy this output exactly." in response.text
     assert "GET /v1/models" in response.text
-    assert "GET /v1/pricing" in response.text
+    assert "POST /v1/chat/completions" in response.text
+    assert "No separate pricing endpoint is required." in response.text
+    assert "per_1m_tokens" in response.text
+    assert "Do not invent a second format." in response.text
+    assert 'href="/providers/apply/catalog.schema.json"' in response.text
     assert "unrestricted administrative key" in response.text
     assert (
         'href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D"'
         in response.text
     )
     assert '<link rel="canonical" href="https://trustedrouter.com/providers/apply">' in response.text
+
+
+def test_provider_catalog_schema_is_public_and_matches_documented_example(
+    client: TestClient,
+) -> None:
+    response = client.get("/providers/apply/catalog.schema.json")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"].startswith("public")
+    assert response.headers["content-type"] == "application/schema+json"
+    schema = response.json()
+    assert schema["$id"] == PROVIDER_CATALOG_SCHEMA_URL
+    assert schema["additionalProperties"] is False
+    model_schema = schema["$defs"]["model"]
+    assert set(model_schema["required"]) == set(PROVIDER_CATALOG_EXAMPLE["data"][0])
+    pricing_schema = model_schema["properties"]["pricing"]
+    pricing_example = PROVIDER_CATALOG_EXAMPLE["data"][0]["pricing"]
+    assert set(pricing_schema["required"]) == set(pricing_example)
+    assert pricing_schema["properties"]["unit"]["const"] == "per_1m_tokens"
+    assert isinstance(pricing_example["input"], str)
+    assert isinstance(pricing_example["output"], str)
+    assert model_schema["properties"]["type"]["const"] == "chat"
+    assert "embeddings" not in model_schema["properties"]["endpoints"]["items"]["enum"]
 
 
 def test_provider_onboarding_page_is_discoverable(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- replace advisory provider onboarding requirements with one canonical OpenAI-compatible contract
- publish a complete model, pricing, capability, and lifecycle example plus validation requests
- expose a machine-readable Draft 2020-12 JSON Schema at /providers/apply/catalog.schema.json

## Verification
- 2002 passed, 47 skipped
- ruff clean
- mypy clean
- schema and example validated with jsonschema
- desktop and 390 px mobile renders inspected