### PR TITLE
Shard window-limited API key usage

### DIFF
--- a/docs/design/key-usage-row-sharding.md
+++ b/docs/design/key-usage-row-sharding.md
@@ -1,4 +1,4 @@
-# Uncapped API-key usage-row sharding
+# API-key usage-row sharding
 
 Date: 2026-07-11
 
@@ -12,22 +12,20 @@ fake Spanner retry budget on the one API-key row.
 
 The table and reservation schema already support `(key_hash, shard)` and
 `key_shard`. We use those fields to spread usage writes for high-throughput,
-fully uncapped keys.
+keys without an exact lifetime cap.
 
 ## Scope and hard safety boundary
 
-`ApiKey.usage_shard_count` defaults to 1. A value above 1 is valid only when all
-of these are unset:
+`ApiKey.usage_shard_count` defaults to 1. A value above 1 is invalid when an
+exact lifetime spend limit is configured. That cap reserves headroom inside the
+same transaction and therefore remains byte-identical on shard zero.
 
-- lifetime spend limit
-- daily spend limit
-- weekly spend limit
-- monthly spend limit
-
-Capped keys remain byte-identical on shard zero. Code, management routes, the
-mirror, and the operator all fail closed if a sharded key acquires a limit.
-This deliberately avoids claiming that an unimplemented partitioned key budget
-is exact.
+Daily, weekly, and monthly limits are already approximate, lock-free snapshot
+checks. For sharded keys, the check reads the configured shard set and sums the
+current window usage before applying the same approximate decision. A missing
+configured shard fails closed. Settle records usage on the reservation's
+randomly selected shard. This removes the hot row without claiming an exact
+partitioned lifetime budget.
 
 ## Request lifecycle
 
@@ -35,8 +33,8 @@ is exact.
    typed authorize path. There is no extra hot-path database read.
 2. TrustedRouter randomizes all key usage shards outside the Spanner retry
    callback.
-3. An uncapped row returns `KEY_NO_HOLD`; authorize records the selected
-   `key_shard` on `tr_reservation`.
+3. A row without a lifetime cap returns `KEY_NO_HOLD`; authorize records the
+   selected `key_shard` on `tr_reservation`.
 4. Settle/refund books against exactly that recorded row.
 5. Idempotent replay returns the originally committed key shard.
 
@@ -56,8 +54,9 @@ python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 Prepare pauses the workspace, refuses open typed or legacy requests, atomically
 partitions each ledger, verifies it, runs the invariant audit, and leaves the
 workspace paused. Finish re-verifies credit and key row sets before unpausing.
-Capped keys stay at one row. Reverse with `--shards 1` before any typed-to-JSON
-rollback or shard-zero repair; those older tools now refuse sharded state.
+Keys with an exact lifetime cap stay at one row. Reverse with `--shards 1`
+before any typed-to-JSON rollback or shard-zero repair; those older tools now
+refuse sharded state.
 
 Lifetime usage, BYOK usage, and current daily/weekly/monthly usage are preserved
 as exact global sums. Stale window epochs are discarded because they already

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -1,4 +1,4 @@
-"""Safely split or consolidate a workspace's credit and uncapped key rows.
+"""Safely split or consolidate workspace credit and key-usage rows.
 
 The operation is intentionally two phase so a failed verification can never
 silently resume billing:
@@ -12,8 +12,10 @@ silently resume billing:
   # Verify the committed shape + global billing invariants, then unpause.
   python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 
-Eligible uncapped API-key usage rows are split to the same count; capped keys
-remain on one exact row. Reverse with the same commands and ``--shards 1``.
+Eligible API-key usage rows are split to the same count; keys with an exact
+lifetime cap remain on one row. Approximate daily/weekly/monthly windows sum
+usage across the configured rows. Reverse with the same commands and
+``--shards 1``.
 Without ``--apply`` every command is read-only. A failed prepare/finish always
 leaves the workspace paused.
 """
@@ -100,16 +102,7 @@ def _print_key_status(status: KeyUsageReshardResult) -> None:
 
 
 def _key_target(key: ApiKey, requested_shards: int) -> int:
-    has_limit = any(
-        value is not None
-        for value in (
-            key.limit_microdollars,
-            key.limit_daily_microdollars,
-            key.limit_weekly_microdollars,
-            key.limit_monthly_microdollars,
-        )
-    )
-    return 1 if has_limit else requested_shards
+    return 1 if key.limit_microdollars is not None else requested_shards
 
 
 def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
@@ -117,7 +110,9 @@ def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
     for key in store.api_keys.list_for_workspace(workspace_id):
         target = _key_target(key, requested_shards)
         if target != requested_shards:
-            print(f"  key {key.hash}: capped; keeping exact usage_shards=1")
+            print(
+                f"  key {key.hash}: exact lifetime cap; keeping usage_shards=1"
+            )
         status = reshard_key_usage(store, key.hash, target, apply=True)
         _print_key_status(status)
         clean = clean and status.ready

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1344,6 +1344,7 @@ class SpannerBigtableStore:
                 key_hash=key_hash,
                 estimate=estimate,
                 window_limits=window_limits,
+                shard_count=key_counter_shards,
                 idempotency_scope=scope,
                 idempotency_fingerprint=idempotency_fingerprint,
             )

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -76,6 +76,7 @@ def check_key_window_limits(
     key_hash: str,
     estimate: int,
     window_limits: dict[str, int],
+    shard_count: int = 1,
     idempotency_scope: str | None = None,
     idempotency_fingerprint: str | None = None,
 ) -> str | None:
@@ -92,11 +93,15 @@ def check_key_window_limits(
     must REPLAY, never 429 — so an existing same-fingerprint reservation makes
     this check a pass-through (the in-txn idempotency read stays the final
     authority). A missing typed row also passes through: reserve_key's in-txn
-    classification fail-closes it as KEY_MISSING.
+    classification fail-closes it as KEY_MISSING. When the configured set has
+    multiple rows, usage is summed over every row and an incomplete set fails
+    closed.
 
     The CALLER must omit windows that don't apply (e.g. a BYOK request on a key
     that excludes BYOK from its caps).
     """
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
     pt = param_types
     with database.snapshot(multi_use=True) as snapshot:
         if idempotency_scope is not None:
@@ -106,24 +111,38 @@ def check_key_window_limits(
                 and existing["idempotency_fingerprint"] == idempotency_fingerprint
             ):
                 return None  # replayable — let the transaction replay it
-        rows = list(snapshot.execute_sql(
-            "SELECT day_usage, day_start, week_usage, week_start, "
-            "month_usage, month_start FROM tr_key_limit "
-            "WHERE key_hash=@kh AND shard=0",
-            params={"kh": key_hash},
-            param_types={"kh": pt.STRING},
-        ))
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT shard, day_usage, day_start, week_usage, week_start, "
+                "month_usage, month_start FROM tr_key_limit "
+                "WHERE key_hash=@kh AND shard>=0 AND shard<@shard_count "
+                "ORDER BY shard",
+                params={"kh": key_hash, "shard_count": shard_count},
+                param_types={"kh": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
     if not rows:
         return None  # no typed row -> reserve_key fail-closes as KEY_MISSING
+    if [int(row[0]) for row in rows] != list(range(shard_count)):
+        raise RuntimeError("configured tr_key_limit usage shard set is incomplete")
     floors = window_floors(utcnow())
-    day_u, day_s, week_u, week_s, month_u, month_s = rows[0]
     # Pre-DDL rows read NULL usage; a NULL/stale start means the window rolled
     # over (or never started) = zero spend this window.
     current = {
-        "daily": int(day_u or 0) if day_s is not None and day_s >= floors["daily"] else 0,
-        "weekly": int(week_u or 0) if week_s is not None and week_s >= floors["weekly"] else 0,
-        "monthly": (
-            int(month_u or 0) if month_s is not None and month_s >= floors["monthly"] else 0
+        "daily": sum(
+            int(row[1] or 0)
+            for row in rows
+            if row[2] is not None and row[2] >= floors["daily"]
+        ),
+        "weekly": sum(
+            int(row[3] or 0)
+            for row in rows
+            if row[4] is not None and row[4] >= floors["weekly"]
+        ),
+        "monthly": sum(
+            int(row[5] or 0)
+            for row in rows
+            if row[6] is not None and row[6] >= floors["monthly"]
         ),
     }
     for window in ("daily", "weekly", "monthly"):

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -73,10 +73,10 @@ def credit_shard_count(value: Any) -> int:
 def key_usage_shard_count(value: Any) -> int:
     """Return and validate an API key's usage-counter shard count.
 
-    Only fully uncapped keys may fan usage writes across rows. Partitioning
-    spend limits needs separate sub-budget/rebalance semantics; accepting such
-    a mixed configuration here could weaken a hard user budget, so it fails
-    closed instead.
+    An exact lifetime spend limit must remain on one row because authorize
+    reserves against that row atomically. Daily/weekly/monthly limits are
+    intentionally approximate snapshot checks; their usage can be summed over
+    shards without changing that contract.
     """
     raw = _field(value, "usage_shard_count", 1)
     if isinstance(raw, bool):
@@ -88,16 +88,10 @@ def key_usage_shard_count(value: Any) -> int:
         raise ValueError(
             f"key usage_shard_count must not exceed {MAX_KEY_USAGE_SHARDS}"
         )
-    if count > 1 and any(
-        _field(value, field_name, None) is not None
-        for field_name in (
-            "limit_microdollars",
-            "limit_daily_microdollars",
-            "limit_weekly_microdollars",
-            "limit_monthly_microdollars",
+    if count > 1 and _field(value, "limit_microdollars", None) is not None:
+        raise ValueError(
+            "API keys with an exact lifetime limit must use one usage shard"
         )
-    ):
-        raise ValueError("only uncapped API keys may use sharded usage counters")
     return count
 
 

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -55,15 +55,6 @@ class KeyUsageReshardResult:
         return not self.reasons
 
 
-def _limits(key: ApiKey) -> tuple[int | None, int | None, int | None, int | None]:
-    return (
-        key.limit_microdollars,
-        key.limit_daily_microdollars,
-        key.limit_weekly_microdollars,
-        key.limit_monthly_microdollars,
-    )
-
-
 def _typed_key_state(
     store: Any,
     key_hash: str,
@@ -115,8 +106,10 @@ def inspect_key_usage_reshard(
         result.reasons.append("workspace not found")
     elif not workspace.billing_paused:
         result.reasons.append("workspace not billing-paused")
-    if target_count > 1 and any(limit is not None for limit in _limits(key)):
-        result.reasons.append("capped API key must remain on one usage shard")
+    if target_count > 1 and key.limit_microdollars is not None:
+        result.reasons.append(
+            "API key with an exact lifetime limit must remain on one usage shard"
+        )
 
     try:
         current_count = key_usage_shard_count(key)
@@ -183,7 +176,7 @@ def reshard_key_usage(
         )
         if workspace is None or not workspace.billing_paused:
             return None
-        if target_count > 1 and any(limit is not None for limit in _limits(key)):
+        if target_count > 1 and key.limit_microdollars is not None:
             return None
         current_count = key_usage_shard_count(key)
         rows = list(
@@ -242,14 +235,14 @@ def reshard_key_usage(
                 (
                     key_hash,
                     shard,
-                    None,
+                    key.limit_microdollars,
                     usage_parts[shard],
                     byok_parts[shard],
                     0,
                     key.include_byok_in_limit,
-                    None,
-                    None,
-                    None,
+                    key.limit_daily_microdollars,
+                    key.limit_weekly_microdollars,
+                    key.limit_monthly_microdollars,
                     day_parts[shard],
                     floors["daily"],
                     week_parts[shard],

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -153,17 +153,12 @@ class SpannerApiKeys:
         if key is None:
             return None
         if key.usage_shard_count > 1:
-            requested_limits = [
-                patch.get("limit_microdollars"),
-                patch.get("limit_daily_microdollars"),
-                patch.get("limit_weekly_microdollars"),
-                patch.get("limit_monthly_microdollars"),
-            ]
-            if patch.get("limit") is not None or any(
-                value is not None for value in requested_limits
-            ):
+            if patch.get("limit") is not None or patch.get(
+                "limit_microdollars"
+            ) is not None:
                 raise ValueError(
-                    "consolidate API-key usage to one shard before adding a spend limit"
+                    "consolidate API-key usage to one shard before adding "
+                    "an exact lifetime spend limit"
                 )
         if "name" in patch and patch["name"]:
             key.name = str(patch["name"])

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -127,9 +127,9 @@ class ApiKey:
     created_at: str = field(default_factory=iso_now)
     updated_at: str | None = None
     reserved_microdollars: int = 0
-    # Independent usage-counter rows for a high-throughput UNCAPPED key. Keys
-    # with any lifetime/window spend limit must remain at one shard so their
-    # hard cap keeps its existing exact semantics.
+    # Independent usage-counter rows for a high-throughput key. Keys with an
+    # exact lifetime spend limit remain at one shard. Fixed-window limits are
+    # approximate snapshot checks and may sum usage across shards.
     usage_shard_count: int = 1
     tags: dict[str, str] = field(default_factory=dict)
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1070,6 +1070,29 @@ def _execute_sql(
         return [[rec.get(c) for c in cols]]
     # Typed key-limit point-read (reserve_key 0-row classification). Honors the
     # WHERE, so it must precede the full-scan branch below.
+    compact_sql = sql.replace(" ", "")
+    if (
+        "FROM tr_key_limit WHERE key_hash=@kh" in sql
+        and "shard<@shard_count" in compact_sql
+    ):
+        items = [
+            (pk, rec)
+            for pk, rec in db.typed.get("tr_key_limit", {}).items()
+            if rec.get("key_hash") == params["kh"]
+            and 0 <= int(rec.get("shard", 0)) < int(params["shard_count"])
+        ]
+        items.sort(key=lambda item: int(item[1].get("shard", 0)))
+        recs = [
+            txn._typed_current("tr_key_limit", pk)
+            if txn is not None
+            else dict(rec)
+            for pk, rec in items
+        ]
+        cols = [
+            c.strip()
+            for c in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[rec.get(c) for c in cols] for rec in recs if rec is not None]
     if "FROM tr_key_limit WHERE key_hash=@kh" in sql:
         # `shard` may be a literal 0 in the SQL (window/typed-usage point reads)
         # rather than a bound param (reserve_key classification).

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -11,6 +11,7 @@ from trusted_router.storage_gcp_authorize import (
     AuthorizeOutcome,
     SettleOutcome,
     authorize_atomic,
+    check_key_window_limits,
     settle_atomic,
 )
 from trusted_router.storage_gcp_counter_reconcile import (
@@ -97,21 +98,23 @@ def _auth_body(authorization_id: str, reservation_id: str) -> str:
     )
 
 
-def test_key_usage_shards_default_and_fail_closed_for_capped_keys() -> None:
+def test_key_usage_shards_default_and_fail_closed_for_lifetime_caps() -> None:
     assert key_usage_shard_count({}) == 1
     assert key_usage_shard_count({"usage_shard_count": 16}) == 16
     with pytest.raises(ValueError, match="positive integer"):
         key_usage_shard_count({"usage_shard_count": 0})
     with pytest.raises(ValueError, match="must not exceed"):
         key_usage_shard_count({"usage_shard_count": 65})
-    with pytest.raises(ValueError, match="only uncapped"):
+    with pytest.raises(ValueError, match="exact lifetime limit"):
         key_usage_shard_count(
             {"usage_shard_count": 2, "limit_microdollars": 1_000_000}
         )
-    with pytest.raises(ValueError, match="only uncapped"):
+    assert (
         key_usage_shard_count(
             {"usage_shard_count": 2, "limit_daily_microdollars": 1_000_000}
         )
+        == 2
+    )
 
 
 def test_sharded_key_metadata_update_does_not_clobber_typed_counters() -> None:
@@ -255,8 +258,119 @@ def test_adding_a_limit_to_sharded_key_is_rejected_atomically() -> None:
     assert persisted.usage_shard_count == 4
 
 
+def test_adding_window_limits_to_sharded_key_preserves_usage_rows() -> None:
+    store, database, key = _seed(key_shards=4)
+    rows = database.typed[KEY_LIMIT_TABLE]
+    rows[(key.hash, 2)]["usage"] = 123
+    rows[(key.hash, 2)]["day_usage"] = 45
+    rows[(key.hash, 2)]["day_start"] = window_floors(utcnow())["daily"]
+
+    updated = store.api_keys.update(
+        key.hash,
+        {
+            "limit_daily_microdollars": 1_000_000,
+            "limit_weekly_microdollars": 4_000_000,
+        },
+    )
+
+    assert updated is not None
+    assert updated.usage_shard_count == 4
+    for shard in range(4):
+        assert rows[(key.hash, shard)]["day_limit_micro"] == 1_000_000
+        assert rows[(key.hash, shard)]["week_limit_micro"] == 4_000_000
+    assert rows[(key.hash, 2)]["usage"] == 123
+    assert rows[(key.hash, 2)]["day_usage"] == 45
+
+
+def test_window_limit_check_sums_all_usage_shards_and_fails_closed() -> None:
+    store, database, key = _seed(key_shards=4)
+    floors = window_floors(utcnow())
+    rows = database.typed[KEY_LIMIT_TABLE]
+    for shard, usage in enumerate((200, 250, 300, 150)):
+        rows[(key.hash, shard)]["day_usage"] = usage
+        rows[(key.hash, shard)]["day_start"] = floors["daily"]
+
+    assert (
+        check_key_window_limits(
+            store._database,
+            store._param_types,
+            key_hash=key.hash,
+            estimate=101,
+            window_limits={"daily": 1_000},
+            shard_count=4,
+        )
+        == "daily"
+    )
+    assert (
+        check_key_window_limits(
+            store._database,
+            store._param_types,
+            key_hash=key.hash,
+            estimate=100,
+            window_limits={"daily": 1_000},
+            shard_count=4,
+        )
+        is None
+    )
+
+    rows.pop((key.hash, 3))
+    with pytest.raises(RuntimeError, match="usage shard set is incomplete"):
+        check_key_window_limits(
+            store._database,
+            store._param_types,
+            key_hash=key.hash,
+            estimate=1,
+            window_limits={"daily": 1_000},
+            shard_count=4,
+        )
+    with pytest.raises(ValueError, match="shard_count must be positive"):
+        check_key_window_limits(
+            store._database,
+            store._param_types,
+            key_hash=key.hash,
+            estimate=1,
+            window_limits={"daily": 1_000},
+            shard_count=0,
+        )
+
+
+def test_typed_gateway_authorize_applies_window_limit_across_shards() -> None:
+    store, database, key = _seed(key_shards=4)
+    floors = window_floors(utcnow())
+    rows = database.typed[KEY_LIMIT_TABLE]
+    for shard in range(4):
+        rows[(key.hash, shard)]["day_usage"] = 250
+        rows[(key.hash, shard)]["day_start"] = floors["daily"]
+
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=1,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="test/model",
+        provider="test",
+        requested_model_id="test/model",
+        candidate_model_ids=["test/model"],
+        region="test",
+        endpoint_id="test-endpoint",
+        candidate_endpoint_ids=["test-endpoint"],
+        idempotency_key="window-shard-limit",
+        idempotency_fingerprint="same-body",
+        key_usage_shards=4,
+        window_limits={"daily": 1_000},
+    )
+
+    assert outcome == f"{AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED}:daily"
+    assert authorization is None
+
+
 def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
     store, database, key = _seed(key_shards=1)
+    key.limit_daily_microdollars = 1_000_000
+    key.limit_weekly_microdollars = 4_000_000
+    key.limit_monthly_microdollars = 10_000_000
+    store._write_entity("api_key", key.hash, key)
     floors = window_floors(utcnow())
     row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
     row.update(
@@ -283,6 +397,9 @@ def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
     assert sum(row["week_usage"] for row in rows) == 23
     assert sum(row["month_usage"] for row in rows) == 29
     assert all(row["reserved"] == 0 for row in rows)
+    assert all(row["day_limit_micro"] == 1_000_000 for row in rows)
+    assert all(row["week_limit_micro"] == 4_000_000 for row in rows)
+    assert all(row["month_limit_micro"] == 10_000_000 for row in rows)
 
     unshard = reshard_key_usage(store, key.hash, 1, apply=True)
 
@@ -303,14 +420,17 @@ def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
     assert persisted.byok_usage_microdollars == 37
 
 
-def test_key_usage_operator_refuses_capped_or_undrained_key() -> None:
+def test_key_usage_operator_refuses_lifetime_capped_or_undrained_key() -> None:
     store, database, key = _seed(key_shards=1)
     key.limit_microdollars = 1_000_000
     store._write_entity("api_key", key.hash, key)
 
     capped = reshard_key_usage(store, key.hash, 4, apply=True)
     assert not capped.ready
-    assert "capped API key must remain on one usage shard" in capped.reasons
+    assert (
+        "API key with an exact lifetime limit must remain on one usage shard"
+        in capped.reasons
+    )
 
     key.limit_microdollars = None
     store._write_entity("api_key", key.hash, key)


### PR DESCRIPTION
## Summary
- allow usage-row sharding for keys with approximate daily, weekly, or monthly limits
- preserve single-row atomic enforcement for exact lifetime limits
- sum fixed-window usage across the complete configured shard set and fail closed if a shard is missing
- preserve window configuration and usage during operator split/consolidation

## Production incident
A single active key serialized authorize/settle traffic through tr_key_limit shard 0. Spanner reported up to 1,079 lock-wait seconds per minute and internal gateway calls returned 503 after 20-second transaction budgets. Its workspace credit row was the secondary hot row.

## Verification
- uv run pytest -q: 2,042 passed, 47 skipped
- focused post-edit tests: 25 passed
- uv run ruff check .
- uv run mypy
