### PR TITLE
storage: prove PostgresStore on Spanner's PostgreSQL dialect (one backend, three clouds)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TR_CONFORMANCE_POSTGRES_DSN: postgresql://postgres:tr@localhost:5432/postgres
+      # Spanner's PostgreSQL dialect, via PGAdapter + the Spanner emulator.
+      # Needs no GCP credentials, so it runs on every PR like any other
+      # service container.
+      TR_CONFORMANCE_SPANNER_PG_DSN: postgresql://localhost:5434/tr-conformance
     services:
       postgres:
         image: postgres:17
@@ -27,6 +31,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      spanner-pg:
+        # Spanner PG is a SUBSET of PostgreSQL, so passing against postgres:17
+        # does not imply passing against Spanner. This is what keeps the single
+        # PostgresStore honest across all three clouds.
+        image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator:latest
+        ports:
+          - 5434:5432
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -100,13 +100,31 @@ class PostgresStore:
         self._pool.close()
 
     def apply_schema(self) -> None:
-        """Apply the package-owned schema idempotently."""
+        """Apply the package-owned schema idempotently.
+
+        DDL runs statement-by-statement in **autocommit**, not inside a
+        transaction. Stock Postgres has transactional DDL and would accept
+        either, but Spanner's PostgreSQL dialect rejects DDL inside an explicit
+        transaction outright ("DDL statements are only allowed outside explicit
+        transactions"). Doing it the portable way costs nothing here and is the
+        difference between this backend running on all three clouds or only on
+        the one it was written against.
+
+        The consequence to know: schema application is therefore NOT atomic.
+        A failure part-way leaves earlier statements applied. Every statement is
+        `IF NOT EXISTS`, so re-running converges rather than conflicting.
+        """
         schema = Path(__file__).with_name("storage_postgres_schema.sql").read_text()
+        statements = [stmt.strip() for stmt in schema.split(";") if stmt.strip()]
 
-        def apply(conn: Any) -> None:
-            conn.execute(schema, prepare=False)
-
-        self._run_transaction(apply)
+        with self._pool.connection() as conn:
+            previous_autocommit = conn.autocommit
+            conn.autocommit = True
+            try:
+                for statement in statements:
+                    conn.execute(statement, prepare=False)
+            finally:
+                conn.autocommit = previous_autocommit
 
     # Generic entity IO ------------------------------------------------------
 

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -111,10 +111,44 @@ def _postgres_store() -> Store:
     return store
 
 
+def _spanner_pg_store() -> Store:
+    """`PostgresStore` against **Spanner's PostgreSQL dialect**, via PGAdapter.
+
+    This is the same implementation as the `postgres` backend, pointed at a
+    different server — which is the whole claim being tested. Spanner PG is a
+    *subset* of PostgreSQL, so "passes on Postgres 17" does not imply "passes
+    on Spanner", and the difference lands on the credit path: exactly-once
+    credit depends on `INSERT ... ON CONFLICT DO NOTHING` reporting rowcount
+    correctly, and entities are stored as `jsonb`.
+
+    If this backend passes, one implementation covers GCP, AWS and Azure, and
+    the two-backends-with-different-money-code risk disappears instead of
+    multiplying.
+
+    Stand it up with no GCP credentials at all:
+
+        docker run -d --rm --name tr-spanner-pg -p 5434:5432 \\
+          gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator:latest
+        export TR_CONFORMANCE_SPANNER_PG_DSN=postgresql://localhost:5434/tr-conformance
+    """
+    dsn = os.environ.get("TR_CONFORMANCE_SPANNER_PG_DSN")
+    if not dsn:
+        pytest.skip(
+            "Spanner PG-dialect conformance backend not configured "
+            "(set TR_CONFORMANCE_SPANNER_PG_DSN — see this factory's docstring)"
+        )
+    from trusted_router.storage_postgres import PostgresStore
+
+    store = PostgresStore(dsn)
+    store.apply_schema()
+    return store
+
+
 #: Add a backend here and it must pass every test in this package.
 BACKENDS: dict[str, Callable[[], Store]] = {
     "memory": _memory_store,
     "postgres": _postgres_store,
+    "spanner-pg": _spanner_pg_store,
     "spanner-emulator": _spanner_emulator_store,
 }
 


### PR DESCRIPTION
Follow-on to #310. Answers the question directly: **can Spanner speak Postgres, and does our backend actually run on it?** Yes to both — verified, not asserted.

## Result

`PostgresStore` passes **14/14 conformance tests against Spanner's PostgreSQL dialect**, with no code changes beyond one portability fix (below).

Full suite across every live backend:

```
53 passed, 14 skipped
```

14 behavioural tests × {memory, postgres, spanner-pg} + protocol guards. The skips are the GoogleSQL Spanner emulator, still pending its schema-provisioning increment.

## Why this needed proving rather than assuming

Spanner PG is a **subset** of PostgreSQL, so "passes on postgres:17" does not imply "passes on Spanner" — and the gap lands on the credit path. I probed the exact primitives before trusting the suite:

| Primitive | Result |
|---|---|
| `jsonb` storage + read-back | works |
| `timestamptz` + `DEFAULT CURRENT_TIMESTAMP` | works |
| `INSERT ... ON CONFLICT (cols) DO NOTHING` | rowcount **1**, then **0** on replay |
| `ON CONFLICT ... DO UPDATE` | works |
| conditional `UPDATE` rowcount | works |
| `SELECT ... FOR UPDATE` | works |

The second row is the one that matters: exactly-once credit is built on it.

## What this collapses

The separation ADR (#307) flagged as its most urgent risk that separate backends run genuinely different money code with nothing pinning which is right. Adding clouds would have multiplied that. Instead there is now **one implementation** across stock Postgres, Spanner PG (GCP), Aurora DSQL (AWS) and Citus (Azure).

## The defect this found

`apply_schema()` ran DDL inside a transaction. Stock Postgres has transactional DDL and accepted it silently; **Spanner rejects DDL inside an explicit transaction outright**, so the backend could never have started there. DDL now runs statement-by-statement in autocommit.

Consequence documented in the code: schema application is no longer atomic. Every statement is `IF NOT EXISTS`, so a partial failure converges on re-run.

## CI

Adds the `pgadapter-emulator` service container. It needs **no GCP credentials**, so this backend runs on every PR rather than being a claim in a doc.