### PR TITLE
Preserve live holds during billing reshard

### DIFF
--- a/.github/workflows/reshard-billing-workspace.yml
+++ b/.github/workflows/reshard-billing-workspace.yml
@@ -7,7 +7,7 @@ on:
         description: "Read status, pause/drain/split, or verify/unpause"
         type: choice
         required: true
-        options: [status, prepare, finish]
+        options: [status, prepare, finish, online-split]
         default: status
       workspace_id:
         description: "Exact workspace ID (preferred after initial lookup)"
@@ -27,6 +27,11 @@ on:
         description: "Type APPLY for prepare/finish; status is always read-only"
         type: string
         required: false
+      preserve_open_holds:
+        description: "Preserve typed open holds while increasing shard count"
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
@@ -62,6 +67,7 @@ jobs:
           OWNER_EMAIL: ${{ inputs.owner_email }}
           SHARDS: ${{ inputs.shards }}
           CONFIRMATION: ${{ inputs.confirmation }}
+          PRESERVE_OPEN_HOLDS: ${{ inputs.preserve_open_holds }}
         run: |
           set -euo pipefail
           if [ -n "${WORKSPACE_ID}" ] && [ -n "${OWNER_EMAIL}" ]; then
@@ -79,10 +85,13 @@ jobs:
           else
             args+=(--owner-email "${OWNER_EMAIL}")
           fi
+          if [ "${PRESERVE_OPEN_HOLDS}" = "true" ]; then
+            args+=(--preserve-open-holds)
+          fi
 
           case "${OPERATION}" in
             status) ;;
-            prepare|finish)
+            prepare|finish|online-split)
               if [ "${CONFIRMATION}" != "APPLY" ]; then
                 echo "Mutation refused: type APPLY in confirmation."
                 exit 2

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -12,6 +12,10 @@ silently resume billing:
   # Verify the committed shape + global billing invariants, then unpause.
   python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 
+  # Preserve active typed holds and minimize the pause to one guarded process.
+  python scripts/shard_workspace.py online-split --workspace WS --shards 16 \
+    --preserve-open-holds --apply
+
 Eligible API-key usage rows are split to the same count; keys with an exact
 lifetime cap remain on one row. Approximate daily/weekly/monthly windows sum
 usage across the configured rows. Reverse with the same commands and
@@ -115,7 +119,13 @@ def _key_target(key: ApiKey, requested_shards: int) -> int:
     return 1 if key.limit_microdollars is not None else requested_shards
 
 
-def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+def _prepare_keys(
+    store: Any,
+    workspace_id: str,
+    requested_shards: int,
+    *,
+    preserve_open_holds: bool,
+) -> bool:
     clean = True
     for key in store.api_keys.list_for_workspace(workspace_id):
         target = _key_target(key, requested_shards)
@@ -123,19 +133,32 @@ def _prepare_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
             print(
                 f"  key {key.hash}: exact lifetime cap; keeping usage_shards=1"
             )
-        status = reshard_key_usage(store, key.hash, target, apply=True)
+        status = reshard_key_usage(
+            store,
+            key.hash,
+            target,
+            apply=True,
+            preserve_open_holds=preserve_open_holds,
+        )
         _print_key_status(status)
         clean = clean and status.ready
     return clean
 
 
-def _verify_keys(store: Any, workspace_id: str, requested_shards: int) -> bool:
+def _verify_keys(
+    store: Any,
+    workspace_id: str,
+    requested_shards: int,
+    *,
+    preserve_open_holds: bool,
+) -> bool:
     clean = True
     for key in store.api_keys.list_for_workspace(workspace_id):
         status = inspect_key_usage_reshard(
             store,
             key.hash,
             _key_target(key, requested_shards),
+            preserve_open_holds=preserve_open_holds,
         )
         _print_key_status(status)
         clean = clean and status.ready
@@ -152,28 +175,77 @@ def _pause(store: Any, workspace_id: str) -> bool:
 
 
 def run_status(store: Any, args: argparse.Namespace) -> int:
-    _print_status(inspect_credit_reshard(store, args.workspace, args.shards))
-    _verify_keys(store, args.workspace, args.shards)
+    _print_status(
+        inspect_credit_reshard(
+            store,
+            args.workspace,
+            args.shards,
+            preserve_open_holds=args.preserve_open_holds,
+        )
+    )
+    _verify_keys(
+        store,
+        args.workspace,
+        args.shards,
+        preserve_open_holds=args.preserve_open_holds,
+    )
     return 0
 
 
 def run_prepare(store: Any, args: argparse.Namespace) -> int:
     if not args.apply:
-        status = inspect_credit_reshard(store, args.workspace, args.shards)
+        status = inspect_credit_reshard(
+            store,
+            args.workspace,
+            args.shards,
+            preserve_open_holds=args.preserve_open_holds,
+        )
         _print_status(status)
-        _verify_keys(store, args.workspace, args.shards)
-        print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
+        _verify_keys(
+            store,
+            args.workspace,
+            args.shards,
+            preserve_open_holds=args.preserve_open_holds,
+        )
+        if args.preserve_open_holds:
+            print(
+                "DRY-RUN: would pause, preserve open typed holds on their "
+                "current shards, then atomically split"
+            )
+        else:
+            print("DRY-RUN: would pause, wait for all holds, then atomically reshard")
         return 0
     if not _pause(store, args.workspace):
         print("ERROR: could not pause workspace", file=sys.stderr)
         return 1
-    status = reshard_credit_account(store, args.workspace, args.shards, apply=True)
+    if args.preserve_open_holds:
+        audit = audit_typed_invariants(store)
+        print(f"pre-reshard {audit.summary()}")
+        if not audit.clean:
+            print(
+                "Workspace remains paused because the pre-reshard invariant "
+                "audit failed.",
+                file=sys.stderr,
+            )
+            return 1
+    status = reshard_credit_account(
+        store,
+        args.workspace,
+        args.shards,
+        apply=True,
+        preserve_open_holds=args.preserve_open_holds,
+    )
     _print_status(status)
     if not status.ready:
         print("Workspace remains paused. Re-run prepare after holds drain.")
         draining = any("drain" in reason or "open" in reason for reason in status.reasons)
         return 2 if draining else 1
-    if not _prepare_keys(store, args.workspace, args.shards):
+    if not _prepare_keys(
+        store,
+        args.workspace,
+        args.shards,
+        preserve_open_holds=args.preserve_open_holds,
+    ):
         print("Workspace remains paused because an API-key reshard failed.", file=sys.stderr)
         return 1
     audit = audit_typed_invariants(store)
@@ -189,12 +261,22 @@ def run_prepare(store: Any, args: argparse.Namespace) -> int:
 
 
 def run_finish(store: Any, args: argparse.Namespace) -> int:
-    status = inspect_credit_reshard(store, args.workspace, args.shards)
+    status = inspect_credit_reshard(
+        store,
+        args.workspace,
+        args.shards,
+        preserve_open_holds=args.preserve_open_holds,
+    )
     _print_status(status)
     if not status.ready:
         print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
         return 1
-    if not _verify_keys(store, args.workspace, args.shards):
+    if not _verify_keys(
+        store,
+        args.workspace,
+        args.shards,
+        preserve_open_holds=args.preserve_open_holds,
+    ):
         print("ERROR: refusing to unpause; API-key shard verification failed", file=sys.stderr)
         return 1
     audit = audit_typed_invariants(store)
@@ -220,6 +302,48 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     return 0
 
 
+def run_online_split(store: Any, args: argparse.Namespace) -> int:
+    """Preflight while live, then pause/split/verify/unpause in one process."""
+    if not args.preserve_open_holds:
+        print(
+            "ERROR: online-split requires --preserve-open-holds",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.apply:
+        return run_prepare(store, args)
+
+    # Warm the legacy aggregate and reject a pre-existing ledger violation
+    # before pausing customer traffic. The prepare path repeats all decisive
+    # checks after the pause; this live preflight only shortens the outage.
+    inspect_credit_reshard(
+        store,
+        args.workspace,
+        args.shards,
+        preserve_open_holds=True,
+    )
+    for key in store.api_keys.list_for_workspace(args.workspace):
+        inspect_key_usage_reshard(
+            store,
+            key.hash,
+            _key_target(key, args.shards),
+            preserve_open_holds=True,
+        )
+    audit = audit_typed_invariants(store)
+    print(f"live preflight {audit.summary()}")
+    if not audit.clean:
+        print(
+            "ERROR: refusing to pause; live invariant audit failed",
+            file=sys.stderr,
+        )
+        return 1
+
+    prepared = run_prepare(store, args)
+    if prepared != 0:
+        return prepared
+    return run_finish(store, args)
+
+
 def _shard_count_arg(raw: str) -> int:
     try:
         value = int(raw)
@@ -242,12 +366,21 @@ def _parser() -> argparse.ArgumentParser:
         ("status", run_status),
         ("prepare", run_prepare),
         ("finish", run_finish),
+        ("online-split", run_online_split),
     ):
         command = sub.add_parser(name)
         target = command.add_mutually_exclusive_group(required=True)
         target.add_argument("--workspace")
         target.add_argument("--owner-email")
         command.add_argument("--shards", required=True, type=_shard_count_arg)
+        command.add_argument(
+            "--preserve-open-holds",
+            action="store_true",
+            help=(
+                "allow an increasing split while preserving typed open holds "
+                "on their current shards"
+            ),
+        )
         if name != "status":
             command.add_argument("--apply", action="store_true")
         command.set_defaults(handler=handler)

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -50,7 +50,7 @@ def _typed_state(
     store: Any,
     workspace_id: str,
     shard_count: int,
-) -> tuple[list[list[Any]], int]:
+) -> tuple[list[list[Any]], int, dict[int, int]]:
     pt = store._param_types
     with store._database.snapshot(multi_use=True) as snapshot:
         rows = list(
@@ -62,25 +62,59 @@ def _typed_state(
                 param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             )
         )
-        open_reservations = int(
-            list(
-                snapshot.execute_sql(
-                    "SELECT COUNT(*) FROM tr_reservation "
-                    "WHERE workspace_id=@ws AND settled = false",
-                    params={"ws": workspace_id},
-                    param_types={"ws": pt.STRING},
-                )
-            )[0][0]
+        hold_rows = list(
+            snapshot.execute_sql(
+                "SELECT credit_shard, ws_shard, COUNT(*), "
+                "COALESCE(SUM(credit_reserved_micro), 0) "
+                "FROM tr_reservation WHERE workspace_id=@ws AND settled=false "
+                "GROUP BY credit_shard, ws_shard",
+                params={"ws": workspace_id},
+                param_types={"ws": pt.STRING},
+            )
         )
-    return rows, open_reservations
+    open_reservations = 0
+    reserved_by_shard: dict[int, int] = {}
+    for credit_shard, ws_shard, count, reserved in hold_rows:
+        shard = int(credit_shard if credit_shard is not None else (ws_shard or 0))
+        open_reservations += int(count)
+        reserved_by_shard[shard] = reserved_by_shard.get(shard, 0) + int(
+            reserved or 0
+        )
+    return rows, open_reservations, reserved_by_shard
+
+
+def _validate_open_holds(
+    rows: list[list[Any]],
+    reserved_by_shard: dict[int, int],
+) -> list[str]:
+    reasons: list[str] = []
+    observed = {int(row[0]): int(row[3]) for row in rows}
+    unknown = sorted(set(reserved_by_shard) - set(observed))
+    if unknown:
+        reasons.append(f"open typed credit holds reference unknown shards {unknown}")
+    for shard, reserved in observed.items():
+        held = reserved_by_shard.get(shard, 0)
+        if reserved != held:
+            reasons.append(
+                f"typed credit shard {shard} reserved={reserved} "
+                f"but open holds={held}"
+            )
+    return reasons
 
 
 def inspect_credit_reshard(
     store: Any,
     workspace_id: str,
     target_shard_count: int,
+    *,
+    preserve_open_holds: bool = False,
 ) -> CreditReshardResult:
-    """Read-only readiness check for a paused, fully drained reshard."""
+    """Read-only readiness check for a paused reshard.
+
+    The default requires a fully drained ledger. The explicit online mode only
+    permits splits and verifies that each typed reserved counter exactly matches
+    the open holds that will continue settling against that shard.
+    """
     target_count = credit_shard_count({"shard_count": target_shard_count})
     result = CreditReshardResult(
         workspace_id=workspace_id,
@@ -98,7 +132,9 @@ def inspect_credit_reshard(
 
     current_count = credit_shard_count(account)
     result.current_shard_count = current_count
-    rows, typed_open = _typed_state(store, workspace_id, current_count)
+    rows, typed_open, reserved_by_shard = _typed_state(
+        store, workspace_id, current_count
+    )
     result.typed_open_reservations = typed_open
     legacy = legacy_reservation_snapshot(store)
     result.legacy_open_reservations = legacy.live_by_workspace.get(workspace_id, 0)
@@ -116,14 +152,21 @@ def inspect_credit_reshard(
     result.total_credits_micro = total_credits
     result.total_usage_micro = total_usage
     result.reserved_micro = reserved
+    result.reasons.extend(_validate_open_holds(rows, reserved_by_shard))
     if any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows):
         result.reasons.append("typed credit shard has a negative counter")
     if any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows):
         result.reasons.append("typed credit shard exceeds its sub-budget")
-    if reserved != 0:
-        result.reasons.append(f"typed credit has reserved={reserved}; wait for drain")
-    if typed_open != 0:
-        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if preserve_open_holds:
+        if target_count < current_count:
+            result.reasons.append(
+                "hold-preserving reshard only supports increasing the shard count"
+            )
+    else:
+        if reserved != 0:
+            result.reasons.append(f"typed credit has reserved={reserved}; wait for drain")
+        if typed_open != 0:
+            result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
     if result.legacy_open_reservations != 0:
         result.reasons.append(
             f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
@@ -137,13 +180,23 @@ def reshard_credit_account(
     target_shard_count: int,
     *,
     apply: bool = False,
+    preserve_open_holds: bool = False,
 ) -> CreditReshardResult:
-    """Atomically repartition a paused and drained workspace's credit ledger.
+    """Atomically repartition a paused workspace's credit ledger.
 
     Both splitting and consolidation use this function. A dry run never writes.
     The JSON shard configuration and every typed row commit in one transaction.
+    ``preserve_open_holds`` is an opt-in split-only path: existing usage and
+    reserved counters remain on their original shard IDs, while only free
+    capacity is distributed to new shards. Existing reservations can therefore
+    settle normally after the split.
     """
-    status = inspect_credit_reshard(store, workspace_id, target_shard_count)
+    status = inspect_credit_reshard(
+        store,
+        workspace_id,
+        target_shard_count,
+        preserve_open_holds=preserve_open_holds,
+    )
     if not status.ready or not apply:
         return status
     assert status.current_shard_count is not None
@@ -171,31 +224,58 @@ def reshard_credit_account(
         observed = [int(row[0]) for row in rows]
         if observed != list(range(current_count)):
             return None
-        open_typed = int(
-            list(
-                transaction.execute_sql(
-                    "SELECT COUNT(*) FROM tr_reservation "
-                    "WHERE workspace_id=@ws AND settled = false",
-                    params={"ws": workspace_id},
-                    param_types={"ws": pt.STRING},
-                )
-            )[0][0]
-        )
         total_credits = sum(int(row[1]) for row in rows)
         total_usage = sum(int(row[2]) for row in rows)
         reserved = sum(int(row[3]) for row in rows)
-        if (
-            open_typed != 0
-            or reserved != 0
-            or any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows)
+        invalid_counters = (
+            any(int(row[2]) < 0 or int(row[3]) < 0 for row in rows)
             or any(int(row[2]) + int(row[3]) > int(row[1]) for row in rows)
-        ):
+        )
+        if invalid_counters:
             return None
 
-        credit_parts = distribute_credit_amount(total_credits, target_count)
-        usage_parts = distribute_credit_amount(total_usage, target_count)
-        if any(usage > credit for usage, credit in zip(usage_parts, credit_parts, strict=True)):
-            return None  # defensive; global usage<=credits should make this impossible.
+        if preserve_open_holds:
+            if target_count < current_count:
+                return None
+            usage_parts = [int(row[2]) for row in rows] + [0] * (
+                target_count - current_count
+            )
+            reserved_parts = [int(row[3]) for row in rows] + [0] * (
+                target_count - current_count
+            )
+            committed = sum(usage_parts) + sum(reserved_parts)
+            if committed > total_credits:
+                return None
+            free_parts = distribute_credit_amount(
+                total_credits - committed, target_count
+            )
+            credit_parts = [
+                usage_parts[shard] + reserved_parts[shard] + free_parts[shard]
+                for shard in range(target_count)
+            ]
+        else:
+            open_typed = int(
+                list(
+                    transaction.execute_sql(
+                        "SELECT COUNT(*) FROM tr_reservation "
+                        "WHERE workspace_id=@ws AND settled = false",
+                        params={"ws": workspace_id},
+                        param_types={"ws": pt.STRING},
+                    )
+                )[0][0]
+            )
+            if open_typed != 0 or reserved != 0:
+                return None
+            credit_parts = list(distribute_credit_amount(total_credits, target_count))
+            usage_parts = list(distribute_credit_amount(total_usage, target_count))
+            reserved_parts = [0] * target_count
+            if any(
+                usage > credit
+                for usage, credit in zip(
+                    usage_parts, credit_parts, strict=True
+                )
+            ):
+                return None
         commit_timestamp = store._spanner.COMMIT_TIMESTAMP
         transaction.insert_or_update(
             table=CREDIT_BALANCE_TABLE,
@@ -206,7 +286,7 @@ def reshard_credit_account(
                     shard,
                     credit_parts[shard],
                     usage_parts[shard],
-                    0,
+                    reserved_parts[shard],
                     commit_timestamp,
                     commit_timestamp,
                 )
@@ -252,7 +332,12 @@ def reshard_credit_account(
         )
         return status
     store._credit_shard_counts.invalidate(workspace_id)
-    verified = inspect_credit_reshard(store, workspace_id, target_count)
+    verified = inspect_credit_reshard(
+        store,
+        workspace_id,
+        target_count,
+        preserve_open_holds=preserve_open_holds,
+    )
     if not verified.ready:
         verified.reasons.append("post-commit reshard verification failed")
         return verified

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -1,4 +1,9 @@
-"""Operator-only split/consolidation for uncapped API-key usage rows."""
+"""Operator-only split/consolidation for API-key usage rows.
+
+The default path requires a fully drained key. The opt-in online split keeps
+usage, window usage, and reserved counters on existing shard IDs so already
+authorized requests can settle normally after new shards are added.
+"""
 
 from __future__ import annotations
 
@@ -63,7 +68,7 @@ def _typed_key_state(
     store: Any,
     key_hash: str,
     shard_count: int,
-) -> tuple[list[list[Any]], int]:
+) -> tuple[list[list[Any]], int, dict[int, int]]:
     pt = store._param_types
     with store._database.snapshot(multi_use=True) as snapshot:
         rows = list(
@@ -77,23 +82,51 @@ def _typed_key_state(
                 param_types={"pk": pt.STRING, "shard_count": pt.INT64},
             )
         )
-        open_reservations = int(
-            list(
-                snapshot.execute_sql(
-                    "SELECT COUNT(*) FROM tr_reservation "
-                    "WHERE key_hash=@kh AND settled = false",
-                    params={"kh": key_hash},
-                    param_types={"kh": pt.STRING},
-                )
-            )[0][0]
+        hold_rows = list(
+            snapshot.execute_sql(
+                "SELECT key_shard, COUNT(*), "
+                "COALESCE(SUM(key_reserved_micro), 0) "
+                "FROM tr_reservation WHERE key_hash=@kh AND settled=false "
+                "GROUP BY key_shard",
+                params={"kh": key_hash},
+                param_types={"kh": pt.STRING},
+            )
         )
-    return rows, open_reservations
+    open_reservations = 0
+    reserved_by_shard: dict[int, int] = {}
+    for key_shard, count, reserved in hold_rows:
+        shard = int(key_shard or 0)
+        open_reservations += int(count)
+        reserved_by_shard[shard] = reserved_by_shard.get(shard, 0) + int(
+            reserved or 0
+        )
+    return rows, open_reservations, reserved_by_shard
+
+
+def _validate_open_holds(
+    rows: list[list[Any]],
+    reserved_by_shard: dict[int, int],
+) -> list[str]:
+    reasons: list[str] = []
+    observed = {int(row[0]): int(row[4]) for row in rows}
+    unknown = sorted(set(reserved_by_shard) - set(observed))
+    if unknown:
+        reasons.append(f"open typed key holds reference unknown shards {unknown}")
+    for shard, reserved in observed.items():
+        held = reserved_by_shard.get(shard, 0)
+        if reserved != held:
+            reasons.append(
+                f"typed key shard {shard} reserved={reserved} but open holds={held}"
+            )
+    return reasons
 
 
 def inspect_key_usage_reshard(
     store: Any,
     key_hash: str,
     target_shard_count: int,
+    *,
+    preserve_open_holds: bool = False,
 ) -> KeyUsageReshardResult:
     target_count = key_usage_shard_count({"usage_shard_count": target_shard_count})
     key = store.api_keys.get_by_hash(key_hash)
@@ -121,7 +154,9 @@ def inspect_key_usage_reshard(
         result.reasons.append(str(exc))
         return result
     result.current_shard_count = current_count
-    rows, typed_open = _typed_key_state(store, key_hash, current_count)
+    rows, typed_open, reserved_by_shard = _typed_key_state(
+        store, key_hash, current_count
+    )
     result.typed_open_reservations = typed_open
     legacy = legacy_reservation_snapshot(store)
     result.legacy_open_reservations = legacy.live_by_key.get(key_hash, 0)
@@ -136,12 +171,19 @@ def inspect_key_usage_reshard(
     result.usage_micro = usage
     result.byok_usage_micro = byok_usage
     result.reserved_micro = reserved
+    result.reasons.extend(_validate_open_holds(rows, reserved_by_shard))
     if any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows):
         result.reasons.append("typed key usage shard has a negative counter")
-    if reserved != 0:
-        result.reasons.append(f"typed key has reserved={reserved}; wait for drain")
-    if typed_open != 0:
-        result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
+    if preserve_open_holds:
+        if target_count < current_count:
+            result.reasons.append(
+                "hold-preserving reshard only supports increasing the shard count"
+            )
+    else:
+        if reserved != 0:
+            result.reasons.append(f"typed key has reserved={reserved}; wait for drain")
+        if typed_open != 0:
+            result.reasons.append(f"{typed_open} open typed reservations; wait for drain")
     if result.legacy_open_reservations != 0:
         result.reasons.append(
             f"{result.legacy_open_reservations} open legacy reservations; wait for drain"
@@ -155,8 +197,14 @@ def reshard_key_usage(
     target_shard_count: int,
     *,
     apply: bool = False,
+    preserve_open_holds: bool = False,
 ) -> KeyUsageReshardResult:
-    status = inspect_key_usage_reshard(store, key_hash, target_shard_count)
+    status = inspect_key_usage_reshard(
+        store,
+        key_hash,
+        target_shard_count,
+        preserve_open_holds=preserve_open_holds,
+    )
     if not status.ready or not apply:
         return status
     assert status.current_shard_count is not None
@@ -194,25 +242,30 @@ def reshard_key_usage(
         )
         if [int(row[0]) for row in rows] != list(range(current_count)):
             return None
-        open_typed = int(
-            list(
-                transaction.execute_sql(
-                    "SELECT COUNT(*) FROM tr_reservation "
-                    "WHERE key_hash=@kh AND settled = false",
-                    params={"kh": key_hash},
-                    param_types={"kh": pt.STRING},
-                )
-            )[0][0]
-        )
         usage = sum(int(row[2]) for row in rows)
         byok_usage = sum(int(row[3]) for row in rows)
         reserved = sum(int(row[4]) for row in rows)
-        if (
-            open_typed != 0
-            or reserved != 0
-            or any(int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0 for row in rows)
+        if any(
+            int(row[2]) < 0 or int(row[3]) < 0 or int(row[4]) < 0
+            for row in rows
         ):
             return None
+        if preserve_open_holds:
+            if target_count < current_count:
+                return None
+        else:
+            open_typed = int(
+                list(
+                    transaction.execute_sql(
+                        "SELECT COUNT(*) FROM tr_reservation "
+                        "WHERE key_hash=@kh AND settled = false",
+                        params={"kh": key_hash},
+                        param_types={"kh": pt.STRING},
+                    )
+                )[0][0]
+            )
+            if open_typed != 0 or reserved != 0:
+                return None
 
         def window_total(usage_index: int, start_index: int, window: str) -> int:
             return sum(
@@ -224,11 +277,38 @@ def reshard_key_usage(
         day_usage = window_total(9, 10, "daily")
         week_usage = window_total(11, 12, "weekly")
         month_usage = window_total(13, 14, "monthly")
-        usage_parts = distribute_credit_amount(usage, target_count)
-        byok_parts = distribute_credit_amount(byok_usage, target_count)
-        day_parts = distribute_credit_amount(day_usage, target_count)
-        week_parts = distribute_credit_amount(week_usage, target_count)
-        month_parts = distribute_credit_amount(month_usage, target_count)
+        if preserve_open_holds:
+            usage_parts = [int(row[2]) for row in rows] + [0] * (
+                target_count - current_count
+            )
+            byok_parts = [int(row[3]) for row in rows] + [0] * (
+                target_count - current_count
+            )
+            reserved_parts = [int(row[4]) for row in rows] + [0] * (
+                target_count - current_count
+            )
+
+            def current_window_parts(
+                usage_index: int, start_index: int, window: str
+            ) -> list[int]:
+                return [
+                    int(row[usage_index] or 0)
+                    if row[start_index] is not None
+                    and row[start_index] >= floors[window]
+                    else 0
+                    for row in rows
+                ] + [0] * (target_count - current_count)
+
+            day_parts = current_window_parts(9, 10, "daily")
+            week_parts = current_window_parts(11, 12, "weekly")
+            month_parts = current_window_parts(13, 14, "monthly")
+        else:
+            usage_parts = list(distribute_credit_amount(usage, target_count))
+            byok_parts = list(distribute_credit_amount(byok_usage, target_count))
+            reserved_parts = [0] * target_count
+            day_parts = list(distribute_credit_amount(day_usage, target_count))
+            week_parts = list(distribute_credit_amount(week_usage, target_count))
+            month_parts = list(distribute_credit_amount(month_usage, target_count))
         commit_timestamp = store._spanner.COMMIT_TIMESTAMP
         transaction.insert_or_update(
             table=KEY_LIMIT_TABLE,
@@ -240,7 +320,7 @@ def reshard_key_usage(
                     key.limit_microdollars,
                     usage_parts[shard],
                     byok_parts[shard],
-                    0,
+                    reserved_parts[shard],
                     key.include_byok_in_limit,
                     key.limit_daily_microdollars,
                     key.limit_weekly_microdollars,
@@ -270,7 +350,7 @@ def reshard_key_usage(
         key.usage_shard_count = target_count
         key.usage_microdollars = usage
         key.byok_usage_microdollars = byok_usage
-        key.reserved_microdollars = 0
+        key.reserved_microdollars = reserved
         key.updated_at = iso_now()
         transaction.insert_or_update(
             table=store.entity_table,
@@ -292,7 +372,12 @@ def reshard_key_usage(
             "atomic key reshard preconditions changed; workspace remains paused"
         )
         return status
-    verified = inspect_key_usage_reshard(store, key_hash, target_count)
+    verified = inspect_key_usage_reshard(
+        store,
+        key_hash,
+        target_count,
+        preserve_open_holds=preserve_open_holds,
+    )
     if not verified.ready:
         verified.reasons.append("post-commit key reshard verification failed")
         return verified

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -985,6 +985,40 @@ def _execute_sql(
             1 for rec in db.reservations.values()
             if rec.get("workspace_id") == ws and not rec.get("settled") and rec.get("ws_shard", 0) != 0
         )]]
+    if (
+        "FROM tr_reservation WHERE workspace_id=@ws AND settled=false" in sql
+        and "GROUP BY credit_shard, ws_shard" in sql
+    ):
+        ws = params["ws"]
+        groups: dict[tuple[Any, Any], list[int]] = {}
+        for rec in db.reservations.values():
+            if rec.get("workspace_id") != ws or rec.get("settled"):
+                continue
+            group = (rec.get("credit_shard"), rec.get("ws_shard", 0))
+            values = groups.setdefault(group, [0, 0])
+            values[0] += 1
+            values[1] += int(rec.get("credit_reserved_micro") or 0)
+        return [
+            [credit_shard, ws_shard, values[0], values[1]]
+            for (credit_shard, ws_shard), values in groups.items()
+        ]
+    if (
+        "FROM tr_reservation WHERE key_hash=@kh AND settled=false" in sql
+        and "GROUP BY key_shard" in sql
+    ):
+        kh = params["kh"]
+        groups: dict[Any, list[int]] = {}
+        for rec in db.reservations.values():
+            if rec.get("key_hash") != kh or rec.get("settled"):
+                continue
+            shard = rec.get("key_shard", 0)
+            values = groups.setdefault(shard, [0, 0])
+            values[0] += 1
+            values[1] += int(rec.get("key_reserved_micro") or 0)
+        return [
+            [shard, values[0], values[1]]
+            for shard, values in groups.items()
+        ]
     # Open typed holds for this workspace. Checked BEFORE the generic count
     # below, which this query string contains.
     if "COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled = false" in sql:

--- a/tests/test_credit_row_sharding_increment4.py
+++ b/tests/test_credit_row_sharding_increment4.py
@@ -276,3 +276,125 @@ def test_transaction_rechecks_drain_after_preflight_race(
     assert "atomic reshard preconditions changed" in result.reasons[0]
     assert _rows(database) == before
     assert store.get_credit_account("ws-reshard").shard_count == 1
+
+
+def test_online_split_preserves_open_hold_on_original_shard() -> None:
+    store, database = _seed(
+        shard_credits=[100],
+        shard_usage=[20],
+        shard_reserved=[10],
+    )
+    database.reservations["live"] = {
+        "reservation_id": "live",
+        "workspace_id": "ws-reshard",
+        "credit_shard": 0,
+        "ws_shard": 0,
+        "credit_reserved_micro": 10,
+        "settled": False,
+    }
+
+    result = reshard_credit_account(
+        store,
+        "ws-reshard",
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert result.ready and result.applied
+    rows = _rows(database)
+    assert [row["total_usage"] for row in rows] == [20, 0, 0, 0]
+    assert [row["reserved"] for row in rows] == [10, 0, 0, 0]
+    assert [row["total_credits"] for row in rows] == [49, 17, 17, 17]
+    assert sum(row["total_credits"] for row in rows) == 100
+
+
+def test_online_split_refuses_counter_hold_mismatch() -> None:
+    store, database = _seed(
+        shard_credits=[100],
+        shard_usage=[20],
+        shard_reserved=[10],
+    )
+    database.reservations["live"] = {
+        "reservation_id": "live",
+        "workspace_id": "ws-reshard",
+        "credit_shard": 0,
+        "ws_shard": 0,
+        "credit_reserved_micro": 9,
+        "settled": False,
+    }
+    before = [dict(row) for row in _rows(database)]
+
+    result = reshard_credit_account(
+        store,
+        "ws-reshard",
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert not result.ready
+    assert not result.applied
+    assert any("reserved=10 but open holds=9" in reason for reason in result.reasons)
+    assert _rows(database) == before
+
+
+def test_online_split_rechecks_latest_reserved_counter_after_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database = _seed(shard_credits=[100], shard_usage=[20])
+    original_run = store._run_in_transaction
+
+    def inject_atomic_hold(callback: Any, *, attempts: int = 8) -> Any:
+        database.typed[CREDIT_BALANCE_TABLE][("ws-reshard", 0)]["reserved"] = 10
+        database.reservations["arrived-after-preflight"] = {
+            "reservation_id": "arrived-after-preflight",
+            "workspace_id": "ws-reshard",
+            "credit_shard": 0,
+            "ws_shard": 0,
+            "credit_reserved_micro": 10,
+            "settled": False,
+        }
+        return original_run(callback, attempts=attempts)
+
+    monkeypatch.setattr(store, "_run_in_transaction", inject_atomic_hold)
+
+    result = reshard_credit_account(
+        store,
+        "ws-reshard",
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert result.ready and result.applied
+    assert result.typed_open_reservations == 1
+    assert [row["reserved"] for row in _rows(database)] == [10, 0, 0, 0]
+
+
+def test_online_reshard_refuses_consolidation_even_with_matching_holds() -> None:
+    store, database = _seed(
+        shard_credits=[50, 50],
+        shard_usage=[10, 10],
+        shard_reserved=[0, 5],
+    )
+    database.reservations["live"] = {
+        "reservation_id": "live",
+        "workspace_id": "ws-reshard",
+        "credit_shard": 1,
+        "ws_shard": 1,
+        "credit_reserved_micro": 5,
+        "settled": False,
+    }
+
+    result = reshard_credit_account(
+        store,
+        "ws-reshard",
+        1,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert not result.ready
+    assert not result.applied
+    assert any("only supports increasing" in reason for reason in result.reasons)

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -23,6 +23,7 @@ from trusted_router.storage_gcp_counters import (
     KEY_LIMIT_TABLE,
     key_usage_shard_count,
 )
+from trusted_router.storage_gcp_credit_shard_admin import reshard_credit_account
 from trusted_router.storage_gcp_key_shard_admin import (
     inspect_key_usage_reshard,
     reshard_key_usage,
@@ -419,6 +420,106 @@ def test_key_usage_operator_split_and_unshard_preserve_all_usage() -> None:
     assert persisted.usage_shard_count == 1
     assert persisted.usage_microdollars == 101
     assert persisted.byok_usage_microdollars == 37
+
+
+def test_online_credit_and_key_split_preserve_then_settle_live_request() -> None:
+    store, database, key = _seed(key_shards=1)
+    authorized = authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=1_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope="online-reshard-live",
+        idempotency_fingerprint="same-body",
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        credit_shard_candidates=(0,),
+        key_shard_candidates=(0,),
+    )
+    assert authorized["outcome"] == AuthorizeOutcome.ACCEPTED
+    reservation_id = authorized["reservation_id"]
+
+    credit_split = reshard_credit_account(
+        store,
+        key.workspace_id,
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+    key_split = reshard_key_usage(
+        store,
+        key.hash,
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert credit_split.ready and credit_split.applied
+    assert key_split.ready and key_split.applied
+    credit_rows = database.typed[CREDIT_BALANCE_TABLE]
+    key_rows = database.typed[KEY_LIMIT_TABLE]
+    assert [credit_rows[(key.workspace_id, shard)]["reserved"] for shard in range(4)] == [
+        1_000,
+        0,
+        0,
+        0,
+    ]
+    assert [key_rows[(key.hash, shard)]["reserved"] for shard in range(4)] == [
+        0,
+        0,
+        0,
+        0,
+    ]
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation_id,
+        actual_micro=900,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert settled["outcome"] == SettleOutcome.SETTLED
+    assert sum(row["reserved"] for row in credit_rows.values()) == 0
+    assert sum(row["total_usage"] for row in credit_rows.values()) == 900
+    assert sum(row["usage"] for row in key_rows.values()) == 900
+    assert database.reservations[reservation_id]["settled"] is True
+
+
+def test_online_key_split_keeps_history_and_windows_on_existing_shard() -> None:
+    store, database, key = _seed(key_shards=1)
+    floors = window_floors(utcnow())
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row.update(
+        usage=101,
+        byok_usage=37,
+        day_usage=19,
+        day_start=floors["daily"],
+        week_usage=23,
+        week_start=floors["weekly"],
+        month_usage=29,
+        month_start=floors["monthly"],
+    )
+
+    split = reshard_key_usage(
+        store,
+        key.hash,
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert split.ready and split.applied
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(4)]
+    assert [row["usage"] for row in rows] == [101, 0, 0, 0]
+    assert [row["byok_usage"] for row in rows] == [37, 0, 0, 0]
+    assert [row["day_usage"] for row in rows] == [19, 0, 0, 0]
+    assert [row["week_usage"] for row in rows] == [23, 0, 0, 0]
+    assert [row["month_usage"] for row in rows] == [29, 0, 0, 0]
 
 
 def test_key_usage_operator_refuses_lifetime_capped_or_undrained_key() -> None:

--- a/tests/test_shard_workspace_operator.py
+++ b/tests/test_shard_workspace_operator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 
@@ -59,6 +60,21 @@ def test_parser_requires_exactly_one_target() -> None:
     )
     assert parsed.owner_email == "owner@example.com"
     assert parsed.workspace is None
+    assert parsed.preserve_open_holds is False
+
+    online = parser.parse_args(
+        [
+            "online-split",
+            "--workspace",
+            "ws",
+            "--shards",
+            "16",
+            "--preserve-open-holds",
+            "--apply",
+        ]
+    )
+    assert online.preserve_open_holds is True
+    assert online.handler is shard_workspace.run_online_split
 
     with pytest.raises(SystemExit):
         parser.parse_args(["status", "--shards", "16"])
@@ -74,3 +90,50 @@ def test_parser_requires_exactly_one_target() -> None:
                 "16",
             ]
         )
+
+
+def test_online_split_requires_explicit_hold_preservation() -> None:
+    args = argparse.Namespace(preserve_open_holds=False)
+
+    assert shard_workspace.run_online_split(object(), args) == 2
+
+
+def test_online_split_preflights_then_prepares_and_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    store = SimpleNamespace(
+        api_keys=SimpleNamespace(list_for_workspace=lambda _workspace: [])
+    )
+    args = argparse.Namespace(
+        workspace="ws",
+        shards=16,
+        preserve_open_holds=True,
+        apply=True,
+    )
+    monkeypatch.setattr(
+        shard_workspace,
+        "inspect_credit_reshard",
+        lambda *_args, **_kwargs: calls.append("inspect"),
+    )
+    monkeypatch.setattr(
+        shard_workspace,
+        "audit_typed_invariants",
+        lambda _store: SimpleNamespace(
+            clean=True,
+            summary=lambda: "CLEAN",
+        ),
+    )
+    monkeypatch.setattr(
+        shard_workspace,
+        "run_prepare",
+        lambda _store, _args: calls.append("prepare") or 0,
+    )
+    monkeypatch.setattr(
+        shard_workspace,
+        "run_finish",
+        lambda _store, _args: calls.append("finish") or 0,
+    )
+
+    assert shard_workspace.run_online_split(store, args) == 0
+    assert calls == ["inspect", "prepare", "finish"]


### PR DESCRIPTION
Adds an explicit split-only reshard mode that preserves open typed holds on their existing shard IDs, distributes only free credit capacity to new rows, and runs pre/post fail-closed invariant audits. Default drain-only behavior remains unchanged. Exact lifetime-capped keys stay single-row. Verification: 2062 tests passed, 47 skipped; Ruff and mypy clean; production read-only hold queries validated.