### PR TITLE
deploy: enable the analytics outbox (stage 1 shadow)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -148,6 +148,18 @@ ENV_VARS=(
   # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
   # flag-off settle path is byte-identical.
   "TR_SETTLE_OUTBOX_ENABLED=true"
+  # Analytics outbox → ClickHouse (docs/storage-portability/analytics-ingestion.md
+  # stage 1). Enqueue is a SEPARATE transaction from settle and is best-effort:
+  # analytics is not worth destabilising money code for, and
+  # clickhouse/reconcile_benchmark_samples.py replays from Bigtable to repair
+  # anything dropped. Table DDL applied 2026-07-28 with a 7-day ROW DELETION
+  # POLICY, so a dead drainer cannot grow it without bound the way
+  # tr_settle_outbox and tr_entities did (#334). Ingester + reconciler run on
+  # tr-clickhouse-1 under systemd.
+  #
+  # This is a SHADOW: nothing reads from ClickHouse. Remove this line to
+  # revert — the flag-off path does not touch the outbox at all.
+  "TR_ANALYTICS_OUTBOX_ENABLED=true"
   # The first expand deployment defaults to legacy. After an explicit typed
   # cutover, preserve the primary region's live mode on later deploys unless an
   # operator overrides it. This prevents routine rollouts from reopening the


### PR DESCRIPTION
Flips `TR_ANALYTICS_OUTBOX_ENABLED=true` so `ProviderBenchmarkSample` rows actually flow to ClickHouse through the commit-timestamp outbox from #340.

## Why it's safe to flip now

- **Money path unchanged.** Enqueue is a *separate transaction* from gateway settle and is best-effort. The settle path is identical whether this is on or off.
- **Bounded by construction.** The outbox has a 7-day `ROW DELETION POLICY` (applied to production 2026-07-28). A dead drainer cannot grow it without bound — which is precisely how `tr_settle_outbox` reached ~549k rows and `tr_entities` ~9.4M with no policy at all (#334).
- **The consumer is already live.** Ingester and reconciler run on `tr-clickhouse-1` under systemd, verified: 60s poll, `drain_lag_seconds=0.000`, `clickhouse_insert_errors_total=0`.

## Still a shadow

**Nothing reads from ClickHouse.** Bigtable remains authoritative. Per-consumer differential proofs — route-health first, since it is the smallest surface — come before any read cutover.

## Revert

Delete the line. The flag-off path does not touch the outbox at all.

## What to watch after deploy

`analytics_outbox.metrics` on the node: `rows_per_second` should become non-zero, `drain_lag_seconds` should stay near zero, and `tr_analytics_outbox` row count should stay small (drain-then-delete). A climbing row count means the drainer is behind.