### PR TITLE
Bound synthetic billing concurrency

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -111,6 +111,7 @@ upsert_scheduler() {
 
 SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
 IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
+monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
@@ -118,6 +119,8 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   env_vars=(
     "${BASE_ENV_VARS[@]}"
     "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}"
+    "TR_SYNTHETIC_BILLING_CONCURRENCY=2"
+    "TR_SYNTHETIC_START_DELAY_SECONDS=$((monitor_index * 20))"
     # Short random provider/model probes feed uptime and TTFT. Sustained
     # throughput is deliberately disabled in these health jobs.
     "TR_SYNTHETIC_ROTATION_ENABLED=true"
@@ -148,6 +151,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   # timeout. 2 CPU / 1Gi keeps the concurrent regional probes bounded.
 
   upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/2 * * * *"
+  monitor_index=$((monitor_index + 1))
 done
 
 # Sustained-output benchmark: one deterministic top-200 route per tick. This
@@ -155,11 +159,16 @@ done
 # overlap TLS, attestation, billing, fallback, or short provider probes.
 throughput_region="us-central1"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
-throughput_scheduler_name="${throughput_job_name}-every-minute"
-legacy_throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
+throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
+legacy_throughput_scheduler_names=(
+  "${throughput_job_name}-every-minute"
+  "${throughput_job_name}-every-five-minutes"
+)
 throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
+  "TR_SYNTHETIC_BILLING_CONCURRENCY=1"
+  "TR_SYNTHETIC_START_DELAY_SECONDS=45"
   "TR_SYNTHETIC_ROTATION_ENABLED=false"
   "TR_SYNTHETIC_ROTATION_PER_PASS=0"
   "TR_SYNTHETIC_THROUGHPUT_ENABLED=true"
@@ -169,7 +178,7 @@ throughput_env_vars=(
   "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
   "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
   "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
-  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=60"
+  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
 )
 throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
@@ -192,16 +201,18 @@ upsert_scheduler \
   "$throughput_scheduler_name" \
   "$throughput_job_name" \
   "$throughput_region" \
-  "* * * * *"
+  "*/2 * * * *"
 
-# Avoid double-sampling after the cadence change. Delete the legacy scheduler
-# only after the replacement scheduler was created or updated successfully.
-if gc scheduler jobs describe \
-  "$legacy_throughput_scheduler_name" \
-  --location "$throughput_region" >/dev/null 2>&1; then
-  log "deleting legacy throughput scheduler ${legacy_throughput_scheduler_name}"
-  gc scheduler jobs delete \
+# Avoid double-sampling after cadence changes. Delete every historical
+# throughput scheduler only after the canonical scheduler is healthy.
+for legacy_throughput_scheduler_name in "${legacy_throughput_scheduler_names[@]}"; do
+  if gc scheduler jobs describe \
     "$legacy_throughput_scheduler_name" \
-    --location "$throughput_region" \
-    --quiet >/dev/null
-fi
+    --location "$throughput_region" >/dev/null 2>&1; then
+    log "deleting legacy throughput scheduler ${legacy_throughput_scheduler_name}"
+    gc scheduler jobs delete \
+      "$legacy_throughput_scheduler_name" \
+      --location "$throughput_region" \
+      --quiet >/dev/null
+  fi
+done

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -115,7 +115,8 @@ monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
-  scheduler_name="${job_name}-every-minute"
+  scheduler_name="${job_name}-every-five-minutes"
+  legacy_scheduler_name="${job_name}-every-minute"
   env_vars=(
     "${BASE_ENV_VARS[@]}"
     "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}"
@@ -150,7 +151,16 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   # probe latency balloons from ~2s to ~12s, blowing past task-
   # timeout. 2 CPU / 1Gi keeps the concurrent regional probes bounded.
 
-  upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/2 * * * *"
+  upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/5 * * * *"
+  if gc scheduler jobs describe \
+    "$legacy_scheduler_name" \
+    --location "$monitor_region" >/dev/null 2>&1; then
+    log "deleting legacy synthetic scheduler ${legacy_scheduler_name}"
+    gc scheduler jobs delete \
+      "$legacy_scheduler_name" \
+      --location "$monitor_region" \
+      --quiet >/dev/null
+  fi
   monitor_index=$((monitor_index + 1))
 done
 
@@ -159,10 +169,10 @@ done
 # overlap TLS, attestation, billing, fallback, or short provider probes.
 throughput_region="us-central1"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
-throughput_scheduler_name="${throughput_job_name}-every-two-minutes"
+throughput_scheduler_name="${throughput_job_name}-every-five-minutes"
 legacy_throughput_scheduler_names=(
   "${throughput_job_name}-every-minute"
-  "${throughput_job_name}-every-five-minutes"
+  "${throughput_job_name}-every-two-minutes"
 )
 throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
@@ -178,7 +188,7 @@ throughput_env_vars=(
   "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS=512"
   "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS=128"
   "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS=90"
-  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"
+  "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=300"
 )
 throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
@@ -201,7 +211,7 @@ upsert_scheduler \
   "$throughput_scheduler_name" \
   "$throughput_job_name" \
   "$throughput_region" \
-  "*/2 * * * *"
+  "*/5 * * * *"
 
 # Avoid double-sampling after cadence changes. Delete every historical
 # throughput scheduler only after the canonical scheduler is healthy.

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -7,12 +7,14 @@ import random
 import sys
 import time
 from dataclasses import asdict
+from typing import Any
 
 import httpx
 
 from trusted_router.config import Settings, get_settings
 from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.synthetic.probes import (
+    DEFAULT_SYNTHETIC_BILLING_CONCURRENCY,
     SyntheticTarget,
     choose_rotation_target,
     gateway_billing_probe,
@@ -61,12 +63,15 @@ async def _one_probe_pass(
     internal_token: str | None,
     api_key: str | None,
     timeout: httpx.Timeout,
+    billing_semaphore: asyncio.Semaphore | None = None,
 ) -> list[SyntheticProbeSample]:
+    limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     synthetic_task = asyncio.create_task(
         run_synthetic_once(
             settings,
             monitor_region=monitor_region,
             api_key=api_key,
+            billing_semaphore=limiter,
         )
     )
     if not (api_key and internal_token):
@@ -77,26 +82,28 @@ async def _one_probe_pass(
     # router-core failures.
     gateway_samples: list[SyntheticProbeSample] = []
     async with httpx.AsyncClient(timeout=timeout) as client:
-        gateway_samples.extend(
-            await gateway_billing_probe(
-                client,
-                control_plane_base_url=control_plane,
-                monitor_region=monitor_region,
-                api_key=api_key,
-                internal_token=internal_token,
-                model=settings.synthetic_monitor_model,
+        async with limiter:
+            gateway_samples.extend(
+                await gateway_billing_probe(
+                    client,
+                    control_plane_base_url=control_plane,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    internal_token=internal_token,
+                    model=settings.synthetic_monitor_model,
+                )
             )
-        )
-        gateway_samples.extend(
-            await gateway_fallback_probe(
-                client,
-                control_plane_base_url=control_plane,
-                monitor_region=monitor_region,
-                api_key=api_key,
-                internal_token=internal_token,
-                model=settings.synthetic_monitor_model,
+        async with limiter:
+            gateway_samples.extend(
+                await gateway_fallback_probe(
+                    client,
+                    control_plane_base_url=control_plane,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    internal_token=internal_token,
+                    model=settings.synthetic_monitor_model,
+                )
             )
-        )
     synthetic_samples = await synthetic_task
     return [*synthetic_samples, *gateway_samples]
 
@@ -119,7 +126,9 @@ async def _probe_and_rotation_pass(
     throughput_minimum_output_tokens: int = _DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS,
     throughput_timeout_seconds: float = _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS,
     throughput_interval_seconds: int = _DEFAULT_THROUGHPUT_INTERVAL_SECONDS,
+    billing_concurrency: int = DEFAULT_SYNTHETIC_BILLING_CONCURRENCY,
 ) -> tuple[list[SyntheticProbeSample], list[ProviderBenchmarkSample]]:
+    billing_semaphore = asyncio.Semaphore(max(1, billing_concurrency))
     probe_task = asyncio.create_task(
         _one_probe_pass(
             settings=settings,
@@ -128,6 +137,7 @@ async def _probe_and_rotation_pass(
             internal_token=internal_token,
             api_key=api_key,
             timeout=timeout,
+            billing_semaphore=billing_semaphore,
         )
     )
     benchmark_tasks: list[asyncio.Task[list[ProviderBenchmarkSample]]] = []
@@ -141,6 +151,7 @@ async def _probe_and_rotation_pass(
                     timeout=timeout,
                     count=rotation_per_pass,
                     rng=rotation_rng,
+                    billing_semaphore=billing_semaphore,
                 )
             )
         )
@@ -177,9 +188,11 @@ async def _rotation_pass(
     timeout: httpx.Timeout,
     count: int,
     rng: random.Random,
+    billing_semaphore: asyncio.Semaphore | None = None,
 ) -> list[ProviderBenchmarkSample]:
     pool = rotation_candidates()
     target = SyntheticTarget("rotation", settings.api_base_url, monitor_region)
+    limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     probes = []
     async with httpx.AsyncClient(timeout=timeout) as client:
         for _ in range(max(0, count)):
@@ -188,7 +201,8 @@ async def _rotation_pass(
                 break
             provider, model = picked
             probes.append(
-                provider_rotation_probe(
+                _run_rotation_probe(
+                    limiter,
                     client,
                     target,
                     monitor_region=monitor_region,
@@ -200,6 +214,16 @@ async def _rotation_pass(
         if not probes:
             return []
         return list(await asyncio.gather(*probes))
+
+
+async def _run_rotation_probe(
+    semaphore: asyncio.Semaphore,
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    **kwargs: Any,
+) -> ProviderBenchmarkSample:
+    async with semaphore:
+        return await provider_rotation_probe(client, target, **kwargs)
 
 
 async def _throughput_pass(
@@ -351,9 +375,24 @@ async def run() -> int:
             )
         ),
     )
+    billing_concurrency = max(
+        1,
+        int(
+            os.environ.get(
+                "TR_SYNTHETIC_BILLING_CONCURRENCY",
+                str(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY),
+            )
+        ),
+    )
+    start_delay_seconds = max(
+        0.0,
+        float(os.environ.get("TR_SYNTHETIC_START_DELAY_SECONDS", "0")),
+    )
 
     all_samples: list[SyntheticProbeSample] = []
     benchmark_samples: list[ProviderBenchmarkSample] = []
+    if start_delay_seconds:
+        await asyncio.sleep(start_delay_seconds)
     if throughput_only:
         if not throughput_enabled:
             print(
@@ -405,6 +444,7 @@ async def run() -> int:
                 throughput_minimum_output_tokens=throughput_minimum_output_tokens,
                 throughput_timeout_seconds=throughput_timeout_seconds,
                 throughput_interval_seconds=throughput_interval_seconds,
+                billing_concurrency=billing_concurrency,
             )
             all_samples.extend(pass_samples)
             benchmark_samples.extend(pass_benchmark_samples)

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -25,6 +25,8 @@ from trusted_router.storage_models import (
 )
 from trusted_router.types import UsageType
 
+DEFAULT_SYNTHETIC_BILLING_CONCURRENCY = 2
+
 
 @dataclass(frozen=True)
 class SyntheticTarget:
@@ -87,10 +89,12 @@ async def run_synthetic_once(
     *,
     monitor_region: str | None = None,
     api_key: str | None = None,
+    billing_semaphore: asyncio.Semaphore | None = None,
 ) -> list[SyntheticProbeSample]:
     region = monitor_region or settings.synthetic_monitor_region or choose_region(settings)
     key = api_key or settings.synthetic_monitor_api_key
     timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
+    limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     samples: list[SyntheticProbeSample] = []
     async with httpx.AsyncClient(timeout=timeout) as client:
         target_results = await asyncio.gather(
@@ -101,6 +105,7 @@ async def run_synthetic_once(
                     monitor_region=region,
                     api_key=key,
                     model=settings.synthetic_monitor_model,
+                    billing_semaphore=limiter,
                 )
                 for target in configured_targets(settings)
             ]
@@ -117,6 +122,7 @@ async def _run_target_synthetic_probes(
     monitor_region: str,
     api_key: str | None,
     model: str,
+    billing_semaphore: asyncio.Semaphore,
 ) -> list[SyntheticProbeSample]:
     probes = [
         tls_health_probe(client, target, monitor_region=monitor_region),
@@ -133,14 +139,18 @@ async def _run_target_synthetic_probes(
     if api_key:
         probes.extend(
             [
-                openai_chat_pong_probe(
+                _run_billing_probe(
+                    billing_semaphore,
+                    openai_chat_pong_probe,
                     client,
                     target,
                     monitor_region=monitor_region,
                     api_key=api_key,
                     model=model,
                 ),
-                responses_pong_probe(
+                _run_billing_probe(
+                    billing_semaphore,
+                    responses_pong_probe,
                     client,
                     target,
                     monitor_region=monitor_region,
@@ -150,6 +160,16 @@ async def _run_target_synthetic_probes(
             ]
         )
     return list(await asyncio.gather(*probes))
+
+
+async def _run_billing_probe(
+    semaphore: asyncio.Semaphore,
+    probe: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> SyntheticProbeSample:
+    async with semaphore:
+        return await probe(*args, **kwargs)
 
 
 async def tls_health_probe(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1950,14 +1950,16 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=true"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=false"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ENABLED=false"' in body
-    assert '"*/2 * * * *"' in body
-    assert 'throughput_scheduler_name="${throughput_job_name}-every-two-minutes"' in body
-    assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"' in body
+    assert 'scheduler_name="${job_name}-every-five-minutes"' in body
+    assert 'legacy_scheduler_name="${job_name}-every-minute"' in body
+    assert '"*/5 * * * *"' in body
+    assert 'throughput_scheduler_name="${throughput_job_name}-every-five-minutes"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=300"' in body
     assert '"TR_SYNTHETIC_BILLING_CONCURRENCY=2"' in body
     assert '"TR_SYNTHETIC_START_DELAY_SECONDS=$((monitor_index * 20))"' in body
     assert '"TR_SYNTHETIC_START_DELAY_SECONDS=45"' in body
     assert '"${throughput_job_name}-every-minute"' in body
-    assert '"${throughput_job_name}-every-five-minutes"' in body
+    assert '"${throughput_job_name}-every-two-minutes"' in body
 
 
 class _FakeCell:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1621,6 +1621,70 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
+async def test_run_synthetic_once_bounds_credit_bearing_probe_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import probes as probe_module
+
+    targets = [
+        SyntheticTarget(f"target-{index}", f"https://api-{index}.example/v1", "test")
+        for index in range(4)
+    ]
+    active = 0
+    peak = 0
+
+    async def fake_health_probe(
+        _client: httpx.AsyncClient,
+        target: SyntheticTarget,
+        *,
+        monitor_region: str,
+        **_kwargs: Any,
+    ) -> SyntheticProbeSample:
+        return _sample(
+            id=f"health-{target.name}",
+            probe_type="tls_health",
+            status="up",
+            target=target.name,
+            monitor_region=monitor_region,
+        )
+
+    async def fake_billing_probe(
+        _client: httpx.AsyncClient,
+        target: SyntheticTarget,
+        *,
+        monitor_region: str,
+        **_kwargs: Any,
+    ) -> SyntheticProbeSample:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return _sample(
+            id=f"billing-{target.name}",
+            probe_type="openai_sdk_pong",
+            status="up",
+            target=target.name,
+            monitor_region=monitor_region,
+        )
+
+    monkeypatch.setattr(probe_module, "configured_targets", lambda _settings: targets)
+    monkeypatch.setattr(probe_module, "tls_health_probe", fake_health_probe)
+    monkeypatch.setattr(probe_module, "attestation_nonce_probe", fake_health_probe)
+    monkeypatch.setattr(probe_module, "openai_chat_pong_probe", fake_billing_probe)
+    monkeypatch.setattr(probe_module, "responses_pong_probe", fake_billing_probe)
+
+    samples = await run_synthetic_once(
+        Settings(environment="test", synthetic_monitor_api_key="sk-tr-test"),
+        monitor_region="us-central1",
+        api_key="sk-tr-test",
+    )
+
+    assert len(samples) == 16
+    assert peak == 2
+
+
+@pytest.mark.asyncio
 async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPatch) -> None:
     from trusted_router.synthetic import cli as cli_module
 
@@ -1700,6 +1764,52 @@ async def test_probe_and_rotation_pass_runs_independent_blocks_concurrently(
     ]
     assert rotation_samples == ["rotation-a", "rotation-b"]
     assert elapsed < 0.06
+
+
+@pytest.mark.asyncio
+async def test_probe_and_rotation_share_one_billing_concurrency_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import cli as cli_module
+
+    active = 0
+    peak = 0
+
+    async def bounded_work(semaphore: asyncio.Semaphore) -> None:
+        nonlocal active, peak
+        async with semaphore:
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    async def fake_one_probe_pass(**kwargs: Any) -> list[SyntheticProbeSample]:
+        semaphore = kwargs["billing_semaphore"]
+        await asyncio.gather(*(bounded_work(semaphore) for _ in range(4)))
+        return []
+
+    async def fake_rotation_pass(**kwargs: Any) -> list[ProviderBenchmarkSample]:
+        semaphore = kwargs["billing_semaphore"]
+        await asyncio.gather(*(bounded_work(semaphore) for _ in range(4)))
+        return []
+
+    monkeypatch.setattr(cli_module, "_one_probe_pass", fake_one_probe_pass)
+    monkeypatch.setattr(cli_module, "_rotation_pass", fake_rotation_pass)
+
+    await cli_module._probe_and_rotation_pass(
+        settings=Settings(environment="test"),
+        monitor_region="us-central1",
+        control_plane="https://trustedrouter.com",
+        internal_token="internal",  # noqa: S106 - test placeholder.
+        api_key="sk-tr-test",
+        timeout=httpx.Timeout(1),
+        rotation_enabled=True,
+        rotation_per_pass=4,
+        rotation_rng=random.Random(0),  # noqa: S311 - deterministic test selection.
+        billing_concurrency=2,
+    )
+
+    assert peak == 2
 
 
 @pytest.mark.asyncio
@@ -1841,10 +1951,13 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=false"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ENABLED=false"' in body
     assert '"*/2 * * * *"' in body
-    assert 'throughput_scheduler_name="${throughput_job_name}-every-minute"' in body
-    assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=60"' in body
-    assert '"* * * * *"' in body
-    assert "legacy_throughput_scheduler_name" in body
+    assert 'throughput_scheduler_name="${throughput_job_name}-every-two-minutes"' in body
+    assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=120"' in body
+    assert '"TR_SYNTHETIC_BILLING_CONCURRENCY=2"' in body
+    assert '"TR_SYNTHETIC_START_DELAY_SECONDS=$((monitor_index * 20))"' in body
+    assert '"TR_SYNTHETIC_START_DELAY_SECONDS=45"' in body
+    assert '"${throughput_job_name}-every-minute"' in body
+    assert '"${throughput_job_name}-every-five-minutes"' in body
 
 
 class _FakeCell:


### PR DESCRIPTION
Summary:
- Cap all credit-bearing synthetic probes behind one shared semaphore per worker.
- Stagger US, EU, and throughput starts to avoid synchronized billing-row bursts.
- Restore one two-minute throughput schedule and delete historical duplicate schedulers.

Production incident: Spanner transaction insights identified the synthetic monitor key and its workspace credit row as the dominant hot keys. Duplicate one-minute and five-minute throughput schedulers were also active. Both were paused during diagnosis; image 506fae6 replaces them with one bounded scheduler.

Verification: 2017 tests passed, 47 skipped; Ruff, mypy, and shell syntax all pass.