### PR TITLE
console: fix workspace rename returning 405 Method Not Allowed

### DIFF
--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, Response
+from fastapi import FastAPI, Form
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from trusted_router.auth import SettingsDep
 from trusted_router.routes.console._shared import ConsoleDep, render
+from trusted_router.storage import STORE
+
+MAX_WORKSPACE_NAME = 120
 
 
 def register(app: FastAPI) -> None:
     @app.get("/console/settings")
-    async def console_settings(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    async def console_settings(
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+        saved: str = "",
+        error: str = "",
+    ) -> Response:
         return HTMLResponse(render(
             "console/settings.html",
             settings=settings,
@@ -21,4 +29,41 @@ def register(app: FastAPI) -> None:
             page_subtitle="Names, content storage, integrations.",
             workspace=ctx.workspace,
             api_base_url=settings.api_base_url,
+            can_manage=STORE.user_can_manage(ctx.user.id, ctx.workspace.id),
+            saved=bool(saved),
+            error=error,
         ))
+
+    @app.post("/console/settings")
+    async def console_update_settings(
+        ctx: ConsoleDep,
+        name: str = Form(""),
+    ) -> Response:
+        """Rename the workspace.
+
+        This handler did not exist. The template has posted here since the page
+        was written, so every Save returned 405 "Method Not Allowed" and the
+        rename silently never worked.
+        """
+        # Renaming is a management action: the name appears on invoices and in
+        # every member's console, so a plain member must not be able to change
+        # it. Same gate the API-key management routes use.
+        if not STORE.user_can_manage(ctx.user.id, ctx.workspace.id):
+            return RedirectResponse(url="/console/settings?error=forbidden", status_code=303)
+
+        cleaned = name.strip()
+        if not cleaned:
+            # Reject rather than store a blank. An empty name renders as an
+            # unidentifiable entry in the workspace switcher, and the only way
+            # back is this same form.
+            return RedirectResponse(url="/console/settings?error=name", status_code=303)
+        if len(cleaned) > MAX_WORKSPACE_NAME:
+            # The input carries maxlength, but that is a client-side hint, not a
+            # constraint on anything posting directly.
+            return RedirectResponse(url="/console/settings?error=too_long", status_code=303)
+
+        if STORE.update_workspace(ctx.workspace.id, name=cleaned) is None:
+            return RedirectResponse(url="/console/settings?error=missing", status_code=303)
+
+        # POST/redirect/GET: without the redirect, a refresh re-submits the form.
+        return RedirectResponse(url="/console/settings?saved=1", status_code=303)

--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -183,8 +183,25 @@ def init_sentry(settings: Settings) -> None:
             # INFO is Axiom-only by design; Sentry logs stay WARNING+ so chatty
             # INFO can never crowd out error events in the floodgate.
             LoggingIntegration(level=None, event_level=None, sentry_logs_level=logging.WARNING),
-            StarletteIntegration(transaction_style="endpoint"),
-            FastApiIntegration(transaction_style="endpoint"),
+            # 405 is reported alongside 5xx. The SDK default is 5xx only, which
+            # is why a console form that POSTed to a GET-only route returned
+            # "Method Not Allowed" to users indefinitely and never raised an
+            # alert: Starlette answers 405 from the router without an exception
+            # for Sentry to catch.
+            #
+            # 405 is worth the exception to "don't alert on 4xx" because it is
+            # never a client mistake we can't fix — it means a path exists but
+            # not for that method, i.e. our own form or client targets a route
+            # we did not implement. Low volume, high signal. Other 4xx stay
+            # unreported: 401/402/404 are routine and would drown the signal.
+            StarletteIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes={405, *range(500, 600)},
+            ),
+            FastApiIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes={405, *range(500, 600)},
+            ),
         ],
         # cast over Sentry's TypedDict event/log signatures — the scrubbers
         # operate on whatever shape Sentry hands them, and we don't want to

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -288,6 +288,12 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 .checkbox-row input[type="checkbox"] { width:auto; min-width:16px; height:16px; min-height:16px; margin:0; padding:0; accent-color:var(--blue); }
 .notice { border:1px solid var(--good-border); background:var(--good-bg); color:var(--green); border-radius:8px; padding:12px; font-size:13px; line-height:1.45; }
 .notice.warn { border-color:var(--warn-border); background:var(--warn-bg); color:var(--amber); }
+/* `.notice` alone is the success tint, so an unstyled `.notice.bad` rendered
+   every console error message in green — actively telling users a failed
+   action succeeded. Templates have used `notice bad`/`notice ok` all along;
+   these are the rules they were missing. */
+.notice.ok { border-color:var(--good-border); background:var(--good-bg); color:var(--green); }
+.notice.bad { border-color:var(--danger-border); background:var(--danger-bg); color:var(--red); }
 .notice[hidden] { display:none; }
 .auth-grid { display:grid; grid-template-columns:minmax(240px,1fr) minmax(220px,.8fr) minmax(180px,.7fr) auto; gap:10px; align-items:end; }
 .auth-actions { display:flex; gap:8px; flex-wrap:wrap; }

--- a/src/trusted_router/templates/console/settings.html
+++ b/src/trusted_router/templates/console/settings.html
@@ -3,10 +3,17 @@
 <section class="panel">
   <div class="panel-head"><h2>Workspace settings</h2></div>
   <div class="panel-body">
+    {% if saved %}<p class="notice ok">Workspace name saved.</p>{% endif %}
+    {% if error == 'name' %}<p class="notice bad">Enter a workspace name.</p>
+    {% elif error == 'too_long' %}<p class="notice bad">Workspace name is too long (120 characters max).</p>
+    {% elif error == 'forbidden' %}<p class="notice bad">Only workspace owners and admins can rename a workspace.</p>
+    {% elif error == 'missing' %}<p class="notice bad">That workspace no longer exists.</p>
+    {% elif error == 'workspace' %}<p class="notice bad">Select a workspace first.</p>{% endif %}
     <form class="form" method="post" action="/console/settings">
-      <label>Workspace name<input name="name" value="{{ workspace.name }}" maxlength="120"></label>
-      <button class="btn primary" type="submit">Save</button>
+      <label>Workspace name<input name="name" value="{{ workspace.name }}" maxlength="120" {{ '' if can_manage else 'disabled' }}></label>
+      <button class="btn primary" type="submit" {{ '' if can_manage else 'disabled' }}>Save</button>
     </form>
+    {% if not can_manage %}<p class="muted">Only workspace owners and admins can rename a workspace.</p>{% endif %}
   </div>
 </section>
 <section class="panel">

--- a/tests/test_console_settings.py
+++ b/tests/test_console_settings.py
@@ -1,0 +1,135 @@
+"""Workspace rename from /console/settings.
+
+This page shipped with a form posting to a route that only accepted GET, so
+every Save returned 405 "Method Not Allowed" and the rename never worked. It
+went unnoticed because Starlette answers 405 from the router without raising,
+so Sentry (5xx-only by default) never saw it either.
+
+These tests exercise the POST itself, which is the thing nobody was doing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.storage import STORE, InMemoryStore
+
+
+@pytest.fixture
+def console(client: TestClient) -> tuple[TestClient, str]:
+    """A signed-in console session.
+
+    Uses conftest's `client` fixture rather than building a fresh app:
+    /console/* rejects API-key Bearer auth and wants the cookie that OAuth
+    sign-in mints, but standing up a second `create_app` replaces process-wide
+    settings and poisons unrelated tests.
+    """
+    user = STORE.ensure_user("console-settings@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id, provider="test", label="t", ttl_seconds=3600,
+        workspace_id=workspace.id, state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    return client, workspace.id
+
+
+def test_post_is_routable_at_all(console: tuple[TestClient, str]) -> None:
+    """The regression, stated as plainly as possible: POST must not 405.
+
+    Asserting only on the rename would not name the original bug this directly.
+    """
+    client, _ = console
+    response = client.post("/console/settings", data={"name": "Anything"}, follow_redirects=False)
+    assert response.status_code != 405, "the Save button posts here; it must be handled"
+
+
+def test_rename_persists_and_redirects(console: tuple[TestClient, str]) -> None:
+    client, workspace_id = console
+
+    response = client.post(
+        "/console/settings", data={"name": "Metalcraft Inc"}, follow_redirects=False
+    )
+
+    # POST/redirect/GET, so a refresh does not re-submit.
+    assert response.status_code == 303
+    assert response.headers["location"] == "/console/settings?saved=1"
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    assert workspace.name == "Metalcraft Inc"
+
+
+def test_saved_banner_renders(console: tuple[TestClient, str]) -> None:
+    """A silent success is what let the 405 survive — confirm the page says so."""
+    client, _ = console
+    page = client.get("/console/settings?saved=1")
+    assert "Workspace name saved." in page.text
+
+
+@pytest.mark.parametrize(
+    ("submitted", "expected_error"),
+    [
+        ("", "name"),
+        ("   ", "name"),  # whitespace-only is empty once trimmed
+        ("x" * 121, "too_long"),  # maxlength is a client hint, not a constraint
+    ],
+)
+def test_invalid_names_are_rejected_without_changing_anything(
+    console: tuple[TestClient, str], submitted: str, expected_error: str
+) -> None:
+    """A blank name renders as an unidentifiable workspace in the switcher, and
+    this form is the only way back — so it must never be stored."""
+    client, workspace_id = console
+    original = STORE.get_workspace(workspace_id)
+    assert original is not None
+    original_name = original.name
+
+    response = client.post(
+        "/console/settings", data={"name": submitted}, follow_redirects=False
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/console/settings?error={expected_error}"
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    assert workspace.name == original_name
+
+
+def test_name_is_trimmed(console: tuple[TestClient, str]) -> None:
+    client, workspace_id = console
+
+    client.post("/console/settings", data={"name": "  Padded Co  "}, follow_redirects=False)
+
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    assert workspace.name == "Padded Co"
+
+
+def test_non_manager_cannot_rename(
+    console: tuple[TestClient, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The name appears on invoices and in every member's console, so renaming
+    is a management action rather than something any member may do."""
+    client, workspace_id = console
+    original = STORE.get_workspace(workspace_id)
+    assert original is not None
+    original_name = original.name
+
+    # Patch the CLASS, not the STORE proxy. STORE forwards via __getattr__, so
+    # setattr on the proxy installs an instance attribute that monkeypatch then
+    # "restores" as a bound method of the store that existed at patch time —
+    # pinning it past the autouse reset_store swap and poisoning later tests.
+    # conftest's auto_credit_test_workspaces patches at class level for the
+    # same reason.
+    monkeypatch.setattr(InMemoryStore, "user_can_manage", lambda *_a, **_k: False)
+
+    response = client.post(
+        "/console/settings", data={"name": "Hostile Rename"}, follow_redirects=False
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/console/settings?error=forbidden"
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    assert workspace.name == original_name


### PR DESCRIPTION
User-reported: saving the workspace name returns **"Method Not Allowed"**.

`templates/console/settings.html` has posted to `/console/settings` since the page was written, but `routes/console/settings.py` only ever registered a `GET`. **The rename has never worked for anyone.**

Three fixes, because the missing route is only the first.

### 1. The route

Adds the `POST` handler. Gated on `user_can_manage` — the workspace name appears on invoices and in every member's console, so renaming is a management action, consistent with the API-key management routes. Name is trimmed; empty is rejected (a blank name renders as an unidentifiable entry in the workspace switcher, and this form is the only way back); length is capped server-side because `maxlength` is a client hint, not a constraint on anything posting directly. POST/redirect/GET so a refresh doesn't re-submit.

### 2. Why Sentry missed it

Starlette answers 405 **from the router, without raising**, and sentry-sdk reports 5xx only by default (`failed_request_status_codes`). So a permanently broken button generated no events.

405 now joins 5xx. It earns the exception to "don't alert on 4xx" because it's never a client mistake we can't fix — it means a path exists but not for that method, i.e. *our own* form targets a route we didn't implement. Low volume, high signal. 401/402/404 stay unreported; they're routine and would drown it.

### 3. Why it looked like nothing happened

`.notice` is styled as the **success** tint, and there is no `.notice.bad` rule anywhere in the CSS — while templates across the console have been using `class="notice bad"` all along. **Every console error message renders green**, telling users a failed action succeeded.

Added the missing `.bad`/`.ok` rules, and the settings page now renders saved/error banners instead of failing silently.

## Tests

Exercise the `POST`, which is what nobody was doing: that it's routable at all (the regression, stated plainly), that the rename persists, trimming, each rejection path leaving the name unchanged, and the manage gate.

**A trap worth recording:** the manage-gate test patches `InMemoryStore` at *class* level. Patching the `STORE` proxy instead installs an instance attribute that monkeypatch then "restores" as a bound method of the store that existed at patch time — pinning it past the autouse `reset_store` swap and poisoning later tests. That's not hypothetical; it broke **136 tests** while writing this, and conftest's `auto_credit_test_workspaces` patches at class level for the same reason.

Gates locally: ruff, mypy (190 files), `2085 passed, 61 skipped`.