### PR TITLE
Retire Crusoe Nemotron 3 Ultra on schedule

### DIFF
--- a/scripts/pricing/providers/crusoe.py
+++ b/scripts/pricing/providers/crusoe.py
@@ -31,6 +31,7 @@ from scripts.pricing.manifest import (
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
 from scripts.pricing.openai_catalog import positive_int
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "crusoe"
 URL = "https://api.inference.crusoecloud.com/v1/models"
@@ -126,6 +127,8 @@ def fetch() -> ProviderPricingResult:
             continue
         or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
         if or_id is None:
+            continue
+        if provider_model_retired(SLUG, or_id, native_id):
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
         pricing = row.get("pricing")

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -16,6 +16,7 @@ BASETEN_JULY_2026_RETIREMENT_AT = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
 TINFOIL_KIMI_K26_RETIREMENT_AT = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
+CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 
 
 @dataclass(frozen=True)
@@ -33,6 +34,15 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Crusoe announced that Nemotron 3 Ultra retires from its Serverless
+    # offering at 2026-07-28 11:00 PT, which is 2026-07-28 18:00 UTC.
+    # Other providers serving Nemotron 3 Ultra are unaffected.
+    _Retirement(
+        provider="crusoe",
+        model_ids=frozenset({"nvidia/nemotron-3-ultra-550b"}),
+        upstream_ids=frozenset({"nvidia/NVIDIA-Nemotron-3-Ultra-550B"}),
+        effective_at=CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT,
+    ),
     # Baseten announced that these Model API routes become inactive at
     # 2026-07-24 17:00 PT, which is 2026-07-25 00:00 UTC. Dedicated
     # deployments and other providers serving the same checkpoints are

--- a/tests/test_crusoe_july_2026_lifecycle.py
+++ b/tests/test_crusoe_july_2026_lifecycle.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import crusoe
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
+_NEMOTRON = "nvidia/nemotron-3-ultra-550b"
+_NEMOTRON_UPSTREAM = "nvidia/NVIDIA-Nemotron-3-Ultra-550B"
+_GLM = "z-ai/glm-5.2"
+
+
+def test_crusoe_nemotron_retires_at_announced_instant() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "crusoe",
+        _NEMOTRON,
+        _NEMOTRON_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "crusoe",
+        _NEMOTRON,
+        _NEMOTRON_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "crusoe",
+        _GLM,
+        "zai/GLM-5.2",
+        at=_CUTOFF,
+    )
+
+
+def test_crusoe_nemotron_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    providers = {endpoint.provider for endpoint in endpoints_for_model(_NEMOTRON)}
+
+    assert "crusoe" not in providers
+    assert "digitalocean" in providers
+
+
+def test_hourly_refresh_cannot_restore_retired_crusoe_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="crusoe",
+        prices={
+            _NEMOTRON: ModelPrice(1_000_000, 3_200_000),
+            _GLM: ModelPrice(1_400_000, 4_400_000),
+        },
+        source="api",
+        fetched_url=crusoe.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"crusoe": result})
+    assert "crusoe" in before[_NEMOTRON]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"crusoe": result})
+    assert _NEMOTRON not in after
+    assert "crusoe" in after[_GLM]
+
+
+def test_crusoe_parser_drops_retired_model_even_if_feed_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": _NEMOTRON_UPSTREAM,
+                "pricing": {"prompt": "1.00", "completion": "3.20"},
+            },
+            {
+                "id": "zai/GLM-5.2",
+                "pricing": {"prompt": "1.40", "completion": "4.40"},
+            },
+            {
+                "id": "deepseek-ai/Deepseek-V4-Flash",
+                "pricing": {"prompt": "0.14", "completion": "0.28"},
+            },
+            {
+                "id": "moonshotai/Kimi-K2.6",
+                "pricing": {"prompt": "0.70", "completion": "3.50"},
+            },
+            {
+                "id": "openai/gpt-oss-120b",
+                "pricing": {"prompt": "0.05", "completion": "0.25"},
+            },
+        ]
+    }
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(crusoe.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = crusoe.fetch()
+    assert _NEMOTRON in before.prices
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = crusoe.fetch()
+    assert _NEMOTRON not in after.prices
+    assert _NEMOTRON not in crusoe._DISCOVERED_MANIFEST_ROWS
+    assert _GLM in after.prices
+
+
+def test_crusoe_nemotron_native_mapping_matches_announced_route() -> None:
+    assert crusoe.UPSTREAM_ID_MAP[_NEMOTRON] == _NEMOTRON_UPSTREAM


### PR DESCRIPTION
## Summary
- retire only Crusoe's Nemotron 3 Ultra serverless route at 2026-07-28 18:00 UTC
- filter stale Crusoe model-feed rows after the cutoff
- preserve DigitalOcean and other provider routes

## Verification
- uv run pytest -q: 2011 passed, 47 skipped
- focused lifecycle/pricing tests: 7 passed
- uv run ruff check .
- uv run mypy