### PR TITLE
Fix StreamLake live pricing parser

### DIFF
--- a/scripts/pricing/parsers/streamlake.py
+++ b/scripts/pricing/parsers/streamlake.py
@@ -16,9 +16,24 @@ def _micro_per_m(raw: str) -> int:
     return int((Decimal(raw) * Decimal("1000000")).to_integral_value())
 
 
+def _pricing_rows(raw: str) -> list[str]:
+    # The live Next.js document serializes the entire article as one JSON
+    # string with escaped HTML tags. Isolate table rows before looking for
+    # prices so unrelated package prices cannot leak into a model row.
+    decoded = (
+        raw.replace("\\u003c", "<")
+        .replace("\\u003e", ">")
+        .replace("\\u0026", "&")
+    )
+    table_rows = re.findall(r"<tr\b[^>]*>(.*?)</tr>", decoded, re.IGNORECASE | re.DOTALL)
+    if not table_rows:
+        return raw.splitlines()
+    return [re.sub(r"<[^>]+>", " ", table_row) for table_row in table_rows]
+
+
 def parse(html: str) -> dict[str, dict[str, int]]:
     output: dict[str, dict[str, int]] = {}
-    for raw_line in html.splitlines():
+    for raw_line in _pricing_rows(html):
         line = re.sub(r"\s+", " ", raw_line)
         label = next((item for item in MODEL_IDS if item.casefold() in line.casefold()), None)
         if label is None:

--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -47,6 +47,30 @@ def test_provider_owned_pricing_parsers_use_integer_microdollars() -> None:
     }
 
 
+def test_streamlake_parser_isolates_model_rows_on_live_one_line_page() -> None:
+    live_page_shape = (
+        r"<html><script>{\"content\":\""
+        r"\u003ctable\u003e"
+        r"\u003ctr\u003e\u003ctd\u003eKAT-Coder-Pro-V2.5\u003c/td\u003e"
+        r"\u003ctd\u003e0-256K\u003c/td\u003e"
+        r"\u003ctd\u003e$0.74\u003c/td\u003e"
+        r"\u003ctd\u003e$2.96\u003c/td\u003e"
+        r"\u003ctd\u003e-\u003c/td\u003e"
+        r"\u003ctd\u003e$0.15\u003c/td\u003e\u003c/tr\u003e"
+        r"\u003ctr\u003e\u003ctd\u003ePackage 7\u003c/td\u003e"
+        r"\u003ctd\u003e$999.9\u003c/td\u003e\u003c/tr\u003e"
+        r"\u003c/table\u003e\"}</script></html>"
+    )
+
+    assert streamlake_parser.parse(live_page_shape) == {
+        "kwaipilot/kat-coder-pro-v2.5": {
+            "prompt_micro_per_m": 740_000,
+            "completion_micro_per_m": 2_960_000,
+            "prompt_cached_micro_per_m": 150_000,
+        }
+    }
+
+
 def test_morph_checkpoint_fallback_covers_published_live_chat_catalog() -> None:
     prices = morph_parser.parse("Vercel Security Checkpoint")
 


### PR DESCRIPTION
## Summary
- isolate model table rows before parsing StreamLake prices
- support StreamLake's live one-line Next.js document shape
- prevent unrelated resource-package prices from becoming token prices
- add a regression matching the escaped live-page structure

## Root cause
The live document serializes the whole article onto one line. The old line parser found the first model and then used the final dollar value on the page as cached-input pricing. It therefore parsed the official `$0.15/M` cached-input price as `$999.90/M`, and failed to discover the other two live model rows.

The first authenticated refresh after StreamLake's canary recovered surfaced this. Its deployment was canceled before regional rollout.

## Verification
- previous parser reproduced `$999.90/M` against the live page
- corrected parser returns all three live rows and exact official prices
- focused parser and policy tests: 114 passed
- full suite: 2,121 passed, 61 skipped
- Ruff and mypy pass
