### PR TITLE
storage: PostgresStore increment 1 — one backend for both remaining clouds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      TR_CONFORMANCE_POSTGRES_DSN: postgresql://postgres:tr@localhost:5432/postgres
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: tr
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/docs/storage-portability/README.md
+++ b/docs/storage-portability/README.md
@@ -22,6 +22,14 @@ with no deployment risk, and it is what lets a non-GCP process start at all.
 
 ## The architecture decision
 
+> **SUPERSEDED 2026-07-27 by [`multi-cloud-separation.md`](multi-cloud-separation.md).**
+> Each cloud is now a **standalone deployment with its own database**: identity
+> federates across clouds, credits and API keys do not. The shared-Spanner plan
+> below is kept because its *analysis* is still what makes the new decision
+> legible — the tradeoffs in "What this trades away" are exactly the costs that
+> separation avoids, and the phased delivery still applies. Read the new
+> document first; treat the bullets immediately below as history.
+
 The naive plan is "replace Spanner and Bigtable with cloud-native equivalents
 on each cloud." That is three ports of the hardest, most dangerous code we
 own (reserve/settle billing), once per cloud.

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -142,6 +142,28 @@ to a single logical partition, which is weaker than what reserve/settle needs.
 **These are recommendations, not conclusions.** Each is validated the same way:
 implement the `Store`, run the conformance suite, and only then argue about it.
 
+### The unlock: both are Postgres
+
+Aurora DSQL and Cosmos DB for PostgreSQL both speak the Postgres wire protocol.
+So this is **not two backends — it is one**.
+
+Write a single `PostgresStore`. Develop and test it against plain Postgres in a
+container, which costs nothing, runs in CI as a service container, and gives the
+conformance suite a *third real backend* to pin behaviour against — the thing
+that catches divergence, including in the money code. Then deploy that same
+implementation on Aurora DSQL for AWS and on Citus for Azure.
+
+This turns "port the hardest code in the system, twice, against two cloud
+databases we cannot run locally" into "write one SQL backend, test it locally,
+deploy it twice." It is the difference between a tractable project and a
+research project, and it is the reason to prefer these two managed services
+over their more obvious cloud-native alternatives.
+
+Where they diverge from stock Postgres — DSQL's optimistic concurrency and its
+restrictions on some DDL, Citus requiring a distribution column on every
+distributed table — those differences are narrow, known up front, and are the
+first thing the conformance suite should be pointed at once a cluster exists.
+
 ---
 
 ## 6. Open questions

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -1,0 +1,160 @@
+# Each cloud is a separate TrustedRouter
+
+**Status:** decided 2026-07-27. **Supersedes** the 2026-07-26 decision recorded
+in `README.md` that "Spanner stays the system of record even when compute runs
+on AWS/Azure."
+
+---
+
+## 1. Decision
+
+A TrustedRouter deployment on AWS is a **standalone deployment**: its own
+database, its own credits, its own API keys, its own analytics. Same for Azure.
+They are not front-ends onto a GCP database.
+
+Exactly one thing crosses cloud boundaries: **identity**. Everything else is
+cloud-local.
+
+| | Federates across clouds | Cloud-local |
+|---|---|---|
+| Who you are (email, OAuth subject, verified identity) | ✅ | |
+| Credit balance | | ✅ |
+| API keys | | ✅ |
+| Workspaces, members, roles | | ✅ |
+| Usage history, generations, analytics | | ✅ |
+| Provider routing + catalog | | ✅ |
+
+An API key issued on AWS authenticates only on AWS. Credit bought on GCP is
+spendable only on GCP.
+
+---
+
+## 2. Why identity federates and money does not
+
+This asymmetry looks arbitrary. It isn't — the two things are different kinds
+of object.
+
+**Identity is an assertion.** "This is joseph@example.com, signed by an issuer
+you trust." Verifying it requires a public key and nothing else. Every cloud
+can verify the same assertion independently, concurrently, while partitioned
+from every other cloud, and they cannot disagree — because there is no shared
+mutable state to disagree about.
+
+**A credit balance is a mutable quantity with a conservation law.** If two
+clouds can both spend from one balance, they must agree on ordering or the
+balance is spent twice. There are only three ways to get that agreement:
+
+1. **One authoritative store.** Then the clouds are not separate: every AWS
+   request round-trips to GCP, GCP's outages become AWS's outages, and the
+   cross-cloud hop lands on the *hot path* of authorize+settle. This is
+   precisely the design being superseded.
+2. **Cross-cloud consensus (2PC or similar).** Availability becomes the AND of
+   both clouds — strictly worse than either alone. Latency becomes the max.
+   Failure modes become the union. You pay for multi-cloud and receive less
+   reliability than single-cloud.
+3. **Partition the money.** Each cloud owns a disjoint slice. No coordination
+   on the hot path. Correct under partition, because there is nothing to
+   coordinate.
+
+Only (3) preserves the reason for having separate clouds at all.
+
+The analogy is exact: one passport, separate accounts at separate institutions.
+Nobody expects a balance at one bank to be spendable at another because it is
+the same person.
+
+### If credit must move between clouds
+
+It moves as an **explicit, asynchronous, idempotent transfer** with a
+settlement record on both sides — debit here, credit there, reconciled, with a
+visible in-flight state. Never a shared balance, never a synchronous
+cross-cloud debit. This is the same shape as the settle outbox already in the
+codebase (`storage_gcp_settle_outbox.py`), and it should reuse that thinking.
+
+Not in scope now. Recorded so that "just let credits work everywhere" is
+recognised as a request for a money-movement feature, not a config change.
+
+---
+
+## 3. The product consequence, which is not optional
+
+**Separateness must be visible.** A user who tops up on GCP and then gets a 402
+from their AWS key will file a support ticket every single time unless:
+
+* the console shows balances **per cloud**, never one merged number;
+* the 402 body names the cloud and the balance it checked;
+* API keys are visibly scoped to the cloud that issued them.
+
+A hidden partition is a permanent support tax. An explicit one is a feature —
+it is what data residency and cloud sovereignty actually mean, and it is
+sellable.
+
+---
+
+## 4. What this changes in the plan
+
+**Promoted to critical path.** The `Store` protocol and the behavioural
+conformance suite (`tests/conformance/`, PR #288) were a nice refactor when
+Spanner was universal. Now they are the mechanism: a new cloud is a new `Store`
+implementation that passes the conformance suite. Everything the suite does not
+pin is a place where two clouds can silently diverge in behaviour — and one of
+those behaviours is money.
+
+Known gap, now urgent: `InMemoryStore` does not implement `TypedBillingStore`
+and Spanner's legacy `reserve()` raises, so the two existing backends run
+genuinely different money code and nothing pins which is right. A third and
+fourth backend make that unacceptable.
+
+**Demoted.** The cross-cloud Workload Identity Federation path (this branch)
+was built to let AWS compute reach GCP Spanner. Under separation, no data path
+needs it. It is kept because it is keyless, narrowly scoped, and still the
+right way to do cross-cloud *operations* (bootstrap, image pull, ops tooling)
+without a long-lived key — but nothing new should be built on top of it.
+
+**Unchanged.** ClickHouse as the analytics backend, one per cloud — that is
+already how it is built (self-hosted node, no managed dependency). Per-cloud
+attestation (Confidential Space / Nitro / SEV-SNP) matters *more*, since each
+cloud is now a standalone product surface rather than a failover target.
+
+---
+
+## 5. Database per cloud
+
+The system of record needs: strong consistency, distributed transactions
+spanning a workspace's rows, conditional writes for the credit invariants, and
+secondary-index lookups. That is what Spanner gives us today.
+
+| Cloud | System of record | Why |
+|---|---|---|
+| GCP | Spanner *(today)* | — |
+| AWS | **Aurora DSQL** | The genuine Spanner analogue: distributed SQL, strong consistency, active-active, no failover step. Keeps the reserve/settle logic recognisably the same code rather than a rewrite. |
+| Azure | **Cosmos DB for PostgreSQL** (Citus) | Distributed Postgres with transactions inside a distribution key. Our money code is per-workspace, so distributing by workspace id puts every transaction on one node. |
+
+Rejected: **DynamoDB** as the system of record. It is the Bigtable analogue,
+not the Spanner analogue — `TransactWriteItems` caps at 100 items and there is
+no cross-partition SQL. It would force the billing logic to be rewritten in a
+different idiom, which is the one thing worth avoiding when the logic in
+question is money. Reasonable for the *operational* half (newest-N generation
+lookups) if that is ever split out.
+
+Rejected for Azure: **Cosmos DB (SQL API)** — transactional batches are limited
+to a single logical partition, which is weaker than what reserve/settle needs.
+
+**These are recommendations, not conclusions.** Each is validated the same way:
+implement the `Store`, run the conformance suite, and only then argue about it.
+
+---
+
+## 6. Open questions
+
+1. **Which issuer federates identity?** Today OAuth is Google and GitHub
+   directly (`oauth_provider.py`). Under separation each cloud can verify those
+   assertions independently with no shared state — which is the cheap and
+   correct answer. A TrustedRouter-owned issuer would be needed only for
+   email/password accounts, which need a home.
+2. **Does a single account see all its clouds?** Listing "GCP: $X, AWS: $Y"
+   requires reading N clouds from one console. That is a read-only fan-out and
+   is safe; it must not become a write path.
+3. **What is the canonical hostname per cloud?** `aws.trustedrouter.com` vs a
+   region-style selector. Affects key scoping and the 402 message.
+4. **Signup credit per cloud?** Granting the trial credit once per cloud
+   multiplies the giveaway by the number of clouds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "google-cloud-spanner>=3.50.0",
   "httpx>=0.27.0",
   "jinja2>=3.1.0",
+  "psycopg[binary,pool]>=3.2.0",
   "pydantic-settings>=2.6.0",
   "python-multipart>=0.0.20",
   "sentry-sdk[fastapi]>=2.20.0",

--- a/scripts/deploy/wif_setup.sh
+++ b/scripts/deploy/wif_setup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Provision keyless cross-cloud access to GCP for the AWS and Azure test
+# networks, via Workload Identity Federation.
+#
+# SCOPE — read docs/storage-portability/multi-cloud-separation.md first.
+#
+# Each cloud is a standalone deployment with its own database, so NO DATA PATH
+# crosses clouds. This script is not part of one. It exists so that a workload
+# on AWS or Azure can reach GCP for *operational* reasons — pulling the shared
+# container image, bootstrap, ops tooling — without a long-lived key.
+#
+# The alternative is a service-account key JSON mirrored into each cloud's
+# secret store. That is the single worst artifact in a multi-cloud setup — it
+# never expires, it is copyable, and every new cloud multiplies it. So even for
+# a narrow ops path it is worth not having.
+#
+# Do not extend this to carry application data between clouds. That is the
+# design that was superseded.
+#
+# The answer here is federation. Each cloud already gives its own workloads a
+# verifiable identity (an AWS instance role, an Azure managed identity). GCP
+# STS accepts that identity directly and hands back a short-lived token. The
+# configuration that makes it work is not a secret: it names a pool, a
+# provider, and a service account to impersonate, and points the SDK at the
+# LOCAL cloud's metadata for proof. So it travels as a plain env var — see
+# scripts/entrypoint.sh, which refuses anything carrying key material.
+#
+# Net effect: zero long-lived Google credentials on any other cloud, and one
+# identical mechanism per cloud rather than one bespoke story each.
+#
+# Usage:
+#   bash scripts/deploy/wif_setup.sh                    # dry-run, prints plan
+#   bash scripts/deploy/wif_setup.sh --apply            # create AWS provider
+#   bash scripts/deploy/wif_setup.sh --apply --azure-tenant <TENANT_ID>
+#   bash scripts/deploy/wif_setup.sh --emit-config aws  # print the JSON config
+#   bash scripts/deploy/wif_setup.sh --emit-config azure
+#
+# Idempotent: every create is check-then-create.
+set -euo pipefail
+
+PROJECT="${PROJECT:-quill-cloud-proxy}"
+POOL="${POOL:-multicloud}"
+SA_NAME="${SA_NAME:-tr-multicloud}"
+SPANNER_INSTANCE="${SPANNER_INSTANCE:-trusted-router-nam6}"
+SPANNER_DATABASE="${SPANNER_DATABASE:-trusted-router}"
+BIGTABLE_INSTANCE="${BIGTABLE_INSTANCE:-trusted-router-logs}"
+AWS_ACCOUNT="${AWS_ACCOUNT:-330422590279}"
+# The AWS role the test-network instance runs as. WIF is scoped to exactly
+# this role, so an unrelated principal in the same account cannot impersonate
+# the service account.
+AWS_ROLE_NAME="${AWS_ROLE_NAME:-tr-test-network}"
+AZURE_TENANT="${AZURE_TENANT:-}"
+# Azure hands out tokens per audience. Default to the well-known exchange
+# audience; override if a dedicated App Registration is used instead.
+AZURE_AUDIENCE="${AZURE_AUDIENCE:-api://AzureADTokenExchange}"
+AZURE_PRINCIPAL="${AZURE_PRINCIPAL:-}"   # managed identity object id (the `sub` claim)
+
+APPLY=0
+EMIT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --azure-tenant) AZURE_TENANT="$2"; shift 2 ;;
+    --azure-principal) AZURE_PRINCIPAL="$2"; shift 2 ;;
+    --emit-config) EMIT="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+say() { echo "[wif] $*" >&2; }
+run() {
+  if [ "$APPLY" = "1" ]; then "$@"; else echo "  [dry-run] $*" >&2; fi
+}
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+POOL_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL}"
+
+# ─── config emission ───────────────────────────────────────────────────────
+# Printed, never written to a secret store. These files contain no key
+# material; that is the entire point.
+emit_config() {
+  local cloud="$1"
+  local impersonation="https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${SA_EMAIL}:generateAccessToken"
+  case "$cloud" in
+    aws)
+      cat <<JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/${POOL_RESOURCE}/providers/aws-workloads",
+  "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
+  "service_account_impersonation_url": "${impersonation}",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "environment_id": "aws1",
+    "region_url": "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+    "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+    "regional_cred_verification_url": "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+    "imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
+  }
+}
+JSON
+      ;;
+    azure)
+      # Azure's instance metadata endpoint mints an OIDC token for the VM's
+      # managed identity. Same shape as AWS: proof comes from the local cloud.
+      cat <<JSON
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/${POOL_RESOURCE}/providers/azure-workloads",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "service_account_impersonation_url": "${impersonation}",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "url": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=${AZURE_AUDIENCE}",
+    "headers": {"Metadata": "True"},
+    "format": {"type": "json", "subject_token_field_name": "access_token"}
+  }
+}
+JSON
+      ;;
+    *) echo "unknown cloud: $cloud (want aws|azure)" >&2; exit 2 ;;
+  esac
+}
+
+if [ -n "$EMIT" ]; then
+  emit_config "$EMIT"
+  exit 0
+fi
+
+say "project=$PROJECT (#$PROJECT_NUMBER) pool=$POOL sa=$SA_EMAIL apply=$APPLY"
+
+# ─── service account ───────────────────────────────────────────────────────
+# Deliberately NOT the Cloud Run runtime SA. A test network on another cloud
+# should not be able to do everything production can; it gets the two roles it
+# needs to read and write the system of record, and nothing else. Notably no
+# secretmanager.secretAccessor: nothing on a test network reads secrets yet,
+# and the role can be added when something does.
+if gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" >/dev/null 2>&1; then
+  say "service account exists"
+else
+  say "creating service account $SA_EMAIL"
+  run gcloud iam service-accounts create "$SA_NAME" --project "$PROJECT" \
+    --display-name "TrustedRouter multi-cloud (federated)" \
+    --description "Impersonated by AWS/Azure test networks via Workload Identity Federation. No keys."
+fi
+
+# Scoped to the specific database and instance rather than granted
+# project-wide. A project-level roles/spanner.databaseUser reaches EVERY
+# database in the project, including any future one; a test network on
+# another cloud has no business with that.
+say "granting spanner.databaseUser on ${SPANNER_INSTANCE}/${SPANNER_DATABASE}"
+run gcloud spanner databases add-iam-policy-binding "$SPANNER_DATABASE" \
+  --instance="$SPANNER_INSTANCE" --project "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" --role roles/spanner.databaseUser --quiet
+
+say "granting bigtable.user on ${BIGTABLE_INSTANCE}"
+run gcloud bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE" --project "$PROJECT" \
+  --member "serviceAccount:${SA_EMAIL}" --role roles/bigtable.user --quiet
+
+# ─── pool ──────────────────────────────────────────────────────────────────
+if gcloud iam workload-identity-pools describe "$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+  say "pool exists"
+else
+  say "creating pool $POOL"
+  run gcloud iam workload-identity-pools create "$POOL" --location=global --project "$PROJECT" \
+    --display-name "Multi-cloud test networks" \
+    --description "AWS and Azure workloads federating into GCP. No key material."
+fi
+
+# ─── AWS provider ──────────────────────────────────────────────────────────
+# GCP verifies a signed sts:GetCallerIdentity request, so the trust is in the
+# AWS account, and the attribute mapping narrows it to one role.
+if gcloud iam workload-identity-pools providers describe aws-workloads \
+     --workload-identity-pool="$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+  say "aws provider exists"
+else
+  say "creating aws provider (account $AWS_ACCOUNT)"
+  run gcloud iam workload-identity-pools providers create-aws aws-workloads \
+    --workload-identity-pool="$POOL" --location=global --project "$PROJECT" \
+    --account-id="$AWS_ACCOUNT" \
+    --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.extract('assumed-role/{role}/')"
+fi
+
+say "binding AWS role $AWS_ROLE_NAME to $SA_EMAIL"
+run gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" --project "$PROJECT" \
+  --role roles/iam.workloadIdentityUser \
+  --member "principalSet://iam.googleapis.com/${POOL_RESOURCE}/attribute.aws_role/${AWS_ROLE_NAME}" \
+  --quiet
+
+# ─── Azure provider ────────────────────────────────────────────────────────
+if [ -z "$AZURE_TENANT" ]; then
+  say "skipping Azure provider (pass --azure-tenant <TENANT_ID> to create it)"
+else
+  if gcloud iam workload-identity-pools providers describe azure-workloads \
+       --workload-identity-pool="$POOL" --location=global --project "$PROJECT" >/dev/null 2>&1; then
+    say "azure provider exists"
+  else
+    say "creating azure provider (tenant $AZURE_TENANT)"
+    run gcloud iam workload-identity-pools providers create-oidc azure-workloads \
+      --workload-identity-pool="$POOL" --location=global --project "$PROJECT" \
+      --issuer-uri="https://sts.windows.net/${AZURE_TENANT}/" \
+      --allowed-audiences="$AZURE_AUDIENCE" \
+      --attribute-mapping="google.subject=assertion.sub"
+  fi
+
+  if [ -z "$AZURE_PRINCIPAL" ]; then
+    say "NOTE: no --azure-principal given, so nothing is bound yet."
+    say "      Pass the managed identity's object id (the token's 'sub' claim)."
+  else
+    say "binding Azure principal $AZURE_PRINCIPAL to $SA_EMAIL"
+    run gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" --project "$PROJECT" \
+      --role roles/iam.workloadIdentityUser \
+      --member "principal://iam.googleapis.com/${POOL_RESOURCE}/subject/${AZURE_PRINCIPAL}" \
+      --quiet
+  fi
+fi
+
+say "done."
+say ""
+say "Credential config for a deployment (no secrets — pass as a plain env var):"
+say "  bash $0 --emit-config aws"
+say "  bash $0 --emit-config azure"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 # Container entrypoint for trusted-router.
 #
-# Production hosting is GCP-only. The GCP SDK's default ADC chain finds the
-# runtime service account from the metadata server, so there is no cross-cloud
-# external credential unwrap path here.
+# On GCP the SDK's default ADC chain finds the runtime service account from the
+# metadata server, and everything below is skipped.
+#
+# Off GCP, a container that needs to reach a Google API has no metadata server
+# to ask. It proves its identity with Workload Identity Federation instead, and
+# the important property is that a WIF configuration is *not a secret*: it names
+# a pool, a provider and a service account to impersonate, and points the SDK at
+# the **local** cloud's instance metadata for the proof. No key material is
+# involved, so it travels as a plain environment variable and needs no secret
+# store.
+#
+# Note the narrow scope. Each cloud runs its own database (see
+# docs/storage-portability/multi-cloud-separation.md), so this is for
+# operational access — shared image registry, bootstrap, ops tooling — not for
+# application data. Same image, same entrypoint, no long-lived Google
+# credentials on any cloud.
 
 set -euo pipefail
 
-# Exec uvicorn (or whatever CMD the image specifies). Using exec replaces
-# this shell so signals reach uvicorn directly.
+if [ -n "${TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG:-}" ]; then
+  # Guard the seam. This path exists to REMOVE long-lived keys, so refuse to
+  # materialise a service-account key through it — otherwise the keyless
+  # design quietly degrades back into a key file the first time someone is in
+  # a hurry.
+  case "$TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG" in
+    *'"private_key"'*|*'"service_account"'*)
+      echo "entrypoint: refusing a credential config that carries key material." >&2
+      echo "entrypoint: this variable takes a keyless external_account (Workload" >&2
+      echo "entrypoint: Identity Federation) config only." >&2
+      exit 1
+      ;;
+  esac
+
+  config_path="${TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH:-/tmp/gcp-external-credential.json}"
+  (umask 077 && printf '%s' "$TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG" > "$config_path")
+  export GOOGLE_APPLICATION_CREDENTIALS="$config_path"
+fi
+
+# exec replaces this shell so signals reach uvicorn directly.
 exec "$@"

--- a/src/trusted_router/storage_errors.py
+++ b/src/trusted_router/storage_errors.py
@@ -91,6 +91,28 @@ def _google_error_types() -> tuple[tuple[type[Exception], ...], tuple[type[Excep
 
 
 @lru_cache(maxsize=1)
+def _postgres_error_types() -> tuple[tuple[type[Exception], ...], tuple[type[Exception], ...]]:
+    """``(transient, conflict)`` types contributed by psycopg.
+
+    Psycopg is optional for non-Postgres deployments, so this follows the
+    Google adapter's lazy-import boundary.
+    """
+    try:
+        import psycopg
+    except ImportError:  # pragma: no cover - only hit without Postgres deps
+        return ((), ())
+
+    transient: tuple[type[Exception], ...] = (
+        psycopg.InterfaceError,
+        psycopg.OperationalError,
+    )
+    conflict: tuple[type[Exception], ...] = (
+        psycopg.errors.SerializationFailure,
+    )
+    return (transient, conflict)
+
+
+@lru_cache(maxsize=1)
 def transient_store_error_types() -> tuple[type[Exception], ...]:
     """Types meaning "the write did not land; try again later".
 
@@ -98,14 +120,21 @@ def transient_store_error_types() -> tuple[type[Exception], ...]:
     which is how the settle-outbox drain consumes it.
     """
     google_transient, _ = _google_error_types()
-    return (StoreConflict, StoreUnavailable, *google_transient)
+    postgres_transient, _ = _postgres_error_types()
+    return (
+        StoreConflict,
+        StoreUnavailable,
+        *google_transient,
+        *postgres_transient,
+    )
 
 
 @lru_cache(maxsize=1)
 def conflict_store_error_types() -> tuple[type[Exception], ...]:
     """Types meaning "a concurrent writer aborted this; replaying may work"."""
     _, google_conflict = _google_error_types()
-    return (StoreConflict, *google_conflict)
+    _, postgres_conflict = _postgres_error_types()
+    return (StoreConflict, *google_conflict, *postgres_conflict)
 
 
 def is_transient_store_error(exc: BaseException) -> bool:

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -1,0 +1,1439 @@
+"""Postgres implementation of the portable Store contract, increment 1.
+
+The generic ``tr_entities`` table mirrors the Spanner adapter's entity model.
+Money remains in typed tables and is changed only with conditional DML.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+import secrets
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Never, TypeVar, cast
+
+import psycopg
+from psycopg_pool import ConnectionPool
+
+from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
+from trusted_router.security import (
+    hash_api_key,
+    key_label,
+    lookup_hash_api_key,
+    new_api_key,
+    new_hash_salt,
+    new_key_id,
+    verify_api_key,
+)
+from trusted_router.storage_errors import StoreConflict, StoreUnavailable
+from trusted_router.storage_gcp_codec import (
+    json_body,
+    member_id,
+    normalize_email,
+    workspace_key_id,
+)
+from trusted_router.storage_models import (
+    AcquisitionAttribution,
+    ApiKey,
+    AuthSession,
+    BroadcastDeliveryJob,
+    BroadcastDestination,
+    ByokProviderConfig,
+    CreditAccount,
+    CustomModel,
+    EmailSendBlock,
+    EncryptedSecretEnvelope,
+    GatewayAuthorization,
+    Generation,
+    GoogleAdsConversion,
+    Member,
+    OAuthAuthorizationCode,
+    ProviderBenchmarkSample,
+    RateLimitHit,
+    Reservation,
+    SignupResult,
+    SyntheticProbeSample,
+    SyntheticRollup,
+    User,
+    VerificationToken,
+    WalletChallenge,
+    Workspace,
+    _is_expired,
+    iso_now,
+    utcnow,
+)
+from trusted_router.types import UsageType
+
+T = TypeVar("T")
+
+
+class PostgresStore:
+    """Psycopg-backed Store implementation for the first portability increment."""
+
+    entity_table = "tr_entities"
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        pool_min_size: int = 0,
+        pool_max_size: int = 4,
+        transaction_attempts: int = 8,
+    ) -> None:
+        if not dsn:
+            raise ValueError("Postgres DSN is required")
+        if transaction_attempts < 1:
+            raise ValueError("transaction_attempts must be positive")
+        self._transaction_attempts = transaction_attempts
+        self._pool = ConnectionPool(
+            conninfo=dsn,
+            min_size=pool_min_size,
+            max_size=pool_max_size,
+            open=True,
+        )
+
+    def close(self) -> None:
+        """Close the connection pool."""
+        self._pool.close()
+
+    def apply_schema(self) -> None:
+        """Apply the package-owned schema idempotently."""
+        schema = Path(__file__).with_name("storage_postgres_schema.sql").read_text()
+
+        def apply(conn: Any) -> None:
+            conn.execute(schema, prepare=False)
+
+        self._run_transaction(apply)
+
+    # Generic entity IO ------------------------------------------------------
+
+    def _run_transaction(self, operation: Callable[[Any], T]) -> T:
+        last_serialization_error: BaseException | None = None
+        for _attempt in range(self._transaction_attempts):
+            try:
+                with self._pool.connection() as conn:
+                    with conn.transaction():
+                        return operation(conn)
+            except psycopg.errors.TransactionRollback as exc:
+                # Covers SerializationFailure (40001) *and* DeadlockDetected
+                # (40P01). Both mean "the server rolled you back, try again",
+                # and both are routine: 40001 is how Aurora DSQL reports every
+                # optimistic-concurrency abort, and 40P01 is ordinary Postgres
+                # lock ordering. Retrying only the first would surface
+                # deadlocks to callers as hard failures.
+                #
+                # Safe to retry because the transaction rolled back whole: an
+                # idempotency row inserted on the failed attempt is gone, so
+                # the retry re-inserts and credits exactly once.
+                last_serialization_error = exc
+                continue
+            except psycopg.IntegrityError as exc:
+                raise StoreConflict("Postgres write conflict") from exc
+            except psycopg.Error as exc:
+                raise StoreUnavailable("Postgres could not service the storage operation") from exc
+        raise StoreConflict(
+            "Postgres transaction repeatedly rolled back (serialization failure or deadlock)"
+        ) from last_serialization_error
+
+    def _read_entity_tx(
+        self,
+        conn: Any,
+        kind: str,
+        entity_id: str,
+        cls: type[T],
+        *,
+        for_update: bool = False,
+    ) -> T | None:
+        query = "SELECT body FROM tr_entities WHERE kind = %s AND id = %s"
+        if for_update:
+            query += " FOR UPDATE"
+        row = conn.execute(query, (kind, entity_id)).fetchone()
+        if row is None:
+            return None
+        raw = row[0]
+        data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+        if cls is dict:
+            return cast(T, data)
+        if dataclasses.is_dataclass(cls):
+            known = {field.name for field in dataclasses.fields(cls)}
+            data = {key: value for key, value in data.items() if key in known}
+        return cls(**data)
+
+    def _read_entity(self, kind: str, entity_id: str, cls: type[T]) -> T | None:
+        return self._run_transaction(
+            lambda conn: self._read_entity_tx(conn, kind, entity_id, cls)
+        )
+
+    def _write_entity_tx(
+        self,
+        conn: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO tr_entities (kind, id, body, updated_at) "
+            "VALUES (%s, %s, %s::jsonb, CURRENT_TIMESTAMP) "
+            "ON CONFLICT (kind, id) DO UPDATE "
+            "SET body = EXCLUDED.body, updated_at = EXCLUDED.updated_at",
+            (kind, entity_id, json_body(value)),
+        )
+
+    def _delete_entity_tx(self, conn: Any, kind: str, entity_id: str) -> int:
+        cursor = conn.execute(
+            "DELETE FROM tr_entities WHERE kind = %s AND id = %s",
+            (kind, entity_id),
+        )
+        return int(cursor.rowcount)
+
+    def _insert_entity_once_tx(
+        self,
+        conn: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> bool:
+        cursor = conn.execute(
+            "INSERT INTO tr_entities (kind, id, body, updated_at) "
+            "VALUES (%s, %s, %s::jsonb, CURRENT_TIMESTAMP) "
+            "ON CONFLICT (kind, id) DO NOTHING",
+            (kind, entity_id, json_body(value)),
+        )
+        return cursor.rowcount == 1
+
+    def _create_workspace_tx(
+        self,
+        conn: Any,
+        owner_user_id: str,
+        name: str,
+        trial_credit_microdollars: int | None,
+    ) -> Workspace:
+        workspace = Workspace(
+            id=str(uuid.uuid4()),
+            name=name,
+            owner_user_id=owner_user_id,
+        )
+        member = Member(
+            workspace_id=workspace.id,
+            user_id=owner_user_id,
+            role="owner",
+        )
+        credit = CreditAccount(workspace_id=workspace.id)
+        initial_total = 0 if trial_credit_microdollars is None else int(
+            trial_credit_microdollars
+        )
+        self._write_entity_tx(conn, "workspace", workspace.id, workspace)
+        self._write_entity_tx(
+            conn,
+            "member",
+            member_id(workspace.id, owner_user_id),
+            member,
+        )
+        self._write_entity_tx(conn, "credit", workspace.id, credit)
+        conn.execute(
+            "INSERT INTO tr_credit_balance "
+            "(workspace_id, shard, total_credits, source_updated_at, updated_at) "
+            "VALUES (%s, 0, %s, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            (workspace.id, initial_total),
+        )
+        return workspace
+
+    def _consume_secret(
+        self,
+        *,
+        raw_secret: str,
+        lookup_kind: str,
+        lookup_field: str,
+        entity_kind: str,
+        cls: type[T],
+        expiry_field: str,
+        purpose: str | None = None,
+    ) -> T | None:
+        lookup_hash = lookup_hash_api_key(raw_secret)
+
+        def consume(conn: Any) -> T | None:
+            lookup = self._read_entity_tx(
+                conn,
+                lookup_kind,
+                lookup_hash,
+                dict,
+            )
+            if lookup is None:
+                return None
+            record = self._read_entity_tx(
+                conn,
+                entity_kind,
+                str(lookup[lookup_field]),
+                cls,
+                for_update=True,
+            )
+            if record is None or getattr(record, "consumed_at", None) is not None:
+                return None
+            if purpose is not None and getattr(record, "purpose", None) != purpose:
+                return None
+            if _is_expired(cast(str | None, getattr(record, expiry_field))):
+                return None
+            secret_record = cast(Any, record)
+            if not verify_api_key(
+                raw_secret,
+                secret_record.salt,
+                secret_record.secret_hash,
+            ):
+                return None
+            secret_record.consumed_at = iso_now()
+            self._write_entity_tx(
+                conn,
+                entity_kind,
+                secret_record.hash,
+                record,
+            )
+            return record
+
+        return self._run_transaction(consume)
+
+    @staticmethod
+    def _expires_at(ttl_seconds: int) -> str:
+        return (
+            utcnow() + dt.timedelta(seconds=max(ttl_seconds, 60))
+        ).isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _not_implemented(method: str) -> Never:
+        raise NotImplementedError(
+            f"PostgresStore.{method} is not implemented in increment 1"
+        )
+
+    # Lifecycle --------------------------------------------------------------
+
+    def reset(self) -> None:
+        self._not_implemented("reset")
+
+    # Users + workspaces -----------------------------------------------------
+
+    def ensure_user(
+        self,
+        user_id: str,
+        email: str | None = None,
+        *,
+        trial_credit_microdollars: int | None = None,
+    ) -> User:
+        normalized_email = normalize_email(email or user_id)
+
+        def ensure(conn: Any) -> User:
+            existing = self._read_entity_tx(
+                conn,
+                "email_user",
+                normalized_email,
+                dict,
+                for_update=True,
+            )
+            if existing is not None:
+                user = self._read_entity_tx(
+                    conn,
+                    "user",
+                    str(existing["user_id"]),
+                    User,
+                )
+                if user is not None:
+                    return user
+
+            user = User(id=str(uuid.uuid4()), email=normalized_email)
+            self._write_entity_tx(conn, "user", user.id, user)
+            self._write_entity_tx(
+                conn,
+                "email_user",
+                normalized_email,
+                {"user_id": user.id},
+            )
+            self._create_workspace_tx(
+                conn,
+                user.id,
+                "Personal Workspace",
+                trial_credit_microdollars,
+            )
+            return user
+
+        return self._run_transaction(ensure)
+
+    def signup(
+        self,
+        *,
+        email: str,
+        workspace_name: str | None = None,
+        trial_credit_microdollars: int = DEFAULT_SIGNUP_CREDIT_MICRODOLLARS,
+    ) -> SignupResult | None:
+        self._not_implemented("signup")
+
+    def create_acquisition_attribution(
+        self, record: AcquisitionAttribution
+    ) -> bool:
+        self._not_implemented("create_acquisition_attribution")
+
+    def get_acquisition_attribution(
+        self, workspace_id: str
+    ) -> AcquisitionAttribution | None:
+        self._not_implemented("get_acquisition_attribution")
+
+    def claim_acquisition_milestones(
+        self,
+        workspace_id: str,
+        milestones: list[str],
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, list[str]]:
+        self._not_implemented("claim_acquisition_milestones")
+
+    def record_acquisition_purchase(
+        self,
+        workspace_id: str,
+        *,
+        amount_microdollars: int,
+        occurred_at: str,
+    ) -> AcquisitionAttribution | None:
+        self._not_implemented("record_acquisition_purchase")
+
+    def list_google_ads_conversions(
+        self,
+        *,
+        since: str,
+        limit: int,
+    ) -> list[GoogleAdsConversion]:
+        self._not_implemented("list_google_ads_conversions")
+
+    def backfill_google_ads_conversions(self, *, limit: int) -> int:
+        self._not_implemented("backfill_google_ads_conversions")
+
+    def create_workspace(
+        self,
+        owner_user_id: str,
+        name: str,
+        *,
+        trial_credit_microdollars: int | None = None,
+    ) -> Workspace:
+        return self._run_transaction(
+            lambda conn: self._create_workspace_tx(
+                conn,
+                owner_user_id,
+                name,
+                trial_credit_microdollars,
+            )
+        )
+
+    def list_workspaces_for_user(self, user_id: str) -> list[Workspace]:
+        self._not_implemented("list_workspaces_for_user")
+
+    def get_workspace(self, workspace_id: str) -> Workspace | None:
+        workspace = self._read_entity("workspace", workspace_id, Workspace)
+        if workspace is None or workspace.deleted:
+            return None
+        return workspace
+
+    def update_workspace(
+        self,
+        workspace_id: str,
+        *,
+        name: str | None = None,
+        deleted: bool | None = None,
+        billing_paused: bool | None = None,
+        billing_pause_reason: str | None = None,
+    ) -> Workspace | None:
+        self._not_implemented("update_workspace")
+
+    def add_members(
+        self,
+        workspace_id: str,
+        emails: list[str],
+        role: str = "member",
+    ) -> list[Member]:
+        self._not_implemented("add_members")
+
+    def remove_members(self, workspace_id: str, user_ids: list[str]) -> None:
+        self._not_implemented("remove_members")
+
+    def list_members(self, workspace_id: str) -> list[Member]:
+        self._not_implemented("list_members")
+
+    def user_can_manage(self, user_id: str, workspace_id: str) -> bool:
+        self._not_implemented("user_can_manage")
+
+    def user_is_member(self, user_id: str, workspace_id: str) -> bool:
+        self._not_implemented("user_is_member")
+
+    def get_user(self, user_id: str) -> User | None:
+        self._not_implemented("get_user")
+
+    def find_user_by_email(self, email: str) -> User | None:
+        self._not_implemented("find_user_by_email")
+
+    def find_user_by_wallet(self, address: str) -> User | None:
+        self._not_implemented("find_user_by_wallet")
+
+    def create_wallet_user(self, address: str) -> User:
+        self._not_implemented("create_wallet_user")
+
+    def set_user_email(self, user_id: str, email: str) -> User | None:
+        self._not_implemented("set_user_email")
+
+    def mark_user_email_verified(self, user_id: str) -> User | None:
+        self._not_implemented("mark_user_email_verified")
+
+    # Auth sessions ----------------------------------------------------------
+
+    def create_auth_session(
+        self,
+        *,
+        user_id: str,
+        provider: str,
+        label: str,
+        ttl_seconds: int,
+        workspace_id: str | None = None,
+        state: str = "active",
+    ) -> tuple[str, AuthSession]:
+        raw = new_api_key(prefix="trsess-v1")
+        session = AuthSession(
+            hash=new_key_id(prefix="sess"),
+            salt=new_hash_salt(),
+            secret_hash="",
+            lookup_hash=lookup_hash_api_key(raw),
+            user_id=user_id,
+            provider=provider,
+            label=label,
+            workspace_id=workspace_id,
+            expires_at=self._expires_at(ttl_seconds),
+            state=state,
+        )
+        session.secret_hash = hash_api_key(raw, session.salt)
+
+        def create(conn: Any) -> None:
+            self._write_entity_tx(conn, "auth_session", session.hash, session)
+            self._write_entity_tx(
+                conn,
+                "auth_session_lookup",
+                session.lookup_hash,
+                {"session_id": session.hash},
+            )
+
+        self._run_transaction(create)
+        return raw, session
+
+    def upgrade_auth_session(
+        self, raw_token: str, *, state: str
+    ) -> AuthSession | None:
+        self._not_implemented("upgrade_auth_session")
+
+    def set_auth_session_workspace(
+        self, raw_token: str, workspace_id: str
+    ) -> AuthSession | None:
+        self._not_implemented("set_auth_session_workspace")
+
+    def get_auth_session_by_raw(self, raw_token: str) -> AuthSession | None:
+        lookup_hash = lookup_hash_api_key(raw_token)
+
+        def get(conn: Any) -> AuthSession | None:
+            lookup = self._read_entity_tx(
+                conn,
+                "auth_session_lookup",
+                lookup_hash,
+                dict,
+            )
+            if lookup is None:
+                return None
+            session = self._read_entity_tx(
+                conn,
+                "auth_session",
+                str(lookup["session_id"]),
+                AuthSession,
+            )
+            if session is None:
+                return None
+            if _is_expired(session.expires_at):
+                self._delete_entity_tx(conn, "auth_session", session.hash)
+                self._delete_entity_tx(conn, "auth_session_lookup", lookup_hash)
+                return None
+            if verify_api_key(raw_token, session.salt, session.secret_hash):
+                return session
+            return None
+
+        return self._run_transaction(get)
+
+    def delete_auth_session_by_raw(self, raw_token: str) -> bool:
+        lookup_hash = lookup_hash_api_key(raw_token)
+
+        def delete(conn: Any) -> bool:
+            lookup = self._read_entity_tx(
+                conn,
+                "auth_session_lookup",
+                lookup_hash,
+                dict,
+                for_update=True,
+            )
+            if lookup is None:
+                return False
+            self._delete_entity_tx(
+                conn,
+                "auth_session",
+                str(lookup["session_id"]),
+            )
+            return self._delete_entity_tx(
+                conn,
+                "auth_session_lookup",
+                lookup_hash,
+            ) == 1
+
+        return self._run_transaction(delete)
+
+    # Wallet, verification, and OAuth one-shot secrets ----------------------
+
+    def create_wallet_challenge(
+        self,
+        *,
+        address: str,
+        message: str,
+        ttl_seconds: int,
+        raw_nonce: str | None = None,
+    ) -> tuple[str, WalletChallenge]:
+        raw = raw_nonce or secrets.token_urlsafe(32)
+        challenge = WalletChallenge(
+            hash=new_key_id(prefix="siwe"),
+            salt=new_hash_salt(),
+            secret_hash="",
+            lookup_hash=lookup_hash_api_key(raw),
+            address=address.strip().lower(),
+            message=message,
+            expires_at=self._expires_at(ttl_seconds),
+        )
+        challenge.secret_hash = hash_api_key(raw, challenge.salt)
+
+        def create(conn: Any) -> None:
+            self._write_entity_tx(
+                conn,
+                "wallet_challenge",
+                challenge.hash,
+                challenge,
+            )
+            self._write_entity_tx(
+                conn,
+                "wallet_challenge_lookup",
+                challenge.lookup_hash,
+                {"challenge_id": challenge.hash},
+            )
+
+        self._run_transaction(create)
+        return raw, challenge
+
+    def consume_wallet_challenge(
+        self, raw_nonce: str
+    ) -> WalletChallenge | None:
+        return self._consume_secret(
+            raw_secret=raw_nonce,
+            lookup_kind="wallet_challenge_lookup",
+            lookup_field="challenge_id",
+            entity_kind="wallet_challenge",
+            cls=WalletChallenge,
+            expiry_field="expires_at",
+        )
+
+    def create_verification_token(
+        self,
+        *,
+        user_id: str,
+        purpose: str,
+        ttl_seconds: int,
+    ) -> tuple[str, VerificationToken]:
+        raw = secrets.token_urlsafe(32)
+        token = VerificationToken(
+            hash=new_key_id(prefix="verify"),
+            salt=new_hash_salt(),
+            secret_hash="",
+            lookup_hash=lookup_hash_api_key(raw),
+            user_id=user_id,
+            purpose=purpose,
+            expires_at=self._expires_at(ttl_seconds),
+        )
+        token.secret_hash = hash_api_key(raw, token.salt)
+
+        def create(conn: Any) -> None:
+            self._write_entity_tx(
+                conn,
+                "verification_token",
+                token.hash,
+                token,
+            )
+            self._write_entity_tx(
+                conn,
+                "verification_token_lookup",
+                token.lookup_hash,
+                {"token_id": token.hash},
+            )
+
+        self._run_transaction(create)
+        return raw, token
+
+    def consume_verification_token(
+        self,
+        raw_token: str,
+        *,
+        purpose: str,
+    ) -> VerificationToken | None:
+        return self._consume_secret(
+            raw_secret=raw_token,
+            lookup_kind="verification_token_lookup",
+            lookup_field="token_id",
+            entity_kind="verification_token",
+            cls=VerificationToken,
+            expiry_field="expires_at",
+            purpose=purpose,
+        )
+
+    def create_oauth_authorization_code(
+        self,
+        *,
+        workspace_id: str,
+        user_id: str | None,
+        callback_url: str,
+        key_label: str,
+        ttl_seconds: int,
+        app_id: int,
+        limit_microdollars: int | None = None,
+        limit_reset: str | None = None,
+        expires_at: str | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+        spawn_agent: str | None = None,
+        spawn_cloud: str | None = None,
+    ) -> tuple[str, OAuthAuthorizationCode]:
+        raw = new_api_key(prefix="auth_code")
+        code = OAuthAuthorizationCode(
+            hash=new_key_id(prefix="oauth"),
+            salt=new_hash_salt(),
+            secret_hash="",
+            lookup_hash=lookup_hash_api_key(raw),
+            workspace_id=workspace_id,
+            user_id=user_id,
+            app_id=app_id,
+            callback_url=callback_url,
+            key_label=key_label,
+            limit_microdollars=limit_microdollars,
+            limit_reset=limit_reset,
+            expires_at=expires_at,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            code_expires_at=self._expires_at(ttl_seconds),
+            spawn_agent=spawn_agent,
+            spawn_cloud=spawn_cloud,
+        )
+        code.secret_hash = hash_api_key(raw, code.salt)
+
+        def create(conn: Any) -> None:
+            self._write_entity_tx(conn, "oauth_code", code.hash, code)
+            self._write_entity_tx(
+                conn,
+                "oauth_code_lookup",
+                code.lookup_hash,
+                {"code_id": code.hash},
+            )
+
+        self._run_transaction(create)
+        return raw, code
+
+    def consume_oauth_authorization_code(
+        self, raw_code: str
+    ) -> OAuthAuthorizationCode | None:
+        return self._consume_secret(
+            raw_secret=raw_code,
+            lookup_kind="oauth_code_lookup",
+            lookup_field="code_id",
+            entity_kind="oauth_code",
+            cls=OAuthAuthorizationCode,
+            expiry_field="code_expires_at",
+        )
+
+    # Email send blocks ------------------------------------------------------
+
+    def block_email_sending(
+        self,
+        *,
+        email: str,
+        reason: str,
+        bounce_type: str | None = None,
+        feedback_id: str | None = None,
+    ) -> EmailSendBlock:
+        self._not_implemented("block_email_sending")
+
+    def is_email_blocked(self, email: str) -> bool:
+        self._not_implemented("is_email_blocked")
+
+    def get_email_block(self, email: str) -> EmailSendBlock | None:
+        self._not_implemented("get_email_block")
+
+    def record_sns_message_once(self, message_id: str) -> bool:
+        return self._run_transaction(
+            lambda conn: self._insert_entity_once_tx(
+                conn,
+                "sns_message",
+                message_id,
+                {"created_at": iso_now()},
+            )
+        )
+
+    # API keys ---------------------------------------------------------------
+
+    def create_api_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str | None,
+        management: bool = False,
+        raw_key: str | None = None,
+        limit_microdollars: int | None = None,
+        limit_reset: str | None = None,
+        include_byok_in_limit: bool = True,
+        expires_at: str | None = None,
+        limit_daily_microdollars: int | None = None,
+        limit_weekly_microdollars: int | None = None,
+        limit_monthly_microdollars: int | None = None,
+        budget_alert_only: bool = False,
+        tags: dict[str, str] | None = None,
+    ) -> tuple[str, ApiKey]:
+        raw = raw_key or new_api_key()
+        key = ApiKey(
+            hash=new_key_id(),
+            salt=new_hash_salt(),
+            secret_hash="",
+            lookup_hash=lookup_hash_api_key(raw),
+            name=name,
+            label=key_label(raw),
+            workspace_id=workspace_id,
+            creator_user_id=creator_user_id,
+            management=management,
+            limit_microdollars=limit_microdollars,
+            limit_reset=limit_reset,
+            include_byok_in_limit=include_byok_in_limit,
+            expires_at=expires_at,
+            limit_daily_microdollars=limit_daily_microdollars,
+            limit_weekly_microdollars=limit_weekly_microdollars,
+            limit_monthly_microdollars=limit_monthly_microdollars,
+            budget_alert_only=budget_alert_only,
+            tags=dict(tags or {}),
+        )
+        key.secret_hash = hash_api_key(raw, key.salt)
+
+        def create(conn: Any) -> None:
+            self._write_entity_tx(conn, "api_key", key.hash, key)
+            self._write_entity_tx(
+                conn,
+                "api_key_lookup",
+                key.lookup_hash,
+                {"key_id": key.hash},
+            )
+            self._write_entity_tx(
+                conn,
+                "api_key_by_workspace",
+                workspace_key_id(workspace_id, key.hash),
+                {"key_id": key.hash},
+            )
+            conn.execute(
+                "INSERT INTO tr_key_limit "
+                "(workspace_id, key_hash, shard, limit_micro, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "source_updated_at, updated_at) "
+                "VALUES (%s, %s, 0, %s, %s, %s, %s, %s, "
+                "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (
+                    workspace_id,
+                    key.hash,
+                    limit_microdollars,
+                    include_byok_in_limit,
+                    limit_daily_microdollars,
+                    limit_weekly_microdollars,
+                    limit_monthly_microdollars,
+                ),
+            )
+
+        self._run_transaction(create)
+        return raw, key
+
+    def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
+        return self._read_entity("api_key", key_hash, ApiKey)
+
+    def typed_key_usage(self, key_hash: str) -> dict[str, Any] | None:
+        self._not_implemented("typed_key_usage")
+
+    def get_key_by_lookup_hash(self, lookup_hash: str) -> ApiKey | None:
+        lookup = self._read_entity("api_key_lookup", lookup_hash, dict)
+        if lookup is None:
+            return None
+        return self.get_key_by_hash(str(lookup["key_id"]))
+
+    def get_key_by_raw(self, raw_key: str) -> ApiKey | None:
+        key = self.get_key_by_lookup_hash(lookup_hash_api_key(raw_key))
+        if key is not None and verify_api_key(
+            raw_key,
+            key.salt,
+            key.secret_hash,
+        ):
+            return key
+        return None
+
+    def list_keys(self, workspace_id: str) -> list[ApiKey]:
+        self._not_implemented("list_keys")
+
+    def delete_key(self, key_hash: str) -> bool:
+        def delete(conn: Any) -> bool:
+            key = self._read_entity_tx(
+                conn,
+                "api_key",
+                key_hash,
+                ApiKey,
+                for_update=True,
+            )
+            if key is None:
+                return False
+            self._delete_entity_tx(conn, "api_key", key.hash)
+            self._delete_entity_tx(
+                conn,
+                "api_key_lookup",
+                key.lookup_hash,
+            )
+            self._delete_entity_tx(
+                conn,
+                "api_key_by_workspace",
+                workspace_key_id(key.workspace_id, key.hash),
+            )
+            conn.execute(
+                "DELETE FROM tr_key_limit "
+                "WHERE workspace_id = %s AND key_hash = %s",
+                (key.workspace_id, key.hash),
+            )
+            return True
+
+        return self._run_transaction(delete)
+
+    def reserve_key_limit(
+        self,
+        key_hash: str,
+        amount_microdollars: int,
+        *,
+        usage_type: UsageType | str,
+    ) -> None:
+        self._not_implemented("reserve_key_limit")
+
+    def settle_key_limit(
+        self,
+        key_hash: str,
+        reserved_microdollars: int,
+        actual_microdollars: int,
+        *,
+        usage_type: UsageType | str,
+    ) -> None:
+        self._not_implemented("settle_key_limit")
+
+    def refund_key_limit(
+        self,
+        key_hash: str,
+        reserved_microdollars: int,
+        *,
+        usage_type: UsageType | str,
+    ) -> None:
+        self._not_implemented("refund_key_limit")
+
+    def update_key(
+        self,
+        key_hash: str,
+        patch: dict[str, Any],
+    ) -> ApiKey | None:
+        self._not_implemented("update_key")
+
+    # BYOK -------------------------------------------------------------------
+
+    def upsert_byok_provider(
+        self,
+        *,
+        workspace_id: str,
+        provider: str,
+        secret_ref: str,
+        key_hint: str | None,
+        encrypted_secret: EncryptedSecretEnvelope | None = None,
+    ) -> ByokProviderConfig:
+        self._not_implemented("upsert_byok_provider")
+
+    def list_byok_providers(
+        self, workspace_id: str
+    ) -> list[ByokProviderConfig]:
+        self._not_implemented("list_byok_providers")
+
+    def get_byok_provider(
+        self,
+        workspace_id: str,
+        provider: str,
+    ) -> ByokProviderConfig | None:
+        self._not_implemented("get_byok_provider")
+
+    def delete_byok_provider(
+        self,
+        workspace_id: str,
+        provider: str,
+    ) -> bool:
+        self._not_implemented("delete_byok_provider")
+
+    # Custom models ----------------------------------------------------------
+
+    def create_custom_model(
+        self,
+        *,
+        owner_user_id: str,
+        owner_workspace_id: str,
+        name: str,
+        base_model_id: str,
+        hidden_prompt: str,
+        enabled: bool = True,
+        slug: str | None = None,
+    ) -> CustomModel:
+        self._not_implemented("create_custom_model")
+
+    def list_custom_models_for_user(
+        self, owner_user_id: str
+    ) -> list[CustomModel]:
+        self._not_implemented("list_custom_models_for_user")
+
+    def get_custom_model(self, model_id: str) -> CustomModel | None:
+        self._not_implemented("get_custom_model")
+
+    def update_custom_model(
+        self,
+        model_id: str,
+        *,
+        owner_user_id: str,
+        patch: dict[str, Any],
+    ) -> CustomModel | None:
+        self._not_implemented("update_custom_model")
+
+    def delete_custom_model(
+        self,
+        model_id: str,
+        *,
+        owner_user_id: str,
+    ) -> bool:
+        self._not_implemented("delete_custom_model")
+
+    # Broadcast destinations ------------------------------------------------
+
+    def create_broadcast_destination(
+        self,
+        *,
+        workspace_id: str,
+        type: str,
+        name: str,
+        endpoint: str,
+        enabled: bool = True,
+        include_content: bool = False,
+        method: str = "POST",
+        encrypted_api_key: EncryptedSecretEnvelope | None = None,
+        encrypted_headers: EncryptedSecretEnvelope | None = None,
+        header_names: list[str] | None = None,
+    ) -> BroadcastDestination:
+        self._not_implemented("create_broadcast_destination")
+
+    def list_broadcast_destinations(
+        self, workspace_id: str
+    ) -> list[BroadcastDestination]:
+        self._not_implemented("list_broadcast_destinations")
+
+    def get_broadcast_destination(
+        self,
+        workspace_id: str,
+        destination_id: str,
+    ) -> BroadcastDestination | None:
+        self._not_implemented("get_broadcast_destination")
+
+    def update_broadcast_destination(
+        self,
+        workspace_id: str,
+        destination_id: str,
+        **patch: Any,
+    ) -> BroadcastDestination | None:
+        self._not_implemented("update_broadcast_destination")
+
+    def delete_broadcast_destination(
+        self,
+        workspace_id: str,
+        destination_id: str,
+    ) -> bool:
+        self._not_implemented("delete_broadcast_destination")
+
+    def enqueue_broadcast_delivery(
+        self,
+        *,
+        workspace_id: str,
+        destination_id: str,
+        generation_id: str,
+        settle_body: dict[str, Any],
+    ) -> BroadcastDeliveryJob:
+        self._not_implemented("enqueue_broadcast_delivery")
+
+    def due_broadcast_deliveries(
+        self, *, limit: int = 100
+    ) -> list[BroadcastDeliveryJob]:
+        self._not_implemented("due_broadcast_deliveries")
+
+    def claim_broadcast_deliveries(
+        self,
+        *,
+        limit: int = 100,
+        lease_seconds: int = 60,
+    ) -> list[BroadcastDeliveryJob]:
+        self._not_implemented("claim_broadcast_deliveries")
+
+    def mark_broadcast_delivery(
+        self,
+        job_id: str,
+        *,
+        success: bool,
+        error: str | None = None,
+        lease_owner: str | None = None,
+    ) -> BroadcastDeliveryJob | None:
+        self._not_implemented("mark_broadcast_delivery")
+
+    # Credit ledger ----------------------------------------------------------
+
+    def get_credit_account(
+        self, workspace_id: str
+    ) -> CreditAccount | None:
+        self._not_implemented("get_credit_account")
+
+    def credit_workspace_typed_direct(
+        self,
+        workspace_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool:
+        def credit(conn: Any) -> bool:
+            won = self._insert_entity_once_tx(
+                conn,
+                "stripe_event",
+                event_id,
+                {
+                    "created_at": iso_now(),
+                    "workspace_id": workspace_id,
+                },
+            )
+            if not won:
+                return False
+            cursor = conn.execute(
+                "UPDATE tr_credit_balance "
+                "SET total_credits = total_credits + %s, "
+                "source_updated_at = CURRENT_TIMESTAMP, "
+                "updated_at = CURRENT_TIMESTAMP "
+                "WHERE workspace_id = %s AND shard = 0",
+                (int(amount_microdollars), workspace_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError(
+                    f"missing authoritative tr_credit_balance for workspace {workspace_id}"
+                )
+            return True
+
+        return self._run_transaction(credit)
+
+    def credit_workspace_once(
+        self,
+        workspace_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool:
+        return self.credit_workspace_typed_direct(
+            workspace_id,
+            amount_microdollars,
+            event_id,
+        )
+
+    def reserve(
+        self,
+        workspace_id: str,
+        key_hash: str,
+        amount_microdollars: int,
+        *,
+        idempotency_key: str | None = None,
+    ) -> Reservation:
+        self._not_implemented("reserve")
+
+    def settle(
+        self,
+        reservation_id: str,
+        actual_microdollars: int,
+    ) -> None:
+        self._not_implemented("settle")
+
+    def refund(self, reservation_id: str) -> None:
+        self._not_implemented("refund")
+
+    def update_auto_refill_settings(
+        self,
+        workspace_id: str,
+        *,
+        enabled: bool,
+        threshold_microdollars: int,
+        amount_microdollars: int,
+    ) -> CreditAccount | None:
+        self._not_implemented("update_auto_refill_settings")
+
+    def set_stripe_customer(
+        self,
+        workspace_id: str,
+        *,
+        customer_id: str,
+        payment_method_id: str | None = None,
+    ) -> CreditAccount | None:
+        self._not_implemented("set_stripe_customer")
+
+    def clear_stripe_payment_method(
+        self, workspace_id: str
+    ) -> CreditAccount | None:
+        self._not_implemented("clear_stripe_payment_method")
+
+    def record_auto_refill_outcome(
+        self,
+        workspace_id: str,
+        *,
+        status: str,
+    ) -> CreditAccount | None:
+        self._not_implemented("record_auto_refill_outcome")
+
+    # Gateway authorizations -------------------------------------------------
+
+    def create_gateway_authorization(
+        self,
+        *,
+        workspace_id: str,
+        key_hash: str,
+        model_id: str,
+        provider: str,
+        usage_type: UsageType | str,
+        estimated_microdollars: int,
+        credit_reservation_id: str | None,
+        requested_model_id: str | None = None,
+        candidate_model_ids: list[str] | None = None,
+        region: str | None = None,
+        endpoint_id: str | None = None,
+        candidate_endpoint_ids: list[str] | None = None,
+        idempotency_key: str | None = None,
+        tags: dict[str, str] | None = None,
+        idempotency_fingerprint: str | None = None,
+        custom_model_id: str | None = None,
+        custom_model_revision: int | None = None,
+        additional_cost_reservation_microdollars: int = 0,
+    ) -> GatewayAuthorization:
+        self._not_implemented("create_gateway_authorization")
+
+    def get_gateway_authorization(
+        self, authorization_id: str
+    ) -> GatewayAuthorization | None:
+        self._not_implemented("get_gateway_authorization")
+
+    def get_gateway_authorization_by_idempotency_key(
+        self,
+        workspace_id: str,
+        key_hash: str,
+        idempotency_key: str,
+    ) -> GatewayAuthorization | None:
+        self._not_implemented(
+            "get_gateway_authorization_by_idempotency_key"
+        )
+
+    def mark_gateway_authorization_settled(
+        self, authorization_id: str
+    ) -> None:
+        self._not_implemented("mark_gateway_authorization_settled")
+
+    def finalize_gateway_authorization(
+        self,
+        authorization_id: str,
+        *,
+        success: bool,
+        actual_microdollars: int,
+        selected_usage_type: UsageType | str,
+        generation: Generation | None = None,
+    ) -> bool:
+        self._not_implemented("finalize_gateway_authorization")
+
+    # Generations + activity -------------------------------------------------
+
+    def add_generation(self, generation: Generation) -> None:
+        self._not_implemented("add_generation")
+
+    def record_provider_benchmark(
+        self, sample: ProviderBenchmarkSample
+    ) -> None:
+        self._run_transaction(
+            lambda conn: self._write_entity_tx(
+                conn,
+                "provider_benchmark",
+                sample.id,
+                sample,
+            )
+        )
+
+    def provider_benchmark_samples(
+        self,
+        *,
+        date: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        limit: int = 1000,
+    ) -> list[ProviderBenchmarkSample]:
+        date_pattern = None if date is None else f"{date}%"
+
+        def list_samples(conn: Any) -> list[ProviderBenchmarkSample]:
+            rows = conn.execute(
+                "SELECT body FROM tr_entities "
+                "WHERE kind = 'provider_benchmark' "
+                "AND (%s::text IS NULL OR body ->> 'created_at' LIKE %s) "
+                "AND (%s::text IS NULL OR body ->> 'provider' = %s) "
+                "AND (%s::text IS NULL OR body ->> 'model' = %s) "
+                "ORDER BY body ->> 'created_at' DESC, id DESC "
+                "LIMIT %s",
+                (
+                    date_pattern,
+                    date_pattern,
+                    provider,
+                    provider,
+                    model,
+                    model,
+                    max(0, int(limit)),
+                ),
+            ).fetchall()
+            samples: list[ProviderBenchmarkSample] = []
+            for row in rows:
+                raw = row[0]
+                data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                known = {
+                    field.name
+                    for field in dataclasses.fields(ProviderBenchmarkSample)
+                }
+                samples.append(
+                    ProviderBenchmarkSample(
+                        **{
+                            key: value
+                            for key, value in data.items()
+                            if key in known
+                        }
+                    )
+                )
+            return samples
+
+        return self._run_transaction(list_samples)
+
+    def record_synthetic_probe_sample(
+        self, sample: SyntheticProbeSample
+    ) -> None:
+        self._not_implemented("record_synthetic_probe_sample")
+
+    def synthetic_probe_samples(
+        self,
+        *,
+        date: str | None = None,
+        target: str | None = None,
+        probe_type: str | None = None,
+        monitor_region: str | None = None,
+        limit: int = 1000,
+    ) -> list[SyntheticProbeSample]:
+        self._not_implemented("synthetic_probe_samples")
+
+    def synthetic_rollups(
+        self,
+        *,
+        period: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        include_histograms: bool = True,
+        limit: int = 1000,
+    ) -> list[SyntheticRollup]:
+        self._not_implemented("synthetic_rollups")
+
+    def get_generation(self, generation_id: str) -> Generation | None:
+        self._not_implemented("get_generation")
+
+    def activity(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None = None,
+        date: str | None = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        group_by_tag: str | None = None,
+    ) -> list[dict[str, Any]]:
+        self._not_implemented("activity")
+
+    def activity_events(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None = None,
+        date: str | None = None,
+        limit: int = 100,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+    ) -> list[dict[str, Any]]:
+        self._not_implemented("activity_events")
+
+    def activity_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None = None,
+        date: str | None = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        group_by_tag: str | None = None,
+    ) -> Any:
+        self._not_implemented("activity_result")
+
+    def activity_events_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None = None,
+        date: str | None = None,
+        limit: int = 100,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+    ) -> Any:
+        self._not_implemented("activity_events_result")
+
+    def usage_series(
+        self,
+        workspace_id: str,
+        *,
+        window_minutes: int,
+        granularity: str,
+        api_key_hash: str | None = None,
+        by_model: bool = False,
+    ) -> dict[str, Any]:
+        self._not_implemented("usage_series")
+
+    def reconcile_generation_activity(
+        self,
+        workspace_id: str,
+        *,
+        date: str | None = None,
+        limit: int = 1000,
+    ) -> int:
+        self._not_implemented("reconcile_generation_activity")
+
+    # Rate limiting ----------------------------------------------------------
+
+    def hit_rate_limit(
+        self,
+        *,
+        namespace: str,
+        subject: str,
+        limit: int,
+        window_seconds: int,
+        now: dt.datetime | None = None,
+    ) -> RateLimitHit:
+        self._not_implemented("hit_rate_limit")

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS tr_entities (
+    kind TEXT NOT NULL,
+    id TEXT NOT NULL,
+    body JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (kind, id)
+);
+
+CREATE TABLE IF NOT EXISTS tr_credit_balance (
+    workspace_id TEXT NOT NULL,
+    shard BIGINT NOT NULL DEFAULT 0,
+    total_credits BIGINT NOT NULL DEFAULT 0,
+    total_usage BIGINT NOT NULL DEFAULT 0,
+    reserved BIGINT NOT NULL DEFAULT 0,
+    source_updated_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (workspace_id, shard)
+);
+
+CREATE TABLE IF NOT EXISTS tr_key_limit (
+    workspace_id TEXT NOT NULL,
+    key_hash TEXT NOT NULL,
+    shard BIGINT NOT NULL DEFAULT 0,
+    limit_micro BIGINT,
+    usage BIGINT NOT NULL DEFAULT 0,
+    byok_usage BIGINT NOT NULL DEFAULT 0,
+    reserved BIGINT NOT NULL DEFAULT 0,
+    include_byok BOOLEAN NOT NULL DEFAULT TRUE,
+    day_limit_micro BIGINT,
+    week_limit_micro BIGINT,
+    month_limit_micro BIGINT,
+    source_updated_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (workspace_id, key_hash, shard)
+);

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -19,7 +19,7 @@ rather than tribal knowledge living in one implementation.
 Backend availability
 --------------------
 `memory` always runs. Backends that need a live server (the Spanner/Bigtable
-emulators today, a Postgres container later) are opt-in: their factory calls
+emulators or a Postgres container) are opt-in: their factory calls
 `pytest.skip()` when the server isn't reachable, so the suite stays green on a
 laptop and gains real cross-backend enforcement in CI. A backend that is
 skipped proves nothing, which is why `test_memory_backend_is_always_runnable`
@@ -96,9 +96,25 @@ def _spanner_emulator_store() -> Store:
     )
 
 
+def _postgres_store() -> Store:
+    """A PostgresStore pointed at the conformance database."""
+    dsn = os.environ.get("TR_CONFORMANCE_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip(
+            "Postgres conformance backend not configured "
+            "(set TR_CONFORMANCE_POSTGRES_DSN)"
+        )
+    from trusted_router.storage_postgres import PostgresStore
+
+    store = PostgresStore(dsn)
+    store.apply_schema()
+    return store
+
+
 #: Add a backend here and it must pass every test in this package.
 BACKENDS: dict[str, Callable[[], Store]] = {
     "memory": _memory_store,
+    "postgres": _postgres_store,
     "spanner-emulator": _spanner_emulator_store,
 }
 
@@ -112,7 +128,12 @@ def store(request: pytest.FixtureRequest) -> Iterator[Store]:
     counted as a pass.
     """
     backend = BACKENDS[request.param]()
-    yield backend
+    try:
+        yield backend
+    finally:
+        close = getattr(backend, "close", None)
+        if close is not None:
+            close()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,21 +1,23 @@
 """The container entrypoint is the only cross-cloud credential seam.
 
-It runs on AWS and Azure test networks where there is no GCP metadata server,
-so a mistake here is a deployment that either cannot reach Spanner at all or —
-worse — reaches it with a long-lived key that the whole Workload Identity
-Federation design exists to eliminate. Shell is untested by default in this
-repo, so these tests execute the real script.
+It runs on AWS and Azure, where there is no GCP metadata server, so a mistake
+here is a deployment that either cannot reach Google APIs at all or — worse —
+reaches them with a long-lived key that the whole Workload Identity Federation
+design exists to eliminate. Shell is untested by default in this repo, so these
+tests execute the real script.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
 
 ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+BASH = shutil.which("bash") or "/bin/bash"
 
 # A realistic keyless config: it names the pool/provider/service account and
 # points at the *local* cloud's metadata for proof. No key material.
@@ -23,7 +25,7 @@ AWS_WIF_CONFIG = {
     "type": "external_account",
     "audience": (
         "//iam.googleapis.com/projects/44325983244/locations/global/"
-        "workloadIdentityPools/multicloud/providers/aws"
+        "workloadIdentityPools/multicloud/providers/aws-workloads"
     ),
     "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
     "token_url": "https://sts.googleapis.com/v1/token",
@@ -39,8 +41,8 @@ AWS_WIF_CONFIG = {
 def _run(env: dict[str, str], *argv: str) -> subprocess.CompletedProcess[str]:
     """Run the entrypoint with a harmless command in place of uvicorn."""
     child_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env}
-    return subprocess.run(  # noqa: S603,S607 - test-owned argv, bash resolved from PATH
-        ["bash", str(ENTRYPOINT), *argv],
+    return subprocess.run(  # noqa: S603 - test-owned argv, no shell
+        [BASH, str(ENTRYPOINT), *argv],
         env=child_env,
         capture_output=True,
         text=True,

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,116 @@
+"""The container entrypoint is the only cross-cloud credential seam.
+
+It runs on AWS and Azure test networks where there is no GCP metadata server,
+so a mistake here is a deployment that either cannot reach Spanner at all or —
+worse — reaches it with a long-lived key that the whole Workload Identity
+Federation design exists to eliminate. Shell is untested by default in this
+repo, so these tests execute the real script.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+
+# A realistic keyless config: it names the pool/provider/service account and
+# points at the *local* cloud's metadata for proof. No key material.
+AWS_WIF_CONFIG = {
+    "type": "external_account",
+    "audience": (
+        "//iam.googleapis.com/projects/44325983244/locations/global/"
+        "workloadIdentityPools/multicloud/providers/aws"
+    ),
+    "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
+    "token_url": "https://sts.googleapis.com/v1/token",
+    "credential_source": {
+        "environment_id": "aws1",
+        "regional_cred_verification_url": (
+            "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15"
+        ),
+    },
+}
+
+
+def _run(env: dict[str, str], *argv: str) -> subprocess.CompletedProcess[str]:
+    """Run the entrypoint with a harmless command in place of uvicorn."""
+    child_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), **env}
+    return subprocess.run(  # noqa: S603,S607 - test-owned argv, bash resolved from PATH
+        ["bash", str(ENTRYPOINT), *argv],
+        env=child_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_exec_passes_through_without_credential_config() -> None:
+    """On GCP nothing is set and the entrypoint must stay out of the way."""
+    result = _run({}, "printenv")
+    assert result.returncode == 0, result.stderr
+    exported = dict(
+        line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+    )
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in exported
+
+
+def test_materialises_keyless_config_and_points_adc_at_it(tmp_path: Path) -> None:
+    target = tmp_path / "cred.json"
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": json.dumps(AWS_WIF_CONFIG),
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "printenv",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(target)
+    # Round-trips exactly: a truncated or shell-mangled config fails at token
+    # exchange time, in a deployed container, with an opaque error.
+    assert json.loads(target.read_text()) == AWS_WIF_CONFIG
+
+
+def test_config_file_is_not_world_readable(tmp_path: Path) -> None:
+    """Not key material, but it names an impersonation target — don't leak it
+    to every other process in the container."""
+    target = tmp_path / "cred.json"
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": json.dumps(AWS_WIF_CONFIG),
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "true",
+    )
+    assert result.returncode == 0, result.stderr
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert not mode & (stat.S_IRGRP | stat.S_IROTH), oct(mode)
+
+
+def test_refuses_a_service_account_key(tmp_path: Path) -> None:
+    """The whole point of this seam is to remove long-lived keys. If someone
+    pastes a key JSON in, fail loudly rather than silently accepting it."""
+    target = tmp_path / "cred.json"
+    key_json = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "quill-cloud-proxy",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----\n",
+            "client_email": "tr@quill-cloud-proxy.iam.gserviceaccount.com",
+        }
+    )
+    result = _run(
+        {
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG": key_json,
+            "TR_GOOGLE_EXTERNAL_CREDENTIAL_CONFIG_PATH": str(target),
+        },
+        "printenv",
+    )
+    assert result.returncode == 1
+    assert "key material" in result.stderr
+    # And it must not have been written to disk on the way to failing.
+    assert not target.exists()

--- a/tests/test_store_protocol_conformance.py
+++ b/tests/test_store_protocol_conformance.py
@@ -1,10 +1,9 @@
 """Storage backend Protocol conformance.
 
-The `Store` Protocol is the contract route code talks to. Both
-`InMemoryStore` and `SpannerBigtableStore` must implement every method
-declared on it. Adding a method to the Protocol without implementing it
-in both backends would silently break in production for the unaffected
-backend the moment that method gets called.
+The `Store` Protocol is the contract route code talks to. Every backend must
+implement every method declared on it. Adding a method to the Protocol without
+implementing it across backends would silently break in production for the
+unaffected backend the moment that method gets called.
 
 The runtime `isinstance(_, Store)` check is light — Protocols are
 structural — but combined with mypy on the `Store` type alias it makes
@@ -60,29 +59,54 @@ def test_in_memory_store_class_declares_every_protocol_method() -> None:
     assert not missing, f"InMemoryStore is missing Protocol members: {missing}"
 
 
+def test_postgres_store_class_declares_every_protocol_method() -> None:
+    """Incremental backends still declare the whole Protocol surface.
+
+    Methods outside the current increment may raise a named
+    NotImplementedError, but a missing method or drifted signature is never
+    allowed to reach production as an AttributeError.
+    """
+    from trusted_router.storage_postgres import PostgresStore
+
+    protocol_members = _public_method_names(Store)
+    missing = [
+        name for name in protocol_members if not hasattr(PostgresStore, name)
+    ]
+    assert not missing, f"PostgresStore is missing Protocol members: {missing}"
+
+
 def test_protocol_methods_have_consistent_signatures_across_backends() -> None:
     """Each method's parameter list (excluding `self`) must match between
-    the two backends. mypy enforces this at type-check time; this is a
+    all backends. mypy enforces this at type-check time; this is a
     runtime tripwire for the case where someone added a kwarg to one
     backend and forgot the other, and the test runner doesn't happen to
     exercise that exact call site."""
     from trusted_router.storage_gcp import SpannerBigtableStore
+    from trusted_router.storage_postgres import PostgresStore
 
     diffs: list[str] = []
+    backend_classes = {
+        "spanner": SpannerBigtableStore,
+        "postgres": PostgresStore,
+    }
     for name in _public_method_names(Store):
         if name == "reset":
             # Spanner's reset deliberately raises — its signature
             # matches but the behavior differs.
             continue
-        try:
-            in_mem = inspect.signature(getattr(InMemoryStore, name))
-            spanner = inspect.signature(getattr(SpannerBigtableStore, name))
-        except (ValueError, TypeError):
-            continue  # builtins / wrappers we can't inspect
-        in_mem_params = _named_params(in_mem)
-        spanner_params = _named_params(spanner)
-        if in_mem_params != spanner_params:
-            diffs.append(f"{name}: in_memory={in_mem_params} vs spanner={spanner_params}")
+        for backend_name, backend_class in backend_classes.items():
+            try:
+                in_mem = inspect.signature(getattr(InMemoryStore, name))
+                backend = inspect.signature(getattr(backend_class, name))
+            except (ValueError, TypeError):
+                continue  # builtins / wrappers we can't inspect
+            in_mem_params = _named_params(in_mem)
+            backend_params = _named_params(backend)
+            if in_mem_params != backend_params:
+                diffs.append(
+                    f"{name}: in_memory={in_mem_params} "
+                    f"vs {backend_name}={backend_params}"
+                )
     assert not diffs, "Backend signatures drifted:\n" + "\n".join(diffs)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2864,6 +2864,90 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4410,6 +4494,7 @@ dependencies = [
     { name = "google-cloud-spanner" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "sentry-sdk", extra = ["fastapi"] },
@@ -4444,6 +4529,7 @@ requires-dist = [
     { name = "google-cloud-spanner", specifier = ">=3.50.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.20.0" },


### PR DESCRIPTION
Implements the database half of [`multi-cloud-separation.md`](docs/storage-portability/multi-cloud-separation.md) (merged in #307).

## Why one backend covers two clouds

AWS's Aurora DSQL and Azure's Cosmos DB for PostgreSQL both speak the Postgres wire protocol. So the two remaining clouds need **one** `Store` implementation, developed and tested against a plain Postgres container — not two bespoke ports of the money code against cloud databases we cannot run locally.

## What is verified, not claimed

`tests/conformance/` now runs **three** backends:

```
39 passed, 14 skipped
```

14 behavioural tests × {memory, postgres} + protocol guards passing; the 14 skips are the Spanner emulator, still pending its schema-provisioning increment. CI gains a Postgres 17 service container so this executes on every run — a skipped backend proves nothing.

Confirmed against the live container rather than trusting the test count: `tr_entities` held 312 rows and `tr_credit_balance` 52 after a run.

## Money is enforced by the database

Exactly-once credit is `INSERT ... ON CONFLICT DO NOTHING` against the entity primary key, with the caller learning whether it won from `rowcount`, then a conditional in-place `UPDATE`. **No read-modify-write anywhere on the credit path.**

Retries catch psycopg's `TransactionRollback` rather than `SerializationFailure` alone, so both `40001` and deadlock (`40P01`) retry. 40001 is how Aurora DSQL reports *every* optimistic-concurrency abort; 40P01 is ordinary Postgres lock ordering. Catching only the former would surface routine deadlocks to callers as hard failures. Retrying is safe because the transaction rolls back whole — an idempotency row from a failed attempt is gone, so the retry credits exactly once.

## Target-database constraints honoured up front

- DSQL: plain DDL only (no triggers, no stored procedures); optimistic-concurrency aborts retried.
- Citus: workspace-owned tables keyed on `workspace_id` so it can be the distribution column.

## Scope

75 `Store` methods outside this increment raise a **named** `NotImplementedError`. They still exist with matching signatures, and `test_store_protocol_conformance.py` was **extended** (not weakened) to cover `PostgresStore`, so drift surfaces as a test failure rather than an `AttributeError` in production. Notably absent and next: `reserve`/`settle`/`refund`, generations, and usage series.

## Provenance

Written by codex-cli from a spec. Reviewed here; the `TransactionRollback` widening is my change. Gates run locally: ruff, mypy (186 files), full pytest.