### PR TITLE
Rename provider application to marketplace

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -106,7 +106,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/choose",
     "/models",
     "/providers",
-    "/providers/apply",
+    "/providers/marketplace",
     "/benchmarks",
     "/rankings",
     "/leaderboard",
@@ -1206,13 +1206,13 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             ),
         ),
     ),
-    "providers/apply": PublicPage(
-        template="public/provider_apply.html",
-        title="List Your Models on TrustedRouter",
+    "providers/marketplace": PublicPage(
+        template="public/provider_marketplace.html",
+        title="TrustedRouter Provider Marketplace",
         description=(
-            "Give TrustedRouter a dedicated API key and one OpenAI-compatible API "
-            "base URL implementing our exact model catalog contract. We will "
-            "validate, list, monitor, and keep your routes current automatically."
+            "Apply to list your models in the TrustedRouter marketplace. Send "
+            "company, privacy, compliance, catalog, pricing, and API information "
+            "by email; credentials are exchanged separately through a secure channel."
         ),
         faq_items=(
             (
@@ -1224,8 +1224,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
                 "TrustedRouter refreshes provider catalogs automatically. The canonical GET /v1/models response includes availability, capabilities, pricing, and lifecycle in one document, so a separate pricing API is not required.",
             ),
             (
-                "What kind of API key should we send?",
-                "Create a dedicated, revocable production key scoped only to inference and model discovery. Do not send an account password, owner credential, billing credential, or unrestricted administrative key.",
+                "How should we provide an API key?",
+                "Do not include any API key or credential in the application email. After review, TrustedRouter will arrange a separate secure handoff for a dedicated, revocable production key scoped only to inference and model discovery.",
             ),
         ),
     ),
@@ -2537,7 +2537,7 @@ def llms_txt(settings: Settings) -> str:
         f"- Homepage: https://{domain}/",
         f"- Models: https://{domain}/models",
         f"- Providers: https://{domain}/providers",
-        f"- Provider onboarding: https://{domain}/providers/apply",
+        f"- Provider marketplace: https://{domain}/providers/marketplace",
         f"- EU routing: https://{domain}/eu",
         f"- TrustedOS for AI clouds: https://{domain}/trustedos",
         f"- Benchmarks: https://{domain}/benchmarks",
@@ -2656,7 +2656,7 @@ def docs_llms_txt(settings: Settings) -> str:
             f"- Model catalog: https://{domain}/models",
             f"- Canonical live model API (public, no API key): https://{domain}/v1/models",
             f"- Provider transparency: https://{domain}/providers",
-            f"- Provider onboarding: https://{domain}/providers/apply",
+            f"- Provider marketplace: https://{domain}/providers/marketplace",
             f"- EU routing: https://{domain}/eu",
             f"- TrustedOS for AI clouds: https://{domain}/trustedos",
             "- Public status: https://status.trustedrouter.com/",

--- a/src/trusted_router/provider_contract.py
+++ b/src/trusted_router/provider_contract.py
@@ -1,11 +1,11 @@
-"""Canonical provider onboarding contract published on the provider apply page."""
+"""Canonical provider onboarding contract published on the marketplace page."""
 
 from __future__ import annotations
 
 from typing import Final
 
 PROVIDER_CATALOG_SCHEMA_URL: Final = (
-    "https://trustedrouter.com/providers/apply/catalog.schema.json"
+    "https://trustedrouter.com/providers/marketplace/catalog.schema.json"
 )
 
 PROVIDER_CATALOG_EXAMPLE: Final[dict[str, object]] = {

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -634,12 +634,12 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def for_developers() -> str:
         return public_page_html(settings, "for-developers")
 
-    @public_html_route("/providers/apply")
-    async def provider_apply() -> str:
-        return public_page_html(settings, "providers/apply")
+    @public_html_route("/providers/marketplace")
+    async def provider_marketplace() -> str:
+        return public_page_html(settings, "providers/marketplace")
 
     @app.get(
-        "/providers/apply/catalog.schema.json",
+        "/providers/marketplace/catalog.schema.json",
         include_in_schema=False,
     )
     async def provider_catalog_schema() -> JSONResponse:
@@ -649,6 +649,30 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             headers={
                 "cache-control": "public, max-age=3600, stale-while-revalidate=86400"
             },
+        )
+
+    @app.api_route(
+        "/providers/apply",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    @app.api_route(
+        "/providers/apply/",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    async def legacy_provider_apply() -> RedirectResponse:
+        return RedirectResponse(url="/providers/marketplace", status_code=301)
+
+    @app.api_route(
+        "/providers/apply/catalog.schema.json",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    async def legacy_provider_catalog_schema() -> RedirectResponse:
+        return RedirectResponse(
+            url="/providers/marketplace/catalog.schema.json",
+            status_code=301,
         )
 
     @public_html_route("/apps")

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -16,7 +16,7 @@
       <a href="/models">Models</a>
       <a href="/compare/models">Model comparisons</a>
       <a href="/providers">Providers</a>
-      <a href="/providers/apply">List your models</a>
+      <a href="/providers/marketplace">Provider marketplace</a>
       <a href="/eu">EU routing</a>
       <a href="/synth">Synth</a>
       <a href="/pricing">Pricing</a>

--- a/src/trusted_router/templates/public/provider_marketplace.html
+++ b/src/trusted_router/templates/public/provider_marketplace.html
@@ -3,57 +3,109 @@
 {% block hero %}
 <section class="public-hero marketing-hero">
   <div>
-    <div class="kicker">For inference providers</div>
+    <div class="kicker">Provider marketplace</div>
     <h1>List your models on TrustedRouter.</h1>
-    <p class="lead">Give us stable machine interfaces once. We will validate your routes, publish your models, monitor availability, and keep pricing current.</p>
+    <p class="lead">Send us your company and integration profile. We will review your privacy commitments, validate your routes, publish working models, monitor availability, and keep pricing current.</p>
     <div class="hero-actions">
-      <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">Email providers@trustedrouter.com</a>
+      <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20marketplace%20application%20for%20%5Bcompany%5D">Email providers@trustedrouter.com</a>
       <a class="btn" href="#integration-contract">View requirements <span aria-hidden="true">↓</span></a>
     </div>
   </div>
   <div class="public-hero-metrics" aria-label="Provider integration requirements">
-    <div><strong>1</strong><span>dedicated API key</span></div>
+    <div><strong>Verified</strong><span>company profile</span></div>
     <div><strong>1</strong><span>canonical catalog endpoint</span></div>
-    <div><strong>Hourly</strong><span>catalog refresh</span></div>
+    <div><strong>Separate</strong><span>secure key handoff</span></div>
   </div>
 </section>
 {% endblock %}
 
 {% block body %}
 <section class="public-proof-strip" aria-label="Provider onboarding flow">
-  <div><strong>Connect</strong><span>Send a restricted key and API base URL.</span></div>
-  <div><strong>Implement</strong><span>Copy the canonical catalog response exactly.</span></div>
-  <div><strong>Publish</strong><span>Expose models, prices, and lifecycle together.</span></div>
-  <div><strong>Verify</strong><span>We test, monitor, and list working routes.</span></div>
+  <div><strong>Apply</strong><span>Email your company and integration profile.</span></div>
+  <div><strong>Review</strong><span>We verify privacy, compliance, and API claims.</span></div>
+  <div><strong>Connect</strong><span>Exchange a restricted key through a separate secure channel.</span></div>
+  <div><strong>Publish</strong><span>We test, monitor, and list working routes.</span></div>
 </section>
 
 <section class="marketing-split" id="integration-contract" aria-label="Provider integration contract">
   <div class="marketing-copy">
-    <span class="eyebrow">Send one email</span>
-    <h2>Everything needed to connect.</h2>
-    <p>Email <a href="mailto:providers@trustedrouter.com">providers@trustedrouter.com</a> from your company domain. Include a technical contact who can answer routing and pricing questions.</p>
+    <span class="eyebrow">Marketplace application</span>
+    <h2>Tell us who operates the service.</h2>
+    <p>Email <a href="mailto:providers@trustedrouter.com">providers@trustedrouter.com</a> from your company domain. The application must identify the legal entity, responsible contacts, privacy terms, and service being offered.</p>
     <ul class="check-list">
-      <li><strong>Dedicated API key.</strong> A revocable production key scoped to inference and model discovery.</li>
-      <li><strong>OpenAI-compatible base URL.</strong> One HTTPS base such as <code>https://api.provider.com/v1</code>.</li>
-      <li><strong>Bearer authentication.</strong> Accept <code>Authorization: Bearer PROVIDER_API_KEY</code> for discovery and inference.</li>
-      <li><strong>Canonical catalog.</strong> Serve the exact response below from <code>GET /v1/models</code>.</li>
-      <li><strong>Chat inference.</strong> Serve OpenAI-compatible requests from <code>POST /v1/chat/completions</code>.</li>
+      <li><strong>Company identity.</strong> Legal name, brand or DBA, website, jurisdiction, entity type, and DUNS number.</li>
+      <li><strong>Company details.</strong> Registered address, operating address if different, business phone, and corporate tax ID such as EIN or VAT ID. Never send a personal tax identifier.</li>
+      <li><strong>Leadership.</strong> CEO name and title, authorized contract signer, and ownership or parent company where applicable.</li>
+      <li><strong>Contacts.</strong> Technical, security and privacy, legal, billing, and incident-response contacts.</li>
+      <li><strong>Policies.</strong> Privacy policy, terms, DPA, subprocessor list, security or trust center, and compliance reports or certifications.</li>
+      <li><strong>Data handling.</strong> Retention period, training use, zero-retention terms, serving regions, data residency, and confidential-compute or attestation evidence.</li>
     </ul>
-    <p class="small-copy">Never send an account password, owner credential, billing credential, or unrestricted administrative key.</p>
+    <p class="small-copy"><strong>Do not email an API key or any other credential.</strong> After the application is reviewed, TrustedRouter will arrange a separate secure handoff for a dedicated, revocable inference key.</p>
   </div>
   <div class="copy-terminal" aria-label="Provider onboarding email template">
-    <div class="code-head"><span>Email checklist</span><span>providers@trustedrouter.com</span></div>
-    <pre><code>Company:
+    <div class="code-head"><span>Application email</span><span>No credentials</span></div>
+    <pre><code>Legal company name:
+Brand / DBA:
+Website:
+Jurisdiction and entity type:
+DUNS number:
+Registered address:
+Operating address:
+Business phone:
+Corporate tax ID:
+CEO:
+Authorized contract signer:
+
 Technical contact:
+Security / privacy contact:
+Legal contact:
+Billing contact:
+Incident contact:
+
+Privacy policy:
+Terms of service:
+DPA:
+Subprocessor list:
+Security / trust center:
+Compliance reports:
+
+Data retention:
+Training use:
+ZDR terms:
+Serving regions / residency:
+Confidential compute evidence:
 
 API base URL:
 API documentation:
-Dedicated API key:
+Catalog endpoint:
+Deprecation feed or contact:
 
-Regions:
-Retention policy URL:
-Confidential compute URL:
-Deprecation feed or contact:</code></pre>
+API key: DO NOT INCLUDE</code></pre>
+  </div>
+</section>
+
+<section class="marketing-split" aria-label="Provider API requirements">
+  <div class="marketing-copy">
+    <span class="eyebrow">Integration profile</span>
+    <h2>Describe the API without sending secrets.</h2>
+    <ul class="check-list">
+      <li><strong>OpenAI-compatible base URL.</strong> One HTTPS base such as <code>https://api.provider.com/v1</code>.</li>
+      <li><strong>Authentication format.</strong> Describe bearer authentication and supported credential scopes without including a live key.</li>
+      <li><strong>Canonical catalog.</strong> Serve the exact response below from <code>GET /v1/models</code>.</li>
+      <li><strong>Chat inference.</strong> Serve OpenAI-compatible requests from <code>POST /v1/chat/completions</code>.</li>
+      <li><strong>Operational limits.</strong> Document rate limits, capacity tiers, timeout behavior, error contracts, maintenance notices, and support escalation.</li>
+    </ul>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">Credential handoff</span>
+    <h2>Keys travel separately.</h2>
+    <p>The marketplace application is non-secret business and technical information. Once accepted, create a dedicated production credential restricted to model discovery and inference.</p>
+    <ul class="check-list">
+      <li>Use a revocable key created only for TrustedRouter.</li>
+      <li>Exclude account administration, billing, user management, and key creation permissions.</li>
+      <li>Deliver it only through the secure channel arranged during review.</li>
+      <li>Never place the key in email, support tickets, documents, chat, source code, or the catalog response.</li>
+    </ul>
   </div>
 </section>
 
@@ -69,7 +121,7 @@ Deprecation feed or contact:</code></pre>
       <li><strong>Use UTC timestamps.</strong> Lifecycle timestamps use RFC 3339, for example <code>2026-08-05T00:00:00Z</code>.</li>
       <li><strong>Use one row per billable tier.</strong> If rates or capabilities differ, publish a distinct stable model ID for that tier.</li>
     </ul>
-    <p><a href="/providers/apply/catalog.schema.json">Download the JSON Schema</a> and validate the response before emailing us.</p>
+    <p><a href="/providers/marketplace/catalog.schema.json">Download the JSON Schema</a> and validate the response before emailing us.</p>
   </div>
   <div class="copy-terminal" aria-label="Canonical provider catalog response">
     <div class="code-head"><span>GET /v1/models</span><span>application/json</span></div>
@@ -171,8 +223,8 @@ curl --fail --silent --show-error \
 <section class="panel">
   <div class="panel-head"><h2>Ready to connect?</h2></div>
   <div class="panel-body">
-    <p>Send the integration details and dedicated key to <a href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">providers@trustedrouter.com</a>.</p>
-    <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D">Start provider integration</a>
+    <p>Send the company and integration profile, without credentials, to <a href="mailto:providers@trustedrouter.com?subject=Provider%20marketplace%20application%20for%20%5Bcompany%5D">providers@trustedrouter.com</a>. We will reply with review questions and secure key-delivery instructions.</p>
+    <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20marketplace%20application%20for%20%5Bcompany%5D">Apply to the marketplace</a>
   </div>
 </section>
 {% endblock %}

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -15,7 +15,7 @@
     </div>
     <div>
       <p>Zero data retention, confidential compute, and encrypted provider routes are shown only when explicitly tracked. Unknown stays unknown.</p>
-      <a class="btn" href="/providers/apply">List your models <span aria-hidden="true">→</span></a>
+      <a class="btn" href="/providers/marketplace">List your models <span aria-hidden="true">→</span></a>
     </div>
   </div>
   <div class="model-table-wrap">

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -11,12 +11,22 @@ from trusted_router.provider_contract import (
 def test_provider_onboarding_page_has_machine_readable_requirements(
     client: TestClient,
 ) -> None:
-    response = client.get("/providers/apply")
+    response = client.get("/providers/marketplace")
 
     assert response.status_code == 200
     assert "List your models on TrustedRouter." in response.text
     assert "providers@trustedrouter.com" in response.text
-    assert "Dedicated API key." in response.text
+    assert "Legal company name:" in response.text
+    assert "Privacy policy:" in response.text
+    assert "DUNS number:" in response.text
+    assert "Registered address:" in response.text
+    assert "Business phone:" in response.text
+    assert "Corporate tax ID:" in response.text
+    assert "CEO:" in response.text
+    assert "Subprocessor list:" in response.text
+    assert "Do not email an API key" in response.text
+    assert "API key: DO NOT INCLUDE" in response.text
+    assert "separate secure handoff" in response.text
     assert "OpenAI-compatible base URL." in response.text
     assert "Canonical catalog." in response.text
     assert "Copy this output exactly." in response.text
@@ -25,19 +35,22 @@ def test_provider_onboarding_page_has_machine_readable_requirements(
     assert "No separate pricing endpoint is required." in response.text
     assert "per_1m_tokens" in response.text
     assert "Do not invent a second format." in response.text
-    assert 'href="/providers/apply/catalog.schema.json"' in response.text
-    assert "unrestricted administrative key" in response.text
+    assert 'href="/providers/marketplace/catalog.schema.json"' in response.text
+    assert "Exclude account administration, billing, user management" in response.text
     assert (
-        'href="mailto:providers@trustedrouter.com?subject=Provider%20integration%20for%20%5Bcompany%5D"'
+        'href="mailto:providers@trustedrouter.com?subject=Provider%20marketplace%20application%20for%20%5Bcompany%5D"'
         in response.text
     )
-    assert '<link rel="canonical" href="https://trustedrouter.com/providers/apply">' in response.text
+    assert (
+        '<link rel="canonical" href="https://trustedrouter.com/providers/marketplace">'
+        in response.text
+    )
 
 
 def test_provider_catalog_schema_is_public_and_matches_documented_example(
     client: TestClient,
 ) -> None:
-    response = client.get("/providers/apply/catalog.schema.json")
+    response = client.get("/providers/marketplace/catalog.schema.json")
 
     assert response.status_code == 200
     assert response.headers["cache-control"].startswith("public")
@@ -64,14 +77,32 @@ def test_provider_onboarding_page_is_discoverable(client: TestClient) -> None:
     llms = client.get("/llms.txt")
 
     assert providers.status_code == footer.status_code == sitemap.status_code == llms.status_code == 200
-    assert 'href="/providers/apply"' in providers.text
-    assert 'href="/providers/apply"' in footer.text
-    assert "<loc>https://trustedrouter.com/providers/apply</loc>" in sitemap.text
-    assert "Provider onboarding: https://trustedrouter.com/providers/apply" in llms.text
+    assert 'href="/providers/marketplace"' in providers.text
+    assert 'href="/providers/marketplace"' in footer.text
+    assert "<loc>https://trustedrouter.com/providers/marketplace</loc>" in sitemap.text
+    assert "Provider marketplace: https://trustedrouter.com/providers/marketplace" in llms.text
+    assert "https://trustedrouter.com/providers/apply" not in sitemap.text
+    assert "https://trustedrouter.com/providers/apply" not in llms.text
 
 
 def test_provider_onboarding_page_supports_head(client: TestClient) -> None:
-    response = client.head("/providers/apply")
+    response = client.head("/providers/marketplace")
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
+
+
+def test_legacy_provider_apply_routes_redirect_permanently(client: TestClient) -> None:
+    page = client.get("/providers/apply", follow_redirects=False)
+    page_with_slash = client.get("/providers/apply/", follow_redirects=False)
+    schema = client.get(
+        "/providers/apply/catalog.schema.json",
+        follow_redirects=False,
+    )
+
+    assert page.status_code == 301
+    assert page.headers["location"] == "/providers/marketplace"
+    assert page_with_slash.status_code == 301
+    assert page_with_slash.headers["location"] == "/providers/marketplace"
+    assert schema.status_code == 301
+    assert schema.headers["location"] == "/providers/marketplace/catalog.schema.json"


### PR DESCRIPTION
## Summary
- make /providers/marketplace the canonical provider onboarding page
- collect company, privacy, compliance, and API metadata by email
- prohibit credentials in email and require a separate secure key handoff
- permanently redirect legacy /providers/apply URLs
- update canonical tags, sitemap, llms.txt, navigation, schema ID, and regression tests

## Verification
- uv run pytest -q tests/test_provider_onboarding_page.py tests/test_public_seo_pages.py tests/test_core_api.py
- uv run ruff check src/trusted_router/provider_contract.py src/trusted_router/dashboard.py src/trusted_router/routes/public.py tests/test_provider_onboarding_page.py
- git diff --check