### PR TITLE
Avoid denied IAM writes during deploy

### DIFF
--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -125,11 +125,18 @@ ensure_secret_value() {
 ensure_project_role() {
   local member="$1"
   local role="$2"
-  # Retry on the etag-conflict error gcloud's own message says to retry on.
-  # Concurrent IAM changes on a busy project — including the parallel
-  # Cloud Run deploys later in this script, which each provision their
-  # own service-account bindings — collide on add-iam-policy-binding's
-  # read-modify-write. Sleep + retry is the documented mitigation.
+  local bound_roles=""
+  if bound_roles="$(gc projects get-iam-policy "$PROJECT_ID" \
+      --flatten='bindings[].members' \
+      --filter="bindings.role=${role} AND bindings.members=${member}" \
+      --format='value(bindings.role)' 2>/dev/null)"; then
+    if grep -Fxq "$role" <<<"$bound_roles"; then
+      return 0
+    fi
+  fi
+
+  # Retry only etag conflicts. Retrying an authorization failure creates a
+  # burst of misleading ERROR audit entries and cannot make the call succeed.
   local attempt=0
   local max_attempts=6
   local last_stderr=""
@@ -141,24 +148,13 @@ ensure_project_role() {
       return 0
     fi
     attempt=$((attempt + 1))
+    if echo "$last_stderr" | grep -qE 'PERMISSION_DENIED|setIamPolicy|Policy update access denied'; then
+      break
+    fi
     if [ "$attempt" -lt "$max_attempts" ]; then
       sleep "$attempt"
     fi
   done
-  # PERMISSION_DENIED means the caller lacks
-  # resourcemanager.projects.setIamPolicy — typically the case in CI
-  # where the deploy service account has run.developer but not IAM
-  # admin. In that case the role binding is expected to already be in
-  # place from a prior local provisioning run; treat as soft-success
-  # and let the actual Cloud Run deploy fail loudly if the perm IS
-  # missing. Without this, every CI deploy of a job requiring
-  # ensure_project_role would silently no-op via continue-on-error
-  # AND leave the underlying Cloud Run Job unchanged — exactly the
-  # silent failure mode that hid the 2026-06-02 pong surge for 8h.
-  if echo "$last_stderr" | grep -qE 'PERMISSION_DENIED|setIamPolicy'; then
-    echo "WARN: caller lacks setIamPolicy on ${PROJECT_ID}; assuming ${role} for ${member} is already bound (provisioned in a prior local run). The Cloud Run deploy below will surface a clear error if the binding is actually missing." >&2
-    return 0
-  fi
-  echo "ERROR: failed to bind ${role} to ${member} after ${max_attempts} attempts. Last stderr: ${last_stderr}" >&2
+  echo "ERROR: failed to bind ${role} to ${member} after ${attempt} attempt(s). Last stderr: ${last_stderr}" >&2
   return 1
 }

--- a/tests/test_deploy_iam_helpers.py
+++ b/tests/test_deploy_iam_helpers.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fake_gcloud(tmp_path: Path) -> tuple[Path, Path]:
+    binary = tmp_path / "gcloud"
+    calls = tmp_path / "calls.log"
+    binary.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${FAKE_GCLOUD_CALLS}"
+case "$*" in
+  *"projects describe"*)
+    printf '123456\\n'
+    ;;
+  *"projects get-iam-policy"*)
+    if [ "${FAKE_BINDING_PRESENT:-0}" = "1" ]; then
+      printf '%s\\n' "${FAKE_ROLE}"
+    fi
+    ;;
+  *"projects add-iam-policy-binding"*)
+    if [ "${FAKE_ADD_DENIED:-0}" = "1" ]; then
+      printf 'ERROR: PERMISSION_DENIED: Policy update access denied. setIamPolicy\\n' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    printf 'unexpected fake gcloud call: %s\\n' "$*" >&2
+    exit 2
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    return binary, calls
+
+
+def _run_ensure_project_role(
+    tmp_path: Path,
+    *,
+    binding_present: bool,
+    add_denied: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    _, calls = _fake_gcloud(tmp_path)
+    role = "roles/run.developer"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "PROJECT_ID": "test-project",
+        "FAKE_GCLOUD_CALLS": str(calls),
+        "FAKE_BINDING_PRESENT": "1" if binding_present else "0",
+        "FAKE_ADD_DENIED": "1" if add_denied else "0",
+        "FAKE_ROLE": role,
+    }
+    result = subprocess.run(  # noqa: S603 - fixed local test command
+        [
+            "/bin/bash",
+            "-c",
+            (
+                "source scripts/deploy/_lib.sh; "
+                "ensure_project_role "
+                "'serviceAccount:runtime@test-project.iam.gserviceaccount.com' "
+                f"'{role}'"
+            ),
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, calls.read_text(encoding="utf-8").splitlines()
+
+
+def test_existing_project_role_is_read_without_policy_write(tmp_path: Path) -> None:
+    result, calls = _run_ensure_project_role(tmp_path, binding_present=True)
+
+    assert result.returncode == 0, result.stderr
+    assert sum("get-iam-policy" in call for call in calls) == 1
+    assert not any("add-iam-policy-binding" in call for call in calls)
+
+
+def test_missing_project_role_fails_after_one_denied_write(tmp_path: Path) -> None:
+    result, calls = _run_ensure_project_role(
+        tmp_path,
+        binding_present=False,
+        add_denied=True,
+    )
+
+    assert result.returncode != 0
+    assert sum("add-iam-policy-binding" in call for call in calls) == 1
+    assert "Policy update access denied" in result.stderr


### PR DESCRIPTION
## Summary
- read existing project IAM bindings before attempting a write
- stop immediately on permission denial instead of generating six audit errors per role
- fail closed when a genuinely missing binding cannot be added

## Tests
- `uv run pytest -q tests/test_deploy_iam_helpers.py tests/test_synthetic_monitoring.py` (91 passed)
- `uv run ruff check tests/test_deploy_iam_helpers.py`
- real read-only production IAM filter validation