### PR TITLE
Separate Router Core reliability measurements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,10 +265,8 @@ jobs:
       # Staged regional deploy. Deploy us-central1 first, gate on a
       # 3-min single-region synthetic watch; only proceed to the
       # secondary warm regions if us-central1 stays up. A bad change
-      # reaches at most one region before the secondaries start. Once
-      # the primary canary is green, europe-west4 and us-east4 roll in
-      # parallel with independent rollback. Final 10-min watch catches
-      # issues that surface after warm regions are converged.
+      # reaches at most one region at a time: europe-west4 and us-east4
+      # roll sequentially, each with independent staged traffic and rollback.
       #
       # Hotfix mode (workflow_dispatch input `hotfix: true`): the
       # watchdogs skip baseline + use --skip-baseline so a sick prod
@@ -381,7 +379,7 @@ jobs:
           echo "europe-west4 NEVER received the bad image; safe."
           exit 1
 
-      - name: Roll secondary warm regions in parallel (europe-west4 + us-east4)
+      - name: Roll secondary warm regions sequentially (europe-west4, then us-east4)
         env:
           IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
           PREV_EU: ${{ steps.prev.outputs.europe_west4_revision }}
@@ -390,9 +388,6 @@ jobs:
           TR_WATCHDOG_SLO_CLASS: control_plane
         run: |
           set -euo pipefail
-
-          log_dir="$(mktemp -d)"
-          echo "secondary rollout logs: ${log_dir}"
 
           previous_revision() {
             case "$1" in
@@ -446,32 +441,15 @@ jobs:
           }
 
           regions=(europe-west4 us-east4)
-          pids=()
           for region in "${regions[@]}"; do
-            (
-              set -euo pipefail
-              deploy_secondary "${region}"
-            ) >"${log_dir}/${region}.log" 2>&1 &
-            pids+=("$!")
-          done
-
-          failed=0
-          for i in "${!regions[@]}"; do
-            region="${regions[$i]}"
-            pid="${pids[$i]}"
-            if ! wait "${pid}"; then
-              echo "::error::${region} rollout failed"
-              failed=1
+            echo "::group::${region} sequential rollout"
+            if ! deploy_secondary "${region}"; then
+              echo "::endgroup::"
+              echo "::error::${region} rollout failed; no later warm region was touched."
+              exit 1
             fi
-            echo "::group::${region} rollout log"
-            cat "${log_dir}/${region}.log"
             echo "::endgroup::"
           done
-
-          if [ "${failed}" -ne 0 ]; then
-            echo "one or more secondary warm regions failed; us-central1 keeps the new release; cold regions have NOT received it."
-            exit 1
-          fi
 
       - name: Deploy cold regions (no canary, scale-to-zero)
         # Stage 3.5 cold region: southamerica-east1. min-instances=0
@@ -506,7 +484,7 @@ jobs:
 
       # No cross-region "final watchdog" step. Each region's health is
       # gated by its own per-region canary above (us-central1, then
-      # europe-west4 + us-east4 in parallel, each with its own 3-min
+      # europe-west4, then us-east4, each with its own 3-min
       # watchdog AFTER the staged_traffic 10/50/100 ramp). The prior cross-
       # region watchdog at this point caused recurring spurious
       # rollbacks: by the time it ran, earlier regions had finished
@@ -542,6 +520,7 @@ jobs:
 
           check_url homepage https://trustedrouter.com/
           check_url health https://trustedrouter.com/health
+          check_url ready https://trustedrouter.com/ready
           check_url regions https://trustedrouter.com/v1/regions
           check_url status_json https://trustedrouter.com/status.json
           check_url status_host https://status.trustedrouter.com/status.json
@@ -553,6 +532,7 @@ jobs:
             service_url=$(gcloud run services describe "${SERVICE}" \
               --project="${PROJECT_ID}" --region="${region}" \
               --format='value(status.url)')
+            check_url "ready_${region}" "${service_url}/ready"
             check_url "status_${region}" "${service_url}/status.json"
           done
 
@@ -573,4 +553,4 @@ jobs:
           count=$(curl -fsS --max-time 15 https://trustedrouter.com/v1/models \
             | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('data',[])))")
           [[ "$count" -gt 100 ]] || { echo "/v1/models has only $count models, expected >100"; exit 1; }
-          echo "smoke ok: homepage, health, regions, status, and $count catalog models"
+          echo "smoke ok: homepage, liveness, readiness, regions, status, and $count catalog models"

--- a/scripts/provision_synthetic_monitor.py
+++ b/scripts/provision_synthetic_monitor.py
@@ -99,11 +99,10 @@ def provision(
     if workspace is None:
         raise ValueError("synthetic monitoring workspace is missing")
 
-    existing_keys = [
-        key
-        for key in store.list_keys(workspace.id)
-        if key.name == key_name and not key.disabled
-    ]
+    active_keys = [key for key in store.list_keys(workspace.id) if not key.disabled]
+    existing_keys = [key for key in active_keys if key.name == key_name]
+    if len(active_keys) != len(existing_keys):
+        raise ValueError("synthetic monitoring workspace has unexpected active keys")
     if len(existing_keys) > 1:
         raise ValueError("multiple active synthetic monitor keys exist")
     if existing_keys:
@@ -114,14 +113,20 @@ def provision(
             or existing_key.limit_daily_microdollars is not None
             or existing_key.limit_weekly_microdollars is not None
             or existing_key.limit_monthly_microdollars is not None
+            or existing_key.expires_at is not None
             or existing_key.tags.get("purpose") != "synthetic_monitoring"
+            or existing_key.tags.get("analytics") != "excluded"
+            or existing_key.tags.get("spend_control") != "workspace_funding_only"
         ):
             raise ValueError("existing synthetic monitor key has unsafe configuration")
 
     account = store.get_credit_account(workspace.id)
     if account is None:
         raise ValueError("synthetic monitoring credit account is missing")
+    if account.auto_refill_enabled:
+        raise ValueError("synthetic monitoring workspace must not use auto-refill")
     current_shards = account.shard_count
+    current_key_shards = existing_keys[0].usage_shard_count if existing_keys else 1
 
     result: dict[str, Any] = {
         "apply": apply,
@@ -136,8 +141,11 @@ def provision(
         "credited": False,
         "funding_microdollars": funding_microdollars,
         "current_shards": current_shards,
+        "current_key_shards": current_key_shards,
         "target_shards": target_shards,
-        "requires_reshard": current_shards != target_shards,
+        "requires_reshard": (
+            current_shards != target_shards or current_key_shards != target_shards
+        ),
     }
     if not apply:
         result["would_create_key"] = not existing_keys

--- a/scripts/provision_synthetic_monitor.py
+++ b/scripts/provision_synthetic_monitor.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Provision the isolated production workspace used by synthetic monitoring.
+
+Dry-run is the default. The apply path uses only public Store operations and
+the typed credit ledger; it never issues ad hoc production DML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.money import dollars_to_microdollars
+from trusted_router.security import new_api_key
+from trusted_router.storage import create_store
+
+DEFAULT_EMAIL = "synthetic-monitor@trustedrouter.internal"
+DEFAULT_WORKSPACE_NAME = "TrustedRouter Synthetic Monitoring"
+DEFAULT_KEY_NAME = "Synthetic monitor"
+DEFAULT_FUNDING_EVENT = "synthetic_monitor_workspace_funding_v1"
+DEFAULT_TARGET_SHARDS = 16
+
+
+def provision(
+    store: Any,
+    *,
+    email: str,
+    workspace_name: str,
+    key_name: str,
+    funding_microdollars: int,
+    funding_event_id: str,
+    target_shards: int,
+    apply: bool,
+    key_output_file: Path | None,
+) -> dict[str, Any]:
+    user = store.find_user_by_email(email)
+    created_user = False
+    created_workspace = False
+    created_key = False
+    credited = False
+
+    if user is None and not apply:
+        return {
+            "apply": False,
+            "email": email,
+            "workspace_name": workspace_name,
+            "would_create_user": True,
+            "would_create_workspace": True,
+            "would_create_key": True,
+            "funding_microdollars": funding_microdollars,
+        }
+    if user is None:
+        user = store.ensure_user(
+            email,
+            email=email,
+            trial_credit_microdollars=0,
+        )
+        created_user = True
+
+    workspaces = store.list_workspaces_for_user(user.id)
+    matching = [workspace for workspace in workspaces if workspace.name == workspace_name]
+    if len(matching) > 1:
+        raise ValueError("multiple synthetic monitoring workspaces exist")
+    workspace = matching[0] if matching else None
+    if workspace is None:
+        personal = [
+            candidate
+            for candidate in workspaces
+            if candidate.name == "Personal Workspace"
+            and candidate.owner_user_id == user.id
+        ]
+        if len(personal) == 1 and len(workspaces) == 1:
+            workspace = personal[0]
+            if apply:
+                workspace = store.update_workspace(workspace.id, name=workspace_name)
+                if workspace is None:
+                    raise RuntimeError("failed to rename synthetic monitoring workspace")
+            created_workspace = created_user
+        elif apply:
+            workspace = store.create_workspace(
+                user.id,
+                workspace_name,
+                trial_credit_microdollars=0,
+            )
+            created_workspace = True
+
+    if workspace is None:
+        raise ValueError("synthetic monitoring workspace is missing")
+
+    existing_keys = [
+        key
+        for key in store.list_keys(workspace.id)
+        if key.name == key_name and not key.disabled
+    ]
+    if len(existing_keys) > 1:
+        raise ValueError("multiple active synthetic monitor keys exist")
+    if existing_keys:
+        existing_key = existing_keys[0]
+        if (
+            existing_key.management
+            or existing_key.limit_microdollars is not None
+            or existing_key.limit_daily_microdollars is not None
+            or existing_key.limit_weekly_microdollars is not None
+            or existing_key.limit_monthly_microdollars is not None
+            or existing_key.tags.get("purpose") != "synthetic_monitoring"
+        ):
+            raise ValueError("existing synthetic monitor key has unsafe configuration")
+
+    account = store.get_credit_account(workspace.id)
+    if account is None:
+        raise ValueError("synthetic monitoring credit account is missing")
+    current_shards = account.shard_count
+
+    result: dict[str, Any] = {
+        "apply": apply,
+        "email": email,
+        "user_id": user.id,
+        "workspace_id": workspace.id,
+        "workspace_name": workspace.name,
+        "key_id": existing_keys[0].hash if existing_keys else None,
+        "created_user": created_user,
+        "created_workspace": created_workspace,
+        "created_key": False,
+        "credited": False,
+        "funding_microdollars": funding_microdollars,
+        "current_shards": current_shards,
+        "target_shards": target_shards,
+        "requires_reshard": current_shards != target_shards,
+    }
+    if not apply:
+        result["would_create_key"] = not existing_keys
+        return result
+
+    if not existing_keys:
+        if key_output_file is None:
+            raise ValueError("--key-output-file is required when creating the monitor key")
+        if key_output_file.exists():
+            raise ValueError("refusing to overwrite the key output file")
+
+    credited = store.credit_workspace_typed_direct(
+        workspace.id,
+        funding_microdollars,
+        funding_event_id,
+    )
+
+    if not existing_keys:
+        assert key_output_file is not None
+        raw_key = new_api_key()
+        # A lifetime key cap requires one exact usage row and therefore cannot
+        # be sharded. This isolated workspace has no auto-refill; its explicitly
+        # funded balance is the hard total spend cap while both credit and
+        # uncapped-key counters can safely use 16 shards.
+        raw_key, api_key = store.create_api_key(
+            workspace_id=workspace.id,
+            name=key_name,
+            creator_user_id=user.id,
+            management=False,
+            raw_key=raw_key,
+            tags={
+                "purpose": "synthetic_monitoring",
+                "analytics": "excluded",
+                "spend_control": "workspace_funding_only",
+            },
+        )
+        try:
+            key_output_file.write_text(f"{raw_key}\n", encoding="utf-8")
+            key_output_file.chmod(0o600)
+        except Exception:
+            store.delete_key(api_key.hash)
+            raise
+        result["key_id"] = api_key.hash
+        created_key = True
+
+    result["created_key"] = created_key
+    result["credited"] = credited
+    return result
+
+
+def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    parser.add_argument("--workspace-name", default=DEFAULT_WORKSPACE_NAME)
+    parser.add_argument("--key-name", default=DEFAULT_KEY_NAME)
+    parser.add_argument("--fund-usd", default="1000")
+    parser.add_argument("--funding-event-id", default=DEFAULT_FUNDING_EVENT)
+    parser.add_argument("--target-shards", type=int, default=DEFAULT_TARGET_SHARDS)
+    parser.add_argument("--key-output-file", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.apply and os.environ.get("TR_STORAGE_BACKEND") != "spanner-bigtable":
+        print("ERROR: --apply requires TR_STORAGE_BACKEND=spanner-bigtable", file=sys.stderr)
+        return 2
+    if args.target_shards < 1 or args.target_shards > 64:
+        print("ERROR: --target-shards must be between 1 and 64", file=sys.stderr)
+        return 2
+    try:
+        active_store = create_store(Settings()) if store is None else store
+        result = provision(
+            active_store,
+            email=args.email.strip().lower(),
+            workspace_name=args.workspace_name.strip(),
+            key_name=args.key_name.strip(),
+            funding_microdollars=dollars_to_microdollars(args.fund_usd),
+            funding_event_id=args.funding_event_id.strip(),
+            target_shards=args.target_shards,
+            apply=args.apply,
+            key_output_file=args.key_output_file,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not args.apply:
+        print("DRY-RUN: no production state changed; pass --apply after review.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/provision_synthetic_monitor.py
+++ b/scripts/provision_synthetic_monitor.py
@@ -174,11 +174,20 @@ def provision(
                 "spend_control": "workspace_funding_only",
             },
         )
+        created_output_file = False
         try:
-            key_output_file.write_text(f"{raw_key}\n", encoding="utf-8")
-            key_output_file.chmod(0o600)
+            fd = os.open(
+                key_output_file,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            created_output_file = True
+            with os.fdopen(fd, "w", encoding="utf-8") as output:
+                output.write(f"{raw_key}\n")
         except Exception:
             store.delete_key(api_key.hash)
+            if created_output_file:
+                key_output_file.unlink(missing_ok=True)
             raise
         result["key_id"] = api_key.hash
         created_key = True

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -135,8 +135,12 @@ def _authoritative_provider_model_ids(provider_slug: str) -> frozenset[str]:
         }:
             continue
         model_id = row.get("id")
-        if isinstance(model_id, str) and model_id:
-            allowed.add(model_id)
+        if not isinstance(model_id, str) or not model_id:
+            continue
+        upstream_id = str(row.get("upstream_id") or model_id)
+        if provider_model_retired(provider_slug, model_id, upstream_id):
+            continue
+        allowed.add(model_id)
     return frozenset(allowed)
 
 _AUTHOR_TO_PROVIDER_SLUG: dict[str, str] = {

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -49,6 +49,7 @@ from trusted_router.routes.wallet_oauth import register_wallet_oauth_routes
 from trusted_router.routes.workspaces import register_workspace_routes
 from trusted_router.sentry_config import init_sentry
 from trusted_router.storage import (
+    STORE,
     configure_analytics_sink,
     configure_store,
     create_store,
@@ -165,6 +166,27 @@ def _make_api_router(settings: Settings) -> APIRouter:
     @router.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    @router.get("/ready")
+    def ready() -> Response:
+        try:
+            STORE.readiness_check()
+        except Exception:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "status": "not_ready",
+                    "checks": {"billing_store": "unavailable"},
+                },
+                headers={"Retry-After": "5"},
+            )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "ready",
+                "checks": {"billing_store": "ready"},
+            },
+        )
 
     @router.get("/coverage/openrouter")
     async def coverage() -> dict[str, Any]:

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -61,12 +61,14 @@ STATUS_HOST_EXACT_PATHS = frozenset(
         "/favicon.ico",
         "/health",
         "/healthz",
+        "/ready",
         "/og.png",
         "/robots.txt",
         "/status",
         "/status.json",
         "/v1/health",
         "/v1/healthz",
+        "/v1/ready",
     }
 )
 STATUS_HOST_PATH_PREFIXES = ("/static/", "/status/")
@@ -279,7 +281,9 @@ def _rate_limit_request(request: Request, settings: Settings) -> JSONResponse | 
     if not settings.rate_limit_enabled:
         return None
     path = request.url.path
-    if path in {"/health", "/v1/health"} or path.startswith(("/docs", "/openapi.json")):
+    if path in {"/health", "/v1/health", "/ready", "/v1/ready"} or path.startswith(
+        ("/docs", "/openapi.json")
+    ):
         return None
 
     bearer = get_authorization_bearer(request)
@@ -401,6 +405,7 @@ def _is_public_html_response(path: str, response: Response) -> bool:
         "/v1",
         "/static",
         "/health",
+        "/ready",
         "/openapi",
     )
     if path.startswith(excluded) or path.endswith("_oauth_callback"):

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -117,6 +117,9 @@ STATUS_HISTORY_CACHE_SECONDS = 300
 STATUS_HISTORY_STALE_SECONDS = 1_800
 LEADERBOARD_SAMPLE_LIMIT = PUBLIC_BENCHMARK_SAMPLE_LIMIT
 LEADERBOARD_MIN_SAMPLES = 1
+LEADERBOARD_MODEL_RANK_MIN_SAMPLES = 10
+LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES = 30
+LEADERBOARD_RANK_MIN_TTFT_SAMPLES = 3
 LEADERBOARD_RECENT_WINDOW_MINUTES = PUBLIC_BENCHMARK_RECENT_MINUTES
 LEADERBOARD_SNAPSHOT_CACHE_SECONDS = 300
 LEADERBOARD_RESPONSE_CACHE_SECONDS = 60
@@ -1307,7 +1310,18 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
         limit=LEADERBOARD_SAMPLE_LIMIT,
         recent_minutes=LEADERBOARD_RECENT_WINDOW_MINUTES,
     )
-    payload = aggregate_leaderboard(samples, min_samples=LEADERBOARD_MIN_SAMPLES)
+    payload = aggregate_leaderboard(
+        samples,
+        min_samples=LEADERBOARD_MIN_SAMPLES,
+        model_rank_min_samples=LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
+        provider_rank_min_samples=LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
+        rank_min_ttft_samples=LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
+    )
+    payload["rank_minimums"] = {
+        "model_availability_samples": LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
+        "provider_availability_samples": LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
+        "ttft_samples": LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
+    }
     payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
     payload["sample_window_count"] = len(samples)
     payload["sample_limit"] = LEADERBOARD_SAMPLE_LIMIT

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -119,6 +119,9 @@ class InMemoryStore:
             self.verification_tokens.reset()
             self.email_blocks.reset()
 
+    def readiness_check(self) -> None:
+        """The in-memory backend has no external serving dependency."""
+
     def ensure_user(
         self,
         user_id: str,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -261,6 +261,17 @@ class SpannerBigtableStore:
         self.verification_tokens = SpannerVerificationTokens(io)
         self.email_blocks = SpannerEmailBlocks(io)
 
+    def readiness_check(self) -> None:
+        """Verify the strongly consistent billing store within a hard deadline."""
+
+        with self._database.snapshot() as snapshot:
+            list(
+                snapshot.execute_sql(
+                    "SELECT 1 FROM tr_credit_balance LIMIT 1",
+                    timeout=3.0,
+                )
+            )
+
     def reset(self) -> None:
         raise RuntimeError("refusing to reset production Spanner/Bigtable store")
 

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -99,6 +99,14 @@ class PostgresStore:
         """Close the connection pool."""
         self._pool.close()
 
+    def readiness_check(self) -> None:
+        """Verify the billing database without permitting an unbounded wait."""
+
+        with self._pool.connection(timeout=3.0) as conn:
+            with conn.transaction():
+                conn.execute("SET LOCAL statement_timeout = '3s'")
+                conn.execute("SELECT 1 FROM tr_credit_balance LIMIT 1").fetchone()
+
     def apply_schema(self) -> None:
         """Apply the package-owned schema idempotently."""
         schema = Path(__file__).with_name("storage_postgres_schema.sql").read_text()

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -48,6 +48,7 @@ class Store(Protocol):
 
     # Lifecycle ---------------------------------------------------------------
     def reset(self) -> None: ...
+    def readiness_check(self) -> None: ...
 
     # Users + workspaces ------------------------------------------------------
     def ensure_user(

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from trusted_router.storage_models import SyntheticProbeSample
+from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
 
-API_PROBES = {"tls_health", "attestation_nonce", "openai_sdk_pong", "responses_pong"}
-ROUTER_CORE_PROBES = {
-    "tls_health",
-    "attestation_nonce",
-    "gateway_authorize_settle",
-    "provider_fallback",
-}
+REGIONAL_GATEWAY_PROBES = {"tls_health", "attestation_nonce"}
 CONTROL_PLANE_PROBES = {"control_plane_health"}
 IMAGE_GENERATION_PROBES = {"image_generation"}
 
-SLO_PROBES: dict[str, set[str]] = {
-    "router_core": ROUTER_CORE_PROBES,
-    "control_plane": CONTROL_PLANE_PROBES,
+COMPONENT_PROBES: dict[str, set[str]] = {
+    "canonical_api": REGIONAL_GATEWAY_PROBES,
+    "us_central1_regional_api": REGIONAL_GATEWAY_PROBES,
+    "us_east4_regional_api": REGIONAL_GATEWAY_PROBES,
+    "eu_regional_api": REGIONAL_GATEWAY_PROBES,
+    "attestation": {"attestation_nonce"},
+    "billing_settlement": {"gateway_authorize_settle"},
+    "provider_fallback": {"provider_fallback"},
+    "image_generation": IMAGE_GENERATION_PROBES,
 }
 
 SLO_DEFINITIONS: tuple[dict[str, str], ...] = (
@@ -39,22 +39,22 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
     {
         "id": "canonical_api",
         "name": "Canonical API",
-        "description": "api.trustedrouter.com chat, Responses, TLS, and attestation checks.",
+        "description": "api.trustedrouter.com attested TLS reachability and trust checks.",
     },
     {
         "id": "us_central1_regional_api",
         "name": "US Central Regional API",
-        "description": "api-us-central1.quillrouter.com regional attested gateway checks.",
+        "description": "US Central attested TLS reachability and trust checks.",
     },
     {
         "id": "us_east4_regional_api",
         "name": "US East Regional API",
-        "description": "api-us-east4.quillrouter.com regional attested gateway checks.",
+        "description": "US East attested TLS reachability and trust checks.",
     },
     {
         "id": "eu_regional_api",
         "name": "EU Regional API",
-        "description": "api-europe-west4.quillrouter.com regional attested gateway checks.",
+        "description": "EU attested TLS reachability and trust checks.",
     },
     {
         "id": "attestation",
@@ -81,13 +81,13 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
 
 def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
     ids: list[str] = []
-    if sample.target == "canonical" and sample.probe_type in API_PROBES:
+    if sample.target == "canonical" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("canonical_api")
-    if sample.target == "us-central1" and sample.probe_type in API_PROBES:
+    if sample.target == "us-central1" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("us_central1_regional_api")
-    if sample.target == "us-east4" and sample.probe_type in API_PROBES:
+    if sample.target == "us-east4" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("us_east4_regional_api")
-    if sample.target == "europe-west4" and sample.probe_type in API_PROBES:
+    if sample.target == "europe-west4" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_regional_api")
     if sample.probe_type == "attestation_nonce":
         ids.append("attestation")
@@ -101,13 +101,44 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
 
 
 def sample_slo_class_ids(sample: SyntheticProbeSample) -> list[str]:
-    return [
-        slo_id for slo_id, probe_types in SLO_PROBES.items() if sample.probe_type in probe_types
-    ]
+    return _slo_class_ids(probe_type=sample.probe_type, target=sample.target)
 
 
-def slo_probe_types(slo_id: str) -> set[str]:
-    return set(SLO_PROBES.get(slo_id, set()))
+def rollup_slo_class_ids(rollup: SyntheticRollup) -> list[str]:
+    ids = _slo_class_ids(probe_type=rollup.probe_type, target=rollup.target)
+    if "router_core" not in ids:
+        return ids
+    # Samples can feed more than one public display component. Select exactly
+    # one component for each Router Core dimension so SLO rollups never count
+    # the same underlying probe twice.
+    expected_component = {
+        "tls_health": "canonical_api",
+        "attestation_nonce": "canonical_api",
+        "gateway_authorize_settle": "billing_settlement",
+        "provider_fallback": "provider_fallback",
+    }.get(rollup.probe_type)
+    if rollup.component != expected_component:
+        ids.remove("router_core")
+    return ids
+
+
+def _slo_class_ids(*, probe_type: str, target: str) -> list[str]:
+    ids: list[str] = []
+    if (
+        (target == "canonical" and probe_type in REGIONAL_GATEWAY_PROBES)
+        or (
+            target == "control-plane"
+            and probe_type in {"gateway_authorize_settle", "provider_fallback"}
+        )
+    ):
+        ids.append("router_core")
+    if probe_type in CONTROL_PLANE_PROBES:
+        ids.append("control_plane")
+    return ids
+
+
+def component_probe_types(component_id: str) -> set[str]:
+    return set(COMPONENT_PROBES.get(component_id, set()))
 
 
 def component_name(component_id: str) -> str:

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -111,7 +111,10 @@ class ProviderModelStats:
     success_count: int = 0
     error_count: int = 0
     excluded_count: int = 0
+    ttft_sample_count: int = 0
     throughput_sample_count: int = 0
+    rank: int | None = None
+    rank_eligible: bool = False
     p50_ttft_ms: int | None = None
     p95_ttft_ms: int | None = None
     p50_ttfb_ms: int | None = None
@@ -147,7 +150,10 @@ class ProviderModelStats:
             "uptime": round(self.uptime, 4) if self.sample_count else None,
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
+            "ttft_sample_count": self.ttft_sample_count,
             "throughput_sample_count": self.throughput_sample_count,
+            "rank": self.rank,
+            "rank_eligible": self.rank_eligible,
             "top_error": self.top_error,
             "top_excluded": self.top_excluded,
             "errors": dict(self.errors),
@@ -173,7 +179,10 @@ class ProviderStats:
     success_count: int = 0
     error_count: int = 0
     excluded_count: int = 0
+    ttft_sample_count: int = 0
     throughput_sample_count: int = 0
+    rank: int | None = None
+    rank_eligible: bool = False
     p50_ttft_ms: int | None = None
     p50_tokens_per_second: float | None = None
     errors: Counter[str] = field(default_factory=Counter)
@@ -205,7 +214,10 @@ class ProviderStats:
             "uptime": round(self.uptime, 4) if self.sample_count else None,
             "error_rate": round(self.error_rate, 4),
             "excluded_count": self.excluded_count,
+            "ttft_sample_count": self.ttft_sample_count,
             "throughput_sample_count": self.throughput_sample_count,
+            "rank": self.rank,
+            "rank_eligible": self.rank_eligible,
             "top_error": self.top_error,
             "top_excluded": self.top_excluded,
             "errors": dict(self.errors),
@@ -225,7 +237,12 @@ def _sort_key(p50_ttft_ms: int | None) -> tuple[int, int]:
 
 
 def aggregate_leaderboard(
-    samples: Iterable[ProviderBenchmarkSample], *, min_samples: int = 1
+    samples: Iterable[ProviderBenchmarkSample],
+    *,
+    min_samples: int = 1,
+    model_rank_min_samples: int = 1,
+    provider_rank_min_samples: int = 1,
+    rank_min_ttft_samples: int = 1,
 ) -> dict[str, Any]:
     """Aggregate samples into ranked per-model and per-provider stats.
 
@@ -235,7 +252,6 @@ def aggregate_leaderboard(
     by_model: dict[tuple[str, str], ProviderModelStats] = {}
     ttft: dict[tuple[str, str], list[int]] = {}
     ttfb: dict[tuple[str, str], list[int]] = {}
-    legacy_tps: dict[tuple[str, str], list[float]] = {}
     sustained_tps: dict[tuple[str, str], list[float]] = {}
 
     for sample in samples:
@@ -246,7 +262,6 @@ def aggregate_leaderboard(
             by_model[key] = stats
             ttft[key] = []
             ttfb[key] = []
-            legacy_tps[key] = []
             sustained_tps[key] = []
         if sample.source == "synthetic_throughput":
             effective_tps = _effective_throughput(sample)
@@ -276,26 +291,45 @@ def aggregate_leaderboard(
             ttft[key].append(sample.first_token_milliseconds)
         if sample.ttfb_milliseconds is not None:
             ttfb[key].append(sample.ttfb_milliseconds)
-        if sample.speed_tokens_per_second:
-            legacy_tps[key].append(sample.speed_tokens_per_second)
         if stats.last_seen is None or sample.created_at > stats.last_seen:
             stats.last_seen = sample.created_at
 
     for key, stats in by_model.items():
+        stats.ttft_sample_count = len(ttft[key])
         stats.p50_ttft_ms = _percentile(ttft[key], 50)
         stats.p95_ttft_ms = _percentile(ttft[key], 95)
         stats.p50_ttfb_ms = _percentile(ttfb[key], 50)
         stats.p95_ttfb_ms = _percentile(ttfb[key], 95)
-        stats.p50_tokens_per_second = _median_float(sustained_tps[key] or legacy_tps[key])
+        stats.p50_tokens_per_second = _median_float(sustained_tps[key])
+        stats.rank_eligible = (
+            stats.sample_count >= model_rank_min_samples
+            and stats.ttft_sample_count >= rank_min_ttft_samples
+        )
 
     models = [
         stats
         for stats in by_model.values()
         if stats.sample_count >= min_samples or stats.throughput_sample_count >= min_samples
     ]
-    models.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
+    models.sort(
+        key=lambda stats: (
+            0 if stats.rank_eligible else 1,
+            *_sort_key(stats.p50_ttft_ms),
+            stats.model,
+            stats.provider,
+        )
+    )
+    next_rank = 1
+    for stats in models:
+        if stats.rank_eligible:
+            stats.rank = next_rank
+            next_rank += 1
 
-    providers = _aggregate_providers(models)
+    providers = _aggregate_providers(
+        models,
+        provider_rank_min_samples=provider_rank_min_samples,
+        rank_min_ttft_samples=rank_min_ttft_samples,
+    )
     return {
         "models": [s.as_dict() for s in models],
         "providers": [s.as_dict() for s in providers],
@@ -307,36 +341,61 @@ def aggregate_leaderboard(
     }
 
 
-def _aggregate_providers(model_stats: list[ProviderModelStats]) -> list[ProviderStats]:
+def _aggregate_providers(
+    model_stats: list[ProviderModelStats],
+    *,
+    provider_rank_min_samples: int,
+    rank_min_ttft_samples: int,
+) -> list[ProviderStats]:
     by_provider: dict[str, ProviderStats] = {}
     ttft: dict[str, list[int]] = {}
     tps: dict[str, list[float]] = {}
-    for stats in model_stats:
-        agg = by_provider.get(stats.provider)
+    for model_stat in model_stats:
+        agg = by_provider.get(model_stat.provider)
         if agg is None:
-            agg = ProviderStats(provider=stats.provider)
-            by_provider[stats.provider] = agg
-            ttft[stats.provider] = []
-            tps[stats.provider] = []
+            agg = ProviderStats(provider=model_stat.provider)
+            by_provider[model_stat.provider] = agg
+            ttft[model_stat.provider] = []
+            tps[model_stat.provider] = []
         agg.model_count += 1
-        agg.sample_count += stats.sample_count
-        agg.success_count += stats.success_count
-        agg.error_count += stats.error_count
-        agg.excluded_count += stats.excluded_count
-        agg.throughput_sample_count += stats.throughput_sample_count
-        agg.errors.update(stats.errors)
-        agg.excluded_reasons.update(stats.excluded_reasons)
+        agg.sample_count += model_stat.sample_count
+        agg.success_count += model_stat.success_count
+        agg.error_count += model_stat.error_count
+        agg.excluded_count += model_stat.excluded_count
+        agg.ttft_sample_count += model_stat.ttft_sample_count
+        agg.throughput_sample_count += model_stat.throughput_sample_count
+        agg.errors.update(model_stat.errors)
+        agg.excluded_reasons.update(model_stat.excluded_reasons)
         # Weight each model's p50 by its sample count for the provider median.
-        if stats.p50_ttft_ms is not None:
-            ttft[stats.provider].extend([stats.p50_ttft_ms] * stats.sample_count)
-        if stats.p50_tokens_per_second is not None:
-            weight = stats.throughput_sample_count or stats.sample_count
-            tps[stats.provider].extend([stats.p50_tokens_per_second] * weight)
+        if model_stat.p50_ttft_ms is not None:
+            ttft[model_stat.provider].extend(
+                [model_stat.p50_ttft_ms] * model_stat.sample_count
+            )
+        if model_stat.p50_tokens_per_second is not None:
+            weight = model_stat.throughput_sample_count
+            tps[model_stat.provider].extend(
+                [model_stat.p50_tokens_per_second] * weight
+            )
     providers = list(by_provider.values())
     for agg in providers:
         agg.p50_ttft_ms = _percentile(ttft[agg.provider], 50)
         agg.p50_tokens_per_second = _median_float(tps[agg.provider])
-    providers.sort(key=lambda s: _sort_key(s.p50_ttft_ms))
+        agg.rank_eligible = (
+            agg.sample_count >= provider_rank_min_samples
+            and agg.ttft_sample_count >= rank_min_ttft_samples
+        )
+    providers.sort(
+        key=lambda stats: (
+            0 if stats.rank_eligible else 1,
+            *_sort_key(stats.p50_ttft_ms),
+            stats.provider,
+        )
+    )
+    next_rank = 1
+    for provider_stat in providers:
+        if provider_stat.rank_eligible:
+            provider_stat.rank = next_rank
+            next_rank += 1
     return providers
 
 

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -11,9 +11,10 @@ from trusted_router.synthetic.components import (
     COMPONENT_DEFINITIONS,
     SLO_DEFINITIONS,
     component_name,
+    component_probe_types,
+    rollup_slo_class_ids,
     sample_component_ids,
     sample_slo_class_ids,
-    slo_probe_types,
 )
 from trusted_router.synthetic.rollups import merge_rollups, new_rollup_for_sample
 
@@ -62,24 +63,47 @@ def status_snapshot(
     precomputed_rollups = rollups or []
     ordered = sorted(samples, key=lambda sample: sample.created_at, reverse=True)
     freshness = _monitor_freshness(ordered, now=now)
-    current = _current_status(ordered, now=now)
-    five_minute = _window_rollup(ordered, now=now, seconds=WINDOW_SECONDS["5m"])
-    twenty_four_hour = _window_rollup_with_rollup_backfill(
-        ordered,
-        precomputed_rollups,
+    router_core_samples = [
+        sample for sample in ordered if ROUTER_CORE_SLO_ID in sample_slo_class_ids(sample)
+    ]
+    current = _current_status(router_core_samples, now=now)
+    router_core_rollups = [
+        rollup
+        for rollup in precomputed_rollups
+        if ROUTER_CORE_SLO_ID in rollup_slo_class_ids(rollup)
+    ]
+    five_minute = _scoped_window(
+        router_core_samples,
+        router_core_rollups,
+        now=now,
+        seconds=WINDOW_SECONDS["5m"],
+    )
+    twenty_four_hour = _scoped_window(
+        router_core_samples,
+        router_core_rollups,
         now=now,
         seconds=WINDOW_SECONDS["24h"],
     )
-    forty_eight_hour = _window_rollup_with_rollup_backfill(
-        ordered,
-        precomputed_rollups,
+    forty_eight_hour = _scoped_window(
+        router_core_samples,
+        router_core_rollups,
         now=now,
         seconds=WINDOW_SECONDS["48h"],
     )
-    daily = _rollup_history(precomputed_rollups, period="day") or _daily_rollups(ordered)
-    monthly = _rollup_history(precomputed_rollups, period="month")
+    daily = _rollup_history(router_core_rollups, period="day") or _daily_rollups(
+        router_core_samples
+    )
+    monthly = _monthly_history(router_core_rollups)
     components = _components(ordered, now=now, rollups=precomputed_rollups)
     slo_classes = _slo_classes(ordered, precomputed_rollups, now=now)
+    slo_history = {
+        str(definition["id"]): _slo_long_term_history(
+            ordered,
+            precomputed_rollups,
+            slo_id=str(definition["id"]),
+        )
+        for definition in SLO_DEFINITIONS
+    }
     router_core_status = str(slo_classes.get(ROUTER_CORE_SLO_ID, {}).get("status") or "unknown")
     overall_status = router_core_status
     return {
@@ -92,9 +116,11 @@ def status_snapshot(
         "headline_metrics": _headline_metrics(ordered, now=now),
         "current": current,
         "slo_classes": slo_classes,
+        "slo_history": slo_history,
         "burn_rate_alerts": _burn_rate_alerts(slo_classes),
         "components": components,
         "recent_events": _recent_events(ordered, now=now),
+        "history_scope": ROUTER_CORE_SLO_ID,
         "windows": {
             "5m": five_minute,
             "24h": twenty_four_hour,
@@ -180,17 +206,26 @@ def history_payload(
     rollups: list[SyntheticRollup] | None = None,
 ) -> dict[str, Any]:
     precomputed_rollups = rollups or []
+    snapshot = status_snapshot(samples, rollups=precomputed_rollups)
     if window == "daily":
         return {
             "window": "daily",
-            "data": _rollup_history(precomputed_rollups, period="day") or _daily_rollups(samples),
+            "scope": ROUTER_CORE_SLO_ID,
+            "data": snapshot["daily"],
         }
     if window == "monthly":
-        return {"window": "monthly", "data": _monthly_history(precomputed_rollups)}
-    snapshot = status_snapshot(samples, rollups=precomputed_rollups)
+        return {
+            "window": "monthly",
+            "scope": ROUTER_CORE_SLO_ID,
+            "data": snapshot["monthly"],
+        }
     if window in snapshot["windows"]:
-        return {"window": window, "data": snapshot["windows"][window]}
-    return {"window": window, "data": {}}
+        return {
+            "window": window,
+            "scope": ROUTER_CORE_SLO_ID,
+            "data": snapshot["windows"][window],
+        }
+    return {"window": window, "scope": ROUTER_CORE_SLO_ID, "data": {}}
 
 
 def _current_status(
@@ -335,6 +370,42 @@ def _window_rollup_with_rollup_backfill(
     return _rollup_from_rollups(combined_rollups)
 
 
+def _scoped_window(
+    samples: list[SyntheticProbeSample],
+    rollups: list[SyntheticRollup],
+    *,
+    now: dt.datetime,
+    seconds: int,
+) -> dict[str, Any]:
+    detail = _window_rollup_with_rollup_backfill(
+        samples,
+        rollups,
+        now=now,
+        seconds=seconds,
+    )
+    metrics = _slo_window(samples, rollups, now=now, seconds=seconds)
+    return {**detail, **metrics}
+
+
+def _slo_long_term_history(
+    samples: list[SyntheticProbeSample],
+    rollups: list[SyntheticRollup],
+    *,
+    slo_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    scoped_samples = [
+        sample for sample in samples if slo_id in sample_slo_class_ids(sample)
+    ]
+    scoped_rollups = [
+        rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)
+    ]
+    return {
+        "daily": _rollup_history(scoped_rollups, period="day")
+        or _daily_rollups(scoped_samples),
+        "monthly": _monthly_history(scoped_rollups),
+    }
+
+
 def _hour_rollups_in_window(
     rollups: list[SyntheticRollup],
     *,
@@ -390,12 +461,13 @@ def _slo_classes(
     for definition in SLO_DEFINITIONS:
         slo_id = str(definition["id"])
         slo_samples = [sample for sample in samples if slo_id in sample_slo_class_ids(sample)]
-        slo_rollups = [rollup for rollup in rollups if rollup.probe_type in slo_probe_types(slo_id)]
+        slo_rollups = [
+            rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)
+        ]
         current = _slo_current(slo_samples, now=now)
         windows = {
             name: _slo_window(slo_samples, slo_rollups, now=now, seconds=seconds)
             for name, seconds in WINDOW_SECONDS.items()
-            if name in SLO_BURN_WINDOWS
         }
         rows[slo_id] = {
             **definition,
@@ -570,7 +642,10 @@ def _components(
             sample for sample in samples if component_id in sample_component_ids(sample)
         ]
         component_rollups = [
-            rollup for rollup in precomputed_rollups if rollup.component == component_id
+            rollup
+            for rollup in precomputed_rollups
+            if rollup.component == component_id
+            and rollup.probe_type in component_probe_types(component_id)
         ]
         component_hour_rollups = [rollup for rollup in component_rollups if rollup.period == "hour"]
         day_rollups = _hour_rollups_in_window(
@@ -1020,6 +1095,8 @@ def _recent_events(
     events = []
     for sample in samples:
         if _parse_time(sample.created_at) < cutoff or sample.status == "up":
+            continue
+        if not sample_component_ids(sample) and not sample_slo_class_ids(sample):
             continue
         component_names = [
             str(definition["name"])

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -1219,7 +1219,10 @@ def _summary(status: str, *, freshness: dict[str, Any] | None = None) -> dict[st
     if status in {"degraded", "routing_degraded"}:
         return {
             "headline": "Router Core Degraded",
-            "detail": "One or more authorization, fallback, or regional router-core checks are degraded.",
+            "detail": (
+                "One or more canonical reachability, authorization, fallback, "
+                "or settlement checks are degraded."
+            ),
         }
     return {
         "headline": "Status Unknown",

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -37,7 +37,8 @@
         <h2>Providers</h2>
         <p>Ranked by measured p50 time-to-first-token across all of a provider's models
           ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} availability samples ·
-          {{ snapshot.total_throughput_samples }} throughput samples).</p>
+          {{ snapshot.total_throughput_samples }} sustained throughput samples). Providers below the
+          evidence floor remain visible as warming, but do not receive a rank.</p>
       </div>
     </div>
     <div class="leaderboard-table-wrap">
@@ -51,11 +52,13 @@
         <tbody>
           {% for p in snapshot.providers %}
           <tr>
-            <td>{{ loop.index }}</td>
-            <td><a href="/providers/{{ p.provider }}">{{ p.provider }}</a></td>
+            <td>{% if p.rank is not none %}{{ p.rank }}{% else %}—{% endif %}</td>
+            <td><a href="/providers/{{ p.provider }}">{{ p.provider }}</a>
+              {% if not p.rank_eligible %}<span class="lb-badge">warming</span>{% endif %}
+            </td>
             <td>{{ p.model_count }}</td>
             <td>{% if p.p50_ttft_ms is not none %}{{ p.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if p.p50_tokens_per_second is not none %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ p.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
+            <td>{% if p.p50_tokens_per_second is not none and p.throughput_sample_count %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ p.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
             <td>{% if p.sample_count %}{{ '%.2f'|format(p.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if p.top_error %}<code>{{ p.top_error }}</code> {{ '%.0f'|format(p.error_rate * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if p.excluded_count %}{{ p.excluded_count }}{% if p.top_excluded %} <code>{{ p.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
@@ -71,8 +74,8 @@
     <div class="status-section-head">
       <div>
         <h2>Models</h2>
-        <p>Models in the current benchmark set, fastest measured TTFT first.
-          Thin availability and throughput measurements are labeled independently.</p>
+        <p>Qualified models are ranked by measured p50 TTFT. Thin availability and
+          throughput measurements stay visible below the ranked set as warming.</p>
       </div>
     </div>
     <div class="leaderboard-table-wrap">
@@ -87,15 +90,15 @@
         <tbody>
           {% for m in snapshot.models %}
           <tr>
-            <td>{{ loop.index }}</td>
+            <td>{% if m.rank is not none %}{{ m.rank }}{% else %}—{% endif %}</td>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a>
-              {% if m.sample_count < 5 %}<span class="lb-badge">limited availability</span>{% endif %}
+              {% if not m.rank_eligible %}<span class="lb-badge">warming</span>{% endif %}
             </td>
             <td>{{ m.provider }}</td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p95_ttft_ms is not none %}{{ m.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% if m.throughput_sample_count < 3 %} <span class="lb-badge">warming</span>{% endif %}{% else %}—{% endif %}</td>
+            <td>{% if m.p50_tokens_per_second is not none and m.throughput_sample_count %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% if m.throughput_sample_count < 3 %} <span class="lb-badge">warming</span>{% endif %}{% else %}—{% endif %}</td>
             <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ m.sample_count }}</td>

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -177,8 +177,8 @@
     <div class="status-section">
       <div class="status-section-head">
         <div>
-          <h2>Uptime</h2>
-          <p>Precomputed public rollups from metadata samples.</p>
+          <h2>Router Core uptime</h2>
+          <p>Precomputed Router Core rollups. Control Plane and upstream providers are measured separately.</p>
         </div>
       </div>
       <table class="activity-table status-table">
@@ -195,7 +195,7 @@
         </tbody>
       </table>
       {% if snapshot.monthly %}
-      <h3 class="status-subhead">Monthly reliability</h3>
+      <h3 class="status-subhead">Monthly Router Core reliability</h3>
       <table class="activity-table status-table">
         <thead><tr><th>Month</th><th>Status</th><th>Uptime</th><th>Samples</th></tr></thead>
         <tbody>

--- a/src/trusted_router/templates/public/status_history.html
+++ b/src/trusted_router/templates/public/status_history.html
@@ -39,7 +39,7 @@
     <div class="status-section-head">
       <div>
         <h2>{{ heading }}</h2>
-        <p>Latency is broken out by target, probe, monitor region, and target region. Detailed component bars below show the last 48 hourly buckets.</p>
+        <p>Router Core latency and availability are broken out by target, probe, monitor region, and target region. Control Plane and upstream providers are never blended into this history.</p>
       </div>
       <span class="component-status status-{{ rollup.overall_status|replace('_', '-') }}">{{ rollup.overall_status|replace('_', ' ') }}</span>
     </div>
@@ -140,7 +140,7 @@
     <div class="status-section-head">
       <div>
         <h2>{% if window == "monthly" %}Monthly rollups{% else %}Daily rollups{% endif %}</h2>
-        <p>Precomputed reliability history from compact rollup records, retained for long-term public status reporting.</p>
+        <p>Precomputed Router Core reliability from compact rollup records. Control Plane and upstream providers have separate measurements.</p>
       </div>
       <div class="status-legend" aria-label="Rollup legend">
         <span><i class="history-day status-up"></i>Operational</span>

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -21,4 +21,20 @@ def test_prod_smoke_checks_each_control_plane_region_directly() -> None:
         "for region in us-central1 us-east4 europe-west4 southamerica-east1; do"
         in workflow
     )
+    assert 'check_url "ready_${region}" "${service_url}/ready"' in workflow
     assert 'check_url "status_${region}" "${service_url}/status.json"' in workflow
+
+
+def test_warm_secondary_regions_roll_sequentially() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    start = workflow.index(
+        "- name: Roll secondary warm regions sequentially (europe-west4, then us-east4)"
+    )
+    end = workflow.index("- name: Deploy cold regions", start)
+    rollout = workflow[start:end]
+
+    assert "regions=(europe-west4 us-east4)" in rollout
+    assert 'for region in "${regions[@]}"; do' in rollout
+    assert 'deploy_secondary "${region}"' in rollout
+    assert "pids=(" not in rollout
+    assert " &" not in rollout

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -58,7 +58,9 @@ def test_aggregate_computes_per_model_metrics() -> None:
     assert model["error_rate"] == 0.25
     assert model["p50_ttft_ms"] == 200  # median of [100,200,300]
     assert model["p50_ttfb_ms"] == 120
-    assert model["p50_tokens_per_second"] == 300.0  # median of [280,300,320]
+    # Short request speed is not a sustained-throughput measurement.
+    assert model["p50_tokens_per_second"] is None
+    assert model["throughput_sample_count"] == 0
     assert result["total_samples"] == 4
 
 
@@ -198,6 +200,54 @@ def test_throughput_only_route_is_visible_without_claiming_availability() -> Non
     assert model["p50_tokens_per_second"] == 40.0
     assert result["providers"][0]["sample_count"] == 0
     assert result["providers"][0]["uptime"] is None
+
+
+def test_thin_rows_stay_visible_but_do_not_receive_ranks() -> None:
+    samples = [
+        _sample(provider="thin", model="thin/fast", ttft=10),
+        *[
+            _sample(
+                provider="qualified",
+                model="qualified/model",
+                ttft=100 + index,
+                created_at=f"2026-06-04T00:00:{index:02d}Z",
+            )
+            for index in range(10)
+        ],
+    ]
+
+    result = aggregate_leaderboard(
+        samples,
+        model_rank_min_samples=10,
+        provider_rank_min_samples=10,
+        rank_min_ttft_samples=3,
+    )
+
+    assert [row["model"] for row in result["models"]] == [
+        "qualified/model",
+        "thin/fast",
+    ]
+    assert result["models"][0]["rank"] == 1
+    assert result["models"][0]["rank_eligible"] is True
+    assert result["models"][1]["rank"] is None
+    assert result["models"][1]["rank_eligible"] is False
+    assert result["providers"][0]["provider"] == "qualified"
+    assert result["providers"][0]["rank"] == 1
+    assert result["providers"][1]["provider"] == "thin"
+    assert result["providers"][1]["rank"] is None
+
+
+def test_legacy_short_request_speed_never_creates_zero_sample_throughput() -> None:
+    result = aggregate_leaderboard(
+        [_sample(provider="p", model="p/m", ttft=50, tps=9999.0)]
+    )
+
+    model = result["models"][0]
+    provider = result["providers"][0]
+    assert model["throughput_sample_count"] == 0
+    assert model["p50_tokens_per_second"] is None
+    assert provider["throughput_sample_count"] == 0
+    assert provider["p50_tokens_per_second"] is None
 
 
 def test_public_benchmark_samples_reads_each_provider(monkeypatch) -> None:

--- a/tests/test_provision_synthetic_monitor.py
+++ b/tests/test_provision_synthetic_monitor.py
@@ -67,6 +67,7 @@ def test_provision_synthetic_monitor_is_isolated_funding_limited_and_idempotent(
     assert keys[0].tags["spend_control"] == "workspace_funding_only"
     assert first["target_shards"] == 16
     assert first["current_shards"] == 1
+    assert first["current_key_shards"] == 1
     assert first["requires_reshard"] is True
     snapshot = store.credit_money_snapshot(workspaces[0].id)
     assert snapshot is not None
@@ -132,3 +133,38 @@ def test_provision_synthetic_monitor_refuses_existing_key_output_path(
     else:
         raise AssertionError("existing key output path was overwritten")
     assert key_file.read_text(encoding="utf-8") == "do-not-overwrite\n"
+
+
+def test_provision_synthetic_monitor_rejects_auto_refill(tmp_path: Path) -> None:
+    store = InMemoryStore()
+    first = provision(
+        store,
+        email="synthetic-monitor@trustedrouter.internal",
+        workspace_name="TrustedRouter Synthetic Monitoring",
+        key_name="Synthetic monitor",
+        funding_microdollars=1_000_000_000,
+        funding_event_id="synthetic_monitor_workspace_funding_v1",
+        target_shards=16,
+        apply=True,
+        key_output_file=tmp_path / "monitor.key",
+    )
+    account = store.get_credit_account(first["workspace_id"])
+    assert account is not None
+    account.auto_refill_enabled = True
+
+    try:
+        provision(
+            store,
+            email="synthetic-monitor@trustedrouter.internal",
+            workspace_name="TrustedRouter Synthetic Monitoring",
+            key_name="Synthetic monitor",
+            funding_microdollars=1_000_000_000,
+            funding_event_id="synthetic_monitor_workspace_funding_v1",
+            target_shards=16,
+            apply=True,
+            key_output_file=None,
+        )
+    except ValueError as exc:
+        assert str(exc) == "synthetic monitoring workspace must not use auto-refill"
+    else:
+        raise AssertionError("auto-refill monitor workspace was accepted")

--- a/tests/test_provision_synthetic_monitor.py
+++ b/tests/test_provision_synthetic_monitor.py
@@ -106,3 +106,29 @@ def test_provision_synthetic_monitor_rejects_reused_capped_key(tmp_path: Path) -
         assert str(exc) == "existing synthetic monitor key has unsafe configuration"
     else:
         raise AssertionError("unsafe existing key was accepted")
+
+
+def test_provision_synthetic_monitor_refuses_existing_key_output_path(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryStore()
+    key_file = tmp_path / "monitor.key"
+    key_file.write_text("do-not-overwrite\n", encoding="utf-8")
+
+    try:
+        provision(
+            store,
+            email="synthetic-monitor@trustedrouter.internal",
+            workspace_name="TrustedRouter Synthetic Monitoring",
+            key_name="Synthetic monitor",
+            funding_microdollars=1_000_000_000,
+            funding_event_id="synthetic_monitor_workspace_funding_v1",
+            target_shards=16,
+            apply=True,
+            key_output_file=key_file,
+        )
+    except ValueError as exc:
+        assert str(exc) == "refusing to overwrite the key output file"
+    else:
+        raise AssertionError("existing key output path was overwritten")
+    assert key_file.read_text(encoding="utf-8") == "do-not-overwrite\n"

--- a/tests/test_provision_synthetic_monitor.py
+++ b/tests/test_provision_synthetic_monitor.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.provision_synthetic_monitor import provision
+from trusted_router.storage import InMemoryStore
+
+
+def test_provision_synthetic_monitor_dry_run_is_read_only() -> None:
+    store = InMemoryStore()
+
+    result = provision(
+        store,
+        email="synthetic-monitor@trustedrouter.internal",
+        workspace_name="TrustedRouter Synthetic Monitoring",
+        key_name="Synthetic monitor",
+        funding_microdollars=1_000_000_000,
+        funding_event_id="synthetic_monitor_workspace_funding_v1",
+        target_shards=16,
+        apply=False,
+        key_output_file=None,
+    )
+
+    assert result["would_create_user"] is True
+    assert store.find_user_by_email("synthetic-monitor@trustedrouter.internal") is None
+
+
+def test_provision_synthetic_monitor_is_isolated_funding_limited_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryStore()
+    key_file = tmp_path / "monitor.key"
+    kwargs = {
+        "email": "synthetic-monitor@trustedrouter.internal",
+        "workspace_name": "TrustedRouter Synthetic Monitoring",
+        "key_name": "Synthetic monitor",
+        "funding_microdollars": 1_000_000_000,
+        "funding_event_id": "synthetic_monitor_workspace_funding_v1",
+        "target_shards": 16,
+        "apply": True,
+    }
+
+    first = provision(store, key_output_file=key_file, **kwargs)
+    second = provision(store, key_output_file=None, **kwargs)
+
+    assert first["created_user"] is True
+    assert first["created_key"] is True
+    assert first["credited"] is True
+    assert second["created_key"] is False
+    assert second["credited"] is False
+    assert second["workspace_id"] == first["workspace_id"]
+    assert second["key_id"] == first["key_id"]
+    assert key_file.stat().st_mode & 0o777 == 0o600
+    assert key_file.read_text(encoding="utf-8").startswith("sk-tr-v1-")
+    user = store.find_user_by_email("synthetic-monitor@trustedrouter.internal")
+    assert user is not None
+    workspaces = store.list_workspaces_for_user(user.id)
+    assert len(workspaces) == 1
+    assert workspaces[0].name == "TrustedRouter Synthetic Monitoring"
+    keys = store.list_keys(workspaces[0].id)
+    assert len(keys) == 1
+    assert keys[0].management is False
+    assert keys[0].limit_daily_microdollars is None
+    assert keys[0].limit_monthly_microdollars is None
+    assert keys[0].budget_alert_only is False
+    assert keys[0].tags["purpose"] == "synthetic_monitoring"
+    assert keys[0].tags["spend_control"] == "workspace_funding_only"
+    assert first["target_shards"] == 16
+    assert first["current_shards"] == 1
+    assert first["requires_reshard"] is True
+    snapshot = store.credit_money_snapshot(workspaces[0].id)
+    assert snapshot is not None
+    assert snapshot[0] == 1_000_000_000
+
+
+def test_provision_synthetic_monitor_rejects_reused_capped_key(tmp_path: Path) -> None:
+    store = InMemoryStore()
+    first = provision(
+        store,
+        email="synthetic-monitor@trustedrouter.internal",
+        workspace_name="TrustedRouter Synthetic Monitoring",
+        key_name="Synthetic monitor",
+        funding_microdollars=1_000_000_000,
+        funding_event_id="synthetic_monitor_workspace_funding_v1",
+        target_shards=16,
+        apply=True,
+        key_output_file=tmp_path / "monitor.key",
+    )
+    key = store.get_key_by_hash(first["key_id"])
+    assert key is not None
+    key.limit_daily_microdollars = 10_000
+
+    try:
+        provision(
+            store,
+            email="synthetic-monitor@trustedrouter.internal",
+            workspace_name="TrustedRouter Synthetic Monitoring",
+            key_name="Synthetic monitor",
+            funding_microdollars=1_000_000_000,
+            funding_event_id="synthetic_monitor_workspace_funding_v1",
+            target_shards=16,
+            apply=True,
+            key_output_file=None,
+        )
+    except ValueError as exc:
+        assert str(exc) == "existing synthetic monitor key has unsafe configuration"
+    else:
+        raise AssertionError("unsafe existing key was accepted")

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE
+
+
+def test_readiness_checks_billing_store_under_both_paths() -> None:
+    app = create_app(
+        Settings(environment="test"),
+        init_observability=False,
+    )
+    client = TestClient(app)
+
+    bare = client.get("/ready")
+    versioned = client.get("/v1/ready")
+
+    assert bare.status_code == 200
+    assert bare.json() == {
+        "status": "ready",
+        "checks": {"billing_store": "ready"},
+    }
+    assert versioned.json() == bare.json()
+
+
+def test_readiness_fails_closed_without_leaking_storage_error(
+    monkeypatch,
+) -> None:
+    app = create_app(
+        Settings(environment="test"),
+        init_observability=False,
+    )
+    client = TestClient(app)
+
+    def unavailable() -> None:
+        raise RuntimeError("private database hostname")
+
+    monkeypatch.setattr(STORE.in_memory_target, "readiness_check", unavailable)
+
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "5"
+    assert response.json() == {
+        "status": "not_ready",
+        "checks": {"billing_store": "unavailable"},
+    }
+    assert "hostname" not in response.text
+
+
+def test_status_host_allows_readiness_endpoint() -> None:
+    app = create_app(
+        Settings(environment="test"),
+        init_observability=False,
+    )
+    client = TestClient(app)
+
+    response = client.get(
+        "/ready",
+        headers={"host": "status.trustedrouter.com"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -332,9 +332,7 @@ def test_status_history_browser_requests_render_48h_visual_page(client: TestClie
     assert history.status_code == 200
     assert history.headers["content-type"].startswith("text/html")
     assert "48 hour status history" in history.text
-    assert (
-        "Latency is broken out by target, probe, monitor region, and target region" in history.text
-    )
+    assert "Router Core latency and availability are broken out" in history.text
     assert "48 hour component timeline" in history.text
     assert "View JSON" in history.text
     assert "reply exactly PONG" not in history.text
@@ -358,7 +356,7 @@ def test_status_history_browser_requests_render_monthly_visual_page(client: Test
     assert history.headers["content-type"].startswith("text/html")
     assert "Monthly status history" in history.text
     assert "Monthly rollups" in history.text
-    assert "Precomputed reliability history" in history.text
+    assert "Precomputed Router Core reliability" in history.text
     assert "Latency breakdown" in history.text
     assert "View JSON" in history.text
     assert "reply exactly PONG" not in history.text
@@ -434,7 +432,7 @@ def test_public_status_snapshot_uses_live_samples_plus_precomputed_rollups(
     assert all(call["since"] for call in rollup_calls)
     assert all("until" not in call for call in rollup_calls)
     assert payload["windows"]["5m"]["sample_count"] == 1
-    assert payload["windows"]["48h"]["sample_count"] == 2
+    assert payload["windows"]["48h"]["sample_count"] == 1
     assert payload["headline_metrics"]["gateway_overhead_p50_milliseconds"] == 31
 
 
@@ -562,21 +560,22 @@ def test_status_rollups_cover_current_5m_24h_and_daily_windows() -> None:
     assert snapshot["overall_status"] == "up"
     assert snapshot["slo_classes"]["router_core"]["status"] == "up"
     assert set(snapshot["slo_classes"]) == {"router_core", "control_plane"}
-    assert snapshot["windows"]["5m"]["sample_count"] == 3
-    assert snapshot["windows"]["24h"]["sample_count"] == 4
-    assert snapshot["windows"]["48h"]["sample_count"] == 4
-    assert sum(row["sample_count"] for row in snapshot["daily"]) == 4
+    assert snapshot["history_scope"] == "router_core"
+    assert snapshot["windows"]["5m"]["sample_count"] == 1
+    assert snapshot["windows"]["24h"]["sample_count"] == 1
+    assert snapshot["windows"]["48h"]["sample_count"] == 1
+    assert sum(row["sample_count"] for row in snapshot["daily"]) == 1
     assert snapshot["headline_metrics"]["gateway_overhead_p50_milliseconds"] == 25
     assert snapshot["headline_metrics"]["gateway_overhead_scope"] == "in_region"
     canonical = next(
         component for component in snapshot["components"] if component["id"] == "canonical_api"
     )
-    assert canonical["status"] == "down"
-    assert canonical["uptime_24h_percent"] == pytest.approx(50.0)
+    assert canonical["status"] == "up"
+    assert canonical["uptime_24h_percent"] == pytest.approx(100.0)
     assert canonical["p50_latency_milliseconds"] == 25
-    assert canonical["end_to_end_p50_latency_milliseconds"] == 120
+    assert canonical["end_to_end_p50_latency_milliseconds"] == 25
     assert len(canonical["history"]) == 48
-    assert snapshot["recent_events"][0]["component"] == "Canonical API"
+    assert snapshot["recent_events"] == []
 
 
 def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
@@ -626,10 +625,66 @@ def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
     assert snapshot["slo_classes"]["router_core"]["status"] == "up"
     assert snapshot["slo_classes"]["router_core"]["windows"]["5m"]["bad_count"] == 0
     assert set(snapshot["slo_classes"]) == {"router_core", "control_plane"}
+    assert {
+        row["probe_type"] for row in snapshot["current"]["checks"]
+    } == {
+        "tls_health",
+        "gateway_authorize_settle",
+        "provider_fallback",
+    }
     assert all(
         alert["slo_class"] != "provider_effective"
         for alert in snapshot["burn_rate_alerts"]
     )
+    canonical = next(
+        row for row in snapshot["components"] if row["id"] == "canonical_api"
+    )
+    assert canonical["status"] == "up"
+    assert canonical["sample_count_24h"] == 1
+    assert snapshot["windows"]["5m"]["sample_count"] == 3
+    assert all(
+        event["probe_type"] not in {"openai_sdk_pong", "responses_pong"}
+        for event in snapshot["recent_events"]
+    )
+
+
+def test_regional_gateway_maintenance_never_reduces_global_router_core_slo() -> None:
+    now = utcnow()
+    samples = [
+        _sample(
+            id="syn_canonical_up",
+            probe_type="tls_health",
+            status="up",
+            created_at=(now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
+        ),
+        _sample(
+            id="syn_eu_tls_down",
+            target="europe-west4",
+            target_region="europe-west4",
+            probe_type="tls_health",
+            status="down",
+            created_at=(now - dt.timedelta(seconds=11)).isoformat().replace("+00:00", "Z"),
+        ),
+        _sample(
+            id="syn_eu_attestation_down",
+            target="europe-west4",
+            target_region="europe-west4",
+            probe_type="attestation_nonce",
+            status="trust_degraded",
+            created_at=(now - dt.timedelta(seconds=12)).isoformat().replace("+00:00", "Z"),
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now)
+
+    router_core = snapshot["slo_classes"]["router_core"]
+    assert router_core["status"] == "up"
+    assert router_core["windows"]["5m"]["sample_count"] == 1
+    assert router_core["windows"]["5m"]["uptime_percent"] == 100.0
+    eu_component = next(
+        row for row in snapshot["components"] if row["id"] == "eu_regional_api"
+    )
+    assert eu_component["status"] == "trust_degraded"
 
 
 def test_status_router_core_burn_rate_alerts_on_short_window_failures() -> None:
@@ -818,6 +873,62 @@ def test_status_uses_hourly_rollups_for_48h_history_when_raw_samples_are_recent_
     assert sum(bucket["sample_count"] for bucket in canonical["history"]) == 2
 
 
+def test_historical_provider_pong_rollups_never_blend_into_router_core() -> None:
+    now = utcnow()
+    tls = _sample(
+        id="syn_router_tls",
+        probe_type="tls_health",
+        status="up",
+        created_at=(now - dt.timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+        latency_milliseconds=25,
+    )
+    provider_pong = _sample(
+        id="syn_provider_pong",
+        probe_type="openai_sdk_pong",
+        status="down",
+        created_at=(now - dt.timedelta(hours=2, seconds=1))
+        .isoformat()
+        .replace("+00:00", "Z"),
+        error_type="provider_error",
+    )
+    rollups = _rollups_for_samples([tls])
+    rollups.extend(
+        new_rollup_for_sample(
+            provider_pong,
+            period=period,
+            component="canonical_api",
+        )
+        for period in ("hour", "day", "month")
+    )
+
+    snapshot = status_snapshot([], rollups=rollups, now=now)
+
+    assert snapshot["windows"]["24h"]["sample_count"] == 1
+    assert snapshot["windows"]["24h"]["uptime_percent"] == 100.0
+    canonical = next(
+        row for row in snapshot["components"] if row["id"] == "canonical_api"
+    )
+    assert canonical["sample_count_24h"] == 1
+    assert sum(bucket["sample_count"] for bucket in canonical["history"]) == 1
+
+
+def test_historical_attestation_rollup_counts_once_in_router_core() -> None:
+    now = utcnow()
+    attestation = _sample(
+        id="syn_attestation_once",
+        probe_type="attestation_nonce",
+        status="up",
+        created_at=(now - dt.timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+        latency_milliseconds=40,
+    )
+
+    snapshot = status_snapshot([], rollups=_rollups_for_samples([attestation]), now=now)
+
+    assert snapshot["windows"]["24h"]["sample_count"] == 1
+    assert snapshot["windows"]["24h"]["uptime_percent"] == 100.0
+    assert sum(row["sample_count"] for row in snapshot["daily"]) == 1
+
+
 def test_status_history_fills_missing_rollup_hours_from_raw_samples() -> None:
     now = utcnow()
     recent = _sample(
@@ -853,7 +964,7 @@ def test_status_components_group_regions_and_control_plane() -> None:
     samples = [
         _sample(
             id="syn_canonical",
-            probe_type="responses_pong",
+            probe_type="tls_health",
             status="up",
             created_at=(now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
         ),
@@ -861,7 +972,7 @@ def test_status_components_group_regions_and_control_plane() -> None:
             id="syn_eu",
             target="europe-west4",
             target_region="europe-west4",
-            probe_type="openai_sdk_pong",
+            probe_type="tls_health",
             status="up",
             created_at=(now - dt.timedelta(seconds=11)).isoformat().replace("+00:00", "Z"),
         ),
@@ -954,7 +1065,7 @@ def test_status_component_current_uses_latest_sample_per_probe() -> None:
             id="syn_old_down_1",
             target="europe-west4",
             target_region="europe-west4",
-            probe_type="openai_sdk_pong",
+            probe_type="tls_health",
             status="down",
             created_at=(now - dt.timedelta(minutes=2)).isoformat().replace("+00:00", "Z"),
         ),
@@ -962,7 +1073,7 @@ def test_status_component_current_uses_latest_sample_per_probe() -> None:
             id="syn_old_down_2",
             target="europe-west4",
             target_region="europe-west4",
-            probe_type="openai_sdk_pong",
+            probe_type="tls_health",
             status="down",
             created_at=(now - dt.timedelta(minutes=2, seconds=10))
             .isoformat()
@@ -972,7 +1083,7 @@ def test_status_component_current_uses_latest_sample_per_probe() -> None:
             id="syn_latest_up",
             target="europe-west4",
             target_region="europe-west4",
-            probe_type="openai_sdk_pong",
+            probe_type="tls_health",
             status="up",
             created_at=(now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
         ),


### PR DESCRIPTION
## Summary
- scope all headline, 5m, 24h, 48h, daily, and monthly uptime to Router Core only
- keep direct regional maintenance, control-plane availability, and provider outcomes in separate histories
- replace misleading low-sample and zero-sample leaderboard ranks with explicit warming states
- add real billing-store readiness at `/ready` and `/v1/ready`
- roll warm control-plane regions sequentially with per-region staged traffic, health gates, and rollback
- add a fail-closed, idempotent provisioner for a dedicated 16-shard synthetic-monitor workspace
- make authoritative provider manifests honor effective-dated model retirements

## Production findings
- the existing shared monitor workspace caused recurring Spanner row contention before its 16-shard activation
- no Router Core failures have occurred since that activation at 2026-07-28 16:01 UTC
- direct regional maintenance was incorrectly counted in global Router Core history
- Crusoe's retired Nemotron route remained in the raw authoritative manifest after its July 28 cutover

## Verification
- `uv run ruff check .`
- `uv run mypy`
- focused reliability suite: 116 passed
- full suite after the date-sensitive manifest correction: 2075 passed, 61 skipped
- fail-closed monitor provisioning tests: 5 passed
- production provisioning dry run completed without mutation
