### PR TITLE
Fail closed when preserving request record mode

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -83,13 +83,22 @@ if [ -z "$REQUEST_RECORD_WRITE_MODE" ]; then
   REQUEST_RECORD_WRITE_MODE="$(
     gc run services describe "$SERVICE" \
       --region="$TR_PRIMARY_REGION" \
-      --format="value(spec.template.spec.containers[0].env[?name='TR_REQUEST_RECORD_WRITE_MODE'].value)" \
-      2>/dev/null || true
+      --format=json 2>/dev/null \
+      | jq -r '
+          [
+            .spec.template.spec.containers[0].env[]?
+            | select(.name == "TR_REQUEST_RECORD_WRITE_MODE")
+            | .value
+          ][0] // empty
+        ' || true
   )"
 fi
 case "$REQUEST_RECORD_WRITE_MODE" in
   legacy|typed) ;;
-  *) REQUEST_RECORD_WRITE_MODE="legacy" ;;
+  *)
+    log "refusing rollout: cannot determine TR_REQUEST_RECORD_WRITE_MODE; set it explicitly"
+    exit 1
+    ;;
 esac
 
 ENV_VARS=(

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -15,6 +15,16 @@ def test_deploy_pins_ten_cent_signup_credit_policy() -> None:
     assert '"TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=100000"' in rollout
 
 
+def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+
+    assert '--format=json 2>/dev/null' in rollout
+    assert 'select(.name == "TR_REQUEST_RECORD_WRITE_MODE")' in rollout
+    assert 'cannot determine TR_REQUEST_RECORD_WRITE_MODE' in rollout
+    assert '*) REQUEST_RECORD_WRITE_MODE="legacy"' not in rollout
+    assert "[?name='TR_REQUEST_RECORD_WRITE_MODE']" not in rollout
+
+
 def test_deploy_provider_secrets_include_priced_glm52_backends() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()


### PR DESCRIPTION
## Summary
- parse the live Cloud Run request-record mode from JSON instead of an invalid gcloud projection
- fail the rollout when the mode cannot be determined instead of silently reverting to legacy writes
- add a regression test for the deploy guard

## Production incident
The hourly price-refresh rollout read an empty mode and fell back to legacy, re-enabling growth in tr_entities. Typed mode has been restored directly in all four regions.

## Verification
- uv run pytest -q tests/test_deploy_secret_wiring.py
- uv run ruff check tests/test_deploy_secret_wiring.py
- bash -n scripts/deploy/rollout.sh