### PR TITLE
Fix provider recovery validation

### DIFF
--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -128,15 +128,23 @@ def test_wave2_manifests_publish_only_live_eligible_routes() -> None:
         for row in atlas_image_rows
     )
     assert all(row["upstream_id"] for raw in manifests.values() for row in raw["models"])
-    assert all(
-        row.get("routable") is False
-        and row.get("routable_reason") == "provider-canary-failed"
-        for row in manifests["streamlake"]["models"]
-    )
-
     route_providers = {endpoint.provider for endpoint in MODEL_ENDPOINTS.values()}
     assert {"inceptron", "morph", "atlas-cloud"}.issubset(route_providers)
-    assert "streamlake" not in route_providers
+    streamlake_route_models = {
+        endpoint.model_id
+        for endpoint in MODEL_ENDPOINTS.values()
+        if endpoint.provider == "streamlake"
+    }
+    streamlake_manifest_models = {
+        row["id"]
+        for row in manifests["streamlake"]["models"]
+        if row.get("routable") is not False
+    }
+    assert streamlake_route_models == streamlake_manifest_models
+    assert all(
+        row.get("routable") is not False or row.get("routable_reason")
+        for row in manifests["streamlake"]["models"]
+    )
 
 
 def test_wave2_exact_upstream_ids_are_committed() -> None:


### PR DESCRIPTION
## Summary
- make the live catalog validation accept either StreamLake canary state
- require published StreamLake routes to exactly match currently routable manifest rows
- preserve fail-closed and operator-hold transition coverage

## Root cause
The authenticated hourly refresh correctly cleared `provider-canary-failed` after StreamLake recovered, but a static test required StreamLake to remain dark forever. This caused every recovered refresh to fail after generating a valid catalog.

## Verification
- `uv run ruff check tests/test_provider_wave2_catalogs.py`
- `uv run mypy`
- focused tests: 20 passed
- full suite: 2,120 passed, 61 skipped
- the old assertion is proven failing by refresh run 30474563888
