### PR TITLE
clickhouse: live ingestion via a commit-timestamp outbox (stage 1 shadow)

### DIFF
--- a/clickhouse/001_provider_benchmark_samples.sql
+++ b/clickhouse/001_provider_benchmark_samples.sql
@@ -8,7 +8,7 @@
 --
 -- Design notes:
 --
--- * ReplacingMergeTree keyed on the full sort key makes ingestion IDEMPOTENT.
+-- * ReplacingMergeTree keyed on the full sort key makes replay converge.
 --   Backfill from Bigtable can be re-run, and the dual-write path can retry,
 --   without double-counting. This is the property that makes the migration
 --   safe to attempt more than once.
@@ -54,58 +54,7 @@ PARTITION BY toYYYYMM(created_at)
 ORDER BY (provider, model, created_at, id)
 TTL toDateTime(created_at) + INTERVAL 400 DAY;
 
-
--- Hourly route-health aggregates, maintained incrementally.
---
--- Scope: this covers the ProviderBenchmarkSample dataset (provider/model)
--- only. It is NOT a replacement for synthetic/backfill_rollups.py, which
--- rolls up a DIFFERENT dataset — SyntheticProbeSample, keyed by
--- component/target/probe_type/region. Retiring that job is separate work.
---
--- The WHERE clause deliberately mirrors synthetic/route_health.py: synthetic
--- source only, only `error`/`success` statuses (so `unsupported` is excluded
--- from BOTH numerator and denominator), and transient failures dropped
--- entirely rather than counted. Without those exclusions this view is not
--- route health at all — on a 30.8k-row sample the unfiltered numbers are
--- 30832 samples / 1176 failures, against the correct 28214 / 59. A 20x
--- overstatement of failures is precisely the kind of plausible-looking wrong
--- answer that survives code review.
---
--- ifNull() on the transient predicate is load-bearing for the same reason it
--- is in the query path: `NULL IN (...)` is NULL, not false, and a NULL here
--- would silently drop rows from the aggregate.
---
--- Aggregate STATES are stored (not finalised numbers) so they can be merged
--- across any window at read time: the same view answers "last 48h" and
--- "last 90 days" without storing either.
---
--- !! IDEMPOTENCY WARNING !!
--- The source table's ReplacingMergeTree does NOT protect this view.
--- Materialized views run per INSERT BLOCK, before any replacement happens,
--- so re-inserting the same rows adds duplicate aggregate states here even
--- though the source table later collapses them. Re-running a backfill
--- therefore inflates this view permanently. Ingestion must either be
--- append-once, or use insert_deduplication_token, or the view must be
--- rebuilt (DROP + re-populate) alongside any source reload.
-CREATE MATERIALIZED VIEW IF NOT EXISTS route_health_hourly
-ENGINE = AggregatingMergeTree()
-PARTITION BY toYYYYMM(hour)
-ORDER BY (provider, model, hour)
-AS
-SELECT
-    provider,
-    model,
-    toStartOfHour(created_at)                        AS hour,
-    countState()                                     AS samples_state,
-    countIfState(status = 'error')                   AS failures_state,
-    countIfState(status = 'success')                 AS successes_state,
-    quantileState(0.95)(elapsed_milliseconds)        AS p95_elapsed_state,
-    sumState(toInt64(input_tokens + output_tokens))  AS tokens_state
-FROM provider_benchmark_samples
-WHERE source = 'synthetic'
-  AND status IN ('error', 'success')
-  AND NOT (status = 'error' AND (
-        ifNull(error_status, 0) IN (429,500,502,503,504,529)
-     OR ifNull(error_type, '') IN ('ReadTimeout','ConnectTimeout','WriteTimeout','PoolTimeout',
-                                   'ConnectError','ReadError','WriteError','RemoteProtocolError')))
-GROUP BY provider, model, hour;
+-- Stage 1 is at-least-once. An additive materialized view would process every
+-- replay before ReplacingMergeTree collapse and permanently double-count.
+-- Remove the pre-stage-1 view if this schema is applied to an existing node.
+DROP VIEW IF EXISTS route_health_hourly;

--- a/clickhouse/__init__.py
+++ b/clickhouse/__init__.py
@@ -1,0 +1,1 @@
+"""TrustedRouter ClickHouse ingestion and verification tools."""

--- a/clickhouse/backfill_benchmark_samples.py
+++ b/clickhouse/backfill_benchmark_samples.py
@@ -25,9 +25,12 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import math
 import os
+import struct
 import subprocess
 from collections import Counter
+from typing import Any
 
 from google.cloud import bigtable
 from google.cloud.bigtable.row_set import RowSet
@@ -35,7 +38,7 @@ from google.cloud.bigtable.row_set import RowSet
 PROJECT = "quill-cloud-proxy"
 INSTANCE = "trusted-router-logs"
 TABLE = "trustedrouter-generations"
-FAMILY = "m"
+FAMILIES = ("benchmark", "m")
 CH_DB = "tr"
 CH_TABLE = "provider_benchmark_samples"
 
@@ -44,8 +47,15 @@ def ch(sql: str, stdin: bytes | None = None) -> str:
     """Run a query through clickhouse-client on localhost."""
     password = os.environ["CH_PASSWORD"]
     cmd = [
-        "clickhouse-client", "--user", "tr", "--password", password,
-        "--database", CH_DB, "--query", sql,
+        "clickhouse-client",
+        "--user",
+        "tr",
+        "--password",
+        password,
+        "--database",
+        CH_DB,
+        "--query",
+        sql,
     ]
     result = subprocess.run(  # noqa: S603 - fixed argv, no shell, callers pass literal SQL
         cmd, input=stdin, capture_output=True, check=False
@@ -55,7 +65,30 @@ def ch(sql: str, stdin: bytes | None = None) -> str:
     return result.stdout.decode()
 
 
-def normalise(raw: dict) -> dict | None:
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            return None
+        # The ClickHouse column is Float32. Round here so backfill, outbox
+        # ingestion, and reconciliation fingerprint the same stored value.
+        return struct.unpack("!f", struct.pack("!f", parsed))[0]
+    except (OverflowError, TypeError, ValueError):
+        return None
+
+
+def normalise(raw: dict[str, Any]) -> dict[str, Any] | None:
     """Canonical row shape. Shared coercions matter: a historical string
     "429" must become the same UInt16 the query path compares against, or the
     two disagree by construction."""
@@ -68,11 +101,7 @@ def normalise(raw: dict) -> dict | None:
         parsed = parsed.replace(tzinfo=dt.UTC)
     parsed = parsed.astimezone(dt.UTC)
 
-    status_code = raw.get("error_status")
-    if isinstance(status_code, str):
-        status_code = int(status_code) if status_code.isdigit() else None
-    elif status_code is not None:
-        status_code = int(status_code)
+    status_code = _optional_int(raw.get("error_status"))
 
     provider, model = raw.get("provider"), raw.get("model")
     if not provider or not model:
@@ -91,10 +120,10 @@ def normalise(raw: dict) -> dict | None:
         "input_tokens": int(raw.get("input_tokens") or 0),
         "output_tokens": int(raw.get("output_tokens") or 0),
         "total_cost_microdollars": int(raw.get("total_cost_microdollars") or 0),
-        "speed_tokens_per_second": raw.get("speed_tokens_per_second"),
-        "elapsed_milliseconds": raw.get("elapsed_milliseconds"),
-        "first_token_milliseconds": raw.get("first_token_milliseconds"),
-        "ttfb_milliseconds": raw.get("ttfb_milliseconds"),
+        "speed_tokens_per_second": _optional_float(raw.get("speed_tokens_per_second")),
+        "elapsed_milliseconds": _optional_int(raw.get("elapsed_milliseconds")),
+        "first_token_milliseconds": _optional_int(raw.get("first_token_milliseconds")),
+        "ttfb_milliseconds": _optional_int(raw.get("ttfb_milliseconds")),
         "finish_reason": raw.get("finish_reason"),
         "error_type": raw.get("error_type"),
         "error_status": status_code,
@@ -131,7 +160,11 @@ def main() -> int:
     for index, row in enumerate(table.read_rows(row_set=rs)):
         if index >= args.limit:
             break
-        cells = row.cells.get(FAMILY, {}).get(b"body", [])
+        cells = []
+        for family in FAMILIES:
+            cells = row.cells.get(family, {}).get(b"body", [])
+            if cells:
+                break
         if not cells:
             continue
         try:

--- a/clickhouse/ingest_outbox.py
+++ b/clickhouse/ingest_outbox.py
@@ -1,0 +1,330 @@
+"""Continuously drain the Spanner analytics outbox into local ClickHouse.
+
+The durable cursor is the outbox itself: ClickHouse must acknowledge a batch
+before its exact Spanner primary keys are deleted. A crash between those two
+operations replays the batch, which is safe because canonical queries use
+``FINAL`` over a ReplacingMergeTree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import math
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from clickhouse.backfill_benchmark_samples import normalise
+
+PROJECT = "quill-cloud-proxy"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+OUTBOX_TABLE = "tr_analytics_outbox"
+CLICKHOUSE_DATABASE = "tr"
+CLICKHOUSE_TABLE = "provider_benchmark_samples"
+OUTBOX_SHARDS = 16
+
+log = logging.getLogger("trusted_router.analytics_ingest")
+
+
+@dataclass(frozen=True)
+class OutboxRow:
+    shard: int
+    commit_ts: dt.datetime
+    event_id: str
+    payload: str
+
+    @property
+    def key(self) -> tuple[int, dt.datetime, str]:
+        return (self.shard, self.commit_ts, self.event_id)
+
+
+@dataclass
+class DrainMetrics:
+    rows_ingested_total: int = 0
+    clickhouse_insert_errors_total: int = 0
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    fetched: int
+    inserted: int
+    rows_per_second: float
+
+
+class OutboxSource(Protocol):
+    def fetch(self, *, limit: int) -> list[OutboxRow]: ...
+
+    def delete(self, rows: list[OutboxRow]) -> None: ...
+
+    def oldest_commit_ts(self) -> dt.datetime | None: ...
+
+
+class BatchWriter(Protocol):
+    def insert(self, rows: list[dict[str, Any]]) -> None: ...
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+class SpannerOutboxSource:
+    """Read each key shard in order, then merge by commit timestamp."""
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        instance: str,
+        database: str,
+        shard_count: int = OUTBOX_SHARDS,
+    ) -> None:
+        from google.cloud import spanner
+        from google.cloud.spanner_v1 import param_types
+
+        self._database = (
+            spanner.Client(project=project, disable_builtin_metrics=True)
+            .instance(instance)
+            .database(database)
+        )
+        self._pt = param_types
+        self._shard_count = shard_count
+
+    def fetch(self, *, limit: int) -> list[OutboxRow]:
+        if limit < 1:
+            return []
+        # IDs are UUID-derived and uniformly sharded. The 2x headroom avoids
+        # returning a short global batch from normal hash variance while
+        # bounding each shard read.
+        per_shard = max(1, math.ceil(limit / self._shard_count) * 2)
+        rows: list[OutboxRow] = []
+        # One consistent multi-use snapshot is required because the sharded
+        # primary key needs one ordered query per shard. The SDK's default
+        # single-use snapshot rejects the second query.
+        with self._database.snapshot(multi_use=True) as snapshot:
+            for shard in range(self._shard_count):
+                values = snapshot.execute_sql(
+                    "SELECT shard, commit_ts, event_id, payload "
+                    "FROM tr_analytics_outbox "
+                    "WHERE shard=@shard ORDER BY commit_ts, event_id LIMIT @limit",
+                    params={"shard": shard, "limit": per_shard},
+                    param_types={"shard": self._pt.INT64, "limit": self._pt.INT64},
+                )
+                rows.extend(
+                    OutboxRow(
+                        shard=int(row[0]),
+                        commit_ts=_utc(row[1]),
+                        event_id=str(row[2]),
+                        payload=str(row[3]),
+                    )
+                    for row in values
+                )
+        rows.sort(key=lambda row: (row.commit_ts, row.shard, row.event_id))
+        return rows[:limit]
+
+    def delete(self, rows: list[OutboxRow]) -> None:
+        if not rows:
+            return
+        from google.cloud.spanner_v1 import KeySet
+
+        with self._database.batch() as batch:
+            batch.delete(OUTBOX_TABLE, KeySet(keys=[list(row.key) for row in rows]))
+
+    def oldest_commit_ts(self) -> dt.datetime | None:
+        oldest: dt.datetime | None = None
+        with self._database.snapshot(multi_use=True) as snapshot:
+            for shard in range(self._shard_count):
+                values = list(
+                    snapshot.execute_sql(
+                        "SELECT commit_ts "
+                        "FROM tr_analytics_outbox "
+                        "WHERE shard=@shard ORDER BY commit_ts LIMIT 1",
+                        params={"shard": shard},
+                        param_types={"shard": self._pt.INT64},
+                    )
+                )
+                if values:
+                    candidate = _utc(values[0][0])
+                    oldest = candidate if oldest is None else min(oldest, candidate)
+        return oldest
+
+
+class ClickHouseWriter:
+    """Large synchronous inserts; process success is the durable ack."""
+
+    def __init__(
+        self,
+        *,
+        password: str,
+        database: str = CLICKHOUSE_DATABASE,
+        table: str = CLICKHOUSE_TABLE,
+    ) -> None:
+        self._password = password
+        self._database = database
+        self._table = table
+
+    def insert(self, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        payload = "\n".join(
+            json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows
+        ).encode("utf-8")
+        command = [
+            "clickhouse-client",
+            "--user",
+            "tr",
+            "--password",
+            self._password,
+            "--database",
+            self._database,
+            "--query",
+            f"INSERT INTO {self._table} FORMAT JSONEachRow",
+        ]
+        result = subprocess.run(  # noqa: S603 - fixed executable and argv, no shell
+            command,
+            input=payload,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace")[:1000]
+            raise RuntimeError(f"ClickHouse insert failed: {detail}")
+
+
+def normalise_outbox_payload(payload: str) -> dict[str, Any]:
+    raw = json.loads(payload)
+    if not isinstance(raw, dict):
+        raise ValueError("outbox payload is not a JSON object")
+    row = normalise(raw)
+    if row is None:
+        raise ValueError("outbox payload cannot be normalised")
+    return row
+
+
+def drain_once(
+    source: OutboxSource,
+    writer: BatchWriter,
+    metrics: DrainMetrics,
+    *,
+    batch_size: int,
+) -> DrainResult:
+    """Insert then advance the durable cursor by deleting acknowledged rows."""
+    rows = source.fetch(limit=batch_size)
+    if not rows:
+        return DrainResult(fetched=0, inserted=0, rows_per_second=0.0)
+    canonical = [normalise_outbox_payload(row.payload) for row in rows]
+    started = time.monotonic()
+    try:
+        writer.insert(canonical)
+    except Exception:
+        metrics.clickhouse_insert_errors_total += 1
+        raise
+    # This is the cursor advance. It is intentionally after the acknowledged
+    # insert; delete failure causes safe replay on the next pass.
+    source.delete(rows)
+    elapsed = max(time.monotonic() - started, 0.000_001)
+    metrics.rows_ingested_total += len(rows)
+    return DrainResult(
+        fetched=len(rows),
+        inserted=len(rows),
+        rows_per_second=len(rows) / elapsed,
+    )
+
+
+def _lag_seconds(oldest: dt.datetime | None) -> float:
+    if oldest is None:
+        return 0.0
+    return max(0.0, (dt.datetime.now(dt.UTC) - _utc(oldest)).total_seconds())
+
+
+def _log_metrics(
+    metrics: DrainMetrics,
+    *,
+    result: DrainResult,
+    oldest: dt.datetime | None,
+) -> None:
+    log.info(
+        "analytics_outbox.metrics rows=%d rows_per_second=%.3f "
+        "drain_lag_seconds=%.3f clickhouse_insert_errors_total=%d "
+        "rows_ingested_total=%d",
+        result.inserted,
+        result.rows_per_second,
+        _lag_seconds(oldest),
+        metrics.clickhouse_insert_errors_total,
+        metrics.rows_ingested_total,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
+    )
+    parser.add_argument("--shards", type=int, default=OUTBOX_SHARDS)
+    parser.add_argument("--batch-size", type=int, default=5000)
+    parser.add_argument("--poll-seconds", type=float, default=5.0)
+    parser.add_argument("--metrics-seconds", type=float, default=60.0)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    source = SpannerOutboxSource(
+        project=args.project,
+        instance=args.spanner_instance,
+        database=args.spanner_database,
+        shard_count=args.shards,
+    )
+    writer = ClickHouseWriter(password=os.environ["CH_PASSWORD"])
+    metrics = DrainMetrics()
+    last_metrics = 0.0
+
+    log.info(
+        "analytics_outbox.started project=%s instance=%s database=%s shards=%d batch_size=%d",
+        args.project,
+        args.spanner_instance,
+        args.spanner_database,
+        args.shards,
+        args.batch_size,
+    )
+    while True:
+        result = DrainResult(fetched=0, inserted=0, rows_per_second=0.0)
+        try:
+            result = drain_once(source, writer, metrics, batch_size=args.batch_size)
+        except Exception:
+            log.exception(
+                "analytics_outbox.drain_failed clickhouse_insert_errors_total=%d",
+                metrics.clickhouse_insert_errors_total,
+            )
+        now = time.monotonic()
+        if result.inserted or now - last_metrics >= args.metrics_seconds:
+            try:
+                oldest = source.oldest_commit_ts()
+            except Exception:
+                log.exception("analytics_outbox.lag_measurement_failed")
+                oldest = None
+            _log_metrics(metrics, result=result, oldest=oldest)
+            last_metrics = now
+        if args.once:
+            return 0
+        if not result.inserted:
+            time.sleep(max(0.1, args.poll_seconds))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/reconcile_benchmark_samples.py
+++ b/clickhouse/reconcile_benchmark_samples.py
@@ -1,0 +1,219 @@
+"""Compare recent Bigtable benchmark rows with ClickHouse ``FINAL`` row sets."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import logging
+import os
+from collections import defaultdict
+from typing import Any
+
+from google.cloud import bigtable
+from google.cloud.bigtable.row_set import RowSet
+
+from clickhouse.backfill_benchmark_samples import FAMILIES, ch, normalise
+
+PROJECT = "quill-cloud-proxy"
+BIGTABLE_INSTANCE = "trusted-router-logs"
+BIGTABLE_TABLE = "trustedrouter-generations"
+CLICKHOUSE_TABLE = "provider_benchmark_samples"
+
+log = logging.getLogger("trusted_router.analytics_reconciler")
+
+CLICKHOUSE_COLUMNS = (
+    "id, created_at, provider, model, provider_name, status, usage_type, source, "
+    "streamed, input_tokens, output_tokens, total_cost_microdollars, "
+    "speed_tokens_per_second, elapsed_milliseconds, first_token_milliseconds, "
+    "ttfb_milliseconds, finish_reason, error_type, error_status, error_message, "
+    "region, app"
+)
+
+
+def _fingerprint(row: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        row,
+        separators=(",", ":"),
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _reverse_time_key(value: dt.datetime) -> str:
+    epoch_ms = int(value.timestamp() * 1000)
+    return f"{9_999_999_999_999 - epoch_ms:013d}"
+
+
+def _add_row(
+    target: dict[str, dict[str, str]],
+    row: dict[str, Any],
+    *,
+    cutoff: dt.datetime,
+    upper: dt.datetime,
+) -> None:
+    canonical = normalise(row)
+    if canonical is None:
+        return
+    created = dt.datetime.fromisoformat(canonical["created_at"]).replace(tzinfo=dt.UTC)
+    if created < cutoff or created >= upper:
+        return
+    target.setdefault(canonical["created_at"][:10], {})[canonical["id"]] = _fingerprint(
+        canonical
+    )
+
+
+def bigtable_rows(
+    *,
+    project: str,
+    instance: str,
+    table_name: str,
+    cutoff: dt.datetime,
+    upper: dt.datetime,
+    max_rows: int,
+) -> tuple[dict[str, dict[str, str]], int, bool]:
+    client = bigtable.Client(project=project, admin=False)
+    table = client.instance(instance).table(table_name)
+    row_set = RowSet()
+    # The reverse timestamp is event time, so it is invalid as a live cursor.
+    # It is useful for this bounded, periodic completeness window: ask
+    # Bigtable to stop at the wall-clock cutoff instead of scanning all
+    # history and silently hitting the safety cap.
+    row_set.add_row_range_from_keys(
+        b"benchmark_recent#",
+        f"benchmark_recent#{_reverse_time_key(cutoff)}~".encode(),
+    )
+    by_day: dict[str, dict[str, str]] = defaultdict(dict)
+    scanned = 0
+    for row in table.read_rows(row_set=row_set, limit=max_rows + 1):
+        scanned += 1
+        if scanned > max_rows:
+            return dict(by_day), scanned, True
+        cells = []
+        for family in FAMILIES:
+            cells = row.cells.get(family, {}).get(b"body", [])
+            if cells:
+                break
+        if not cells:
+            continue
+        try:
+            raw = json.loads(cells[0].value.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            continue
+        if isinstance(raw, dict):
+            _add_row(by_day, raw, cutoff=cutoff, upper=upper)
+    return dict(by_day), scanned, False
+
+
+def clickhouse_rows(
+    *,
+    cutoff: dt.datetime,
+    upper: dt.datetime,
+) -> dict[str, dict[str, str]]:
+    cutoff_text = cutoff.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    upper_text = upper.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    output = ch(
+        f"SELECT {CLICKHOUSE_COLUMNS} FROM {CLICKHOUSE_TABLE} FINAL "  # noqa: S608
+        f"WHERE created_at >= toDateTime64('{cutoff_text}', 3, 'UTC') "
+        f"AND created_at < toDateTime64('{upper_text}', 3, 'UTC') "
+        "FORMAT JSONEachRow"
+    )
+    by_day: dict[str, dict[str, str]] = defaultdict(dict)
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        raw = json.loads(line)
+        if isinstance(raw, dict):
+            _add_row(by_day, raw, cutoff=cutoff, upper=upper)
+    return dict(by_day)
+
+
+def report(
+    source: dict[str, dict[str, str]],
+    destination: dict[str, dict[str, str]],
+) -> int:
+    mismatched_days = 0
+    for day in sorted(set(source) | set(destination), reverse=True):
+        source_rows = source.get(day, {})
+        destination_rows = destination.get(day, {})
+        source_ids = set(source_rows)
+        destination_ids = set(destination_rows)
+        missing_in_clickhouse = source_ids - destination_ids
+        missing_in_bigtable = destination_ids - source_ids
+        changed = {
+            event_id
+            for event_id in source_ids & destination_ids
+            if source_rows[event_id] != destination_rows[event_id]
+        }
+        if missing_in_clickhouse or missing_in_bigtable or changed:
+            mismatched_days += 1
+        log.info(
+            "analytics_reconciler.daily day=%s bigtable_rows=%d clickhouse_rows=%d "
+            "bigtable_minus_clickhouse=%d clickhouse_minus_bigtable=%d changed=%d",
+            day,
+            len(source_rows),
+            len(destination_rows),
+            len(missing_in_clickhouse),
+            len(missing_in_bigtable),
+            len(changed),
+        )
+    return mismatched_days
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--settle-delay-minutes", type=int, default=15)
+    parser.add_argument("--max-rows", type=int, default=1_000_000)
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument(
+        "--bigtable-instance",
+        default=os.environ.get("BIGTABLE_INSTANCE_ID", BIGTABLE_INSTANCE),
+    )
+    parser.add_argument(
+        "--bigtable-table",
+        default=os.environ.get("BIGTABLE_TABLE_ID", BIGTABLE_TABLE),
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    upper = dt.datetime.now(dt.UTC) - dt.timedelta(
+        minutes=max(args.settle_delay_minutes, 0)
+    )
+    cutoff = upper - dt.timedelta(days=max(args.days, 1))
+    source, scanned, truncated = bigtable_rows(
+        project=args.project,
+        instance=args.bigtable_instance,
+        table_name=args.bigtable_table,
+        cutoff=cutoff,
+        upper=upper,
+        max_rows=args.max_rows,
+    )
+    if truncated:
+        log.error(
+            "analytics_reconciler.source_truncated scanned=%d max_rows=%d",
+            scanned,
+            args.max_rows,
+        )
+        return 2
+    destination = clickhouse_rows(cutoff=cutoff, upper=upper)
+    mismatched_days = report(source, destination)
+    log.info(
+        "analytics_reconciler.summary scanned=%d days=%d mismatched_days=%d "
+        "window_start=%s window_end=%s",
+        scanned,
+        len(set(source) | set(destination)),
+        mismatched_days,
+        cutoff.isoformat(),
+        upper.isoformat(),
+    )
+    return 1 if mismatched_days else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/requirements-live.txt
+++ b/clickhouse/requirements-live.txt
@@ -1,0 +1,2 @@
+google-cloud-bigtable>=2.26.0
+google-cloud-spanner>=3.50.0

--- a/clickhouse/tr-clickhouse-ingest.service
+++ b/clickhouse/tr-clickhouse-ingest.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=TrustedRouter Spanner analytics outbox ingester
+After=network-online.target clickhouse-server.service
+Wants=network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=simple
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+Environment=GCP_PROJECT_ID=quill-cloud-proxy
+Environment=SPANNER_INSTANCE_ID=trusted-router-nam6
+Environment=SPANNER_DATABASE_ID=trusted-router
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.ingest_outbox
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-reconcile.service
+++ b/clickhouse/tr-clickhouse-reconcile.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=TrustedRouter Bigtable to ClickHouse analytics reconciliation
+After=network-online.target clickhouse-server.service
+Wants=network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+Environment=GCP_PROJECT_ID=quill-cloud-proxy
+Environment=BIGTABLE_INSTANCE_ID=trusted-router-logs
+Environment=BIGTABLE_TABLE_ID=trustedrouter-generations
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.reconcile_benchmark_samples --days 7
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict

--- a/clickhouse/tr-clickhouse-reconcile.timer
+++ b/clickhouse/tr-clickhouse-reconcile.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hourly TrustedRouter analytics reconciliation
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deploy stage-1 outbox ingestion to the internal-only ClickHouse VM.
+#
+# All node access goes through `gcloud compute ssh --tunnel-through-iap`.
+# This script does not add an external IP and does not enable the application
+# enqueue setting.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROJECT="${PROJECT:-quill-cloud-proxy}"
+ZONE="${ZONE:-us-central1-a}"
+NAME="${NAME:-tr-clickhouse-1}"
+SECRET="${SECRET:-trustedrouter-clickhouse-password}"
+
+ssh_node() {
+  gcloud compute ssh "$NAME" \
+    --project="$PROJECT" \
+    --zone="$ZONE" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+external_ip=$(gcloud compute instances describe "$NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
+if [ -n "$external_ip" ]; then
+  echo "refusing deployment: $NAME has external IP $external_ip" >&2
+  exit 1
+fi
+
+archive=$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-live.XXXXXX.tar.gz")
+trap 'rm -f "$archive"' EXIT
+tar -C "$ROOT" -czf "$archive" clickhouse
+
+ssh_node --command="sudo mkdir -p /opt/tr-clickhouse"
+ssh_node --command="sudo tar -xzf - -C /opt/tr-clickhouse" < "$archive"
+
+password=$(gcloud secrets versions access latest \
+  --secret="$SECRET" \
+  --project="$PROJECT")
+printf 'CH_PASSWORD=%s\n' "$password" |
+  ssh_node --command="sudo sh -c 'umask 077; cat > /etc/tr-clickhouse-ingest.env'"
+unset password
+
+ssh_node --command="sudo sh -c '
+  set -eu
+  if ! id tr-clickhouse-ingest >/dev/null 2>&1; then
+    useradd --system --home /var/lib/tr-clickhouse-ingest --create-home \
+      --shell /usr/sbin/nologin tr-clickhouse-ingest
+  fi
+  apt-get update -y
+  apt-get install -y python3-venv
+  python3 -m venv /opt/tr-clickhouse/venv
+  /opt/tr-clickhouse/venv/bin/pip install --disable-pip-version-check \
+    -r /opt/tr-clickhouse/clickhouse/requirements-live.txt
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-ingest.service \
+    /etc/systemd/system/tr-clickhouse-ingest.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-reconcile.service \
+    /etc/systemd/system/tr-clickhouse-reconcile.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-reconcile.timer \
+    /etc/systemd/system/tr-clickhouse-reconcile.timer
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --multiquery < /opt/tr-clickhouse/clickhouse/001_provider_benchmark_samples.sql
+  systemctl daemon-reload
+  systemctl enable tr-clickhouse-ingest.service
+  systemctl restart tr-clickhouse-ingest.service
+  systemctl enable --now tr-clickhouse-reconcile.timer
+  systemctl is-active tr-clickhouse-ingest.service
+  systemctl is-active tr-clickhouse-reconcile.timer
+'"
+
+echo "deployed through IAP; TR_ANALYTICS_OUTBOX_ENABLED was not changed"

--- a/scripts/deploy/migrate_analytics_outbox.sh
+++ b/scripts/deploy/migrate_analytics_outbox.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Apply the stage-1 live analytics outbox DDL.
+#
+# Idempotent and additive. The table is dormant until
+# TR_ANALYTICS_OUTBOX_ENABLED=true; this script never changes that setting.
+set -euo pipefail
+
+PROJECT="${GCP_PROJECT_ID:-quill-cloud-proxy}"
+INSTANCE="${SPANNER_INSTANCE_ID:-trusted-router-nam6}"
+DATABASE="${SPANNER_DATABASE_ID:-trusted-router}"
+
+log() { printf '%s %s\n' "[migrate_analytics_outbox]" "$*"; }
+
+table_exists() {
+  local count
+  count=$(gcloud spanner databases execute-sql "$DATABASE" \
+    --project="$PROJECT" \
+    --instance="$INSTANCE" \
+    --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+           WHERE table_name='tr_analytics_outbox'" \
+    --format='value(rows[0])' 2>/dev/null || echo 0)
+  [ "${count:-0}" != "0" ]
+}
+
+if table_exists; then
+  log "tr_analytics_outbox exists, skip"
+else
+  # The ROW DELETION POLICY below is a BACKSTOP, not the cleanup mechanism.
+  # Normal operation is drain-then-delete by primary key, which keeps this
+  # table near-empty. The policy exists for the failure mode where the drainer
+  # stops — unit crashed, node down, ClickHouse full — because an outbox with a
+  # dead drainer grows without bound on the production database.
+  #
+  # That is not hypothetical here: tr_settle_outbox is sitting at ~549k rows
+  # and tr_entities has ~9.4M rows with no policy at all (issue #334). Every
+  # one of those grew for exactly this reason.
+  #
+  # 7 days is safe specifically BECAUSE analytics is loss-tolerant: rows older
+  # than that mean the ingester has been dead for a week, and the documented
+  # recovery is clickhouse/reconcile_benchmark_samples.py replaying from
+  # Bigtable, not this table. Never copy this policy onto a money table, where
+  # dropping an undrained row would lose a settlement.
+  log "creating tr_analytics_outbox on ${PROJECT}/${INSTANCE}/${DATABASE}"
+  gcloud spanner databases ddl update "$DATABASE" \
+    --project="$PROJECT" \
+    --instance="$INSTANCE" \
+    --ddl="CREATE TABLE tr_analytics_outbox (
+      shard INT64 NOT NULL,
+      commit_ts TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+      event_id STRING(128) NOT NULL,
+      payload STRING(MAX) NOT NULL,
+    ) PRIMARY KEY (shard, commit_ts, event_id),
+      ROW DELETION POLICY (OLDER_THAN(commit_ts, INTERVAL 7 DAY))"
+fi
+
+log "done; enqueue setting was not changed"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -40,14 +40,14 @@ class Settings(BaseSettings):
     spanner_database_id: str | None = None
     bigtable_instance_id: str | None = None
     bigtable_generation_table: str = "trustedrouter-generations"
-    # ClickHouse analytics mirror (phase 2 of the storage-portability plan).
-    # Empty URL = disabled, which is the default: the sink is a no-op until a
-    # deployment explicitly points it somewhere. Bigtable stays authoritative
-    # while both are compared.
+    # Legacy in-process ClickHouse mirror. Empty URL keeps it disabled.
     clickhouse_url: str = ""
     clickhouse_user: str = ""
     clickhouse_password: str = ""
     clickhouse_benchmark_table: str = "provider_benchmark_samples"
+    # Stage 1 live analytics outbox. This is intentionally off by default and
+    # must remain off until the shadow ingester and reconciler are observed.
+    analytics_outbox_enabled: bool = False
 
     # Starter credit granted exactly once with a new email/OAuth account's
     # first workspace. Wallet-only and secondary workspaces receive no grant.

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1295,6 +1295,9 @@ def create_store(settings: Any) -> Store:
             request_record_write_mode=getattr(
                 settings, "request_record_write_mode", "legacy"
             ),
+            analytics_outbox_enabled=getattr(
+                settings, "analytics_outbox_enabled", False
+            ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -40,6 +40,7 @@ from trusted_router.storage import (
     Workspace,
     iso_now,
 )
+from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
 from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
@@ -132,6 +133,7 @@ class SpannerBigtableStore:
         generation_table: str,
         bigtable_app_profile_id: str = "",
         request_record_write_mode: str = "legacy",
+        analytics_outbox_enabled: bool = False,
     ) -> None:
         if not spanner_instance_id or not spanner_database_id or not bigtable_instance_id:
             raise ValueError("Spanner and Bigtable IDs are required")
@@ -245,6 +247,11 @@ class SpannerBigtableStore:
             benchmark_family=self.benchmark_family,
             legacy_family=self.legacy_generation_family,
             add_usage_to_key=self.api_keys.add_usage,
+            analytics_outbox=(
+                SpannerAnalyticsOutbox(self._database, self._param_types)
+                if analytics_outbox_enabled
+                else None
+            ),
         )
         self.byok_store = SpannerByok(io)
         self.custom_model_store = SpannerCustomModels(io)

--- a/src/trusted_router/storage_gcp_analytics_outbox.py
+++ b/src/trusted_router/storage_gcp_analytics_outbox.py
@@ -1,0 +1,77 @@
+"""Best-effort enqueue side of the live analytics Spanner outbox.
+
+The outbox is deliberately separate from gateway settlement. Analytics must
+never make the money transaction slower or less reliable. A failed enqueue is
+logged and tolerated by ``SpannerGenerations``; the Bigtable reconciler is the
+completeness backstop.
+
+The primary key starts with a deterministic shard. A commit timestamp alone is
+a monotonically increasing key and would concentrate all writes on one Spanner
+split. Within each shard, ``commit_ts`` is the live cursor: unlike benchmark
+``created_at``, it records when Spanner committed the outbox row and therefore
+cannot strand a late event behind an already-consumed range.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_models import ProviderBenchmarkSample
+
+ANALYTICS_OUTBOX_SHARDS = 16
+
+
+def analytics_outbox_shard(event_id: str, *, shard_count: int = ANALYTICS_OUTBOX_SHARDS) -> int:
+    """Return a stable, evenly distributed shard for an analytics event."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    digest = hashlib.blake2b(event_id.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % shard_count
+
+
+class SpannerAnalyticsOutbox:
+    """Append immutable benchmark payloads using Spanner commit timestamps."""
+
+    def __init__(
+        self,
+        database: Any,
+        param_types: Any,
+        *,
+        shard_count: int = ANALYTICS_OUTBOX_SHARDS,
+    ) -> None:
+        if shard_count < 1:
+            raise ValueError("shard_count must be positive")
+        self._database = database
+        self._pt = param_types
+        self._shard_count = shard_count
+
+    def enqueue(self, sample: ProviderBenchmarkSample) -> None:
+        """Commit one immutable payload in its own transaction.
+
+        Repeated calls intentionally create repeated outbox rows. Delivery is
+        at-least-once and ClickHouse's ReplacingMergeTree collapses replays by
+        the sample's stable ``id`` when queries use ``FINAL``.
+        """
+        shard = analytics_outbox_shard(sample.id, shard_count=self._shard_count)
+        payload = json_body(sample)
+
+        def txn(transaction: Any) -> None:
+            transaction.execute_update(
+                "INSERT INTO tr_analytics_outbox "
+                "(shard, commit_ts, event_id, payload) "
+                "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_id, @payload)",
+                params={
+                    "shard": shard,
+                    "event_id": sample.id,
+                    "payload": payload,
+                },
+                param_types={
+                    "shard": self._pt.INT64,
+                    "event_id": self._pt.STRING,
+                    "payload": self._pt.STRING,
+                },
+            )
+
+        self._database.run_in_transaction(txn)

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -42,6 +42,7 @@ from trusted_router.storage_gcp_activity_index import (
 from trusted_router.storage_gcp_activity_index import (
     write_generation as _bt_write_generation,
 )
+from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_benchmark_index import (
     provider_benchmark_samples as _bt_provider_benchmark_samples,
 )
@@ -79,6 +80,7 @@ class SpannerGenerations:
         benchmark_family: str | None = None,
         legacy_family: str | None = None,
         add_usage_to_key: _AddUsageCallback,
+        analytics_outbox: SpannerAnalyticsOutbox | None = None,
     ) -> None:
         self._io = io
         self._bt_table = bt_table
@@ -98,6 +100,7 @@ class SpannerGenerations:
             legacy,
         )
         self._add_usage_to_key = add_usage_to_key
+        self._analytics_outbox = analytics_outbox
 
     def add(self, generation: Generation) -> None:
         # Two separate transactions instead of one fused one. Per-key
@@ -182,6 +185,26 @@ class SpannerGenerations:
                     # Benchmarks are not repairable — they're loss-tolerant
                     # observability data, not billing. Log and move on.
                     "loss_tolerated": True,
+                },
+            )
+        if self._analytics_outbox is None:
+            return
+        try:
+            # A separate transaction by construction. Do not move this into
+            # gateway settlement: analytics is best-effort; money is not.
+            self._analytics_outbox.enqueue(sample)
+        except Exception as exc:
+            log.exception(
+                "spanner.analytics_outbox_enqueue_failed",
+                extra={
+                    "event_id": sample.id,
+                    "model": sample.model,
+                    "provider": sample.provider,
+                    "status": sample.status,
+                    "error_class": type(exc).__name__,
+                    "error_message": str(exc)[:500],
+                    "loss_tolerated": True,
+                    "repairable_via": "clickhouse/reconcile_benchmark_samples.py",
                 },
             )
 

--- a/tests/test_analytics_outbox.py
+++ b/tests/test_analytics_outbox.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+from typing import Any
+
+import pytest
+
+from clickhouse.backfill_benchmark_samples import normalise
+from clickhouse.ingest_outbox import (
+    DrainMetrics,
+    OutboxRow,
+    SpannerOutboxSource,
+    drain_once,
+    normalise_outbox_payload,
+)
+from clickhouse.reconcile_benchmark_samples import _add_row, _reverse_time_key
+from trusted_router.config import Settings
+from trusted_router.storage_gcp_analytics_outbox import (
+    SpannerAnalyticsOutbox,
+    analytics_outbox_shard,
+)
+from trusted_router.storage_gcp_generations import SpannerGenerations
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.types import UsageType
+
+
+def _sample() -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample(
+        id="bench-0123456789abcdef0123456789abcdef",
+        model="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        provider_name="Anthropic",
+        status="error",
+        usage_type=UsageType.CREDITS,
+        streamed=True,
+        input_tokens=12,
+        output_tokens=3,
+        speed_tokens_per_second=7.125,
+        elapsed_milliseconds=210,
+        first_token_milliseconds=90,
+        error_status=429,
+        error_type="rate_limit",
+        created_at="2026-07-28T12:34:56.789Z",
+    )
+
+
+class _ParamTypes:
+    INT64 = "INT64"
+    STRING = "STRING"
+
+
+class _Transaction:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def execute_update(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any],
+        param_types: dict[str, Any],
+    ) -> None:
+        self.calls.append((sql, params, param_types))
+
+
+class _Database:
+    def __init__(self) -> None:
+        self.transaction = _Transaction()
+
+    def run_in_transaction(self, callback: Any) -> None:
+        callback(self.transaction)
+
+
+def test_analytics_outbox_is_disabled_by_default() -> None:
+    assert Settings().analytics_outbox_enabled is False
+
+
+def test_enqueue_uses_commit_timestamp_and_deterministic_shard() -> None:
+    database = _Database()
+    sample = _sample()
+    SpannerAnalyticsOutbox(database, _ParamTypes()).enqueue(sample)
+
+    [(sql, params, param_types)] = database.transaction.calls
+    assert "PENDING_COMMIT_TIMESTAMP()" in sql
+    assert params["event_id"] == sample.id
+    assert params["shard"] == analytics_outbox_shard(sample.id)
+    assert json.loads(params["payload"])["error_status"] == 429
+    assert param_types == {
+        "shard": "INT64",
+        "event_id": "STRING",
+        "payload": "STRING",
+    }
+
+
+def test_bigtable_and_outbox_best_effort_attempts_are_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[str] = []
+
+    def fail_bigtable(*_args: Any) -> None:
+        attempts.append("bigtable")
+        raise RuntimeError("Bigtable unavailable")
+
+    class FailingOutbox:
+        def enqueue(self, _sample: ProviderBenchmarkSample) -> None:
+            attempts.append("outbox")
+            raise RuntimeError("Spanner unavailable")
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_generations._bt_write_provider_benchmark",
+        fail_bigtable,
+    )
+    generations = object.__new__(SpannerGenerations)
+    generations._bt_table = object()
+    generations._benchmark_family = "benchmark"
+    generations._analytics_outbox = FailingOutbox()
+
+    # Both failures are analytics-only and may not escape to settle callers.
+    generations.record_benchmark(_sample())
+    assert attempts == ["bigtable", "outbox"]
+
+
+def test_normalise_is_identical_for_backfill_and_outbox_payload() -> None:
+    raw = dataclasses.asdict(_sample())
+    # Exercise the coercions that historically diverged between ingestion
+    # paths: string status codes and nullable numeric strings.
+    raw["error_status"] = "429"
+    raw["elapsed_milliseconds"] = "210"
+    raw["speed_tokens_per_second"] = "7.125"
+    expected = normalise(raw)
+
+    assert normalise_outbox_payload(json.dumps(raw)) == expected
+    assert expected is not None
+    assert expected["error_status"] == 429
+    assert expected["elapsed_milliseconds"] == 210
+
+
+class _Source:
+    def __init__(self, rows: list[OutboxRow], *, fail_delete_once: bool = False) -> None:
+        self.rows = rows
+        self.deleted: list[OutboxRow] = []
+        self.fail_delete_once = fail_delete_once
+
+    def fetch(self, *, limit: int) -> list[OutboxRow]:
+        return self.rows[:limit]
+
+    def delete(self, rows: list[OutboxRow]) -> None:
+        if self.fail_delete_once:
+            self.fail_delete_once = False
+            raise RuntimeError("Spanner delete unavailable")
+        self.deleted.extend(rows)
+        deleted = set(rows)
+        self.rows = [row for row in self.rows if row not in deleted]
+
+    def oldest_commit_ts(self) -> dt.datetime | None:
+        return self.rows[0].commit_ts if self.rows else None
+
+
+class _Writer:
+    def __init__(self, *, failures: int = 0) -> None:
+        self.failures = failures
+        self.batches: list[list[dict[str, Any]]] = []
+
+    def insert(self, rows: list[dict[str, Any]]) -> None:
+        self.batches.append(rows)
+        if self.failures:
+            self.failures -= 1
+            raise RuntimeError("ClickHouse unavailable")
+
+
+def _outbox_row() -> OutboxRow:
+    return OutboxRow(
+        shard=3,
+        commit_ts=dt.datetime(2026, 7, 28, 12, 35, tzinfo=dt.UTC),
+        event_id=_sample().id,
+        payload=json.dumps(dataclasses.asdict(_sample())),
+    )
+
+
+def test_cursor_does_not_advance_until_clickhouse_ack_and_retry_succeeds() -> None:
+    row = _outbox_row()
+    source = _Source([row])
+    writer = _Writer(failures=1)
+    metrics = DrainMetrics()
+
+    with pytest.raises(RuntimeError, match="ClickHouse unavailable"):
+        drain_once(source, writer, metrics, batch_size=100)
+    assert source.rows == [row]
+    assert source.deleted == []
+    assert metrics.clickhouse_insert_errors_total == 1
+
+    result = drain_once(source, writer, metrics, batch_size=100)
+    assert result.inserted == 1
+    assert source.rows == []
+    assert source.deleted == [row]
+    assert metrics.rows_ingested_total == 1
+
+
+def test_delete_failure_replays_acknowledged_batch_without_losing_cursor() -> None:
+    row = _outbox_row()
+    source = _Source([row], fail_delete_once=True)
+    writer = _Writer()
+    metrics = DrainMetrics()
+
+    with pytest.raises(RuntimeError, match="Spanner delete unavailable"):
+        drain_once(source, writer, metrics, batch_size=100)
+    assert source.rows == [row]
+    assert len(writer.batches) == 1
+    assert metrics.clickhouse_insert_errors_total == 0
+
+    drain_once(source, writer, metrics, batch_size=100)
+    assert source.rows == []
+    assert len(writer.batches) == 2
+
+
+class _ReadSnapshot:
+    def __enter__(self) -> _ReadSnapshot:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute_sql(self, *_args: Any, **_kwargs: Any) -> list[tuple[Any, ...]]:
+        return []
+
+
+class _ReadDatabase:
+    def __init__(self) -> None:
+        self.multi_use_values: list[bool] = []
+
+    def snapshot(self, *, multi_use: bool = False) -> _ReadSnapshot:
+        self.multi_use_values.append(multi_use)
+        return _ReadSnapshot()
+
+
+def test_sharded_reads_request_multi_use_spanner_snapshots() -> None:
+    database = _ReadDatabase()
+    source = object.__new__(SpannerOutboxSource)
+    source._database = database
+    source._pt = _ParamTypes()
+    source._shard_count = 2
+
+    assert source.fetch(limit=10) == []
+    assert source.oldest_commit_ts() is None
+    assert database.multi_use_values == [True, True]
+
+
+def test_reconciler_reverse_range_sorts_newer_events_first() -> None:
+    older = dt.datetime(2026, 7, 20, tzinfo=dt.UTC)
+    newer = dt.datetime(2026, 7, 21, tzinfo=dt.UTC)
+    assert _reverse_time_key(newer) < _reverse_time_key(older)
+
+
+def test_reconciler_uses_a_closed_wall_clock_window() -> None:
+    target: dict[str, dict[str, str]] = {}
+    raw = dataclasses.asdict(_sample())
+    lower = dt.datetime(2026, 7, 28, 12, tzinfo=dt.UTC)
+    upper = dt.datetime(2026, 7, 28, 13, tzinfo=dt.UTC)
+
+    _add_row(target, raw, cutoff=lower, upper=upper)
+    assert set(target["2026-07-28"]) == {_sample().id}
+
+    raw["created_at"] = upper.isoformat()
+    _add_row(target, raw, cutoff=lower, upper=upper)
+    assert len(target["2026-07-28"]) == 1

--- a/tests/test_clickhouse_replay_functional.py
+++ b/tests/test_clickhouse_replay_functional.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from clickhouse.backfill_benchmark_samples import normalise
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TR_RUN_CLICKHOUSE_FUNCTIONAL") != "1",
+    reason="set TR_RUN_CLICKHOUSE_FUNCTIONAL=1 to run the Docker ClickHouse proof",
+)
+
+
+def _docker(
+    executable: str,
+    *args: str,
+    input_bytes: bytes | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(  # noqa: S603 - resolved executable, fixed argv, no shell
+        [executable, *args],
+        input=input_bytes,
+        capture_output=True,
+        check=check,
+    )
+
+
+def test_replayed_batch_collapses_under_final() -> None:
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("docker executable is unavailable")
+    name = f"tr-clickhouse-replay-{uuid.uuid4().hex[:12]}"
+    image = os.environ.get("TR_CLICKHOUSE_TEST_IMAGE", "clickhouse/clickhouse-server:latest")
+    _docker(docker, "run", "--rm", "-d", "--name", name, image)
+    try:
+        for _ in range(60):
+            ready = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--query",
+                "SELECT 1",
+                check=False,
+            )
+            if ready.returncode == 0:
+                break
+            time.sleep(0.25)
+        else:
+            pytest.fail("ClickHouse container did not become ready")
+
+        database = f"replay_{uuid.uuid4().hex}"
+        _docker(
+            docker,
+            "exec",
+            name,
+            "clickhouse-client",
+            "--query",
+            f"CREATE DATABASE {database}",
+        )
+        schema = (
+            Path(__file__).parents[1] / "clickhouse" / "001_provider_benchmark_samples.sql"
+        ).read_bytes()
+        _docker(
+            docker,
+            "exec",
+            "-i",
+            name,
+            "clickhouse-client",
+            "--database",
+            database,
+            "--multiquery",
+            input_bytes=schema,
+        )
+
+        raw = {
+            "id": "bench-functional-replay",
+            "created_at": "2026-07-28T12:34:56.789Z",
+            "provider": "anthropic",
+            "model": "anthropic/claude-haiku-4.5",
+            "provider_name": "Anthropic",
+            "status": "success",
+            "usage_type": "Credits",
+            "source": "organic",
+            "streamed": True,
+            "input_tokens": 12,
+            "output_tokens": 3,
+            "total_cost_microdollars": 9,
+        }
+        canonical = normalise(raw)
+        assert canonical is not None
+        payload = (json.dumps(canonical) + "\n").encode()
+        for _ in range(2):
+            _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "INSERT INTO provider_benchmark_samples FORMAT JSONEachRow",
+                input_bytes=payload,
+            )
+        count = _docker(
+            docker,
+            "exec",
+            name,
+            "clickhouse-client",
+            "--database",
+            database,
+            "--query",
+            "SELECT count() FROM provider_benchmark_samples FINAL",
+        )
+        assert count.stdout.decode().strip() == "1"
+    finally:
+        _docker(docker, "rm", "-f", name, check=False)


### PR DESCRIPTION
Stage 1 of [`analytics-ingestion.md`](docs/storage-portability/analytics-ingestion.md), merged in #299. **Shadow only — nothing reads from ClickHouse, and enqueue is off by default.**

## The cursor problem this exists to solve

The Bigtable row key is derived from `created_at` — *event* time, not commit time. A row that commits late sorts behind an already-consumed range and is **missed forever**. That trap already produced one false "data loss" conclusion.

So the cursor is a Spanner outbox keyed `(shard, commit_ts, event_id)` with `allow_commit_timestamp`. Commit timestamps are monotonic by construction. The shard prefix stops a bare commit-timestamp key from being the textbook Spanner hotspot.

## Money code is untouched

Enqueue is a **separate transaction** from gateway settlement, best-effort, and its failure log carries `loss_tolerated` plus the reconciler that repairs it. Analytics is not worth destabilising settlement for — and best-effort is acceptable *because* the Bigtable range scan is retained as a completeness reconciler.

## At-least-once, absorbed rather than assumed

The ingester inserts into ClickHouse and only **then** deletes the exact primary keys it drained. A crash between the two replays rather than loses. Verified against the real node: a duplicated batch collapses to one row under `FINAL`. Still no `AggregatingMergeTree` view — it double-counts on replay.

## Reconciler, verified against production

| UTC day | Bigtable | ClickHouse | Missing CH | Missing BT |
|---|---:|---:|---:|---:|
| Jul 28 | 5,841 | 5,841 | 0 | 0 |
| Jul 27 | 7,470 | 7,470 | 0 | 0 |
| Jul 26 | 6,541 | 6,541 | 0 | 0 |
| Jul 25 | 6,462 | 6,462 | 0 | 0 |
| Jul 24 | 5,857 | 5,857 | 0 | 0 |
| Jul 23 | 9,929 | 9,929 | 0 | 0 |
| Jul 22 | 8,744 | 8,744 | 0 | 0 |
| Jul 21 | 2,100 | 2,100 | 0 | 0 |

## Added on review: a TTL backstop

The outbox had no row-deletion policy. Drain-then-delete keeps it near-empty in normal operation, but a **dead drainer grows it without bound on the production database** — and that is not hypothetical: `tr_settle_outbox` sits at ~549k rows and `tr_entities` has ~9.4M with no policy at all (#334). Every one of those grew for exactly this reason.

Now `ROW DELETION POLICY (OLDER_THAN(commit_ts, INTERVAL 7 DAY))`, **already applied to production**. Seven days is safe *specifically because* analytics is loss-tolerant and the documented recovery is replay from Bigtable. The comment says explicitly never to copy this onto a money table, where dropping an undrained row would lose a settlement.

## Also

Rebased over 23 commits of `main` — a stale base was failing an unrelated catalog test that passes on current main. Full suite: **2129 passed, 62 skipped**.

## Not verified

Continuous live flow and 7-day stability, because enqueue is deliberately still disabled. That is the next step and it is a production config change.