### PR TITLE
Bound per-request storage retention

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,12 +211,25 @@ jobs:
           workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
       - uses: google-github-actions/setup-gcloud@v2
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Install migration runtime
+        run: uv sync --frozen --no-dev
       - name: Apply idempotent Spanner schema prerequisites
         env:
           GCP_PROJECT_ID: quill-cloud-proxy
           SPANNER_INSTANCE_ID: trusted-router-nam6
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/migrate_typed_counters.sh
+      - name: Apply bounded request-retention schema
+        env:
+          TR_GCP_PROJECT_ID: quill-cloud-proxy
+          TR_SPANNER_INSTANCE_ID: trusted-router-nam6
+          TR_SPANNER_DATABASE_ID: trusted-router
+          TR_BIGTABLE_INSTANCE_ID: trusted-router-logs
+          TR_BIGTABLE_GENERATION_TABLE: trustedrouter-generations
+        run: scripts/deploy/migrate_request_retention.sh --apply
 
   deploy:
     needs: [gate-on-ci, build-image, migrate-schema]

--- a/README.md
+++ b/README.md
@@ -359,10 +359,12 @@ stateless:
   They authorize, reserve, and settle through the control plane, but prompt
   bytes never leave the attested path.
 - Spanner stores strongly consistent control-plane and billing state: users,
-  workspaces, keys, BYOK metadata, Stripe event idempotency, reservations, and
-  spend limits.
-- Bigtable stores high-volume generation metadata rows keyed by workspace/date.
-  Prompt and output content are still not stored.
+  workspaces, keys, BYOK metadata, payment event idempotency, balances,
+  aggregates, active reservations, and a 30-day terminal request audit window.
+- Bigtable stores bounded high-volume activity metadata keyed by workspace and
+  date. Activity and provider benchmarks retain 30 days, raw synthetic samples
+  retain 14 days, and compact status rollups retain 24 months. Prompt, output,
+  and tool-call arguments are not stored.
 - API-key verification uses a high-entropy lookup hash for point reads; it does
   not scan keys.
 - Rate limits are enforced before route handlers and use the configured store,
@@ -427,8 +429,9 @@ The code paths that support this roadmap today are:
   do not automatically roll back a control-plane deploy.
 - SDKs are expected to retry connection failures and 502/503/504 across
   regional attested endpoints before surfacing failure.
-- Bigtable activity writes are repairable from Spanner generation records via
-  `/v1/internal/reconcile/generation-activity`.
+- Bigtable activity writes are repairable from the durable settlement outbox.
+  Settlement uses deterministic generation IDs, so retries overwrite the same
+  index rows and cannot double charge or duplicate activity.
 
 Before making a public 5 9s claim, require three warm GCP attested regions, one
 exercised non-GCP failover pool, tested paging, router-core chaos tests, staged

--- a/docs/design/durable-settle-outbox.md
+++ b/docs/design/durable-settle-outbox.md
@@ -141,12 +141,13 @@ what the inline attempt already resolved:
 | `selected_endpoint_id` | STRING     | frozen (for the generation record)                 |
 | `model_id`           | STRING       | frozen                                             |
 | `selected_usage_type`| STRING       | frozen                                             |
-| `settle_body`        | STRING(MAX)  | raw `GatewaySettleRequest` JSON (audit/generation) |
+| `settle_body`        | STRING(MAX)  | allowlisted metadata needed to repair activity; never prompt/output/tool arguments |
 | `status`             | STRING       | `pending` / `done` / `dead` / `release_approved`   |
 | `attempts`           | INT64        |                                                    |
 | `next_attempt_at`    | TIMESTAMP    |                                                    |
 | `lease_owner` / `leased_until` | STRING / TIMESTAMP | drain lease                          |
 | `created_at` / `updated_at` | TIMESTAMP |                                                   |
+| `terminal_at`        | TIMESTAMP    | NULL until repair is complete; starts 30-day TTL   |
 
 DDL: guarded `CREATE TABLE` **and** a `CREATE INDEX` on `(status, next_attempt_at)`
 for the due-scan (a full-table scan under a whale burst is the very load the
@@ -178,7 +179,7 @@ lease-claims due `pending` rows and for each:
   store is currently unavailable, **PARK** the row (retry later) — never reroute to
   legacy, never dead-letter.
 - Applies the **frozen `actual_cost_micro`** through a **narrow finalize primitive**
-  (counter claim + `gateway_authorization` finalize + generation write), NOT the
+  (counter claim + `gateway_authorization` finalize + activity index), NOT the
   full `_settle_gateway_authorization` HTTP handler — which would re-run pricing
   and re-fire non-idempotent side effects (budget alerts, auto-refill, metadata
   broadcast, provider-benchmark samples) on every replay (SF7).
@@ -187,9 +188,16 @@ lease-claims due `pending` rows and for each:
   row that intended a charge → **`dead` + alert** (the reaper beat us — invariant
   violation, do not report "recovered"); deterministic non-retryable errors →
   `dead` (no page); transient → backoff. After `max_attempts` → `dead` + alert.
-- Accepted SF7 loss: drained generations never reach metadata-broadcast
+- Drained generations never reach metadata-broadcast
   destinations.
-- Accepted SF7 loss: drained refunds record no provider-error benchmark sample.
+- Drained refunds record no provider-error benchmark sample.
+- A Bigtable activity failure parks the row without consuming retry attempts.
+  The generation ID and benchmark ID are deterministic, so replay is
+  idempotent. Only a confirmed activity write allows the outbox to become
+  `done`, clear `settle_body`, and set the reservation, authorization, and
+  outbox terminal retention timestamps in the same transaction. The
+  authorization keeps only its content-free replay record so a client
+  idempotency key remains valid for the full window.
 - Final `ApplyOutcome` contract for the drain:
   `settled_now` → done. `already_settled_with_charge` means done for settle
   intent; for refund intent with a charged reservation, done plus the same

--- a/docs/spanner-reliability.md
+++ b/docs/spanner-reliability.md
@@ -88,9 +88,43 @@ WHERE interval_end = (
 ORDER BY used_bytes DESC;
 ```
 
-Do not retain unbounded per-request authorization, idempotency, generation, or
-outbox rows in Spanner. Before high-volume traffic, move ephemeral records to
-typed tables with row deletion policies, or run a tested partitioned-DML
-retention job that deletes only terminal records after their replay and audit
-windows. Bigtable remains the metadata activity store; prompt and output
-content must never enter either system.
+Per-request state is bounded without deleting active or unresolved billing
+records:
+
+- `tr_gateway_authorization`, `tr_reservation`, and `tr_settle_outbox` use a
+  nullable `terminal_at` and a 30-day row deletion policy.
+- Active, pending, dead, and repairable rows keep `terminal_at=NULL`. Spanner
+  TTL does not select a row while that value is NULL.
+- A successful settlement makes the reservation immutable but leaves all three
+  retention clocks stopped while Bigtable repair is pending. After the
+  deterministic activity row is confirmed, one transaction sets
+  `terminal_at` on the reservation, authorization, and outbox. It also clears
+  the terminal outbox body. The authorization keeps its content-free replay
+  record for the bounded idempotency window.
+- New terminal generations are not written to `tr_entities`. Existing generic
+  rows remain untouched by the migration and can be archived or removed in a
+  separate, reviewed operation.
+- Bigtable writes new activity, benchmark, synthetic, and rollup cells to
+  distinct families with 30-day, 30-day, 14-day, and 730-day GC policies.
+  Readers prefer those families and fall back to legacy `m` cells. The
+  migration never adds a GC policy to `m`.
+
+Apply the additive migration:
+
+```bash
+scripts/deploy/migrate_request_retention.sh
+scripts/deploy/migrate_request_retention.sh --apply
+```
+
+The first command is a dry run. The apply path refuses to add a Spanner policy
+if any row would be immediately eligible. It performs no `DELETE`, `DROP`, or
+`terminal_at` backfill.
+
+Roll out application code with `TR_REQUEST_RECORD_WRITE_MODE=legacy` in every
+region first. After all revisions can read both layouts and production smoke
+passes, switch regions to `typed`. Do not roll back to a revision that predates
+typed-table reads after the first typed authorization is created.
+
+Spanner table-size metrics include retained historical versions. TTL deletion
+is asynchronous, and physical storage can remain visible until the database
+version-retention window and compaction have elapsed.

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -8,16 +8,19 @@
 # partial deploys. The shared config + helpers live in scripts/deploy/_lib.sh.
 #
 #   1. infra.sh    — enable APIs, provision Spanner + Bigtable
-#   2. image.sh    — Artifact Registry repo + buildx push (linux/amd64)
-#   3. secrets.sh  — Secret Manager + runtime IAM bindings
-#   4. rollout.sh  — parallel multi-region Cloud Run deploy + LB wiring
-#   5. synthetic.sh — US/EU synthetic monitor jobs + schedules
+#   2. migrate_typed_counters.sh + migrate_request_retention.sh — additive schema
+#   3. image.sh    — Artifact Registry repo + buildx push (linux/amd64)
+#   4. secrets.sh  — Secret Manager + runtime IAM bindings
+#   5. rollout.sh  — parallel multi-region Cloud Run deploy + LB wiring
+#   6. synthetic.sh — US/EU synthetic monitor jobs + schedules
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "${SCRIPT_DIR}/deploy/infra.sh"
+bash "${SCRIPT_DIR}/deploy/migrate_typed_counters.sh"
+bash "${SCRIPT_DIR}/deploy/migrate_request_retention.sh" --apply
 bash "${SCRIPT_DIR}/deploy/image.sh"
 bash "${SCRIPT_DIR}/deploy/secrets.sh"
 bash "${SCRIPT_DIR}/deploy/rollout.sh"

--- a/scripts/deploy/configure_bigtable_retention.py
+++ b/scripts/deploy/configure_bigtable_retention.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Configure bounded Bigtable column families without touching legacy data."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from types import SimpleNamespace
+
+from trusted_router.storage_gcp_synthetic_index import (
+    configure_retention_families,
+    open_generation_table,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="create/update the bounded families; default is a dry run",
+    )
+    args = parser.parse_args()
+    settings = SimpleNamespace(
+        gcp_project_id=os.environ.get(
+            "TR_GCP_PROJECT_ID",
+            os.environ.get("GCP_PROJECT_ID", "quill-cloud-proxy"),
+        ),
+        bigtable_instance_id=os.environ.get(
+            "TR_BIGTABLE_INSTANCE_ID",
+            "trusted-router-logs",
+        ),
+        bigtable_generation_table=os.environ.get(
+            "TR_BIGTABLE_GENERATION_TABLE",
+            "trustedrouter-generations",
+        ),
+    )
+    table = open_generation_table(settings)
+    actions = configure_retention_families(table, apply=args.apply)
+    mode = "applied" if args.apply else "dry-run"
+    for action in actions:
+        print(
+            f"{mode}: {action['action']} family={action['family']} "
+            f"max_age_days={action['max_age_days']} max_versions=1"
+        )
+    print(f"{mode}: legacy family=m unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/infra.sh
+++ b/scripts/deploy/infra.sh
@@ -60,6 +60,28 @@ if ! gc bigtable instances tables describe "$BIGTABLE_GENERATION_TABLE" --instan
     --column-families=m
 fi
 
+# Retention migrations need only table-schema reads and column-family updates.
+# Keep that capability table-scoped and separate from row-data access.
+BIGTABLE_SCHEMA_ROLE_ID="${TR_BIGTABLE_SCHEMA_ROLE_ID:-trustedRouterBigtableSchemaManager}"
+BIGTABLE_SCHEMA_ROLE="projects/${PROJECT_ID}/roles/${BIGTABLE_SCHEMA_ROLE_ID}"
+DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+OPS_SERVICE_ACCOUNT="${TR_OPS_SERVICE_ACCOUNT:-tr-ops-local@${PROJECT_ID}.iam.gserviceaccount.com}"
+if ! gc iam roles describe "$BIGTABLE_SCHEMA_ROLE_ID" >/dev/null 2>&1; then
+  gc iam roles create "$BIGTABLE_SCHEMA_ROLE_ID" \
+    --title="TrustedRouter Bigtable Schema Manager" \
+    --description="May read table schema and update column-family GC policies; no row data access." \
+    --permissions=bigtable.tables.get,bigtable.tables.update \
+    --stage=GA \
+    --quiet
+fi
+for service_account in "$DEPLOY_SERVICE_ACCOUNT" "$OPS_SERVICE_ACCOUNT"; do
+  gc bigtable tables add-iam-policy-binding "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID" \
+    --member="serviceAccount:${service_account}" \
+    --role="$BIGTABLE_SCHEMA_ROLE" \
+    --quiet >/dev/null
+done
+
 log "ensuring BYOK envelope KMS key"
 if ! gc kms keyrings describe "$KMS_KEYRING_ID" --location "$REGION" >/dev/null 2>&1; then
   gc kms keyrings create "$KMS_KEYRING_ID" --location "$REGION"

--- a/scripts/deploy/migrate_request_retention.sh
+++ b/scripts/deploy/migrate_request_retention.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Add bounded per-request state without making any existing row eligible for
+# deletion. Dry-run by default; pass --apply explicitly after reviewing output.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+APPLY=false
+SCHEMA_PENDING=false
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=true
+elif [ -n "${1:-}" ]; then
+  printf 'usage: %s [--apply]\n' "$0" >&2
+  exit 2
+fi
+
+INSTANCE="${TR_SPANNER_INSTANCE_ID:-${SPANNER_INSTANCE_ID}}"
+DATABASE="${TR_SPANNER_DATABASE_ID:-${SPANNER_DATABASE_ID}}"
+PROJECT="${TR_GCP_PROJECT_ID:-${PROJECT_ID}}"
+
+log() { printf '%s %s\n' "[migrate_request_retention]" "$*"; }
+
+sql_value() {
+  gcloud --project "$PROJECT" spanner databases execute-sql "$DATABASE" \
+    --instance="$INSTANCE" --sql="$1" --format='value(rows[0])'
+}
+
+table_exists() {
+  [ "$(sql_value "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='$1'")" != "0" ]
+}
+
+column_exists() {
+  [ "$(sql_value "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='$1' AND column_name='$2'")" != "0" ]
+}
+
+policy_expression() {
+  sql_value "SELECT COALESCE(ROW_DELETION_POLICY_EXPRESSION, '') FROM INFORMATION_SCHEMA.TABLES WHERE table_name='$1'"
+}
+
+ddl() {
+  if $APPLY; then
+    log "apply DDL: $1"
+    gcloud --project "$PROJECT" spanner databases ddl update "$DATABASE" \
+      --instance="$INSTANCE" --ddl="$1"
+  else
+    log "dry-run DDL: $1"
+    SCHEMA_PENDING=true
+  fi
+}
+
+ensure_column() {
+  if column_exists "$1" "$2"; then
+    log "$1.$2 exists"
+  else
+    ddl "ALTER TABLE $1 ADD COLUMN $2 TIMESTAMP"
+  fi
+}
+
+ensure_policy() {
+  local table="$1" expected="OLDER_THAN(terminal_at, INTERVAL 30 DAY)" eligible current
+  current="$(policy_expression "$table")"
+  if [ -n "$current" ]; then
+    local normalized expected_normalized
+    normalized="$(printf '%s' "$current" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    expected_normalized="$(printf '%s' "$expected" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    if [ "$normalized" != "$expected_normalized" ]; then
+      log "refusing: $table has unexpected policy: $current"
+      exit 1
+    fi
+    log "$table policy already correct"
+    return
+  fi
+  eligible="$(sql_value "SELECT COUNT(*) FROM $table WHERE terminal_at IS NOT NULL AND TIMESTAMP_ADD(terminal_at, INTERVAL 30 DAY) < CURRENT_TIMESTAMP()")"
+  if [ "${eligible:-0}" != "0" ]; then
+    log "refusing: $table has $eligible rows immediately eligible for TTL"
+    exit 1
+  fi
+  ddl "ALTER TABLE $table ADD ROW DELETION POLICY (OLDER_THAN(terminal_at, INTERVAL 30 DAY))"
+}
+
+if ! table_exists tr_reservation || ! table_exists tr_settle_outbox; then
+  log "typed billing tables are missing; run migrate_typed_counters.sh first"
+  exit 1
+fi
+
+if table_exists tr_gateway_authorization; then
+  log "tr_gateway_authorization exists"
+else
+  ddl "CREATE TABLE tr_gateway_authorization (
+    authorization_id STRING(64) NOT NULL,
+    workspace_id STRING(64) NOT NULL,
+    key_hash STRING(64) NOT NULL,
+    reservation_id STRING(64),
+    model_id STRING(256) NOT NULL,
+    provider STRING(64) NOT NULL,
+    usage_type STRING(16) NOT NULL,
+    estimated_microdollars INT64 NOT NULL,
+    settled BOOL NOT NULL DEFAULT (false),
+    created_at TIMESTAMP NOT NULL,
+    terminal_at TIMESTAMP,
+    payload STRING(MAX)
+  ) PRIMARY KEY (authorization_id)"
+fi
+
+# Existing rows receive NULL. Spanner TTL ignores NULL terminal timestamps.
+ensure_column tr_reservation terminal_at
+ensure_column tr_settle_outbox terminal_at
+
+# In dry-run mode missing objects cannot be queried yet; report the intended
+# policy and stop before family configuration.
+if ! $APPLY && $SCHEMA_PENDING; then
+  log "dry-run: policies will be added only after zero-eligible-row preflight"
+else
+  ensure_policy tr_gateway_authorization
+  ensure_policy tr_reservation
+  ensure_policy tr_settle_outbox
+fi
+
+if $APPLY; then
+  (cd "$REPO_ROOT" && uv run python "${SCRIPT_DIR}/configure_bigtable_retention.py" --apply)
+else
+  (cd "$REPO_ROOT" && uv run python "${SCRIPT_DIR}/configure_bigtable_retention.py")
+fi
+
+log "complete; no DELETE, DROP, or terminal_at backfill was executed"

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -133,6 +133,7 @@ if table_exists tr_reservation; then log "tr_reservation exists, skip"; else
     idempotency_fingerprint STRING(64),
     created_at TIMESTAMP OPTIONS (allow_commit_timestamp=true),
     expires_at TIMESTAMP,
+    terminal_at TIMESTAMP,
   ) PRIMARY KEY (reservation_id)"
 fi
 
@@ -217,6 +218,7 @@ if table_exists tr_settle_outbox; then log "tr_settle_outbox exists, skip"; else
     leased_until TIMESTAMP,
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
+    terminal_at TIMESTAMP,
   ) PRIMARY KEY (authorization_id, intent_kind)"
 fi
 

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Phase 4: parallel Cloud Run rollout across every TR_REGIONS entry, then
+# Phase 4: parallel Cloud Run rollout across every control-plane region, then
 # attach a Serverless NEG per region to the global LB backend service so
-# trustedrouter.com routes to the nearest healthy region. Finally ensures
-# the HTTP -> HTTPS redirect on :80.
+# trustedrouter.com routes to the nearest healthy region. Finally ensures the
+# HTTP -> HTTPS redirect on :80.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
@@ -78,6 +78,20 @@ add_secret_env_if_exists "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token"
 add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-prompt-v1"
 UPDATE_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
 
+REQUEST_RECORD_WRITE_MODE="${TR_REQUEST_RECORD_WRITE_MODE:-}"
+if [ -z "$REQUEST_RECORD_WRITE_MODE" ]; then
+  REQUEST_RECORD_WRITE_MODE="$(
+    gc run services describe "$SERVICE" \
+      --region="$TR_PRIMARY_REGION" \
+      --format="value(spec.template.spec.containers[0].env[?name='TR_REQUEST_RECORD_WRITE_MODE'].value)" \
+      2>/dev/null || true
+  )"
+fi
+case "$REQUEST_RECORD_WRITE_MODE" in
+  legacy|typed) ;;
+  *) REQUEST_RECORD_WRITE_MODE="legacy" ;;
+esac
+
 ENV_VARS=(
   "TR_ENVIRONMENT=production"
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
@@ -124,6 +138,11 @@ ENV_VARS=(
   # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
   # flag-off settle path is byte-identical.
   "TR_SETTLE_OUTBOX_ENABLED=true"
+  # The first expand deployment defaults to legacy. After an explicit typed
+  # cutover, preserve the primary region's live mode on later deploys unless an
+  # operator overrides it. This prevents routine rollouts from reopening the
+  # unbounded generic write path.
+  "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 
@@ -244,7 +263,7 @@ if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
   exit 1
 fi
 
-DEPLOY_TARGET_REGIONS="${TR_DEPLOY_TARGET_REGIONS:-$TR_REGIONS}"
+DEPLOY_TARGET_REGIONS="${TR_DEPLOY_TARGET_REGIONS:-$TR_CONTROL_PLANE_REGIONS}"
 IFS=',' read -ra _REGION_LIST <<<"$DEPLOY_TARGET_REGIONS"
 TARGETS=()
 for r in "${_REGION_LIST[@]}"; do

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -181,6 +181,12 @@ class Settings(BaseSettings):
     # a billing prod-behavior change — flip deliberately, per the design's
     # rollout section, after the shadow metrics are clean.
     settle_outbox_enabled: bool = False
+    # Expand/contract switch for per-request Spanner records. ``legacy`` keeps
+    # writing gateway authorizations and generation repair rows to tr_entities
+    # while every region learns to read the typed table. ``typed`` moves new
+    # authorizations to tr_gateway_authorization and uses the settle outbox as
+    # the bounded repair source for Bigtable activity metadata.
+    request_record_write_mode: str = "legacy"
     # Bigtable application profile name. The default profile uses
     # single-cluster routing; `tr-multi` enables
     # multi-cluster-routing-use-any once we have ≥3 BT clusters
@@ -282,6 +288,10 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_GOOGLE_ADS_CONVERSION_FEED_RETENTION_DAYS must be between 1 and 90"
             )
+        if self.request_record_write_mode not in {"legacy", "typed"}:
+            raise ValueError(
+                "TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'"
+            )
         if self.google_ads_conversion_feed_max_rows < 1:
             raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_MAX_ROWS must be positive")
         if ":" in self.google_ads_conversion_feed_username:
@@ -326,6 +336,11 @@ class Settings(BaseSettings):
                 missing.append("TR_SPANNER_DATABASE_ID")
             if not self.bigtable_instance_id:
                 missing.append("TR_BIGTABLE_INSTANCE_ID")
+        if self.request_record_write_mode == "typed" and not self.settle_outbox_enabled:
+            missing.append(
+                "TR_SETTLE_OUTBOX_ENABLED=true when "
+                "TR_REQUEST_RECORD_WRITE_MODE=typed"
+            )
         if not self.byok_kms_key_name:
             missing.append("TR_BYOK_KMS_KEY_NAME")
         # OAuth providers are independently optional in production. We DO

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -16,7 +16,7 @@ import logging
 import uuid
 from datetime import datetime
 from time import perf_counter
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, BackgroundTasks, Request
 from starlette.concurrency import run_in_threadpool
@@ -85,11 +85,48 @@ from trusted_router.storage import (
     typed_billing_store,
 )
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
-from trusted_router.storage_models import SettleOutboxRow
+from trusted_router.storage_models import SettleOutboxRow, TypedFinalizeResult
 from trusted_router.types import ErrorType, UsageType
 
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
+_SETTLE_REPAIR_FIELDS = frozenset(
+    {
+        "authorization_id",
+        "actual_input_tokens",
+        "actual_output_tokens",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "request_id",
+        "finish_reason",
+        "status",
+        "streamed",
+        "usage_estimated",
+        "elapsed_seconds",
+        "first_token_seconds",
+        "first_byte_seconds",
+        "time_to_first_token_seconds",
+        "time_to_first_byte_seconds",
+        "cached_input_tokens",
+        "cached_tokens",
+        "reasoning_tokens",
+        "error_status",
+        "error_type",
+        "app",
+        "model",
+        "selected_model",
+        "endpoint",
+        "selected_endpoint",
+        "user",
+        "session_id",
+        "http_referer",
+        "app_categories",
+        "route_type",
+        "additional_cost_microdollars",
+    }
+)
 
 
 async def authorize_gateway(
@@ -1068,10 +1105,11 @@ def _settle_gateway_authorization(
     is_typed = _typed_store is not None
     intent_kind = "settle" if success else "refund"
     enqueue_ms = 0.0
+    outbox_enqueued = False
     if settings.settle_outbox_enabled:
         enqueue_start = perf_counter()
         try:
-            frozen_settle_body = dict(settle_body)
+            frozen_settle_body = _settle_repair_metadata(settle_body)
             if operator_cost is not None:
                 frozen_settle_body[PARTNER_OPERATOR_COST_SETTLE_FIELD] = operator_cost
             # §5.4 honest scope: durability starts only when this INSERT commits;
@@ -1093,6 +1131,7 @@ def _settle_gateway_authorization(
                 # sees rows whose inline attempt is dead >=60s, avoiding replays.
                 initial_delay_seconds=60,
             )
+            outbox_enqueued = True
         except Exception:
             logger.error(
                 "settle outbox enqueue failed authorization_id=%s",
@@ -1101,18 +1140,58 @@ def _settle_gateway_authorization(
             )
         enqueue_ms = (perf_counter() - enqueue_start) * 1000
 
+    if (
+        is_typed
+        and getattr(_typed_store, "request_record_write_mode", "legacy") == "typed"
+        and settings.settle_outbox_enabled
+        and not outbox_enqueued
+    ):
+        raise api_error(
+            503,
+            "Settlement durability is temporarily unavailable",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+
     finalize_start = perf_counter()
+    finalize_result = TypedFinalizeResult(
+        finalized=False,
+        activity_indexed=False,
+    )
     if is_typed:
         assert _typed_store is not None
         # Typed finalize includes the Bigtable activity-index and benchmark
         # write inside the wrapper's index_after_commit.
-        finalized = _typed_store.typed_finalize_gateway_authorization(
-            authorization.id,
-            success=success,
-            actual_microdollars=actual_cost,
-            selected_usage_type=selected_usage_type,
-            generation=generation,
+        result_method = getattr(
+            _typed_store,
+            "typed_finalize_gateway_authorization_result",
+            None,
         )
+        if callable(result_method):
+            finalize_result = cast(
+                TypedFinalizeResult,
+                result_method(
+                    authorization.id,
+                    success=success,
+                    actual_microdollars=actual_cost,
+                    selected_usage_type=selected_usage_type,
+                    generation=generation,
+                ),
+            )
+        else:
+            finalized_legacy_contract = (
+                _typed_store.typed_finalize_gateway_authorization(
+                    authorization.id,
+                    success=success,
+                    actual_microdollars=actual_cost,
+                    selected_usage_type=selected_usage_type,
+                    generation=generation,
+                )
+            )
+            finalize_result = TypedFinalizeResult(
+                finalized=finalized_legacy_contract,
+                activity_indexed=finalized_legacy_contract,
+            )
+        finalized = finalize_result.finalized
     else:
         finalized = STORE.finalize_gateway_authorization(
             authorization.id,
@@ -1120,6 +1199,10 @@ def _settle_gateway_authorization(
             actual_microdollars=actual_cost,
             selected_usage_type=selected_usage_type,
             generation=generation,
+        )
+        finalize_result = TypedFinalizeResult(
+            finalized=finalized,
+            activity_indexed=finalized,
         )
     finalize_ms = (perf_counter() - finalize_start) * 1000
     if not finalized:
@@ -1137,7 +1220,11 @@ def _settle_gateway_authorization(
             }
         }
     mark_ms = 0.0
-    if settings.settle_outbox_enabled:
+    if (
+        settings.settle_outbox_enabled
+        and outbox_enqueued
+        and finalize_result.activity_indexed
+    ):
         mark_start = perf_counter()
         try:
             marked = spanner_settle_outbox().mark(authorization.id, intent_kind, done=True)
@@ -1158,6 +1245,11 @@ def _settle_gateway_authorization(
                 exc_info=True,
             )
         mark_ms = (perf_counter() - mark_start) * 1000
+    elif finalized and settings.settle_outbox_enabled and outbox_enqueued:
+        logger.warning(
+            "settle activity index pending repair authorization_id=%s",
+            authorization.id,
+        )
 
     is_customer_billing_event = partner_mode != PartnerBillingMode.INTERNAL
     if (
@@ -1292,18 +1384,41 @@ def _settle_body_with_safe_attribution(
     return settle_body
 
 
-def _is_synthetic_settlement(body: GatewaySettleRequest) -> bool:
-    if body.app == "TrustedRouter Synthetic":
-        return True
-    metadata = body.metadata
-    if not isinstance(metadata, dict):
-        return False
+def _settle_repair_metadata(settle_body: dict[str, Any]) -> dict[str, Any]:
+    """Freeze only fields needed to reconstruct activity metadata.
+
+    The durable outbox is an operational repair log, not a content store.
+    Lenient request extras, trace dictionaries, and arbitrary metadata are
+    deliberately excluded. The one metadata bit retained marks synthetic
+    traffic so repaired rows stay out of public provider benchmarks.
+    """
+    frozen = {
+        key: value
+        for key, value in settle_body.items()
+        if key in _SETTLE_REPAIR_FIELDS
+    }
+    metadata = settle_body.get("metadata")
+    if isinstance(metadata, dict) and _synthetic_metadata_enabled(metadata):
+        frozen["metadata"] = {"trustedrouter_synthetic": "true"}
+    return frozen
+
+
+def _synthetic_metadata_enabled(metadata: dict[str, Any]) -> bool:
     return str(metadata.get("trustedrouter_synthetic")).strip().lower() in {
         "1",
         "true",
         "yes",
         "on",
     }
+
+
+def _is_synthetic_settlement(body: GatewaySettleRequest) -> bool:
+    if body.app == "TrustedRouter Synthetic":
+        return True
+    metadata = body.metadata
+    if not isinstance(metadata, dict):
+        return False
+    return _synthetic_metadata_enabled(metadata)
 
 
 def _gateway_candidate_payload(

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -38,6 +38,7 @@ _TRANSIENT_STORE_EXCS = transient_store_error_types()
 
 class ApplyOutcome:
     SETTLED_NOW = "settled_now"
+    ACTIVITY_PENDING = "activity_pending"
     ALREADY_SETTLED_WITH_CHARGE = "already_settled_with_charge"
     RESOLVED_ZERO_COST_ELSEWHERE = "resolved_zero_cost_elsewhere"
     # Legacy origin cannot disambiguate a charged replay from a refund/
@@ -248,6 +249,7 @@ def _apply_typed(
             actual_micro=row.actual_cost_micro,
             settled_usage_type=str(usage_type),
             now=dt.datetime.now(dt.UTC),
+            authorization=auth_settled,
             auth_body_settled=_json_body(auth_settled),
             generation_writes=generation_writes,
         )
@@ -256,7 +258,8 @@ def _apply_typed(
     outcome = result.get("outcome")
     if outcome == SettleOutcome.SETTLED:
         if success and generation is not None:
-            _index_generation_after_commit(typed_store, generation)
+            if not _index_generation_after_commit(typed_store, generation):
+                return ApplyOutcome.ACTIVITY_PENDING
         return ApplyOutcome.SETTLED_NOW
     if outcome == SettleOutcome.NOT_FOUND:
         return ApplyOutcome.RESERVATION_MISSING
@@ -271,12 +274,10 @@ def _apply_typed(
             return ApplyOutcome.RESERVATION_MISSING
         actual_micro = int(reservation.get("actual_micro") or 0)
         if actual_micro > 0:
-            # Charged replay. Parity with the inline path's known post-commit
-            # index hole; the drain's retry-after-ambiguous-failure purpose
-            # makes it likelier.
-            logger.info(
-                "drain replay of a charged settle; if the charge was committed by a finalize whose response was lost (park->retry), its Bigtable activity-index entry may be absent; repairable via reconcile_activity"
-            )
+            if generation is None:
+                return ApplyOutcome.INVALID_ROW
+            if not _index_generation_after_commit(typed_store, generation):
+                return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
         if row.actual_cost_micro == 0:
             return ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE
@@ -313,6 +314,9 @@ def _apply_legacy(
     return ApplyOutcome.ALREADY_SETTLED_LEGACY
 
 
-def _index_generation_after_commit(typed_store: Any, generation: Generation) -> None:
+def _index_generation_after_commit(
+    typed_store: Any,
+    generation: Generation,
+) -> bool:
     generation_store = cast(Any, typed_store).generation_store
-    generation_store.index_after_commit(generation)
+    return bool(generation_store.index_after_commit(generation))

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -107,6 +107,20 @@ def _resolve_row(
         )
         return
 
+    if outcome == ApplyOutcome.ACTIVITY_PENDING:
+        outbox.park(
+            row.authorization_id,
+            row.intent_kind,
+            lease_owner=lease_owner,
+            retry_after_seconds=60,
+            note="bigtable activity index pending",
+        )
+        logger.warning(
+            "settle outbox activity repair pending authorization_id=%s",
+            row.authorization_id,
+        )
+        return
+
     if outcome == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE:
         outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
         if row.intent_kind == "refund" and row.actual_cost_micro > 0:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1289,6 +1289,9 @@ def create_store(settings: Any) -> Store:
             bigtable_app_profile_id=getattr(
                 settings, "bigtable_app_profile_id", ""
             ),
+            request_record_write_mode=getattr(
+                settings, "request_record_write_mode", "legacy"
+            ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -78,6 +78,7 @@ from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_ret
 from trusted_router.storage_gcp_keys import SpannerApiKeys
 from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
 from trusted_router.storage_gcp_rate_limits import SpannerRateLimits
+from trusted_router.storage_gcp_request_records import read_gateway_authorization
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_gcp_synthetic_index import (
     synthetic_probe_samples as _bt_synthetic_probe_samples,
@@ -90,6 +91,7 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 )
 from trusted_router.storage_gcp_verification_tokens import SpannerVerificationTokens
 from trusted_router.storage_gcp_wallet_challenges import SpannerWalletChallenges
+from trusted_router.storage_models import TypedFinalizeResult
 from trusted_router.types import UsageType
 
 T = TypeVar("T")
@@ -111,7 +113,14 @@ class SpannerBigtableStore:
     """
 
     entity_table = "tr_entities"
-    generation_family = "m"
+    # New Bigtable writes are separated by retention class. ``m`` is retained
+    # as a read-only compatibility family until legacy history ages out.
+    legacy_generation_family = "m"
+    activity_family = "activity"
+    benchmark_family = "benchmark"
+    synthetic_family = "synthetic"
+    synthetic_rollup_family = "rollup"
+    generation_family = legacy_generation_family
 
     def __init__(
         self,
@@ -122,9 +131,13 @@ class SpannerBigtableStore:
         bigtable_instance_id: str,
         generation_table: str,
         bigtable_app_profile_id: str = "",
+        request_record_write_mode: str = "legacy",
     ) -> None:
         if not spanner_instance_id or not spanner_database_id or not bigtable_instance_id:
             raise ValueError("Spanner and Bigtable IDs are required")
+        if request_record_write_mode not in {"legacy", "typed"}:
+            raise ValueError("request_record_write_mode must be 'legacy' or 'typed'")
+        self.request_record_write_mode = request_record_write_mode
         try:
             from google.cloud import bigtable, spanner
             from google.cloud.spanner_v1 import FixedSizePool, param_types
@@ -228,7 +241,9 @@ class SpannerBigtableStore:
         self.generation_store = SpannerGenerations(
             io,
             bt_table=self._bt_table,
-            generation_family=self.generation_family,
+            activity_family=self.activity_family,
+            benchmark_family=self.benchmark_family,
+            legacy_family=self.legacy_generation_family,
             add_usage_to_key=self.api_keys.add_usage,
         )
         self.byok_store = SpannerByok(io)
@@ -1098,6 +1113,14 @@ class SpannerBigtableStore:
     def get_gateway_authorization(
         self, authorization_id: str
     ) -> GatewayAuthorization | None:
+        with self._database.snapshot() as snapshot:
+            typed = read_gateway_authorization(
+                snapshot,
+                self._param_types,
+                authorization_id,
+            )
+        if typed is not None:
+            return typed
         return self.api_keys.get_gateway_authorization(authorization_id)
 
     def get_gateway_authorization_by_idempotency_key(
@@ -1145,17 +1168,35 @@ class SpannerBigtableStore:
         selected_usage_type: UsageType | str,
         generation: Generation | None = None,
     ) -> bool:
+        return self.typed_finalize_gateway_authorization_result(
+            authorization_id,
+            success=success,
+            actual_microdollars=actual_microdollars,
+            selected_usage_type=selected_usage_type,
+            generation=generation,
+        ).finalized
+
+    def typed_finalize_gateway_authorization_result(
+        self,
+        authorization_id: str,
+        *,
+        success: bool,
+        actual_microdollars: int,
+        selected_usage_type: UsageType | str,
+        generation: Generation | None = None,
+    ) -> TypedFinalizeResult:
         """Route-facing typed settle: same contract as
-        finalize_gateway_authorization (returns False on replay/already-settled)
-        but via the DML-only typed_finalize_atomic. Builds the generation entity
-        bodies + the settled gateway_authorization body, then indexes Bigtable
-        after commit (NOT generation_store.add — that would double-book key usage
-        the typed settle already booked)."""
+        finalize_gateway_authorization, with explicit activity-index status.
+
+        The billing transaction commits before the Bigtable activity write. A
+        false ``activity_indexed`` leaves the durable outbox pending so its
+        deterministic generation can be retried without double charging.
+        """
         from trusted_router.storage_gcp_authorize import SettleOutcome, typed_finalize_atomic
 
         authorization = self.get_gateway_authorization(authorization_id)
         if authorization is None or authorization.credit_reservation_id is None:
-            return False
+            return TypedFinalizeResult(finalized=False, activity_indexed=False)
         actual_usage_type = UsageType.coerce(selected_usage_type)
         generation_writes: list[tuple[str, str, str]] = []
         if success and generation is not None:
@@ -1178,6 +1219,7 @@ class SpannerBigtableStore:
             actual_micro=actual_microdollars,
             settled_usage_type=str(actual_usage_type),
             now=dt.datetime.now(dt.UTC),
+            authorization=authorization,
             auth_body_settled=_json_body(authorization),
             generation_writes=generation_writes,
         )
@@ -1186,9 +1228,10 @@ class SpannerBigtableStore:
             raise RuntimeError("typed finalize failed: release row-count != 1")
         if result["outcome"] == SettleOutcome.SETTLED:
             index_ms = 0.0
+            activity_indexed = True
             if success and generation is not None:
                 index_start = time.perf_counter()
-                self.generation_store.index_after_commit(generation)
+                activity_indexed = self.generation_store.index_after_commit(generation)
                 index_ms = (time.perf_counter() - index_start) * 1000
             # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
             # into Spanner-txn vs Bigtable-index time.
@@ -1202,8 +1245,15 @@ class SpannerBigtableStore:
                 index_ms,
                 result.get("attempts", 1),
             )
-            return True
-        return False  # already_settled / not_found
+            return TypedFinalizeResult(
+                finalized=True,
+                activity_indexed=activity_indexed,
+                request_record_typed=bool(result.get("request_record_typed")),
+            )
+        return TypedFinalizeResult(
+            finalized=False,
+            activity_indexed=False,
+        )  # already_settled / not_found
 
     def authorize_gateway_typed(
         self,
@@ -1252,8 +1302,11 @@ class SpannerBigtableStore:
             else None
         )
 
-        def build_body(authorization_id: str, reservation_id: str) -> str:
-            auth = GatewayAuthorization(
+        def build_authorization(
+            authorization_id: str,
+            reservation_id: str,
+        ) -> GatewayAuthorization:
+            return GatewayAuthorization(
                 id=authorization_id,
                 workspace_id=workspace_id,
                 key_hash=key_hash,
@@ -1274,7 +1327,9 @@ class SpannerBigtableStore:
                 custom_model_revision=custom_model_revision,
                 additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
             )
-            return _json_body(auth)
+
+        def build_body(authorization_id: str, reservation_id: str) -> str:
+            return _json_body(build_authorization(authorization_id, reservation_id))
 
         if window_limits:
             # Lock-free snapshot check BEFORE the DML-only transaction (keeps
@@ -1315,7 +1370,9 @@ class SpannerBigtableStore:
                 idempotency_scope=scope,
                 idempotency_fingerprint=idempotency_fingerprint,
                 expires_at=expires_at,
+                build_authorization=build_authorization,
                 build_auth_body=build_body,
+                request_record_write_mode=self.request_record_write_mode,
                 credit_shard_candidates=candidates,
                 key_shard_candidates=key_shard_candidates,
             )
@@ -1641,7 +1698,13 @@ class SpannerBigtableStore:
         )
 
     def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
-        _bt_write_synthetic_probe_sample(self._bt_table, self.generation_family, sample)
+        _bt_write_synthetic_probe_sample(
+            self._bt_table,
+            self.synthetic_family,
+            sample,
+            rollup_family=self.synthetic_rollup_family,
+            legacy_family=self.legacy_generation_family,
+        )
 
     def synthetic_probe_samples(
         self,
@@ -1654,7 +1717,7 @@ class SpannerBigtableStore:
     ) -> list[SyntheticProbeSample]:
         return _bt_synthetic_probe_samples(
             self._bt_table,
-            self.generation_family,
+            (self.synthetic_family, self.legacy_generation_family),
             date=date,
             target=target,
             probe_type=probe_type,
@@ -1673,7 +1736,7 @@ class SpannerBigtableStore:
     ) -> list[SyntheticRollup]:
         return _bt_synthetic_rollups(
             self._bt_table,
-            self.generation_family,
+            (self.synthetic_rollup_family, self.legacy_generation_family),
             period=period,
             since=since,
             until=until,

--- a/src/trusted_router/storage_gcp_activity_index.py
+++ b/src/trusted_router/storage_gcp_activity_index.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, TypeAlias
 
 from trusted_router.storage_activity import generation_metrics, usage_bucket_key
 from trusted_router.storage_gcp_codec import json_body, reverse_time_key
 from trusted_router.storage_models import Generation
+
+FamilyNames: TypeAlias = str | tuple[str, ...]
 
 
 def write_generation(table: Any, family: str, generation: Generation) -> None:
@@ -25,7 +27,7 @@ def write_generation(table: Any, family: str, generation: Generation) -> None:
 
 def activity_generations(
     table: Any,
-    family: str,
+    family: FamilyNames,
     workspace_id: str,
     *,
     api_key_hash: str | None,
@@ -53,7 +55,7 @@ def activity_generations(
 
 def iter_activity_generations(
     table: Any,
-    family: str,
+    family: FamilyNames,
     workspace_id: str,
     *,
     api_key_hash: str | None,
@@ -90,7 +92,7 @@ def iter_activity_generations(
 
 def usage_series(
     table: Any,
-    family: str,
+    family: FamilyNames,
     workspace_id: str,
     *,
     start_day: str,
@@ -153,7 +155,7 @@ def usage_series(
 
 def _generations_from_rows(
     rows: Any,
-    family: str,
+    family: FamilyNames,
     *,
     api_key_hash: str | None,
 ) -> list[Generation]:
@@ -162,12 +164,12 @@ def _generations_from_rows(
 
 def _iter_generations_from_rows(
     rows: Any,
-    family: str,
+    family: FamilyNames,
     *,
     api_key_hash: str | None,
 ) -> Iterator[Generation]:
     for row in rows:
-        cells = row.cells.get(family, {}).get(b"body", [])
+        cells = _body_cells(row, family)
         if not cells:
             continue
         generation = Generation(**json.loads(cells[0].value.decode("utf-8")))
@@ -175,11 +177,32 @@ def _iter_generations_from_rows(
             yield generation
 
 
-def _generation_from_row(row: Any, family: str) -> Generation | None:
-    cells = row.cells.get(family, {}).get(b"body", [])
+def _generation_from_row(row: Any, family: FamilyNames) -> Generation | None:
+    cells = _body_cells(row, family)
     if not cells:
         return None
     return Generation(**json.loads(cells[0].value.decode("utf-8")))
+
+
+def generation_by_id(
+    table: Any,
+    family: FamilyNames,
+    generation_id: str,
+) -> Generation | None:
+    key = f"gen#{generation_id}".encode()
+    rows = table.read_rows(start_key=key, end_key=key + b"\x00", limit=1)
+    for row in rows:
+        return _generation_from_row(row, family)
+    return None
+
+
+def _body_cells(row: Any, families: FamilyNames) -> list[Any]:
+    ordered = (families,) if isinstance(families, str) else families
+    for family in ordered:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if cells:
+            return cells
+    return []
 
 
 def _bucket(buckets: dict[str, dict[str, Any]], bucket: str) -> dict[str, Any]:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -32,6 +32,7 @@ from trusted_router.storage_gcp_counter_dml import (
     KEY_ACCEPTED,
     KEY_INSUFFICIENT,
     KEY_MISSING,
+    complete_reservation_retention,
     insert_entity_dml,
     insert_reservation,
     read_reservation_by_idempotency,
@@ -40,7 +41,13 @@ from trusted_router.storage_gcp_counter_dml import (
 )
 from trusted_router.storage_gcp_counters import UNSHARDED
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_request_records import (
+    close_reaped_gateway_authorization,
+    insert_gateway_authorization,
+    mark_gateway_authorization_settled,
+)
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
+from trusted_router.storage_models import GatewayAuthorization
 
 log = logging.getLogger(__name__)
 
@@ -138,15 +145,19 @@ def authorize_atomic(
     idempotency_scope: str | None,
     idempotency_fingerprint: str | None,
     expires_at: Any,
-    build_auth_body: Callable[[str, str], str],
+    build_authorization: Callable[[str, str], GatewayAuthorization] | None = None,
+    build_auth_body: Callable[[str, str], str] | None = None,
+    request_record_write_mode: str = "legacy",
     credit_shard: int = UNSHARDED,
     credit_shard_candidates: tuple[int, ...] | None = None,
     key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
-    `build_auth_body(authorization_id, reservation_id) -> json str` lets the caller
-    construct the gateway_authorization body once the ids are known.
+    `request_record_write_mode="legacy"` preserves the generic tr_entities write
+    during the expand rollout. `"typed"` writes the same authorization into the
+    bounded typed table. The corresponding builder is required for the selected
+    mode.
     `reservation_usage_type` is the HOLD usage type (Credits if any credit
     candidate, else BYOK). `has_credit_candidate` gates the credit hold.
     `credit_shard_candidates` is a bounded, pre-randomized order built outside
@@ -160,6 +171,12 @@ def authorize_atomic(
     transaction exists to eliminate (codex #93 review).
     """
     pt = param_types
+    if request_record_write_mode not in {"legacy", "typed"}:
+        raise ValueError("request_record_write_mode must be 'legacy' or 'typed'")
+    if request_record_write_mode == "typed" and build_authorization is None:
+        raise ValueError("typed request records require build_authorization")
+    if request_record_write_mode == "legacy" and build_auth_body is None:
+        raise ValueError("legacy request records require build_auth_body")
     shard_candidates: tuple[int, ...]
     if credit_shard_candidates is None:
         shard_candidates = (credit_shard,)
@@ -186,6 +203,19 @@ def authorize_atomic(
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
     authorization_id = f"gwa-{uuid.uuid4().hex}"
+    created_at = utcnow()
+    authorization = (
+        build_authorization(authorization_id, reservation_id)
+        if build_authorization is not None
+        else None
+    )
+    if authorization is not None:
+        authorization.created_at = created_at.isoformat().replace("+00:00", "Z")
+    legacy_auth_body = (
+        build_auth_body(authorization_id, reservation_id)
+        if build_auth_body is not None
+        else None
+    )
 
     def _replay(existing: dict) -> dict:
         return {
@@ -252,11 +282,25 @@ def authorize_atomic(
             hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
             idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
             expires_at=expires_at,
+            created_at=created_at,
         )
-        insert_entity_dml(
-            transaction, pt, "gateway_authorization", authorization_id,
-            build_auth_body(authorization_id, reservation_id),
-        )
+        if request_record_write_mode == "typed":
+            assert authorization is not None
+            insert_gateway_authorization(
+                transaction,
+                pt,
+                authorization,
+                created_at=created_at,
+            )
+        else:
+            assert legacy_auth_body is not None
+            insert_entity_dml(
+                transaction,
+                pt,
+                "gateway_authorization",
+                authorization_id,
+                legacy_auth_body,
+            )
         return {
             "outcome": AuthorizeOutcome.ACCEPTED,
             "reservation_id": reservation_id,
@@ -363,6 +407,7 @@ def settle_atomic(
     settled_usage_type: str,
     success: bool,
     guard_outbox: bool = False,
+    mark_authorization_terminal: bool = False,
 ) -> dict:
     """Claim-gated settle/refund in ONE transaction (key then credit lock order).
 
@@ -381,6 +426,7 @@ def settle_atomic(
     pt = param_types
     book_actual = actual_micro if success else 0
     book_to_byok = settled_usage_type == "BYOK"
+    terminal_at = utcnow()
 
     def txn(transaction: Any) -> dict:
         res = read_reservation(transaction, pt, reservation_id)
@@ -402,7 +448,9 @@ def settle_atomic(
                     return {"outcome": SettleOutcome.OUTBOX_GUARDED}
         won = claim_reservation(
             transaction, pt, reservation_id,
-            actual_micro=book_actual, settled_usage_type=settled_usage_type,
+            actual_micro=book_actual,
+            settled_usage_type=settled_usage_type,
+            terminal_at=terminal_at,
         )
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}  # replay, no double-apply
@@ -429,6 +477,13 @@ def settle_atomic(
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
+        if mark_authorization_terminal and res.get("authorization_id"):
+            close_reaped_gateway_authorization(
+                transaction,
+                pt,
+                str(res["authorization_id"]),
+                terminal_at=terminal_at,
+            )
         return {
             "outcome": SettleOutcome.SETTLED,
             "missing_key_releases": missing_key_releases,
@@ -526,6 +581,7 @@ def reap_expired_reservations(
         result = settle_atomic(
             database, pt, reservation_id=reservation_id, actual_micro=0,
             settled_usage_type="Credits", success=False, guard_outbox=guard_active,
+            mark_authorization_terminal=True,
         )
         if result["outcome"] == SettleOutcome.SETTLED:
             reaped += 1
@@ -542,24 +598,22 @@ def typed_finalize_atomic(
     actual_micro: int,
     settled_usage_type: str,
     now: Any,
+    authorization: GatewayAuthorization | None = None,
     auth_body_settled: str,
-    generation_writes: list | None = None,
+    generation_writes: list[tuple[str, str, str]] | None = None,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
 
     ONE transaction reproduces legacy finalize_gateway_authorization's whole
-    behavior so a crash can't leave counters charged but the generation missing /
-    auth unsettled: claim the reservation -> release the EXACT holds (key then
-    credit) and book actual -> on success DML-insert the generation entities ->
-    DML-mark the gateway_authorization settled. All writes use a client `now`
-    timestamp (NOT PENDING_COMMIT_TIMESTAMP) so the multiple tr_entities DML
-    statements don't hit the PCT same-table trap. The caller does the Bigtable
-    index AFTER commit (like legacy index_after_commit), and must NOT use
-    SpannerGenerations.add() (it would double-book key usage already booked here).
+    behavior so a crash can't leave counters charged but the authorization
+    active: claim the reservation -> release the EXACT holds (key then credit)
+    and book actual -> DML-mark the authorization settled. Typed request records
+    keep their repair payload until Bigtable indexing is confirmed; rolling
+    legacy records retain the old generic generation repair rows.
 
-    `generation_writes` = [(kind, entity_id, body_json), ...] inserted only on
-    success. `auth_body_settled` = the gateway_authorization JSON body with
-    settled=true. Returns {outcome: settled|already_settled|not_found|error}.
+    `auth_body_settled` and `generation_writes` remain for rolling compatibility
+    with an authorization created by the generic-table revision. Returns
+    {outcome: settled|already_settled|not_found|error}.
     """
     from trusted_router.storage_gcp_counter_dml import (
         claim_reservation,
@@ -580,7 +634,10 @@ def typed_finalize_atomic(
             return {"outcome": SettleOutcome.NOT_FOUND}
         won = claim_reservation(
             transaction, pt, reservation_id,
-            actual_micro=book_actual, settled_usage_type=settled_usage_type,
+            actual_micro=book_actual,
+            settled_usage_type=settled_usage_type,
+            terminal_at=now,
+            defer_retention=True,
         )
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}
@@ -604,19 +661,46 @@ def typed_finalize_atomic(
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
 
-        if success:
-            for kind, entity_id, body_json in writes:
-                insert_entity_dml_at(transaction, pt, kind, entity_id, body_json, now)
-
-        marked = update_entity_body_dml(
-            transaction, pt, "gateway_authorization", authorization_id,
-            auth_body_settled, now,
-        )
+        marked = 0
+        request_record_typed = False
+        if authorization is not None:
+            marked = mark_gateway_authorization_settled(
+                transaction,
+                pt,
+                authorization,
+            )
+            request_record_typed = marked == 1
+        if not request_record_typed:
+            if success:
+                for kind, entity_id, body_json in writes:
+                    insert_entity_dml_at(
+                        transaction,
+                        pt,
+                        kind,
+                        entity_id,
+                        body_json,
+                        now,
+                    )
+            marked = update_entity_body_dml(
+                transaction,
+                pt,
+                "gateway_authorization",
+                authorization_id,
+                auth_body_settled,
+                now,
+            )
+            complete_reservation_retention(
+                transaction,
+                pt,
+                reservation_id,
+                terminal_at=now,
+            )
         if marked != 1:
             raise _SettleError("gateway_authorization update row-count != 1")
         return {
             "outcome": SettleOutcome.SETTLED,
             "missing_key_releases": missing_key_releases,
+            "request_record_typed": request_record_typed,
         }
 
     try:
@@ -627,4 +711,3 @@ def typed_finalize_atomic(
         return result
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
-

--- a/src/trusted_router/storage_gcp_benchmark_index.py
+++ b/src/trusted_router/storage_gcp_benchmark_index.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import Any
+from typing import Any, TypeAlias
 
 from trusted_router.storage_gcp_codec import json_body, reverse_time_key
 from trusted_router.storage_models import ProviderBenchmarkSample
+
+FamilyNames: TypeAlias = str | tuple[str, ...]
 
 
 def write_provider_benchmark(table: Any, family: str, sample: ProviderBenchmarkSample) -> None:
@@ -28,7 +30,7 @@ def write_provider_benchmark(table: Any, family: str, sample: ProviderBenchmarkS
 
 def provider_benchmark_samples(
     table: Any,
-    family: str,
+    family: FamilyNames,
     *,
     date: str | None,
     provider: str | None,
@@ -78,11 +80,19 @@ def _benchmark_prefix(
     return b"benchmark_recent#", False
 
 
-def _samples_from_rows(rows: Any, family: str) -> list[ProviderBenchmarkSample]:
+def _samples_from_rows(
+    rows: Any,
+    family: FamilyNames,
+) -> list[ProviderBenchmarkSample]:
     field_names = {field.name for field in dataclasses.fields(ProviderBenchmarkSample)}
     samples: list[ProviderBenchmarkSample] = []
     for row in rows:
-        cells = row.cells.get(family, {}).get(b"body", [])
+        ordered = (family,) if isinstance(family, str) else family
+        cells = []
+        for family_name in ordered:
+            cells = row.cells.get(family_name, {}).get(b"body", [])
+            if cells:
+                break
         if not cells:
             continue
         decoded = json.loads(cells[0].value.decode("utf-8"))

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -22,6 +22,7 @@ transaction (docs §5) — the authorize/settle transactions are DML-only.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from trusted_router.storage_gcp_counters import UNSHARDED
@@ -309,6 +310,7 @@ RESERVATION_COLUMNS = (
     "reservation_id", "workspace_id", "key_hash", "ws_shard", "credit_shard", "key_shard",
     "credit_reserved_micro", "key_reserved_micro", "hold_usage_type",
     "authorization_id", "idempotency_scope", "idempotency_fingerprint", "expires_at",
+    "created_at",
 )
 
 
@@ -385,7 +387,7 @@ def insert_reservation(transaction: Any, param_types: Any, **fields: Any) -> Non
         "credit_reserved_micro": pt.INT64, "key_reserved_micro": pt.INT64,
         "hold_usage_type": pt.STRING, "authorization_id": pt.STRING,
         "idempotency_scope": pt.STRING, "idempotency_fingerprint": pt.STRING,
-        "expires_at": pt.TIMESTAMP,
+        "expires_at": pt.TIMESTAMP, "created_at": pt.TIMESTAMP,
     }
     cols = ", ".join(RESERVATION_COLUMNS)
     binds = ", ".join(f"@{c}" for c in RESERVATION_COLUMNS)
@@ -407,6 +409,8 @@ def claim_reservation(
     *,
     actual_micro: int,
     settled_usage_type: str,
+    terminal_at: Any | None = None,
+    defer_retention: bool = False,
 ) -> bool:
     """Claim a reservation for settle/refund: first caller wins.
 
@@ -415,17 +419,49 @@ def claim_reservation(
     Persists `actual_micro` + `settled_usage_type` so the durable reservation
     records the exact settled amount for audit / reaper reconciliation.
     """
+    resolved_terminal_at = (
+        None if defer_retention else (terminal_at or datetime.now(UTC))
+    )
     count = transaction.execute_update(
         "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "
-        "settled_usage_type=@sut WHERE reservation_id=@rid AND settled=false",
-        params={"rid": reservation_id, "actual": int(actual_micro), "sut": settled_usage_type},
+        "settled_usage_type=@sut, terminal_at=@terminal_at "
+        "WHERE reservation_id=@rid AND settled=false",
+        params={
+            "rid": reservation_id,
+            "actual": int(actual_micro),
+            "sut": settled_usage_type,
+            "terminal_at": resolved_terminal_at,
+        },
         param_types={
             "rid": param_types.STRING,
             "actual": param_types.INT64,
             "sut": param_types.STRING,
+            "terminal_at": param_types.TIMESTAMP,
         },
     )
     return count == 1
+
+
+def complete_reservation_retention(
+    transaction: Any,
+    param_types: Any,
+    reservation_id: str,
+    *,
+    terminal_at: Any,
+) -> int:
+    """Start TTL only after all durable settlement repair work is complete."""
+    return transaction.execute_update(
+        "UPDATE tr_reservation SET terminal_at=@terminal_at "
+        "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL",
+        params={
+            "rid": reservation_id,
+            "terminal_at": terminal_at,
+        },
+        param_types={
+            "rid": param_types.STRING,
+            "terminal_at": param_types.TIMESTAMP,
+        },
+    )
 
 
 def insert_entity_dml(

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -1,13 +1,16 @@
-"""Spanner-backed generation log + Bigtable activity index.
+"""Bigtable activity index with a legacy Spanner compatibility path.
 
-Sibling of InMemoryGenerations. add() runs:
+Sibling of InMemoryGenerations. The general ``add()`` path remains compatible
+with non-gateway callers and rolling legacy records:
   1. add_usage_to_key — roll cost into per-key counters (own txn).
   2. Spanner txn — generation row + workspace index entry.
-  3. Bigtable activity-index write (best-effort, repairable from Spanner).
+  3. Bigtable activity-index write.
   4. Provider-benchmark sample (Bigtable, best-effort).
 
-The user-facing reads (activity, activity_events) come from the Bigtable
-index, not Spanner."""
+The high-volume gateway path does not call ``add()``. Billing settles in typed
+Spanner tables and writes bounded Bigtable metadata directly. Its durable
+settle outbox retains repair inputs until ``index_after_commit`` succeeds.
+User-facing reads prefer bounded families and fall back to legacy cells."""
 
 from __future__ import annotations
 
@@ -26,6 +29,9 @@ from trusted_router.storage_activity import (
 )
 from trusted_router.storage_gcp_activity_index import (
     activity_generations as _bt_activity_generations,
+)
+from trusted_router.storage_gcp_activity_index import (
+    generation_by_id as _bt_generation_by_id,
 )
 from trusted_router.storage_gcp_activity_index import (
     iter_activity_generations as _bt_iter_activity_generations,
@@ -68,12 +74,29 @@ class SpannerGenerations:
         io: SpannerIO,
         *,
         bt_table: Any,
-        generation_family: str,
+        generation_family: str | None = None,
+        activity_family: str | None = None,
+        benchmark_family: str | None = None,
+        legacy_family: str | None = None,
         add_usage_to_key: _AddUsageCallback,
     ) -> None:
         self._io = io
         self._bt_table = bt_table
-        self._family = generation_family
+        legacy = legacy_family or generation_family or "m"
+        self._activity_family = activity_family or generation_family or legacy
+        self._benchmark_family = benchmark_family or generation_family or legacy
+        self._legacy_family = legacy
+        # Retain the historical attribute for internal test doubles and rolling
+        # code that still constructs this adapter with one shared family.
+        self._family = legacy
+        self._activity_read_families = _ordered_families(
+            self._activity_family,
+            legacy,
+        )
+        self._benchmark_read_families = _ordered_families(
+            self._benchmark_family,
+            legacy,
+        )
         self._add_usage_to_key = add_usage_to_key
 
     def add(self, generation: Generation) -> None:
@@ -97,13 +120,17 @@ class SpannerGenerations:
         self._io.database.run_in_transaction(txn)
         self.index_after_commit(generation)
 
-    def index_after_commit(self, generation: Generation) -> None:
-        # Spanner is the source of truth for billing and generation metadata.
-        # Bigtable is the activity index optimized for high-volume reads;
-        # this post-transaction write is intentionally idempotent and can
-        # be repaired from generation_by_workspace if the process crashes.
+    def index_after_commit(self, generation: Generation) -> bool:
+        # Spanner remains the source of truth for billing. Bigtable owns bounded
+        # per-request activity metadata. Gateway callers retain a durable outbox
+        # row until this idempotent write succeeds; legacy add() callers can
+        # still repair from generation_by_workspace.
         try:
-            _bt_write_generation(self._bt_table, self._family, generation)
+            _bt_write_generation(
+                self._bt_table,
+                self._activity_family,
+                generation,
+            )
         except Exception as exc:
             log.exception(
                 "bigtable.activity_index_write_failed",
@@ -119,15 +146,30 @@ class SpannerGenerations:
                     "repairable_via": "reconcile_activity()",
                 },
             )
+            activity_indexed = False
+        else:
+            activity_indexed = True
         if generation.app != "TrustedRouter Synthetic":
             self.record_benchmark(ProviderBenchmarkSample.from_generation(generation))
+        return activity_indexed
 
     def get(self, generation_id: str) -> Generation | None:
+        generation = _bt_generation_by_id(
+            self._bt_table,
+            self._activity_families(),
+            generation_id,
+        )
+        if generation is not None:
+            return generation
         return self._io.read_entity("generation", generation_id, Generation)
 
     def record_benchmark(self, sample: ProviderBenchmarkSample) -> None:
         try:
-            _bt_write_provider_benchmark(self._bt_table, self._family, sample)
+            _bt_write_provider_benchmark(
+                self._bt_table,
+                self._benchmark_family,
+                sample,
+            )
         except Exception as exc:
             log.exception(
                 "bigtable.benchmark_index_write_failed",
@@ -153,7 +195,7 @@ class SpannerGenerations:
     ) -> list[ProviderBenchmarkSample]:
         return _bt_provider_benchmark_samples(
             self._bt_table,
-            self._family,
+            self._benchmark_families(),
             date=date,
             provider=provider,
             model=model,
@@ -364,7 +406,7 @@ class SpannerGenerations:
     ) -> dict[str, Any]:
         return _bt_usage_series(
             self._bt_table,
-            self._family,
+            self._activity_families(),
             workspace_id,
             start_day=start_day,
             end_day=end_day,
@@ -389,7 +431,11 @@ class SpannerGenerations:
             if generation is None:
                 continue
             try:
-                _bt_write_generation(self._bt_table, self._family, generation)
+                _bt_write_generation(
+                    self._bt_table,
+                    self._activity_family,
+                    generation,
+                )
                 repaired += 1
             except Exception as exc:
                 log.exception(
@@ -418,7 +464,7 @@ class SpannerGenerations:
     ) -> list[Generation]:
         return _bt_activity_generations(
             self._bt_table,
-            self._family,
+            self._activity_families(),
             workspace_id,
             api_key_hash=api_key_hash,
             date=date,
@@ -435,11 +481,25 @@ class SpannerGenerations:
     ) -> Iterator[Generation]:
         return _bt_iter_activity_generations(
             self._bt_table,
-            self._family,
+            self._activity_families(),
             workspace_id,
             api_key_hash=api_key_hash,
             date=date,
             limit=limit,
+        )
+
+    def _activity_families(self) -> tuple[str, ...]:
+        return getattr(
+            self,
+            "_activity_read_families",
+            (getattr(self, "_family", "m"),),
+        )
+
+    def _benchmark_families(self) -> tuple[str, ...]:
+        return getattr(
+            self,
+            "_benchmark_read_families",
+            (getattr(self, "_family", "m"),),
         )
 
     def _tagged_activity_result(
@@ -555,3 +615,7 @@ def _activity_tag_cache_key(
     tag_value: str | None,
 ) -> storage_activity.ActivityTagCacheKey:
     return (workspace_id, api_key_hash, date, group_by, limit, tag_key, tag_value)
+
+
+def _ordered_families(primary: str, legacy: str) -> tuple[str, ...]:
+    return (primary,) if primary == legacy else (primary, legacy)

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -1,0 +1,210 @@
+"""Typed Spanner storage for bounded gateway authorization state.
+
+The generic ``tr_entities`` table is appropriate for low-volume control-plane
+objects, but not for one row per inference request. Gateway authorizations are
+active billing state until settle/refund wins the reservation claim. Once the
+durable settle outbox confirms the index write, ``terminal_at`` starts a bounded
+idempotency/audit window.
+
+``terminal_at`` is deliberately nullable. Spanner TTL ignores NULL timestamps,
+so an unresolved authorization or a settled request with pending metadata
+repair can never be deleted by the row-deletion policy.
+
+The JSON payload is the minimal content-free replay record needed to honor an
+idempotency key after settlement. It expires with the typed row after 30 days.
+Prompt and output content are never present in either representation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.types import UsageType
+
+AUTHORIZATION_TABLE = "tr_gateway_authorization"
+
+
+def insert_gateway_authorization(
+    transaction: Any,
+    param_types: Any,
+    authorization: GatewayAuthorization,
+    *,
+    created_at: Any,
+) -> None:
+    """Insert active authorization state in the caller's billing transaction."""
+    transaction.execute_update(
+        "INSERT INTO tr_gateway_authorization ("
+        "authorization_id, workspace_id, key_hash, reservation_id, model_id, "
+        "provider, usage_type, estimated_microdollars, settled, created_at, "
+        "terminal_at, payload"
+        ") VALUES ("
+        "@authorization_id, @workspace_id, @key_hash, @reservation_id, @model_id, "
+        "@provider, @usage_type, @estimated_microdollars, false, @created_at, "
+        "NULL, @payload"
+        ")",
+        params={
+            "authorization_id": authorization.id,
+            "workspace_id": authorization.workspace_id,
+            "key_hash": authorization.key_hash,
+            "reservation_id": authorization.credit_reservation_id,
+            "model_id": authorization.model_id,
+            "provider": authorization.provider,
+            "usage_type": str(authorization.usage_type),
+            "estimated_microdollars": int(authorization.estimated_microdollars),
+            "created_at": created_at,
+            "payload": json_body(authorization),
+        },
+        param_types={
+            "authorization_id": param_types.STRING,
+            "workspace_id": param_types.STRING,
+            "key_hash": param_types.STRING,
+            "reservation_id": param_types.STRING,
+            "model_id": param_types.STRING,
+            "provider": param_types.STRING,
+            "usage_type": param_types.STRING,
+            "estimated_microdollars": param_types.INT64,
+            "created_at": param_types.TIMESTAMP,
+            "payload": param_types.STRING,
+        },
+    )
+
+
+def read_gateway_authorization(
+    reader: Any,
+    param_types: Any,
+    authorization_id: str,
+) -> GatewayAuthorization | None:
+    rows = list(
+        reader.execute_sql(
+            "SELECT authorization_id, workspace_id, key_hash, reservation_id, "
+            "model_id, provider, usage_type, estimated_microdollars, settled, "
+            "created_at, payload FROM tr_gateway_authorization "
+            "WHERE authorization_id=@authorization_id",
+            params={"authorization_id": authorization_id},
+            param_types={"authorization_id": param_types.STRING},
+        )
+    )
+    if not rows:
+        return None
+    (
+        row_id,
+        workspace_id,
+        key_hash,
+        reservation_id,
+        model_id,
+        provider,
+        usage_type,
+        estimated_microdollars,
+        settled,
+        created_at,
+        payload,
+    ) = rows[0]
+    if payload:
+        authorization = _authorization_from_payload(payload)
+        authorization.settled = bool(settled)
+        authorization.created_at = _timestamp_string(created_at)
+        return authorization
+    return GatewayAuthorization(
+        id=str(row_id),
+        workspace_id=str(workspace_id),
+        key_hash=str(key_hash),
+        model_id=str(model_id),
+        provider=str(provider),
+        usage_type=UsageType.coerce(usage_type),
+        estimated_microdollars=int(estimated_microdollars),
+        credit_reservation_id=(
+            str(reservation_id) if reservation_id is not None else None
+        ),
+        settled=bool(settled),
+        created_at=_timestamp_string(created_at),
+    )
+
+
+def mark_gateway_authorization_settled(
+    transaction: Any,
+    param_types: Any,
+    authorization: GatewayAuthorization,
+) -> int:
+    """Mark billing settled while keeping repair metadata and TTL disabled."""
+    return transaction.execute_update(
+        "UPDATE tr_gateway_authorization SET settled=true, payload=@payload "
+        "WHERE authorization_id=@authorization_id",
+        params={
+            "authorization_id": authorization.id,
+            "payload": json_body(authorization),
+        },
+        param_types={
+            "authorization_id": param_types.STRING,
+            "payload": param_types.STRING,
+        },
+    )
+
+
+def complete_gateway_authorization_retention(
+    transaction: Any,
+    param_types: Any,
+    authorization_id: str,
+    *,
+    terminal_at: Any,
+) -> int:
+    """Start the retention clock for a settled, replayable authorization.
+
+    The settled predicate guards active authorizations. The NULL predicate makes
+    retries idempotent without extending the 30-day replay/audit window.
+    """
+    return transaction.execute_update(
+        "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "
+        "WHERE authorization_id=@authorization_id AND settled=true "
+        "AND terminal_at IS NULL",
+        params={
+            "authorization_id": authorization_id,
+            "terminal_at": terminal_at,
+        },
+        param_types={
+            "authorization_id": param_types.STRING,
+            "terminal_at": param_types.TIMESTAMP,
+        },
+    )
+
+
+def close_reaped_gateway_authorization(
+    transaction: Any,
+    param_types: Any,
+    authorization_id: str,
+    *,
+    terminal_at: Any,
+) -> int:
+    """Close an expired authorization whose hold was released by the reaper."""
+    return transaction.execute_update(
+        "UPDATE tr_gateway_authorization SET settled=true, terminal_at=@terminal_at, "
+        "payload=NULL WHERE authorization_id=@authorization_id AND settled=false",
+        params={
+            "authorization_id": authorization_id,
+            "terminal_at": terminal_at,
+        },
+        param_types={
+            "authorization_id": param_types.STRING,
+            "terminal_at": param_types.TIMESTAMP,
+        },
+    )
+
+
+def _authorization_from_payload(payload: str) -> GatewayAuthorization:
+    data = json.loads(payload)
+    known = {field.name for field in dataclasses.fields(GatewayAuthorization)}
+    return GatewayAuthorization(**{key: value for key, value in data.items() if key in known})
+
+
+def _timestamp_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    raise TypeError("gateway authorization created_at is not a timestamp")

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -19,6 +19,10 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from trusted_router.storage_gcp_counter_dml import complete_reservation_retention
+from trusted_router.storage_gcp_request_records import (
+    complete_gateway_authorization_retention,
+)
 from trusted_router.storage_models import SettleOutboxRow
 
 # Column order shared by INSERT and the row-tuple SELECTs (keep in sync with the
@@ -41,6 +45,7 @@ OUTBOX_COLUMNS = [
     "leased_until",
     "created_at",
     "updated_at",
+    "terminal_at",
 ]
 
 # Statuses that must FREEZE the hold — the reaper may not free-release a
@@ -104,6 +109,7 @@ def _row_from_tuple(values: Any) -> SettleOutboxRow:
         leased_until=_ts_str(d["leased_until"]),
         created_at=_ts_str(d["created_at"]) or "",
         updated_at=_ts_str(d["updated_at"]),
+        terminal_at=_ts_str(d["terminal_at"]),
     )
 
 
@@ -162,6 +168,7 @@ class SpannerSettleOutbox:
                 "leased_until": None,
                 "created_at": now,
                 "updated_at": now,
+                "terminal_at": None,
             }
             types = {
                 "authorization_id": pt.STRING, "intent_kind": pt.STRING,
@@ -172,6 +179,7 @@ class SpannerSettleOutbox:
                 "last_error": pt.STRING, "next_attempt_at": pt.TIMESTAMP,
                 "lease_owner": pt.STRING, "leased_until": pt.TIMESTAMP,
                 "created_at": pt.TIMESTAMP, "updated_at": pt.TIMESTAMP,
+                "terminal_at": pt.TIMESTAMP,
             }
             transaction.execute_update(
                 f"INSERT INTO tr_settle_outbox ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
@@ -305,36 +313,55 @@ class SpannerSettleOutbox:
 
         def txn(transaction: Any) -> str | None:
             rows = list(transaction.execute_sql(
-                "SELECT attempts, lease_owner FROM tr_settle_outbox "
+                "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
                 "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
                 params={"aid": authorization_id, "kind": intent_kind},
                 param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
             ))
             if not rows:
                 return None
-            attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
+            attempts, cur_owner, reservation_id = (
+                int(rows[0][0] or 0),
+                rows[0][1],
+                rows[0][2],
+            )
             if lease_owner is not None and cur_owner not in (None, lease_owner):
                 return None  # lost the lease to another worker
             next_attempts = attempts + 1
             if done:
-                new_status, next_at, err = "done", None, None
+                new_status, next_at, err, terminal_at = "done", None, None, now
             elif force_dead:
-                new_status, next_at, err = "dead", None, (error or "drain failed")[:1000]
+                new_status, next_at, err, terminal_at = (
+                    "dead",
+                    None,
+                    (error or "drain failed")[:1000],
+                    None,
+                )
             elif next_attempts >= max_attempts:
-                new_status, next_at, err = "dead", None, (error or "drain failed")[:1000]
+                new_status, next_at, err, terminal_at = (
+                    "dead",
+                    None,
+                    (error or "drain failed")[:1000],
+                    None,
+                )
             else:
                 new_status = "pending"
                 next_at = _iso_after_seconds(_backoff_seconds(next_attempts))
                 err = (error or "drain failed")[:1000]
+                terminal_at = None
             updated = transaction.execute_update(
                 "UPDATE tr_settle_outbox SET status=@status, attempts=@attempts, "
                 "last_error=@err, next_attempt_at=@next_at, lease_owner=NULL, "
-                "leased_until=NULL, updated_at=@now WHERE authorization_id=@aid "
+                "leased_until=NULL, updated_at=@now, terminal_at=@terminal_at, "
+                "settle_body=IF(@done, CAST(NULL AS STRING), settle_body) "
+                "WHERE authorization_id=@aid "
                 "AND intent_kind=@kind AND status='pending' "
                 "AND (lease_owner IS NULL OR lease_owner=@lease_owner)",
                 params={
                     "status": new_status, "attempts": next_attempts, "err": err,
                     "next_at": next_at, "now": now,
+                    "terminal_at": terminal_at,
+                    "done": done,
                     "aid": authorization_id, "kind": intent_kind,
                     "lease_owner": lease_owner,
                 },
@@ -343,9 +370,27 @@ class SpannerSettleOutbox:
                     "err": self._pt.STRING, "next_at": self._pt.TIMESTAMP,
                     "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
                     "kind": self._pt.STRING, "lease_owner": self._pt.STRING,
+                    "terminal_at": self._pt.TIMESTAMP,
+                    "done": self._pt.BOOL,
                 },
             )
-            return new_status if updated == 1 else None
+            if updated != 1:
+                return None
+            if done:
+                complete_gateway_authorization_retention(
+                    transaction,
+                    self._pt,
+                    authorization_id,
+                    terminal_at=now,
+                )
+                if reservation_id:
+                    complete_reservation_retention(
+                        transaction,
+                        self._pt,
+                        str(reservation_id),
+                        terminal_at=now,
+                    )
+            return new_status
 
         return self._database.run_in_transaction(txn)
 
@@ -425,21 +470,14 @@ class SpannerSettleOutbox:
         return _row_from_tuple(rows[0]) if rows else None
 
     def purge_done(self, *, older_than_days: int = 30) -> int:
-        cutoff = (
-            datetime.now(UTC).replace(microsecond=0) - timedelta(days=int(older_than_days))
-        ).isoformat().replace("+00:00", "Z")
+        """Compatibility no-op; Spanner TTL owns bounded terminal cleanup.
 
-        def txn(transaction: Any) -> int:
-            # Done is the only safe-to-delete status: pending/dead/release_approved
-            # guard or document holds, and release_approved cleanup stays manual.
-            return transaction.execute_update(
-                "DELETE FROM tr_settle_outbox WHERE status='done' "
-                "AND updated_at < @cutoff",
-                params={"cutoff": cutoff},
-                param_types={"cutoff": self._pt.TIMESTAMP},
-            )
-
-        return int(self._database.run_in_transaction(txn))
+        Existing production rows intentionally retain ``terminal_at=NULL`` and
+        are not deleted by this rollout. The argument remains to avoid breaking
+        older drain callers during the rolling deployment.
+        """
+        _ = older_than_days
+        return 0
 
 
 def _is_already_exists(exc: Exception) -> bool:

--- a/src/trusted_router/storage_gcp_synthetic_index.py
+++ b/src/trusted_router/storage_gcp_synthetic_index.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from datetime import timedelta
+from typing import Any, TypeAlias
 
 from trusted_router.storage_gcp_codec import json_body, reverse_time_key
 from trusted_router.storage_gcp_synthetic_rollups import write_synthetic_rollups
 from trusted_router.storage_models import SyntheticProbeSample, utcnow
 from trusted_router.synthetic.rollups import raw_sample_is_within_retention
 
+FamilyNames: TypeAlias = str | tuple[str, ...]
+RETENTION_FAMILY_MAX_AGES = {
+    "activity": 30,
+    "benchmark": 30,
+    "synthetic": 14,
+    "rollup": 730,
+}
 
-def write_synthetic_probe_sample(table: Any, family: str, sample: SyntheticProbeSample) -> None:
+
+def write_synthetic_probe_sample(
+    table: Any,
+    family: str,
+    sample: SyntheticProbeSample,
+    *,
+    rollup_family: str | None = None,
+    legacy_family: str | None = None,
+) -> None:
     body = json_body(sample).encode("utf-8")
     day = sample.created_at[:10]
     reverse_time = reverse_time_key(sample.created_at)
@@ -25,12 +41,22 @@ def write_synthetic_probe_sample(table: Any, family: str, sample: SyntheticProbe
         row = table.direct_row(key.encode("utf-8"))
         row.set_cell(family, b"body", body)
         row.commit()
-    write_synthetic_rollups(table, family, sample)
+    resolved_rollup_family = rollup_family or family
+    rollup_read_families = _ordered_families(
+        resolved_rollup_family,
+        legacy_family,
+    )
+    write_synthetic_rollups(
+        table,
+        resolved_rollup_family,
+        sample,
+        read_families=rollup_read_families,
+    )
 
 
 def synthetic_probe_samples(
     table: Any,
-    family: str,
+    family: FamilyNames,
     *,
     date: str | None,
     target: str | None,
@@ -80,14 +106,32 @@ def _synthetic_prefix(
     return b"synthetic_recent#", False
 
 
-def _samples_from_rows(rows: Any, family: str) -> list[SyntheticProbeSample]:
+def _samples_from_rows(
+    rows: Any,
+    family: FamilyNames,
+) -> list[SyntheticProbeSample]:
     samples: list[SyntheticProbeSample] = []
     for row in rows:
-        cells = row.cells.get(family, {}).get(b"body", [])
+        cells = _body_cells(row, family)
         if not cells:
             continue
         samples.append(SyntheticProbeSample(**json.loads(cells[0].value.decode("utf-8"))))
     return samples
+
+
+def _ordered_families(primary: str, legacy: str | None) -> tuple[str, ...]:
+    if not legacy or primary == legacy:
+        return (primary,)
+    return (primary, legacy)
+
+
+def _body_cells(row: Any, families: FamilyNames) -> list[Any]:
+    ordered = (families,) if isinstance(families, str) else families
+    for family in ordered:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if cells:
+            return cells
+    return []
 
 
 def open_generation_table(settings: Any) -> Any:
@@ -114,3 +158,44 @@ def open_generation_table(settings: Any) -> Any:
         .instance(settings.bigtable_instance_id)
         .table(settings.bigtable_generation_table)
     )
+
+
+def configure_retention_families(
+    table: Any,
+    *,
+    apply: bool,
+) -> list[dict[str, Any]]:
+    """Create/update only the bounded Bigtable families.
+
+    The legacy ``m`` family is intentionally absent from
+    ``RETENTION_FAMILY_MAX_AGES`` and is never mutated here. That makes the
+    expand migration non-destructive even when old rows share the same table.
+    """
+    try:
+        from google.cloud.bigtable.column_family import (
+            GCRuleUnion,
+            MaxAgeGCRule,
+            MaxVersionsGCRule,
+        )
+    except ImportError as exc:  # pragma: no cover - dependency exists in prod.
+        raise RuntimeError("google-cloud-bigtable is required") from exc
+
+    existing = table.list_column_families()
+    actions: list[dict[str, Any]] = []
+    for name, days in RETENTION_FAMILY_MAX_AGES.items():
+        action = "update" if name in existing else "create"
+        actions.append({"family": name, "max_age_days": days, "action": action})
+        if not apply:
+            continue
+        rule = GCRuleUnion(
+            [
+                MaxAgeGCRule(timedelta(days=days)),
+                MaxVersionsGCRule(1),
+            ]
+        )
+        family = table.column_family(name, gc_rule=rule)
+        if action == "create":
+            family.create()
+        else:
+            family.update()
+    return actions

--- a/src/trusted_router/storage_gcp_synthetic_rollups.py
+++ b/src/trusted_router/storage_gcp_synthetic_rollups.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, TypeAlias
 
 from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
 
@@ -14,14 +14,27 @@ from trusted_router.synthetic.rollups import (
     sample_rollup_ids,
 )
 
+FamilyNames: TypeAlias = str | tuple[str, ...]
 
-def write_synthetic_rollups(table: Any, family: str, sample: SyntheticProbeSample) -> None:
+
+def write_synthetic_rollups(
+    table: Any,
+    family: str,
+    sample: SyntheticProbeSample,
+    *,
+    read_families: FamilyNames | None = None,
+) -> None:
+    resolved_read_families = read_families or family
     for period, component in sample_rollup_ids(sample):
         update = new_rollup_for_sample(sample, period=period, component=component)
         marker_key = _seen_key(update, sample.id)
-        if _row_exists(table, family, marker_key):
+        if _row_exists(table, resolved_read_families, marker_key):
             continue
-        existing = _read_rollup(table, family, _rollup_key(update))
+        existing = _read_rollup(
+            table,
+            resolved_read_families,
+            _rollup_key(update),
+        )
         if existing is None:
             existing = update
         else:
@@ -32,7 +45,7 @@ def write_synthetic_rollups(table: Any, family: str, sample: SyntheticProbeSampl
 
 def synthetic_rollups(
     table: Any,
-    family: str,
+    family: FamilyNames,
     *,
     period: str | None,
     since: str | None = None,
@@ -80,16 +93,20 @@ def _seen_key(rollup: SyntheticRollup, sample_id: str) -> bytes:
     return _rollup_key(rollup).replace(b"synthetic_rollup#", b"synthetic_rollup_seen#", 1) + b"#" + sample_id.encode("utf-8")
 
 
-def _row_exists(table: Any, family: str, key: bytes) -> bool:
+def _row_exists(table: Any, family: FamilyNames, key: bytes) -> bool:
     rows = _read_latest_rows(table, start_key=key, end_key=key + b"\x00", limit=1)
     for row in rows:
-        cells = row.cells.get(family, {}).get(b"body", [])
+        cells = _body_cells(row, family)
         if cells:
             return True
     return False
 
 
-def _read_rollup(table: Any, family: str, key: bytes) -> SyntheticRollup | None:
+def _read_rollup(
+    table: Any,
+    family: FamilyNames,
+    key: bytes,
+) -> SyntheticRollup | None:
     rows = _read_latest_rows(table, start_key=key, end_key=key + b"\x00", limit=1)
     rollups = _rollups_from_rows(rows, family, include_histograms=True)
     return rollups[0] if rollups else None
@@ -106,13 +123,13 @@ def _read_latest_rows(table: Any, *, start_key: bytes, end_key: bytes, limit: in
 
 def _rollups_from_rows(
     rows: Any,
-    family: str,
+    family: FamilyNames,
     *,
     include_histograms: bool,
 ) -> list[SyntheticRollup]:
     rollups: list[SyntheticRollup] = []
     for row in rows:
-        cells = row.cells.get(family, {}).get(b"body", [])
+        cells = _body_cells(row, family)
         if not cells:
             continue
         try:
@@ -132,3 +149,12 @@ def _write_json_row(table: Any, family: str, key: bytes, value: Any) -> None:
     row = table.direct_row(key)
     row.set_cell(family, b"body", json_body(value).encode("utf-8"))
     row.commit()
+
+
+def _body_cells(row: Any, families: FamilyNames) -> list[Any]:
+    ordered = (families,) if isinstance(families, str) else families
+    for family in ordered:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if cells:
+            return cells
+    return []

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -245,6 +245,9 @@ class SettleOutboxRow:
     leased_until: str | None = None
     created_at: str = field(default_factory=iso_now)
     updated_at: str | None = None
+    # NULL while unresolved. Spanner row deletion policies ignore NULL, so a
+    # pending/dead row can never expire before settlement repair is complete.
+    terminal_at: str | None = None
 
 
 @dataclass
@@ -328,6 +331,13 @@ class GatewayAuthorization:
         # is always a UsageType at runtime regardless of construction path.
         if not isinstance(self.usage_type, UsageType):
             self.usage_type = UsageType.coerce(self.usage_type)
+
+
+@dataclass(frozen=True)
+class TypedFinalizeResult:
+    finalized: bool
+    activity_indexed: bool
+    request_record_typed: bool = False
 
 
 @dataclass
@@ -489,8 +499,11 @@ class Generation:
         if _is_synthetic_metadata(body.get("metadata")):
             app = "TrustedRouter Synthetic"
         return cls(
-            id=f"gen-{uuid.uuid4().hex}",
-            request_id=str(body.get("request_id") or f"req-{uuid.uuid4()}"),
+            id=generation_id_for_authorization(authorization.id),
+            request_id=str(
+                body.get("request_id")
+                or f"req-{uuid.uuid5(uuid.NAMESPACE_URL, authorization.id)}"
+            ),
             workspace_id=authorization.workspace_id,
             key_hash=authorization.key_hash,
             model=model_id or authorization.model_id,
@@ -507,7 +520,10 @@ class Generation:
             usage_estimated=bool(body.get("usage_estimated", False)),
             cached_input_tokens=int(body.get("cached_input_tokens") or body.get("cached_tokens") or 0),
             reasoning_tokens=int(body.get("reasoning_tokens") or 0),
-            tool_calls=_coerce_tool_calls(body.get("tool_calls")),
+            # Tool-call arguments are model output content, not activity
+            # metadata. The attested gateway returns them to the caller but the
+            # control-plane activity index never persists them.
+            tool_calls=None,
             provider=provider,
             elapsed_milliseconds=_seconds_to_milliseconds(elapsed),
             first_token_milliseconds=(
@@ -529,6 +545,7 @@ class Generation:
             app_categories=[str(item) for item in body.get("app_categories") or []],
             tags=dict(authorization.tags),
             operator_cost_microdollars=operator_cost_microdollars,
+            created_at=authorization.created_at,
         )
 
     def to_openrouter_generation(self) -> dict[str, Any]:
@@ -570,6 +587,17 @@ class Generation:
             "usage_type": self.usage_type,
             "usage_estimated": self.usage_estimated,
         }
+
+
+def generation_id_for_authorization(authorization_id: str) -> str:
+    """Return the stable generation id for one gateway authorization.
+
+    Settlement can commit while its HTTP response is lost.  The durable outbox
+    then rebuilds and re-indexes the same metadata.  A deterministic id makes
+    that repair idempotent in Bigtable instead of creating duplicate activity
+    rows on every replay.
+    """
+    return f"gen-{uuid.uuid5(uuid.NAMESPACE_URL, f'trustedrouter:{authorization_id}').hex}"
 
 
 # Redaction for provider error strings persisted on benchmark samples. Shared
@@ -634,7 +662,7 @@ class ProviderBenchmarkSample:
     @classmethod
     def from_generation(cls, generation: Generation) -> ProviderBenchmarkSample:
         return cls(
-            id=f"bench-{uuid.uuid4().hex}",
+            id=f"bench-{uuid.uuid5(uuid.NAMESPACE_URL, generation.id).hex}",
             model=generation.model,
             provider=generation.provider or _provider_from_model_id(generation.model),
             provider_name=generation.provider_name,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -130,6 +130,11 @@ class FakeSpannerDatabase:
         self.reservations: dict[str, dict] = {}
         self.reservation_versions: dict[str, int] = {}
         self.reservation_idemp: dict[str, str] = {}  # idempotency_scope -> reservation_id
+        # tr_gateway_authorization: bounded per-request state keyed by
+        # authorization_id. Kept separate from generic tr_entities so tests
+        # catch accidental fallback writes after the typed cutover.
+        self.gateway_authorizations: dict[str, dict] = {}
+        self.gateway_authorization_versions: dict[str, int] = {}
         # tr_settle_outbox: PK (authorization_id, intent_kind) -> {column: value}.
         self.settle_outbox: dict[tuple, dict] = {}
         self.settle_outbox_versions: dict[tuple, int] = {}
@@ -177,6 +182,11 @@ class FakeSpannerDatabase:
                     current_version = 1 if key[1] in self.reservation_idemp else 0
                 elif isinstance(key, tuple) and len(key) == 2 and key[0] == "outbox":
                     current_version = self.settle_outbox_versions.get(key[1], 0)
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "gateway_auth":
+                    current_version = self.gateway_authorization_versions.get(
+                        key[1],
+                        0,
+                    )
                 else:
                     current = self.rows.get(key)
                     current_version = current.version if current is not None else 0
@@ -228,6 +238,13 @@ class FakeSpannerDatabase:
                     _, rid, record = op
                     self.reservations[rid] = record
                     self.reservation_versions[rid] = new_version
+                elif op[0] in (
+                    "insert_gateway_authorization",
+                    "update_gateway_authorization",
+                ):
+                    _, authorization_id, record = op
+                    self.gateway_authorizations[authorization_id] = record
+                    self.gateway_authorization_versions[authorization_id] = new_version
                 elif op[0] == "insert_entity_dml":  # DML INSERT into tr_entities
                     _, kind, entity_id, body = op
                     self.rows[(kind, entity_id)] = _Row(body=body, version=new_version)
@@ -289,6 +306,24 @@ class _FakeTransaction:
         if version_key not in self.read_versions:
             self.read_versions[version_key] = self.db.settle_outbox_versions.get(pk, 0)
         rec = self.db.settle_outbox.get(pk)
+        return dict(rec) if rec is not None else None
+
+    def _gateway_authorization_current(
+        self,
+        authorization_id: str,
+    ) -> dict | None:
+        for op in reversed(self.pending_writes):
+            if op[0] in (
+                "insert_gateway_authorization",
+                "update_gateway_authorization",
+            ) and op[1] == authorization_id:
+                return dict(op[2])
+        version_key = ("gateway_auth", authorization_id)
+        if version_key not in self.read_versions:
+            self.read_versions[version_key] = (
+                self.db.gateway_authorization_versions.get(authorization_id, 0)
+            )
+        rec = self.db.gateway_authorizations.get(authorization_id)
         return dict(rec) if rec is not None else None
 
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
@@ -470,6 +505,7 @@ class _FakeTransaction:
             record["settled"] = False
             record["settled_usage_type"] = None
             record["actual_micro"] = None
+            record["terminal_at"] = None
             self.pending_writes.append(("insert_reservation", record))
             return 1
         if "UPDATE tr_reservation SET settled=true" in sql:
@@ -478,9 +514,88 @@ class _FakeTransaction:
             if rec is None or rec["settled"]:
                 return 0  # missing or already-claimed (replay)
             new = dict(
-                rec, settled=True, settled_usage_type=p["sut"], actual_micro=p["actual"]
+                rec,
+                settled=True,
+                settled_usage_type=p["sut"],
+                actual_micro=p["actual"],
+                terminal_at=p["terminal_at"],
             )
             self.pending_writes.append(("update_reservation", p["rid"], new))
+            return 1
+        if sql.startswith("UPDATE tr_reservation SET terminal_at=@terminal_at"):
+            _require_pred(
+                sql,
+                "reservation_id=@rid AND settled=true AND terminal_at IS NULL",
+                "reservation-complete",
+            )
+            rec = self._reservation_current(p["rid"])
+            if rec is None or not rec.get("settled") or rec.get("terminal_at") is not None:
+                return 0
+            new = dict(rec, terminal_at=p["terminal_at"])
+            self.pending_writes.append(("update_reservation", p["rid"], new))
+            return 1
+        if sql.startswith("INSERT INTO tr_gateway_authorization"):
+            authorization_id = p["authorization_id"]
+            if authorization_id in self.db.gateway_authorizations:
+                raise FakeAlreadyExists(authorization_id)
+            version_key = ("gateway_auth", authorization_id)
+            if version_key not in self.read_versions:
+                self.read_versions[version_key] = 0
+            record = dict(p)
+            record["settled"] = False
+            record["terminal_at"] = None
+            self.pending_writes.append(
+                ("insert_gateway_authorization", authorization_id, record)
+            )
+            return 1
+        if sql.startswith(
+            "UPDATE tr_gateway_authorization SET settled=true, payload=@payload"
+        ):
+            authorization_id = p["authorization_id"]
+            rec = self._gateway_authorization_current(authorization_id)
+            if rec is None:
+                return 0
+            new = dict(rec, settled=True, payload=p["payload"])
+            self.pending_writes.append(
+                ("update_gateway_authorization", authorization_id, new)
+            )
+            return 1
+        if sql.startswith("UPDATE tr_gateway_authorization SET terminal_at=@terminal_at"):
+            _require_pred(
+                sql,
+                "AND settled=true AND terminal_at IS NULL",
+                "authorization-complete",
+            )
+            authorization_id = p["authorization_id"]
+            rec = self._gateway_authorization_current(authorization_id)
+            if (
+                rec is None
+                or not rec.get("settled")
+                or rec.get("terminal_at") is not None
+            ):
+                return 0
+            new = dict(rec, terminal_at=p["terminal_at"])
+            self.pending_writes.append(
+                ("update_gateway_authorization", authorization_id, new)
+            )
+            return 1
+        if sql.startswith(
+            "UPDATE tr_gateway_authorization SET settled=true, terminal_at=@terminal_at"
+        ):
+            _require_pred(sql, "AND settled=false", "authorization-reaper-close")
+            authorization_id = p["authorization_id"]
+            rec = self._gateway_authorization_current(authorization_id)
+            if rec is None or rec.get("settled"):
+                return 0
+            new = dict(
+                rec,
+                settled=True,
+                terminal_at=p["terminal_at"],
+                payload=None,
+            )
+            self.pending_writes.append(
+                ("update_gateway_authorization", authorization_id, new)
+            )
             return 1
         if sql.startswith("INSERT INTO tr_entities"):
             entity_key = (p["kind"], p["id"])
@@ -600,7 +715,8 @@ class _FakeTransaction:
             new = dict(
                 rec, status=p["status"], attempts=p["attempts"], last_error=p["err"],
                 next_attempt_at=p["next_at"], lease_owner=None, leased_until=None,
-                updated_at=p["now"],
+                updated_at=p["now"], terminal_at=p["terminal_at"],
+                settle_body=None if p["done"] else rec.get("settle_body"),
             )
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
@@ -742,7 +858,9 @@ def _execute_settle_outbox_sql(
     predicates it relies on are present in the real query, so a dropped guard/
     status/key predicate fails a test rather than silently matching."""
     p = params
-    if sql.startswith("SELECT attempts, lease_owner FROM tr_settle_outbox"):
+    if sql.startswith("SELECT attempts, lease_owner FROM tr_settle_outbox") or sql.startswith(
+        "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox"
+    ):
         _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark-read")
         _require_pred(sql, "status='pending'", "mark-read")
         pk = (p["aid"], p["kind"])
@@ -751,7 +869,12 @@ def _execute_settle_outbox_sql(
         rec = txn._settle_outbox_current(pk) if txn is not None else db.settle_outbox.get(pk)
         if rec is None or rec.get("status") != "pending":
             return []
-        return [[rec.get("attempts", 0), rec.get("lease_owner")]]
+        values = [rec.get("attempts", 0), rec.get("lease_owner")]
+        if sql.startswith(
+            "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox"
+        ):
+            values.append(rec.get("reservation_id"))
+        return [values]
     if "WHERE status='pending' AND next_attempt_at <= @now" in sql:  # due scan
         now = p["now"]
         limit = int(p.get("limit", 100))
@@ -833,6 +956,20 @@ def _execute_sql(
     # generic branch (the substring-collision hazard the design flags).
     if "tr_settle_outbox" in sql:
         return _execute_settle_outbox_sql(db, txn, sql, params)
+    if "FROM tr_gateway_authorization" in sql:
+        authorization_id = params["authorization_id"]
+        rec = (
+            txn._gateway_authorization_current(authorization_id)
+            if txn is not None
+            else db.gateway_authorizations.get(authorization_id)
+        )
+        if rec is None:
+            return []
+        cols = [
+            col.strip()
+            for col in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[rec.get(col) for col in cols]]
     # Repair: any OPEN holds on a nonzero shard? (checked first — its query string
     # contains the generic count substrings below.)
     if "key_shard!=0" in sql:
@@ -1028,7 +1165,14 @@ class FakeBigtableTable:
     def direct_row(self, key: bytes) -> _FakeDirectRow:
         return _FakeDirectRow(key, self)
 
-    def read_rows(self, *, start_key: bytes, end_key: bytes, limit: int) -> list[Any]:
+    def read_rows(
+        self,
+        *,
+        start_key: bytes,
+        end_key: bytes,
+        limit: int,
+        **_kwargs: Any,
+    ) -> list[Any]:
         with self.lock:
             self.reads.append((start_key, end_key, limit))
             keys = [key for key in sorted(self.rows) if start_key <= key < end_key]
@@ -1051,17 +1195,35 @@ class _FakeDirectRow:
         self.table = table
         self.cells: dict[str, dict[bytes, list[Any]]] = {}
 
-    def set_cell(self, family: str, qualifier: bytes, value: bytes) -> None:
+    def set_cell(
+        self,
+        family: str,
+        qualifier: bytes,
+        value: bytes,
+        timestamp: Any | None = None,
+    ) -> None:
+        _ = timestamp
         self.cells.setdefault(family, {})[qualifier] = [_FakeCell(value)]
 
     def commit(self) -> None:
         with self.table.lock:
             self.table.committed.append(self.key)
-            self.table.rows[self.key] = self.cells
+            merged = {
+                family: {
+                    qualifier: list(cells)
+                    for qualifier, cells in qualifiers.items()
+                }
+                for family, qualifiers in self.table.rows.get(self.key, {}).items()
+            }
+            for family, qualifiers in self.cells.items():
+                merged.setdefault(family, {}).update(qualifiers)
+            self.table.rows[self.key] = merged
 
 
 def make_fake_store(
-    *, ready_barrier: threading.Barrier | None = None
+    *,
+    ready_barrier: threading.Barrier | None = None,
+    request_record_write_mode: str = "legacy",
 ) -> tuple[Any, FakeSpannerDatabase, FakeBigtableTable]:
     from trusted_router.storage_gcp import SpannerBigtableStore
     from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
@@ -1085,6 +1247,7 @@ def make_fake_store(
     store._param_types = _ParamTypes
     store._database = db
     store._bt_table = bt
+    store.request_record_write_mode = request_record_write_mode
     from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
 
     store._credit_shard_counts = CreditShardCountCache()
@@ -1105,7 +1268,9 @@ def make_fake_store(
     store.generation_store = SpannerGenerations(
         io,
         bt_table=bt,
-        generation_family=store.generation_family,
+        activity_family=store.activity_family,
+        benchmark_family=store.benchmark_family,
+        legacy_family=store.legacy_generation_family,
         add_usage_to_key=store.api_keys.add_usage,
     )
     store.byok_store = SpannerByok(io)

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services import settle_outbox_drain as drain_mod
+from trusted_router.services.settle_outbox_apply import ApplyOutcome
+from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage_gcp_activity_index import (
+    generation_by_id,
+    write_generation,
+)
+from trusted_router.storage_gcp_authorize import (
+    AuthorizeOutcome,
+    reap_expired_reservations,
+)
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
+from trusted_router.storage_gcp_synthetic_index import (
+    RETENTION_FAMILY_MAX_AGES,
+    configure_retention_families,
+)
+from trusted_router.storage_models import CreditAccount, Generation, Workspace
+from trusted_router.types import UsageType
+
+MODEL_ID = "anthropic/claude-haiku-4.5"
+PROVIDER = "anthropic"
+ENDPOINT_ID = "anthropic/claude-haiku-4.5@anthropic/prepaid"
+ESTIMATE = 1_000_000
+TOTAL_CREDIT = 5_000_000
+
+
+@pytest.fixture
+def typed_request_store() -> Iterator[tuple[Any, Any, Any]]:
+    store, database, bigtable = make_fake_store(request_record_write_mode="typed")
+    configure_store(store)
+    try:
+        yield store, database, bigtable
+    finally:
+        configure_store(InMemoryStore())
+
+
+def _seed_credit(store: Any, workspace_id: str) -> None:
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id),
+    )
+    store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace_id, 0)] = {
+        "workspace_id": workspace_id,
+        "shard": 0,
+        "total_credits": TOTAL_CREDIT,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _make_key(store: Any, workspace_id: str) -> Any:
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="primary",
+        creator_user_id=None,
+        limit_microdollars=TOTAL_CREDIT,
+    )
+    return key
+
+
+def _authorize(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+    idempotency_key: str | None = None,
+    idempotency_fingerprint: str | None = None,
+    expires_at: str = "2099-01-01T00:00:00Z",
+) -> tuple[str, Any]:
+    return store.authorize_gateway_typed(
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=ESTIMATE,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        requested_model_id=MODEL_ID,
+        candidate_model_ids=[MODEL_ID],
+        region="us",
+        endpoint_id=ENDPOINT_ID,
+        candidate_endpoint_ids=[ENDPOINT_ID],
+        idempotency_key=idempotency_key,
+        idempotency_fingerprint=idempotency_fingerprint,
+        expires_at=expires_at,
+    )
+
+
+def _settle_body(authorization_id: str) -> dict[str, Any]:
+    return {
+        "authorization_id": authorization_id,
+        "actual_input_tokens": 14,
+        "actual_output_tokens": 7,
+        "request_id": "req-retention-test",
+        "finish_reason": "stop",
+        "status": "success",
+        "streamed": True,
+        "elapsed_seconds": 2.0,
+        "selected_model": MODEL_ID,
+        "selected_endpoint": ENDPOINT_ID,
+    }
+
+
+def _outbox(store: Any) -> SpannerSettleOutbox:
+    return SpannerSettleOutbox(store._database, store._param_types)
+
+
+def _client() -> TestClient:
+    settings = Settings(environment="test", settle_outbox_enabled=True)
+    return TestClient(
+        create_app(settings, configure_store_arg=False, init_observability=False)
+    )
+
+
+def _generic_request_kinds(database: Any) -> set[str]:
+    request_kinds = {
+        "gateway_authorization",
+        "gateway_authorization_idempotency",
+        "generation",
+        "generation_by_workspace",
+    }
+    return {kind for kind, _entity_id in database.rows if kind in request_kinds}
+
+
+def test_typed_authorize_avoids_generic_rows_and_replays_one_hold(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-typed-authorize"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+
+    first_outcome, first = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        idempotency_key="same-request",
+        idempotency_fingerprint="fingerprint",
+    )
+    replay_outcome, replay = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        idempotency_key="same-request",
+        idempotency_fingerprint="fingerprint",
+    )
+
+    assert first_outcome == AuthorizeOutcome.ACCEPTED
+    assert replay_outcome == AuthorizeOutcome.REPLAY
+    assert first is not None and replay is not None
+    assert replay.id == first.id
+    assert len(database.reservations) == 1
+    assert len(database.gateway_authorizations) == 1
+    assert database.gateway_authorizations[first.id]["terminal_at"] is None
+    assert _generic_request_kinds(database) == set()
+
+
+def test_typed_settle_starts_bounded_replay_window_after_activity_commit(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, bigtable = typed_request_store
+    workspace_id = "ws-typed-settle"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    response = _client().post(
+        "/v1/internal/gateway/settle",
+        json=_settle_body(authorization.id),
+    )
+
+    assert response.status_code == 200, response.text
+    auth_row = database.gateway_authorizations[authorization.id]
+    reservation = database.reservations[authorization.credit_reservation_id]
+    outbox = database.settle_outbox[(authorization.id, "settle")]
+    assert auth_row["settled"] is True
+    assert auth_row["payload"] is not None
+    assert auth_row["terminal_at"] is not None
+    assert reservation["settled"] is True
+    assert database.reservations[authorization.credit_reservation_id][
+        "terminal_at"
+    ] is not None
+    assert outbox["status"] == "done"
+    assert outbox["settle_body"] is None
+    assert outbox["terminal_at"] is not None
+    assert _generic_request_kinds(database) == set()
+    assert any(
+        "activity" in cells
+        for row_key, cells in bigtable.rows.items()
+        if row_key.startswith(b"gen#")
+    )
+    assert any(
+        "benchmark" in cells
+        for row_key, cells in bigtable.rows.items()
+        if row_key.startswith(b"benchmark")
+    )
+    assert all("m" not in cells for cells in bigtable.rows.values())
+
+
+def test_settled_idempotency_key_replays_for_full_retention_window(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-typed-settled-replay"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        idempotency_key="settled-replay",
+        idempotency_fingerprint="same-request",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    response = _client().post(
+        "/v1/internal/gateway/settle",
+        json=_settle_body(authorization.id),
+    )
+    assert response.status_code == 200, response.text
+
+    replay_outcome, replay = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        idempotency_key="settled-replay",
+        idempotency_fingerprint="same-request",
+    )
+    mismatch_outcome, mismatch = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        idempotency_key="settled-replay",
+        idempotency_fingerprint="different-request",
+    )
+
+    assert replay_outcome == AuthorizeOutcome.REPLAY
+    assert replay is not None and replay.id == authorization.id
+    assert replay.candidate_endpoint_ids == [ENDPOINT_ID]
+    assert mismatch_outcome == AuthorizeOutcome.IDEMPOTENCY_MISMATCH
+    assert mismatch is None
+    assert len(database.reservations) == 1
+    assert len(database.gateway_authorizations) == 1
+    assert database.gateway_authorizations[authorization.id]["payload"] is not None
+
+
+def test_gateway_route_replays_settled_request_from_bounded_record(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-route-settled-replay"
+    store._write_entity(
+        "workspace",
+        workspace_id,
+        Workspace(id=workspace_id, name="Replay", owner_user_id="user-replay"),
+    )
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    client = _client()
+    authorize_body = {
+        "api_key_hash": key.hash,
+        "idempotency_key": "route-settled-replay",
+        "model": MODEL_ID,
+        "estimated_input_tokens": 14,
+        "max_output_tokens": 7,
+    }
+
+    first = client.post("/v1/internal/gateway/authorize", json=authorize_body)
+    assert first.status_code == 200, first.text
+    first_data = first.json()["data"]
+    settled = client.post(
+        "/v1/internal/gateway/settle",
+        json=_settle_body(first_data["authorization_id"]),
+    )
+    assert settled.status_code == 200, settled.text
+
+    replay = client.post("/v1/internal/gateway/authorize", json=authorize_body)
+
+    assert replay.status_code == 200, replay.text
+    replay_data = replay.json()["data"]
+    assert replay_data["authorization_id"] == first_data["authorization_id"]
+    assert replay_data["route_candidates"] == first_data["route_candidates"]
+    assert replay_data["idempotent_replay"] is True
+    assert len(database.reservations) == 1
+    assert len(database.gateway_authorizations) == 1
+
+
+def test_bigtable_failure_preserves_private_repair_state_until_retry(
+    typed_request_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import storage_gcp_generations as generations_mod
+
+    store, database, bigtable = typed_request_store
+    workspace_id = "ws-typed-repair"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    original_write = generations_mod._bt_write_generation
+    calls = 0
+
+    def fail_once(*args: Any, **kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("injected Bigtable outage")
+        original_write(*args, **kwargs)
+
+    monkeypatch.setattr(generations_mod, "_bt_write_generation", fail_once)
+    body = _settle_body(authorization.id)
+    body.update(
+        {
+            "prompt": "private prompt must not persist",
+            "output": "private output must not persist",
+            "tool_calls": [{"function": {"arguments": "private tool output"}}],
+            "metadata": {
+                "trustedrouter_synthetic": "true",
+                "private": "private metadata must not persist",
+            },
+            "trace": {"private": "private trace must not persist"},
+        }
+    )
+
+    response = _client().post("/v1/internal/gateway/settle", json=body)
+
+    assert response.status_code == 200, response.text
+    auth_row = database.gateway_authorizations[authorization.id]
+    reservation = database.reservations[authorization.credit_reservation_id]
+    pending = _outbox(store).get(authorization.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.terminal_at is None
+    assert pending.settle_body is not None
+    assert auth_row["settled"] is True
+    assert auth_row["terminal_at"] is None
+    assert auth_row["payload"] is not None
+    assert reservation["settled"] is True
+    assert reservation.get("terminal_at") is None
+    frozen = json.loads(pending.settle_body)
+    assert frozen["metadata"] == {"trustedrouter_synthetic": "true"}
+    durable_state = json.dumps(
+        {
+            "authorization": auth_row,
+            "reservation": reservation,
+            "outbox": database.settle_outbox[(authorization.id, "settle")],
+        },
+        default=str,
+    )
+    for secret in (
+        "private prompt",
+        "private output",
+        "private tool output",
+        "private metadata",
+        "private trace",
+    ):
+        assert secret not in durable_state
+
+    database.settle_outbox[(authorization.id, "settle")][
+        "next_attempt_at"
+    ] = "2000-01-01T00:00:00Z"
+    drained = drain_mod.drain_settle_outbox(10)
+
+    assert drained["outcomes"] == {
+        ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE: 1
+    }
+    completed = _outbox(store).get(authorization.id, "settle")
+    assert completed is not None and completed.status == "done"
+    assert completed.settle_body is None
+    assert completed.terminal_at is not None
+    assert database.gateway_authorizations[authorization.id]["payload"] is not None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is not None
+    assert database.reservations[authorization.credit_reservation_id][
+        "terminal_at"
+    ] is not None
+    generation_keys = {
+        key for key in bigtable.rows if key.startswith(b"gen#")
+    }
+    assert len(generation_keys) == 1
+    assert calls == 2
+    assert _generic_request_kinds(database) == set()
+
+
+def test_typed_enqueue_failure_rejects_without_charging(
+    typed_request_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-typed-enqueue-failure"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    def fail_enqueue(
+        self: SpannerSettleOutbox,
+        row: Any,
+        *,
+        initial_delay_seconds: int = 0,
+    ) -> str:
+        _ = self, row, initial_delay_seconds
+        raise RuntimeError("injected outbox outage")
+
+    monkeypatch.setattr(SpannerSettleOutbox, "enqueue", fail_enqueue)
+    response = _client().post(
+        "/v1/internal/gateway/settle",
+        json=_settle_body(authorization.id),
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["type"] == "service_unavailable"
+    reservation = database.reservations[authorization.credit_reservation_id]
+    assert reservation["settled"] is False
+    assert reservation["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["settled"] is False
+    assert database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)][
+        "total_usage"
+    ] == 0
+    assert _outbox(store).get(authorization.id, "settle") is None
+
+
+def test_typed_reaper_compacts_unresolved_authorization(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-typed-reaper"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        expires_at="2000-01-01T00:00:00Z",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    reaped = reap_expired_reservations(
+        store._database,
+        store._param_types,
+        now="2026-07-27T00:00:00Z",
+    )
+
+    assert reaped == 1
+    reservation = database.reservations[authorization.credit_reservation_id]
+    auth_row = database.gateway_authorizations[authorization.id]
+    assert reservation["settled"] is True
+    assert reservation["actual_micro"] == 0
+    assert reservation["terminal_at"] is not None
+    assert auth_row["settled"] is True
+    assert auth_row["payload"] is None
+    assert auth_row["terminal_at"] is not None
+
+
+def _generation(generation_id: str, *, cost: int) -> Generation:
+    return Generation(
+        id=generation_id,
+        request_id=f"req-{generation_id}",
+        workspace_id="ws-family-read",
+        key_hash="key-family-read",
+        model=MODEL_ID,
+        provider_name="Anthropic",
+        app="Family read test",
+        tokens_prompt=2,
+        tokens_completion=1,
+        total_cost_microdollars=cost,
+        usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=1.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        provider=PROVIDER,
+        created_at="2026-07-27T12:00:00Z",
+    )
+
+
+def test_bigtable_reads_prefer_bounded_family_and_fall_back_to_legacy(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    _store, _database, bigtable = typed_request_store
+    legacy = _generation("gen-shared", cost=1)
+    bounded = _generation("gen-shared", cost=2)
+    legacy_only = _generation("gen-legacy-only", cost=3)
+    write_generation(bigtable, "m", legacy)
+    write_generation(bigtable, "activity", bounded)
+    write_generation(bigtable, "m", legacy_only)
+
+    preferred = generation_by_id(
+        bigtable,
+        ("activity", "m"),
+        "gen-shared",
+    )
+    fallback = generation_by_id(
+        bigtable,
+        ("activity", "m"),
+        "gen-legacy-only",
+    )
+
+    assert preferred is not None
+    assert preferred.total_cost_microdollars == 2
+    assert fallback is not None
+    assert fallback.total_cost_microdollars == 3
+
+
+def test_typed_production_mode_requires_durable_outbox() -> None:
+    internal_token = "internal-" + "token"
+    webhook_secret = "whsec_" + "test"
+    stripe_secret = "sk_" + "test"
+    with pytest.raises(
+        ValidationError,
+        match="TR_SETTLE_OUTBOX_ENABLED=true",
+    ):
+        Settings(
+            environment="production",
+            internal_gateway_token=internal_token,
+            stripe_webhook_secret=webhook_secret,
+            stripe_secret_key=stripe_secret,
+            sentry_dsn="https://example@example.ingest.sentry.io/1",
+            storage_backend="spanner-bigtable",
+            spanner_instance_id="trusted-router",
+            spanner_database_id="trusted-router",
+            bigtable_instance_id="trusted-router-logs",
+            byok_kms_key_name="projects/p/locations/global/keyRings/r/cryptoKeys/k",
+            request_record_write_mode="typed",
+            settle_outbox_enabled=False,
+        )
+
+
+class _FakeFamily:
+    def __init__(self, name: str, calls: list[tuple[str, str]]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def create(self) -> None:
+        self.calls.append(("create", self.name))
+
+    def update(self) -> None:
+        self.calls.append(("update", self.name))
+
+
+class _FakeAdminTable:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def list_column_families(self) -> dict[str, object]:
+        return {"activity": object(), "m": object()}
+
+    def column_family(self, name: str, *, gc_rule: Any) -> _FakeFamily:
+        assert gc_rule is not None
+        return _FakeFamily(name, self.calls)
+
+
+def test_bigtable_retention_config_never_mutates_legacy_family() -> None:
+    table = _FakeAdminTable()
+
+    actions = configure_retention_families(table, apply=True)
+
+    assert {action["family"] for action in actions} == set(
+        RETENTION_FAMILY_MAX_AGES
+    )
+    assert table.calls == [
+        ("update", "activity"),
+        ("create", "benchmark"),
+        ("create", "synthetic"),
+        ("create", "rollup"),
+    ]
+    assert all(name != "m" for _action, name in table.calls)
+
+
+def test_retention_migration_is_additive_and_dry_run_by_default() -> None:
+    script = (
+        Path(__file__).parents[1]
+        / "scripts"
+        / "deploy"
+        / "migrate_request_retention.sh"
+    ).read_text()
+    executable_lines = [
+        line.strip().lower()
+        for line in script.splitlines()
+        if line.strip()
+        and not line.lstrip().startswith("#")
+        and not line.lstrip().startswith("log ")
+    ]
+
+    assert "apply=false" in executable_lines
+    assert any('if [ "${1:-}" = "--apply" ]' in line for line in executable_lines)
+    assert not any("delete from" in line for line in executable_lines)
+    assert not any("drop table" in line for line in executable_lines)
+    assert not any("update tr_" in line and "terminal_at" in line for line in executable_lines)

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -12,7 +12,6 @@ from fastapi.testclient import TestClient
 from tests.fakes.spanner import _FakeTransaction, make_fake_store
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.schemas import GatewaySettleRequest
 from trusted_router.services import settle_outbox_apply as apply_mod
 from trusted_router.services import settle_outbox_drain as drain_mod
 from trusted_router.services.settle_outbox_apply import ApplyOutcome
@@ -382,9 +381,8 @@ def test_flag_on_successful_typed_settle_enqueues_frozen_done_row(
     assert row.selected_endpoint_id == ENDPOINT_ID
     assert row.model_id == MODEL_ID
     assert row.selected_usage_type == "Credits"
-    assert json.loads(row.settle_body or "{}") == GatewaySettleRequest(
-        **body
-    ).model_dump(exclude_none=True)
+    assert row.settle_body is None
+    assert row.terminal_at is not None
 
 
 def test_settle_emits_timing_line(
@@ -752,16 +750,16 @@ def test_lost_charge_recovery_end_to_end(
     _seed_credit(store, ws)
     key = _make_key(store, ws)
     auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
-    original = store.typed_finalize_gateway_authorization
+    original = store.typed_finalize_gateway_authorization_result
     state = {"crash": True}
 
-    def crash_once(*args: Any, **kwargs: Any) -> bool:
+    def crash_once(*args: Any, **kwargs: Any) -> Any:
         if state["crash"]:
             state["crash"] = False
             raise RuntimeError("crash after enqueue")
         return original(*args, **kwargs)
 
-    store.typed_finalize_gateway_authorization = crash_once
+    store.typed_finalize_gateway_authorization_result = crash_once
     client = _client(
         Settings(environment="test", settle_outbox_enabled=True),
         raise_server_exceptions=False,
@@ -790,7 +788,7 @@ def test_lost_charge_recovery_end_to_end(
     assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
 
 
-def test_drain_purges_only_old_done_rows_and_reports_count(
+def test_drain_leaves_terminal_rows_for_spanner_ttl(
     fake_store: tuple[Any, Any, Any],
 ) -> None:
     store, db, _bt = fake_store
@@ -823,9 +821,9 @@ def test_drain_purges_only_old_done_rows_and_reports_count(
 
     result = drain_mod.drain_settle_outbox(10)
 
-    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 2, "reaped": 0}
-    assert ob.get("gwa-old-done-a", "settle") is None
-    assert ob.get("gwa-old-done-b", "settle") is None
+    assert result == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0, "reaped": 0}
+    assert ob.get("gwa-old-done-a", "settle").status == "done"
+    assert ob.get("gwa-old-done-b", "settle").status == "done"
     assert ob.get("gwa-fresh-done", "settle").status == "done"
     assert ob.get("gwa-pending", "settle").status == "pending"
     assert ob.get("gwa-dead", "settle").status == "dead"


### PR DESCRIPTION
## Summary
- move new gateway authorization state into a typed Spanner table with nullable terminal clocks and 30-day row deletion policies
- keep Bigtable activity, benchmark, synthetic, and rollup metadata in separate bounded families while preserving legacy reads
- make settlement activity repair durable and content-free, with deterministic generation IDs and idempotent replay
- deploy every control-plane region before typed cutover and provision least-privilege Bigtable schema IAM

## Safety
- additive migration only; no DELETE, DROP, or terminal_at backfill
- existing production rows remain in place and ineligible for TTL
- runtime defaults to legacy writes until an explicit typed cutover

## Verification
- 2,028 pytest tests passed, 47 skipped
- Ruff and mypy passed
- coverage 84.63% (70% gate)
- frontend TypeScript, ESLint, and Stylelint gates passed
- migration dry-run confirms all policies/families and legacy family m is unchanged