### PR TITLE
Activate verified OpenAI prepaid ZDR

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -264,20 +264,22 @@ PROVIDERS: dict[str, Provider] = {
         supports_embeddings=True,
         supports_prepaid=True,
         provider_zero_data_retention=False,
-        # Activation gate: flip only after the managed production key passes
-        # the store=true/create then retrieve-must-fail ZDR smoke on/after the
-        # contractual effective date. BYOK remains outside this flag.
-        prepaid_zero_data_retention=False,
+        # Verified 2026-07-29 against the managed production project:
+        # a Responses request with store=true succeeded, then retrieval
+        # returned 404. BYOK remains outside this account-scoped flag.
+        prepaid_zero_data_retention=True,
         prepaid_zero_data_retention_effective_on="2026-07-28",
         provider_policy=(
-            "Contracted Zero Data Retention is scheduled to begin for "
-            "TrustedRouter's managed OpenAI account on July 28, 2026. OpenAI remains "
-            "outside trustedrouter/zdr until live activation verification passes. "
-            "Once verified, the guarantee will apply only to TrustedRouter-funded "
-            "prepaid routes; customer BYOK credentials use the data controls on the "
-            "customer's own OpenAI organization or project."
+            "Contracted Zero Data Retention is active for TrustedRouter's managed "
+            "OpenAI account, effective July 28, 2026, and live enforcement was "
+            "verified on July 29, 2026. This guarantee applies only to "
+            "TrustedRouter-funded prepaid routes; customer BYOK credentials use the "
+            "data controls on the customer's own OpenAI organization or project."
         ),
-        provider_policy_url="https://platform.openai.com/docs/models/default-usage-policies-by-endpoint",
+        provider_policy_url=(
+            "https://developers.openai.com/api/docs/guides/your-data"
+            "#data-retention-controls-for-abuse-monitoring"
+        ),
         provider_headquarters_country=PROVIDER_JURISDICTION_US,
     ),
     "google-ai-studio": Provider(

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -286,11 +286,19 @@ def test_model_storage_flag_is_gateway_scoped_endpoint_flag_is_provider_scoped()
 
     # Endpoint rows still expose upstream-provider posture separately, so
     # dashboards can distinguish TR no-retention from provider ZDR/unknown.
-    openai_endpoint = next(
+    openai_endpoints = [
         endpoint for endpoint in meta["endpoints"] if endpoint["provider"] == "openai"
-    )
-    assert openai_endpoint["stores_content"] is True
-    assert openai_endpoint["provider_zero_data_retention"] is False
+    ]
+    by_usage = {
+        endpoint["usage_type"]: endpoint
+        for endpoint in openai_endpoints
+    }
+    assert by_usage["Credits"]["stores_content"] is False
+    assert by_usage["Credits"]["provider_zero_data_retention"] is True
+    assert by_usage["Credits"]["zero_data_retention_scope"] == "trustedrouter_prepaid"
+    assert by_usage["BYOK"]["stores_content"] is True
+    assert by_usage["BYOK"]["provider_zero_data_retention"] is False
+    assert by_usage["BYOK"]["zero_data_retention_scope"] is None
 
 
 @pytest.mark.parametrize(
@@ -636,11 +644,20 @@ def test_closed_provider_zdr_claims_are_route_scoped() -> None:
     assert all(endpoint_zero_data_retention(endpoint) is True for endpoint in vertex_endpoints)
 
     # OpenAI's guarantee is deliberately narrower: it belongs to
-    # TrustedRouter's managed prepaid account, starts on July 28, and is not
-    # activated until a live retention smoke passes.
+    # TrustedRouter's managed prepaid account, starts on July 28, and was
+    # activated only after a live retention smoke passed.
     assert PROVIDERS["openai"].provider_zero_data_retention is False
-    assert PROVIDERS["openai"].prepaid_zero_data_retention is False
+    assert PROVIDERS["openai"].prepaid_zero_data_retention is True
     assert PROVIDERS["openai"].prepaid_zero_data_retention_effective_on == "2026-07-28"
+    openai_endpoints = [
+        endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "openai"
+    ]
+    assert any(endpoint.usage_type == "Credits" for endpoint in openai_endpoints)
+    assert any(endpoint.usage_type == "BYOK" for endpoint in openai_endpoints)
+    assert all(
+        endpoint_zero_data_retention(endpoint) is (endpoint.usage_type == "Credits")
+        for endpoint in openai_endpoints
+    )
 
 
 def test_provider_deprecated_models_have_no_catalog_endpoints() -> None:
@@ -1402,7 +1419,7 @@ def test_privacy_meta_models_force_endpoint_privacy_floor() -> None:
         endpoint.provider for _model, endpoint in zdr_endpoints
     }
     assert "google-vertex" in {endpoint.provider for _model, endpoint in zdr_endpoints}
-    assert "openai" not in {endpoint.provider for _model, endpoint in zdr_endpoints}
+    assert "openai" in {endpoint.provider for _model, endpoint in zdr_endpoints}
     assert all(
         endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION
         for _model, endpoint in zdr_endpoints

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -611,8 +611,11 @@ def test_embeddings_and_model_endpoints(
         for item in openai_endpoints
         if item["provider"] == "openai"
     }
-    assert openai_by_usage["Credits"]["provider_zero_data_retention"] is False
-    assert openai_by_usage["Credits"]["zero_data_retention_scope"] is None
+    assert openai_by_usage["Credits"]["provider_zero_data_retention"] is True
+    assert (
+        openai_by_usage["Credits"]["zero_data_retention_scope"]
+        == "trustedrouter_prepaid"
+    )
     assert openai_by_usage["BYOK"]["provider_zero_data_retention"] is False
     assert openai_by_usage["BYOK"]["zero_data_retention_scope"] is None
 
@@ -1101,9 +1104,12 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     # for debugging/security and therefore must not satisfy strict ZDR routing.
     assert provider_flags["deepinfra"]["provider_zero_data_retention"] is False
     assert provider_flags["openai"]["provider_zero_data_retention"] is False
-    assert provider_flags["openai"]["prepaid_zero_data_retention"] is False
+    assert provider_flags["openai"]["prepaid_zero_data_retention"] is True
     assert provider_flags["openai"]["prepaid_zero_data_retention_effective_on"] == ("2026-07-28")
-    assert provider_flags["openai"]["zero_data_retention_scope"] is None
+    assert (
+        provider_flags["openai"]["zero_data_retention_scope"]
+        == "trustedrouter_prepaid"
+    )
     assert provider_flags["google-ai-studio"]["provider_zero_data_retention"] is False
     assert provider_flags["google-ai-studio"]["supports_byok"] is True
     assert provider_flags["google-vertex"]["provider_zero_data_retention"] is False
@@ -1119,6 +1125,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert "Not currently marked ZDR" in provider_flags["anthropic"]["provider_policy"]
     assert "Contracted Zero Data Retention" in provider_flags["openai"]["provider_policy"]
     assert "July 28, 2026" in provider_flags["openai"]["provider_policy"]
+    assert "verified on July 29, 2026" in provider_flags["openai"]["provider_policy"]
     assert "customer BYOK" in provider_flags["openai"]["provider_policy"]
     assert "Not currently marked ZDR" in provider_flags["google-ai-studio"]["provider_policy"]
     assert "contractual Zero Data Retention" in provider_flags["google-vertex"][
@@ -1176,7 +1183,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert "anthropic" not in zdr_providers
     assert "google-ai-studio" not in zdr_providers
     assert "google-vertex" in zdr_providers
-    assert "openai" not in zdr_providers
+    assert "openai" in zdr_providers
     assert "deepseek" not in zdr_providers
     assert "gmi" not in zdr_providers
     vertex_zdr = [item for item in zdr if item["provider"] == "google-vertex"]
@@ -1185,6 +1192,13 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert all(
         item["zero_data_retention_scope"] == "trustedrouter_prepaid"
         for item in vertex_zdr
+    )
+    openai_zdr = [item for item in zdr if item["provider"] == "openai"]
+    assert openai_zdr
+    assert all(item["prepaid_zero_data_retention"] is True for item in openai_zdr)
+    assert all(
+        item["zero_data_retention_scope"] == "trustedrouter_prepaid"
+        for item in openai_zdr
     )
     credits = client.get("/v1/credits", headers=user_headers)
     assert credits.status_code == 200

--- a/tests/test_openai_contracted_zdr.py
+++ b/tests/test_openai_contracted_zdr.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
 from fastapi.testclient import TestClient
-from pytest import MonkeyPatch
 
 from trusted_router.catalog import (
     MODELS,
@@ -33,31 +30,20 @@ def _first_party_openai_endpoints() -> tuple[ModelEndpoint, ModelEndpoint]:
     return credits, byok
 
 
-def _activate_openai_prepaid_zdr(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setitem(
-        PROVIDERS,
-        "openai",
-        replace(PROVIDERS["openai"], prepaid_zero_data_retention=True),
-    )
-
-
-def test_openai_zdr_contract_is_scheduled_but_not_active() -> None:
+def test_openai_zdr_contract_is_active_for_managed_prepaid_only() -> None:
     provider = PROVIDERS["openai"]
     credits, byok = _first_party_openai_endpoints()
 
     assert provider.provider_zero_data_retention is False
-    assert provider.prepaid_zero_data_retention is False
+    assert provider.prepaid_zero_data_retention is True
     assert provider.prepaid_zero_data_retention_effective_on == "2026-07-28"
-    assert endpoint_zero_data_retention(credits) is False
-    assert endpoint_privacy_tier(credits) == PRIVACY_TIER_STANDARD
+    assert endpoint_zero_data_retention(credits) is True
+    assert endpoint_privacy_tier(credits) == PRIVACY_TIER_ZERO_RETENTION
     assert endpoint_zero_data_retention(byok) is False
     assert endpoint_privacy_tier(byok) == PRIVACY_TIER_STANDARD
 
 
-def test_openai_zdr_activation_is_scoped_to_trustedrouter_prepaid_routes(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    _activate_openai_prepaid_zdr(monkeypatch)
+def test_openai_zdr_activation_is_scoped_to_trustedrouter_prepaid_routes() -> None:
     credits, byok = _first_party_openai_endpoints()
 
     assert endpoint_zero_data_retention(credits) is True
@@ -66,10 +52,7 @@ def test_openai_zdr_activation_is_scoped_to_trustedrouter_prepaid_routes(
     assert endpoint_privacy_tier(byok) == PRIVACY_TIER_STANDARD
 
 
-def test_openai_catalog_metadata_does_not_extend_tr_contract_to_byok(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    _activate_openai_prepaid_zdr(monkeypatch)
+def test_openai_catalog_metadata_does_not_extend_tr_contract_to_byok() -> None:
     provider_shape = provider_to_openrouter_shape(PROVIDERS["openai"])
     assert provider_shape["provider_zero_data_retention"] is False
     assert provider_shape["prepaid_zero_data_retention"] is True
@@ -88,10 +71,7 @@ def test_openai_catalog_metadata_does_not_extend_tr_contract_to_byok(
     assert by_usage["BYOK"]["zero_data_retention_scope"] is None
 
 
-def test_openai_zdr_filter_selects_credits_and_never_inherits_byok(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    _activate_openai_prepaid_zdr(monkeypatch)
+def test_openai_zdr_filter_selects_credits_and_never_inherits_byok() -> None:
     candidates = chat_route_endpoint_candidates(
         {
             "model": "openai/gpt-5.5",
@@ -109,10 +89,7 @@ def test_openai_zdr_filter_selects_credits_and_never_inherits_byok(
     )
 
 
-def test_zdr_alias_can_use_openai_only_through_contracted_credits_route(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    _activate_openai_prepaid_zdr(monkeypatch)
+def test_zdr_alias_can_use_openai_only_through_contracted_credits_route() -> None:
     candidates = chat_route_endpoint_candidates(
         {"model": ZDR_MODEL_ID, "provider": {"only": ["openai"]}},
         Settings(environment="test"),
@@ -123,15 +100,18 @@ def test_zdr_alias_can_use_openai_only_through_contracted_credits_route(
     assert all(endpoint.usage_type == "Credits" for _model, endpoint in candidates)
 
 
-def test_public_pages_explain_scheduled_openai_prepaid_scope(client: TestClient) -> None:
+def test_public_pages_explain_active_openai_prepaid_scope(client: TestClient) -> None:
     providers = client.get("/providers")
     assert providers.status_code == 200
-    assert "scheduled 2026-07-28" in providers.text
+    assert "prepaid only" in providers.text
+    assert "Contracted Zero Data Retention is active" in providers.text
     assert "July 28, 2026" in providers.text
+    assert "verified on July 29, 2026" in providers.text
     assert "customer BYOK credentials" in providers.text
 
     model = client.get("/models/openai/gpt-5.5")
     assert model.status_code == 200
     assert "Credits" in model.text
     assert "BYOK" in model.text
+    assert ">ZDR<" in model.text
     assert "no verified privacy claim" in model.text

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -488,7 +488,7 @@ def test_embeddings_data_collection_deny_soft_fallback_keeps_standard_model_endp
         endpoints_for_model,
     )
 
-    model_id = "openai/text-embedding-3-large"
+    model_id = "google/gemini-embedding-001"
     catalog_endpoints = endpoints_for_model(model_id)
     assert catalog_endpoints
     assert all(endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE for endpoint in catalog_endpoints)
@@ -525,7 +525,7 @@ def test_catalog_data_collection_deny_soft_fallback_and_satisfiable_filtering() 
         endpoints_for_model,
     )
 
-    standard_model_id = "openai/text-embedding-3-large"
+    standard_model_id = "google/gemini-embedding-001"
     standard_endpoints = endpoints_for_model(standard_model_id)
     assert standard_endpoints
     assert all(


### PR DESCRIPTION
## What changed

- mark TrustedRouter-funded OpenAI Credits routes as Zero Data Retention
- keep OpenAI BYOK routes outside the managed-account guarantee
- replace scheduled activation copy with the verified effective and enforcement dates
- update provider, endpoint, alias, and public-page regression coverage

## Why

Lore Hex Corp's OpenAI organization now has Zero Data Retention enabled. A live production-key probe verified enforcement on project `proj_6dRdxxhjpzGn9elXW68PSUzq`: a Responses request with `store=true` succeeded and subsequent retrieval returned `404`.

## Validation

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (`2122 passed, 61 skipped`)
- live OpenAI ZDR retention probe
