### PR TITLE
Add Neurometric provider catalog

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -154,7 +154,8 @@ jobs:
                       INCEPTRON_API_KEY:trustedrouter-inceptron-api-key \
                       MORPH_API_KEY:trustedrouter-morph-api-key \
                       ATLAS_CLOUD_API_KEY:trustedrouter-atlas-cloud-api-key \
-                      STREAMLAKE_API_KEY:trustedrouter-streamlake-api-key; do
+                      STREAMLAKE_API_KEY:trustedrouter-streamlake-api-key \
+                      NEUROMETRIC_API_KEY:trustedrouter-neurometric-api-key; do
             env="${pair%%:*}"
             secret="${pair#*:}"
             KEY=$(gcloud secrets versions access latest --secret="${secret}" --project=quill-cloud-proxy)

--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -340,6 +340,12 @@ _DISCOVERABLE_MANIFEST_PROVIDERS: tuple[
         ("ALIBABA_API_KEY", "DASHSCOPE_API_KEY", "ALIYUN_API_KEY"),
         _alibaba_model_id,
     ),
+    (
+        "neurometric",
+        "https://wharf.neurometric.ai/v1/models",
+        ("NEUROMETRIC_API_KEY",),
+        _identity_model_id,
+    ),
 )
 
 _GLM_DISCOVERABLE_PROVIDER_APIS: tuple[tuple[str, str, tuple[str, ...]], ...] = (

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -153,6 +153,7 @@ ensure_secret_from_env_file "INCEPTRON_API_KEY" "trustedrouter-inceptron-api-key
 ensure_secret_from_env_file "MORPH_API_KEY" "trustedrouter-morph-api-key"
 ensure_secret_from_env_file "ATLAS_CLOUD_API_KEY" "trustedrouter-atlas-cloud-api-key"
 ensure_secret_from_env_file "STREAMLAKE_API_KEY" "trustedrouter-streamlake-api-key"
+ensure_secret_from_env_file "NEUROMETRIC_API_KEY" "trustedrouter-neurometric-api-key"
 
 SYNTH_PROMPTS_FILE="${TR_SYNTH_PROMPTS_FILE:-${HOME}/.trustedrouter_synth_prompts_v1.md}"
 SYNTH_CODE_PROMPTS_FILE="${TR_SYNTH_CODE_PROMPTS_FILE:-/Users/jperla/claude/fusion-code-prompts-v1.md}"
@@ -218,6 +219,7 @@ grant_tr_deploy_secret_access "trustedrouter-inceptron-api-key"
 grant_tr_deploy_secret_access "trustedrouter-morph-api-key"
 grant_tr_deploy_secret_access "trustedrouter-atlas-cloud-api-key"
 grant_tr_deploy_secret_access "trustedrouter-streamlake-api-key"
+grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,

--- a/scripts/pricing/provider_contract_catalog.py
+++ b/scripts/pricing/provider_contract_catalog.py
@@ -1,0 +1,294 @@
+"""Strict parsing for TrustedRouter's canonical provider catalog contract."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any
+
+from scripts.pricing.base import ModelPrice
+from scripts.pricing.model_ids import remember_upstream_id
+
+_MODEL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$")
+_OWNER_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_TOP_LEVEL_FIELDS = frozenset({"object", "data"})
+_MODEL_FIELDS = frozenset(
+    {
+        "id",
+        "object",
+        "owned_by",
+        "name",
+        "type",
+        "context_length",
+        "max_output_tokens",
+        "endpoints",
+        "input_modalities",
+        "output_modalities",
+        "capabilities",
+        "pricing",
+        "lifecycle",
+    }
+)
+_CAPABILITY_FIELDS = frozenset(
+    {"streaming", "tools", "structured_output", "reasoning", "prompt_caching"}
+)
+_PRICING_FIELDS = frozenset(
+    {
+        "currency",
+        "unit",
+        "input",
+        "output",
+        "cached_input",
+        "cache_write",
+        "minimum_request",
+    }
+)
+_LIFECYCLE_FIELDS = frozenset(
+    {"status", "deprecation_at", "retirement_at", "replacement_model_id"}
+)
+_ENDPOINTS = frozenset({"chat/completions", "responses"})
+_INPUT_MODALITIES = frozenset({"text", "image", "audio", "video", "file"})
+_OUTPUT_MODALITIES = frozenset({"text", "image", "audio"})
+_LIFECYCLE_STATUSES = frozenset({"active", "deprecated", "retired"})
+_MICRODOLLARS_PER_DOLLAR = Decimal("1000000")
+
+
+def _require_exact_fields(
+    value: object,
+    expected: frozenset[str],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must be an object")
+    keys = frozenset(str(key) for key in value)
+    missing = sorted(expected - keys)
+    extra = sorted(keys - expected)
+    if missing or extra:
+        raise RuntimeError(f"{label} fields invalid: missing={missing}, extra={extra}")
+    return value
+
+
+def _require_string(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_positive_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise RuntimeError(f"{label} must be a positive integer")
+    return value
+
+
+def _require_string_set(
+    value: object,
+    *,
+    allowed: frozenset[str],
+    label: str,
+) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise RuntimeError(f"{label} must be a non-empty array")
+    if any(not isinstance(item, str) for item in value):
+        raise RuntimeError(f"{label} entries must be strings")
+    parsed = [str(item) for item in value]
+    if len(parsed) != len(set(parsed)):
+        raise RuntimeError(f"{label} entries must be unique")
+    unsupported = sorted(set(parsed) - allowed)
+    if unsupported:
+        raise RuntimeError(f"{label} has unsupported values: {unsupported}")
+    return parsed
+
+
+def _require_bool(value: object, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise RuntimeError(f"{label} must be a boolean")
+    return value
+
+
+def _decimal(value: object, *, label: str, nullable: bool = False) -> Decimal | None:
+    if value is None and nullable:
+        return None
+    if not isinstance(value, str) or not re.fullmatch(r"(0|[1-9][0-9]*)(\.[0-9]+)?", value):
+        raise RuntimeError(f"{label} must be a non-negative decimal string")
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise RuntimeError(f"{label} is not a valid decimal") from exc
+    if not parsed.is_finite() or parsed < 0:
+        raise RuntimeError(f"{label} must be finite and non-negative")
+    return parsed
+
+
+def _microdollars_per_million(value: Decimal, *, label: str) -> int:
+    scaled = value * _MICRODOLLARS_PER_DOLLAR
+    rounded = scaled.to_integral_value(ROUND_HALF_UP)
+    if scaled != rounded:
+        raise RuntimeError(f"{label} exceeds microdollar-per-million precision")
+    return int(rounded)
+
+
+def _nullable_timestamp(value: object, *, label: str) -> str | None:
+    if value is None:
+        return None
+    text = _require_string(value, label=label)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError(f"{label} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeError(f"{label} must include a timezone")
+    return text
+
+
+def discover_provider_contract_catalog(
+    payload: object,
+    *,
+    upstream_id_map: dict[str, str],
+) -> tuple[dict[str, ModelPrice], dict[str, dict[str, Any]]]:
+    """Validate and normalize one canonical provider `/v1/models` response."""
+
+    top = _require_exact_fields(payload, _TOP_LEVEL_FIELDS, label="catalog")
+    if top["object"] != "list":
+        raise RuntimeError("catalog.object must equal 'list'")
+    source_rows = top["data"]
+    if not isinstance(source_rows, list):
+        raise RuntimeError("catalog.data must be an array")
+
+    prices: dict[str, ModelPrice] = {}
+    discovered: dict[str, dict[str, Any]] = {}
+    for index, source in enumerate(source_rows):
+        label = f"catalog.data[{index}]"
+        row = _require_exact_fields(source, _MODEL_FIELDS, label=label)
+        model_id = _require_string(row["id"], label=f"{label}.id")
+        if _MODEL_ID_RE.fullmatch(model_id) is None:
+            raise RuntimeError(f"{label}.id is not a canonical model id")
+        if row["object"] != "model" or row["type"] != "chat":
+            raise RuntimeError(f"{label} must describe a chat model")
+        owner = _require_string(row["owned_by"], label=f"{label}.owned_by")
+        if _OWNER_RE.fullmatch(owner) is None:
+            raise RuntimeError(f"{label}.owned_by is invalid")
+        name = _require_string(row["name"], label=f"{label}.name")
+        context_length = _require_positive_int(
+            row["context_length"], label=f"{label}.context_length"
+        )
+        max_output_tokens = _require_positive_int(
+            row["max_output_tokens"], label=f"{label}.max_output_tokens"
+        )
+        endpoints = _require_string_set(
+            row["endpoints"], allowed=_ENDPOINTS, label=f"{label}.endpoints"
+        )
+        input_modalities = _require_string_set(
+            row["input_modalities"],
+            allowed=_INPUT_MODALITIES,
+            label=f"{label}.input_modalities",
+        )
+        output_modalities = _require_string_set(
+            row["output_modalities"],
+            allowed=_OUTPUT_MODALITIES,
+            label=f"{label}.output_modalities",
+        )
+
+        capabilities = _require_exact_fields(
+            row["capabilities"], _CAPABILITY_FIELDS, label=f"{label}.capabilities"
+        )
+        parsed_capabilities = {
+            key: _require_bool(value, label=f"{label}.capabilities.{key}")
+            for key, value in capabilities.items()
+        }
+        pricing = _require_exact_fields(
+            row["pricing"], _PRICING_FIELDS, label=f"{label}.pricing"
+        )
+        if pricing["currency"] != "USD" or pricing["unit"] != "per_1m_tokens":
+            raise RuntimeError(f"{label}.pricing must use USD per_1m_tokens")
+        prompt = _decimal(pricing["input"], label=f"{label}.pricing.input")
+        completion = _decimal(pricing["output"], label=f"{label}.pricing.output")
+        cached = _decimal(
+            pricing["cached_input"],
+            label=f"{label}.pricing.cached_input",
+            nullable=True,
+        )
+        cache_write = _decimal(
+            pricing["cache_write"],
+            label=f"{label}.pricing.cache_write",
+            nullable=True,
+        )
+        minimum_request = _decimal(
+            pricing["minimum_request"], label=f"{label}.pricing.minimum_request"
+        )
+        if prompt is None or completion is None or minimum_request is None:
+            raise RuntimeError(f"{label}.pricing token prices must not be null")
+        if minimum_request != 0:
+            raise RuntimeError(f"{label}.pricing.minimum_request is not supported yet")
+        if cache_write not in (None, Decimal(0)):
+            raise RuntimeError(f"{label}.pricing.cache_write is not supported yet")
+        if parsed_capabilities["prompt_caching"] != (cached is not None):
+            raise RuntimeError(
+                f"{label}.capabilities.prompt_caching must match pricing.cached_input"
+            )
+
+        lifecycle = _require_exact_fields(
+            row["lifecycle"], _LIFECYCLE_FIELDS, label=f"{label}.lifecycle"
+        )
+        lifecycle_status = _require_string(
+            lifecycle["status"], label=f"{label}.lifecycle.status"
+        )
+        if lifecycle_status not in _LIFECYCLE_STATUSES:
+            raise RuntimeError(f"{label}.lifecycle.status is invalid")
+        deprecation_at = _nullable_timestamp(
+            lifecycle["deprecation_at"], label=f"{label}.lifecycle.deprecation_at"
+        )
+        retirement_at = _nullable_timestamp(
+            lifecycle["retirement_at"], label=f"{label}.lifecycle.retirement_at"
+        )
+        replacement = lifecycle["replacement_model_id"]
+        if replacement is not None:
+            replacement = _require_string(
+                replacement, label=f"{label}.lifecycle.replacement_model_id"
+            )
+            if _MODEL_ID_RE.fullmatch(replacement) is None:
+                raise RuntimeError(f"{label}.lifecycle.replacement_model_id is invalid")
+
+        if lifecycle_status == "retired":
+            continue
+        if "chat/completions" not in endpoints or "text" not in output_modalities:
+            continue
+
+        supported_features = ["chat", "completion"]
+        if parsed_capabilities["tools"]:
+            supported_features.append("tools")
+        if parsed_capabilities["structured_output"]:
+            supported_features.extend(["json_mode", "structured_outputs"])
+        if parsed_capabilities["reasoning"]:
+            supported_features.append("reasoning")
+
+        remember_upstream_id(upstream_id_map, model_id, model_id)
+        discovered[model_id] = {
+            "id": model_id,
+            "upstream_id": model_id,
+            "display_name": name,
+            "context_length": context_length,
+            "max_output_tokens": max_output_tokens,
+            "endpoints": endpoints,
+            "input_modalities": input_modalities,
+            "output_modalities": output_modalities,
+            "supported_features": supported_features,
+            "lifecycle_status": lifecycle_status,
+            "deprecation_at": deprecation_at,
+            "retirement_at": retirement_at,
+            "replacement_model_id": replacement,
+            "routable": True,
+        }
+        prices[model_id] = ModelPrice(
+            _microdollars_per_million(prompt, label=f"{label}.pricing.input"),
+            _microdollars_per_million(completion, label=f"{label}.pricing.output"),
+            prompt_cached_micro_per_m=(
+                _microdollars_per_million(
+                    cached, label=f"{label}.pricing.cached_input"
+                )
+                if cached is not None
+                else None
+            ),
+        )
+    return prices, discovered

--- a/scripts/pricing/providers/neurometric.py
+++ b/scripts/pricing/providers/neurometric.py
@@ -1,0 +1,101 @@
+"""Neurometric canonical model catalog, pricing, and account canary."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from scripts.pricing.base import (
+    PROVIDER_FETCH_TIMEOUT,
+    PROVIDER_FETCH_TRANSPORT_RETRIES,
+    PROVIDER_FETCH_UA,
+    ProviderPricingResult,
+    validate,
+)
+from scripts.pricing.manifest import (
+    set_manifest_canary_state,
+    write_discovered_chat_manifest,
+)
+from scripts.pricing.openai_catalog import probe_openai_chat
+from scripts.pricing.provider_contract_catalog import (
+    discover_provider_contract_catalog,
+)
+
+SLUG = "neurometric"
+BASE_URL = "https://wharf.neurometric.ai/v1"
+URL = f"{BASE_URL}/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "neurometric.json"
+)
+EXPECTED_MODELS = ["ibm-granite/granite-4.1-8b"]
+UPSTREAM_ID_MAP: dict[str, str] = {}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+_LIVE_CANARY_OK = False
+
+
+def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS, _LIVE_CANARY_OK  # noqa: PLW0603
+
+    api_key = os.environ.get("NEUROMETRIC_API_KEY")
+    if not api_key:
+        raise RuntimeError("NEUROMETRIC_API_KEY is required for model discovery")
+    transport = httpx.HTTPTransport(retries=PROVIDER_FETCH_TRANSPORT_RETRIES)
+    with httpx.Client(
+        timeout=PROVIDER_FETCH_TIMEOUT,
+        follow_redirects=True,
+        transport=transport,
+    ) as client:
+        response = client.get(
+            URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+                "User-Agent": PROVIDER_FETCH_UA,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    prices, discovered = discover_provider_contract_catalog(
+        payload,
+        upstream_id_map=UPSTREAM_ID_MAP,
+    )
+    _DISCOVERED_MANIFEST_ROWS = discovered
+    canary_model = UPSTREAM_ID_MAP.get(EXPECTED_MODELS[0], EXPECTED_MODELS[0])
+    _LIVE_CANARY_OK = probe_openai_chat(
+        base_url=BASE_URL,
+        api_key=api_key,
+        model=canary_model,
+    )
+    errors = validate(prices, EXPECTED_MODELS)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    return ProviderPricingResult(
+        slug=SLUG,
+        prices=prices,
+        source="api",
+        fetched_url=URL,
+        notes=[
+            f"validated canonical provider contract with {len(discovered)} active chat models",
+            f"account canary {'passed' if _LIVE_CANARY_OK else 'failed'}",
+        ],
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    notes = write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=URL,
+    )
+    set_manifest_canary_state(MANIFEST_PATH, healthy=_LIVE_CANARY_OK)
+    return notes

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -116,6 +116,7 @@ PROVIDER_SLUGS = [
     "morph",
     "atlas_cloud",
     "streamlake",
+    "neurometric",
     # First-party embedding providers. Their parsers feed committed provider
     # manifests that the runtime embedding catalog reads directly.
     "cohere",

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -386,6 +386,7 @@ _OPEN_WEIGHT_PREFIXES = (
     "amd/",
     "deepseek/",
     "google/gemma",
+    "ibm-granite/",
     "meta-llama/",
     "minimax/minimax-m3",
     "moonshotai/kimi",

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -751,6 +751,25 @@ PROVIDERS: dict[str, Provider] = {
         ),
         provider_headquarters_country="SG",
     ),
+    "neurometric": Provider(
+        slug="neurometric",
+        name="Neurometric AI",
+        supports_prepaid=True,
+        supports_byok=False,
+        stores_content=False,
+        provider_zero_data_retention=False,
+        provider_confidential_compute=False,
+        provider_e2ee=False,
+        provider_policy=(
+            "Neurometric states that TrustedRouter requests run with upstream "
+            "trace logging disabled: prompts and completions are not written "
+            "to observability or object storage, and only aggregate request "
+            "counts and token totals are retained. This is classified as "
+            "no-store, not contractual ZDR or confidential compute."
+        ),
+        provider_policy_url="https://www.neurometric.ai/privacy",
+        provider_headquarters_country=PROVIDER_JURISDICTION_US,
+    ),
     # DeepInfra — large open-weight catalog (Llama, Gemma 4, Qwen,
     # DeepSeek, etc.). OpenAI-compatible at api.deepinfra.com/v1/openai.
     # Pricing in the /v1/openai/models response under
@@ -943,6 +962,7 @@ GATEWAY_PREPAID_PROVIDER_SLUGS = frozenset(
         "morph",
         "atlas-cloud",
         "streamlake",
+        "neurometric",
         "nebius",
         "minimax",
         # Cohere — embeddings only for now (native /v2/embed in the enclave).

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -700,6 +700,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "morph",
         "atlas-cloud",
         "streamlake",
+        "neurometric",
         "kimi",
         "zai",
         "tinfoil",

--- a/src/trusted_router/data/provider_models/neurometric.json
+++ b/src/trusted_router/data/provider_models/neurometric.json
@@ -1,0 +1,109 @@
+{
+  "provider": "neurometric",
+  "source": "https://wharf.neurometric.ai/v1/models",
+  "price_scale": "microdollars_per_million",
+  "models": [
+    {
+      "display_name": "granite-4.1-8b",
+      "title": "ibm-granite/granite-4.1-8b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "ibm-granite/granite-4.1-8b",
+      "upstream_id": "ibm-granite/granite-4.1-8b",
+      "context_length": 32768,
+      "max_output_tokens": 16384,
+      "supported_features": [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "lifecycle_status": "active",
+      "deprecation_at": null,
+      "retirement_at": null,
+      "replacement_model_id": null,
+      "routable": true,
+      "input_token_price_per_m": 50000,
+      "output_token_price_per_m": 100000
+    },
+    {
+      "display_name": "Qwen3-VL-8B-Instruct",
+      "title": "qwen/qwen3-vl-8b-instruct",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen3-vl-8b-instruct",
+      "upstream_id": "qwen/qwen3-vl-8b-instruct",
+      "context_length": 32768,
+      "max_output_tokens": 16384,
+      "supported_features": [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "lifecycle_status": "active",
+      "deprecation_at": null,
+      "retirement_at": null,
+      "replacement_model_id": null,
+      "routable": true,
+      "input_token_price_per_m": 105000,
+      "output_token_price_per_m": 410000
+    },
+    {
+      "display_name": "Qwen3-VL-8B-Thinking",
+      "title": "qwen/qwen3-vl-8b-thinking",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen3-vl-8b-thinking",
+      "upstream_id": "qwen/qwen3-vl-8b-thinking",
+      "context_length": 32768,
+      "max_output_tokens": 16384,
+      "supported_features": [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "lifecycle_status": "active",
+      "deprecation_at": null,
+      "retirement_at": null,
+      "replacement_model_id": null,
+      "routable": true,
+      "input_token_price_per_m": 162000,
+      "output_token_price_per_m": 1890000
+    }
+  ],
+  "generated_at": "2026-07-29T16:13:55Z",
+  "model_count": 3
+}

--- a/src/trusted_router/providers.py
+++ b/src/trusted_router/providers.py
@@ -87,6 +87,10 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, tuple[tuple[str, ...], str]] = {
         ("STREAMLAKE_API_KEY",),
         "https://vanchin.streamlake.ai/api/gateway/v1/endpoints",
     ),
+    "neurometric": (
+        ("NEUROMETRIC_API_KEY",),
+        "https://wharf.neurometric.ai/v1",
+    ),
     # Alibaba Cloud Model Studio / DashScope — workspace-scoped OpenAI-compatible endpoint.
     "alibaba": (
         ("ALIBABA_API_KEY", "DASHSCOPE_API_KEY", "ALIYUN_API_KEY"),

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -38,6 +38,8 @@ def _known_provider_model_payload(url: str, _env_names: tuple[str, ...]) -> dict
         return {"data": [{"id": "glm-5.2"}]}
     if "inference.makora.com" in url:
         return {"data": [{"id": "deepseek-ai/DeepSeek-V4-Flash"}]}
+    if "wharf.neurometric.ai" in url:
+        return {"data": [{"id": "ibm-granite/granite-4.1-8b"}]}
     return {"data": []}
 
 

--- a/tests/test_neurometric_provider.py
+++ b/tests/test_neurometric_provider.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.check_price_coverage import _DISCOVERABLE_MANIFEST_PROVIDERS
+from scripts.pricing.provider_contract_catalog import (
+    discover_provider_contract_catalog,
+)
+from scripts.pricing.providers import neurometric
+from trusted_router.catalog import MODEL_ENDPOINTS, MODELS, PROVIDERS, model_open_weights
+
+
+def _model_row(
+    model_id: str = "ibm-granite/granite-4.1-8b",
+    *,
+    status: str = "active",
+) -> dict[str, Any]:
+    return {
+        "id": model_id,
+        "object": "model",
+        "owned_by": model_id.split("/", 1)[0],
+        "name": "Granite 4.1 8B",
+        "type": "chat",
+        "context_length": 32768,
+        "max_output_tokens": 16384,
+        "endpoints": ["chat/completions"],
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "capabilities": {
+            "streaming": True,
+            "tools": True,
+            "structured_output": True,
+            "reasoning": False,
+            "prompt_caching": False,
+        },
+        "pricing": {
+            "currency": "USD",
+            "unit": "per_1m_tokens",
+            "input": "0.050000",
+            "output": "0.100000",
+            "cached_input": None,
+            "cache_write": None,
+            "minimum_request": "0",
+        },
+        "lifecycle": {
+            "status": status,
+            "deprecation_at": None,
+            "retirement_at": None,
+            "replacement_model_id": None,
+        },
+    }
+
+
+def _payload(*rows: dict[str, Any]) -> dict[str, Any]:
+    return {"object": "list", "data": list(rows)}
+
+
+def test_canonical_contract_parser_preserves_exact_price_and_capabilities() -> None:
+    upstream_ids: dict[str, str] = {}
+    prices, discovered = discover_provider_contract_catalog(
+        _payload(_model_row()),
+        upstream_id_map=upstream_ids,
+    )
+
+    price = prices["ibm-granite/granite-4.1-8b"]
+    assert price.prompt_micro_per_m == 50_000
+    assert price.completion_micro_per_m == 100_000
+    assert upstream_ids == {
+        "ibm-granite/granite-4.1-8b": "ibm-granite/granite-4.1-8b"
+    }
+    row = discovered["ibm-granite/granite-4.1-8b"]
+    assert row["routable"] is True
+    assert row["supported_features"] == [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda row: row.__setitem__("unexpected", True), "fields invalid"),
+        (
+            lambda row: row["pricing"].__setitem__("minimum_request", "0.01"),
+            "minimum_request is not supported",
+        ),
+        (
+            lambda row: row["pricing"].__setitem__("input", "0.0000001"),
+            "exceeds microdollar-per-million precision",
+        ),
+        (
+            lambda row: row["capabilities"].__setitem__("prompt_caching", True),
+            "must match pricing.cached_input",
+        ),
+    ],
+)
+def test_canonical_contract_parser_fails_closed(
+    mutation: Any,
+    message: str,
+) -> None:
+    row = _model_row()
+    mutation(row)
+
+    with pytest.raises(RuntimeError, match=message):
+        discover_provider_contract_catalog(
+            _payload(row),
+            upstream_id_map={},
+        )
+
+
+def test_canonical_contract_parser_excludes_retired_models() -> None:
+    prices, discovered = discover_provider_contract_catalog(
+        _payload(_model_row(status="retired")),
+        upstream_id_map={},
+    )
+
+    assert prices == {}
+    assert discovered == {}
+
+
+def test_neurometric_fetch_discovers_new_models_and_runs_canary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = [
+        _model_row(),
+        _model_row("qwen/qwen3-vl-8b-instruct"),
+    ]
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return _payload(*rows)
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setenv("NEUROMETRIC_API_KEY", "test-key")
+    monkeypatch.setattr(neurometric.httpx, "Client", FakeClient)
+    monkeypatch.setattr(neurometric, "probe_openai_chat", lambda **_kwargs: True)
+
+    result = neurometric.fetch()
+
+    assert set(result.prices) == {
+        "ibm-granite/granite-4.1-8b",
+        "qwen/qwen3-vl-8b-instruct",
+    }
+    assert set(neurometric._DISCOVERED_MANIFEST_ROWS) == set(result.prices)
+    assert neurometric._LIVE_CANARY_OK is True
+
+
+def test_neurometric_manifest_tombstones_only_after_repeated_fresh_miss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "neurometric.json"
+    raw = json.loads(neurometric.MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest_path.write_text(json.dumps(raw) + "\n", encoding="utf-8")
+    payload = _payload(
+        _model_row(),
+        _model_row("qwen/qwen3-vl-8b-instruct"),
+    )
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return copy.deepcopy(payload)
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setenv("NEUROMETRIC_API_KEY", "test-key")
+    monkeypatch.setattr(neurometric, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(neurometric.httpx, "Client", FakeClient)
+    monkeypatch.setattr(neurometric, "probe_openai_chat", lambda **_kwargs: True)
+
+    result = neurometric.fetch()
+    neurometric.write_provider_manifest(result)
+    first = json.loads(manifest_path.read_text(encoding="utf-8"))
+    first_rows = {row["id"]: row for row in first["models"]}
+    assert first_rows["qwen/qwen3-vl-8b-thinking"]["missing_since"]
+    assert first_rows["qwen/qwen3-vl-8b-thinking"].get("routable") is not False
+
+    result = neurometric.fetch()
+    neurometric.write_provider_manifest(result)
+    second = json.loads(manifest_path.read_text(encoding="utf-8"))
+    second_rows = {row["id"]: row for row in second["models"]}
+    assert second_rows["qwen/qwen3-vl-8b-thinking"]["routable"] is False
+    assert (
+        second_rows["qwen/qwen3-vl-8b-thinking"]["routable_reason"]
+        == "delisted-upstream"
+    )
+
+
+def test_neurometric_catalog_routes_are_prepaid_only_and_no_store() -> None:
+    provider = PROVIDERS["neurometric"]
+    assert provider.supports_prepaid is True
+    assert provider.supports_byok is False
+    assert provider.stores_content is False
+    assert provider.provider_zero_data_retention is False
+    assert provider.provider_confidential_compute is False
+    assert provider.provider_e2ee is False
+
+    assert "ibm-granite/granite-4.1-8b" in MODELS
+    assert model_open_weights(MODELS["ibm-granite/granite-4.1-8b"]) is True
+    endpoints = [
+        endpoint
+        for endpoint in MODEL_ENDPOINTS.values()
+        if endpoint.provider == "neurometric"
+    ]
+    assert len(endpoints) == 3
+    assert {endpoint.usage_type for endpoint in endpoints} == {"Credits"}
+    assert {
+        endpoint.upstream_id
+        for endpoint in endpoints
+    } == {
+        "ibm-granite/granite-4.1-8b",
+        "qwen/qwen3-vl-8b-instruct",
+        "qwen/qwen3-vl-8b-thinking",
+    }
+
+
+def test_neurometric_public_api_exposes_provider_and_exact_endpoint(client: Any) -> None:
+    providers = {
+        row["id"]: row for row in client.get("/v1/providers").json()["data"]
+    }
+    provider = providers["neurometric"]
+    assert provider["name"] == "Neurometric AI"
+    assert provider["supports_prepaid"] is True
+    assert provider["supports_byok"] is False
+    assert provider["stores_content"] is False
+    assert provider["provider_zero_data_retention"] is False
+    assert provider["provider_confidential_compute"] is False
+
+    response = client.get(
+        "/v1/models/ibm-granite/granite-4.1-8b/endpoints"
+    )
+    assert response.status_code == 200
+    endpoints = response.json()["data"]
+    neurometric = next(
+        endpoint for endpoint in endpoints if endpoint["provider_name"] == "Neurometric AI"
+    )
+    assert neurometric["upstream_id"] == "ibm-granite/granite-4.1-8b"
+    assert neurometric["pricing"]["prompt"] == "0.0000000525"
+    assert neurometric["pricing"]["completion"] == "0.000000105"
+
+
+def test_neurometric_hourly_refresh_and_secret_wiring_are_complete() -> None:
+    discoverable = {
+        slug: (url, env_names)
+        for slug, url, env_names, _normalize in _DISCOVERABLE_MANIFEST_PROVIDERS
+    }
+    assert discoverable["neurometric"] == (
+        "https://wharf.neurometric.ai/v1/models",
+        ("NEUROMETRIC_API_KEY",),
+    )
+
+    root = Path(__file__).resolve().parents[1]
+    secrets = (root / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
+    workflow = (root / ".github/workflows/refresh-prices.yml").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        'ensure_secret_from_env_file "NEUROMETRIC_API_KEY" '
+        '"trustedrouter-neurometric-api-key"'
+    ) in secrets
+    assert (
+        'grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"'
+        in secrets
+    )
+    assert (
+        "NEUROMETRIC_API_KEY:trustedrouter-neurometric-api-key"
+        in workflow
+    )


### PR DESCRIPTION
## Summary

- add Neurometric AI provider metadata with conservative no-store privacy labeling
- ingest Neurometric's authenticated canonical catalog and exact decimal pricing hourly
- publish all live models as prepaid-only routes with capability and lifecycle metadata
- fail closed on schema drift, unsupported minimum charges, pricing precision loss, and canary failure
- add safe two-pass delisting and open-weights classification for IBM Granite
- keep the operator key out of the production control-plane service

## Validation

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`: 2,112 passed, 61 skipped
- 42 focused discovery, catalog, API, pricing, and secret-wiring tests
- live Neurometric PONG, streaming, tools, structured output, and integer usage probes passed

Deployment order: publish this catalog only after the gateway provider change is live.
