### PR TITLE
Keep synthetic monitor API keys byte exact

### DIFF
--- a/scripts/provision_synthetic_monitor.py
+++ b/scripts/provision_synthetic_monitor.py
@@ -191,7 +191,10 @@ def provision(
             )
             created_output_file = True
             with os.fdopen(fd, "w", encoding="utf-8") as output:
-                output.write(f"{raw_key}\n")
+                # Secret Manager preserves every byte from --data-file. Keep
+                # this file byte-identical to the key so env injection cannot
+                # change its lookup hash with a trailing newline.
+                output.write(raw_key)
         except Exception:
             store.delete_key(api_key.hash)
             if created_output_file:

--- a/tests/test_provision_synthetic_monitor.py
+++ b/tests/test_provision_synthetic_monitor.py
@@ -51,7 +51,12 @@ def test_provision_synthetic_monitor_is_isolated_funding_limited_and_idempotent(
     assert second["workspace_id"] == first["workspace_id"]
     assert second["key_id"] == first["key_id"]
     assert key_file.stat().st_mode & 0o777 == 0o600
-    assert key_file.read_text(encoding="utf-8").startswith("sk-tr-v1-")
+    raw_key = key_file.read_text(encoding="utf-8")
+    assert raw_key.startswith("sk-tr-v1-")
+    assert raw_key == raw_key.strip()
+    stored_key = store.get_key_by_raw(raw_key)
+    assert stored_key is not None
+    assert stored_key.hash == first["key_id"]
     user = store.find_user_by_email("synthetic-monitor@trustedrouter.internal")
     assert user is not None
     workspaces = store.list_workspaces_for_user(user.id)


### PR DESCRIPTION
## Summary
- write provisioned synthetic monitor keys without a trailing newline
- verify the output file resolves to the exact stored API key
- prevent Secret Manager data-file uploads from changing the lookup hash

## Verification
- `uv run pytest -q tests/test_provision_synthetic_monitor.py`
- `uv run ruff check scripts/provision_synthetic_monitor.py tests/test_provision_synthetic_monitor.py`

## Incident context
Secret Manager preserves data-file bytes. A trailing newline caused monitor jobs to hash a different credential than the control plane, producing 401/403 synthetic failures during the isolated monitor cutover.