### PR TITLE
Add Alibaba Qwen 3.7 Flash routing

### DIFF
--- a/scripts/pricing/providers/alibaba.py
+++ b/scripts/pricing/providers/alibaba.py
@@ -17,6 +17,7 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_TRANSPORT_RETRIES,
     PROVIDER_FETCH_UA,
     ModelPrice,
+    PriceTier,
     ProviderPricingResult,
     validate,
 )
@@ -35,6 +36,7 @@ EXPECTED_MODELS = [
     "deepseek/deepseek-v4-pro",
     "qwen/qwen3.7-max",
     "qwen/qwen3.7-plus",
+    "qwen/qwen3.7-flash",
 ]
 
 
@@ -77,6 +79,29 @@ def _price(native_id: str) -> ModelPrice | None:
         prompt, completion, cached = 2.50, 7.50, 0.25
     elif model.startswith("qwen3.7-plus"):
         prompt, completion, cached = 0.40, 1.60, 0.04
+    elif model.startswith("qwen3.7-flash"):
+        return ModelPrice(
+            tiers=[
+                PriceTier(
+                    max_prompt_tokens=32_000,
+                    prompt_micro_per_m=30_000,
+                    completion_micro_per_m=130_000,
+                    prompt_cached_micro_per_m=6_000,
+                ),
+                PriceTier(
+                    max_prompt_tokens=256_000,
+                    prompt_micro_per_m=100_000,
+                    completion_micro_per_m=400_000,
+                    prompt_cached_micro_per_m=20_000,
+                ),
+                PriceTier(
+                    max_prompt_tokens=None,
+                    prompt_micro_per_m=200_000,
+                    completion_micro_per_m=800_000,
+                    prompt_cached_micro_per_m=40_000,
+                ),
+            ]
+        )
     elif model.startswith("qwen3.6-plus"):
         prompt, completion, cached = 0.50, 3.00, 0.05
     elif model.startswith("qwen3.6-flash"):

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -872,7 +872,7 @@ PROVIDERS: dict[str, Provider] = {
     "alibaba": Provider(
         slug="alibaba",
         name="Alibaba Cloud Model Studio",
-        supports_prepaid=False,
+        supports_prepaid=True,
         supports_byok=False,
         provider_policy=(
             "No provider-ZDR claim is tracked here. Alibaba Cloud Model Studio "
@@ -982,6 +982,7 @@ GATEWAY_PREPAID_PROVIDER_SLUGS = frozenset(
         "atlas-cloud",
         "streamlake",
         "neurometric",
+        "alibaba",
         "nebius",
         "minimax",
         # Cohere — embeddings only for now (native /v2/embed in the enclave).

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -701,6 +701,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "atlas-cloud",
         "streamlake",
         "neurometric",
+        "alibaba",
         "kimi",
         "zai",
         "tinfoil",

--- a/src/trusted_router/data/provider_models/alibaba.json
+++ b/src/trusted_router/data/provider_models/alibaba.json
@@ -5,8 +5,94 @@
   "price_source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
   "generated_at": "2026-07-01T00:00:00Z",
   "price_scale": "microdollars_per_million",
-  "model_count": 72,
+  "model_count": 74,
   "models": [
+    {
+      "id": "qwen/qwen3.7-flash",
+      "upstream_id": "qwen3.7-flash",
+      "display_name": "Qwen3.7 Flash",
+      "title": "qwen3.7-flash",
+      "created": 1784505600,
+      "context_length": 1048576,
+      "input_token_price_per_m": 30000,
+      "output_token_price_per_m": 130000,
+      "cached_input_token_price_per_m": 6000,
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 32000,
+          "input_token_price_per_m": 30000,
+          "output_token_price_per_m": 130000,
+          "cached_input_token_price_per_m": 6000
+        },
+        {
+          "max_prompt_tokens": 256000,
+          "input_token_price_per_m": 100000,
+          "output_token_price_per_m": 400000,
+          "cached_input_token_price_per_m": 20000
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 200000,
+          "output_token_price_per_m": 800000,
+          "cached_input_token_price_per_m": 40000
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-flash-2026-07-15",
+      "upstream_id": "qwen3.7-flash-2026-07-15",
+      "display_name": "Qwen3.7 Flash 2026 07 15",
+      "title": "qwen3.7-flash-2026-07-15",
+      "created": 1784073600,
+      "context_length": 1048576,
+      "input_token_price_per_m": 30000,
+      "output_token_price_per_m": 130000,
+      "cached_input_token_price_per_m": 6000,
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 32000,
+          "input_token_price_per_m": 30000,
+          "output_token_price_per_m": 130000,
+          "cached_input_token_price_per_m": 6000
+        },
+        {
+          "max_prompt_tokens": 256000,
+          "input_token_price_per_m": 100000,
+          "output_token_price_per_m": 400000,
+          "cached_input_token_price_per_m": 20000
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 200000,
+          "output_token_price_per_m": 800000,
+          "cached_input_token_price_per_m": 40000
+        }
+      ]
+    },
     {
       "id": "z-ai/glm-5.2",
       "upstream_id": "glm-5.2",

--- a/tests/test_alibaba_pricing.py
+++ b/tests/test_alibaba_pricing.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from scripts.pricing.base import ModelPrice, PriceTier
+from scripts.pricing.providers import alibaba
+
+
+def test_qwen_37_flash_uses_published_context_tiers() -> None:
+    expected = ModelPrice(
+        tiers=[
+            PriceTier(
+                max_prompt_tokens=32_000,
+                prompt_micro_per_m=30_000,
+                completion_micro_per_m=130_000,
+                prompt_cached_micro_per_m=6_000,
+            ),
+            PriceTier(
+                max_prompt_tokens=256_000,
+                prompt_micro_per_m=100_000,
+                completion_micro_per_m=400_000,
+                prompt_cached_micro_per_m=20_000,
+            ),
+            PriceTier(
+                max_prompt_tokens=None,
+                prompt_micro_per_m=200_000,
+                completion_micro_per_m=800_000,
+                prompt_cached_micro_per_m=40_000,
+            ),
+        ]
+    )
+
+    assert alibaba._price("qwen3.7-flash") == expected  # noqa: SLF001
+    assert alibaba._price("qwen3.7-flash-2026-07-15") == expected  # noqa: SLF001
+
+
+def test_qwen_37_flash_is_a_required_alibaba_model() -> None:
+    assert "qwen/qwen3.7-flash" in alibaba.EXPECTED_MODELS
+
+
+def test_qwen_37_flash_native_ids_are_canonicalized() -> None:
+    assert alibaba._canonical_model_id("qwen3.7-flash") == "qwen/qwen3.7-flash"  # noqa: SLF001
+    assert (  # noqa: SLF001
+        alibaba._canonical_model_id("qwen3.7-flash-2026-07-15")
+        == "qwen/qwen3.7-flash-2026-07-15"
+    )
+
+
+def test_fetch_discovers_flash_alias_and_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALIBABA_API_KEY", "test-key")
+
+    class FakeClient:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def get(self, url: str, *, headers: dict[str, str]) -> httpx.Response:
+            assert url == alibaba.URL
+            assert headers["Authorization"] == "Bearer test-key"
+            return httpx.Response(
+                200,
+                request=httpx.Request("GET", url),
+                json={
+                    "data": [
+                        {"id": "qwen3.7-flash"},
+                        {"id": "qwen3.7-flash-2026-07-15"},
+                        {"id": "qwen-unknown-unpriced"},
+                    ]
+                },
+            )
+
+    monkeypatch.setattr(alibaba.httpx, "Client", FakeClient)
+    monkeypatch.setattr(alibaba, "EXPECTED_MODELS", ["qwen/qwen3.7-flash"])
+
+    result = alibaba.fetch()
+
+    assert set(result.prices) == {
+        "qwen/qwen3.7-flash",
+        "qwen/qwen3.7-flash-2026-07-15",
+    }
+    assert alibaba.UPSTREAM_ID_MAP == {
+        "qwen/qwen3.7-flash": "qwen3.7-flash",
+        "qwen/qwen3.7-flash-2026-07-15": "qwen3.7-flash-2026-07-15",
+    }

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1079,7 +1079,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "alibaba",
     }.issubset(provider_flags)
     assert provider_flags["openai"]["supports_prepaid"] is True
-    assert provider_flags["alibaba"]["supports_prepaid"] is False
+    assert provider_flags["alibaba"]["supports_prepaid"] is True
     assert provider_flags["alibaba"]["supports_byok"] is False
     assert provider_flags["deepseek"]["supports_byok"] is True
     assert provider_flags["kimi"]["supports_byok"] is True

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -49,8 +49,8 @@ def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) ->
     assert "phala" not in glm_providers
     assert glm_providers
     assert "phala" not in qwen_providers
-    # Phala is currently the only live route for this exact Qwen revision.
-    assert not qwen_providers
+    # Alibaba still serves this exact Qwen revision after the Phala route retires.
+    assert qwen_providers == {"alibaba"}
 
 
 def test_non_confidential_phala_qwen_route_is_not_published() -> None:

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -709,21 +709,34 @@ def test_baseten_catalog_exposes_glm_52_fast_router() -> None:
     } == {220_500}
 
 
-def test_alibaba_catalog_is_staged_but_not_routable_until_entitled() -> None:
+def test_alibaba_catalog_is_routable_after_model_studio_activation() -> None:
     from trusted_router.catalog import GATEWAY_PREPAID_PROVIDER_SLUGS, PROVIDERS
 
-    # Alibaba /models works, but the current workspace key returns
-    # AccessDenied.Unpurchased for sampled chat calls. Keep the provider and
-    # manifest staged, but do not publish user-routable endpoints until the
-    # Model Studio workspace is entitled to the selected models.
     assert "alibaba" in PROVIDERS
-    assert PROVIDERS["alibaba"].supports_prepaid is False
+    assert PROVIDERS["alibaba"].supports_prepaid is True
     assert PROVIDERS["alibaba"].supports_byok is False
-    assert "alibaba" not in GATEWAY_PREPAID_PROVIDER_SLUGS
-    assert not [
+    assert "alibaba" in GATEWAY_PREPAID_PROVIDER_SLUGS
+    endpoints = [
         endpoint
-        for endpoint in endpoints_for_model("qwen/qwen3.5-397b-a17b")
+        for endpoint in endpoints_for_model("qwen/qwen3.7-flash")
         if endpoint.provider == "alibaba"
+    ]
+    assert len(endpoints) == 1
+    endpoint = endpoints[0]
+    assert endpoint.usage_type == "Credits"
+    assert endpoint.upstream_id == "qwen3.7-flash"
+    assert [
+        (
+            tier.max_prompt_tokens,
+            tier.prompt_price_microdollars_per_million_tokens,
+            tier.completion_price_microdollars_per_million_tokens,
+            tier.prompt_cached_price_microdollars_per_million_tokens,
+        )
+        for tier in endpoint.price_tiers
+    ] == [
+        (32_000, 31_500, 136_500, 10_000),
+        (256_000, 105_000, 420_000, 21_000),
+        (None, 210_000, 840_000, 42_000),
     ]
 
 


### PR DESCRIPTION
## Summary
- add Qwen 3.7 Flash and dated snapshot to the Alibaba catalog
- use official three-band input, output, and cache pricing
- enable prepaid Alibaba routes only, with exact upstream IDs
- extend hourly discovery so future Qwen 3.7 Flash snapshots are picked up

## Tests
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2156 passed, 76 skipped)

## Rollout gate
Draft until Alibaba Model Studio inference is activated and a direct provider-pinned PONG passes.