### PR TITLE
Rank status and leaderboard routes by reliability

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1467,7 +1467,12 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
             for provider in leaderboard.get("providers", [])
             if provider.get("sample_count", 0) > 0
         ),
-        key=lambda p: (-p.get("error_rate", 0.0), p.get("provider", "")),
+        key=lambda p: (
+            p.get("error_rate", 0.0),
+            0 if p.get("p50_ttft_ms") is not None else 1,
+            p.get("p50_ttft_ms") or 0,
+            p.get("provider", ""),
+        ),
     )
     return render_template(
         "public/status.html",

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -7,6 +7,12 @@ from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
 REGIONAL_GATEWAY_PROBES = {"tls_health", "attestation_nonce"}
 CONTROL_PLANE_PROBES = {"control_plane_health"}
 IMAGE_GENERATION_PROBES = {"image_generation"}
+MONITOR_CONFIGURATION_ERROR_TYPES = frozenset(
+    {
+        "monitor_account_unavailable",
+        "monitor_workspace_paused",
+    }
+)
 
 COMPONENT_PROBES: dict[str, set[str]] = {
     "canonical_api": REGIONAL_GATEWAY_PROBES,
@@ -80,6 +86,8 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
 
 
 def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
+    if sample.error_type in MONITOR_CONFIGURATION_ERROR_TYPES:
+        return []
     ids: list[str] = []
     if sample.target == "canonical" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("canonical_api")
@@ -101,7 +109,20 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
 
 
 def sample_slo_class_ids(sample: SyntheticProbeSample) -> list[str]:
+    if sample.error_type in MONITOR_CONFIGURATION_ERROR_TYPES:
+        return []
     return _slo_class_ids(probe_type=sample.probe_type, target=sample.target)
+
+
+def is_router_origin_error(error_type: str | None) -> bool:
+    """Return whether a benchmark failure happened before provider invocation."""
+    return bool(
+        error_type
+        and (
+            error_type in MONITOR_CONFIGURATION_ERROR_TYPES
+            or error_type.startswith("router_")
+        )
+    )
 
 
 def rollup_slo_class_ids(rollup: SyntheticRollup) -> list[str]:

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.components import is_router_origin_error
 
 NON_DOWNTIME_ERROR_TYPES = frozenset(
     {
@@ -232,7 +233,7 @@ class ProviderStats:
 
 
 def _sort_key(p50_ttft_ms: int | None) -> tuple[int, int]:
-    # Fastest measured TTFT first; un-measured (None) sink to the bottom.
+    # Latency breaks reliability ties; un-measured (None) sinks to the bottom.
     return (0 if p50_ttft_ms is not None else 1, p50_ttft_ms or 0)
 
 
@@ -314,6 +315,7 @@ def aggregate_leaderboard(
     models.sort(
         key=lambda stats: (
             0 if stats.rank_eligible else 1,
+            -stats.uptime,
             *_sort_key(stats.p50_ttft_ms),
             stats.model,
             stats.provider,
@@ -387,6 +389,7 @@ def _aggregate_providers(
     providers.sort(
         key=lambda stats: (
             0 if stats.rank_eligible else 1,
+            -stats.uptime,
             *_sort_key(stats.p50_ttft_ms),
             stats.provider,
         )
@@ -401,6 +404,8 @@ def _aggregate_providers(
 
 def _excluded_from_uptime(sample: ProviderBenchmarkSample) -> bool:
     if sample.status == "unsupported":
+        return True
+    if is_router_origin_error(sample.error_type):
         return True
     if sample.error_type in NON_DOWNTIME_ERROR_TYPES:
         return True

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -24,6 +24,7 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     scrub_provider_error_message,
 )
+from trusted_router.synthetic.components import is_router_origin_error
 from trusted_router.types import UsageType
 
 DEFAULT_SYNTHETIC_BILLING_CONCURRENCY = 2
@@ -656,7 +657,7 @@ async def gateway_billing_probe(
                     status="down",
                     latency_milliseconds=_elapsed_ms(started),
                     http_status=authorize.status_code,
-                    error_type="authorize_failed",
+                    error_type=_probe_response_error(authorize, operation="authorize"),
                     model=model,
                 )
             ]
@@ -681,6 +682,15 @@ async def gateway_billing_probe(
         )
         settle_data = settle.json().get("data", {}) if settle.content else {}
         ok = settle.status_code == 200 and bool(settle_data.get("settled"))
+        settle_error = (
+            None
+            if ok
+            else (
+                _probe_response_error(settle, operation="settle")
+                if settle.status_code != 200
+                else "settle_failed"
+            )
+        )
         return [
             _sample(
                 "gateway_authorize_settle",
@@ -690,7 +700,7 @@ async def gateway_billing_probe(
                 status="up" if ok else "down",
                 latency_milliseconds=_elapsed_ms(started),
                 http_status=settle.status_code,
-                error_type=None if ok else "settle_failed",
+                error_type=settle_error,
                 model=model,
                 selected_model=settle_data.get("model"),
                 selected_provider=settle_data.get("provider"),
@@ -750,7 +760,7 @@ async def gateway_fallback_probe(
                     status="routing_degraded",
                     latency_milliseconds=_elapsed_ms(started),
                     http_status=authorize.status_code,
-                    error_type="authorize_failed",
+                    error_type=_probe_response_error(authorize, operation="authorize"),
                     model=model,
                 )
             ]
@@ -796,6 +806,15 @@ async def gateway_fallback_probe(
             and bool(settle_data.get("settled"))
             and settle_data.get("endpoint_id") == expected_endpoint
         )
+        settle_error = (
+            None
+            if ok
+            else (
+                _probe_response_error(settle, operation="fallback_settle")
+                if settle.status_code != 200
+                else "fallback_settle_failed"
+            )
+        )
         return [
             _sample(
                 "provider_fallback",
@@ -805,7 +824,7 @@ async def gateway_fallback_probe(
                 status="up" if ok else "routing_degraded",
                 latency_milliseconds=_elapsed_ms(started),
                 http_status=settle.status_code,
-                error_type=None if ok else "fallback_settle_failed",
+                error_type=settle_error,
                 model=model,
                 selected_model=settle_data.get("model") or fallback.get("model"),
                 selected_provider=settle_data.get("provider") or fallback.get("provider"),
@@ -960,13 +979,14 @@ def _sse_line_error(line: str) -> tuple[str, int | None, str | None] | None:
         return None
     error_type = str(error.get("type") or "provider_error")
     message = str(error.get("message") or "") or None
+    source = str(error.get("source") or "") or None
     status_raw = error.get("status") or error.get("code") or error.get("status_code")
     status: int | None
     try:
         status = int(status_raw) if status_raw is not None else None
     except (TypeError, ValueError):
         status = None
-    return _rotation_error_type(error_type, status, message), status, message
+    return _rotation_error_type(error_type, status, message, source=source), status, message
 
 
 def _sse_line_finish_reason(line: str) -> str | None:
@@ -1062,16 +1082,27 @@ def _response_error(response: httpx.Response) -> tuple[str, int | None, str | No
     except ValueError:
         return f"http_{response.status_code}", response.status_code, None
     error = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(error, dict) and isinstance(payload, dict):
+        detail = payload.get("detail")
+        error = detail.get("error") if isinstance(detail, dict) else None
     if not isinstance(error, dict):
         return f"http_{response.status_code}", response.status_code, None
     error_type = str(error.get("type") or f"http_{response.status_code}")
     message = str(error.get("message") or "") or None
+    source = str(error.get("source") or "") or None
     status_raw = error.get("status") or error.get("code") or error.get("status_code")
     try:
         status = int(status_raw) if status_raw is not None else response.status_code
     except (TypeError, ValueError):
         status = response.status_code
-    return _rotation_error_type(error_type, status, message), status, message
+    return _rotation_error_type(error_type, status, message, source=source), status, message
+
+
+def _probe_response_error(response: httpx.Response, *, operation: str) -> str:
+    error_type, _status, _message = _response_error(response)
+    if is_router_origin_error(error_type):
+        return error_type
+    return f"{operation}_{error_type}"
 
 
 _UNSUPPORTED_ROUTE_ERROR_TYPES = frozenset(
@@ -1128,9 +1159,29 @@ def _rotation_error_type(
     error_type: str,
     status: int | None,
     message: str | None,
+    *,
+    source: str | None = None,
 ) -> str:
     raw_type = error_type.casefold()
     raw_message = (message or "").casefold()
+    raw_source = (source or "").casefold()
+    if "workspace billing is paused" in raw_message:
+        return "monitor_workspace_paused"
+    if "database contention" in raw_message or "deadlock" in raw_message:
+        return "router_database_contention"
+    if "read-only mode" in raw_message or "planned maintenance" in raw_message:
+        return "router_maintenance"
+    if raw_source == "router" and any(
+        marker in raw_message
+        for marker in (
+            "insufficient credits",
+            "api key is disabled",
+            "api key expired",
+            "invalid api key",
+            "api key not found",
+        )
+    ):
+        return "monitor_account_unavailable"
     if raw_type in _UNSUPPORTED_ROUTE_ERROR_TYPES or any(
         marker in raw_message for marker in _UNSUPPORTED_ROUTE_MESSAGE_MARKERS
     ):
@@ -1140,6 +1191,8 @@ def _rotation_error_type(
         and any(marker in raw_message for marker in _PROBE_CONFIG_MESSAGE_MARKERS)
     ):
         return "probe_config_error"
+    if raw_source == "router":
+        return "router_error"
     if status in {401, 403}:
         return "provider_auth_config"
     return error_type
@@ -1508,7 +1561,7 @@ def _rotation_error_sample(
 
 
 def _rotation_error_excluded_from_uptime(error_type: str | None) -> bool:
-    return error_type in {
+    return is_router_origin_error(error_type) or error_type in {
         "unsupported_route",
         "probe_config_error",
         "provider_auth_config",

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -35,7 +35,7 @@
     <div class="status-section-head">
       <div>
         <h2>Providers</h2>
-        <p>Ranked by measured p50 time-to-first-token across all of a provider's models
+        <p>Ranked by measured success rate, then p50 time-to-first-token across all of a provider's models
           ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} availability samples ·
           {{ snapshot.total_throughput_samples }} sustained throughput samples). Providers below the
           evidence floor remain visible as warming, but do not receive a rank.</p>
@@ -74,7 +74,7 @@
     <div class="status-section-head">
       <div>
         <h2>Models</h2>
-        <p>Qualified models are ranked by measured p50 TTFT. Thin availability and
+        <p>Qualified models are ranked by measured success rate, then p50 TTFT. Thin availability and
           throughput measurements stay visible below the ranked set as warming.</p>
       </div>
     </div>

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -78,6 +78,39 @@ def test_models_sorted_fastest_first_unmeasured_last() -> None:
     assert ordered[2] == "unknown/m"  # un-measured at the bottom
 
 
+def test_models_and_providers_rank_reliability_before_latency() -> None:
+    samples = [
+        _sample(provider="reliable", model="reliable/m", ttft=500),
+        _sample(
+            provider="reliable",
+            model="reliable/m",
+            ttft=520,
+            created_at="2026-06-04T00:00:01Z",
+        ),
+        _sample(provider="flaky", model="flaky/m", ttft=50),
+        _sample(
+            provider="flaky",
+            model="flaky/m",
+            status="error",
+            error_type="ReadTimeout",
+            created_at="2026-06-04T00:00:01Z",
+        ),
+    ]
+
+    result = aggregate_leaderboard(samples)
+
+    assert [row["model"] for row in result["models"]] == [
+        "reliable/m",
+        "flaky/m",
+    ]
+    assert [row["provider"] for row in result["providers"]] == [
+        "reliable",
+        "flaky",
+    ]
+    assert result["models"][0]["uptime"] == 1.0
+    assert result["models"][1]["uptime"] == 0.5
+
+
 def test_min_samples_filters_thin_models() -> None:
     samples = [
         _sample(provider="a", model="a/keep", ttft=100),
@@ -387,6 +420,27 @@ def test_aggregate_excludes_unsupported_routes_from_uptime() -> None:
     assert provider["top_excluded"] == "unsupported_route"
     assert result["total_samples"] == 2
     assert result["excluded_samples"] == 1
+
+
+def test_aggregate_excludes_router_failures_from_provider_uptime() -> None:
+    samples = [
+        _sample(provider="openai", model="openai/gpt-5.4-nano", ttft=100),
+        _sample(
+            provider="openai",
+            model="openai/gpt-5.4-nano",
+            status="error",
+            error_type="router_database_contention",
+            error_status=503,
+        ),
+    ]
+
+    result = aggregate_leaderboard(samples)
+    model = result["models"][0]
+
+    assert model["sample_count"] == 1
+    assert model["uptime"] == 1.0
+    assert model["excluded_count"] == 1
+    assert model["top_excluded"] == "router_database_contention"
 
 
 def test_aggregate_excluded_only_rows_do_not_surface_as_provider_errors() -> None:

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -92,6 +92,7 @@ def test_leaderboard_page_renders_measurements() -> None:
     assert "Effective throughput" in body
     assert "200 tok/s" in body
     assert "n=1" in body
+    assert "Ranked by measured success rate, then p50" in body
     assert "cerebras" in body  # seeded provider row
     assert "meta/llama-3.3-70b" in body  # seeded model row
 
@@ -154,3 +155,27 @@ def test_status_page_separates_config_exclusions_from_provider_errors() -> None:
     assert "Config excluded" in html
     assert "unsupported_route" in html
     assert "Unsupported route and probe-configuration rows" in html
+
+
+def test_status_page_sorts_healthiest_provider_first() -> None:
+    _seed("reliable", "reliable/model", ttft=500, ttfb=400)
+    _seed("flaky", "flaky/model", ttft=50, ttfb=40)
+    STORE.record_provider_benchmark(
+        ProviderBenchmarkSample(
+            id="bench-page-flaky-error",
+            model="flaky/model",
+            provider="flaky",
+            provider_name="Flaky",
+            status="error",
+            usage_type="Credits",
+            streamed=True,
+            error_type="ReadTimeout",
+            source="synthetic",
+        )
+    )
+
+    html = _status_page_html(_settings(), host="trustedrouter.com")
+
+    assert html.index('href="/providers/reliable"') < html.index(
+        'href="/providers/flaky"'
+    )

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -45,6 +45,7 @@ from trusted_router.storage_gcp_synthetic_rollups import (
     synthetic_rollups as _bt_synthetic_rollups,
 )
 from trusted_router.storage_models import ProviderBenchmarkSample, iso_now, utcnow
+from trusted_router.synthetic.components import sample_slo_class_ids
 from trusted_router.synthetic.probes import (
     IMAGE_GENERATION_MODEL,
     IMAGE_GENERATION_PROVIDER,
@@ -56,6 +57,8 @@ from trusted_router.synthetic.probes import (
     _sse_line_has_content,
     attestation_nonce_probe,
     choose_rotation_target,
+    gateway_billing_probe,
+    gateway_fallback_probe,
     image_generation_probe,
     openai_chat_pong_probe,
     provider_rotation_probe,
@@ -2496,6 +2499,79 @@ def test_sse_line_error_detects_openai_error_frames() -> None:
     assert _sse_line_error("data: [DONE]") is None
 
 
+def test_sse_line_error_distinguishes_router_failure_from_provider_failure() -> None:
+    assert _sse_line_error(
+        'data: {"error":{"message":"transient database contention",'
+        '"type":"service_unavailable","source":"router","status":503}}'
+    ) == ("router_database_contention", 503, "transient database contention")
+
+
+@pytest.mark.asyncio
+async def test_gateway_billing_probe_classifies_monitor_workspace_pause() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/v1/internal/gateway/authorize")
+        return httpx.Response(
+            503,
+            json={
+                "error": {
+                    "code": 503,
+                    "message": "Workspace billing is paused",
+                    "type": "service_unavailable",
+                    "source": "router",
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        samples = await gateway_billing_probe(
+            client,
+            control_plane_base_url="https://trustedrouter.com",
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            internal_token="internal-test",  # noqa: S106 - test placeholder.
+            model="trustedrouter/monitor",
+        )
+
+    assert samples[0].error_type == "monitor_workspace_paused"
+    assert sample_slo_class_ids(samples[0]) == []
+    assert {component for _period, component in sample_rollup_ids(samples[0])} == {
+        "uncategorized"
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_fallback_probe_classifies_router_contention() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/v1/internal/gateway/authorize")
+        return httpx.Response(
+            503,
+            json={
+                "error": {
+                    "code": 503,
+                    "message": (
+                        "The request was aborted due to transient database "
+                        "contention; retry."
+                    ),
+                    "type": "service_unavailable",
+                    "source": "router",
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        samples = await gateway_fallback_probe(
+            client,
+            control_plane_base_url="https://trustedrouter.com",
+            monitor_region="europe-west4",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            internal_token="internal-test",  # noqa: S106 - test placeholder.
+            model="trustedrouter/monitor",
+        )
+
+    assert samples[0].error_type == "router_database_contention"
+    assert sample_slo_class_ids(samples[0]) == ["router_core"]
+
+
 def test_sse_line_finish_reason_detects_length_stop() -> None:
     assert (
         _sse_line_finish_reason(
@@ -2782,6 +2858,37 @@ async def test_provider_rotation_probe_records_http_error() -> None:
     assert "rk-route5678" not in str(sample.error_message)
     assert sample.first_token_milliseconds is None
     assert sample.source == "synthetic"
+
+
+@pytest.mark.asyncio
+async def test_provider_rotation_probe_excludes_router_failure_from_uptime() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            json={
+                "error": {
+                    "code": 503,
+                    "message": "Workspace billing is paused",
+                    "type": "service_unavailable",
+                    "source": "router",
+                }
+            },
+        )
+
+    target = SyntheticTarget("rotation", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_rotation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="openai",
+            model="openai/gpt-5.4-nano",
+        )
+
+    assert sample.status == "unsupported"
+    assert sample.error_type == "monitor_workspace_paused"
+    assert sample.error_status == 503
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- sort status provider health and leaderboard rankings by success rate before TTFT
- distinguish monitor-account failures, router failures, and provider failures
- exclude monitor configuration from Router Core SLO and router-origin errors from provider uptime

## Root cause
The July 28 status dip was caused by a failed billing reshard run that left the old shared monitor workspace paused until the repair run completed. The monitor key has since moved to its dedicated 16-shard workspace. Separate Spanner contention ended after the user workspace was sharded.

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (2108 passed, 61 skipped)
- direct production Minimax smoke returned 200