### PR TITLE
Alert early on gateway billing failures

### DIFF
--- a/.github/workflows/gateway-reliability.yml
+++ b/.github/workflows/gateway-reliability.yml
@@ -1,0 +1,40 @@
+name: Configure Gateway Reliability Alerts
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type APPLY to reconcile production alert policies"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: production-gateway-reliability-alerts
+  cancel-in-progress: false
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require explicit confirmation
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          if [ "${CONFIRMATION}" != "APPLY" ]; then
+            echo "Refusing production mutation: type APPLY in confirmation."
+            exit 2
+          fi
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Reconcile gateway reliability alerts
+        run: bash scripts/deploy/gateway_reliability.sh --apply

--- a/docs/spanner-reliability.md
+++ b/docs/spanner-reliability.md
@@ -28,6 +28,30 @@ bash scripts/deploy/spanner_reliability.sh --apply
 Set `TR_DR_BILLING_ACCOUNT` on the first run if the DR project does not exist.
 Without `--apply`, the script prints the intended changes.
 
+Customer-facing billing-path alerts are managed separately so they can be
+reconciled without touching Spanner capacity or backup resources:
+
+```bash
+bash scripts/deploy/gateway_reliability.sh --apply
+```
+
+These policies deliberately trigger before the broad Spanner contention
+policy:
+
+- Any `5xx` from `/internal/gateway/authorize`, `settle`, or `refund` opens an
+  incident immediately.
+- Successful billing calls taking at least 10 seconds are counted. More than
+  two per minute for three consecutive minutes opens one incident.
+- More than 10 Spanner aborts per minute for three consecutive minutes opens
+  one early-pressure incident. The main contention policy remains at 100 per
+  minute for 10 minutes.
+
+Every condition reduces all regions and revisions into one time series. The
+log-based `5xx` policy rate-limits notifications to one every 30 minutes and
+auto-closes after 30 quiet minutes. Metric policies do not renotify while an
+incident remains open. The alerts use status, latency, path, and aggregate
+transaction metadata only; they never inspect or export prompts or outputs.
+
 ## Alert response
 
 ### High CPU
@@ -48,6 +72,19 @@ raising capacity again.
 Separate Spanner server latency from network and application latency. Inspect
 the `method`, `status`, and serving-region labels. `ABORTED` is tracked by the
 contention policy; unexpected statuses are tracked by the API-failure policy.
+
+For a gateway billing-path incident:
+
+1. Query Cloud Run request logs for the affected internal gateway path and
+   note status, latency, service region, and request ID.
+2. Check `SPANNER_SYS.TXN_STATS_TOP_MINUTE` and
+   `SPANNER_SYS.LOCK_STATS_TOP_MINUTE`. Decode hot row keys and determine
+   whether one workspace or API key dominates.
+3. Run the typed billing invariant audit before changing counters.
+4. Verify shard distribution. Use the guarded online split for an eligible
+   hot workspace; never delete or rewrite live reservations.
+5. Confirm post-fix requests settle across multiple shards, no new `5xx`
+   appears, and the invariant audit remains clean.
 
 ### Backup workflow
 

--- a/scripts/deploy/gateway-alerts/billing-5xx.yaml
+++ b/scripts/deploy/gateway-alerts/billing-5xx.yaml
@@ -1,0 +1,19 @@
+displayName: "TR Gateway: billing path 5xx"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    A customer-facing authorize, settle, or refund call returned a 5xx. Treat
+    this as immediate router-core impact. Inspect Cloud Run request logs,
+    Spanner transaction contention, and billing invariants. Do not silence the
+    alert merely because Spanner is otherwise healthy. Runbook:
+    docs/spanner-reliability.md.
+conditions:
+  - displayName: "Any internal gateway billing 5xx"
+    conditionMatchedLog:
+      filter: 'resource.type = "cloud_run_revision" AND resource.labels.service_name = "trusted-router" AND httpRequest.status >= 500 AND httpRequest.status < 600 AND httpRequest.requestUrl =~ "/internal/gateway/(authorize|settle|refund)([?].*)?$"'
+alertStrategy:
+  notificationRateLimit:
+    period: 1800s
+  autoClose: 1800s

--- a/scripts/deploy/gateway-alerts/billing-pressure.yaml
+++ b/scripts/deploy/gateway-alerts/billing-pressure.yaml
@@ -1,0 +1,43 @@
+displayName: "TR Gateway: billing path pressure"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    The billing path is degrading before broad customer-visible failures.
+    Check authorize/settle latency, Spanner aborts, and lock insights. Decode
+    hot row keys, verify shard distribution, and run the typed billing audit.
+    This warning intentionally fires below the main Spanner contention page.
+    Runbook: docs/spanner-reliability.md.
+conditions:
+  - displayName: "More than two successful 10-second billing calls per minute for 3 minutes"
+    conditionThreshold:
+      filter: 'resource.type = "cloud_run_revision" AND metric.type = "logging.googleapis.com/user/trustedrouter_gateway_billing_slow"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_SUM
+          crossSeriesReducer: REDUCE_SUM
+      comparison: COMPARISON_GT
+      thresholdValue: 2
+      duration: 180s
+      evaluationMissingData: EVALUATION_MISSING_DATA_INACTIVE
+      trigger:
+        count: 1
+  - displayName: "More than 10 aborted commits per minute for 3 minutes"
+    conditionThreshold:
+      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/transaction_stat/total/commit_attempt_count" AND metric.labels.status = "abort"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_RATE
+          crossSeriesReducer: REDUCE_SUM
+      comparison: COMPARISON_GT
+      thresholdValue: 0.166666667
+      duration: 180s
+      evaluationMissingData: EVALUATION_MISSING_DATA_INACTIVE
+      trigger:
+        count: 1
+alertStrategy:
+  autoClose: 1800s
+  notificationPrompts:
+    - OPENED
+    - CLOSED

--- a/scripts/deploy/gateway_reliability.sh
+++ b/scripts/deploy/gateway_reliability.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Provision early, customer-facing billing-path alerts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ALERT_EMAIL="${TR_GATEWAY_ALERT_EMAIL:-security@trustedrouter.com}"
+# Reuse the verified production channel unless an operator explicitly selects
+# another one. Creating a second email channel would require another manual
+# verification and could silently leave the new policies unable to notify.
+ALERT_CHANNEL_DISPLAY_NAME="${TR_GATEWAY_ALERT_CHANNEL_DISPLAY_NAME:-TrustedRouter Spanner on-call}"
+SLOW_METRIC_NAME="trustedrouter_gateway_billing_slow"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+source_gc() {
+  gcloud --project "$PROJECT_ID" "$@"
+}
+
+ensure_slow_metric() {
+  local description filter
+  description="Successful TrustedRouter internal gateway billing requests taking at least 10 seconds."
+  filter='resource.type = "cloud_run_revision" AND resource.labels.service_name = "trusted-router" AND httpRequest.status < 500 AND httpRequest.latency >= "10s" AND httpRequest.requestUrl =~ "/internal/gateway/(authorize|settle|refund)([?].*)?$"'
+
+  log "ensuring logs-based slow billing-path counter"
+  if source_gc logging metrics describe "$SLOW_METRIC_NAME" >/dev/null 2>&1; then
+    run source_gc logging metrics update "$SLOW_METRIC_NAME" \
+      --description="$description" \
+      --log-filter="$filter"
+  else
+    run source_gc logging metrics create "$SLOW_METRIC_NAME" \
+      --description="$description" \
+      --log-filter="$filter"
+  fi
+}
+
+ensure_channel() {
+  local channel
+  channel="$(source_gc beta monitoring channels list \
+    --filter="displayName=\"${ALERT_CHANNEL_DISPLAY_NAME}\"" \
+    --format='value(name)' | head -1)"
+  if [ -n "$channel" ]; then
+    printf '%s\n' "$channel"
+    return 0
+  fi
+
+  if [ "$APPLY" -eq 0 ]; then
+    run source_gc beta monitoring channels create \
+      --display-name="$ALERT_CHANNEL_DISPLAY_NAME" \
+      --description="Primary notification channel for TrustedRouter reliability incidents" \
+      --type=email \
+      --channel-labels="email_address=${ALERT_EMAIL}"
+    printf 'projects/%s/notificationChannels/DRY_RUN\n' "$PROJECT_ID"
+    return 0
+  fi
+
+  source_gc beta monitoring channels create \
+    --display-name="$ALERT_CHANNEL_DISPLAY_NAME" \
+    --description="Primary notification channel for TrustedRouter reliability incidents" \
+    --type=email \
+    --channel-labels="email_address=${ALERT_EMAIL}" \
+    --format='value(name)'
+}
+
+ensure_policies() {
+  local channel="$1"
+  local policy_file display_name policy_name
+
+  log "ensuring customer-facing gateway alert policies"
+  for policy_file in "${SCRIPT_DIR}"/gateway-alerts/*.yaml; do
+    display_name="$(sed -n 's/^displayName: "\(.*\)"$/\1/p' "$policy_file")"
+    policy_name="$(source_gc monitoring policies list \
+      --filter="displayName=\"${display_name}\"" \
+      --format='value(name)' | head -1)"
+    if [ -z "$policy_name" ]; then
+      run source_gc monitoring policies create \
+        --policy-from-file="$policy_file" \
+        --notification-channels="$channel"
+    else
+      run source_gc monitoring policies update "$policy_name" \
+        --policy-from-file="$policy_file" \
+        --set-notification-channels="$channel"
+    fi
+  done
+}
+
+ensure_slow_metric
+channel="$(ensure_channel)"
+ensure_policies "$channel"
+log "Gateway billing-path alerting is configured"

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "scripts" / "deploy"
+
+
+def test_gateway_5xx_alert_is_immediate_and_debounced() -> None:
+    policy = (DEPLOY / "gateway-alerts" / "billing-5xx.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'displayName: "TR Gateway: billing path 5xx"' in policy
+    assert "conditionMatchedLog:" in policy
+    assert 'resource.labels.service_name = "trusted-router"' in policy
+    assert "httpRequest.status >= 500" in policy
+    assert "httpRequest.status < 600" in policy
+    assert "/internal/gateway/(authorize|settle|refund)" in policy
+    assert "notificationRateLimit:" in policy
+    assert "period: 1800s" in policy
+    assert "autoClose: 1800s" in policy
+
+
+def test_gateway_pressure_alert_warns_before_original_spanner_page() -> None:
+    pressure = (DEPLOY / "gateway-alerts" / "billing-pressure.yaml").read_text(
+        encoding="utf-8"
+    )
+    original = (DEPLOY / "spanner-alerts" / "contention.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "trustedrouter_gateway_billing_slow" in pressure
+    assert "thresholdValue: 2" in pressure
+    assert pressure.count("duration: 180s") == 2
+    assert "thresholdValue: 0.166666667" in pressure
+    assert pressure.count("crossSeriesReducer: REDUCE_SUM") == 2
+    assert pressure.count("groupByFields:") == 0
+    assert "EVALUATION_MISSING_DATA_INACTIVE" in pressure
+
+    assert "thresholdValue: 1.666666667" in original
+    assert "duration: 600s" in original
+
+
+def test_gateway_alert_deploy_is_idempotent_and_dry_run_by_default() -> None:
+    script = (DEPLOY / "gateway_reliability.sh").read_text(encoding="utf-8")
+
+    assert 'if [ "${1:-}" = "--apply" ]' in script
+    assert "logging metrics describe" in script
+    assert "logging metrics create" in script
+    assert "logging metrics update" in script
+    assert "monitoring policies create" in script
+    assert "monitoring policies update" in script
+    assert "TrustedRouter Spanner on-call" in script
+    assert 'httpRequest.status < 500' in script
+    assert 'httpRequest.latency >= "10s"' in script
+
+
+def test_gateway_alert_workflow_requires_explicit_apply() -> None:
+    workflow = (
+        ROOT / ".github" / "workflows" / "gateway-reliability.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'if [ "${CONFIRMATION}" != "APPLY" ]' in workflow
+    assert "id-token: write" in workflow
+    assert "tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com" in workflow
+    assert "gateway_reliability.sh --apply" in workflow


### PR DESCRIPTION
## Summary
- page immediately on customer-facing authorize, settle, or refund 5xx responses with notification debounce
- warn on sustained 10-second billing calls and lower Spanner abort pressure before the broad contention alarm
- add an idempotent, dry-run-first deployment workflow and incident runbook
- keep authoritative provider manifests lifecycle-aware after effective route retirements

## Validation
- `uv run pytest -q` (2068 passed, 61 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `bash -n scripts/deploy/gateway_reliability.sh`
- production dry-run against the existing verified on-call channel
- alert filters validated against the historical 20-call incident and post-fix latency baseline