### PR TITLE
Ignore expired legacy holds during typed reshard

### DIFF
--- a/docs/design/key-usage-row-sharding.md
+++ b/docs/design/key-usage-row-sharding.md
@@ -58,6 +58,12 @@ Keys with an exact lifetime cap stay at one row. Reverse with `--shards 1`
 before any typed-to-JSON rollback or shard-zero repair; those older tools now
 refuse sharded state.
 
+The operator retains legacy reservation rows for audit but does not let
+pre-cutover debris block typed-ledger maintenance forever. Unsettled legacy
+rows newer than 24 hours, or with malformed timestamps, block the operation.
+Older rows are counted and reported as stale while the authoritative typed
+hold set must still be completely drained.
+
 Lifetime usage, BYOK usage, and current daily/weekly/monthly usage are preserved
 as exact global sums. Stale window epochs are discarded because they already
 read as zero under normal lazy-reset semantics.

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -86,6 +86,11 @@ def _print_status(status: CreditReshardResult) -> None:
         "  open reservations: "
         f"typed={status.typed_open_reservations} legacy={status.legacy_open_reservations}"
     )
+    if status.stale_legacy_reservations_ignored:
+        print(
+            "  retained stale legacy reservations ignored: "
+            f"{status.stale_legacy_reservations_ignored}"
+        )
     for reason in status.reasons:
         print(f"  BLOCKED: {reason}")
 
@@ -97,6 +102,11 @@ def _print_key_status(status: KeyUsageReshardResult) -> None:
         f"applied={status.applied} usage={status.usage_micro} "
         f"byok_usage={status.byok_usage_micro} reserved={status.reserved_micro}"
     )
+    if status.stale_legacy_reservations_ignored:
+        print(
+            "    retained stale legacy reservations ignored: "
+            f"{status.stale_legacy_reservations_ignored}"
+        )
     for reason in status.reasons:
         print(f"    BLOCKED: {reason}")
 

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -11,7 +11,10 @@ from trusted_router.storage_gcp_counters import (
     credit_shard_count,
     distribute_credit_amount,
 )
-from trusted_router.storage_models import CreditAccount, Reservation, Workspace
+from trusted_router.storage_gcp_legacy_reservations import (
+    legacy_reservation_snapshot,
+)
+from trusted_router.storage_models import CreditAccount, Workspace
 
 _RESHARD_COLUMNS = (
     "workspace_id",
@@ -34,6 +37,7 @@ class CreditReshardResult:
     reserved_micro: int | None = None
     typed_open_reservations: int = 0
     legacy_open_reservations: int = 0
+    stale_legacy_reservations_ignored: int = 0
     reasons: list[str] = field(default_factory=list)
     applied: bool = False
 
@@ -96,10 +100,10 @@ def inspect_credit_reshard(
     result.current_shard_count = current_count
     rows, typed_open = _typed_state(store, workspace_id, current_count)
     result.typed_open_reservations = typed_open
-    result.legacy_open_reservations = sum(
-        1
-        for reservation in store._list_entities("reservation", cls=Reservation)
-        if reservation.workspace_id == workspace_id and not reservation.settled
+    legacy = legacy_reservation_snapshot(store)
+    result.legacy_open_reservations = legacy.live_by_workspace.get(workspace_id, 0)
+    result.stale_legacy_reservations_ignored = legacy.stale_by_workspace.get(
+        workspace_id, 0
     )
     observed = [int(row[0]) for row in rows]
     if observed != list(range(current_count)):

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -12,7 +12,10 @@ from trusted_router.storage_gcp_counters import (
     distribute_credit_amount,
     key_usage_shard_count,
 )
-from trusted_router.storage_models import ApiKey, Reservation, Workspace, iso_now
+from trusted_router.storage_gcp_legacy_reservations import (
+    legacy_reservation_snapshot,
+)
+from trusted_router.storage_models import ApiKey, Workspace, iso_now
 
 _KEY_RESHARD_COLUMNS = (
     "key_hash",
@@ -47,6 +50,7 @@ class KeyUsageReshardResult:
     reserved_micro: int | None = None
     typed_open_reservations: int = 0
     legacy_open_reservations: int = 0
+    stale_legacy_reservations_ignored: int = 0
     reasons: list[str] = field(default_factory=list)
     applied: bool = False
 
@@ -119,11 +123,9 @@ def inspect_key_usage_reshard(
     result.current_shard_count = current_count
     rows, typed_open = _typed_key_state(store, key_hash, current_count)
     result.typed_open_reservations = typed_open
-    result.legacy_open_reservations = sum(
-        1
-        for reservation in store._list_entities("reservation", cls=Reservation)
-        if reservation.key_hash == key_hash and not reservation.settled
-    )
+    legacy = legacy_reservation_snapshot(store)
+    result.legacy_open_reservations = legacy.live_by_key.get(key_hash, 0)
+    result.stale_legacy_reservations_ignored = legacy.stale_by_key.get(key_hash, 0)
     if [int(row[0]) for row in rows] != list(range(current_count)):
         result.reasons.append("configured typed key usage shard set is incomplete")
         return result

--- a/src/trusted_router/storage_gcp_legacy_reservations.py
+++ b/src/trusted_router/storage_gcp_legacy_reservations.py
@@ -1,0 +1,84 @@
+"""Bounded legacy-reservation guard for typed-ledger maintenance."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+
+_LIVE_MAX_AGE = dt.timedelta(hours=24)
+_CACHE_ATTR = "_typed_maintenance_legacy_reservation_snapshot"
+
+
+@dataclass
+class LegacyReservationSnapshot:
+    live_by_workspace: dict[str, int] = field(default_factory=dict)
+    stale_by_workspace: dict[str, int] = field(default_factory=dict)
+    live_by_key: dict[str, int] = field(default_factory=dict)
+    stale_by_key: dict[str, int] = field(default_factory=dict)
+
+
+def legacy_reservation_snapshot(
+    store: Any,
+    *,
+    now: dt.datetime | None = None,
+) -> LegacyReservationSnapshot:
+    """Return compact counts for unsettled legacy reservations.
+
+    Typed billing is authoritative, but a genuinely live request from a rolling
+    legacy revision must still block a ledger reshard. Reservations newer than
+    24 hours, plus rows with malformed/missing timestamps, therefore remain
+    blocking. Older rows are pre-cutover debris: retain them for audit, report
+    them, but do not let them permanently prevent typed-ledger maintenance.
+
+    The aggregate scan is cached on the short-lived operator store so a
+    workspace with many keys scans the legacy reservation range only once.
+    """
+    cached = getattr(store, _CACHE_ATTR, None)
+    if isinstance(cached, LegacyReservationSnapshot):
+        return cached
+
+    observed_at = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+    cutoff = observed_at - _LIVE_MAX_AGE
+    pt = store._param_types
+    sql = """
+        /* legacy_reshard_guard */
+        SELECT
+          JSON_VALUE(body, '$.workspace_id') AS workspace_id,
+          JSON_VALUE(body, '$.key_hash') AS key_hash,
+          COUNTIF(
+            SAFE_CAST(JSON_VALUE(body, '$.created_at') AS TIMESTAMP) IS NULL
+            OR SAFE_CAST(JSON_VALUE(body, '$.created_at') AS TIMESTAMP) >= @cutoff
+          ) AS live_count,
+          COUNTIF(
+            SAFE_CAST(JSON_VALUE(body, '$.created_at') AS TIMESTAMP) < @cutoff
+          ) AS stale_count
+        FROM tr_entities
+        WHERE kind='reservation' AND JSON_VALUE(body, '$.settled')='false'
+        GROUP BY workspace_id, key_hash
+    """
+    result = LegacyReservationSnapshot()
+    with store._database.snapshot() as snapshot:
+        rows = snapshot.execute_sql(
+            sql,
+            params={"cutoff": cutoff},
+            param_types={"cutoff": pt.TIMESTAMP},
+        )
+        for workspace_id, key_hash, live_count, stale_count in rows:
+            live = int(live_count or 0)
+            stale = int(stale_count or 0)
+            if workspace_id:
+                workspace = str(workspace_id)
+                result.live_by_workspace[workspace] = (
+                    result.live_by_workspace.get(workspace, 0) + live
+                )
+                result.stale_by_workspace[workspace] = (
+                    result.stale_by_workspace.get(workspace, 0) + stale
+                )
+            if key_hash:
+                key = str(key_hash)
+                result.live_by_key[key] = result.live_by_key.get(key, 0) + live
+                result.stale_by_key[key] = result.stale_by_key.get(key, 0) + stale
+
+    setattr(store, _CACHE_ATTR, result)
+    return result

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import threading
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -1038,6 +1039,34 @@ def _execute_sql(
                 grp = (rec["key_hash"], rec.get("key_shard", 0))
                 ksums[grp] = ksums.get(grp, 0) + (rec.get("key_reserved_micro") or 0)
         return [[kh, shard, total] for (kh, shard), total in ksums.items()]
+    if "legacy_reshard_guard" in sql:
+        cutoff = params["cutoff"]
+        grouped: dict[tuple[str | None, str | None], list[int]] = {}
+        for (row_kind, _entity_id), row in db.rows.items():
+            if row_kind != "reservation":
+                continue
+            body = json.loads(row.body)
+            if body.get("settled") is not False:
+                continue
+            key = (body.get("workspace_id"), body.get("key_hash"))
+            counts = grouped.setdefault(key, [0, 0])
+            raw_created = body.get("created_at")
+            try:
+                created = dt.datetime.fromisoformat(
+                    str(raw_created).replace("Z", "+00:00")
+                )
+                if created.tzinfo is None:
+                    raise ValueError("naive timestamp")
+            except (TypeError, ValueError):
+                counts[0] += 1
+                continue
+            counts[0 if created >= cutoff else 1] += 1
+        return [
+            [workspace_id, key_hash, counts[0], counts[1]]
+            for (workspace_id, key_hash), counts in sorted(
+                grouped.items(), key=lambda item: repr(item[0])
+            )
+        ]
     # tr_reservation reads (idempotency replay + by-id for settle/reaper).
     if "FROM tr_reservation WHERE idempotency_scope=@scope" in sql:
         scope = params["scope"]

--- a/tests/test_credit_row_sharding_increment4.py
+++ b/tests/test_credit_row_sharding_increment4.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 from typing import Any
 
 import pytest
@@ -177,6 +178,29 @@ def test_reshard_refuses_any_undrained_hold(
     assert any("drain" in reason for reason in result.reasons)
     assert _rows(database) == before
     assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_reshard_ignores_but_reports_retained_stale_legacy_holds() -> None:
+    store, _database = _seed(shard_credits=[100], shard_usage=[20])
+    store._write_entity(
+        "reservation",
+        "legacy-stale",
+        Reservation(
+            id="legacy-stale",
+            workspace_id="ws-reshard",
+            key_hash="key",
+            amount_microdollars=1,
+            created_at=(
+                dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+            ).isoformat(),
+        ),
+    )
+
+    result = reshard_credit_account(store, "ws-reshard", 4, apply=True)
+
+    assert result.ready and result.applied
+    assert result.legacy_open_reservations == 0
+    assert result.stale_legacy_reservations_ignored == 1
 
 
 def test_reshard_refuses_incomplete_rows_and_uses_typed_totals() -> None:

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 from typing import Any
 
@@ -26,7 +27,7 @@ from trusted_router.storage_gcp_key_shard_admin import (
     inspect_key_usage_reshard,
     reshard_key_usage,
 )
-from trusted_router.storage_models import CreditAccount, Workspace
+from trusted_router.storage_models import CreditAccount, Reservation, Workspace
 
 
 def _seed(*, key_shards: int = 4) -> tuple[Any, Any, Any]:
@@ -443,6 +444,29 @@ def test_key_usage_operator_refuses_lifetime_capped_or_undrained_key() -> None:
     undrained = reshard_key_usage(store, key.hash, 4, apply=True)
     assert not undrained.ready
     assert any("open typed reservations" in reason for reason in undrained.reasons)
+
+
+def test_key_reshard_ignores_but_reports_retained_stale_legacy_hold() -> None:
+    store, _database, key = _seed(key_shards=1)
+    store._write_entity(
+        "reservation",
+        "legacy-stale-key",
+        Reservation(
+            id="legacy-stale-key",
+            workspace_id=key.workspace_id,
+            key_hash=key.hash,
+            amount_microdollars=1,
+            created_at=(
+                dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+            ).isoformat(),
+        ),
+    )
+
+    result = reshard_key_usage(store, key.hash, 4, apply=True)
+
+    assert result.ready and result.applied
+    assert result.legacy_open_reservations == 0
+    assert result.stale_legacy_reservations_ignored == 1
 
 
 def test_key_usage_operator_status_is_idempotent_after_split() -> None:


### PR DESCRIPTION
## Summary
- keep recent or malformed unsettled legacy reservations as fail-closed reshard blockers
- retain but ignore legacy reservations older than 24 hours once the authoritative typed hold set is drained
- aggregate and cache legacy counts once per operator run instead of loading every reservation once per key
- report retained stale counts in operator output

## Production finding
The synthetic monitor workspace has zero typed open holds but 9,334 unsettled legacy rows, all created May 8 through June 21 and all older than 30 days. They permanently blocked the guarded operator and left the monitor workspace paused after the failed prepare. No rows are deleted by this change.

## Verification
- production read-only aggregate: 0 live legacy holds for the monitor workspace
- uv run pytest -q: 2,054 passed, 47 skipped
- uv run ruff check: clean
- uv run mypy: clean
