### PR TITLE
Add GMI and Phala Kimi K3 routes

### DIFF
--- a/scripts/pricing/providers/gmi.py
+++ b/scripts/pricing/providers/gmi.py
@@ -39,6 +39,7 @@ URL = "https://api.gmi-serving.com/v1/models"
 
 EXPECTED_MODELS = [
     "google/gemma-4-31b-it",
+    "moonshotai/kimi-k3",
     "z-ai/glm-5.2",
 ]
 
@@ -52,6 +53,7 @@ _NATIVE_TO_OR_ID = {
     "google/gemma-4-26b-a4b-it": "google/gemma-4-26b-a4b-it",
     "deepseek-ai/DeepSeek-V4-Pro": "deepseek/deepseek-v4-pro",
     "deepseek-ai/DeepSeek-V3.1": "deepseek/deepseek-v3.1",
+    "moonshotai/kimi-k3": "moonshotai/kimi-k3",
     "zai-org/GLM-5-FP8": "z-ai/glm-5",
     "zai-org/GLM-5.1-FP8": "z-ai/glm-5.1",
     "zai-org/GLM-5.2-FP8": "z-ai/glm-5.2",

--- a/scripts/pricing/providers/phala.py
+++ b/scripts/pricing/providers/phala.py
@@ -1,11 +1,12 @@
-"""Phala (Confidential AI) — human-only provider config.
+"""Phala model discovery with route-specific confidentiality boundaries.
 
 Phala runs inference inside Intel TDX + NVIDIA Confidential Compute
-TEEs. We route exclusively to their GPU-TEE-attested tier (the
-`phala/<bare>` model id form), NOT the upstream pass-through tier
-(`openai/gpt-oss-120b`, `anthropic/claude-haiku-4.5`, etc.) which
-requires a different — separately-issued — redpill key our TR
-account isn't entitled to. See
+TEEs. Most TrustedRouter routes use their GPU-TEE tier (the
+`phala/<bare>` model id form). A small explicit allowlist may use an
+upstream-author pass-through ID after a direct account canary succeeds.
+Those exact routes receive a model/provider privacy override in
+catalog_data.py and must never inherit the confidential posture of
+`phala/*`. See
 docs.phala.com/phala-cloud/confidential-ai/confidential-model/confidential-ai-api
 for the official model-id convention.
 
@@ -21,15 +22,18 @@ the fetch may still succeed (Phala's /v1/models tolerates anon GET)
 but is treated as one failure under MAX_TOLERATED_FAILURES if it
 401s for any reason.
 
-To add a new Phala-served model: probe /v1/models, find the
-`phala/<bare>` row, and add the `phala/<bare>` → OR-canonical pair
-to `_NATIVE_TO_OR_ID`. Refresh.py overlays the price automatically.
+To add a confidential model, probe /v1/models, find the `phala/<bare>`
+row, and add its canonical mapping. A non-phala pass-through route
+requires an explicit standard-privacy override and a visible-content
+chat canary before it can enter `_STANDARD_PASSTHROUGH_TO_OR_ID`.
 """
 
 from __future__ import annotations
 
 import os
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -41,10 +45,8 @@ from scripts.pricing.base import (
     ProviderPricingResult,
     validate,
 )
-from scripts.pricing.model_ids import (
-    canonicalize_unqualified_model_id,
-    remember_upstream_id,
-)
+from scripts.pricing.manifest import write_discovered_chat_manifest
+from scripts.pricing.openai_catalog import discover_openai_chat_catalog
 from trusted_router.provider_lifecycle import (
     provider_model_retired,
     provider_price_microdollars,
@@ -52,6 +54,14 @@ from trusted_router.provider_lifecycle import (
 
 SLUG = "phala"
 URL = "https://api.redpill.ai/v1/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "phala.json"
+)
 
 EXPECTED_MODELS = [
     "openai/gpt-oss-120b",
@@ -59,6 +69,7 @@ EXPECTED_MODELS = [
     "z-ai/glm-5",
     "z-ai/glm-5.2",
     "moonshotai/kimi-k2.6",
+    "moonshotai/kimi-k3",
     "google/gemma-3-27b-it",
 ]
 
@@ -90,7 +101,17 @@ _NATIVE_TO_OR_ID = {
     "phala/mimo-v2-flash": "xiaomi/mimo-v2-flash",
     "phala/minimax-m2.5": "minimax/minimax-m2.5",
 }
-UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+_STANDARD_PASSTHROUGH_TO_OR_ID = {
+    # Direct visible-content canary passed on 2026-07-29. This is not a
+    # phala/* Confidential AI ID, so catalog_data.py forces Standard privacy.
+    "moonshotai/kimi-k3": "moonshotai/kimi-k3",
+}
+_DISCOVERED_ID_MAP = {
+    **_NATIVE_TO_OR_ID,
+    **_STANDARD_PASSTHROUGH_TO_OR_ID,
+}
+UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _DISCOVERED_ID_MAP.items()}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
 def _apply_lifecycle_policy(
@@ -120,30 +141,9 @@ def _apply_lifecycle_policy(
     return effective
 
 
-def _extract_rates(pricing: object) -> tuple[float, float, float | None] | None:
-    """Phala /v1/models pricing block is a flat dict of strings in
-    USD/token:
-        {"prompt": "0.00000032", "completion": "0.00000048",
-         "image": "0", "request": "0",
-         "input_cache_reads": "0", "input_cache_writes": "0"}
-    Return (prompt_per_token, completion_per_token,
-    cached_per_token) or None if structurally broken or zero rate.
-    Cached returns None when the published rate is 0 (no discount)
-    so downstream pricing doesn't store a literal free cache."""
-    if not isinstance(pricing, dict):
-        return None
-    try:
-        prompt = float(pricing.get("prompt") or 0)
-        completion = float(pricing.get("completion") or 0)
-        cached = float(pricing.get("input_cache_reads") or 0)
-    except (TypeError, ValueError):
-        return None
-    if prompt <= 0 or completion <= 0:
-        return None
-    return prompt, completion, (cached if cached > 0 else None)
-
-
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
     api_key = os.environ.get("PHALA_CONFIDENTIAL_API_KEY") or os.environ.get("PHALA_API_KEY")
     headers = {"User-Agent": PROVIDER_FETCH_UA, "Accept": "application/json"}
     if api_key:
@@ -158,38 +158,19 @@ def fetch() -> ProviderPricingResult:
         response.raise_for_status()
         payload = response.json()
     rows = payload.get("data") or []
-    prices: dict[str, ModelPrice] = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        native_id = row.get("id")
-        if not isinstance(native_id, str):
-            continue
-        # /v1/models mixes Phala's confidential `phala/*` endpoints with
-        # ordinary provider pass-through rows. Only the former are covered by
-        # this key and by the TEE claim. Never canonicalize an arbitrary row
-        # into a confidential route.
-        if not native_id.startswith("phala/"):
-            continue
-        or_id = _NATIVE_TO_OR_ID.get(native_id) or canonicalize_unqualified_model_id(native_id)
-        if or_id is None:
-            continue
-        remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
-        rates = _extract_rates(row.get("pricing"))
-        if rates is None:
-            continue
-        prompt_per_token, completion_per_token, cached_per_token = rates
-        prices[or_id] = ModelPrice(
-            prompt_micro_per_m=int(round(prompt_per_token * 1_000_000_000_000)),
-            completion_micro_per_m=int(round(completion_per_token * 1_000_000_000_000)),
-            prompt_cached_micro_per_m=(
-                int(round(cached_per_token * 1_000_000_000_000))
-                if cached_per_token is not None
-                else None
-            ),
-        )
+    if not isinstance(rows, list):
+        raise RuntimeError("phala: /v1/models response has no data list")
+    prices, discovered = discover_openai_chat_catalog(
+        [row for row in rows if isinstance(row, dict)],
+        explicit_map=_DISCOVERED_ID_MAP,
+        upstream_id_map=UPSTREAM_ID_MAP,
+        include=lambda row: row.get("id") in _DISCOVERED_ID_MAP,
+    )
 
     prices = _apply_lifecycle_policy(prices)
+    _DISCOVERED_MANIFEST_ROWS = {
+        model_id: row for model_id, row in discovered.items() if model_id in prices
+    }
     notes: list[str] = []
     errors = validate(prices, EXPECTED_MODELS)
     if errors:
@@ -201,4 +182,13 @@ def fetch() -> ProviderPricingResult:
         source="api",
         fetched_url=URL,
         notes=notes,
+    )
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=URL,
     )

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -134,6 +134,8 @@ from trusted_router.catalog_ingest import (  # noqa: F401 - used by import-time 
 # modules (#38); re-exported here so `from trusted_router.catalog import ...`
 # keeps working for every existing caller.
 from trusted_router.catalog_privacy import (  # noqa: F401 - re-exported for back-compat
+    endpoint_confidential_compute,
+    endpoint_e2ee,
     endpoint_privacy_tier,
     endpoint_stores_content,
     endpoint_zero_data_retention,
@@ -623,10 +625,8 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
                 "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
                 "privacy_tier": endpoint_privacy_tier(endpoint),
                 "privacy_tier_label": PRIVACY_TIER_LABELS[endpoint_privacy_tier(endpoint)],
-                "provider_confidential_compute": PROVIDERS[
-                    endpoint.provider
-                ].provider_confidential_compute,
-                "provider_e2ee": PROVIDERS[endpoint.provider].provider_e2ee,
+                "provider_confidential_compute": endpoint_confidential_compute(endpoint),
+                "provider_e2ee": endpoint_e2ee(endpoint),
                 "provider_policy": model_provider_policy(endpoint.model_id, endpoint.provider),
                 "provider_policy_url": model_provider_policy_url(
                     endpoint.model_id, endpoint.provider

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -86,6 +86,8 @@ PROVIDER_JURISDICTION_US = "US"
 class ModelProviderPrivacyOverride:
     privacy_tier: int
     provider_zero_data_retention: bool | None = None
+    provider_confidential_compute: bool | None = None
+    provider_e2ee: bool | None = None
     provider_policy: str | None = None
     provider_policy_url: str | None = None
 
@@ -143,6 +145,25 @@ _MODEL_PROVIDER_PRIVACY_OVERRIDES: dict[tuple[str, str], ModelProviderPrivacyOve
             "(capabilities.zdr.supported=false in their /v1/models). The "
             "route is served at standard tier and excluded from "
             "trustedrouter/zdr and provider.min_privacy=zdr routing."
+        ),
+    ),
+    (
+        "moonshotai/kimi-k3",
+        "phala",
+    ): ModelProviderPrivacyOverride(
+        privacy_tier=PRIVACY_TIER_STANDARD,
+        provider_zero_data_retention=False,
+        provider_confidential_compute=False,
+        provider_e2ee=False,
+        provider_policy=(
+            "Phala currently serves this model through the upstream-author "
+            "pass-through route, not a phala/* Confidential AI endpoint. "
+            "TrustedRouter therefore makes no ZDR, confidential-compute, or "
+            "E2EE claim for this exact route."
+        ),
+        provider_policy_url=(
+            "https://docs.phala.com/phala-cloud/confidential-ai/"
+            "confidential-model/confidential-ai-api"
         ),
     ),
     **{
@@ -451,9 +472,7 @@ PROVIDERS: dict[str, Provider] = {
             "on every routed request. The route is therefore not classified as "
             "provider E2EE and is excluded from trustedrouter/e2e."
         ),
-        provider_policy_url=(
-            "https://docs.phala.com/phala-cloud/confidential-ai/verify/overview"
-        ),
+        provider_policy_url=("https://docs.phala.com/phala-cloud/confidential-ai/verify/overview"),
     ),
     # SiliconFlow — Chinese serverless inference with 200+ open-weight
     # models. OpenAI-compatible at api.siliconflow.com/v1.
@@ -746,9 +765,7 @@ PROVIDERS: dict[str, Provider] = {
             "No provider-ZDR claim is tracked. StreamLake's public privacy "
             "policy is linked for API data-handling review."
         ),
-        provider_policy_url=(
-            "https://www.streamlake.ai/document/DOC/mgkci47q13qr66h9i54"
-        ),
+        provider_policy_url=("https://www.streamlake.ai/document/DOC/mgkci47q13qr66h9i54"),
         provider_headquarters_country="SG",
     ),
     "neurometric": Provider(
@@ -1629,6 +1646,7 @@ _PROVIDER_SERVED_MODEL_ALLOWLIST: dict[str, frozenset[str]] = {
     "gmi": frozenset(
         {
             "deepseek/deepseek-v4-pro",
+            "moonshotai/kimi-k3",
             "z-ai/glm-5",
             "z-ai/glm-5.1",
             "z-ai/glm-5.2",
@@ -1659,11 +1677,6 @@ _PROVIDER_UNSERVED_CREDITS_MODELS: dict[str, frozenset[str]] = {
         {
             "anthropic/claude-opus-4.7",
             "openai/gpt-5.5",
-            # 2026-07-18: GMI's authenticated /models feed still advertises
-            # Kimi K3, but direct prepaid inference returns 404 "No matching
-            # target server found". Keep BYOK visible for accounts with
-            # different capacity while removing the broken operator route.
-            "moonshotai/kimi-k3",
             # 2026-07-15: the snapshot route returns 404 when pinned to GMI.
             # Keep the directly verified Baseten route.
             "nvidia/nemotron-3-ultra-550b-a55b",

--- a/src/trusted_router/catalog_privacy.py
+++ b/src/trusted_router/catalog_privacy.py
@@ -92,6 +92,28 @@ def endpoint_zero_data_retention_scope(endpoint: ModelEndpoint) -> str | None:
     return "provider"
 
 
+def model_provider_confidential_compute(model_id: str, provider_slug: str) -> bool | None:
+    override = _model_provider_privacy_override(model_id, provider_slug)
+    if override is not None and override.provider_confidential_compute is not None:
+        return override.provider_confidential_compute
+    return PROVIDERS[provider_slug].provider_confidential_compute
+
+
+def model_provider_e2ee(model_id: str, provider_slug: str) -> bool | None:
+    override = _model_provider_privacy_override(model_id, provider_slug)
+    if override is not None and override.provider_e2ee is not None:
+        return override.provider_e2ee
+    return PROVIDERS[provider_slug].provider_e2ee
+
+
+def endpoint_confidential_compute(endpoint: ModelEndpoint) -> bool | None:
+    return model_provider_confidential_compute(endpoint.model_id, endpoint.provider)
+
+
+def endpoint_e2ee(endpoint: ModelEndpoint) -> bool | None:
+    return model_provider_e2ee(endpoint.model_id, endpoint.provider)
+
+
 def model_provider_zero_data_retention(model_id: str, provider_slug: str) -> bool | None:
     override = _model_provider_privacy_override(model_id, provider_slug)
     if override is not None and override.provider_zero_data_retention is not None:

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -29,11 +29,14 @@ from trusted_router.catalog import (
     ModelEndpoint,
     Provider,
     canonical_orchestration_model_id,
+    endpoint_confidential_compute,
+    endpoint_e2ee,
     endpoint_zero_data_retention,
     endpoints_for_model,
     meta_candidate_models,
     model_eu_focused_provider_available,
     model_open_weights,
+    model_provider_policy,
     model_us_provider_available,
     orchestration_primitive,
     orchestration_role,
@@ -2847,8 +2850,8 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
     endpoint_postures = {
         (
             endpoint_zero_data_retention(endpoint),
-            PROVIDERS[endpoint.provider].provider_confidential_compute,
-            PROVIDERS[endpoint.provider].provider_e2ee,
+            endpoint_confidential_compute(endpoint),
+            endpoint_e2ee(endpoint),
         )
         for endpoint in endpoints
     }
@@ -3046,10 +3049,14 @@ def _model_detail_view(
                     endpoint_zero_data_retention(endpoint) if ep_provider else None
                 ),
                 "provider_confidential_compute": (
-                    ep_provider.provider_confidential_compute if ep_provider else None
+                    endpoint_confidential_compute(endpoint) if ep_provider else None
                 ),
-                "provider_e2ee": ep_provider.provider_e2ee if ep_provider else None,
-                "provider_policy": ep_provider.provider_policy if ep_provider else "",
+                "provider_e2ee": endpoint_e2ee(endpoint) if ep_provider else None,
+                "provider_policy": (
+                    model_provider_policy(endpoint.model_id, endpoint.provider)
+                    if ep_provider
+                    else ""
+                ),
                 "endpoint_id": endpoint.id,
             }
         )
@@ -3072,9 +3079,7 @@ def _model_detail_view(
         "context_length_int": model.context_length,
         "fixed_price": fixed_price,
         "prompt_price": _price(model.prompt_price_microdollars_per_million_tokens),
-        "completion_price": _price(
-            model.completion_price_microdollars_per_million_tokens
-        ),
+        "completion_price": _price(model.completion_price_microdollars_per_million_tokens),
         "minimum_charge": (
             format_money_precise(model.minimum_charge_microdollars)
             if model.minimum_charge_microdollars
@@ -3418,10 +3423,9 @@ def _best_measured_ttft(model_id: str) -> int | None:
 
 def _privacy_summary(model: Model) -> str:
     endpoints = endpoints_for_model(model.id)
-    providers = [PROVIDERS.get(endpoint.provider) for endpoint in endpoints]
-    if any(provider and provider.provider_e2ee for provider in providers):
+    if any(endpoint_e2ee(endpoint) for endpoint in endpoints):
         return "has provider E2EE route"
-    if any(provider and provider.provider_confidential_compute for provider in providers):
+    if any(endpoint_confidential_compute(endpoint) for endpoint in endpoints):
         return "has confidential-compute route"
     if any(endpoint_zero_data_retention(endpoint) is True for endpoint in endpoints):
         return "has ZDR route"

--- a/src/trusted_router/data/provider_models/gmi.json
+++ b/src/trusted_router/data/provider_models/gmi.json
@@ -1,9 +1,9 @@
 {
-  "_about": "Provider-native supplement for GMI Cloud models whose live /v1/models feed is ahead of the shared snapshot. Verified against https://api.gmi-serving.com/v1/models on 2026-06-22. GMI exposes GLM 5.2 as zai-org/GLM-5.2-FP8.",
+  "_about": "Provider-native supplement for GMI Cloud models whose live /v1/models feed is ahead of the shared snapshot. Verified against https://api.gmi-serving.com/v1/models and direct chat canaries. Kimi K3 was promoted after a visible-content PONG canary succeeded on 2026-07-29.",
   "provider": "gmi",
   "source": "https://api.gmi-serving.com/v1/models",
-  "generated_at": "2026-06-22T00:00:00Z",
-  "model_count": 1,
+  "generated_at": "2026-07-29T21:30:00Z",
+  "model_count": 2,
   "models": [
     {
       "id": "z-ai/glm-5.2",
@@ -20,6 +20,34 @@
       "input_modalities": ["text"],
       "output_modalities": ["text"],
       "endpoints": ["chat/completions"],
+      "status": 1
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "upstream_id": "moonshotai/kimi-k3",
+      "display_name": "GMI Cloud Kimi K3",
+      "title": "moonshotai/kimi-k3",
+      "context_length": 262144,
+      "max_output_tokens": 65535,
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 300000,
+      "model_type": "chat",
+      "features": [
+        "reasoning",
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     }
   ]

--- a/src/trusted_router/data/provider_models/phala.json
+++ b/src/trusted_router/data/provider_models/phala.json
@@ -1,9 +1,9 @@
 {
-  "_about": "Provider-native supplement for Phala Confidential AI routes live ahead of the shared OpenRouter snapshot. Verified against https://api.redpill.ai/v1/models with the confidential tier key on 2026-06-22. The enclave maps z-ai/glm-5.2 to phala/glm-5.2 for the TEE tier.",
+  "_about": "Provider-native supplement for Phala routes live ahead of the shared snapshot. phala/* upstream IDs select the Confidential AI tier. Kimi K3 currently uses the separately classified upstream-author pass-through route and must not inherit the confidential or ZDR posture of phala/* routes.",
   "provider": "phala",
   "source": "https://api.redpill.ai/v1/models",
-  "generated_at": "2026-06-22T00:00:00Z",
-  "model_count": 1,
+  "generated_at": "2026-07-29T21:30:00Z",
+  "model_count": 2,
   "models": [
     {
       "id": "z-ai/glm-5.2",
@@ -20,6 +20,35 @@
       "input_modalities": ["text"],
       "output_modalities": ["text"],
       "endpoints": ["chat/completions"],
+      "status": 1
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "upstream_id": "moonshotai/kimi-k3",
+      "display_name": "Kimi K3 via Phala",
+      "title": "moonshotai/kimi-k3",
+      "context_length": 1048576,
+      "max_output_tokens": 65535,
+      "input_token_price_per_m": 3000000,
+      "output_token_price_per_m": 15000000,
+      "cached_input_token_price_per_m": 1500000,
+      "model_type": "chat",
+      "features": [
+        "reasoning",
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
       "status": 1
     }
   ]

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -11,6 +11,8 @@ from trusted_router.catalog import (
     PRIVACY_TIER_LABELS,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
+    endpoint_confidential_compute,
+    endpoint_e2ee,
     endpoint_privacy_tier,
     endpoint_stores_content,
     endpoint_zero_data_retention,
@@ -177,10 +179,8 @@ def register_catalog_routes(router: APIRouter) -> None:
                         "zero_data_retention_scope": endpoint_zero_data_retention_scope(endpoint),
                         "privacy_tier": endpoint_privacy_tier(endpoint),
                         "privacy_tier_label": PRIVACY_TIER_LABELS[endpoint_privacy_tier(endpoint)],
-                        "provider_confidential_compute": PROVIDERS[
-                            endpoint.provider
-                        ].provider_confidential_compute,
-                        "provider_e2ee": PROVIDERS[endpoint.provider].provider_e2ee,
+                        "provider_confidential_compute": endpoint_confidential_compute(endpoint),
+                        "provider_e2ee": endpoint_e2ee(endpoint),
                         "provider_headquarters_country": PROVIDERS[
                             endpoint.provider
                         ].provider_headquarters_country,

--- a/src/trusted_router/templates/public/provider_marketplace.html
+++ b/src/trusted_router/templates/public/provider_marketplace.html
@@ -34,9 +34,10 @@
     <p>Email <a href="mailto:providers@trustedrouter.com">providers@trustedrouter.com</a> from your company domain. The application must identify the legal entity, responsible contacts, privacy terms, and service being offered.</p>
     <ul class="check-list">
       <li><strong>Company identity.</strong> Legal name, brand or DBA, website, jurisdiction, entity type, and DUNS number.</li>
-      <li><strong>Company details.</strong> Registered address, operating address if different, business phone, and corporate tax ID such as EIN or VAT ID. Never send a personal tax identifier.</li>
+      <li><strong>Company details.</strong> Registered address, operating address if different, business phone, company registration number, EIN or VAT ID, and DUNS number. Never send a personal tax identifier.</li>
       <li><strong>Leadership.</strong> CEO name and title, authorized contract signer, and ownership or parent company where applicable.</li>
-      <li><strong>Contacts.</strong> Technical, security and privacy, legal, billing, and incident-response contacts.</li>
+      <li><strong>Primary contact.</strong> Name, title, company email, and direct business phone for the person responsible for the application.</li>
+      <li><strong>Operational contacts.</strong> Named technical, security and privacy, legal, billing, and incident-response contacts with titles, company email addresses, and phone numbers where available.</li>
       <li><strong>Policies.</strong> Privacy policy, terms, DPA, subprocessor list, security or trust center, and compliance reports or certifications.</li>
       <li><strong>Data handling.</strong> Retention period, training use, zero-retention terms, serving regions, data residency, and confidential-compute or attestation evidence.</li>
     </ul>
@@ -49,18 +50,25 @@ Brand / DBA:
 Website:
 Jurisdiction and entity type:
 DUNS number:
+Company registration number:
 Registered address:
 Operating address:
 Business phone:
-Corporate tax ID:
+EIN / VAT / corporate tax ID:
 CEO:
 Authorized contract signer:
 
-Technical contact:
-Security / privacy contact:
-Legal contact:
-Billing contact:
-Incident contact:
+Primary contact name:
+Primary contact title:
+Primary contact email:
+Primary contact phone:
+
+Technical contact name / title / email / phone:
+Security contact name / title / email / phone:
+Privacy contact name / title / email / phone:
+Legal contact name / title / email / phone:
+Billing contact name / title / email / phone:
+Incident contact name / title / email / phone:
 
 Privacy policy:
 Terms of service:

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -111,10 +111,12 @@ def test_dark_authoritative_manifest_rows_cannot_return_through_shared_snapshot(
 
 
 def test_gmi_only_credits_serves_allowlisted_models() -> None:
-    # GMI's /models listing is aspirational: 7d probes (2026-07-18) show four
+    # GMI's /models listing is aspirational: 7d probes (2026-07-18) showed four
     # models served on our account and ~45 listed phantoms with zero successes
-    # ever. Credits endpoints must stay within the verified set; BYOK uses the
-    # customer's own key and keeps GMI's full listing visible.
+    # ever. Kimi K3 joined the verified set after a direct visible-content
+    # canary passed on 2026-07-29. Credits endpoints must stay within the
+    # verified set; BYOK uses the customer's own key and keeps GMI's full
+    # listing visible.
     allow = _PROVIDER_SERVED_MODEL_ALLOWLIST["gmi"]
     gmi_credits = {
         e.model_id
@@ -124,6 +126,7 @@ def test_gmi_only_credits_serves_allowlisted_models() -> None:
     assert gmi_credits <= allow
     assert gmi_credits == {
         "deepseek/deepseek-v4-pro",
+        "moonshotai/kimi-k3",
         "z-ai/glm-5",
         "z-ai/glm-5.1",
         "z-ai/glm-5.2",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -100,8 +100,9 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert "moonshotai/kimi-k3@kimi/byok" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@novita/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@novita/byok" in MODEL_ENDPOINTS
-    assert "moonshotai/kimi-k3@gmi/prepaid" not in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@gmi/prepaid" in MODEL_ENDPOINTS
     assert "moonshotai/kimi-k3@gmi/byok" in MODEL_ENDPOINTS
+    assert "moonshotai/kimi-k3@phala/prepaid" in MODEL_ENDPOINTS
     kimi_k3_routes = {
         (endpoint.provider, endpoint.usage_type)
         for endpoint in endpoints_for_model("moonshotai/kimi-k3")

--- a/tests/test_kimi_k3_gmi_phala.py
+++ b/tests/test_kimi_k3_gmi_phala.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.pricing.providers import gmi
+from trusted_router.catalog import MODEL_ENDPOINTS
+from trusted_router.catalog_data import PRIVACY_TIER_STANDARD
+from trusted_router.catalog_privacy import (
+    endpoint_confidential_compute,
+    endpoint_e2ee,
+    endpoint_privacy_tier,
+    endpoint_stores_content,
+    endpoint_zero_data_retention,
+)
+
+KIMI_K3 = "moonshotai/kimi-k3"
+
+
+def test_gmi_hourly_parser_discovers_kimi_k3_exact_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "id": KIMI_K3,
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "input_cache_read": "0.0000003",
+                },
+            }
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(gmi.httpx, "Client", FakeClient)
+
+    result = gmi.fetch()
+
+    assert result.prices[KIMI_K3].prompt_micro_per_m == 3_000_000
+    assert result.prices[KIMI_K3].completion_micro_per_m == 15_000_000
+    assert result.prices[KIMI_K3].tiers[0].prompt_cached_micro_per_m == 300_000
+    assert gmi.UPSTREAM_ID_MAP[KIMI_K3] == KIMI_K3
+
+
+def test_gmi_kimi_k3_is_a_verified_prepaid_route() -> None:
+    endpoint = MODEL_ENDPOINTS[f"{KIMI_K3}@gmi/prepaid"]
+
+    assert endpoint.upstream_id == "moonshotai/kimi-k3"
+    assert endpoint.prompt_price_microdollars_per_million_tokens == 3_150_000
+    assert endpoint.completion_price_microdollars_per_million_tokens == 15_750_000
+
+
+def test_phala_kimi_k3_pass_through_is_standard_not_confidential() -> None:
+    endpoint = MODEL_ENDPOINTS[f"{KIMI_K3}@phala/prepaid"]
+
+    assert endpoint.upstream_id == "moonshotai/kimi-k3"
+    assert endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD
+    assert endpoint_stores_content(endpoint) is True
+    assert endpoint_zero_data_retention(endpoint) is False
+    assert endpoint_confidential_compute(endpoint) is False
+    assert endpoint_e2ee(endpoint) is False
+
+
+def test_kimi_k3_public_catalog_reports_route_specific_phala_posture(
+    client: TestClient,
+) -> None:
+    response = client.get("/v1/models/moonshotai/kimi-k3/endpoints")
+
+    assert response.status_code == 200
+    phala = next(
+        row
+        for row in response.json()["data"]
+        if row["provider"] == "phala" and row["usage_type"] == "Credits"
+    )
+    assert phala["upstream_id"] == "moonshotai/kimi-k3"
+    assert phala["trustedrouter"]["privacy_tier"] == PRIVACY_TIER_STANDARD
+    assert phala["trustedrouter"]["stores_content"] is True
+    assert phala["trustedrouter"]["provider_zero_data_retention"] is False
+    assert phala["trustedrouter"]["provider_confidential_compute"] is False
+    assert phala["trustedrouter"]["provider_e2ee"] is False
+    assert "pass-through" in phala["trustedrouter"]["provider_policy"].casefold()

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -33,20 +35,15 @@ def test_phala_retirements_switch_at_announced_instant() -> None:
         assert not provider_lifecycle.provider_model_retired(
             "phala", model_id, upstream_id, at=before
         )
-        assert provider_lifecycle.provider_model_retired(
-            "phala", model_id, upstream_id, at=_CUTOFF
-        )
+        assert provider_lifecycle.provider_model_retired("phala", model_id, upstream_id, at=_CUTOFF)
 
 
 def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
 
-    glm_providers = {
-        endpoint.provider for endpoint in endpoints_for_model("z-ai/glm-4.7")
-    }
+    glm_providers = {endpoint.provider for endpoint in endpoints_for_model("z-ai/glm-4.7")}
     qwen_providers = {
-        endpoint.provider
-        for endpoint in endpoints_for_model("qwen/qwen3-30b-a3b-instruct-2507")
+        endpoint.provider for endpoint in endpoints_for_model("qwen/qwen3-30b-a3b-instruct-2507")
     }
 
     assert "phala" not in glm_providers
@@ -73,19 +70,13 @@ def test_public_catalog_uses_effective_price_and_active_routes(
     qwen_endpoints = endpoints_for_model("qwen/qwen-2.5-7b-instruct")
     assert qwen_endpoints
     assert all(endpoint.provider != "phala" for endpoint in qwen_endpoints)
-    assert qwen_price["trustedrouter"][
-        "prompt_price_microdollars_per_million_tokens"
-    ] == min(
-        endpoint.prompt_price_microdollars_per_million_tokens
-        for endpoint in qwen_endpoints
+    assert qwen_price["trustedrouter"]["prompt_price_microdollars_per_million_tokens"] == min(
+        endpoint.prompt_price_microdollars_per_million_tokens for endpoint in qwen_endpoints
     )
 
-    retired_qwen = model_to_openrouter_shape(
-        MODELS["qwen/qwen3-30b-a3b-instruct-2507"]
-    )
+    retired_qwen = model_to_openrouter_shape(MODELS["qwen/qwen3-30b-a3b-instruct-2507"])
     assert all(
-        endpoint["provider"] != "phala"
-        for endpoint in retired_qwen["trustedrouter"]["endpoints"]
+        endpoint["provider"] != "phala" for endpoint in retired_qwen["trustedrouter"]["endpoints"]
     )
 
 
@@ -97,9 +88,7 @@ def test_phala_hourly_parser_applies_announced_policy() -> None:
         "z-ai/glm-5.2": ModelPrice(300_000, 2_000_000),
     }
 
-    before = phala._apply_lifecycle_policy(
-        prices, at=_CUTOFF - timedelta(microseconds=1)
-    )
+    before = phala._apply_lifecycle_policy(prices, at=_CUTOFF - timedelta(microseconds=1))
     after = phala._apply_lifecycle_policy(prices, at=_CUTOFF)
 
     assert set(before) == set(prices)
@@ -110,8 +99,9 @@ def test_phala_hourly_parser_applies_announced_policy() -> None:
     assert after["z-ai/glm-5.2"] == prices["z-ai/glm-5.2"]
 
 
-def test_phala_parser_only_publishes_explicit_confidential_routes(
+def test_phala_parser_publishes_confidential_routes_and_verified_k3_pass_through(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     payload = {
         "data": [
@@ -122,6 +112,20 @@ def test_phala_parser_only_publishes_explicit_confidential_routes(
             {
                 "id": "openai/gpt-5.5",
                 "pricing": {"prompt": "0.000005", "completion": "0.00003"},
+            },
+            {
+                "id": "moonshotai/kimi-k3",
+                "name": "Kimi K3",
+                "context_length": 1_048_576,
+                "max_output_length": 65_535,
+                "input_modalities": ["text", "image"],
+                "output_modalities": ["text"],
+                "supported_features": ["reasoning", "tools"],
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "input_cache_read": "0.0000015",
+                },
             },
             {
                 "id": "unmapped/ordinary-pass-through",
@@ -154,8 +158,50 @@ def test_phala_parser_only_publishes_explicit_confidential_routes(
 
     result = phala.fetch()
 
-    assert set(result.prices) == {"z-ai/glm-5.2"}
+    assert set(result.prices) == {"moonshotai/kimi-k3", "z-ai/glm-5.2"}
     assert phala.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "phala/glm-5.2"
+    assert phala.UPSTREAM_ID_MAP["moonshotai/kimi-k3"] == "moonshotai/kimi-k3"
+    assert result.prices["moonshotai/kimi-k3"] == ModelPrice(
+        3_000_000,
+        15_000_000,
+        prompt_cached_micro_per_m=1_500_000,
+    )
+    assert (
+        phala._DISCOVERED_MANIFEST_ROWS["moonshotai/kimi-k3"]["upstream_id"] == "moonshotai/kimi-k3"
+    )
+    assert "openai/gpt-5.5" not in phala._DISCOVERED_MANIFEST_ROWS
+
+    manifest_path = tmp_path / "phala.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "phala",
+                "models": [
+                    {
+                        "id": "z-ai/glm-5.2",
+                        "display_name": "GLM 5.2",
+                        "title": "phala/glm-5.2",
+                        "model_type": "chat",
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                        "endpoints": ["chat/completions"],
+                        "status": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(phala, "MANIFEST_PATH", manifest_path)
+
+    phala.write_provider_manifest(result)
+
+    written = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows_by_id = {row["id"]: row for row in written["models"]}
+    assert rows_by_id["moonshotai/kimi-k3"]["upstream_id"] == "moonshotai/kimi-k3"
+    assert rows_by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 3_000_000
+    assert "openai/gpt-5.5" not in rows_by_id
+    assert "unmapped/ordinary-pass-through" not in rows_by_id
 
 
 def test_non_confidential_phala_route_is_rejected_before_authorization(

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -21,7 +21,13 @@ def test_provider_onboarding_page_has_machine_readable_requirements(
     assert "DUNS number:" in response.text
     assert "Registered address:" in response.text
     assert "Business phone:" in response.text
-    assert "Corporate tax ID:" in response.text
+    assert "EIN / VAT / corporate tax ID:" in response.text
+    assert "Primary contact name:" in response.text
+    assert "Primary contact title:" in response.text
+    assert "Primary contact email:" in response.text
+    assert "Primary contact phone:" in response.text
+    assert "Company registration number:" in response.text
+    assert "Technical contact name / title / email / phone:" in response.text
     assert "CEO:" in response.text
     assert "Subprocessor list:" in response.text
     assert "Do not email an API key" in response.text


### PR DESCRIPTION
## Summary
- promote the directly verified GMI Kimi K3 route to prepaid
- add Phala Kimi K3 as an explicitly allowlisted Standard pass-through route
- prevent the Phala pass-through from inheriting confidential, E2EE, or ZDR claims
- make the hourly Phala parser safely persist the exact K3 route while rejecting arbitrary pass-throughs
- expand the provider marketplace intake with explicit company registration and named contact fields

## Validation
- 2,126 pytest tests passed; 61 skipped
- ruff clean
- mypy clean
- focused K3, lifecycle, catalog, and marketplace regression suite passed