### PR TITLE
Fix window-floor and retention-TTL interleavings in the recent Spanner changes

### DIFF
--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -24,7 +24,6 @@ import logging
 import threading
 import time
 import uuid
-import weakref
 from collections.abc import Callable
 from typing import Any
 
@@ -544,24 +543,40 @@ def _is_table_missing(exc: Exception) -> bool:
 
 
 _OUTBOX_ABSENT_CACHE_SECONDS = 5.0
-_OUTBOX_AVAILABILITY_CACHE: weakref.WeakKeyDictionary[
-    Any, tuple[bool, float]
-] = weakref.WeakKeyDictionary()
+# Keyed by a STABLE STRING, never by the Database object itself: the production
+# google.cloud.spanner_v1.database.Database defines __eq__ and sets
+# __hash__ = None, so keying a (Weak)dict on it raises TypeError on every
+# get/set. A cache that swallowed that error silently never cached in prod and
+# every settle/refund paid an extra GUARD_COUNT_SQL probe round trip on the hot
+# path — invisible to tests, whose fake database happens to be hashable.
+_OUTBOX_AVAILABILITY_CACHE: dict[str, tuple[bool, float]] = {}
 _OUTBOX_AVAILABILITY_CACHE_LOCK = threading.Lock()
 _OUTBOX_AVAILABILITY_PROBE_LOCK = threading.Lock()
 
 
+def _outbox_cache_key(database: Any) -> str:
+    """Stable, hashable identity for a Spanner database.
+
+    `Database.name` is the fully-qualified `projects/.../databases/...` path:
+    unique per database and stable for the process. `id()` is only a fallback
+    for test doubles that lack it. Either way the cache is bounded by the
+    number of distinct databases a process talks to (one, in practice).
+    """
+    name = getattr(database, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    return f"id:{id(database)}"
+
+
 def _cached_outbox_availability(database: Any, *, now: float) -> bool | None:
+    key = _outbox_cache_key(database)
     with _OUTBOX_AVAILABILITY_CACHE_LOCK:
-        try:
-            cached = _OUTBOX_AVAILABILITY_CACHE.get(database)
-        except TypeError:
-            return None
+        cached = _OUTBOX_AVAILABILITY_CACHE.get(key)
         if cached is None:
             return None
         available, expires_at = cached
         if expires_at <= now:
-            _OUTBOX_AVAILABILITY_CACHE.pop(database, None)
+            _OUTBOX_AVAILABILITY_CACHE.pop(key, None)
             return None
         return available
 
@@ -574,12 +589,10 @@ def _remember_outbox_availability(
 ) -> None:
     expires_at = float("inf") if available else now + _OUTBOX_ABSENT_CACHE_SECONDS
     with _OUTBOX_AVAILABILITY_CACHE_LOCK:
-        try:
-            _OUTBOX_AVAILABILITY_CACHE[database] = (available, expires_at)
-        except TypeError:
-            # An unusual unhashable/non-weak-referenceable database wrapper
-            # still gets the correct variant; it simply cannot use this cache.
-            return
+        _OUTBOX_AVAILABILITY_CACHE[_outbox_cache_key(database)] = (
+            available,
+            expires_at,
+        )
 
 
 def _outbox_table_available(database: Any, param_types: Any) -> bool:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -21,7 +21,10 @@ debit. Replay is resume/no-execute: the caller must NOT re-run the LLM call
 from __future__ import annotations
 
 import logging
+import threading
+import time
 import uuid
+import weakref
 from collections.abc import Callable
 from typing import Any
 
@@ -427,6 +430,7 @@ def settle_atomic(
     success: bool,
     guard_outbox: bool = False,
     mark_authorization_terminal: bool = False,
+    outbox_available: bool | None = None,
 ) -> dict:
     """Claim-gated settle/refund in ONE transaction (key then credit lock order).
 
@@ -446,12 +450,17 @@ def settle_atomic(
     book_actual = actual_micro if success else 0
     book_to_byok = settled_usage_type == "BYOK"
     terminal_at = utcnow()
+    resolved_outbox_available = (
+        _outbox_table_available(database, pt)
+        if outbox_available is None
+        else outbox_available
+    )
 
     def txn(transaction: Any) -> dict:
         res = read_reservation(transaction, pt, reservation_id)
         if res is None:
             return {"outcome": SettleOutcome.NOT_FOUND}
-        if guard_outbox:
+        if guard_outbox and resolved_outbox_available:
             aid = res.get("authorization_id")
             if aid:
                 # MF2: this strong read inside the read-write claim txn is the
@@ -470,6 +479,7 @@ def settle_atomic(
             actual_micro=book_actual,
             settled_usage_type=settled_usage_type,
             terminal_at=terminal_at,
+            outbox_available=resolved_outbox_available,
         )
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}  # replay, no double-apply
@@ -533,6 +543,87 @@ def _is_table_missing(exc: Exception) -> bool:
     )
 
 
+_OUTBOX_ABSENT_CACHE_SECONDS = 5.0
+_OUTBOX_AVAILABILITY_CACHE: weakref.WeakKeyDictionary[
+    Any, tuple[bool, float]
+] = weakref.WeakKeyDictionary()
+_OUTBOX_AVAILABILITY_CACHE_LOCK = threading.Lock()
+_OUTBOX_AVAILABILITY_PROBE_LOCK = threading.Lock()
+
+
+def _cached_outbox_availability(database: Any, *, now: float) -> bool | None:
+    with _OUTBOX_AVAILABILITY_CACHE_LOCK:
+        try:
+            cached = _OUTBOX_AVAILABILITY_CACHE.get(database)
+        except TypeError:
+            return None
+        if cached is None:
+            return None
+        available, expires_at = cached
+        if expires_at <= now:
+            _OUTBOX_AVAILABILITY_CACHE.pop(database, None)
+            return None
+        return available
+
+
+def _remember_outbox_availability(
+    database: Any,
+    *,
+    available: bool,
+    now: float,
+) -> None:
+    expires_at = float("inf") if available else now + _OUTBOX_ABSENT_CACHE_SECONDS
+    with _OUTBOX_AVAILABILITY_CACHE_LOCK:
+        try:
+            _OUTBOX_AVAILABILITY_CACHE[database] = (available, expires_at)
+        except TypeError:
+            # An unusual unhashable/non-weak-referenceable database wrapper
+            # still gets the correct variant; it simply cannot use this cache.
+            return
+
+
+def _outbox_table_available(database: Any, param_types: Any) -> bool:
+    """Return whether guarded SQL may reference the rollout-added outbox table.
+
+    A positive result is stable for the life of the process. A missing-table
+    result has a short TTL so a process deployed before the DDL automatically
+    adopts the guard shortly after the migration lands. Only the exact Spanner
+    table-missing shape selects unguarded SQL; transient/schema probe failures
+    fail toward the guarded variant and are not cached.
+    """
+    now = time.monotonic()
+    cached = _cached_outbox_availability(database, now=now)
+    if cached is not None:
+        return cached
+
+    # Serialize cache misses so concurrent first settles do not stampede the
+    # one process-level availability probe.
+    with _OUTBOX_AVAILABILITY_PROBE_LOCK:
+        now = time.monotonic()
+        cached = _cached_outbox_availability(database, now=now)
+        if cached is not None:
+            return cached
+        try:
+            with database.snapshot() as snapshot:
+                list(snapshot.execute_sql(
+                    GUARD_COUNT_SQL,
+                    params={"aid": ""},
+                    param_types={"aid": param_types.STRING},
+                ))
+        except Exception as exc:
+            if not _is_table_missing(exc):
+                log.warning(
+                    "tr_settle_outbox availability probe failed; using guarded SQL",
+                    exc_info=True,
+                )
+                return True
+            available = False
+        else:
+            available = True
+        _remember_outbox_availability(database, available=available, now=now)
+        return available
+
+
 # Reaper scan, two forms. The guarded form excludes holds with an outbox row
 # whose status is in GUARD_STATUSES IN THE SCAN so frozen holds never consume @limit and cannot
 # starve unguarded expired holds behind them (PR #116 review P2). The NOT
@@ -585,6 +676,11 @@ def reap_expired_reservations(
         # either. Unguarded free-release is exactly today's behavior; the guard
         # arms itself the moment the DDL is applied.
         guard_active = False
+    _remember_outbox_availability(
+        database,
+        available=guard_active,
+        now=time.monotonic(),
+    )
 
     scan_sql = _REAP_SCAN_GUARDED_SQL if guard_active else _REAP_SCAN_SQL
     with database.snapshot() as snapshot:
@@ -601,6 +697,7 @@ def reap_expired_reservations(
             database, pt, reservation_id=reservation_id, actual_micro=0,
             settled_usage_type="Credits", success=False, guard_outbox=guard_active,
             mark_authorization_terminal=True,
+            outbox_available=guard_active,
         )
         if result["outcome"] == SettleOutcome.SETTLED:
             reaped += 1
@@ -617,6 +714,7 @@ def typed_finalize_atomic(
     actual_micro: int,
     settled_usage_type: str,
     now: Any,
+    outbox_available: bool | None = None,
     authorization: GatewayAuthorization | None = None,
     auth_body_settled: str,
     generation_writes: list[tuple[str, str, str]] | None = None,
@@ -646,6 +744,11 @@ def typed_finalize_atomic(
     book_actual = actual_micro if success else 0
     book_to_byok = settled_usage_type == "BYOK"
     writes = generation_writes or []
+    resolved_outbox_available = (
+        _outbox_table_available(database, pt)
+        if outbox_available is None
+        else outbox_available
+    )
 
     def txn(transaction: Any) -> dict:
         res = read_reservation(transaction, pt, reservation_id)
@@ -657,6 +760,7 @@ def typed_finalize_atomic(
             settled_usage_type=settled_usage_type,
             terminal_at=now,
             defer_retention=True,
+            outbox_available=resolved_outbox_available,
         )
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}
@@ -713,6 +817,7 @@ def typed_finalize_atomic(
                 pt,
                 reservation_id,
                 terminal_at=now,
+                outbox_available=resolved_outbox_available,
             )
         if marked != 1:
             raise _SettleError("gateway_authorization update row-count != 1")

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -554,22 +554,31 @@ _OUTBOX_AVAILABILITY_CACHE_LOCK = threading.Lock()
 _OUTBOX_AVAILABILITY_PROBE_LOCK = threading.Lock()
 
 
-def _outbox_cache_key(database: Any) -> str:
-    """Stable, hashable identity for a Spanner database.
+def _outbox_cache_key(database: Any) -> str | None:
+    """Stable identity for a Spanner database, or None to skip caching.
 
     `Database.name` is the fully-qualified `projects/.../databases/...` path:
-    unique per database and stable for the process. `id()` is only a fallback
-    for test doubles that lack it. Either way the cache is bounded by the
-    number of distinct databases a process talks to (one, in practice).
+    unique per database and stable for the process, so the cache is bounded by
+    the number of databases a process talks to (one, in practice).
+
+    A database WITHOUT a name is not cached at all. `id()` would be the obvious
+    fallback, but object addresses are REUSED after garbage collection, so a
+    destroyed double's entry could be inherited by an unrelated database and
+    select stale SQL — present-then-absent would emit guarded DML against a
+    missing table and break settlement. Only test doubles lack a name, and for
+    them the probe is an in-memory call, so re-probing is strictly cheaper than
+    that risk.
     """
     name = getattr(database, "name", None)
     if isinstance(name, str) and name:
         return name
-    return f"id:{id(database)}"
+    return None
 
 
 def _cached_outbox_availability(database: Any, *, now: float) -> bool | None:
     key = _outbox_cache_key(database)
+    if key is None:
+        return None
     with _OUTBOX_AVAILABILITY_CACHE_LOCK:
         cached = _OUTBOX_AVAILABILITY_CACHE.get(key)
         if cached is None:
@@ -587,12 +596,12 @@ def _remember_outbox_availability(
     available: bool,
     now: float,
 ) -> None:
+    key = _outbox_cache_key(database)
+    if key is None:
+        return
     expires_at = float("inf") if available else now + _OUTBOX_ABSENT_CACHE_SECONDS
     with _OUTBOX_AVAILABILITY_CACHE_LOCK:
-        _OUTBOX_AVAILABILITY_CACHE[_outbox_cache_key(database)] = (
-            available,
-            expires_at,
-        )
+        _OUTBOX_AVAILABILITY_CACHE[key] = (available, expires_at)
 
 
 def _outbox_table_available(database: Any, param_types: Any) -> bool:

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -27,6 +27,10 @@ from typing import Any
 
 from trusted_router.storage_gcp_counters import UNSHARDED
 
+# Importing GUARD_STATUSES would cycle because storage_gcp_settle_outbox imports
+# the retention helpers below. Keep this SQL list in sync with that tuple.
+_OUTBOX_GUARD_STATUS_SQL = "'pending', 'dead'"
+
 # reserve_key outcomes (the per-key spend-cap counterpart of reserve_credit).
 KEY_ACCEPTED = "accepted"  # hold taken (row-count 1)
 KEY_NO_HOLD = "no_hold"  # uncapped key, or BYOK excluded from the cap: proceed
@@ -423,8 +427,11 @@ def claim_reservation(
         None if defer_retention else (terminal_at or datetime.now(UTC))
     )
     count = transaction.execute_update(
-        "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "
-        "settled_usage_type=@sut, terminal_at=@terminal_at "
+        "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "  # noqa: S608
+        "settled_usage_type=@sut, terminal_at = IF("
+        "EXISTS (SELECT 1 FROM tr_settle_outbox o "
+        "WHERE o.authorization_id = tr_reservation.authorization_id "
+        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL})), NULL, @terminal_at) "
         "WHERE reservation_id=@rid AND settled=false",
         params={
             "rid": reservation_id,
@@ -451,8 +458,11 @@ def complete_reservation_retention(
 ) -> int:
     """Start TTL only after all durable settlement repair work is complete."""
     return transaction.execute_update(
-        "UPDATE tr_reservation SET terminal_at=@terminal_at "
-        "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL",
+        "UPDATE tr_reservation SET terminal_at=@terminal_at "  # noqa: S608
+        "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL "
+        "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+        "WHERE o.authorization_id = tr_reservation.authorization_id "
+        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))",
         params={
             "rid": reservation_id,
             "terminal_at": terminal_at,

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -464,6 +464,20 @@ def complete_reservation_retention(
     )
 
 
+def clear_reservation_retention(
+    transaction: Any,
+    param_types: Any,
+    reservation_id: str,
+) -> int:
+    """Make a reservation TTL-ineligible while durable repair is outstanding."""
+    return transaction.execute_update(
+        "UPDATE tr_reservation SET terminal_at=NULL "
+        "WHERE reservation_id=@rid AND terminal_at IS NOT NULL",
+        params={"rid": reservation_id},
+        param_types={"rid": param_types.STRING},
+    )
+
+
 def insert_entity_dml(
     transaction: Any, param_types: Any, kind: str, entity_id: str, body_json: str
 ) -> None:

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -31,6 +31,31 @@ from trusted_router.storage_gcp_counters import UNSHARDED
 # the retention helpers below. Keep this SQL list in sync with that tuple.
 _OUTBOX_GUARD_STATUS_SQL = "'pending', 'dead'"
 
+_CLAIM_RESERVATION_SQL = (
+    "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "
+    "settled_usage_type=@sut, terminal_at=@terminal_at "
+    "WHERE reservation_id=@rid AND settled=false"
+)
+_CLAIM_RESERVATION_GUARDED_SQL = (
+    "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "  # noqa: S608
+    "settled_usage_type=@sut, terminal_at = IF("
+    "EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL})), NULL, @terminal_at) "
+    "WHERE reservation_id=@rid AND settled=false"
+)
+_COMPLETE_RESERVATION_RETENTION_SQL = (
+    "UPDATE tr_reservation SET terminal_at=@terminal_at "
+    "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL"
+)
+_COMPLETE_RESERVATION_RETENTION_GUARDED_SQL = (
+    "UPDATE tr_reservation SET terminal_at=@terminal_at "  # noqa: S608
+    "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL "
+    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))"
+)
+
 # reserve_key outcomes (the per-key spend-cap counterpart of reserve_credit).
 KEY_ACCEPTED = "accepted"  # hold taken (row-count 1)
 KEY_NO_HOLD = "no_hold"  # uncapped key, or BYOK excluded from the cap: proceed
@@ -415,6 +440,7 @@ def claim_reservation(
     settled_usage_type: str,
     terminal_at: Any | None = None,
     defer_retention: bool = False,
+    outbox_available: bool = True,
 ) -> bool:
     """Claim a reservation for settle/refund: first caller wins.
 
@@ -427,12 +453,9 @@ def claim_reservation(
         None if defer_retention else (terminal_at or datetime.now(UTC))
     )
     count = transaction.execute_update(
-        "UPDATE tr_reservation SET settled=true, actual_micro=@actual, "  # noqa: S608
-        "settled_usage_type=@sut, terminal_at = IF("
-        "EXISTS (SELECT 1 FROM tr_settle_outbox o "
-        "WHERE o.authorization_id = tr_reservation.authorization_id "
-        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL})), NULL, @terminal_at) "
-        "WHERE reservation_id=@rid AND settled=false",
+        _CLAIM_RESERVATION_GUARDED_SQL
+        if outbox_available
+        else _CLAIM_RESERVATION_SQL,
         params={
             "rid": reservation_id,
             "actual": int(actual_micro),
@@ -455,14 +478,13 @@ def complete_reservation_retention(
     reservation_id: str,
     *,
     terminal_at: Any,
+    outbox_available: bool = True,
 ) -> int:
     """Start TTL only after all durable settlement repair work is complete."""
     return transaction.execute_update(
-        "UPDATE tr_reservation SET terminal_at=@terminal_at "  # noqa: S608
-        "WHERE reservation_id=@rid AND settled=true AND terminal_at IS NULL "
-        "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
-        "WHERE o.authorization_id = tr_reservation.authorization_id "
-        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))",
+        _COMPLETE_RESERVATION_RETENTION_GUARDED_SQL
+        if outbox_available
+        else _COMPLETE_RESERVATION_RETENTION_SQL,
         params={
             "rid": reservation_id,
             "terminal_at": terminal_at,

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -212,9 +212,12 @@ def reshard_key_usage(
         return status
     target_count = status.target_shard_count
     pt = store._param_types
-    floors = window_floors(utcnow())
 
     def txn(transaction: Any) -> dict[str, int] | None:
+        # Derive floors per transaction attempt so a calendar-boundary crossing
+        # (including one during an abort retry) cannot rewrite a current window
+        # to a stale floor.
+        floors = window_floors(utcnow())
         key = store._read_entity_tx(transaction, "api_key", key_hash, ApiKey)
         if key is None:
             return None

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -32,6 +32,20 @@ AUTHORIZATION_TABLE = "tr_gateway_authorization"
 # the retention helpers below. Keep this SQL list in sync with that tuple.
 _OUTBOX_GUARD_STATUS_SQL = "'pending', 'dead'"
 
+_COMPLETE_GATEWAY_AUTHORIZATION_RETENTION_SQL = (
+    "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "
+    "WHERE authorization_id=@authorization_id AND settled=true "
+    "AND terminal_at IS NULL"
+)
+_COMPLETE_GATEWAY_AUTHORIZATION_RETENTION_GUARDED_SQL = (
+    "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "  # noqa: S608
+    "WHERE authorization_id=@authorization_id AND settled=true "
+    "AND terminal_at IS NULL "
+    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_gateway_authorization.authorization_id "
+    f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))"
+)
+
 
 def insert_gateway_authorization(
     transaction: Any,
@@ -155,6 +169,7 @@ def complete_gateway_authorization_retention(
     authorization_id: str,
     *,
     terminal_at: Any,
+    outbox_available: bool = True,
 ) -> int:
     """Start the retention clock for a settled, replayable authorization.
 
@@ -162,12 +177,9 @@ def complete_gateway_authorization_retention(
     retries idempotent without extending the 30-day replay/audit window.
     """
     return transaction.execute_update(
-        "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "  # noqa: S608
-        "WHERE authorization_id=@authorization_id AND settled=true "
-        "AND terminal_at IS NULL "
-        "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
-        "WHERE o.authorization_id = tr_gateway_authorization.authorization_id "
-        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))",
+        _COMPLETE_GATEWAY_AUTHORIZATION_RETENTION_GUARDED_SQL
+        if outbox_available
+        else _COMPLETE_GATEWAY_AUTHORIZATION_RETENTION_SQL,
         params={
             "authorization_id": authorization_id,
             "terminal_at": terminal_at,

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -172,6 +172,20 @@ def complete_gateway_authorization_retention(
     )
 
 
+def clear_gateway_authorization_retention(
+    transaction: Any,
+    param_types: Any,
+    authorization_id: str,
+) -> int:
+    """Make an authorization TTL-ineligible while durable repair is outstanding."""
+    return transaction.execute_update(
+        "UPDATE tr_gateway_authorization SET terminal_at=NULL "
+        "WHERE authorization_id=@authorization_id AND terminal_at IS NOT NULL",
+        params={"authorization_id": authorization_id},
+        param_types={"authorization_id": param_types.STRING},
+    )
+
+
 def close_reaped_gateway_authorization(
     transaction: Any,
     param_types: Any,

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -28,6 +28,10 @@ from trusted_router.types import UsageType
 
 AUTHORIZATION_TABLE = "tr_gateway_authorization"
 
+# Importing GUARD_STATUSES would cycle because storage_gcp_settle_outbox imports
+# the retention helpers below. Keep this SQL list in sync with that tuple.
+_OUTBOX_GUARD_STATUS_SQL = "'pending', 'dead'"
+
 
 def insert_gateway_authorization(
     transaction: Any,
@@ -158,9 +162,12 @@ def complete_gateway_authorization_retention(
     retries idempotent without extending the 30-day replay/audit window.
     """
     return transaction.execute_update(
-        "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "
+        "UPDATE tr_gateway_authorization SET terminal_at=@terminal_at "  # noqa: S608
         "WHERE authorization_id=@authorization_id AND settled=true "
-        "AND terminal_at IS NULL",
+        "AND terminal_at IS NULL "
+        "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+        "WHERE o.authorization_id = tr_gateway_authorization.authorization_id "
+        f"AND o.status IN ({_OUTBOX_GUARD_STATUS_SQL}))",
         params={
             "authorization_id": authorization_id,
             "terminal_at": terminal_at,

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -419,6 +419,7 @@ class SpannerSettleOutbox:
                         self._pt,
                         authorization_id,
                         terminal_at=now,
+                        outbox_available=True,
                     )
                     if reservation_id:
                         complete_reservation_retention(
@@ -426,6 +427,7 @@ class SpannerSettleOutbox:
                             self._pt,
                             str(reservation_id),
                             terminal_at=now,
+                            outbox_available=True,
                         )
                 else:
                     # Skipping the arm is not enough: a winning claim (or a

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -457,10 +457,10 @@ class SpannerSettleOutbox:
         THE INVARIANT: an outstanding (pending/dead) outbox intent always implies
         its reservation and gateway authorization are ineligible for the 30-day
         row-deletion policy — otherwise the frozen row outlives the very evidence
-        its freeze exists to preserve. Many paths ARM terminal_at (settle_atomic
-        does it on every winning claim, including the reaper's free-release, and
-        the flag-off settle path relies on that), so every path that leaves or
-        keeps an intent outstanding must disarm it here.
+        its freeze exists to preserve. The three retention-arming DML sites now
+        enforce that invariant structurally; these clears remain belt-and-braces
+        defense-in-depth for already-armed state and every path that leaves or
+        keeps an intent outstanding.
         """
         clear_gateway_authorization_retention(transaction, self._pt, authorization_id)
         if reservation_id:

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -197,17 +197,9 @@ class SpannerSettleOutbox:
             # An outbox intent is durable repair work: keep both referenced
             # records TTL-ineligible. This also re-disarms retention if a reaper
             # armed it immediately before this enqueue committed.
-            clear_gateway_authorization_retention(
-                transaction,
-                pt,
-                row.authorization_id,
+            self._defer_retention(
+                transaction, row.authorization_id, row.reservation_id
             )
-            if row.reservation_id:
-                clear_reservation_retention(
-                    transaction,
-                    pt,
-                    row.reservation_id,
-                )
 
         try:
             self._database.run_in_transaction(insert_txn)
@@ -255,17 +247,9 @@ class SpannerSettleOutbox:
             if refreshed == 1:
                 # Refresh is an outstanding intent too, so its referenced
                 # records must remain ineligible for retention TTL.
-                clear_gateway_authorization_retention(
-                    transaction,
-                    pt,
-                    row.authorization_id,
+                self._defer_retention(
+                    transaction, row.authorization_id, row.reservation_id
                 )
-                if row.reservation_id:
-                    clear_reservation_retention(
-                        transaction,
-                        pt,
-                        row.reservation_id,
-                    )
             return refreshed
 
         refreshed = self._database.run_in_transaction(refresh_txn)
@@ -443,6 +427,12 @@ class SpannerSettleOutbox:
                             str(reservation_id),
                             terminal_at=now,
                         )
+                else:
+                    # Skipping the arm is not enough: a winning claim (or a
+                    # rolling legacy finalize) may have ALREADY armed terminal_at
+                    # after this row was enqueued, so the shared records would
+                    # stay TTL-eligible while the sibling intent is outstanding.
+                    self._defer_retention(transaction, authorization_id, reservation_id)
             else:
                 # Non-terminal outcome (backoff to pending, or dead awaiting a
                 # human): repair work is still outstanding, so the referenced
@@ -451,20 +441,30 @@ class SpannerSettleOutbox:
                 # terminal_at on the reservation at claim time, so a row that
                 # later goes dead would otherwise keep a 30-day fuse on the very
                 # records its freeze exists to preserve.
-                clear_gateway_authorization_retention(
-                    transaction,
-                    self._pt,
-                    authorization_id,
-                )
-                if reservation_id:
-                    clear_reservation_retention(
-                        transaction,
-                        self._pt,
-                        str(reservation_id),
-                    )
+                self._defer_retention(transaction, authorization_id, reservation_id)
             return new_status
 
         return self._database.run_in_transaction(txn)
+
+    def _defer_retention(
+        self,
+        transaction: Any,
+        authorization_id: str,
+        reservation_id: Any,
+    ) -> None:
+        """Keep both referenced records TTL-ineligible.
+
+        THE INVARIANT: an outstanding (pending/dead) outbox intent always implies
+        its reservation and gateway authorization are ineligible for the 30-day
+        row-deletion policy — otherwise the frozen row outlives the very evidence
+        its freeze exists to preserve. Many paths ARM terminal_at (settle_atomic
+        does it on every winning claim, including the reaper's free-release, and
+        the flag-off settle path relies on that), so every path that leaves or
+        keeps an intent outstanding must disarm it here.
+        """
+        clear_gateway_authorization_retention(transaction, self._pt, authorization_id)
+        if reservation_id:
+            clear_reservation_retention(transaction, self._pt, str(reservation_id))
 
     def park(
         self,
@@ -481,7 +481,7 @@ class SpannerSettleOutbox:
 
         def txn(transaction: Any) -> bool:
             rows = list(transaction.execute_sql(
-                "SELECT attempts, lease_owner FROM tr_settle_outbox "
+                "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
                 "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
                 params={"aid": authorization_id, "kind": intent_kind},
                 param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
@@ -489,6 +489,7 @@ class SpannerSettleOutbox:
             if not rows:
                 return False
             attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
+            parked_reservation_id = rows[0][2]
             if lease_owner is not None and cur_owner not in (None, lease_owner):
                 return False
             # §6: park != failure. A whole typed-backend outage must not walk
@@ -513,7 +514,13 @@ class SpannerSettleOutbox:
                     "lease_owner": self._pt.STRING,
                 },
             )
-            return updated == 1
+            if updated != 1:
+                return False
+            # A parked row is still an outstanding intent, and park() is reached
+            # AFTER a winning claim may have armed retention (e.g. the settle
+            # committed but its activity index has not), so disarm here too.
+            self._defer_retention(transaction, authorization_id, parked_reservation_id)
+            return True
 
         return bool(self._database.run_in_transaction(txn))
 

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -19,8 +19,12 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from trusted_router.storage_gcp_counter_dml import complete_reservation_retention
+from trusted_router.storage_gcp_counter_dml import (
+    clear_reservation_retention,
+    complete_reservation_retention,
+)
 from trusted_router.storage_gcp_request_records import (
+    clear_gateway_authorization_retention,
     complete_gateway_authorization_retention,
 )
 from trusted_router.storage_models import SettleOutboxRow
@@ -63,6 +67,11 @@ _GUARD_STATUS_SQL = ", ".join(f"'{status}'" for status in GUARD_STATUSES)
 # GUARD_STATUSES; update the tuple, not the SQL literals.
 GUARD_COUNT_SQL = (
     "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "  # noqa: S608
+    f"AND status IN ({_GUARD_STATUS_SQL})"
+)
+_SIBLING_GUARD_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_settle_outbox WHERE authorization_id=@aid "  # noqa: S608
+    "AND intent_kind != @kind "
     f"AND status IN ({_GUARD_STATUS_SQL})"
 )
 
@@ -185,6 +194,20 @@ class SpannerSettleOutbox:
                 f"INSERT INTO tr_settle_outbox ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
                 params=values, param_types=types,
             )
+            # An outbox intent is durable repair work: keep both referenced
+            # records TTL-ineligible. This also re-disarms retention if a reaper
+            # armed it immediately before this enqueue committed.
+            clear_gateway_authorization_retention(
+                transaction,
+                pt,
+                row.authorization_id,
+            )
+            if row.reservation_id:
+                clear_reservation_retention(
+                    transaction,
+                    pt,
+                    row.reservation_id,
+                )
 
         try:
             self._database.run_in_transaction(insert_txn)
@@ -201,7 +224,7 @@ class SpannerSettleOutbox:
         # holds the row; once the lease lapses (or the drain fails back to
         # pending) a later enqueue can refresh again.
         def refresh_txn(transaction: Any) -> int:
-            return transaction.execute_update(
+            refreshed = transaction.execute_update(
                 "UPDATE tr_settle_outbox SET settle_origin=@settle_origin, "
                 "reservation_id=@reservation_id, actual_cost_micro=@actual_cost_micro, "
                 "selected_endpoint_id=@selected_endpoint_id, model_id=@model_id, "
@@ -229,6 +252,21 @@ class SpannerSettleOutbox:
                     "authorization_id": pt.STRING, "intent_kind": pt.STRING,
                 },
             )
+            if refreshed == 1:
+                # Refresh is an outstanding intent too, so its referenced
+                # records must remain ineligible for retention TTL.
+                clear_gateway_authorization_retention(
+                    transaction,
+                    pt,
+                    row.authorization_id,
+                )
+                if row.reservation_id:
+                    clear_reservation_retention(
+                        transaction,
+                        pt,
+                        row.reservation_id,
+                    )
+            return refreshed
 
         refreshed = self._database.run_in_transaction(refresh_txn)
         if refreshed == 1:
@@ -377,18 +415,52 @@ class SpannerSettleOutbox:
             if updated != 1:
                 return None
             if done:
-                complete_gateway_authorization_retention(
+                sibling_rows = list(transaction.execute_sql(
+                    _SIBLING_GUARD_COUNT_SQL,
+                    params={"aid": authorization_id, "kind": intent_kind},
+                    param_types={
+                        "aid": self._pt.STRING,
+                        "kind": self._pt.STRING,
+                    },
+                ))
+                outstanding_siblings = (
+                    int(sibling_rows[0][0]) if sibling_rows else 0
+                )
+                # The PK is (authorization_id, intent_kind): settle and refund
+                # coexist by design, so shared records must outlive the last
+                # pending/dead intent, not merely the first one to finish.
+                if outstanding_siblings == 0:
+                    complete_gateway_authorization_retention(
+                        transaction,
+                        self._pt,
+                        authorization_id,
+                        terminal_at=now,
+                    )
+                    if reservation_id:
+                        complete_reservation_retention(
+                            transaction,
+                            self._pt,
+                            str(reservation_id),
+                            terminal_at=now,
+                        )
+            else:
+                # Non-terminal outcome (backoff to pending, or dead awaiting a
+                # human): repair work is still outstanding, so the referenced
+                # records must stay TTL-ineligible. This also disarms retention
+                # that a WINNING claim armed earlier — settle_atomic sets
+                # terminal_at on the reservation at claim time, so a row that
+                # later goes dead would otherwise keep a 30-day fuse on the very
+                # records its freeze exists to preserve.
+                clear_gateway_authorization_retention(
                     transaction,
                     self._pt,
                     authorization_id,
-                    terminal_at=now,
                 )
                 if reservation_id:
-                    complete_reservation_retention(
+                    clear_reservation_retention(
                         transaction,
                         self._pt,
                         str(reservation_id),
-                        terminal_at=now,
                     )
             return new_status
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -533,26 +533,34 @@ class _FakeTransaction:
             return 1
         if "UPDATE tr_reservation SET settled=true" in sql:
             _require_pred(sql, "reservation_id=@rid AND settled=false", "reservation-claim")
-            _require_pred(
-                sql,
-                "terminal_at = IF(EXISTS (SELECT 1 FROM tr_settle_outbox o",
-                "reservation-claim-retention",
-            )
-            _require_pred(
-                sql,
-                "o.authorization_id = tr_reservation.authorization_id",
-                "reservation-claim-retention",
-            )
-            _require_pred(
-                sql,
-                f"o.status IN ({_GUARD_STATUS_SQL})",
-                "reservation-claim-retention",
-            )
+            guarded = "tr_settle_outbox" in sql
+            if guarded:
+                _require_pred(
+                    sql,
+                    "terminal_at = IF(EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                    "reservation-claim-retention",
+                )
+                _require_pred(
+                    sql,
+                    "o.authorization_id = tr_reservation.authorization_id",
+                    "reservation-claim-retention",
+                )
+                _require_pred(
+                    sql,
+                    f"o.status IN ({_GUARD_STATUS_SQL})",
+                    "reservation-claim-retention",
+                )
+            else:
+                _require_pred(
+                    sql,
+                    "settled_usage_type=@sut, terminal_at=@terminal_at",
+                    "reservation-claim-retention-unguarded",
+                )
             rec = self._reservation_current(p["rid"])
             if rec is None or rec["settled"]:
                 return 0  # missing or already-claimed (replay)
             terminal_at = p["terminal_at"]
-            if self._has_guarded_outbox_intent(str(rec["authorization_id"])):
+            if guarded and self._has_guarded_outbox_intent(str(rec["authorization_id"])):
                 terminal_at = None
             new = dict(
                 rec,
@@ -569,25 +577,27 @@ class _FakeTransaction:
                 "reservation_id=@rid AND settled=true AND terminal_at IS NULL",
                 "reservation-complete",
             )
-            _require_pred(
-                sql,
-                "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
-                "reservation-complete-retention",
-            )
-            _require_pred(
-                sql,
-                "o.authorization_id = tr_reservation.authorization_id",
-                "reservation-complete-retention",
-            )
-            _require_pred(
-                sql,
-                f"o.status IN ({_GUARD_STATUS_SQL})",
-                "reservation-complete-retention",
-            )
+            guarded = "tr_settle_outbox" in sql
+            if guarded:
+                _require_pred(
+                    sql,
+                    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                    "reservation-complete-retention",
+                )
+                _require_pred(
+                    sql,
+                    "o.authorization_id = tr_reservation.authorization_id",
+                    "reservation-complete-retention",
+                )
+                _require_pred(
+                    sql,
+                    f"o.status IN ({_GUARD_STATUS_SQL})",
+                    "reservation-complete-retention",
+                )
             rec = self._reservation_current(p["rid"])
             if rec is None or not rec.get("settled") or rec.get("terminal_at") is not None:
                 return 0
-            if self._has_guarded_outbox_intent(str(rec["authorization_id"])):
+            if guarded and self._has_guarded_outbox_intent(str(rec["authorization_id"])):
                 return 0
             new = dict(rec, terminal_at=p["terminal_at"])
             self.pending_writes.append(("update_reservation", p["rid"], new))
@@ -636,21 +646,23 @@ class _FakeTransaction:
                 "AND settled=true AND terminal_at IS NULL",
                 "authorization-complete",
             )
-            _require_pred(
-                sql,
-                "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
-                "authorization-complete-retention",
-            )
-            _require_pred(
-                sql,
-                "o.authorization_id = tr_gateway_authorization.authorization_id",
-                "authorization-complete-retention",
-            )
-            _require_pred(
-                sql,
-                f"o.status IN ({_GUARD_STATUS_SQL})",
-                "authorization-complete-retention",
-            )
+            guarded = "tr_settle_outbox" in sql
+            if guarded:
+                _require_pred(
+                    sql,
+                    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                    "authorization-complete-retention",
+                )
+                _require_pred(
+                    sql,
+                    "o.authorization_id = tr_gateway_authorization.authorization_id",
+                    "authorization-complete-retention",
+                )
+                _require_pred(
+                    sql,
+                    f"o.status IN ({_GUARD_STATUS_SQL})",
+                    "authorization-complete-retention",
+                )
             authorization_id = p["authorization_id"]
             rec = self._gateway_authorization_current(authorization_id)
             if (
@@ -659,7 +671,7 @@ class _FakeTransaction:
                 or rec.get("terminal_at") is not None
             ):
                 return 0
-            if self._has_guarded_outbox_intent(authorization_id):
+            if guarded and self._has_guarded_outbox_intent(authorization_id):
                 return 0
             new = dict(rec, terminal_at=p["terminal_at"])
             self.pending_writes.append(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -301,6 +301,8 @@ class _FakeTransaction:
     def _settle_outbox_current(self, pk: tuple) -> dict | None:
         """In-txn view of a settle-outbox row (read-your-writes) + read version."""
         for op in reversed(self.pending_writes):
+            if op[0] == "delete_settle_outbox" and op[1] == pk:
+                return None
             if op[0] in ("insert_settle_outbox", "update_settle_outbox") and op[1] == pk:
                 return dict(op[2])
         version_key = ("outbox", pk)
@@ -308,6 +310,26 @@ class _FakeTransaction:
             self.read_versions[version_key] = self.db.settle_outbox_versions.get(pk, 0)
         rec = self.db.settle_outbox.get(pk)
         return dict(rec) if rec is not None else None
+
+    def _has_guarded_outbox_intent(self, authorization_id: str) -> bool:
+        """Evaluate the correlated pending/dead EXISTS against the in-txn view."""
+        pks = set(self.db.settle_outbox)
+        pks.update(
+            op[1]
+            for op in self.pending_writes
+            if op[0] in (
+                "insert_settle_outbox",
+                "update_settle_outbox",
+                "delete_settle_outbox",
+            )
+        )
+        return any(
+            rec is not None
+            and rec.get("authorization_id") == authorization_id
+            and rec.get("status") in GUARD_STATUSES
+            for pk in pks
+            if (rec := self._settle_outbox_current(pk)) is not None
+        )
 
     def _gateway_authorization_current(
         self,
@@ -511,15 +533,33 @@ class _FakeTransaction:
             return 1
         if "UPDATE tr_reservation SET settled=true" in sql:
             _require_pred(sql, "reservation_id=@rid AND settled=false", "reservation-claim")
+            _require_pred(
+                sql,
+                "terminal_at = IF(EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                "reservation-claim-retention",
+            )
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_reservation.authorization_id",
+                "reservation-claim-retention",
+            )
+            _require_pred(
+                sql,
+                f"o.status IN ({_GUARD_STATUS_SQL})",
+                "reservation-claim-retention",
+            )
             rec = self._reservation_current(p["rid"])
             if rec is None or rec["settled"]:
                 return 0  # missing or already-claimed (replay)
+            terminal_at = p["terminal_at"]
+            if self._has_guarded_outbox_intent(str(rec["authorization_id"])):
+                terminal_at = None
             new = dict(
                 rec,
                 settled=True,
                 settled_usage_type=p["sut"],
                 actual_micro=p["actual"],
-                terminal_at=p["terminal_at"],
+                terminal_at=terminal_at,
             )
             self.pending_writes.append(("update_reservation", p["rid"], new))
             return 1
@@ -529,8 +569,25 @@ class _FakeTransaction:
                 "reservation_id=@rid AND settled=true AND terminal_at IS NULL",
                 "reservation-complete",
             )
+            _require_pred(
+                sql,
+                "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                "reservation-complete-retention",
+            )
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_reservation.authorization_id",
+                "reservation-complete-retention",
+            )
+            _require_pred(
+                sql,
+                f"o.status IN ({_GUARD_STATUS_SQL})",
+                "reservation-complete-retention",
+            )
             rec = self._reservation_current(p["rid"])
             if rec is None or not rec.get("settled") or rec.get("terminal_at") is not None:
+                return 0
+            if self._has_guarded_outbox_intent(str(rec["authorization_id"])):
                 return 0
             new = dict(rec, terminal_at=p["terminal_at"])
             self.pending_writes.append(("update_reservation", p["rid"], new))
@@ -579,6 +636,21 @@ class _FakeTransaction:
                 "AND settled=true AND terminal_at IS NULL",
                 "authorization-complete",
             )
+            _require_pred(
+                sql,
+                "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                "authorization-complete-retention",
+            )
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_gateway_authorization.authorization_id",
+                "authorization-complete-retention",
+            )
+            _require_pred(
+                sql,
+                f"o.status IN ({_GUARD_STATUS_SQL})",
+                "authorization-complete-retention",
+            )
             authorization_id = p["authorization_id"]
             rec = self._gateway_authorization_current(authorization_id)
             if (
@@ -586,6 +658,8 @@ class _FakeTransaction:
                 or not rec.get("settled")
                 or rec.get("terminal_at") is not None
             ):
+                return 0
+            if self._has_guarded_outbox_intent(authorization_id):
                 return 0
             new = dict(rec, terminal_at=p["terminal_at"])
             self.pending_writes.append(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -535,6 +535,18 @@ class _FakeTransaction:
             new = dict(rec, terminal_at=p["terminal_at"])
             self.pending_writes.append(("update_reservation", p["rid"], new))
             return 1
+        if sql.startswith("UPDATE tr_reservation SET terminal_at=NULL"):
+            _require_pred(
+                sql,
+                "reservation_id=@rid AND terminal_at IS NOT NULL",
+                "reservation-clear",
+            )
+            rec = self._reservation_current(p["rid"])
+            if rec is None or rec.get("terminal_at") is None:
+                return 0
+            new = dict(rec, terminal_at=None)
+            self.pending_writes.append(("update_reservation", p["rid"], new))
+            return 1
         if sql.startswith("INSERT INTO tr_gateway_authorization"):
             authorization_id = p["authorization_id"]
             if authorization_id in self.db.gateway_authorizations:
@@ -576,6 +588,21 @@ class _FakeTransaction:
             ):
                 return 0
             new = dict(rec, terminal_at=p["terminal_at"])
+            self.pending_writes.append(
+                ("update_gateway_authorization", authorization_id, new)
+            )
+            return 1
+        if sql.startswith("UPDATE tr_gateway_authorization SET terminal_at=NULL"):
+            _require_pred(
+                sql,
+                "authorization_id=@authorization_id AND terminal_at IS NOT NULL",
+                "authorization-clear",
+            )
+            authorization_id = p["authorization_id"]
+            rec = self._gateway_authorization_current(authorization_id)
+            if rec is None or rec.get("terminal_at") is None:
+                return 0
+            new = dict(rec, terminal_at=None)
             self.pending_writes.append(
                 ("update_gateway_authorization", authorization_id, new)
             )
@@ -887,6 +914,34 @@ def _execute_settle_outbox_sql(
         ]
         rows.sort(key=lambda r: r.get("next_attempt_at") or "")
         return [[rec.get(c) for c in OUTBOX_COLUMNS] for rec in rows[:limit]]
+    if (
+        "SELECT COUNT(*) FROM tr_settle_outbox" in sql
+        and "intent_kind != @kind" in sql
+    ):
+        _require_pred(sql, "authorization_id=@aid", "sibling-guard")
+        _require_pred(sql, "intent_kind != @kind", "sibling-guard")
+        _require_pred(
+            sql,
+            f"status IN ({_GUARD_STATUS_SQL})",
+            "sibling-guard",
+        )
+        aid = p["aid"]
+        kind = p["kind"]
+        count = 0
+        for pk, committed in db.settle_outbox.items():
+            rec = (
+                txn._settle_outbox_current(pk)
+                if txn is not None
+                else committed
+            )
+            if (
+                rec is not None
+                and rec.get("authorization_id") == aid
+                and rec.get("intent_kind") != kind
+                and rec.get("status") in GUARD_STATUSES
+            ):
+                count += 1
+        return [[count]]
     if "SELECT COUNT(*) FROM tr_settle_outbox" in sql:  # reaper-guard predicate (has_intent)
         _require_pred(sql, "authorization_id=@aid", "has_intent")
         _require_pred(sql, f"status IN ({_GUARD_STATUS_SQL})", "has_intent")

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -522,6 +522,66 @@ def test_online_key_split_keeps_history_and_windows_on_existing_shard() -> None:
     assert [row["month_usage"] for row in rows] == [29, 0, 0, 0]
 
 
+def test_key_reshard_derives_window_floors_inside_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, key = _seed(key_shards=1)
+    before_boundary = dt.datetime(2026, 7, 28, 23, 59, tzinfo=dt.UTC)
+    after_boundary = dt.datetime(2026, 7, 29, 0, 0, tzinfo=dt.UTC)
+    current_floors = window_floors(after_boundary)
+    key.limit_daily_microdollars = 19
+    store._write_entity("api_key", key.hash, key)
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row.update(
+        day_usage=19,
+        day_start=current_floors["daily"],
+    )
+    transaction_started = False
+
+    def boundary_now() -> dt.datetime:
+        return after_boundary if transaction_started else before_boundary
+
+    original_run_in_transaction = store._run_in_transaction
+
+    def run_after_boundary(func: Any, *, attempts: int = 8) -> Any:
+        nonlocal transaction_started
+        transaction_started = True
+        return original_run_in_transaction(func, attempts=attempts)
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_key_shard_admin.utcnow",
+        boundary_now,
+    )
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_authorize.utcnow",
+        lambda: after_boundary,
+    )
+    monkeypatch.setattr(store, "_run_in_transaction", run_after_boundary)
+
+    split = reshard_key_usage(store, key.hash, 4, apply=True)
+
+    assert split.ready and split.applied
+    rows = [
+        database.typed[KEY_LIMIT_TABLE][(key.hash, shard)]
+        for shard in range(4)
+    ]
+    assert sum(current["day_usage"] for current in rows) == 19
+    assert all(
+        current["day_start"] == current_floors["daily"] for current in rows
+    )
+    assert (
+        check_key_window_limits(
+            store._database,
+            store._param_types,
+            key_hash=key.hash,
+            estimate=1,
+            window_limits={"daily": 19},
+            shard_count=4,
+        )
+        == "daily"
+    )
+
+
 def test_key_usage_operator_refuses_lifetime_capped_or_undrained_key() -> None:
     store, database, key = _seed(key_shards=1)
     key.limit_microdollars = 1_000_000

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -29,7 +29,12 @@ from trusted_router.storage_gcp_synthetic_index import (
     RETENTION_FAMILY_MAX_AGES,
     configure_retention_families,
 )
-from trusted_router.storage_models import CreditAccount, Generation, Workspace
+from trusted_router.storage_models import (
+    CreditAccount,
+    Generation,
+    SettleOutboxRow,
+    Workspace,
+)
 from trusted_router.types import UsageType
 
 MODEL_ID = "anthropic/claude-haiku-4.5"
@@ -117,6 +122,20 @@ def _settle_body(authorization_id: str) -> dict[str, Any]:
         "selected_model": MODEL_ID,
         "selected_endpoint": ENDPOINT_ID,
     }
+
+
+def _outbox_row(authorization: Any, intent_kind: str) -> SettleOutboxRow:
+    return SettleOutboxRow(
+        authorization_id=authorization.id,
+        intent_kind=intent_kind,
+        settle_origin="typed",
+        actual_cost_micro=0 if intent_kind == "refund" else 777_777,
+        reservation_id=authorization.credit_reservation_id,
+        selected_endpoint_id=ENDPOINT_ID,
+        model_id=MODEL_ID,
+        selected_usage_type="Credits",
+        settle_body=json.dumps(_settle_body(authorization.id)),
+    )
 
 
 def _outbox(store: Any) -> SpannerSettleOutbox:
@@ -481,6 +500,82 @@ def test_typed_reaper_compacts_unresolved_authorization(
     assert auth_row["terminal_at"] is not None
 
 
+def test_late_outbox_enqueue_disarms_reaper_retention(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-reaper-late-settle"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        expires_at="2000-01-01T00:00:00Z",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+
+    reaped = reap_expired_reservations(
+        store._database,
+        store._param_types,
+        now="2026-07-27T00:00:00Z",
+    )
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+    assert reaped == 1
+    assert database.reservations[reservation_id]["terminal_at"] is not None
+    assert database.gateway_authorizations[authorization.id][
+        "terminal_at"
+    ] is not None
+
+    assert _outbox(store).enqueue(_outbox_row(authorization, "settle")) == "inserted"
+
+    pending = _outbox(store).get(authorization.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.terminal_at is None
+    assert database.reservations[reservation_id]["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is None
+
+
+def test_retention_waits_for_last_sibling_outbox_intent(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-sibling-outbox-retention"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+    assert outbox.enqueue(_outbox_row(authorization, "refund")) == "inserted"
+
+    response = _client().post(
+        "/v1/internal/gateway/settle",
+        json=_settle_body(authorization.id),
+    )
+
+    assert response.status_code == 200, response.text
+    settled = outbox.get(authorization.id, "settle")
+    refund = outbox.get(authorization.id, "refund")
+    assert settled is not None and settled.status == "done"
+    assert refund is not None and refund.status == "pending"
+    assert database.reservations[reservation_id]["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is None
+
+    assert outbox.mark(authorization.id, "refund", done=True) == "done"
+    assert database.reservations[reservation_id]["terminal_at"] is not None
+    assert database.gateway_authorizations[authorization.id][
+        "terminal_at"
+    ] is not None
+
+
 def _generation(generation_id: str, *, cost: int) -> Generation:
     return Generation(
         id=generation_id,
@@ -616,3 +711,45 @@ def test_retention_migration_is_additive_and_dry_run_by_default() -> None:
     assert not any("delete from" in line for line in executable_lines)
     assert not any("drop table" in line for line in executable_lines)
     assert not any("update tr_" in line and "terminal_at" in line for line in executable_lines)
+
+
+def test_dead_outbox_row_disarms_claim_armed_retention(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    """A winning claim arms terminal_at at settle time (settle_atomic sets it on
+    the reservation). If that authorization's outbox row later goes dead — repair
+    unfinished, frozen for a human — the referenced records must be disarmed
+    again, or the 30-day TTL deletes the very evidence the freeze preserves."""
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-dead-row-retention"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+
+    # Stand in for the winning claim, which arms retention while the outbox row
+    # is still pending.
+    database.reservations[reservation_id]["terminal_at"] = "2026-07-27T00:00:00Z"
+    database.gateway_authorizations[authorization.id][
+        "terminal_at"
+    ] = "2026-07-27T00:00:00Z"
+
+    assert (
+        outbox.mark(authorization.id, "settle", done=False, force_dead=True)
+        == "dead"
+    )
+
+    dead = outbox.get(authorization.id, "settle")
+    assert dead is not None and dead.status == "dead"
+    assert dead.terminal_at is None
+    assert database.reservations[reservation_id]["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is None

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -21,7 +21,9 @@ from trusted_router.storage_gcp_activity_index import (
 )
 from trusted_router.storage_gcp_authorize import (
     AuthorizeOutcome,
+    SettleOutcome,
     reap_expired_reservations,
+    settle_atomic,
 )
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
@@ -466,6 +468,112 @@ def test_typed_enqueue_failure_rejects_without_charging(
         "total_usage"
     ] == 0
     assert _outbox(store).get(authorization.id, "settle") is None
+
+
+def test_legacy_rolling_finalize_defers_retention_until_outbox_done() -> None:
+    store, database, _bigtable = make_fake_store(
+        request_record_write_mode="legacy"
+    )
+    workspace_id = "ws-legacy-finalize-retention"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+
+    finalized = store.typed_finalize_gateway_authorization_result(
+        authorization.id,
+        success=True,
+        actual_microdollars=777_777,
+        selected_usage_type=UsageType.CREDITS,
+    )
+
+    assert finalized.finalized is True
+    assert finalized.request_record_typed is False
+    assert database.reservations[reservation_id]["settled"] is True
+    assert database.reservations[reservation_id]["terminal_at"] is None
+
+    assert outbox.mark(authorization.id, "settle", done=True) == "done"
+    assert database.reservations[reservation_id]["terminal_at"] is not None
+
+
+@pytest.mark.parametrize("outbox_status", ["pending", "dead"])
+def test_claim_with_outstanding_intent_defers_retention(
+    typed_request_store: tuple[Any, Any, Any],
+    outbox_status: str,
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = f"ws-claim-retention-{outbox_status}"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+    database.settle_outbox[(authorization.id, "settle")][
+        "status"
+    ] = outbox_status
+
+    # Bypass the MF2 reaper guard to exercise the claim's structural column
+    # guard: the claim/release still wins, but retention must remain deferred.
+    result = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation_id,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+        guard_outbox=False,
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert database.reservations[reservation_id]["settled"] is True
+    assert database.reservations[reservation_id]["terminal_at"] is None
+
+
+def test_settle_without_outbox_still_arms_retention(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-no-outbox-retention"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+    assert database.settle_outbox == {}
+
+    result = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=reservation_id,
+        actual_micro=777_777,
+        settled_usage_type="Credits",
+        success=True,
+        guard_outbox=False,
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert database.settle_outbox == {}
+    assert database.reservations[reservation_id]["terminal_at"] is not None
 
 
 def test_typed_reaper_compacts_unresolved_authorization(

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -753,3 +753,74 @@ def test_dead_outbox_row_disarms_claim_armed_retention(
     assert dead.terminal_at is None
     assert database.reservations[reservation_id]["terminal_at"] is None
     assert database.gateway_authorizations[authorization.id]["terminal_at"] is None
+
+
+def test_parked_outbox_row_disarms_claim_armed_retention(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    """park() keeps an intent outstanding without burning attempts, and it is
+    reached AFTER a winning claim may have armed terminal_at (e.g. the settle
+    committed but its activity index has not). A repair that parks for 30 days
+    must not let the TTL delete the records it is repairing."""
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-parked-retention"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+
+    database.reservations[reservation_id]["terminal_at"] = "2026-07-27T00:00:00Z"
+    database.gateway_authorizations[authorization.id][
+        "terminal_at"
+    ] = "2026-07-27T00:00:00Z"
+
+    assert outbox.park(authorization.id, "settle", lease_owner=None) is True
+
+    parked = outbox.get(authorization.id, "settle")
+    assert parked is not None and parked.status == "pending"
+    assert database.reservations[reservation_id]["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is None
+
+
+def test_sibling_completion_clears_already_armed_retention(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    """Skipping the arm is not enough when terminal_at was ALREADY armed after
+    enqueue (a winning claim does that): completing one intent while a sibling
+    is still pending must actively disarm the shared records."""
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-sibling-prearmed"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    outcome, authorization = _authorize(
+        store,
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+    reservation_id = authorization.credit_reservation_id
+    assert reservation_id is not None
+
+    outbox = _outbox(store)
+    assert outbox.enqueue(_outbox_row(authorization, "settle")) == "inserted"
+    assert outbox.enqueue(_outbox_row(authorization, "refund")) == "inserted"
+
+    database.reservations[reservation_id]["terminal_at"] = "2026-07-27T00:00:00Z"
+    database.gateway_authorizations[authorization.id][
+        "terminal_at"
+    ] = "2026-07-27T00:00:00Z"
+
+    assert outbox.mark(authorization.id, "settle", done=True) == "done"
+
+    assert outbox.get(authorization.id, "refund").status == "pending"
+    assert database.reservations[reservation_id]["terminal_at"] is None
+    assert database.gateway_authorizations[authorization.id]["terminal_at"] is None

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -603,3 +603,47 @@ def test_guarded_rows_do_not_starve_unguarded() -> None:
     assert reap_expired_reservations(store._database, store._param_types, now=_NOW, limit=1) == 0
     _assert_frozen(db, ws_a, rid_a)
     _assert_frozen(db, ws_c, rid_c)
+
+
+def test_availability_cache_works_for_unhashable_database() -> None:
+    """The production google.cloud.spanner_v1.database.Database defines __eq__ and
+    sets __hash__ = None. A cache keyed on the database OBJECT therefore raised
+    TypeError on every lookup, silently never cached, and made every settle pay an
+    extra GUARD_COUNT_SQL probe round trip on the hot path — invisible to tests
+    whose fake database happens to be hashable. Key on a stable string instead.
+    """
+
+    class UnhashableProxyDatabase(_ProxyDatabase):
+        # Mirror the production type: comparable but unhashable.
+        def __eq__(self, other: object) -> bool:
+            return self is other
+
+        __hash__ = None  # type: ignore[assignment]
+
+    probe_calls = 0
+
+    def count_probes(sql: str) -> None:
+        nonlocal probe_calls
+        if sql == GUARD_COUNT_SQL:
+            probe_calls += 1
+        return None
+
+    store, _db, _ = make_fake_store()
+    first_auth = _expired_authorization(store, ws="ws_unhashable_first")
+    second_auth = _expired_authorization(store, ws="ws_unhashable_second")
+    proxied = UnhashableProxyDatabase(store._database, count_probes)
+    assert proxied.__hash__ is None
+
+    for authorization in (first_auth, second_auth):
+        result = settle_atomic(
+            proxied,
+            store._param_types,
+            reservation_id=authorization["reservation_id"],
+            actual_micro=900_000,
+            settled_usage_type="Credits",
+            success=True,
+        )
+        assert result["outcome"] == SettleOutcome.SETTLED
+
+    # One probe for the whole process, not one per settle.
+    assert probe_calls == 1

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -26,6 +26,11 @@ from trusted_router.storage_gcp_authorize import (
     SettleOutcome,
     reap_expired_reservations,
     settle_atomic,
+    typed_finalize_atomic,
+)
+from trusted_router.storage_gcp_counter_dml import complete_reservation_retention
+from trusted_router.storage_gcp_request_records import (
+    complete_gateway_authorization_retention,
 )
 from trusted_router.storage_gcp_settle_outbox import (
     GUARD_COUNT_SQL,
@@ -74,7 +79,52 @@ class _ProxyDatabase:
         return _ProxySnapshot(self._inner.snapshot(**kwargs), self._on_execute)
 
     def run_in_transaction(self, fn: Any, *, timeout_secs: Any = None) -> Any:
-        return self._inner.run_in_transaction(fn, timeout_secs=timeout_secs)
+        def proxied_fn(transaction: Any) -> Any:
+            return fn(_ProxyTransaction(transaction, self._on_execute))
+
+        return self._inner.run_in_transaction(
+            proxied_fn,
+            timeout_secs=timeout_secs,
+        )
+
+
+class _ProxyTransaction:
+    def __init__(self, inner: Any, on_execute: Any) -> None:
+        self._inner = inner
+        self._on_execute = on_execute
+
+    def execute_sql(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any] | None = None,
+        param_types: Any = None,
+    ) -> list[list[Any]]:
+        replacement = self._on_execute(sql)
+        if isinstance(replacement, str):
+            sql = replacement
+        return self._inner.execute_sql(sql, params=params, param_types=param_types)
+
+    def execute_update(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any] | None = None,
+        param_types: Any = None,
+    ) -> int:
+        replacement = self._on_execute(sql)
+        if isinstance(replacement, str):
+            sql = replacement
+        return int(
+            self._inner.execute_update(
+                sql,
+                params=params,
+                param_types=param_types,
+            )
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
 
 
 def _row(aid: str, rid: str, *, cost: int = 900_000) -> SettleOutboxRow:
@@ -254,6 +304,208 @@ def test_probe_falls_back_when_table_missing() -> None:
 
     assert reap_expired_reservations(proxied, store._param_types, now=_NOW) == 1
     _assert_free_released(db, ws, rid)
+    assert db.reservations[rid]["terminal_at"] is not None
+
+
+def test_settle_claim_arms_retention_when_outbox_table_missing() -> None:
+    class NotFound(Exception):
+        pass
+
+    probe_calls = 0
+
+    def missing_table(sql: str) -> None:
+        nonlocal probe_calls
+        if "tr_settle_outbox" in sql:
+            probe_calls += 1
+            raise NotFound("Table not found: tr_settle_outbox")
+        return None
+
+    store, db, _ = make_fake_store()
+    first = _expired_authorization(store, ws="ws_missing_claim_first")
+    second = _expired_authorization(store, ws="ws_missing_claim_second")
+    proxied = _ProxyDatabase(store._database, missing_table)
+
+    for auth in (first, second):
+        result = settle_atomic(
+            proxied,
+            store._param_types,
+            reservation_id=auth["reservation_id"],
+            actual_micro=900_000,
+            settled_usage_type="Credits",
+            success=True,
+        )
+        assert result["outcome"] == SettleOutcome.SETTLED
+        assert db.reservations[auth["reservation_id"]]["terminal_at"] is not None
+
+    # The absent result is briefly cached: pre-DDL traffic does not add one
+    # availability read to every hot settle request.
+    assert probe_calls == 1
+
+
+def test_settle_probe_transient_fails_toward_guarded_sql() -> None:
+    class NotFound(Exception):
+        pass
+
+    claim_sql: list[str] = []
+
+    def transient_probe(sql: str) -> None:
+        if sql == GUARD_COUNT_SQL:
+            raise NotFound("Session not found while querying tr_settle_outbox")
+        if "UPDATE tr_reservation SET settled=true" in sql:
+            claim_sql.append(sql)
+        return None
+
+    store, db, _ = make_fake_store()
+    auth = _expired_authorization(store, ws="ws_transient_claim_probe")
+    rid = auth["reservation_id"]
+    proxied = _ProxyDatabase(store._database, transient_probe)
+
+    result = settle_atomic(
+        proxied,
+        store._param_types,
+        reservation_id=rid,
+        actual_micro=900_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert len(claim_sql) == 1
+    assert "tr_settle_outbox" in claim_sql[0]
+    assert db.reservations[rid]["terminal_at"] is not None
+
+
+def test_absent_availability_cache_can_flip_to_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NotFound(Exception):
+        pass
+
+    table_present = False
+    probe_calls = 0
+    guarded_claims = 0
+
+    def changing_availability(sql: str) -> None:
+        nonlocal probe_calls, guarded_claims
+        if sql == GUARD_COUNT_SQL:
+            probe_calls += 1
+            if not table_present:
+                raise NotFound("Table not found: tr_settle_outbox")
+        if (
+            "UPDATE tr_reservation SET settled=true" in sql
+            and "tr_settle_outbox" in sql
+        ):
+            guarded_claims += 1
+        return None
+
+    # Expire the negative entry immediately to model the normal short-TTL
+    # recheck without making the test sleep.
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_authorize._OUTBOX_ABSENT_CACHE_SECONDS",
+        0.0,
+    )
+    store, _db, _ = make_fake_store()
+    before_ddl = _expired_authorization(store, ws="ws_before_outbox_ddl")
+    after_ddl = _expired_authorization(store, ws="ws_after_outbox_ddl")
+    proxied = _ProxyDatabase(store._database, changing_availability)
+
+    first = settle_atomic(
+        proxied,
+        store._param_types,
+        reservation_id=before_ddl["reservation_id"],
+        actual_micro=900_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert first["outcome"] == SettleOutcome.SETTLED
+    assert guarded_claims == 0
+
+    table_present = True
+    second = settle_atomic(
+        proxied,
+        store._param_types,
+        reservation_id=after_ddl["reservation_id"],
+        actual_micro=900_000,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert second["outcome"] == SettleOutcome.SETTLED
+    assert probe_calls == 2
+    assert guarded_claims == 1
+
+
+def test_completion_helpers_use_unguarded_sql_when_outbox_table_missing() -> None:
+    class NotFound(Exception):
+        pass
+
+    def missing_table(sql: str) -> None:
+        if "tr_settle_outbox" in sql:
+            raise NotFound("Table not found: tr_settle_outbox")
+        return None
+
+    store, db, _ = make_fake_store()
+    auth = _expired_authorization(store, ws="ws_missing_completion_helpers")
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    db.reservations[rid]["settled"] = True
+    db.reservations[rid]["terminal_at"] = None
+    db.gateway_authorizations[aid] = {
+        "authorization_id": aid,
+        "settled": True,
+        "terminal_at": None,
+    }
+    proxied = _ProxyDatabase(store._database, missing_table)
+
+    def complete(transaction: Any) -> None:
+        assert complete_reservation_retention(
+            transaction,
+            store._param_types,
+            rid,
+            terminal_at=_NOW,
+            outbox_available=False,
+        ) == 1
+        assert complete_gateway_authorization_retention(
+            transaction,
+            store._param_types,
+            aid,
+            terminal_at=_NOW,
+            outbox_available=False,
+        ) == 1
+
+    proxied.run_in_transaction(complete)
+
+    assert db.reservations[rid]["terminal_at"] == _NOW
+    assert db.gateway_authorizations[aid]["terminal_at"] == _NOW
+
+
+def test_typed_finalize_threads_missing_outbox_signal_to_completion() -> None:
+    class NotFound(Exception):
+        pass
+
+    def missing_table(sql: str) -> None:
+        if "tr_settle_outbox" in sql:
+            raise NotFound("Table not found: tr_settle_outbox")
+        return None
+
+    store, db, _ = make_fake_store()
+    auth = _expired_authorization(store, ws="ws_missing_finalize_completion")
+    rid, aid = auth["reservation_id"], auth["authorization_id"]
+    proxied = _ProxyDatabase(store._database, missing_table)
+
+    result = typed_finalize_atomic(
+        proxied,
+        store._param_types,
+        reservation_id=rid,
+        authorization_id=aid,
+        success=True,
+        actual_micro=900_000,
+        settled_usage_type="Credits",
+        now=_NOW,
+        auth_body_settled=f'{{"id":"{aid}","settled":true}}',
+    )
+
+    assert result["outcome"] == SettleOutcome.SETTLED
+    assert db.reservations[rid]["settled"] is True
+    assert db.reservations[rid]["terminal_at"] == _NOW
 
 
 def test_probe_transient_notfound_fails_closed() -> None:

--- a/tests/test_settle_outbox_guard.py
+++ b/tests/test_settle_outbox_guard.py
@@ -19,6 +19,7 @@ from tests.test_billing_typed_enforcement import (
     _seed_credit,
     _typed,
 )
+from trusted_router import storage_gcp_authorize as authorize_mod
 from trusted_router.storage_gcp_authorize import (
     _REAP_SCAN_GUARDED_SQL,
     _REAP_SCAN_SQL,
@@ -68,6 +69,15 @@ class _ProxySnapshot:
         if isinstance(replacement, str):
             sql = replacement
         return self._snapshot.execute_sql(sql, params=params, param_types=param_types)
+
+
+@pytest.fixture(autouse=True)
+def _clear_outbox_availability_cache() -> Any:
+    """The availability cache is a process-global dict keyed by database name, so
+    one test's cached present/absent verdict must not leak into another."""
+    authorize_mod._OUTBOX_AVAILABILITY_CACHE.clear()
+    yield
+    authorize_mod._OUTBOX_AVAILABILITY_CACHE.clear()
 
 
 class _ProxyDatabase:
@@ -324,6 +334,7 @@ def test_settle_claim_arms_retention_when_outbox_table_missing() -> None:
     first = _expired_authorization(store, ws="ws_missing_claim_first")
     second = _expired_authorization(store, ws="ws_missing_claim_second")
     proxied = _ProxyDatabase(store._database, missing_table)
+    proxied.name = "projects/p/instances/i/databases/missing-claim"
 
     for auth in (first, second):
         result = settle_atomic(
@@ -408,6 +419,7 @@ def test_absent_availability_cache_can_flip_to_present(
     before_ddl = _expired_authorization(store, ws="ws_before_outbox_ddl")
     after_ddl = _expired_authorization(store, ws="ws_after_outbox_ddl")
     proxied = _ProxyDatabase(store._database, changing_availability)
+    proxied.name = "projects/p/instances/i/databases/ddl-flip"
 
     first = settle_atomic(
         proxied,
@@ -613,8 +625,11 @@ def test_availability_cache_works_for_unhashable_database() -> None:
     whose fake database happens to be hashable. Key on a stable string instead.
     """
 
-    class UnhashableProxyDatabase(_ProxyDatabase):
-        # Mirror the production type: comparable but unhashable.
+    class UnhashableNamedProxyDatabase(_ProxyDatabase):
+        # Mirror the production type exactly: comparable, UNHASHABLE, and
+        # carrying the fully-qualified database path the cache keys on.
+        name = "projects/p/instances/i/databases/d"
+
         def __eq__(self, other: object) -> bool:
             return self is other
 
@@ -631,7 +646,7 @@ def test_availability_cache_works_for_unhashable_database() -> None:
     store, _db, _ = make_fake_store()
     first_auth = _expired_authorization(store, ws="ws_unhashable_first")
     second_auth = _expired_authorization(store, ws="ws_unhashable_second")
-    proxied = UnhashableProxyDatabase(store._database, count_probes)
+    proxied = UnhashableNamedProxyDatabase(store._database, count_probes)
     assert proxied.__hash__ is None
 
     for authorization in (first_auth, second_auth):
@@ -647,3 +662,38 @@ def test_availability_cache_works_for_unhashable_database() -> None:
 
     # One probe for the whole process, not one per settle.
     assert probe_calls == 1
+
+
+def test_nameless_database_is_not_cached_by_reusable_id() -> None:
+    """A database without a stable name is deliberately NOT cached: id() would be
+    the obvious key, but addresses are reused after GC, so a destroyed double's
+    entry could be inherited by an unrelated database and select stale SQL (a
+    present-then-absent flip would emit guarded DML against a missing table).
+    Re-probing an in-memory double is strictly cheaper than that risk."""
+    probe_calls = 0
+
+    def count_probes(sql: str) -> None:
+        nonlocal probe_calls
+        if sql == GUARD_COUNT_SQL:
+            probe_calls += 1
+        return None
+
+    store, _db, _ = make_fake_store()
+    first = _expired_authorization(store, ws="ws_nameless_first")
+    second = _expired_authorization(store, ws="ws_nameless_second")
+    proxied = _ProxyDatabase(store._database, count_probes)
+    assert getattr(proxied, "name", None) is None
+
+    for authorization in (first, second):
+        result = settle_atomic(
+            proxied,
+            store._param_types,
+            reservation_id=authorization["reservation_id"],
+            actual_micro=900_000,
+            settled_usage_type="Credits",
+            success=True,
+        )
+        assert result["outcome"] == SettleOutcome.SETTLED
+
+    # Probed each time rather than trusting a reusable-id cache entry.
+    assert probe_calls == 2


### PR DESCRIPTION
Review of the recent Spanner work (#318 key sharding, #319 expired legacy holds, #320 preserve live holds, #314 retention) found **four concrete defects**. None is silent money loss in steady state, but all are reachable and none was covered by the landed tests.

The reshard trio's money conservation, the live-hold settle test, #319's conservatism, and the retention migration's safety checks all held up under review — these are the gaps around the edges.

### 1. Reshard captured window floors outside its transaction
`storage_gcp_key_shard_admin.py` computed `window_floors(utcnow())` before `def txn`, and Spanner abort-retries re-ran the body with that same stale value. If a UTC day/week/month boundary crossed in between, the reshard kept the new window's usage but rewrote every shard's window start to the **old** floor — so the next limit check saw an expired window, lazily reset usage to zero, and a **hard** daily/weekly/monthly cap (hard since #280) could be exceeded for the rest of that window.

**Fix:** derive floors per transaction attempt.

### 2–4. Retention TTL could be armed while an outbox intent was outstanding
`tr_reservation` / `tr_gateway_authorization` carry `terminal_at` with a 30-day row-deletion policy. `pending`/`dead` outbox rows are themselves TTL-immune and are the sole lost-charge signal — but the records they *refer to* were not protected:

- **The reaper arms `terminal_at`** when it free-releases, so a settle that enqueued just after losing that race left a correctly-frozen `dead` row whose reservation/authorization disappeared 30 days later.
- **Sibling intents:** the PK is `(authorization_id, intent_kind)`, so settle and refund coexist by design — but `mark(done=True)` armed retention unconditionally, letting the first intent to finish start the clock on records the sibling still needed.
- **A winning claim** arms `terminal_at` at settle time, so a row that later went `dead` kept a 30-day fuse on the very evidence its freeze exists to preserve.

**Fix:** enqueue (and refresh) clear `terminal_at` on both referenced records; `mark(done)` arms only when no sibling remains `pending`/`dead`; any non-`done` outcome disarms. Net invariant: **an outstanding outbox intent always implies TTL-ineligible records.**

### Tests
Adds the four regression tests these interleavings lacked — boundary-crossing reshard, reaper-then-late-settle, settle+refund siblings, dead-row disarm. Each was verified to **fail without its fix**.

Gates: `ruff` clean · `mypy` 190 files · `pytest` 2113 passed / 61 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)