### PR TITLE
Prefer the paid Google AI Studio key during deploys

### DIFF
--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -15,6 +15,15 @@ ensure_secret_from_env_file() {
   local value
   value="${!env_name:-}"
   if [ -z "$value" ]; then
+    local alias
+    for alias in "$@"; do
+      value="${!alias:-}"
+      if [ -n "$value" ]; then
+        break
+      fi
+    done
+  fi
+  if [ -z "$value" ]; then
     value="$(read_key_file_var "$env_name" "$@")"
   fi
   if [ -z "$value" ]; then
@@ -87,7 +96,9 @@ PY
 
 ensure_secret_from_env_file "ANTHROPIC_API_KEY" "trustedrouter-anthropic-api-key" "CLAUDE_API_KEY"
 ensure_secret_from_env_file "OPENAI_API_KEY" "trustedrouter-openai-api-key" "CHATGPT_API_KEY"
-ensure_secret_from_env_file "GEMINI_API_KEY" "trustedrouter-gemini-api-key"
+# Prefer the explicitly named AI Studio key. GEMINI_API_KEY remains a
+# compatibility fallback for older environments and key files.
+ensure_secret_from_env_file "GOOGLE_AI_STUDIO_KEY" "trustedrouter-gemini-api-key" "GEMINI_API_KEY"
 ensure_secret_from_env_file "CEREBRAS_API_KEY" "trustedrouter-cerebras-api-key"
 ensure_secret_from_env_file "DEEPSEEK_API_KEY" "trustedrouter-deepseek-api-key"
 ensure_secret_from_env_file "MISTRAL_API_KEY" "trustedrouter-mistral-api-key"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -34,6 +34,17 @@ def test_deploy_provider_secrets_include_priced_glm52_backends() -> None:
         assert f'ensure_secret_from_env_file "{env_name}" "{secret_name}"' in secrets
 
 
+def test_deploy_prefers_explicit_google_ai_studio_key() -> None:
+    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
+
+    assert (
+        'ensure_secret_from_env_file "GOOGLE_AI_STUDIO_KEY" '
+        '"trustedrouter-gemini-api-key" "GEMINI_API_KEY"'
+    ) in secrets
+    assert 'for alias in "$@"; do' in secrets
+    assert 'value="${!alias:-}"' in secrets
+
+
 def test_deploy_wires_athena_worker_prompt_secret() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()


### PR DESCRIPTION
## Summary
- prefer `GOOGLE_AI_STUDIO_KEY` when uploading the production Gemini secret
- keep `GEMINI_API_KEY` as a compatibility fallback
- resolve fallback aliases from the shell environment as well as the local key file

## Verification
- `uv run pytest -q tests/test_deploy_secret_wiring.py` (7 passed)
- `uv run ruff check tests/test_deploy_secret_wiring.py`
- `bash -n scripts/deploy/secrets.sh`
- paid-key direct PONGs for Gemini 2.5 Flash, 3.5 Flash, 3.6 Flash, and 3.1 Pro
- every production enclave returned pinned AI Studio PONG
- global AI Studio and Vertex streaming PONGs completed with `[DONE]`