### PR TITLE
Keep low-cadence status probes current

### DIFF
--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -665,6 +665,8 @@ def _components(
             if _parse_time(sample.created_at) >= five_minute_cutoff
         ]
         status = _aggregate_status([sample.status for sample in current_samples])
+        if not current_samples and component_id == "image_generation":
+            status = _fresh_image_rollup_status(component_hour_rollups, now=now)
         if not current_samples and component_samples:
             status = "unknown"
         latencies = [
@@ -741,6 +743,28 @@ def _components(
             }
         )
     return rows
+
+
+def _fresh_image_rollup_status(
+    rollups: list[SyntheticRollup],
+    *,
+    now: dt.datetime,
+) -> str:
+    """Recover current low-cadence image status from its latest hourly rollup."""
+    latest = max(
+        (
+            rollup
+            for rollup in rollups
+            if rollup.last_checked_at is not None
+            and (now - _parse_time(rollup.last_checked_at)).total_seconds()
+            <= IMAGE_GENERATION_SAMPLE_TTL_SECONDS
+        ),
+        key=lambda rollup: str(rollup.last_checked_at),
+        default=None,
+    )
+    if latest is None:
+        return "unknown"
+    return _aggregate_status_counts(_rollup_status_counts(latest))
 
 
 def _latency_breakdown(samples: list[SyntheticProbeSample]) -> list[dict[str, Any]]:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1061,6 +1061,40 @@ def test_image_generation_component_stays_current_between_six_hour_checks() -> N
     assert stale_component["status"] == "unknown"
 
 
+def test_image_generation_component_uses_fresh_rollup_when_raw_window_is_empty() -> None:
+    now = utcnow()
+    image_sample = _sample(
+        id="syn_image_rollup_only",
+        target="canonical",
+        probe_type="image_generation",
+        status="up",
+        created_at=(now - dt.timedelta(hours=4)).isoformat().replace("+00:00", "Z"),
+    )
+    rollup = new_rollup_for_sample(
+        image_sample,
+        period="hour",
+        component="image_generation",
+    )
+
+    snapshot = status_snapshot([], rollups=[rollup], now=now)
+    component = next(
+        row for row in snapshot["components"] if row["id"] == "image_generation"
+    )
+
+    assert component["status"] == "up"
+    assert component["last_checked_at"] == image_sample.created_at
+
+    stale_snapshot = status_snapshot(
+        [],
+        rollups=[rollup],
+        now=now + dt.timedelta(hours=4),
+    )
+    stale_component = next(
+        row for row in stale_snapshot["components"] if row["id"] == "image_generation"
+    )
+    assert stale_component["status"] == "unknown"
+
+
 def test_status_component_current_uses_latest_sample_per_probe() -> None:
     now = utcnow()
     samples = [


### PR DESCRIPTION
## Summary
- derive current image-generation status from its fresh hourly rollup when the bounded one-hour raw window does not include the six-hour probe
- preserve the existing seven-hour staleness boundary
- add regression coverage for fresh and stale rollup-only snapshots

## Verification
- focused status and leaderboard tests: 121 passed
- ruff clean
- mypy clean