### PR TITLE
Fix Spanner alert hot row from public crawlers

### DIFF
--- a/docs/spanner-reliability.md
+++ b/docs/spanner-reliability.md
@@ -42,15 +42,18 @@ policy:
   incident immediately.
 - Successful billing calls taking at least 10 seconds are counted. More than
   two per minute for three consecutive minutes opens one incident.
-- More than 10 Spanner aborts per minute for three consecutive minutes opens
-  one early-pressure incident. The main contention policy remains at 100 per
-  minute for 10 minutes.
+- The general Spanner contention policy remains at 100 aborted commits per
+  minute for 10 minutes. It is intentionally separate because metadata,
+  rate-limit, and maintenance transactions must not be reported as
+  customer-facing billing degradation.
 
 Every condition reduces all regions and revisions into one time series. The
 log-based `5xx` policy rate-limits notifications to one every 30 minutes and
 auto-closes after 30 quiet minutes. Metric policies do not renotify while an
-incident remains open. The alerts use status, latency, path, and aggregate
-transaction metadata only; they never inspect or export prompts or outputs.
+incident remains open. Unauthenticated safe reads use a process-local
+rate-limit counter so a crawler cannot create a transactional Spanner hot row.
+The alerts use status, latency, path, and aggregate transaction metadata only;
+they never inspect or export prompts or outputs.
 
 ## Alert response
 
@@ -63,9 +66,11 @@ but does not repair transaction contention.
 ### Transaction contention
 
 Inspect Spanner transaction and lock insights. A high abort ratio or lock-wait
-rate generally means transactions repeatedly update the same keys. Check the
-billing shard distribution and recent schema or settlement changes before
-raising capacity again.
+rate generally means transactions repeatedly update the same keys. Decode the
+reported row key before assuming the billing ledger is involved. Check the
+billing shard distribution only when the hot row belongs to a billing table;
+otherwise repair the specific metadata or worker access pattern before raising
+capacity.
 
 ### Latency and API failures
 

--- a/scripts/deploy/gateway-alerts/billing-pressure.yaml
+++ b/scripts/deploy/gateway-alerts/billing-pressure.yaml
@@ -5,10 +5,10 @@ documentation:
   mimeType: text/markdown
   content: |
     The billing path is degrading before broad customer-visible failures.
-    Check authorize/settle latency, Spanner aborts, and lock insights. Decode
-    hot row keys, verify shard distribution, and run the typed billing audit.
-    This warning intentionally fires below the main Spanner contention page.
-    Runbook: docs/spanner-reliability.md.
+    Check authorize, settle, and refund latency, then inspect the matching
+    request IDs and Spanner transactions. General Spanner contention is paged
+    separately so unrelated metadata hot rows cannot masquerade as billing
+    impact. Runbook: docs/spanner-reliability.md.
 conditions:
   - displayName: "More than two successful 10-second billing calls per minute for 3 minutes"
     conditionThreshold:
@@ -19,19 +19,6 @@ conditions:
           crossSeriesReducer: REDUCE_SUM
       comparison: COMPARISON_GT
       thresholdValue: 2
-      duration: 180s
-      evaluationMissingData: EVALUATION_MISSING_DATA_INACTIVE
-      trigger:
-        count: 1
-  - displayName: "More than 10 aborted commits per minute for 3 minutes"
-    conditionThreshold:
-      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/transaction_stat/total/commit_attempt_count" AND metric.labels.status = "abort"'
-      aggregations:
-        - alignmentPeriod: 60s
-          perSeriesAligner: ALIGN_RATE
-          crossSeriesReducer: REDUCE_SUM
-      comparison: COMPARISON_GT
-      thresholdValue: 0.166666667
       duration: 180s
       evaluationMissingData: EVALUATION_MISSING_DATA_INACTIVE
       trigger:

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -6,9 +6,9 @@ HTTP middleware registers in order from outermost to innermost:
   2. canonical_public_host — keeps marketing URLs off www/status aliases.
   3. public_pageview — captures signed first-party attribution and emits
                        metadata-only public pageview events.
-  4. rate_limit  — enforces per-(key|ip|internal-token) windowed limits
-                   via STORE.hit_rate_limit; logs structured 429s with
-                   the request_id from (1).
+  4. rate_limit  — enforces process-local limits for anonymous safe reads and
+                   shared per-(key|ip|internal-token) limits for other traffic;
+                   logs structured 429s with the request_id from (1).
   5. security_headers — sets HSTS so browsers remember to skip http://
                         on subsequent visits.
 
@@ -24,6 +24,7 @@ it could be reused by other ASGI services in the same project.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -44,6 +45,8 @@ from trusted_router.auth import get_authorization_bearer
 from trusted_router.config import Settings
 from trusted_router.errors import error_response
 from trusted_router.storage import STORE
+from trusted_router.storage_models import RateLimitHit
+from trusted_router.storage_rate_limits import InMemoryRateLimits
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
@@ -84,6 +87,7 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
     """
 
     app.add_middleware(GZipMiddleware, minimum_size=1_000, compresslevel=6)
+    public_read_rate_limits = InMemoryRateLimits(lock=threading.RLock())
 
     @app.middleware("http")
     async def request_id_middleware(
@@ -241,7 +245,11 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         # drops the flag.
         if settings.read_only:
             return await call_next(request)
-        limited = _rate_limit_request(request, settings)
+        limited = _rate_limit_request(
+            request,
+            settings,
+            public_read_rate_limits=public_read_rate_limits,
+        )
         if limited is not None:
             return limited
         return await call_next(request)
@@ -277,7 +285,12 @@ def _canonical_public_url(settings: Settings, request: Request) -> str:
     return f"https://{settings.trusted_domain}{request.url.path}{suffix}"
 
 
-def _rate_limit_request(request: Request, settings: Settings) -> JSONResponse | None:
+def _rate_limit_request(
+    request: Request,
+    settings: Settings,
+    *,
+    public_read_rate_limits: InMemoryRateLimits,
+) -> JSONResponse | None:
     if not settings.rate_limit_enabled:
         return None
     path = request.url.path
@@ -290,21 +303,41 @@ def _rate_limit_request(request: Request, settings: Settings) -> JSONResponse | 
     internal_token = request.headers.get("x-trustedrouter-internal-token")
     user = request.headers.get("x-trustedrouter-user")
     ip = _client_ip(request)
-    if path.startswith(("/internal/", "/v1/internal/")):
+    # Public catalog and marketing reads are cacheable. A durable
+    # read-modify-write counter here turns one crawler into a single-row
+    # Spanner hotspot before the application can return the page. Use a
+    # process-local guard for safe anonymous reads; authenticated, internal,
+    # and state-changing requests remain on the shared application limiter.
+    public_read = (
+        request.method.upper() in {"GET", "HEAD", "OPTIONS"}
+        and not bearer
+        and not internal_token
+        and not user
+    )
+    hit_rate_limit: Callable[..., RateLimitHit]
+    if public_read:
+        namespace = "public_ip"
+        subject = _fingerprint(ip)
+        limit = settings.rate_limit_ip_per_window
+        hit_rate_limit = public_read_rate_limits.hit
+    elif path.startswith(("/internal/", "/v1/internal/")):
         namespace = "internal"
         subject = _fingerprint(internal_token or bearer or ip)
         limit = settings.rate_limit_internal_per_window
+        hit_rate_limit = STORE.hit_rate_limit
     elif bearer:
         namespace = "key"
         subject = _fingerprint(bearer)
         limit = settings.rate_limit_key_per_window
+        hit_rate_limit = STORE.hit_rate_limit
     else:
         namespace = "ip"
         subject = _fingerprint(user or ip)
         limit = settings.rate_limit_ip_per_window
+        hit_rate_limit = STORE.hit_rate_limit
 
     try:
-        hit = STORE.hit_rate_limit(
+        hit = hit_rate_limit(
             namespace=namespace,
             subject=subject,
             limit=limit,

--- a/src/trusted_router/storage_rate_limits.py
+++ b/src/trusted_router/storage_rate_limits.py
@@ -1,7 +1,7 @@
-"""Token-bucket rate limit counter for the in-memory store.
+"""Token-bucket rate limit counter for local/test and anonymous safe reads.
 
 Lives in its own module so storage.py doesn't carry the bucket-cleanup
-loop. Production Spanner version is in storage_gcp_rate_limits."""
+loop. Shared production counters are in storage_gcp_rate_limits."""
 
 from __future__ import annotations
 

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -20,7 +20,7 @@ def test_gateway_5xx_alert_is_immediate_and_debounced() -> None:
     assert "autoClose: 1800s" in policy
 
 
-def test_gateway_pressure_alert_warns_before_original_spanner_page() -> None:
+def test_gateway_pressure_alert_only_tracks_the_billing_path() -> None:
     pressure = (DEPLOY / "gateway-alerts" / "billing-pressure.yaml").read_text(
         encoding="utf-8"
     )
@@ -30,11 +30,12 @@ def test_gateway_pressure_alert_warns_before_original_spanner_page() -> None:
 
     assert "trustedrouter_gateway_billing_slow" in pressure
     assert "thresholdValue: 2" in pressure
-    assert pressure.count("duration: 180s") == 2
-    assert "thresholdValue: 0.166666667" in pressure
-    assert pressure.count("crossSeriesReducer: REDUCE_SUM") == 2
+    assert pressure.count("duration: 180s") == 1
+    assert pressure.count("crossSeriesReducer: REDUCE_SUM") == 1
     assert pressure.count("groupByFields:") == 0
     assert "EVALUATION_MISSING_DATA_INACTIVE" in pressure
+    assert "commit_attempt_count" not in pressure
+    assert 'resource.type = "spanner_instance"' not in pressure
 
     assert "thresholdValue: 1.666666667" in original
     assert "duration: 600s" in original

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -581,11 +581,69 @@ def test_rate_limit_returns_stable_openrouter_style_error(
     )
     limited_client = TestClient(limited_app)
     headers = {"x-forwarded-for": "203.0.113.9"}
-    assert limited_client.get("/v1/models", headers=headers).status_code == 200
-    second = limited_client.get("/v1/models", headers=headers)
+    assert limited_client.post("/v1/signup", headers=headers, json={}).status_code == 400
+    second = limited_client.post("/v1/signup", headers=headers, json={})
     assert second.status_code == 429
     assert second.json()["error"]["type"] == "rate_limited"
     assert second.headers["retry-after"]
+
+
+def test_unauthenticated_public_reads_do_not_write_rate_limit_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crawler must not turn cacheable catalog reads into a Spanner hot row."""
+    from trusted_router import middleware
+
+    calls: list[dict[str, object]] = []
+    original_hit_rate_limit = middleware.STORE.hit_rate_limit
+
+    def track_write(*_args, **kwargs):
+        calls.append(kwargs)
+        return original_hit_rate_limit(*_args, **kwargs)
+
+    app = create_app(Settings(environment="test", rate_limit_enabled=True))
+    client = TestClient(app)
+    monkeypatch.setattr(middleware.STORE, "hit_rate_limit", track_write)
+    headers = {"x-forwarded-for": "199.203.99.122"}
+
+    for path in (
+        "/",
+        "/models",
+        "/providers",
+        "/compare/models",
+        "/models/openai/gpt-5.2",
+        "/docs",
+    ):
+        response = client.get(path, headers=headers)
+        assert response.status_code == 200
+    assert calls == []
+
+
+def test_unauthenticated_public_reads_remain_locally_rate_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import storage_rate_limits
+
+    monkeypatch.setattr(
+        storage_rate_limits,
+        "utcnow",
+        lambda: dt.datetime(2026, 7, 30, 0, 18, 30, tzinfo=dt.UTC),
+    )
+    app = create_app(
+        Settings(
+            environment="test",
+            rate_limit_enabled=True,
+            rate_limit_ip_per_window=1,
+            rate_limit_window_seconds=60,
+        )
+    )
+    client = TestClient(app)
+    headers = {"x-forwarded-for": "199.203.99.122"}
+
+    assert client.get("/models", headers=headers).status_code == 200
+    second = client.get("/providers", headers=headers)
+    assert second.status_code == 429
+    assert second.json()["error"]["type"] == "rate_limited"
 
 
 def test_rate_limit_fails_open_on_store_error(monkeypatch) -> None:
@@ -610,10 +668,10 @@ def test_rate_limit_fails_open_on_store_error(monkeypatch) -> None:
     monkeypatch.setattr(middleware.STORE, "hit_rate_limit", boom)
     # Even an aggressive limit + a raising store: both requests pass through
     # (fail-open) — not 429, and crucially not 500.
-    first = client.get("/v1/models")
-    second = client.get("/v1/models")
-    assert first.status_code == 200
-    assert second.status_code == 200
+    first = client.post("/v1/signup", json={})
+    second = client.post("/v1/signup", json={})
+    assert first.status_code == 400
+    assert second.status_code == 400
 
 
 def test_production_config_fails_closed() -> None:


### PR DESCRIPTION
## Summary
- keep anonymous safe-read throttling process-local so crawlers cannot contend on one Spanner counter row
- preserve shared limits for authenticated, internal, and state-changing requests
- restrict the gateway billing-pressure alert to direct billing latency signals; general Spanner contention remains separately alerted
- document the incident response distinction and add regression coverage

## Incident evidence
- one crawler IP generated the hot `tr_entities(rate_limit, ip#...)` rows
- 1,587 aborted rate-limit transactions across the two hottest 10-minute windows
- gateway billing requests remained HTTP 200 and no gateway 5xx occurred

## Verification
- regression tests failed before the implementation and pass after it
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (`2154 passed, 76 skipped`)