### PR TITLE
Fix provider privacy labels and Phala E2EE classification

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -430,10 +430,10 @@ PROVIDERS: dict[str, Provider] = {
         ),
         provider_policy_url="https://novita.ai/legal/privacy-policy",
     ),
-    # Phala (RedPill) — confidential AI inference inside Intel TDX
-    # / NVIDIA Confidential Compute enclaves. Verified attestation,
-    # end-to-end encrypted prompts. **On-brand for TR's trust story.**
-    # OpenAI-compatible at api.red-pill.ai/v1.
+    # Phala publishes Intel TDX / NVIDIA Confidential Compute evidence and
+    # signed request receipts. TrustedRouter does not yet verify that evidence
+    # on every request, so Phala must not satisfy the provider-E2EE routing
+    # floor until the gateway enforces the complete receipt chain.
     "phala": Provider(
         slug="phala",
         name="Phala",
@@ -441,12 +441,16 @@ PROVIDERS: dict[str, Provider] = {
         stores_content=False,
         provider_zero_data_retention=True,
         provider_confidential_compute=True,
-        provider_e2ee=True,
+        provider_e2ee=False,
         provider_policy=(
-            "Tracked as a confidential AI provider with provider-side "
-            "attestation and encrypted prompt transport."
+            "Phala publishes TDX/GPU attestation and signed request receipts, "
+            "but TrustedRouter does not yet verify the complete receipt chain "
+            "on every routed request. The route is therefore not classified as "
+            "provider E2EE and is excluded from trustedrouter/e2e."
         ),
-        provider_policy_url="https://docs.phala.com/confidential-ai-inference/host-llm-in-tee",
+        provider_policy_url=(
+            "https://docs.phala.com/phala-cloud/confidential-ai/verify/overview"
+        ),
     ),
     # SiliconFlow — Chinese serverless inference with 200+ open-weight
     # models. OpenAI-compatible at api.siliconflow.com/v1.

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -2844,6 +2844,28 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         prompt = _price(model.prompt_price_microdollars_per_million_tokens)
         completion = _price(model.completion_price_microdollars_per_million_tokens)
     providers = _endpoint_provider_views(endpoints, fallback_provider=model.provider)
+    endpoint_postures = {
+        (
+            endpoint_zero_data_retention(endpoint),
+            PROVIDERS[endpoint.provider].provider_confidential_compute,
+            PROVIDERS[endpoint.provider].provider_e2ee,
+        )
+        for endpoint in endpoints
+    }
+    if not endpoint_postures:
+        endpoint_postures = {
+            (
+                provider.provider_zero_data_retention,
+                provider.provider_confidential_compute,
+                provider.provider_e2ee,
+            )
+        }
+    provider_policy_varies = len(endpoint_postures) > 1
+    (
+        provider_zero_data_retention,
+        provider_confidential_compute,
+        provider_e2ee,
+    ) = next(iter(endpoint_postures))
     return {
         "id": model.id,
         "name": model.name,
@@ -2861,11 +2883,13 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         or model.prepaid_available,
         "byok": model.byok_available,
         "attested": provider.attested_gateway,
-        "provider_zero_data_retention": any(
-            endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints
+        "provider_zero_data_retention": provider_zero_data_retention,
+        "provider_confidential_compute": provider_confidential_compute,
+        "provider_e2ee": provider_e2ee,
+        "provider_policy_varies": provider_policy_varies,
+        "provider_policy_variation_label": (
+            "varies by route" if len(providers) == 1 else "varies by provider"
         ),
-        "provider_confidential_compute": provider.provider_confidential_compute,
-        "provider_e2ee": provider.provider_e2ee,
         "open_weights": model_open_weights(model),
         "orchestration_primitive": orchestration_primitive(model.id),
         "orchestration_role": orchestration_role(model.id),

--- a/src/trusted_router/templates/public/_provider_privacy_badges.html
+++ b/src/trusted_router/templates/public/_provider_privacy_badges.html
@@ -1,0 +1,15 @@
+{% macro provider_privacy_badges(item) -%}
+  {% if item.provider_policy_varies|default(false) %}
+    <span class="pill warn">{{ item.provider_policy_variation_label }}</span>
+  {% else %}
+    {% if item.provider_e2ee is sameas true %}<span class="pill good">provider E2EE</span>{% endif %}
+    {% if item.provider_confidential_compute is sameas true %}<span class="pill good">confidential</span>{% endif %}
+    {% if item.provider_zero_data_retention is sameas true %}<span class="pill good">ZDR</span>{% endif %}
+    {% if item.provider_e2ee is sameas false and (item.provider_confidential_compute is sameas true or item.provider_zero_data_retention is sameas true) %}<span class="pill warn">provider E2EE not verified</span>{% endif %}
+    {% if item.provider_e2ee is none and item.provider_confidential_compute is none and item.provider_zero_data_retention is none %}
+      <span class="pill warn">privacy unknown</span>
+    {% elif item.provider_e2ee is not sameas true and item.provider_confidential_compute is not sameas true and item.provider_zero_data_retention is not sameas true %}
+      <span class="pill warn">no verified privacy claim</span>
+    {% endif %}
+  {% endif %}
+{%- endmacro %}

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -1,4 +1,5 @@
 {% extends "public/_base.html" %}
+{% from "public/_provider_privacy_badges.html" import provider_privacy_badges %}
 {% block body %}
 <section class="panel">
   <div class="panel-head">
@@ -150,10 +151,7 @@
           <td>{{ endpoint.completion_price }}</td>
           <td>{% if endpoint.attested_gateway %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
           <td>
-            {% if endpoint.provider_e2ee %}<span class="pill good">provider E2EE</span>{% endif %}
-            {% if endpoint.provider_confidential_compute %}<span class="pill good">confidential</span>{% endif %}
-            {% if endpoint.provider_zero_data_retention %}<span class="pill good">ZDR</span>{% endif %}
-            {% if not endpoint.provider_e2ee and not endpoint.provider_confidential_compute and not endpoint.provider_zero_data_retention %}<span class="pill warn">upstream varies</span>{% endif %}
+            {{ provider_privacy_badges(endpoint) }}
           </td>
         </tr>
         {% endfor %}

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -1,4 +1,5 @@
 {% extends "public/_base.html" %}
+{% from "public/_provider_privacy_badges.html" import provider_privacy_badges %}
 {% block body %}
 <section class="panel">
   <div class="panel-head">
@@ -87,10 +88,7 @@
           <td>{{ endpoint.prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
           <td>
-            {% if endpoint.provider_e2ee %}<span class="pill good">provider E2EE</span>{% endif %}
-            {% if endpoint.provider_confidential_compute %}<span class="pill good">confidential</span>{% endif %}
-            {% if endpoint.provider_zero_data_retention %}<span class="pill good">ZDR</span>{% endif %}
-            {% if not endpoint.provider_e2ee and not endpoint.provider_confidential_compute and not endpoint.provider_zero_data_retention %}<span class="pill warn">unknown</span>{% endif %}
+            {{ provider_privacy_badges(endpoint) }}
           </td>
         </tr>
         {% endfor %}

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -1,4 +1,5 @@
 {% extends "public/_base.html" %}
+{% from "public/_provider_privacy_badges.html" import provider_privacy_badges %}
 {% block body %}
 <section class="public-proof-strip">
   <div><strong>Public catalog</strong><span>No auth needed to inspect routes.</span></div>
@@ -79,10 +80,7 @@
             </div>
           </td>
           <td>
-            {% if model.provider_e2ee %}<span class="pill good">provider E2EE</span>{% endif %}
-            {% if model.provider_confidential_compute %}<span class="pill good">confidential</span>{% endif %}
-            {% if model.provider_zero_data_retention %}<span class="pill good">ZDR</span>{% endif %}
-            {% if not model.provider_e2ee and not model.provider_confidential_compute and not model.provider_zero_data_retention %}<span class="pill warn">upstream varies</span>{% endif %}
+            {{ provider_privacy_badges(model) }}
           </td>
           <td>{{ model.prompt_price }}</td>
           <td>{{ model.completion_price }}</td>

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1355,6 +1355,17 @@ def test_privacy_meta_models_force_endpoint_privacy_floor() -> None:
         for _model, endpoint in e2e_endpoints
     )
     assert "venice" not in {endpoint.provider for _model, endpoint in e2e_endpoints}
+    assert "phala" not in {endpoint.provider for _model, endpoint in e2e_endpoints}
+
+
+def test_phala_is_not_classified_as_verified_e2ee() -> None:
+    provider = PROVIDERS["phala"]
+
+    assert provider.provider_confidential_compute is True
+    assert provider.provider_e2ee is False
+    assert provider_privacy_tier(provider) == PRIVACY_TIER_ZERO_RETENTION
+    assert "does not yet verify" in provider.provider_policy
+    assert "excluded from trustedrouter/e2e" in provider.provider_policy
 
 
 def test_venice_privacy_is_model_specific_and_never_claims_tee() -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1084,6 +1084,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["zai"]["supports_byok"] is True
     assert provider_flags["tinfoil"]["provider_e2ee"] is True
     assert provider_flags["phala"]["provider_confidential_compute"] is True
+    assert provider_flags["phala"]["provider_e2ee"] is False
     assert provider_flags["anthropic"]["provider_zero_data_retention"] is False
     assert provider_flags["cerebras"]["provider_zero_data_retention"] is True
     assert provider_flags["cerebras"]["stores_content"] is False

--- a/tests/test_openai_contracted_zdr.py
+++ b/tests/test_openai_contracted_zdr.py
@@ -134,4 +134,4 @@ def test_public_pages_explain_scheduled_openai_prepaid_scope(client: TestClient)
     assert model.status_code == 200
     assert "Credits" in model.text
     assert "BYOK" in model.text
-    assert "upstream varies" in model.text
+    assert "no verified privacy claim" in model.text

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -348,7 +348,7 @@ def test_public_model_pages_never_claim_tr_stores_content(client: TestClient) ->
     assert "stores content" not in catalog.text.lower()
     assert "tr stores content" not in detail.text.lower()
     assert "Provider policy" in detail.text
-    assert "upstream varies" in detail.text
+    assert "varies by provider" in catalog.text
 
 
 def test_public_kimi_k3_page_separates_router_attestation_from_provider_e2ee(
@@ -364,8 +364,31 @@ def test_public_kimi_k3_page_separates_router_attestation_from_provider_e2ee(
     assert "<th>TR router attested</th>" in detail.text
     assert "<th>Attested</th>" not in detail.text
     assert "Provider policy" in detail.text
-    assert "upstream varies" in detail.text
+    assert "privacy unknown" in detail.text
     assert "provider E2EE" not in detail.text
+
+
+def test_single_provider_model_shows_provider_posture_not_variation(
+    client: TestClient,
+) -> None:
+    detail = client.get("/models/qwen/qwen-2.5-72b-instruct")
+
+    assert detail.status_code == 200
+    assert "Novita AI" in detail.text
+    assert "privacy unknown" in detail.text
+    assert "varies by provider" not in detail.text
+    assert "varies by route" not in detail.text
+
+
+def test_phala_pages_do_not_claim_verified_provider_e2ee(client: TestClient) -> None:
+    provider = client.get("/providers/phala")
+    detail = client.get("/models/z-ai/glm-5.2")
+
+    assert provider.status_code == 200
+    assert 'Provider E2EE</th><td><span class="pill ">no</span>' in provider.text
+    assert "does not yet verify the complete receipt chain" in provider.text
+    assert detail.status_code == 200
+    assert "provider E2EE not verified" in detail.text
 
 
 def test_public_meta_model_detail_renders_orchestration_components(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- render exact provider posture for single-provider model routes instead of saying upstream varies
- derive model catalog privacy summaries from serving endpoints and distinguish provider variation from route variation
- remove Phala from the verified provider-E2EE pool until its receipt chain is enforced per request
- make authoritative provider manifests lifecycle-aware at retirement cutovers

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 2066 passed, 61 skipped