### PR TITLE
Add low-cost production image generation canary

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -226,3 +226,38 @@ for legacy_throughput_scheduler_name in "${legacy_throughput_scheduler_names[@]}
       --quiet >/dev/null
   fi
 done
+
+# Image generation is materially more expensive than text PONG probes. Keep it
+# isolated and run one canonical end-to-end request every six hours.
+image_region="us-central1"
+image_job_name="trusted-router-image-generation-${image_region}"
+image_scheduler_name="${image_job_name}-every-six-hours"
+image_env_vars=(
+  "${BASE_ENV_VARS[@]}"
+  "TR_SYNTHETIC_MONITOR_REGION=${image_region}"
+  "TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"
+  "TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"
+  "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS=120"
+)
+image_set_env_vars="$(IFS='|'; echo "^|^${image_env_vars[*]}")"
+
+log "deploying isolated image-generation Cloud Run job ${image_job_name}"
+gc run jobs deploy "$image_job_name" \
+  --region "$image_region" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.synthetic.image_generation" \
+  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --set-env-vars "$image_set_env_vars" \
+  --update-secrets "$UPDATE_SECRETS" \
+  --max-retries 0 \
+  --task-timeout 180s \
+  --cpu 1 \
+  --memory 512Mi \
+  --quiet >/dev/null
+
+upsert_scheduler \
+  "$image_scheduler_name" \
+  "$image_job_name" \
+  "$image_region" \
+  "17 */6 * * *"

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -18,7 +18,11 @@ from trusted_router.synthetic.probes import (
     gateway_fallback_probe,
     run_synthetic_once,
 )
-from trusted_router.synthetic.route_health import evaluate_route_health, report_route_health
+from trusted_router.synthetic.route_health import (
+    evaluate_route_health,
+    report_image_generation_failures,
+    report_route_health,
+)
 from trusted_router.types import ErrorType
 
 
@@ -44,6 +48,7 @@ def register(router: APIRouter) -> None:
         # Offload the blocking storage writes so a slow write never stalls the
         # shared event loop; still awaited so `recorded` stays truthful.
         await run_in_threadpool(_record_probe_samples, samples)
+        await run_in_threadpool(report_image_generation_failures, samples)
         return {"data": {"recorded": len(samples)}}
 
     @router.post("/internal/synthetic/benchmark")

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -13,6 +13,7 @@ ROUTER_CORE_PROBES = {
 }
 PROVIDER_EFFECTIVE_PROBES = {"openai_sdk_pong", "responses_pong"}
 CONTROL_PLANE_PROBES = {"control_plane_health"}
+IMAGE_GENERATION_PROBES = {"image_generation"}
 
 SLO_PROBES: dict[str, set[str]] = {
     "router_core": ROUTER_CORE_PROBES,
@@ -77,6 +78,11 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
         "name": "Provider Fallback",
         "description": "Fail-first route selection and rollover to the next healthy provider.",
     },
+    {
+        "id": "image_generation",
+        "name": "Image Generation",
+        "description": "Public attested Gemini image generation and binary image validation.",
+    },
 )
 
 
@@ -96,6 +102,8 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("billing_settlement")
     if sample.target == "control-plane" and sample.probe_type == "provider_fallback":
         ids.append("provider_fallback")
+    if sample.target == "canonical" and sample.probe_type in IMAGE_GENERATION_PROBES:
+        ids.append("image_generation")
     return ids
 
 

--- a/src/trusted_router/synthetic/image_generation.py
+++ b/src/trusted_router/synthetic/image_generation.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import httpx
+
+from trusted_router.config import get_settings
+from trusted_router.synthetic.probes import (
+    IMAGE_GENERATION_MODEL,
+    IMAGE_GENERATION_PROVIDER,
+    SyntheticTarget,
+    image_generation_probe,
+)
+
+
+async def run() -> int:
+    settings = get_settings()
+    api_key = settings.synthetic_monitor_api_key
+    internal_token = settings.internal_gateway_token
+    if not api_key:
+        print("TR_SYNTHETIC_MONITOR_API_KEY is required", file=sys.stderr)
+        return 2
+    if not internal_token:
+        print("TR_INTERNAL_GATEWAY_TOKEN is required", file=sys.stderr)
+        return 2
+
+    monitor_region = os.environ.get("TR_SYNTHETIC_MONITOR_REGION", "us-central1")
+    model = os.environ.get("TR_SYNTHETIC_IMAGE_MODEL", IMAGE_GENERATION_MODEL)
+    provider = os.environ.get("TR_SYNTHETIC_IMAGE_PROVIDER", IMAGE_GENERATION_PROVIDER)
+    timeout_seconds = float(os.environ.get("TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS", "120"))
+    control_plane = os.environ.get(
+        "TR_SYNTHETIC_CONTROL_PLANE_URL",
+        "https://trustedrouter.com",
+    )
+    ingest_url = os.environ.get(
+        "TR_SYNTHETIC_INGEST_URL",
+        f"{control_plane.rstrip('/')}/v1/internal/synthetic/samples",
+    )
+    target = SyntheticTarget("canonical", settings.api_base_url, settings.primary_region)
+    timeout = httpx.Timeout(timeout_seconds)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        sample = await image_generation_probe(
+            client,
+            target,
+            monitor_region=monitor_region,
+            api_key=api_key,
+            model=model,
+            provider=provider,
+        )
+        response = await client.post(
+            ingest_url,
+            headers={"x-trustedrouter-internal-token": internal_token},
+            json={"samples": [sample.public_dict()]},
+        )
+
+    print(
+        json.dumps(
+            {
+                "probe_type": sample.probe_type,
+                "status": sample.status,
+                "http_status": sample.http_status,
+                "error_type": sample.error_type,
+                "model": sample.model,
+                "provider": sample.selected_provider or sample.provider,
+                "generation_id": sample.generation_id,
+                "cost_microdollars": sample.cost_microdollars,
+                "ingest_status": response.status_code,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+    return 0 if sample.status == "up" and response.status_code == 200 else 1
+
+
+def main() -> int:
+    return asyncio.run(run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import json
 import random
 import secrets
@@ -26,6 +27,16 @@ from trusted_router.storage_models import (
 from trusted_router.types import UsageType
 
 DEFAULT_SYNTHETIC_BILLING_CONCURRENCY = 2
+IMAGE_GENERATION_MODEL = "google/gemini-3.1-flash-image-preview"
+IMAGE_GENERATION_PROVIDER = "google-ai-studio"
+_IMAGE_CANARY_PROMPT = (
+    "Generate and return an actual square image now, not a textual description. "
+    "Show one solid red circle centered on a white background."
+)
+_MAX_IMAGE_DATA_URL_CHARACTERS = 32 * 1024 * 1024
+_MIN_VALID_IMAGE_BYTES = 1024
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_PNG_END = b"\x00\x00\x00\x00IEND\xaeB`\x82"
 
 
 @dataclass(frozen=True)
@@ -426,6 +437,186 @@ async def responses_pong_probe(
             model=model,
             output_match=False,
         )
+
+
+async def image_generation_probe(
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    api_key: str,
+    model: str = IMAGE_GENERATION_MODEL,
+    provider: str = IMAGE_GENERATION_PROVIDER,
+) -> SyntheticProbeSample:
+    """Generate and validate one image without retaining its content."""
+    url = _api_url(target.api_base_url, "/chat/completions")
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": _IMAGE_CANARY_PROMPT}],
+        "provider": {"only": [provider], "allow_fallbacks": False},
+        "max_tokens": 2048,
+        "metadata": {
+            "trustedrouter_synthetic": "true",
+            "probe": "image_generation",
+        },
+    }
+    started = time.perf_counter()
+    try:
+        response = await client.post(url, json=body, headers=_auth_headers(api_key))
+        latency_ms = _elapsed_ms(started)
+        payload = _json_object(response)
+        valid_image = response.status_code == 200 and _has_valid_generated_image(payload)
+        metadata = _completion_metadata(payload)
+        return _sample(
+            "image_generation",
+            target,
+            monitor_region,
+            url,
+            status="up" if valid_image else "down",
+            latency_milliseconds=latency_ms,
+            ttfb_milliseconds=latency_ms,
+            http_status=response.status_code,
+            error_type=None
+            if valid_image
+            else (
+                "invalid_image_payload"
+                if response.status_code == 200
+                else "image_generation_http_error"
+            ),
+            provider=provider,
+            model=model,
+            selected_provider=metadata["selected_provider"],
+            selected_model=metadata["selected_model"],
+            generation_id=metadata["generation_id"],
+            cost_microdollars=metadata["cost_microdollars"],
+            output_match=valid_image,
+        )
+    except httpx.HTTPError as exc:
+        return _sample(
+            "image_generation",
+            target,
+            monitor_region,
+            url,
+            status="down",
+            latency_milliseconds=_elapsed_ms(started),
+            error_type=exc.__class__.__name__,
+            provider=provider,
+            model=model,
+            output_match=False,
+        )
+
+
+def _json_object(response: httpx.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _has_valid_generated_image(payload: dict[str, Any]) -> bool:
+    return any(_valid_image_data_url(value) for value in _generated_image_data_urls(payload))
+
+
+def _generated_image_data_urls(payload: dict[str, Any]) -> list[str]:
+    urls: list[str] = []
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        message = choices[0].get("message")
+        if isinstance(message, dict):
+            urls.extend(_content_image_data_urls(message.get("content")))
+            urls.extend(_content_image_data_urls(message.get("images")))
+    urls.extend(_content_image_data_urls(payload.get("images")))
+    return urls
+
+
+def _content_image_data_urls(content: Any) -> list[str]:
+    if isinstance(content, str):
+        return [content] if content.startswith("data:image/") else []
+    if isinstance(content, dict):
+        image_url = content.get("image_url")
+        if isinstance(image_url, str):
+            return [image_url]
+        if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
+            return [str(image_url["url"])]
+        for key in ("url", "data"):
+            value = content.get(key)
+            if isinstance(value, str) and value.startswith("data:image/"):
+                return [value]
+        return []
+    if not isinstance(content, list):
+        return []
+    return [url for part in content for url in _content_image_data_urls(part)]
+
+
+def _valid_image_data_url(value: str) -> bool:
+    if len(value) > _MAX_IMAGE_DATA_URL_CHARACTERS or "," not in value:
+        return False
+    header, encoded = value.split(",", 1)
+    header_lower = header.lower()
+    if ";base64" not in header_lower:
+        return False
+    if header_lower not in {
+        "data:image/jpeg;base64",
+        "data:image/jpg;base64",
+        "data:image/png;base64",
+    }:
+        return False
+    try:
+        image = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    if len(image) < _MIN_VALID_IMAGE_BYTES:
+        return False
+    if header_lower in {"data:image/jpeg;base64", "data:image/jpg;base64"}:
+        return image.startswith(b"\xff\xd8\xff") and image.endswith(b"\xff\xd9")
+    return image.startswith(_PNG_SIGNATURE) and image.endswith(_PNG_END)
+
+
+def _completion_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    trustedrouter = payload.get("trustedrouter")
+    if not isinstance(trustedrouter, dict):
+        trustedrouter = {}
+    routing = trustedrouter.get("routing")
+    if not isinstance(routing, dict):
+        routing = {}
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+    provider_usage = usage.get("provider_usage")
+    if not isinstance(provider_usage, dict):
+        provider_usage = {}
+    raw_cost = usage.get("total_cost_microdollars") or usage.get("cost_microdollars")
+    if raw_cost is None:
+        raw_cost = provider_usage.get("total_cost_microdollars") or provider_usage.get(
+            "cost_microdollars"
+        )
+    try:
+        cost_microdollars = int(raw_cost or 0)
+    except (TypeError, ValueError):
+        cost_microdollars = 0
+    return {
+        "selected_provider": _optional_metadata_string(
+            routing.get("selected_provider")
+            or provider_usage.get("selected_provider")
+            or payload.get("provider")
+        ),
+        "selected_model": _optional_metadata_string(
+            routing.get("selected_model")
+            or provider_usage.get("selected_model")
+            or payload.get("model")
+        ),
+        "generation_id": _optional_metadata_string(
+            provider_usage.get("generation_id")
+            or trustedrouter.get("generation_id")
+            or payload.get("id")
+        ),
+        "cost_microdollars": cost_microdollars,
+    }
+
+
+def _optional_metadata_string(value: Any) -> str | None:
+    return str(value) if value not in (None, "") else None
 
 
 async def gateway_billing_probe(

--- a/src/trusted_router/synthetic/route_health.py
+++ b/src/trusted_router/synthetic/route_health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 from dataclasses import dataclass
 
+from trusted_router.storage_models import SyntheticProbeSample
 from trusted_router.store_protocol import Store
 from trusted_router.synthetic.probes import rotation_candidates
 
@@ -140,6 +141,36 @@ def report_route_health(flags: list[RouteHealthFlag]) -> None:
             scope.set_tag("route_provider", flag.provider)
             scope.set_tag("route_model", flag.model)
             scope.set_tag("failure_rate", f"{flag.failure_rate:.4f}")
+            sentry_sdk.capture_message(message, level="error")
+
+
+def report_image_generation_failures(samples: list[SyntheticProbeSample]) -> None:
+    """Report image-route failures without carrying generated content."""
+    failures = [
+        sample
+        for sample in samples
+        if sample.probe_type == "image_generation" and sample.status != "up"
+    ]
+    if not failures:
+        return
+    try:
+        import sentry_sdk
+    except ImportError:
+        return
+
+    for sample in failures:
+        provider = sample.selected_provider or sample.provider or "unknown"
+        model = sample.selected_model or sample.model or "unknown"
+        error_type = sample.error_type or "unknown"
+        message = (
+            f"image-generation-canary: {provider}/{model} failed "
+            f"({error_type}, HTTP {sample.http_status or 'none'})"
+        )
+        with sentry_sdk.push_scope() as scope:
+            scope.fingerprint = ["image-generation-canary", provider, model]
+            scope.set_tag("route_provider", provider)
+            scope.set_tag("route_model", model)
+            scope.set_tag("probe_error_type", error_type)
             sentry_sdk.capture_message(message, level="error")
 
 

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -18,6 +18,7 @@ from trusted_router.synthetic.components import (
 from trusted_router.synthetic.rollups import merge_rollups, new_rollup_for_sample
 
 CURRENT_SAMPLE_TTL_SECONDS = 5 * 60
+IMAGE_GENERATION_SAMPLE_TTL_SECONDS = 7 * 60 * 60
 STATUS_HISTORY_HOURS = 48
 # Uptime thresholds for per-bucket coloring. Single-sample blips
 # shouldn't paint a whole hour red; tune the cutoffs to roughly match
@@ -797,8 +798,16 @@ def _latest_recent_component_samples(
         key = (sample.monitor_region, sample.target, sample.probe_type)
         if key not in latest:
             latest[key] = sample
-    cutoff = now - dt.timedelta(seconds=CURRENT_SAMPLE_TTL_SECONDS)
-    return [sample for sample in latest.values() if _parse_time(sample.created_at) >= cutoff]
+    return [
+        sample
+        for sample in latest.values()
+        if (now - _parse_time(sample.created_at)).total_seconds()
+        <= (
+            IMAGE_GENERATION_SAMPLE_TTL_SECONDS
+            if sample.probe_type == "image_generation"
+            else CURRENT_SAMPLE_TTL_SECONDS
+        )
+    ]
 
 
 def _component_history(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -46,6 +46,8 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 )
 from trusted_router.storage_models import ProviderBenchmarkSample, iso_now, utcnow
 from trusted_router.synthetic.probes import (
+    IMAGE_GENERATION_MODEL,
+    IMAGE_GENERATION_PROVIDER,
     SyntheticTarget,
     _rotation_max_tokens,
     _rotation_omits_temperature,
@@ -54,6 +56,7 @@ from trusted_router.synthetic.probes import (
     _sse_line_has_content,
     attestation_nonce_probe,
     choose_rotation_target,
+    image_generation_probe,
     openai_chat_pong_probe,
     provider_rotation_probe,
     responses_pong_probe,
@@ -69,6 +72,7 @@ from trusted_router.synthetic.rollups import (
 from trusted_router.synthetic.route_health import (
     RouteHealthFlag,
     evaluate_route_health,
+    report_image_generation_failures,
     report_route_health,
 )
 from trusted_router.synthetic.status import history_payload, status_snapshot
@@ -883,6 +887,60 @@ def test_status_components_group_regions_and_control_plane() -> None:
     assert snapshot["overall_status"] == "routing_degraded"
 
 
+def test_status_tracks_image_generation_without_changing_slo_classes() -> None:
+    now = utcnow()
+    image_sample = _sample(
+        id="syn_image",
+        target="canonical",
+        target_region="us-central1",
+        monitor_region="us-central1",
+        probe_type="image_generation",
+        status="up",
+        created_at=(now - dt.timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+        model=IMAGE_GENERATION_MODEL,
+        provider=IMAGE_GENERATION_PROVIDER,
+        latency_milliseconds=12_000,
+    )
+
+    snapshot = status_snapshot([image_sample], now=now)
+    components = {component["id"]: component for component in snapshot["components"]}
+
+    assert components["image_generation"]["status"] == "up"
+    assert components["image_generation"]["sample_count_24h"] == 1
+    assert all(
+        slo["windows"]["24h"]["sample_count"] == 0
+        for slo in snapshot["slo_classes"].values()
+    )
+
+
+def test_image_generation_component_stays_current_between_six_hour_checks() -> None:
+    now = utcnow()
+    image_sample = _sample(
+        id="syn_image_between_checks",
+        target="canonical",
+        probe_type="image_generation",
+        status="up",
+        created_at=(now - dt.timedelta(hours=6, minutes=30))
+        .isoformat()
+        .replace("+00:00", "Z"),
+    )
+
+    snapshot = status_snapshot([image_sample], now=now)
+    component = next(
+        row for row in snapshot["components"] if row["id"] == "image_generation"
+    )
+
+    assert component["status"] == "up"
+    stale_snapshot = status_snapshot(
+        [image_sample],
+        now=now + dt.timedelta(minutes=31),
+    )
+    stale_component = next(
+        row for row in stale_snapshot["components"] if row["id"] == "image_generation"
+    )
+    assert stale_component["status"] == "unknown"
+
+
 def test_status_component_current_uses_latest_sample_per_probe() -> None:
     now = utcnow()
     samples = [
@@ -1109,6 +1167,136 @@ async def test_synthetic_http_probes_parse_success_shapes() -> None:
     assert chat.output_match is True
     assert responses.status == "up"
     assert responses.output_match is True
+
+
+@pytest.mark.asyncio
+async def test_image_generation_probe_validates_binary_and_records_only_metadata() -> None:
+    image = b"\xff\xd8\xff" + (b"\x00" * 2048) + b"\xff\xd9"
+    data_url = f"data:image/jpeg;base64,{base64.b64encode(image).decode()}"
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-image",
+                "model": IMAGE_GENERATION_MODEL,
+                "choices": [{"message": {"content": data_url}}],
+                "trustedrouter": {
+                    "routing": {
+                        "selected_provider": IMAGE_GENERATION_PROVIDER,
+                        "selected_model": IMAGE_GENERATION_MODEL,
+                    }
+                },
+                "usage": {
+                    "cost_microdollars": 88_207,
+                    "provider_usage": {"generation_id": "gen-image"},
+                },
+            },
+        )
+
+    target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await image_generation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+        )
+
+    assert sample.status == "up"
+    assert sample.output_match is True
+    assert sample.selected_provider == IMAGE_GENERATION_PROVIDER
+    assert sample.selected_model == IMAGE_GENERATION_MODEL
+    assert sample.generation_id == "gen-image"
+    assert sample.cost_microdollars == 88_207
+    assert requests == [
+        {
+            "model": IMAGE_GENERATION_MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Generate and return an actual square image now, not a textual "
+                        "description. Show one solid red circle centered on a white "
+                        "background."
+                    ),
+                }
+            ],
+            "provider": {
+                "only": [IMAGE_GENERATION_PROVIDER],
+                "allow_fallbacks": False,
+            },
+            "max_tokens": 2048,
+            "metadata": {
+                "trustedrouter_synthetic": "true",
+                "probe": "image_generation",
+            },
+        }
+    ]
+    public = json.dumps(sample.public_dict())
+    assert "solid red circle" not in public
+    assert data_url not in public
+    assert "base64" not in public
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected_error"),
+    [
+        ("plain text instead of an image", "invalid_image_payload"),
+        ("data:image/jpeg;base64,not-base64!", "invalid_image_payload"),
+        (
+            "data:image/jpeg;base64,"
+            + base64.b64encode(b"\xff\xd8\xff" + b"\x00" * 2048).decode(),
+            "invalid_image_payload",
+        ),
+    ],
+)
+async def test_image_generation_probe_rejects_missing_or_invalid_images(
+    content: str,
+    expected_error: str,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": content}}]},
+        )
+
+    target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await image_generation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+        )
+
+    assert sample.status == "down"
+    assert sample.output_match is False
+    assert sample.error_type == expected_error
+
+
+@pytest.mark.asyncio
+async def test_image_generation_probe_does_not_copy_provider_error_body() -> None:
+    provider_error_marker = "provider response body must not be retained"
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, json={"error": {"message": provider_error_marker}})
+
+    target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await image_generation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+        )
+
+    assert sample.status == "down"
+    assert sample.error_type == "image_generation_http_error"
+    assert provider_error_marker not in json.dumps(sample.public_dict())
 
 
 @pytest.mark.asyncio
@@ -1471,9 +1659,12 @@ def _sample(
     target_region: str | None = "us-central1",
     monitor_region: str = "us-central1",
     model: str | None = None,
+    provider: str | None = None,
     output_match: bool | None = None,
     created_at: str | None = None,
     latency_milliseconds: int | None = None,
+    error_type: str | None = None,
+    http_status: int | None = None,
 ) -> SyntheticProbeSample:
     return SyntheticProbeSample(
         id=id,
@@ -1484,8 +1675,11 @@ def _sample(
         target_region=target_region,
         status=status,
         model=model,
+        provider=provider,
         output_match=output_match,
         latency_milliseconds=latency_milliseconds,
+        error_type=error_type,
+        http_status=http_status,
         created_at=created_at or iso_now(),
     )
 
@@ -1960,6 +2154,76 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"TR_SYNTHETIC_START_DELAY_SECONDS=45"' in body
     assert '"${throughput_job_name}-every-minute"' in body
     assert '"${throughput_job_name}-every-two-minutes"' in body
+    assert 'image_job_name="trusted-router-image-generation-${image_region}"' in body
+    assert '"TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"' in body
+    assert '"TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"' in body
+    assert '--args="-m,trusted_router.synthetic.image_generation"' in body
+    assert '"17 */6 * * *"' in body
+
+
+@pytest.mark.asyncio
+async def test_image_generation_job_runs_one_probe_and_ingests_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from trusted_router.synthetic import image_generation as image_job
+
+    image = b"\xff\xd8\xff" + (b"\x00" * 2048) + b"\xff\xd9"
+    data_url = f"data:image/jpeg;base64,{base64.b64encode(image).decode()}"
+    seen_paths: list[str] = []
+    ingested: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-image",
+                    "model": IMAGE_GENERATION_MODEL,
+                    "choices": [{"message": {"content": data_url}}],
+                    "trustedrouter": {
+                        "routing": {"selected_provider": IMAGE_GENERATION_PROVIDER}
+                    },
+                    "usage": {"provider_usage": {"generation_id": "gen-image-job"}},
+                },
+            )
+        if request.url.path == "/v1/internal/synthetic/samples":
+            ingested.append(json.loads(request.content))
+            return httpx.Response(200, json={"data": {"recorded": 1}})
+        return httpx.Response(404)
+
+    settings = Settings(
+        environment="test",
+        api_base_url="https://api.trustedrouter.com/v1",
+        internal_gateway_token="internal-test",  # noqa: S106 - test placeholder.
+        synthetic_monitor_api_key="sk-tr-test",
+    )
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs: Any) -> httpx.AsyncClient:
+        return real_async_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(image_job, "get_settings", lambda: settings)
+    monkeypatch.setattr(image_job.httpx, "AsyncClient", client_factory)
+    monkeypatch.setenv(
+        "TR_SYNTHETIC_INGEST_URL",
+        "https://trustedrouter.com/v1/internal/synthetic/samples",
+    )
+
+    result = await image_job.run()
+
+    assert result == 0
+    assert seen_paths == ["/v1/chat/completions", "/v1/internal/synthetic/samples"]
+    assert len(ingested) == 1
+    sample = ingested[0]["samples"][0]
+    assert sample["probe_type"] == "image_generation"
+    assert sample["status"] == "up"
+    assert data_url not in json.dumps(ingested)
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "up"
+    assert output["generation_id"] == "gen-image-job"
 
 
 class _FakeCell:
@@ -2829,6 +3093,80 @@ def test_report_route_health_uses_one_sentry_fingerprint_per_route(
         "route_model": "model-a",
         "failure_rate": "1.0000",
     }
+
+
+def test_image_generation_failure_alert_is_fingerprinted_and_metadata_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sentry_sdk
+
+    class CapturedScope:
+        def __init__(self) -> None:
+            self.fingerprint: list[str] = []
+            self.tags: dict[str, str] = {}
+
+        def set_tag(self, key: str, value: str) -> None:
+            self.tags[key] = value
+
+    class ScopeManager:
+        def __init__(self, scope: CapturedScope) -> None:
+            self.scope = scope
+
+        def __enter__(self) -> CapturedScope:
+            return self.scope
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+    scopes: list[CapturedScope] = []
+    captured: list[tuple[str, str]] = []
+
+    def push_scope() -> ScopeManager:
+        scope = CapturedScope()
+        scopes.append(scope)
+        return ScopeManager(scope)
+
+    def capture_message(message: str, *, level: str) -> None:
+        captured.append((message, level))
+
+    monkeypatch.setattr(sentry_sdk, "push_scope", push_scope)
+    monkeypatch.setattr(sentry_sdk, "capture_message", capture_message)
+    failed = _sample(
+        id="syn_image_failed",
+        probe_type="image_generation",
+        status="down",
+        provider=IMAGE_GENERATION_PROVIDER,
+        model=IMAGE_GENERATION_MODEL,
+        error_type="invalid_image_payload",
+        http_status=200,
+    )
+    healthy = _sample(
+        id="syn_image_healthy",
+        probe_type="image_generation",
+        status="up",
+        provider=IMAGE_GENERATION_PROVIDER,
+        model=IMAGE_GENERATION_MODEL,
+    )
+
+    report_image_generation_failures([healthy, failed])
+
+    assert captured == [
+        (
+            (
+                "image-generation-canary: google-ai-studio/"
+                "google/gemini-3.1-flash-image-preview failed "
+                "(invalid_image_payload, HTTP 200)"
+            ),
+            "error",
+        )
+    ]
+    assert scopes[0].fingerprint == [
+        "image-generation-canary",
+        IMAGE_GENERATION_PROVIDER,
+        IMAGE_GENERATION_MODEL,
+    ]
+    assert "prompt" not in json.dumps(scopes[0].tags).lower()
+    assert "output" not in json.dumps(scopes[0].tags).lower()
 
 
 def test_internal_route_health_reports_flags_and_requires_token(


### PR DESCRIPTION
## Summary
- probe the canonical attested image-generation path every six hours using `google/gemini-3.1-flash-image-preview` pinned to Google AI Studio
- validate decoded JPEG/PNG signatures while retaining only metadata
- expose a separate Image Generation status component and fingerprint failures in Sentry
- isolate the paid probe from five-minute health and throughput jobs

## Cost
The verified production request cost $0.091616. Four checks per day project to about $11/month.

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2038 passed, 47 skipped)
- `bash -n scripts/deploy/synthetic.sh`
- canonical production smoke: HTTP 200, valid generated JPEG, provider `google-ai-studio`, cost 91,616 microdollars
