### PR TITLE
Activate managed Vertex ZDR routes

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -300,11 +300,14 @@ PROVIDERS: dict[str, Provider] = {
         supports_prepaid=True,
         supports_byok=False,
         provider_zero_data_retention=False,
+        prepaid_zero_data_retention=True,
+        prepaid_zero_data_retention_effective_on="2026-07-28",
         provider_policy=(
-            "Not currently marked ZDR in TrustedRouter. Vertex AI documents a "
-            "separate zero-data-retention configuration process, but this managed "
-            "route stays outside trustedrouter/zdr until its live account settings "
-            "are verified."
+            "TrustedRouter's managed Vertex AI account is covered by contractual "
+            "Zero Data Retention. This guarantee applies only to TrustedRouter-funded "
+            "prepaid routes. TrustedRouter does not invoke Google Search or Maps "
+            "grounding or Gemini Live session resumption on these routes. Google AI "
+            "Studio is classified separately."
         ),
         provider_policy_url=(
             "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/"

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -562,11 +562,12 @@ def test_privacy_meta_models_expand_to_expected_provider_pools() -> None:
     assert eu_shape["trustedrouter"]["auto_candidates"]
 
 
-def test_uncontracted_closed_providers_are_not_marked_zdr() -> None:
+def test_closed_provider_zdr_claims_are_route_scoped() -> None:
     """Keep public ZDR claims fail-closed for major closed providers.
 
-    If Amazon/Bedrock or Google/Vertex are added as explicit providers later,
-    they should remain outside trustedrouter/zdr until reviewed again.
+    Amazon/Bedrock, Anthropic, and Google AI Studio remain outside
+    trustedrouter/zdr until reviewed again. The managed Vertex account is
+    contractually ZDR, but only its prepaid credential path may qualify.
     """
     provider_slugs_requiring_reverification = {
         "amazon",
@@ -574,14 +575,29 @@ def test_uncontracted_closed_providers_are_not_marked_zdr() -> None:
         "aws",
         "bedrock",
         "google-ai-studio",
-        "google-vertex",
     }
     configured = provider_slugs_requiring_reverification & set(PROVIDERS)
 
-    assert {"anthropic", "google-ai-studio", "google-vertex"} <= configured
+    assert {"anthropic", "google-ai-studio"} <= configured
     for provider in sorted(configured):
         assert PROVIDERS[provider].provider_zero_data_retention is not True
         assert provider_privacy_tier(PROVIDERS[provider]) < PRIVACY_TIER_ZERO_RETENTION
+
+    vertex = PROVIDERS["google-vertex"]
+    assert vertex.provider_zero_data_retention is False
+    assert vertex.prepaid_zero_data_retention is True
+    assert vertex.prepaid_zero_data_retention_effective_on == "2026-07-28"
+    assert provider_privacy_tier(vertex) < PRIVACY_TIER_ZERO_RETENTION
+    vertex_endpoints = [
+        endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "google-vertex"
+    ]
+    assert vertex_endpoints
+    assert all(endpoint.usage_type == "Credits" for endpoint in vertex_endpoints)
+    assert all(
+        endpoint_privacy_tier(endpoint) == PRIVACY_TIER_ZERO_RETENTION
+        for endpoint in vertex_endpoints
+    )
+    assert all(endpoint_zero_data_retention(endpoint) is True for endpoint in vertex_endpoints)
 
     # OpenAI's guarantee is deliberately narrower: it belongs to
     # TrustedRouter's managed prepaid account, starts on July 28, and is not
@@ -1349,9 +1365,7 @@ def test_privacy_meta_models_force_endpoint_privacy_floor() -> None:
     assert "google-ai-studio" not in {
         endpoint.provider for _model, endpoint in zdr_endpoints
     }
-    assert "google-vertex" not in {
-        endpoint.provider for _model, endpoint in zdr_endpoints
-    }
+    assert "google-vertex" in {endpoint.provider for _model, endpoint in zdr_endpoints}
     assert "openai" not in {endpoint.provider for _model, endpoint in zdr_endpoints}
     assert all(
         endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1107,13 +1107,26 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert provider_flags["google-ai-studio"]["provider_zero_data_retention"] is False
     assert provider_flags["google-ai-studio"]["supports_byok"] is True
     assert provider_flags["google-vertex"]["provider_zero_data_retention"] is False
+    assert provider_flags["google-vertex"]["prepaid_zero_data_retention"] is True
+    assert provider_flags["google-vertex"][
+        "prepaid_zero_data_retention_effective_on"
+    ] == ("2026-07-28")
+    assert (
+        provider_flags["google-vertex"]["zero_data_retention_scope"]
+        == "trustedrouter_prepaid"
+    )
     assert provider_flags["google-vertex"]["supports_byok"] is False
     assert "Not currently marked ZDR" in provider_flags["anthropic"]["provider_policy"]
     assert "Contracted Zero Data Retention" in provider_flags["openai"]["provider_policy"]
     assert "July 28, 2026" in provider_flags["openai"]["provider_policy"]
     assert "customer BYOK" in provider_flags["openai"]["provider_policy"]
     assert "Not currently marked ZDR" in provider_flags["google-ai-studio"]["provider_policy"]
-    assert "Not currently marked ZDR" in provider_flags["google-vertex"]["provider_policy"]
+    assert "contractual Zero Data Retention" in provider_flags["google-vertex"][
+        "provider_policy"
+    ]
+    assert "Google AI Studio is classified separately" in provider_flags["google-vertex"][
+        "provider_policy"
+    ]
     # GMI runs VPC isolation, NOT an attested TEE — must NOT claim confidential.
     assert provider_flags["gmi"]["provider_confidential_compute"] is None
     assert provider_flags["deepseek"]["provider_zero_data_retention"] is False
@@ -1162,10 +1175,17 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert "venice" not in zdr_providers
     assert "anthropic" not in zdr_providers
     assert "google-ai-studio" not in zdr_providers
-    assert "google-vertex" not in zdr_providers
+    assert "google-vertex" in zdr_providers
     assert "openai" not in zdr_providers
     assert "deepseek" not in zdr_providers
     assert "gmi" not in zdr_providers
+    vertex_zdr = [item for item in zdr if item["provider"] == "google-vertex"]
+    assert vertex_zdr
+    assert all(item["prepaid_zero_data_retention"] is True for item in vertex_zdr)
+    assert all(
+        item["zero_data_retention_scope"] == "trustedrouter_prepaid"
+        for item in vertex_zdr
+    )
     credits = client.get("/v1/credits", headers=user_headers)
     assert credits.status_code == 200
     assert credits.json()["data"]["total_credits"] >= 0

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -670,6 +670,18 @@ def test_provider_detail_page_links_served_models(client: TestClient) -> None:
     assert "Policy source" in response.text
 
 
+def test_vertex_provider_page_scopes_zdr_to_managed_prepaid_routes(
+    client: TestClient,
+) -> None:
+    response = client.get("/providers/google-vertex")
+
+    assert response.status_code == 200
+    assert "No logs (prepaid)" in response.text
+    assert "prepaid only" in response.text
+    assert "contractual Zero Data Retention" in response.text
+    assert "Google AI Studio is classified separately" in response.text
+
+
 def test_provider_detail_links_indexable_performance_page(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- classify only TrustedRouter-funded Vertex Credits routes as contracted ZDR
- keep Google AI Studio and provider-wide/BYOK claims fail-closed
- add catalog, routing, API, and public-page regression coverage

OpenAI is intentionally not activated in this PR: the configured production project still allows a `store=true` Responses object to be retrieved.

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2099 passed, 61 skipped)