### PR TITLE
Fix Spanner settlement outbox write hotspot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -554,3 +554,10 @@ jobs:
             | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('data',[])))")
           [[ "$count" -gt 100 ]] || { echo "/v1/models has only $count models, expected >100"; exit 1; }
           echo "smoke ok: homepage, liveness, readiness, regions, status, and $count catalog models"
+
+      - name: Retire legacy settle-outbox hotspot index
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/retire_settle_outbox_hot_index.sh

--- a/docs/design/durable-settle-outbox.md
+++ b/docs/design/durable-settle-outbox.md
@@ -148,11 +148,17 @@ what the inline attempt already resolved:
 | `lease_owner` / `leased_until` | STRING / TIMESTAMP | drain lease                          |
 | `created_at` / `updated_at` | TIMESTAMP |                                                   |
 | `terminal_at`        | TIMESTAMP    | NULL until repair is complete; starts 30-day TTL   |
+| `queue_shard`        | INT64        | generated stable hash of the PK, range 0–15         |
 
-DDL: guarded `CREATE TABLE` **and** a `CREATE INDEX` on `(status, next_attempt_at)`
-for the due-scan (a full-table scan under a whale burst is the very load the
-feature targets) — using the same `table_exists`/`index_exists` guards the
-typed-counter migration actually uses (SF10), not a hand-wave.
+DDL: guarded `CREATE TABLE` plus a generated stored `queue_shard`, and a
+`NULL_FILTERED` due index on `(queue_shard, next_attempt_at)`. Terminal rows set
+`next_attempt_at=NULL`, so completed history is absent from the index. The shard
+must lead the monotonic timestamp: an index on `(status, next_attempt_at)` sends
+every pending insert and immediate done transition to the same moving key range
+and becomes a Spanner write hotspot. A full-table scan under a whale burst is
+also unacceptable, so the drain forces the sparse sharded index. All DDL uses
+the same `table_exists`/`column_exists`/`index_exists` guards the typed-counter
+migration actually uses (SF10).
 
 ### 5.4 Enqueue ordering
 
@@ -235,7 +241,10 @@ lease-claims due `pending` rows and for each:
 
 ## 8. Rollout (default-off, Joseph-gated)
 
-1. Guarded additive DDL (table + `(status,next_attempt_at)` index) — safe pre-code.
+1. Guarded additive DDL (table + generated shard + sparse sharded due index) —
+   safe pre-code. Keep any legacy due index until every region has passed its
+   canary on code that forces the new index, then retire it after production
+   smoke succeeds.
 2. Merge the mechanism with `settle_outbox_enabled=False` **and the reaper guard
    active-but-inert** (an empty `tr_settle_outbox` makes `NOT EXISTS` always true,
    so the reaper is byte-identical to today). Dead code otherwise.
@@ -274,6 +283,29 @@ rate.
 - **Integration:** authorize → inline settle fails → reaper suppressed by the
   pending row → drain recovers the frozen charge → balance reflects real cost, not
   a free release; and the lost-to-reaper path alerts rather than silently "done".
+- **Index regression:** generated shards are non-null and bounded; done rows
+  clear `next_attempt_at`; due reads force the sparse sharded index; deployment
+  refuses to retire the legacy index before the generated column and replacement
+  index are fully readable.
+
+## 10.1 2026-07-30 production hotspot correction
+
+The first production schema used `(status, next_attempt_at)`. Synthetic monitor
+bursts exposed repeated settlement aborts, 10–16 second successful settle
+requests, and lock waits concentrated on the pending timestamp edge. At the
+time, 569,350 completed rows also remained in the non-null-filtered index.
+
+The correction is rolling-safe:
+
+1. Spanner generates `queue_shard` from immutable primary-key columns, so old
+   revisions need no write-path change.
+2. `tr_settle_outbox_due_v2` is null-filtered and begins with `queue_shard`.
+3. New code forces v2 for due scans.
+4. Regional canaries and production smoke run while both indexes exist.
+5. A guarded post-rollout script verifies v2 and drops the legacy index.
+
+Do not respond to this alert pattern by weakening billing latency thresholds or
+reducing synthetic coverage. The monitor exposed a real hot-path scaling defect.
 
 ## Appendix — review provenance
 
@@ -298,9 +330,9 @@ Read this first if you are continuing the outbox build.
 - **Increment 1 — native-table storage (dormant)** = PR #113 (branch
   `settle-outbox-storage`), codex **PASS** after 3 rounds, full suite 1216 green.
   Adds:
-  - `tr_settle_outbox` DDL (PK `(authorization_id, intent_kind)` + `(status,
-    next_attempt_at)` index) in `scripts/deploy/migrate_typed_counters.sh`
-    (idempotent/guarded; NOT auto-applied — an operator runs it).
+  - Historical v1 `tr_settle_outbox` DDL (PK `(authorization_id, intent_kind)` +
+    `(status, next_attempt_at)` index), superseded by the sharded sparse index in
+    §10.1.
   - `settle_outbox_enabled: bool = False` in `config.py`.
   - `SettleOutboxRow` in `storage_models.py` (frozen inputs: `actual_cost_micro`,
     `settle_origin`, `reservation_id`, `selected_endpoint_id`, `model_id`,

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -168,6 +168,44 @@ ensure_column() {
   fi
 }
 
+wait_generated_column_committed() {
+  local table="$1" col="$2" state=""
+  for _ in $(seq 1 360); do
+    state=$(gcloud spanner databases execute-sql "$DATABASE" \
+      --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+      --sql="SELECT SPANNER_STATE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE table_name='${table}' AND column_name='${col}'" \
+      --format='value(rows[0])' 2>/dev/null || true)
+    if [ "$state" = "COMMITTED" ]; then
+      log "${table}.${col} is committed"
+      return 0
+    fi
+    log "waiting for ${table}.${col} backfill (state=${state:-unknown})"
+    sleep 5
+  done
+  log "timed out waiting for ${table}.${col} to become committed"
+  return 1
+}
+
+wait_index_read_write() {
+  local name="$1" state=""
+  for _ in $(seq 1 360); do
+    state=$(gcloud spanner databases execute-sql "$DATABASE" \
+      --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+      --sql="SELECT INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES
+             WHERE index_name='${name}'" \
+      --format='value(rows[0])' 2>/dev/null || true)
+    if [ "$state" = "READ_WRITE" ]; then
+      log "${name} is read-write"
+      return 0
+    fi
+    log "waiting for ${name} backfill (state=${state:-unknown})"
+    sleep 5
+  done
+  log "timed out waiting for ${name} to become read-write"
+  return 1
+}
+
 # NOTE: Spanner forbids ADD COLUMN ... NOT NULL on an existing table, so the
 # usage columns are added NULLABLE with DEFAULT (0) (future writes default; old
 # rows read NULL until first touched — all readers COALESCE/None-guard). The
@@ -219,13 +257,35 @@ if table_exists tr_settle_outbox; then log "tr_settle_outbox exists, skip"; else
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
     terminal_at TIMESTAMP,
+    queue_shard INT64 NOT NULL AS (
+      MOD(
+        MOD(FARM_FINGERPRINT(CONCAT(authorization_id, '#', intent_kind)), 16) + 16,
+        16
+      )
+    ) STORED,
   ) PRIMARY KEY (authorization_id, intent_kind)"
 fi
 
-# Due-scan index: the drain reads pending rows whose next_attempt_at has passed.
-# Without it the whale-burst backlog the feature exists for would full-scan.
-if index_exists tr_settle_outbox_due; then log "tr_settle_outbox_due exists, skip"; else
-  apply_ddl "CREATE INDEX tr_settle_outbox_due ON tr_settle_outbox (status, next_attempt_at)"
+# Generate the queue shard from immutable PK columns. Old application revisions
+# omit this column on INSERT and are still rolling-safe because Spanner computes
+# it. Existing rows are backfilled by the schema operation before the new index
+# is created.
+ensure_column tr_settle_outbox queue_shard \
+  "INT64 NOT NULL AS (
+    MOD(
+      MOD(FARM_FINGERPRINT(CONCAT(authorization_id, '#', intent_kind)), 16) + 16,
+      16
+    )
+  ) STORED"
+wait_generated_column_committed tr_settle_outbox queue_shard
+
+# Sparse, write-distributed due index. Terminal rows have next_attempt_at=NULL,
+# so NULL_FILTERED keeps the completed history out of this index. The generated
+# shard precedes the monotonic timestamp to avoid a moving-edge write hotspot.
+if index_exists tr_settle_outbox_due_v2; then log "tr_settle_outbox_due_v2 exists, skip"; else
+  apply_ddl "CREATE NULL_FILTERED INDEX tr_settle_outbox_due_v2
+    ON tr_settle_outbox (queue_shard, next_attempt_at)"
 fi
+wait_index_read_write tr_settle_outbox_due_v2
 
 log "done"

--- a/scripts/deploy/retire_settle_outbox_hot_index.sh
+++ b/scripts/deploy/retire_settle_outbox_hot_index.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Retire the legacy status/timestamp settle-outbox index after all serving
+# regions run code that reads tr_settle_outbox_due_v2.
+#
+# This is intentionally a separate, post-rollout step. The additive migration
+# creates and backfills the generated shard plus v2 index before new code serves.
+# Keeping the old index through rollout preserves rollback compatibility; this
+# script removes it only after the regional canaries and production smoke pass.
+set -euo pipefail
+
+INSTANCE="${SPANNER_INSTANCE_ID:?set SPANNER_INSTANCE_ID}"
+DATABASE="${SPANNER_DATABASE_ID:?set SPANNER_DATABASE_ID}"
+PROJECT_ARG=()
+[ -n "${GCP_PROJECT_ID:-}" ] && PROJECT_ARG=(--project "${GCP_PROJECT_ID}")
+
+log() { printf '%s %s\n' "[retire_settle_outbox_hot_index]" "$*"; }
+
+sql_value() {
+  gcloud spanner databases execute-sql "$DATABASE" \
+    --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+    --sql="$1" --format='value(rows[0])'
+}
+
+v2_count="$(sql_value \
+  "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES
+   WHERE table_name='tr_settle_outbox'
+     AND index_name='tr_settle_outbox_due_v2'
+     AND is_null_filtered=true
+     AND index_state='READ_WRITE'")"
+if [ "${v2_count:-0}" != "1" ]; then
+  log "refusing: sparse sharded index tr_settle_outbox_due_v2 is not ready"
+  exit 1
+fi
+
+unsharded="$(sql_value \
+  "SELECT COUNT(*) FROM tr_settle_outbox
+   WHERE status='pending' AND queue_shard IS NULL")"
+if [ "${unsharded:-0}" != "0" ]; then
+  log "refusing: ${unsharded} pending rows have no generated queue shard"
+  exit 1
+fi
+
+# Exercise the exact sparse-index predicate before removing the rollback index.
+sql_value \
+  "SELECT COUNT(*) FROM tr_settle_outbox@{FORCE_INDEX=tr_settle_outbox_due_v2}
+   WHERE queue_shard IS NOT NULL
+     AND next_attempt_at IS NOT NULL
+     AND status='pending'
+     AND next_attempt_at <= CURRENT_TIMESTAMP()" >/dev/null
+
+legacy_count="$(sql_value \
+  "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES
+   WHERE table_name='tr_settle_outbox'
+     AND index_name='tr_settle_outbox_due'")"
+if [ "${legacy_count:-0}" = "0" ]; then
+  log "legacy index already absent"
+  exit 0
+fi
+
+log "dropping legacy unsharded index tr_settle_outbox_due"
+gcloud spanner databases ddl update "$DATABASE" \
+  --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+  --ddl="DROP INDEX tr_settle_outbox_due"
+log "done"

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -268,8 +268,12 @@ class SpannerSettleOutbox:
         now = _iso_now()
         with self._database.snapshot() as snapshot:
             rows = list(snapshot.execute_sql(
-                f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608 - fixed column list
-                "WHERE status='pending' AND next_attempt_at <= @now "
+                f"SELECT {', '.join(OUTBOX_COLUMNS)} "  # noqa: S608 - fixed column list
+                "FROM tr_settle_outbox"
+                "@{FORCE_INDEX=tr_settle_outbox_due_v2} "
+                "WHERE queue_shard IS NOT NULL "
+                "AND next_attempt_at IS NOT NULL "
+                "AND status='pending' AND next_attempt_at <= @now "
                 "ORDER BY next_attempt_at LIMIT @limit",
                 params={"now": now, "limit": int(limit)},
                 param_types={"now": self._pt.TIMESTAMP, "limit": self._pt.INT64},

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -743,7 +743,12 @@ class _FakeTransaction:
             vkey = ("outbox", pk)
             if vkey not in self.read_versions:
                 self.read_versions[vkey] = self.db.settle_outbox_versions.get(pk, 0)
-            self.pending_writes.append(("insert_settle_outbox", pk, dict(p)))
+            record = dict(p)
+            # Production defines this as a generated stored column. The fake
+            # only needs the same non-null/range contract, not FarmHash parity.
+            shard_source = f"{p['authorization_id']}#{p['intent_kind']}".encode()
+            record["queue_shard"] = sum(shard_source) % 16
+            self.pending_writes.append(("insert_settle_outbox", pk, record))
             return 1
         if sql.startswith("UPDATE tr_settle_outbox SET settle_origin="):  # enqueue refresh
             # SQL-SENSITIVE (codex #113 finding 1): assert every load-bearing
@@ -989,12 +994,21 @@ def _execute_settle_outbox_sql(
         ):
             values.append(rec.get("reservation_id"))
         return [values]
-    if "WHERE status='pending' AND next_attempt_at <= @now" in sql:  # due scan
+    if "next_attempt_at <= @now" in sql and "ORDER BY next_attempt_at" in sql:
+        _require_pred(
+            sql,
+            "FORCE_INDEX=tr_settle_outbox_due_v2",
+            "due-scan-index",
+        )
+        _require_pred(sql, "queue_shard IS NOT NULL", "due-scan-shard")
+        _require_pred(sql, "next_attempt_at IS NOT NULL", "due-scan-sparse")
+        _require_pred(sql, "status='pending'", "due-scan-status")
         now = p["now"]
         limit = int(p.get("limit", 100))
         rows = [
             rec for rec in db.settle_outbox.values()
             if rec.get("status") == "pending"
+            and rec.get("queue_shard") is not None
             and rec.get("next_attempt_at") is not None
             and rec["next_attempt_at"] <= now
         ]

--- a/tests/test_settle_outbox_index_retirement.py
+++ b/tests/test_settle_outbox_index_retirement.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/deploy/retire_settle_outbox_hot_index.sh"
+
+
+def _fake_gcloud(tmp_path: Path) -> tuple[Path, Path]:
+    marker = tmp_path / "ddl.txt"
+    executable = tmp_path / "gcloud"
+    executable.write_text(
+        """#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+args = " ".join(sys.argv[1:])
+if "execute-sql" in args:
+    if "tr_settle_outbox_due_v2" in args and "INFORMATION_SCHEMA.INDEXES" in args:
+        print(os.environ.get("FAKE_V2_COUNT", "1"))
+    elif "queue_shard IS NULL" in args:
+        print(os.environ.get("FAKE_UNSHARDED", "0"))
+    elif "FORCE_INDEX=tr_settle_outbox_due_v2" in args:
+        print("0")
+    elif "tr_settle_outbox_due" in args and "INFORMATION_SCHEMA.INDEXES" in args:
+        print(os.environ.get("FAKE_LEGACY_COUNT", "1"))
+    else:
+        raise SystemExit(f"unexpected execute-sql: {args}")
+elif "databases ddl update" in args:
+    Path(os.environ["FAKE_DDL_MARKER"]).write_text(args)
+else:
+    raise SystemExit(f"unexpected gcloud command: {args}")
+"""
+    )
+    executable.chmod(0o755)
+    return executable, marker
+
+
+def _run(tmp_path: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    _fake_gcloud(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "SPANNER_INSTANCE_ID": "instance",
+        "SPANNER_DATABASE_ID": "database",
+        "GCP_PROJECT_ID": "project",
+        "FAKE_DDL_MARKER": str(tmp_path / "ddl.txt"),
+        **overrides,
+    }
+    return subprocess.run(  # noqa: S603 - executes the checked-in deploy script.
+        [str(SCRIPT)],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_retirement_drops_legacy_index_after_all_guards_pass(tmp_path: Path) -> None:
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    ddl = (tmp_path / "ddl.txt").read_text()
+    assert "--ddl=DROP INDEX tr_settle_outbox_due" in ddl
+
+
+def test_retirement_refuses_when_v2_is_not_ready(tmp_path: Path) -> None:
+    result = _run(tmp_path, FAKE_V2_COUNT="0")
+
+    assert result.returncode != 0
+    assert "is not ready" in result.stdout
+    assert not (tmp_path / "ddl.txt").exists()
+
+
+def test_retirement_refuses_unsharded_pending_rows(tmp_path: Path) -> None:
+    result = _run(tmp_path, FAKE_UNSHARDED="2")
+
+    assert result.returncode != 0
+    assert "pending rows have no generated queue shard" in result.stdout
+    assert not (tmp_path / "ddl.txt").exists()
+
+
+def test_retirement_is_idempotent_when_legacy_index_is_absent(
+    tmp_path: Path,
+) -> None:
+    result = _run(tmp_path, FAKE_LEGACY_COUNT="0")
+
+    assert result.returncode == 0
+    assert "legacy index already absent" in result.stdout
+    assert not (tmp_path / "ddl.txt").exists()

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -8,6 +8,8 @@ drain worker, and frozen-cost finalize primitive land in later increments.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tests.fakes.spanner import _execute_settle_outbox_sql, _FakeTransaction, make_fake_store
@@ -17,6 +19,7 @@ from trusted_router.storage_gcp_settle_outbox import (
     ENQ_INSERTED,
     ENQ_LEASED,
     ENQ_REFRESHED,
+    OUTBOX_COLUMNS,
     SpannerSettleOutbox,
 )
 from trusted_router.storage_models import SettleOutboxRow
@@ -41,7 +44,7 @@ def _row(aid: str, *, kind: str = "settle", cost: int = 1000, origin: str = "typ
 
 
 def test_enqueue_inserts_and_get_returns_frozen_inputs() -> None:
-    store, _db, _ = make_fake_store()
+    store, database, _ = make_fake_store()
     ob = _outbox(store)
     assert ob.enqueue(_row("gwa-1", cost=4200)) == ENQ_INSERTED
     got = ob.get("gwa-1", "settle")
@@ -51,6 +54,7 @@ def test_enqueue_inserts_and_get_returns_frozen_inputs() -> None:
     assert got.settle_origin == "typed"
     assert got.reservation_id == "res-gwa-1"
     assert got.selected_usage_type == "Credits"
+    assert 0 <= database.settle_outbox[("gwa-1", "settle")]["queue_shard"] < 16
 
 
 def test_enqueue_is_idempotent_and_refreshes_a_pending_row() -> None:
@@ -101,7 +105,10 @@ def test_mark_done_settles_and_drops_out_of_due() -> None:
     [job] = ob.claim(lease_seconds=300)
     assert ob.mark("gwa-6", "settle", done=True, lease_owner=job.lease_owner) == "done"
     assert ob.due() == []
-    assert ob.get("gwa-6", "settle").status == "done"
+    done = ob.get("gwa-6", "settle")
+    assert done is not None
+    assert done.status == "done"
+    assert done.next_attempt_at is None
 
 
 def test_mark_failure_backs_off_then_dies_at_max_attempts() -> None:
@@ -205,6 +212,18 @@ def test_fake_is_sql_sensitive_dropped_predicate_fails() -> None:
             "AND status='pending'",  # dropped the leased_until fence
             params={"owner": "x", "lease": "z", "now": "z", "aid": "gwa-12", "kind": "settle"},
         )
+    # A due query must stay pinned to the sparse sharded index. Accidentally
+    # dropping the hint can silently restore the production moving-edge scan.
+    with pytest.raises(AssertionError, match="due-scan-index"):
+        _execute_settle_outbox_sql(
+            db,
+            None,
+            f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608
+            "WHERE queue_shard IS NOT NULL AND next_attempt_at IS NOT NULL "
+            "AND status='pending' AND next_attempt_at <= @now "
+            "ORDER BY next_attempt_at LIMIT @limit",
+            {"now": "z", "limit": 10},
+        )
     # A mark query missing the PK key predicate must FAIL — real Spanner would
     # update every matching pending row, not the single pk (codex #113 re-review).
     with pytest.raises(AssertionError, match="mark"):
@@ -255,3 +274,34 @@ def test_has_intent_freezes_on_pending_and_dead_only() -> None:
     # release_approved (human ok'd freeing) does NOT freeze.
     db.settle_outbox[("gwa-10", "settle")]["status"] = "release_approved"
     assert ob.has_intent("gwa-10") is False
+
+
+def test_outbox_schema_uses_generated_shard_and_sparse_due_index() -> None:
+    root = Path(__file__).parents[1]
+    migration = (root / "scripts/deploy/migrate_typed_counters.sh").read_text()
+    retirement = (
+        root / "scripts/deploy/retire_settle_outbox_hot_index.sh"
+    ).read_text()
+    workflow = (root / ".github/workflows/deploy.yml").read_text()
+
+    assert "queue_shard INT64 NOT NULL AS (" in migration
+    assert "FARM_FINGERPRINT(CONCAT(authorization_id, '#', intent_kind))" in migration
+    assert "CREATE NULL_FILTERED INDEX tr_settle_outbox_due_v2" in migration
+    assert "ON tr_settle_outbox (queue_shard, next_attempt_at)" in migration
+    assert "CREATE INDEX tr_settle_outbox_due ON" not in migration
+    assert migration.index(
+        "wait_generated_column_committed tr_settle_outbox queue_shard"
+    ) < migration.index("CREATE NULL_FILTERED INDEX tr_settle_outbox_due_v2")
+    assert migration.index("wait_index_read_write tr_settle_outbox_due_v2") > (
+        migration.index("CREATE NULL_FILTERED INDEX tr_settle_outbox_due_v2")
+    )
+    assert "index_state='READ_WRITE'" in retirement
+    assert retirement.index("tr_settle_outbox_due_v2") < retirement.index(
+        "DROP INDEX tr_settle_outbox_due"
+    )
+    assert retirement.index("queue_shard IS NULL") < retirement.index(
+        "DROP INDEX tr_settle_outbox_due"
+    )
+    assert workflow.index("Smoke test prod") < workflow.index(
+        "Retire legacy settle-outbox hotspot index"
+    )


### PR DESCRIPTION
## Root cause

The legacy `tr_settle_outbox_due(status, next_attempt_at)` index concentrates every pending insert and immediate done transition on one monotonic key range. It also indexes 569,350 completed rows because it is not null-filtered. Synthetic monitoring bursts exposed this as repeated transaction aborts and 10-16 second successful `/internal/gateway/settle` requests.

## Fix

- add a rolling-safe generated 16-way queue shard
- add a null-filtered `(queue_shard, next_attempt_at)` due index
- force drain reads through the sparse sharded index
- retire the legacy index only after regional canaries and prod smoke pass
- add fail-closed migration and retirement tests

## Verification

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2155 passed, 76 skipped)
- `bash -n` on both migration scripts
- workflow YAML parsed successfully