### PR TITLE
Escalate stuck activity repairs to dead; gate reshard unpause on at_target

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -518,7 +518,7 @@ Outcome cheat-sheet:
 | `reservation_missing` | Dead plus alert; investigate missing reservation state. |
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
-| `resolved_zero_cost_elsewhere` | Benign $0 race (reaper free-release or a refund won); done, no page. A row already mid-activity-repair is NOT resolved here — it keeps retrying the index instead, so its payload survives. |
+| `resolved_zero_cost_elsewhere` | Benign $0 race (reaper free-release or a refund won); done, no page. The activity index is attempted first whenever the row carries a generation, so this outcome means the index SUCCEEDED; if it fails the row stays `activity_pending` and keeps its payload. |
 | `activity_pending` | Charge committed but the Bigtable activity-index write failed. Parks every 60s without burning attempts. After 6 hours of *continuous* activity failure the row goes `dead` with `ALERT settle outbox activity repair expired`. See below. |
 
 `activity_pending` is the one outcome where the terminal transition is NOT a
@@ -541,8 +541,11 @@ clobbering it, so typed-outage time counts toward the window and the six hours
 is a genuine bound; without that, alternating activity and typed failures would
 reset it forever, since `park()` never burns attempts. A generic apply error
 does rewrite `last_error` and restart the window, but that path burns an
-attempt, so `max_attempts=8` bounds it. A cluster of expired rows means Bigtable
-writes were failing for six continuous hours; a single one usually does not.
+attempt, so `max_attempts=8` bounds it. Read an expired row precisely: activity
+stayed unrepaired for six hours and the most recent index attempt failed. It
+does NOT prove Bigtable was failing throughout — typed-outage time ages the
+stamp too, so some of that window may be time Bigtable was never attempted.
+Check Bigtable health directly rather than inferring it from the alert.
 
 **The row goes `dead`, not `done` — and that is the point.** `mark(done=True)`
 NULLs `settle_body`, and for a gateway/typed request that payload is normally
@@ -834,10 +837,11 @@ inspects, it never applies.) Then:
   `prepare --apply` with the same arguments; it is idempotent. The usual blocker
   is open holds that had not drained, and since settle keeps running while
   paused, waiting a few minutes and re-running is normally enough. Then run
-  `finish --apply`. When `prepare` fails on drain specifically it exits **2**
-  (retry shortly, nothing is wrong) rather than **1**; note that argument and
-  workspace-resolution errors also exit 2, so confirm from the printed
-  `BLOCKED:` lines rather than the code alone.
+  `finish --apply`. Exit **2** means the *credit ledger* was still draining
+  (retry shortly, nothing is wrong); an API-key drain blocker exits **1**, as do
+  argument and workspace-resolution errors. So read the printed `BLOCKED:` lines
+  rather than the exit code alone — a `wait for drain` reason on a key line is
+  just as retriable as one on the credit line, despite the different code.
 - **`at_target=True` but `ready=False`** → the transition DID land and
   verification found something else wrong. Re-running `prepare` will not help;
   it re-inspects and returns the same unready status. Read the `BLOCKED:` lines

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -518,6 +518,7 @@ Outcome cheat-sheet:
 | `reservation_missing` | Dead plus alert; investigate missing reservation state. |
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
+| `resolved_zero_cost_elsewhere` | Benign $0 race (reaper free-release or a refund won); done, no page. A row already mid-activity-repair is NOT resolved here — it keeps retrying the index instead, so its payload survives. |
 | `activity_pending` | Charge committed but the Bigtable activity-index write failed. Parks every 60s without burning attempts. After 6 hours of *continuous* activity failure the row goes `dead` with `ALERT settle outbox activity repair expired`. See below. |
 
 `activity_pending` is the one outcome where the terminal transition is NOT a
@@ -533,10 +534,13 @@ Two things about this outcome are easy to get wrong:
 the first `ACTIVITY_PENDING` observation, carried forward in the park note
 (`last_error` = `bigtable activity index pending since=<ts>`). A row that sat
 behind a typed-store outage for a day and then fails its Bigtable write once has
-a *fresh* window. A `park_typed_unavailable` in between resets it, deliberately:
-a typed-store outage is not activity-failure time and must not consume this
-budget. So a cluster of expired rows means Bigtable writes were failing for six
-continuous hours; a single one usually does not.
+a *fresh* window. Anything that rewrites `last_error` restarts it — a
+`park_typed_unavailable`, or any generic apply error — which is deliberate for
+the outage case: typed-store-outage time is not activity-failure time. So read
+the bound as **six hours per uninterrupted run**, not six hours absolute; the
+overall bound comes from `max_attempts=8`, because a generic error (unlike a
+park) burns an attempt. A cluster of expired rows means Bigtable writes were
+failing for six continuous hours; a single one usually does not.
 
 **The row goes `dead`, not `done` — and that is the point.** `mark(done=True)`
 NULLs `settle_body`, and for a gateway/typed request that payload is the only
@@ -567,11 +571,19 @@ Repairing `ALERT settle outbox activity repair expired` (the alert carries
      --sql="UPDATE tr_settle_outbox SET status='pending', next_attempt_at=CURRENT_TIMESTAMP(),
             lease_owner=NULL, leased_until=NULL, last_error=NULL
             WHERE authorization_id='<authorization_id>' AND intent_kind='settle'
-            AND status='dead'"
+            AND status='dead' AND last_error='activity_repair_expired'"
    ```
 
-   Clearing `last_error` restarts the six-hour window, which is what you want
-   after a fix. The row settles idempotently; it will not double-charge.
+   The `last_error='activity_repair_expired'` predicate is load-bearing: it scopes
+   the re-arm to THIS cause, so a mistyped or stale authorization id cannot
+   silently resurrect an `already_released_free`, `reservation_missing`, or
+   `invalid_row` dead row — those are money questions that must stay frozen for a
+   human. If the statement reports 0 rows updated, you have the wrong row or the
+   wrong cause; do not widen the predicate to make it match.
+
+   Clearing `last_error` restarts the repair window, which is what you want after
+   a fix. Replay is safe: the row hits the reservation claim gate, sees the prior
+   charge, and only retries the index — it will not double-charge.
 3. Confirm the row reached `done` and the request appears in the workspace's
    activity view.
 
@@ -765,8 +777,8 @@ Symptom: every request from exactly ONE workspace returns
 tenant is healthy. Key creation for that workspace fails the same way
 (`assert_workspace_billing_active` guards authorize/validate and every
 key-minting path). Settle is deliberately NOT guarded, so in-flight work still
-finalizes — a paused workspace drains to zero holds rather than stranding
-money.
+finalizes rather than stranding money. It does not follow that holds always
+reach zero — see the frozen-hold case below.
 
 The near-certain cause is a **reshard that ran `prepare --apply` but never
 reached `finish`**: the runner died, the workflow was cancelled, or the operator
@@ -814,7 +826,7 @@ inspects, it never applies.) Then:
   re-verifies the whole shard set and only then clears `billing_paused`,
   refusing with `ERROR: refusing to unpause; ...` if anything is unclean or not
   at the target.
-- **Anything else** → the transition did not complete. Re-run
+- **`at_target=False`** → the transition did not complete. Re-run
   `prepare --apply` with the same arguments; it is idempotent. The usual blocker
   is open holds that had not drained, and since settle keeps running while
   paused, waiting a few minutes and re-running is normally enough. Then run
@@ -822,6 +834,30 @@ inspects, it never applies.) Then:
   (retry shortly, nothing is wrong) rather than **1**; note that argument and
   workspace-resolution errors also exit 2, so confirm from the printed
   `BLOCKED:` lines rather than the code alone.
+- **`at_target=True` but `ready=False`** → the transition DID land and
+  verification found something else wrong. Re-running `prepare` will not help;
+  it re-inspects and returns the same unready status. Read the `BLOCKED:` lines
+  and fix the named condition.
+
+**If the holds never drain, stop waiting and check the settle outbox.** A
+`pending` or `dead` outbox row deliberately excludes its reservation from the
+reaper (`_REAP_SCAN_GUARDED_SQL`), so a frozen row pins an unsettled hold
+indefinitely and `wait for drain` can never succeed on its own:
+
+```bash
+gcloud spanner databases execute-sql trusted-router \
+  --instance=trusted-router-nam6 --project=quill-cloud-proxy \
+  --sql="SELECT o.authorization_id, o.intent_kind, o.status, o.last_error
+         FROM tr_settle_outbox o JOIN tr_reservation r
+           ON r.authorization_id = o.authorization_id
+         WHERE r.workspace_id='<workspace_id>' AND r.settled=false
+           AND o.status IN ('pending','dead')"
+```
+
+Resolve those rows first — see
+[Settle outbox](#settle-outbox) — then re-run `prepare --apply`. This is a
+correctness feature, not a deadlock to force past: the hold is frozen because a
+money question about it is still open.
 
 Mutating operations need `--apply` locally, or `confirmation: APPLY` in the
 workflow. They differ: locally, omitting `--apply` runs a real dry run

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -518,36 +518,62 @@ Outcome cheat-sheet:
 | `reservation_missing` | Dead plus alert; investigate missing reservation state. |
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
-| `activity_pending` | Charge committed but the Bigtable activity index write failed. Parks every 60s without burning attempts for up to 6 hours, then escalates: marks the row `done` and emits `ALERT settle outbox activity repair expired`. See below. |
+| `activity_pending` | Charge committed but the Bigtable activity-index write failed. Parks every 60s without burning attempts. After 6 hours of *continuous* activity failure the row goes `dead` with `ALERT settle outbox activity repair expired`. See below. |
 
-`activity_pending` is the one outcome where a terminal transition is NOT a money
-problem. The charge already committed in Spanner (the billing source of truth)
-before the index attempt; only the per-request Bigtable activity row is missing,
-so the customer is billed correctly but the request may be absent from their
-activity view. The row escalates to `done` rather than `dead` deliberately —
-`dead` is a guard status that freezes the hold and keeps `terminal_at` NULL, and
-freezing an already-settled hold buys nothing while deferring retention forever.
+`activity_pending` is the one outcome where the terminal transition is NOT a
+money problem. The charge already committed in Spanner (the billing source of
+truth) *before* the index attempt — `ACTIVITY_PENDING` is only returned after
+typed finalize reported `SETTLED`. The customer is billed correctly; only the
+per-request Bigtable activity row is missing, so the request may be absent from
+their activity view.
 
-On `ALERT settle outbox activity repair expired`: the alert carries the
-`authorization_id`, `generation_id`, `request_id`, and `reservation_id`. Repair
-the missing activity row with the reconcile endpoint (see the
-[Spanner or Bigtable is degraded](#storage-degraded) section):
+Two things about this outcome are easy to get wrong:
 
-```bash
-curl -X POST https://trustedrouter.com/v1/internal/reconcile/generation-activity \
-  -H "Authorization: Bearer $TR_INTERNAL_GATEWAY_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"workspace_id":"<workspace_id>","date":"<YYYY-MM-DD>","limit":10000}'
-```
+**The window measures continuous activity failure, not row age.** It starts at
+the first `ACTIVITY_PENDING` observation, carried forward in the park note
+(`last_error` = `bigtable activity index pending since=<ts>`). A row that sat
+behind a typed-store outage for a day and then fails its Bigtable write once has
+a *fresh* window. A `park_typed_unavailable` in between resets it, deliberately:
+a typed-store outage is not activity-failure time and must not consume this
+budget. So a cluster of expired rows means Bigtable writes were failing for six
+continuous hours; a single one usually does not.
 
-Get `<workspace_id>` from the reservation named in the alert; `date` is the UTC
-day the generation was created and narrows the scan (omit it to sweep the
-workspace).
+**The row goes `dead`, not `done` — and that is the point.** `mark(done=True)`
+NULLs `settle_body`, and for a gateway/typed request that payload is the only
+repair evidence there is: typed finalize deliberately skips the generic
+`generation` / `generation_by_workspace` entity writes, and
+`POST /internal/reconcile/generation-activity` repairs by scanning
+`generation_by_workspace`. **That endpoint therefore repairs nothing for these
+rows** — it is for legacy `add()` callers. Do not reach for it here. `dead`
+preserves `settle_body`, stops the drain re-doing the full apply every 60s, and
+puts the row in the `status='dead'` queue that is already monitored above.
+Retention stays pinned (`terminal_at` NULL) on the reservation and gateway
+authorization, which is correct: those records are the evidence a human needs.
+Pinning is now bounded by operator response instead of unbounded.
 
-A single expired row is a transient Bigtable failure that outlived the window;
-repair it and move on. A *cluster* of them means Bigtable writes were failing
-for longer than 6 hours — check Bigtable health before repairing, or the repair
-writes will fail too.
+Repairing `ALERT settle outbox activity repair expired` (the alert carries
+`authorization_id`, `generation_id`, `request_id`, `reservation_id`):
+
+1. Fix the underlying Bigtable problem first — check the
+   `bigtable.activity_index_write_failed` logs for this `generation_id` and the
+   [Spanner or Bigtable is degraded](#storage-degraded) section. Re-driving the
+   row before Bigtable is healthy just fails again.
+2. Re-arm the row. `settle_body` is intact on a `dead` row, so the drain can
+   simply retry it — `due()` selects `status='pending' AND next_attempt_at <= now`:
+
+   ```bash
+   gcloud spanner databases execute-sql trusted-router \
+     --instance=trusted-router-nam6 --project=quill-cloud-proxy \
+     --sql="UPDATE tr_settle_outbox SET status='pending', next_attempt_at=CURRENT_TIMESTAMP(),
+            lease_owner=NULL, leased_until=NULL, last_error=NULL
+            WHERE authorization_id='<authorization_id>' AND intent_kind='settle'
+            AND status='dead'"
+   ```
+
+   Clearing `last_error` restarts the six-hour window, which is what you want
+   after a fix. The row settles idempotently; it will not double-charge.
+3. Confirm the row reached `done` and the request appears in the workspace's
+   activity view.
 
 Monitoring signals:
 
@@ -742,11 +768,12 @@ key-minting path). Settle is deliberately NOT guarded, so in-flight work still
 finalizes — a paused workspace drains to zero holds rather than stranding
 money.
 
-The near-certain cause is a **reshard that ran `prepare` but never reached
-`finish`**: the runner died, the workflow was cancelled, or the operator walked
-away. `prepare` pauses the workspace first, and every one of its exits — success
-and failure alike — leaves it paused on purpose. This is fail-safe, not a bug:
-an unverified shard set must not take live traffic.
+The near-certain cause is a **reshard that ran `prepare --apply` but never
+reached `finish`**: the runner died, the workflow was cancelled, or the operator
+walked away. Once `prepare --apply` has paused the workspace, every subsequent
+exit — success and failure alike — leaves it paused on purpose. This is
+fail-safe, not a bug: an unverified shard set must not take live traffic. (A
+dry run, without `--apply`, returns before pausing and cannot cause this.)
 
 Confirm the cause before touching anything. The pause reason names it:
 
@@ -771,27 +798,39 @@ PYTHONPATH=src uv run python scripts/shard_workspace.py status --workspace <work
 ```
 
 `<N>` must be the SAME target shard count the interrupted run used. It prints
-`current_shards`, `target_shards`, `ready`, `applied`, the typed totals, open
-reservations, and a `BLOCKED:` line per unmet precondition, then one line per API
-key. Then:
+`current_shards`, `target_shards`, `ready`, `at_target`, `applied`, the typed
+totals, open reservations, and a `BLOCKED:` line per unmet precondition, then one
+line per API key. Booleans print as `True`/`False`.
 
-- **`ready=true` on the credit row and every key** → the transition already
-  landed; only the unpause is missing. Run `finish` with the same `--shards <N>`
-  (and the same `--preserve-open-holds` value). `finish` re-verifies the whole
-  shard set and only then clears `billing_paused`; it refuses with
-  `ERROR: refusing to unpause; ...` if anything is unclean.
-- **`ready=false`** → the transition did not complete. Re-run `prepare` with the
-  same arguments. It is idempotent and re-pauses; the usual blocker is open holds
-  that had not drained, and since settle keeps running while paused, waiting a
-  few minutes and re-running is normally enough. Then run `finish`.
-  `prepare` distinguishes the two cases by exit code: **2 = still draining**
-  (retry shortly, nothing is wrong), **1 = a real failure** (read the `BLOCKED:`
-  lines before retrying).
+**Read `at_target`, not `ready`.** `ready` only means "nothing blocks a
+reshard" — a drained, healthy, paused workspace still at 1 shard is `ready=True`
+against a target of 16. `at_target` is the one that says the ledger actually
+adopted the target count. (`applied` is always `False` here: `status` only
+inspects, it never applies.) Then:
 
-Both mutating operations need `--apply` locally, or `confirmation: APPLY` in the
-workflow dispatch; without it they dry-run and change nothing. `finish` without
-`--apply` is the ideal rehearsal — it runs the complete verification and prints
-`DRY-RUN: would unpause this verified workspace` without touching the pause.
+- **`at_target=True` and `ready=True` on the credit row and every key** → the
+  transition landed; only the unpause is missing. Run `finish --apply` with the
+  same `--shards <N>` and the same `--preserve-open-holds` value. `finish`
+  re-verifies the whole shard set and only then clears `billing_paused`,
+  refusing with `ERROR: refusing to unpause; ...` if anything is unclean or not
+  at the target.
+- **Anything else** → the transition did not complete. Re-run
+  `prepare --apply` with the same arguments; it is idempotent. The usual blocker
+  is open holds that had not drained, and since settle keeps running while
+  paused, waiting a few minutes and re-running is normally enough. Then run
+  `finish --apply`. When `prepare` fails on drain specifically it exits **2**
+  (retry shortly, nothing is wrong) rather than **1**; note that argument and
+  workspace-resolution errors also exit 2, so confirm from the printed
+  `BLOCKED:` lines rather than the code alone.
+
+Mutating operations need `--apply` locally, or `confirmation: APPLY` in the
+workflow. They differ: locally, omitting `--apply` runs a real dry run
+(`finish` without `--apply` performs the complete verification and prints
+`DRY-RUN: would unpause this verified workspace` without touching the pause —
+the ideal rehearsal). In the *workflow*, omitting `confirmation: APPLY` on a
+mutating operation is refused outright with
+`Mutation refused: type APPLY in confirmation` and exit 2 — it does not dry-run.
+Dispatch `operation: status` for a read-only look via the workflow.
 
 `finish` is the ONLY way back to serving traffic. Do not hand-clear
 `billing_paused` and do not hand-set shard columns — both bypass the shard-set
@@ -802,9 +841,10 @@ Two things that look like this but are not: the workflow serializes on
 `concurrency: production-billing-workspace-reshard`, so a second dispatch waits
 rather than racing a half-finished workspace — a queued run is expected, not a
 symptom. And a key with an exact lifetime cap (`limit_microdollars` set) is
-pinned to `usage_shards=1` by design; `status` prints
-`exact lifetime cap; keeping usage_shards=1` for it and that is not a `BLOCKED`
-condition.
+pinned to `usage_shards=1` by design, so it correctly reports
+`current_shards=1 target_shards=1 at_target=True` even when the workspace target
+is 16 — that is not a failure. (`prepare` prints
+`exact lifetime cap; keeping usage_shards=1` for such a key; `status` does not.)
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -523,29 +523,33 @@ Outcome cheat-sheet:
 
 `activity_pending` is the one outcome where the terminal transition is NOT a
 money problem. The charge already committed in Spanner (the billing source of
-truth) *before* the index attempt — `ACTIVITY_PENDING` is only returned after
-typed finalize reported `SETTLED`. The customer is billed correctly; only the
-per-request Bigtable activity row is missing, so the request may be absent from
-their activity view.
+truth) *before* the index attempt. It is reached both from a fresh `SETTLED`
+finalize and from the `ALREADY_SETTLED` replay branches, so seeing it on a
+replay is normal. The customer is billed correctly; only the per-request
+Bigtable activity row is missing, so the request may be absent from their
+activity view.
 
 Two things about this outcome are easy to get wrong:
 
-**The window measures continuous activity failure, not row age.** It starts at
-the first `ACTIVITY_PENDING` observation, carried forward in the park note
-(`last_error` = `bigtable activity index pending since=<ts>`). A row that sat
-behind a typed-store outage for a day and then fails its Bigtable write once has
-a *fresh* window. Anything that rewrites `last_error` restarts it — a
-`park_typed_unavailable`, or any generic apply error — which is deliberate for
-the outage case: typed-store-outage time is not activity-failure time. So read
-the bound as **six hours per uninterrupted run**, not six hours absolute; the
-overall bound comes from `max_attempts=8`, because a generic error (unlike a
-park) burns an attempt. A cluster of expired rows means Bigtable writes were
-failing for six continuous hours; a single one usually does not.
+**The window measures continuous unrepaired-activity time, not row age.** It
+starts at the first `ACTIVITY_PENDING` observation and is carried forward in the
+park note (`last_error` = `bigtable activity index pending since=<ts>`). A row
+that sat behind a typed-store outage for a day and then fails its Bigtable write
+once has a *fresh* window — the clock is about the activity failure, not the
+row. A `park_typed_unavailable` **preserves** an existing stamp rather than
+clobbering it, so typed-outage time counts toward the window and the six hours
+is a genuine bound; without that, alternating activity and typed failures would
+reset it forever, since `park()` never burns attempts. A generic apply error
+does rewrite `last_error` and restart the window, but that path burns an
+attempt, so `max_attempts=8` bounds it. A cluster of expired rows means Bigtable
+writes were failing for six continuous hours; a single one usually does not.
 
 **The row goes `dead`, not `done` — and that is the point.** `mark(done=True)`
-NULLs `settle_body`, and for a gateway/typed request that payload is the only
-repair evidence there is: typed finalize deliberately skips the generic
-`generation` / `generation_by_workspace` entity writes, and
+NULLs `settle_body`, and for a gateway/typed request that payload is normally
+the only repair evidence there is: typed finalize skips the generic
+`generation` / `generation_by_workspace` entity writes (the legacy
+request-record compatibility fallback still writes them, so a rolling-legacy
+workspace may have them), and
 `POST /internal/reconcile/generation-activity` repairs by scanning
 `generation_by_workspace`. **That endpoint therefore repairs nothing for these
 rows** — it is for legacy `add()` callers. Do not reach for it here. `dead`

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -25,6 +25,7 @@ Index:
 - [Settle outbox: flip, verify, monitor, roll back](#settle-outbox)
 - [Credit ledger operations (single typed book)](#credit-ledger)
 - [Sentry "Aborted ... deadlock/wounded" burst on gateway authorize](#authorize-deadlock-burst)
+- [One workspace 503s "Workspace billing is paused" (interrupted reshard)](#reshard-interrupted)
 - [DNS-vendor-split symptoms (Cloudflare vs Cloud DNS)](#dns-vendor-split)
 
 ---
@@ -517,6 +518,36 @@ Outcome cheat-sheet:
 | `reservation_missing` | Dead plus alert; investigate missing reservation state. |
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
+| `activity_pending` | Charge committed but the Bigtable activity index write failed. Parks every 60s without burning attempts for up to 6 hours, then escalates: marks the row `done` and emits `ALERT settle outbox activity repair expired`. See below. |
+
+`activity_pending` is the one outcome where a terminal transition is NOT a money
+problem. The charge already committed in Spanner (the billing source of truth)
+before the index attempt; only the per-request Bigtable activity row is missing,
+so the customer is billed correctly but the request may be absent from their
+activity view. The row escalates to `done` rather than `dead` deliberately —
+`dead` is a guard status that freezes the hold and keeps `terminal_at` NULL, and
+freezing an already-settled hold buys nothing while deferring retention forever.
+
+On `ALERT settle outbox activity repair expired`: the alert carries the
+`authorization_id`, `generation_id`, `request_id`, and `reservation_id`. Repair
+the missing activity row with the reconcile endpoint (see the
+[Spanner or Bigtable is degraded](#storage-degraded) section):
+
+```bash
+curl -X POST https://trustedrouter.com/v1/internal/reconcile/generation-activity \
+  -H "Authorization: Bearer $TR_INTERNAL_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workspace_id":"<workspace_id>","date":"<YYYY-MM-DD>","limit":10000}'
+```
+
+Get `<workspace_id>` from the reservation named in the alert; `date` is the UTC
+day the generation was created and narrows the scan (omit it to sweep the
+workspace).
+
+A single expired row is a transient Bigtable failure that outlived the window;
+repair it and move on. A *cluster* of them means Bigtable writes were failing
+for longer than 6 hours — check Bigtable health before repairing, or the repair
+writes will fail too.
 
 Monitoring signals:
 
@@ -698,6 +729,82 @@ the operator. Before activating spreading on any workspace, confirm the
 credit-shard rebalance fix is deployed (a negative per-shard headroom from an
 overage settle must return a clean 402, never a `_RebalanceInvariantError`
 500 — fixed 2026-07).
+
+---
+
+## <a id="reshard-interrupted"></a>One workspace 503s "Workspace billing is paused" (interrupted reshard)
+
+Symptom: every request from exactly ONE workspace returns
+`503 Workspace billing is paused` with `Retry-After: 30`, while every other
+tenant is healthy. Key creation for that workspace fails the same way
+(`assert_workspace_billing_active` guards authorize/validate and every
+key-minting path). Settle is deliberately NOT guarded, so in-flight work still
+finalizes — a paused workspace drains to zero holds rather than stranding
+money.
+
+The near-certain cause is a **reshard that ran `prepare` but never reached
+`finish`**: the runner died, the workflow was cancelled, or the operator walked
+away. `prepare` pauses the workspace first, and every one of its exits — success
+and failure alike — leaves it paused on purpose. This is fail-safe, not a bug:
+an unverified shard set must not take live traffic.
+
+Confirm the cause before touching anything. The pause reason names it:
+
+```bash
+gcloud spanner databases execute-sql trusted-router \
+  --instance=trusted-router-nam6 --project=quill-cloud-proxy \
+  --sql="SELECT body FROM tr_entities WHERE kind='workspace' AND id='<workspace_id>'"
+```
+
+`body` is the workspace JSON; read its `billing_paused` and
+`billing_pause_reason` fields. `"billing_pause_reason": "credit-row reshard
+prepare"` is the interrupted-reshard signature. Any other reason means someone
+paused this workspace for a different purpose — stop and find out why before
+unpausing.
+
+**Recovery.** Read the shard state first (read-only, safe at any time — this is
+the `status` operation of `.github/workflows/reshard-billing-workspace.yml`, or
+locally):
+
+```bash
+PYTHONPATH=src uv run python scripts/shard_workspace.py status --workspace <workspace_id> --shards <N>
+```
+
+`<N>` must be the SAME target shard count the interrupted run used. It prints
+`current_shards`, `target_shards`, `ready`, `applied`, the typed totals, open
+reservations, and a `BLOCKED:` line per unmet precondition, then one line per API
+key. Then:
+
+- **`ready=true` on the credit row and every key** → the transition already
+  landed; only the unpause is missing. Run `finish` with the same `--shards <N>`
+  (and the same `--preserve-open-holds` value). `finish` re-verifies the whole
+  shard set and only then clears `billing_paused`; it refuses with
+  `ERROR: refusing to unpause; ...` if anything is unclean.
+- **`ready=false`** → the transition did not complete. Re-run `prepare` with the
+  same arguments. It is idempotent and re-pauses; the usual blocker is open holds
+  that had not drained, and since settle keeps running while paused, waiting a
+  few minutes and re-running is normally enough. Then run `finish`.
+  `prepare` distinguishes the two cases by exit code: **2 = still draining**
+  (retry shortly, nothing is wrong), **1 = a real failure** (read the `BLOCKED:`
+  lines before retrying).
+
+Both mutating operations need `--apply` locally, or `confirmation: APPLY` in the
+workflow dispatch; without it they dry-run and change nothing. `finish` without
+`--apply` is the ideal rehearsal — it runs the complete verification and prints
+`DRY-RUN: would unpause this verified workspace` without touching the pause.
+
+`finish` is the ONLY way back to serving traffic. Do not hand-clear
+`billing_paused` and do not hand-set shard columns — both bypass the shard-set
+verification that is the entire point of the two-phase design, and a workspace
+serving on an unverified shard set can under-count spend across sub-ledgers.
+
+Two things that look like this but are not: the workflow serializes on
+`concurrency: production-billing-workspace-reshard`, so a second dispatch waits
+rather than racing a half-finished workspace — a queued run is expected, not a
+symptom. And a key with an exact lifetime cap (`limit_microdollars` set) is
+pinned to `usage_shards=1` by design; `status` prints
+`exact lifetime cap; keeping usage_shards=1` for it and that is not a `BLOCKED`
+condition.
 
 ---
 

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -79,7 +79,7 @@ def _print_status(status: CreditReshardResult) -> None:
     print(
         f"{status.workspace_id}: current_shards={status.current_shard_count} "
         f"target_shards={status.target_shard_count} ready={status.ready} "
-        f"applied={status.applied}"
+        f"at_target={status.at_target} applied={status.applied}"
     )
     print(
         "  typed totals: "
@@ -103,6 +103,7 @@ def _print_key_status(status: KeyUsageReshardResult) -> None:
     print(
         f"  key {status.key_hash}: current_shards={status.current_shard_count} "
         f"target_shards={status.target_shard_count} ready={status.ready} "
+        f"at_target={status.at_target} "
         f"applied={status.applied} usage={status.usage_micro} "
         f"byok_usage={status.byok_usage_micro} reserved={status.reserved_micro}"
     )
@@ -161,7 +162,9 @@ def _verify_keys(
             preserve_open_holds=preserve_open_holds,
         )
         _print_key_status(status)
-        clean = clean and status.ready
+        # Same distinction as the credit row: a key that has not been resharded
+        # yet is `ready` for its target without being AT it.
+        clean = clean and status.ready and status.at_target
     return clean
 
 
@@ -270,6 +273,18 @@ def run_finish(store: Any, args: argparse.Namespace) -> int:
     _print_status(status)
     if not status.ready:
         print("ERROR: refusing to unpause; reshard verification is not clean", file=sys.stderr)
+        return 1
+    # `ready` alone does not mean the transition landed: a drained, paused,
+    # healthy workspace is `ready` for a target it has not moved to yet.
+    # Unpausing on `ready` alone would resume traffic while reporting a shard
+    # count the ledger never adopted.
+    if not status.at_target:
+        print(
+            "ERROR: refusing to unpause; credit ledger is at "
+            f"{status.current_shard_count} shards, not the requested "
+            f"{status.target_shard_count}. Run prepare first.",
+            file=sys.stderr,
+        )
         return 1
     if not _verify_keys(
         store,

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -283,9 +283,13 @@ def _apply_typed(
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
         if row.actual_cost_micro == 0:
             # Deliberately index every available generation, including a genuine
-            # zero-cost reaper/refund race. This writes only the Bigtable
-            # activity index, never a Spanner billing record, so the money path
-            # is untouched. A park-note discriminator is unsound: inline settle,
+            # zero-cost reaper/refund race. This writes no billing state: the
+            # reservation already returned ALREADY_SETTLED, so no credit or key
+            # counter moves. It is not activity-ONLY though — index_after_commit
+            # also records a provider benchmark and, when enabled, enqueues an
+            # analytics-outbox event. Both are non-billing and at-least-once by
+            # design with stable ids, so a replay overwrites rather than
+            # duplicates. A park-note discriminator is unsound: inline settle,
             # a lost lease before park(), and operator re-arm can all leave a
             # repairable row without the note, causing silent destruction of its
             # only typed payload. An accurate $0 activity row is better evidence

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -60,12 +60,6 @@ class ApplyOutcome:
     ERROR = "error"
 
 
-def activity_repair_in_progress(row: SettleOutboxRow) -> bool:
-    return isinstance(row.last_error, str) and row.last_error.startswith(
-        _ACTIVITY_PARK_NOTE
-    )
-
-
 def normalized_prompt_accounting(
     provider_slug: str, body: GatewaySettleRequest
 ) -> tuple[int, int, int, int]:
@@ -288,12 +282,16 @@ def _apply_typed(
                 return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
         if row.actual_cost_micro == 0:
-            # Resolving a settled row NULLs settle_body, permanently destroying
-            # the typed repair payload. The park note distinguishes "settled,
-            # activity index missing" from the genuine zero-cost reaper/refund
-            # race, where this row wrote no Generation and an index call would
-            # be a bypass write.
-            if generation is not None and activity_repair_in_progress(row):
+            # Deliberately index every available generation, including a genuine
+            # zero-cost reaper/refund race. This writes only the Bigtable
+            # activity index, never a Spanner billing record, so the money path
+            # is untouched. A park-note discriminator is unsound: inline settle,
+            # a lost lease before park(), and operator re-arm can all leave a
+            # repairable row without the note, causing silent destruction of its
+            # only typed payload. An accurate $0 activity row is better evidence
+            # than none; failure stays ACTIVITY_PENDING and preserves the body.
+            # The activity write is idempotent, so replay cannot duplicate it.
+            if generation is not None:
                 if not _index_generation_after_commit(typed_store, generation):
                     return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 # ServiceUnavailable, plus the backend-neutral StoreConflict/StoreUnavailable.
 _TRANSIENT_STORE_EXCS = transient_store_error_types()
 
+_ACTIVITY_PARK_NOTE = "bigtable activity index pending"
+
 
 class ApplyOutcome:
     SETTLED_NOW = "settled_now"
@@ -56,6 +58,12 @@ class ApplyOutcome:
     PARK_TYPED_UNAVAILABLE = "park_typed_unavailable"
     INVALID_ROW = "invalid_row"
     ERROR = "error"
+
+
+def activity_repair_in_progress(row: SettleOutboxRow) -> bool:
+    return isinstance(row.last_error, str) and row.last_error.startswith(
+        _ACTIVITY_PARK_NOTE
+    )
 
 
 def normalized_prompt_accounting(
@@ -280,6 +288,14 @@ def _apply_typed(
                 return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
         if row.actual_cost_micro == 0:
+            # Resolving a settled row NULLs settle_body, permanently destroying
+            # the typed repair payload. The park note distinguishes "settled,
+            # activity index missing" from the genuine zero-cost reaper/refund
+            # race, where this row wrote no Generation and an index call would
+            # be a bypass write.
+            if generation is not None and activity_repair_in_progress(row):
+                if not _index_generation_after_commit(typed_store, generation):
+                    return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE
         # Booked 0 while this row intended a real charge: the hold was resolved
         # WITHOUT our charge (reaper free-release, or a refund won the race).

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -121,16 +121,8 @@ def _resolve_row(
         now = dt.datetime.now(dt.UTC)
         since = now
         since_text = now.isoformat().replace("+00:00", "Z")
-        if isinstance(row.last_error, str) and row.last_error.startswith(
-            _ACTIVITY_PARK_NOTE
-        ):
-            _note, since_marker, candidate_since_text = row.last_error.partition(
-                "since="
-            )
-        else:
-            since_marker = ""
-            candidate_since_text = ""
-        if since_marker:
+        candidate_since_text = _activity_since_text(row.last_error)
+        if candidate_since_text is not None:
             try:
                 candidate_since = dt.datetime.fromisoformat(
                     candidate_since_text.replace("Z", "+00:00")
@@ -165,13 +157,11 @@ def _resolve_row(
                     since = candidate_since
                     since_text = candidate_since_text
 
-        # last_error is the activity-failure clock. PARK_TYPED_UNAVAILABLE
-        # deliberately overwrites it and restarts this window: typed-store
-        # outage time is not activity-failure time and must not consume this
-        # repair budget. A generic mark(done=False) also overwrites it and
-        # starts a fresh uninterrupted run, but that burns an attempt, so
-        # max_attempts=8 bounds the repair overall: this is six hours per
-        # uninterrupted run, not an absolute six-hour window.
+        # last_error carries the continuous unrepaired-activity clock. The
+        # activity note survives PARK_TYPED_UNAVAILABLE below, making this a
+        # genuine overall bound instead of a per-outage window. Typed-store
+        # outage time deliberately counts: throughout that outage the activity
+        # index is genuinely still unrepaired.
         age_seconds = (now - since).total_seconds()
         if age_seconds > _ACTIVITY_REPAIR_MAX_AGE_SECONDS:
             # Dead preserves settle_body, the only typed activity-repair
@@ -242,14 +232,13 @@ def _resolve_row(
 
     if outcome == ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE:
         outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
-        # Rare $0 race: money is correct and no alert is warranted, but this row
-        # did not write a Generation. reconcile_generation_activity can repair
-        # per-request records if needed; we intentionally avoid a bypass write
-        # primitive for this edge case.
+        # Rare $0 race: the money path is unchanged and no alert is warranted.
+        # Apply verified the idempotent Bigtable activity write before resolving
+        # without creating a Spanner billing Generation.
         logger.warning(
             "settle outbox warning: settle intent found reservation already zero-resolved "
             "authorization_id=%s reservation_id=%s likely reaper race; "
-            "no generation record was written by this row",
+            "activity index verified without a Spanner billing write",
             row.authorization_id,
             row.reservation_id,
         )
@@ -317,11 +306,15 @@ def _resolve_row(
         return
 
     if outcome == ApplyOutcome.PARK_TYPED_UNAVAILABLE:
+        note = "typed store unavailable"
+        activity_since_text = _activity_since_text(row.last_error)
+        if activity_since_text is not None:
+            note = f"{_ACTIVITY_PARK_NOTE} since={activity_since_text}"
         outbox.park(
             row.authorization_id,
             row.intent_kind,
             lease_owner=lease_owner,
-            note="typed store unavailable",
+            note=note,
         )
         logger.warning(
             "settle outbox parked typed row authorization_id=%s intent_kind=%s",
@@ -359,6 +352,15 @@ def _resolve_row(
             row.authorization_id,
             row.intent_kind,
         )
+
+
+def _activity_since_text(last_error: str | None) -> str | None:
+    if not isinstance(last_error, str):
+        return None
+    prefix = f"{_ACTIVITY_PARK_NOTE} since="
+    if not last_error.startswith(prefix):
+        return None
+    return last_error.removeprefix(prefix)
 
 
 def _request_id(row: SettleOutboxRow) -> str | None:

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -14,9 +14,10 @@ from trusted_router.storage_models import SettleOutboxRow, generation_id_for_aut
 logger = logging.getLogger(__name__)
 
 # Six hours is long enough to ride out a real Bigtable outage on 60-second
-# parks, but short enough that a permanently broken row cannot pin retention or
-# churn the drain forever.
+# parks, but short enough that a permanently broken row cannot churn the drain
+# forever before an operator takes over.
 _ACTIVITY_REPAIR_MAX_AGE_SECONDS = 6 * 60 * 60
+_ACTIVITY_PARK_NOTE = "bigtable activity index pending"
 
 # SF7 / §6: the drain fires NONE of the inline post-settle side effects:
 # auto-refill, budget-alert emails, metadata broadcast, or provider-error
@@ -114,53 +115,86 @@ def _resolve_row(
         return
 
     if outcome == ApplyOutcome.ACTIVITY_PENDING:
-        try:
-            created_at = dt.datetime.fromisoformat(
-                row.created_at.replace("Z", "+00:00")
-            )
-            if created_at.tzinfo is None or created_at.utcoffset() is None:
-                raise ValueError("created_at must include a timezone")
-            age_seconds = (dt.datetime.now(dt.UTC) - created_at).total_seconds()
-        except (AttributeError, OverflowError, TypeError, ValueError):
-            # A malformed timestamp is a separate data bug. Park this row as
-            # before instead of risking a premature terminal transition.
-            logger.warning(
-                "settle outbox activity repair has malformed created_at; parking "
-                "authorization_id=%s intent_kind=%s created_at=%r",
-                row.authorization_id,
-                row.intent_kind,
-                row.created_at,
+        now = dt.datetime.now(dt.UTC)
+        since = now
+        since_text = now.isoformat().replace("+00:00", "Z")
+        if isinstance(row.last_error, str) and row.last_error.startswith(
+            _ACTIVITY_PARK_NOTE
+        ):
+            _note, since_marker, candidate_since_text = row.last_error.partition(
+                "since="
             )
         else:
-            if age_seconds > _ACTIVITY_REPAIR_MAX_AGE_SECONDS:
-                # Spanner, the billing source of truth, is already consistent.
-                # Done releases retention and stops permanent drain churn.
-                # Dead would be wrong: it is a guard status, and freezing a hold
-                # that is already settled only defers retention forever.
-                outbox.mark(
+            since_marker = ""
+            candidate_since_text = ""
+        if since_marker:
+            try:
+                candidate_since = dt.datetime.fromisoformat(
+                    candidate_since_text.replace("Z", "+00:00")
+                )
+                if (
+                    candidate_since.tzinfo is None
+                    or candidate_since.utcoffset() is None
+                ):
+                    raise ValueError("activity repair since must include a timezone")
+            except (OverflowError, ValueError):
+                # A malformed timestamp is a separate data bug. Start the
+                # window now instead of risking a premature terminal transition.
+                logger.warning(
+                    "settle outbox activity repair has malformed since; parking "
+                    "authorization_id=%s intent_kind=%s since=%r",
                     row.authorization_id,
                     row.intent_kind,
-                    done=True,
-                    lease_owner=lease_owner,
+                    candidate_since_text,
                 )
-                logger.error(
-                    "ALERT settle outbox activity repair expired "
-                    "authorization_id=%s generation_id=%s request_id=%s "
-                    "reservation_id=%s; CHARGE IS ALREADY APPLIED; only the "
-                    "Bigtable activity row is missing; repair with "
-                    "POST /internal/reconcile/generation-activity",
-                    row.authorization_id,
-                    generation_id_for_authorization(row.authorization_id),
-                    _request_id(row),
-                    row.reservation_id,
-                )
-                return
+            else:
+                since = candidate_since
+                since_text = candidate_since_text
+
+        # last_error is the activity-failure clock. PARK_TYPED_UNAVAILABLE
+        # deliberately overwrites it and restarts this window: typed-store
+        # outage time is not activity-failure time and must not consume this
+        # repair budget.
+        age_seconds = (now - since).total_seconds()
+        if age_seconds > _ACTIVITY_REPAIR_MAX_AGE_SECONDS:
+            # Dead preserves settle_body, the only typed activity-repair
+            # evidence; done destroys it and makes the missing activity
+            # permanently unrecoverable. Dead is the existing human-review
+            # terminal, monitored by the status='dead' count and documented in
+            # the runbook, and stops a full apply every 60 seconds. Keeping
+            # terminal_at NULL is deliberate: the reservation and gateway
+            # authorization are repair evidence, so retention stays pinned only
+            # until an operator responds. Freezing the hold costs nothing
+            # because the reservation is already settled. After fixing
+            # Bigtable, the operator can set this row back to pending with
+            # next_attempt_at in the past for due() to reclaim it.
+            outbox.mark(
+                row.authorization_id,
+                row.intent_kind,
+                done=False,
+                error="activity_repair_expired",
+                lease_owner=lease_owner,
+                force_dead=True,
+            )
+            logger.error(
+                "ALERT settle outbox activity repair expired "
+                "authorization_id=%s generation_id=%s request_id=%s "
+                "reservation_id=%s; CHARGE IS ALREADY APPLIED and Spanner is "
+                "correct; only the per-request Bigtable activity row is missing; "
+                "row is now dead with settle_body PRESERVED for repair; fix "
+                "Bigtable, then set the row back to pending to let the drain retry",
+                row.authorization_id,
+                generation_id_for_authorization(row.authorization_id),
+                _request_id(row),
+                row.reservation_id,
+            )
+            return
         outbox.park(
             row.authorization_id,
             row.intent_kind,
             lease_owner=lease_owner,
             retry_after_seconds=60,
-            note="bigtable activity index pending",
+            note=f"{_ACTIVITY_PARK_NOTE} since={since_text}",
         )
         logger.warning(
             "settle outbox activity repair pending authorization_id=%s",

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import logging
 from collections import Counter
 from typing import Any, cast
@@ -8,9 +9,14 @@ from typing import Any, cast
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
 from trusted_router.storage import STORE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
-from trusted_router.storage_models import SettleOutboxRow
+from trusted_router.storage_models import SettleOutboxRow, generation_id_for_authorization
 
 logger = logging.getLogger(__name__)
+
+# Six hours is long enough to ride out a real Bigtable outage on 60-second
+# parks, but short enough that a permanently broken row cannot pin retention or
+# churn the drain forever.
+_ACTIVITY_REPAIR_MAX_AGE_SECONDS = 6 * 60 * 60
 
 # SF7 / §6: the drain fires NONE of the inline post-settle side effects:
 # auto-refill, budget-alert emails, metadata broadcast, or provider-error
@@ -108,6 +114,47 @@ def _resolve_row(
         return
 
     if outcome == ApplyOutcome.ACTIVITY_PENDING:
+        try:
+            created_at = dt.datetime.fromisoformat(
+                row.created_at.replace("Z", "+00:00")
+            )
+            if created_at.tzinfo is None or created_at.utcoffset() is None:
+                raise ValueError("created_at must include a timezone")
+            age_seconds = (dt.datetime.now(dt.UTC) - created_at).total_seconds()
+        except (AttributeError, OverflowError, TypeError, ValueError):
+            # A malformed timestamp is a separate data bug. Park this row as
+            # before instead of risking a premature terminal transition.
+            logger.warning(
+                "settle outbox activity repair has malformed created_at; parking "
+                "authorization_id=%s intent_kind=%s created_at=%r",
+                row.authorization_id,
+                row.intent_kind,
+                row.created_at,
+            )
+        else:
+            if age_seconds > _ACTIVITY_REPAIR_MAX_AGE_SECONDS:
+                # Spanner, the billing source of truth, is already consistent.
+                # Done releases retention and stops permanent drain churn.
+                # Dead would be wrong: it is a guard status, and freezing a hold
+                # that is already settled only defers retention forever.
+                outbox.mark(
+                    row.authorization_id,
+                    row.intent_kind,
+                    done=True,
+                    lease_owner=lease_owner,
+                )
+                logger.error(
+                    "ALERT settle outbox activity repair expired "
+                    "authorization_id=%s generation_id=%s request_id=%s "
+                    "reservation_id=%s; CHARGE IS ALREADY APPLIED; only the "
+                    "Bigtable activity row is missing; repair with "
+                    "POST /internal/reconcile/generation-activity",
+                    row.authorization_id,
+                    generation_id_for_authorization(row.authorization_id),
+                    _request_id(row),
+                    row.reservation_id,
+                )
+                return
         outbox.park(
             row.authorization_id,
             row.intent_kind,
@@ -249,3 +296,13 @@ def _resolve_row(
             row.authorization_id,
             row.intent_kind,
         )
+
+
+def _request_id(row: SettleOutboxRow) -> str | None:
+    try:
+        body = json.loads(row.settle_body) if row.settle_body is not None else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(body, dict) or body.get("request_id") is None:
+        return None
+    return str(body["request_id"])

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -6,7 +6,11 @@ import logging
 from collections import Counter
 from typing import Any, cast
 
-from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
+from trusted_router.services.settle_outbox_apply import (
+    _ACTIVITY_PARK_NOTE,
+    ApplyOutcome,
+    apply_frozen_settle,
+)
 from trusted_router.storage import STORE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_models import SettleOutboxRow, generation_id_for_authorization
@@ -17,7 +21,6 @@ logger = logging.getLogger(__name__)
 # parks, but short enough that a permanently broken row cannot churn the drain
 # forever before an operator takes over.
 _ACTIVITY_REPAIR_MAX_AGE_SECONDS = 6 * 60 * 60
-_ACTIVITY_PARK_NOTE = "bigtable activity index pending"
 
 # SF7 / §6: the drain fires NONE of the inline post-settle side effects:
 # auto-refill, budget-alert emails, metadata broadcast, or provider-error
@@ -148,13 +151,27 @@ def _resolve_row(
                     candidate_since_text,
                 )
             else:
-                since = candidate_since
-                since_text = candidate_since_text
+                if candidate_since > now:
+                    # A bad writer clock must not create a negative-age repair
+                    # window that can never expire; start its clock locally.
+                    logger.warning(
+                        "settle outbox activity repair has future since; clamping "
+                        "authorization_id=%s intent_kind=%s since=%r",
+                        row.authorization_id,
+                        row.intent_kind,
+                        candidate_since_text,
+                    )
+                else:
+                    since = candidate_since
+                    since_text = candidate_since_text
 
         # last_error is the activity-failure clock. PARK_TYPED_UNAVAILABLE
         # deliberately overwrites it and restarts this window: typed-store
         # outage time is not activity-failure time and must not consume this
-        # repair budget.
+        # repair budget. A generic mark(done=False) also overwrites it and
+        # starts a fresh uninterrupted run, but that burns an attempt, so
+        # max_attempts=8 bounds the repair overall: this is six hours per
+        # uninterrupted run, not an absolute six-hour window.
         age_seconds = (now - since).total_seconds()
         if age_seconds > _ACTIVITY_REPAIR_MAX_AGE_SECONDS:
             # Dead preserves settle_body, the only typed activity-repair
@@ -168,7 +185,7 @@ def _resolve_row(
             # because the reservation is already settled. After fixing
             # Bigtable, the operator can set this row back to pending with
             # next_attempt_at in the past for due() to reclaim it.
-            outbox.mark(
+            status = outbox.mark(
                 row.authorization_id,
                 row.intent_kind,
                 done=False,
@@ -176,6 +193,18 @@ def _resolve_row(
                 lease_owner=lease_owner,
                 force_dead=True,
             )
+            if status != "dead":
+                # The status='dead' monitor is the source of truth. A duplicate
+                # or contradictory page is worse than none; the worker that
+                # actually wins this row will emit the alert.
+                logger.warning(
+                    "settle outbox activity repair escalation skipped because "
+                    "row is no longer claimable by this owner "
+                    "authorization_id=%s intent_kind=%s",
+                    row.authorization_id,
+                    row.intent_kind,
+                )
+                return
             logger.error(
                 "ALERT settle outbox activity repair expired "
                 "authorization_id=%s generation_id=%s request_id=%s "

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -45,6 +45,20 @@ class CreditReshardResult:
     def ready(self) -> bool:
         return not self.reasons
 
+    @property
+    def at_target(self) -> bool:
+        """Whether the ledger is ACTUALLY partitioned at the requested count.
+
+        Deliberately separate from `ready`, which only means "nothing blocks a
+        reshard". Before a reshard the current count differs from the target by
+        definition, so `reshard_credit_account`'s preflight must not require
+        this. Verification after the fact must: a drained, paused, healthy
+        one-shard workspace inspected with a target of 16 is `ready` while still
+        at one shard, and unpausing on `ready` alone would claim a transition
+        that never happened.
+        """
+        return self.current_shard_count == self.target_shard_count
+
 
 def _typed_state(
     store: Any,

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -63,6 +63,15 @@ class KeyUsageReshardResult:
     def ready(self) -> bool:
         return not self.reasons
 
+    @property
+    def at_target(self) -> bool:
+        """Whether this key's usage rows are ACTUALLY at the requested count.
+
+        See `CreditReshardResult.at_target`: `ready` only means "nothing blocks
+        a reshard", which is true before the reshard has happened.
+        """
+        return self.current_shard_count == self.target_shard_count
+
 
 def _typed_key_state(
     store: Any,

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 import logging
 import re
@@ -524,6 +525,192 @@ def test_enqueue_failure_does_not_fail_settle(
 
 
 # Integration (drain + reaper)
+
+
+def test_activity_pending_under_age_bound_parks_without_burning_attempts(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-fresh")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None
+    assert pending.status == "pending"
+    assert pending.attempts == 0
+    assert pending.lease_owner is None
+    assert pending.last_error == "bigtable activity index pending"
+
+
+def test_activity_pending_over_age_bound_marks_done_and_alerts(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-expired")
+    ob = _outbox(store)
+    ob.enqueue(
+        _row(
+            auth,
+            settle_body=json.dumps(
+                _settle_json(auth.id, request_id="req-activity-expired")
+            ),
+        )
+    )
+    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
+        created_at.isoformat().replace("+00:00", "Z")
+    )
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=drain_mod.__name__):
+        result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    completed = ob.get(auth.id, "settle")
+    assert completed is not None and completed.status == "done"
+    alerts = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "ALERT" in record.getMessage()
+    ]
+    assert len(alerts) == 1
+    assert f"authorization_id={auth.id}" in alerts[0]
+    assert "generation_id=gen-" in alerts[0]
+    assert "request_id=req-activity-expired" in alerts[0]
+    assert "CHARGE IS ALREADY APPLIED" in alerts[0]
+    assert "only the Bigtable activity row is missing" in alerts[0]
+    assert "POST /internal/reconcile/generation-activity" in alerts[0]
+
+
+def test_activity_pending_escalation_releases_retention(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-activity-retention"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    row = _row(auth)
+    ob = _outbox(store)
+    ob.enqueue(row)
+    monkeypatch.setattr(
+        apply_mod,
+        "_index_generation_after_commit",
+        lambda typed_store, generation: False,
+    )
+    assert apply_mod.apply_frozen_settle(row) == ApplyOutcome.ACTIVITY_PENDING
+    assert db.reservations[auth.credit_reservation_id]["settled"] is True
+    assert db.gateway_authorizations[auth.id]["settled"] is True
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
+        created_at.isoformat().replace("+00:00", "Z")
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert ob.get(auth.id, "settle").status == "done"
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
+
+
+def test_activity_pending_malformed_created_at_still_parks(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-malformed")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = "not-an-iso-timestamp"
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None
+    assert pending.status == "pending"
+    assert pending.attempts == 0
+    assert any(
+        f"authorization_id={auth.id}" in record.getMessage()
+        and "malformed created_at" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_activity_pending_naive_created_at_still_parks(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A timezone-less created_at parses fine but cannot be aged against an aware
+    now(). Treat it like any other malformed timestamp: park, never escalate on
+    an age we cannot actually compute."""
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-naive")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    naive = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = naive.replace(
+        tzinfo=None
+    ).isoformat()
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None
+    assert pending.status == "pending"
+    assert pending.attempts == 0
+    assert not [
+        record for record in caplog.records if record.levelno == logging.ERROR
+    ]
+    assert any(
+        f"authorization_id={auth.id}" in record.getMessage()
+        and "malformed created_at" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_drain_reaps_expired_unguarded_holds(fake_store: tuple[Any, Any, Any]) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -596,6 +596,80 @@ def test_activity_pending_second_cycle_preserves_original_since(
     assert second_row.attempts == 0
 
 
+def test_zero_cost_activity_pending_keeps_retrying_and_preserves_payload(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-activity-zero-retry"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    ob = _outbox(store)
+    ob.enqueue(_row(auth, cost=0))
+    monkeypatch.setattr(
+        apply_mod,
+        "_index_generation_after_commit",
+        lambda typed_store, generation: False,
+    )
+
+    first = drain_mod.drain_settle_outbox(10)
+    first_row = ob.get(auth.id, "settle")
+    assert first["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert first_row is not None and first_row.status == "pending"
+    assert first_row.settle_body is not None
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    second = drain_mod.drain_settle_outbox(10)
+
+    second_row = ob.get(auth.id, "settle")
+    assert second["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert second_row is not None and second_row.status == "pending"
+    assert second_row.settle_body is not None
+
+
+def test_zero_cost_activity_pending_resolves_after_index_succeeds(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, bt = fake_store
+    ws = "ws-activity-zero-repaired"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    ob = _outbox(store)
+    ob.enqueue(_row(auth, cost=0))
+    original_index = store.generation_store.index_after_commit
+    index_attempts: list[str] = []
+
+    def fail_once(generation: Any) -> bool:
+        index_attempts.append(generation.id)
+        if len(index_attempts) == 1:
+            return False
+        return original_index(generation)
+
+    monkeypatch.setattr(store.generation_store, "index_after_commit", fail_once)
+
+    first = drain_mod.drain_settle_outbox(10)
+    assert first["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert bt.committed == []
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    second = drain_mod.drain_settle_outbox(10)
+
+    completed = ob.get(auth.id, "settle")
+    assert second["outcomes"] == {
+        ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1
+    }
+    assert completed is not None and completed.status == "done"
+    assert len(index_attempts) == 2
+    assert bt.committed
+
+
 def test_activity_pending_old_row_with_new_window_still_parks(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -685,6 +759,47 @@ def test_activity_pending_over_window_marks_dead_preserves_payload_and_alerts(
     assert "settle_body PRESERVED" in alerts[0]
     assert "set the row back to pending to let the drain retry" in alerts[0]
     assert "reconcile/generation-activity" not in alerts[0]
+
+
+def test_activity_pending_lost_lease_skips_false_alert(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-lost-lease")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        f"{since.isoformat().replace('+00:00', 'Z')}"
+    )
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+    monkeypatch.setattr(SpannerSettleOutbox, "mark", lambda *args, **kwargs: None)
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "ALERT" in record.getMessage()
+    ]
+    assert any(
+        record.levelno == logging.WARNING
+        and "escalation skipped" in record.getMessage()
+        and f"authorization_id={auth.id}" in record.getMessage()
+        and "intent_kind=settle" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_activity_pending_escalation_keeps_retention_pinned(
@@ -817,6 +932,54 @@ def test_activity_pending_malformed_or_naive_since_still_parks(
         for record in caplog.records
     )
     assert not [record for record in caplog.records if record.levelno == logging.ERROR]
+
+
+def test_activity_pending_future_since_is_clamped(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-future")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    future_since = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
+        created_at.isoformat().replace("+00:00", "Z")
+    )
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        f"{future_since.isoformat().replace('+00:00', 'Z')}"
+    )
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.last_error is not None
+    stamped_since = dt.datetime.fromisoformat(
+        pending.last_error.removeprefix(
+            f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        ).replace("Z", "+00:00")
+    )
+    assert stamped_since < future_since
+    assert any(
+        record.levelno == logging.WARNING
+        and "future since" in record.getMessage()
+        and f"authorization_id={auth.id}" in record.getMessage()
+        and "intent_kind=settle" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_drain_reaps_expired_unguarded_holds(fake_store: tuple[Any, Any, Any]) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -527,7 +527,7 @@ def test_enqueue_failure_does_not_fail_settle(
 # Integration (drain + reaper)
 
 
-def test_activity_pending_under_age_bound_parks_without_burning_attempts(
+def test_activity_pending_first_observation_parks_and_stamps_note(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -550,10 +550,84 @@ def test_activity_pending_under_age_bound_parks_without_burning_attempts(
     assert pending.status == "pending"
     assert pending.attempts == 0
     assert pending.lease_owner is None
-    assert pending.last_error == "bigtable activity index pending"
+    assert pending.last_error is not None
+    note_prefix = f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+    assert pending.last_error.startswith(note_prefix)
+    since = dt.datetime.fromisoformat(
+        pending.last_error.removeprefix(note_prefix).replace("Z", "+00:00")
+    )
+    assert since.tzinfo is not None and since.utcoffset() is not None
 
 
-def test_activity_pending_over_age_bound_marks_done_and_alerts(
+def test_activity_pending_second_cycle_preserves_original_since(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-two-cycles")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    first = drain_mod.drain_settle_outbox(10)
+    first_row = ob.get(auth.id, "settle")
+    assert first["claimed"] == 1
+    assert first_row is not None and first_row.last_error is not None
+    first_since = first_row.last_error.removeprefix(
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    second = drain_mod.drain_settle_outbox(10)
+
+    second_row = ob.get(auth.id, "settle")
+    assert second["claimed"] == 1
+    assert second_row is not None and second_row.last_error is not None
+    second_since = second_row.last_error.removeprefix(
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+    )
+    assert second_since == first_since
+    assert second_row.attempts == 0
+
+
+def test_activity_pending_old_row_with_new_window_still_parks(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-old-row-new-window")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS * 2
+    )
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
+        created_at.isoformat().replace("+00:00", "Z")
+    )
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = "unrelated failure"
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.ACTIVITY_PENDING,
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.attempts == 0
+    assert pending.last_error is not None
+    assert pending.last_error.startswith(f"{drain_mod._ACTIVITY_PARK_NOTE} since=")
+
+
+def test_activity_pending_over_window_marks_dead_preserves_payload_and_alerts(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -569,11 +643,12 @@ def test_activity_pending_over_age_bound_marks_done_and_alerts(
             ),
         )
     )
-    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
-        created_at.isoformat().replace("+00:00", "Z")
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        f"{since.isoformat().replace('+00:00', 'Z')}"
     )
     monkeypatch.setattr(
         drain_mod,
@@ -587,7 +662,9 @@ def test_activity_pending_over_age_bound_marks_done_and_alerts(
     assert result["claimed"] == 1
     assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
     completed = ob.get(auth.id, "settle")
-    assert completed is not None and completed.status == "done"
+    assert completed is not None and completed.status == "dead"
+    assert completed.settle_body is not None
+    assert completed.last_error == "activity_repair_expired"
     alerts = [
         record.getMessage()
         for record in caplog.records
@@ -595,14 +672,22 @@ def test_activity_pending_over_age_bound_marks_done_and_alerts(
     ]
     assert len(alerts) == 1
     assert f"authorization_id={auth.id}" in alerts[0]
-    assert "generation_id=gen-" in alerts[0]
+    assert (
+        f"generation_id={drain_mod.generation_id_for_authorization(auth.id)}"
+        in alerts[0]
+    )
     assert "request_id=req-activity-expired" in alerts[0]
+    assert f"reservation_id={auth.credit_reservation_id}" in alerts[0]
     assert "CHARGE IS ALREADY APPLIED" in alerts[0]
-    assert "only the Bigtable activity row is missing" in alerts[0]
-    assert "POST /internal/reconcile/generation-activity" in alerts[0]
+    assert "Spanner is correct" in alerts[0]
+    assert "only the per-request Bigtable activity row is missing" in alerts[0]
+    assert "row is now dead" in alerts[0]
+    assert "settle_body PRESERVED" in alerts[0]
+    assert "set the row back to pending to let the drain retry" in alerts[0]
+    assert "reconcile/generation-activity" not in alerts[0]
 
 
-def test_activity_pending_escalation_releases_retention(
+def test_activity_pending_escalation_keeps_retention_pinned(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -625,31 +710,86 @@ def test_activity_pending_escalation_releases_retention(
     assert db.gateway_authorizations[auth.id]["settled"] is True
     assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
     assert db.gateway_authorizations[auth.id]["terminal_at"] is None
-    created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
-        created_at.isoformat().replace("+00:00", "Z")
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        f"{since.isoformat().replace('+00:00', 'Z')}"
     )
 
     result = drain_mod.drain_settle_outbox(10)
 
     assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    assert ob.get(auth.id, "settle").status == "dead"
+    # Deliberate: these records are the evidence needed to repair the activity.
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+
+
+def test_activity_pending_dead_row_reset_to_pending_is_reclaimed(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-retry-dead")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    ob.mark(
+        auth.id,
+        "settle",
+        done=False,
+        error="activity_repair_expired",
+        force_dead=True,
+    )
+    db.settle_outbox[(auth.id, "settle")]["status"] = "pending"
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+    applied: list[str] = []
+
+    def apply_repaired(row: SettleOutboxRow) -> str:
+        applied.append(row.authorization_id)
+        return ApplyOutcome.SETTLED_NOW
+
+    monkeypatch.setattr(drain_mod, "apply_frozen_settle", apply_repaired)
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["claimed"] == 1
+    assert result["outcomes"] == {ApplyOutcome.SETTLED_NOW: 1}
+    assert applied == [auth.id]
     assert ob.get(auth.id, "settle").status == "done"
-    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
-    assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
 
 
-def test_activity_pending_malformed_created_at_still_parks(
+@pytest.mark.parametrize(
+    "since",
+    [
+        "not-an-iso-timestamp",
+        (
+            dt.datetime.now(dt.UTC)
+            - dt.timedelta(
+                seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+            )
+        )
+        .replace(tzinfo=None)
+        .isoformat(),
+    ],
+    ids=["malformed", "naive"],
+)
+def test_activity_pending_malformed_or_naive_since_still_parks(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    since: str,
 ) -> None:
     store, db, _bt = fake_store
     auth = _bare_authorization("gwa-activity-malformed")
     ob = _outbox(store)
     ob.enqueue(_row(auth))
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = "not-an-iso-timestamp"
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={since}"
+    )
     monkeypatch.setattr(
         drain_mod,
         "apply_frozen_settle",
@@ -664,53 +804,19 @@ def test_activity_pending_malformed_created_at_still_parks(
     assert pending is not None
     assert pending.status == "pending"
     assert pending.attempts == 0
+    assert pending.last_error is not None
+    stamped_since = dt.datetime.fromisoformat(
+        pending.last_error.removeprefix(
+            f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        ).replace("Z", "+00:00")
+    )
+    assert stamped_since.tzinfo is not None
     assert any(
         f"authorization_id={auth.id}" in record.getMessage()
-        and "malformed created_at" in record.getMessage()
+        and "malformed since" in record.getMessage()
         for record in caplog.records
     )
-
-
-def test_activity_pending_naive_created_at_still_parks(
-    fake_store: tuple[Any, Any, Any],
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A timezone-less created_at parses fine but cannot be aged against an aware
-    now(). Treat it like any other malformed timestamp: park, never escalate on
-    an age we cannot actually compute."""
-    store, db, _bt = fake_store
-    auth = _bare_authorization("gwa-activity-naive")
-    ob = _outbox(store)
-    ob.enqueue(_row(auth))
-    naive = dt.datetime.now(dt.UTC) - dt.timedelta(
-        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
-    )
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = naive.replace(
-        tzinfo=None
-    ).isoformat()
-    monkeypatch.setattr(
-        drain_mod,
-        "apply_frozen_settle",
-        lambda row: ApplyOutcome.ACTIVITY_PENDING,
-    )
-
-    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
-        result = drain_mod.drain_settle_outbox(10)
-
-    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
-    pending = ob.get(auth.id, "settle")
-    assert pending is not None
-    assert pending.status == "pending"
-    assert pending.attempts == 0
-    assert not [
-        record for record in caplog.records if record.levelno == logging.ERROR
-    ]
-    assert any(
-        f"authorization_id={auth.id}" in record.getMessage()
-        and "malformed created_at" in record.getMessage()
-        for record in caplog.records
-    )
+    assert not [record for record in caplog.records if record.levelno == logging.ERROR]
 
 
 def test_drain_reaps_expired_unguarded_holds(fake_store: tuple[Any, Any, Any]) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -203,6 +203,17 @@ def _settle_json(auth_id: str, *, request_id: str = "req-settle") -> dict[str, A
     }
 
 
+def _zero_cost_settle_json(auth_id: str) -> dict[str, Any]:
+    body = _settle_json(auth_id)
+    body.update(
+        actual_input_tokens=0,
+        actual_output_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    return body
+
+
 def _row(
     auth: GatewayAuthorization,
     *,
@@ -594,6 +605,170 @@ def test_activity_pending_second_cycle_preserves_original_since(
     )
     assert second_since == first_since
     assert second_row.attempts == 0
+
+
+def test_typed_park_preserves_expired_activity_window(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    auth = _bare_authorization("gwa-activity-typed-outage")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
+    )
+    activity_note = (
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
+        f"{since.isoformat().replace('+00:00', 'Z')}"
+    )
+    db.settle_outbox[(auth.id, "settle")]["last_error"] = activity_note
+    outcomes = iter(
+        [
+            ApplyOutcome.PARK_TYPED_UNAVAILABLE,
+            ApplyOutcome.ACTIVITY_PENDING,
+        ]
+    )
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: next(outcomes),
+    )
+
+    first = drain_mod.drain_settle_outbox(10)
+
+    assert first["outcomes"] == {ApplyOutcome.PARK_TYPED_UNAVAILABLE: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.attempts == 0
+    assert pending.last_error == activity_note
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    second = drain_mod.drain_settle_outbox(10)
+
+    assert second["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    dead = ob.get(auth.id, "settle")
+    assert dead is not None and dead.status == "dead"
+    assert dead.last_error == "activity_repair_expired"
+    assert dead.settle_body is not None
+
+
+def test_typed_park_without_activity_stamp_uses_plain_note(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _db, _bt = fake_store
+    auth = _bare_authorization("gwa-typed-outage-plain-note")
+    ob = _outbox(store)
+    ob.enqueue(_row(auth))
+    monkeypatch.setattr(
+        drain_mod,
+        "apply_frozen_settle",
+        lambda row: ApplyOutcome.PARK_TYPED_UNAVAILABLE,
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.PARK_TYPED_UNAVAILABLE: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.attempts == 0
+    assert pending.last_error == "typed store unavailable"
+    assert "since=" not in pending.last_error
+
+
+def test_inline_zero_cost_activity_failure_keeps_payload_without_park_note(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-activity-inline-zero-fails"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    monkeypatch.setattr(
+        store.generation_store,
+        "index_after_commit",
+        lambda generation: False,
+    )
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json=_zero_cost_settle_json(auth.id),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["cost_microdollars"] == 0
+    ob = _outbox(store)
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.last_error is None
+    assert pending.settle_body is not None
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.settle_body is not None
+
+
+def test_inline_zero_cost_without_park_note_resolves_after_index_succeeds(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, bt = fake_store
+    ws = "ws-activity-inline-zero-repaired"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    original_index = store.generation_store.index_after_commit
+    index_attempts: list[str] = []
+
+    def fail_inline_only(generation: Any) -> bool:
+        index_attempts.append(generation.id)
+        if len(index_attempts) == 1:
+            return False
+        return original_index(generation)
+
+    monkeypatch.setattr(
+        store.generation_store,
+        "index_after_commit",
+        fail_inline_only,
+    )
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json=_zero_cost_settle_json(auth.id),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["cost_microdollars"] == 0
+    ob = _outbox(store)
+    pending = ob.get(auth.id, "settle")
+    assert pending is not None and pending.status == "pending"
+    assert pending.last_error is None
+    assert bt.committed == []
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    result = drain_mod.drain_settle_outbox(10)
+
+    assert result["outcomes"] == {
+        ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1
+    }
+    completed = ob.get(auth.id, "settle")
+    assert completed is not None and completed.status == "done"
+    assert len(index_attempts) == 2
+    assert bt.committed
 
 
 def test_zero_cost_activity_pending_keeps_retrying_and_preserves_payload(
@@ -1069,7 +1244,7 @@ def test_drain_reap_limit_respected(fake_store: tuple[Any, Any, Any]) -> None:
     assert again["reaped"] == 0
 
 
-def test_zero_cost_settle_reaper_race_resolves_done_with_warning(
+def test_zero_cost_settle_reaper_race_indexes_activity_and_resolves_done(
     fake_store: tuple[Any, Any, Any],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1104,14 +1279,14 @@ def test_zero_cost_settle_reaper_race_resolves_done_with_warning(
     assert _typed_credit(db, ws) == credit_before
     assert _typed_key(db, key.hash) == key_before
     assert _generation_count(db) == 0
-    assert bt.committed == []
+    assert bt.committed
     messages = [rec.message for rec in caplog.records]
     assert any(
         "settle intent found reservation already zero-resolved" in msg
         and f"authorization_id={auth.id}" in msg
         and f"reservation_id={auth.credit_reservation_id}" in msg
         and "likely reaper race" in msg
-        and "no generation record was written by this row" in msg
+        and "activity index verified without a Spanner billing write" in msg
         for msg in messages
     )
     assert not any("ALERT" in msg for msg in messages)
@@ -1173,6 +1348,7 @@ def test_duplicate_zero_cost_settle_replay_resolves_done_with_warning(
     key_before = dict(_typed_key(db, key.hash))
     generation_count_before = _generation_count(db)
     committed_before = list(bt.committed)
+    activity_rows_before = set(bt.rows)
     assert generation_count_before == 1
     caplog.set_level(logging.WARNING)
 
@@ -1186,13 +1362,14 @@ def test_duplicate_zero_cost_settle_replay_resolves_done_with_warning(
     assert _typed_credit(db, ws) == credit_before
     assert _typed_key(db, key.hash) == key_before
     assert _generation_count(db) == generation_count_before
-    assert bt.committed == committed_before
+    assert len(bt.committed) > len(committed_before)
+    assert set(bt.rows) == activity_rows_before
     messages = [rec.message for rec in caplog.records]
     assert any(
         "settle intent found reservation already zero-resolved" in msg
         and f"authorization_id={auth.id}" in msg
         and f"reservation_id={auth.credit_reservation_id}" in msg
-        and "no generation record was written by this row" in msg
+        and "activity index verified without a Spanner billing write" in msg
         for msg in messages
     )
     assert not any("ALERT" in msg for msg in messages)

--- a/tests/test_shard_workspace_operator.py
+++ b/tests/test_shard_workspace_operator.py
@@ -12,6 +12,7 @@ from trusted_router.storage_gcp_credit_shard_admin import (
     inspect_credit_reshard,
     reshard_credit_account,
 )
+from trusted_router.storage_gcp_key_shard_admin import inspect_key_usage_reshard
 
 
 def _args(*, workspace: str | None = None, owner_email: str | None = None) -> argparse.Namespace:
@@ -176,3 +177,29 @@ def test_finish_unpauses_once_the_ledger_is_actually_at_the_target() -> None:
 
     assert shard_workspace.run_finish(store, _finish_args(shards=16)) == 0
     assert store.get_workspace("ws-reshard").billing_paused is False
+
+
+def test_finish_refuses_when_credit_is_at_target_but_a_key_is_not() -> None:
+    """The credit ledger and the per-key usage rows move independently.
+
+    `prepare` reshards both, so a run that reshards only the credit row is a
+    partially-applied state. Gating the unpause on the credit row alone would
+    resume traffic with a key still counting spend on one shard.
+    """
+    store, _database = _seed(shard_credits=[100], shard_usage=[20])
+    _raw, key = store.api_keys.create(
+        workspace_id="ws-reshard",
+        name="unlimited",
+        creator_user_id=None,
+        limit_microdollars=None,
+    )
+    assert reshard_credit_account(store, "ws-reshard", 16, apply=True).applied
+
+    credit = inspect_credit_reshard(store, "ws-reshard", 16)
+    assert credit.ready and credit.at_target, "precondition: credit row moved"
+    key_status = inspect_key_usage_reshard(store, key.hash, 16)
+    assert key_status.ready, "precondition: nothing blocks the key reshard"
+    assert not key_status.at_target, "precondition: the key never moved"
+
+    assert shard_workspace.run_finish(store, _finish_args(shards=16)) == 1
+    assert store.get_workspace("ws-reshard").billing_paused is True

--- a/tests/test_shard_workspace_operator.py
+++ b/tests/test_shard_workspace_operator.py
@@ -6,7 +6,12 @@ from types import SimpleNamespace
 import pytest
 
 from scripts import shard_workspace
+from tests.test_credit_row_sharding_increment4 import _seed
 from trusted_router.storage import InMemoryStore
+from trusted_router.storage_gcp_credit_shard_admin import (
+    inspect_credit_reshard,
+    reshard_credit_account,
+)
 
 
 def _args(*, workspace: str | None = None, owner_email: str | None = None) -> argparse.Namespace:
@@ -137,3 +142,37 @@ def test_online_split_preflights_then_prepares_and_finishes(
 
     assert shard_workspace.run_online_split(store, args) == 0
     assert calls == ["inspect", "prepare", "finish"]
+
+
+def _finish_args(*, shards: int) -> argparse.Namespace:
+    return argparse.Namespace(
+        workspace="ws-reshard",
+        shards=shards,
+        preserve_open_holds=False,
+        apply=True,
+    )
+
+
+def test_finish_refuses_to_unpause_a_workspace_that_never_resharded() -> None:
+    """`ready` means "nothing blocks a reshard", not "the reshard happened".
+
+    A drained, paused, healthy one-shard workspace inspected against a target of
+    16 has no blocking reasons at all, so gating the unpause on `ready` alone
+    resumed traffic while announcing 16 shards the ledger never adopted.
+    """
+    store, _database = _seed(shard_credits=[100], shard_usage=[20])
+
+    status = inspect_credit_reshard(store, "ws-reshard", 16)
+    assert status.ready, "precondition: nothing blocks a reshard"
+    assert not status.at_target, "precondition: the ledger is still at one shard"
+
+    assert shard_workspace.run_finish(store, _finish_args(shards=16)) == 1
+    assert store.get_workspace("ws-reshard").billing_paused is True
+
+
+def test_finish_unpauses_once_the_ledger_is_actually_at_the_target() -> None:
+    store, _database = _seed(shard_credits=[100], shard_usage=[20])
+    assert reshard_credit_account(store, "ws-reshard", 16, apply=True).applied
+
+    assert shard_workspace.run_finish(store, _finish_args(shards=16)) == 0
+    assert store.get_workspace("ws-reshard").billing_paused is False


### PR DESCRIPTION
Follow-ups from reviewing the Spanner work that landed as #339. Four adversarial
review rounds ran on this branch; the first three each found real defects and
the fourth passed with no blocking findings. The commit history shows the
reasoning, including two designs I got wrong and corrected.

## 1. `ACTIVITY_PENDING` parked forever

`_resolve_row` handled `ApplyOutcome.ACTIVITY_PENDING` with
`park(retry_after_seconds=60)`. `park()` deliberately does not burn attempts —
correct for `PARK_TYPED_UNAVAILABLE`, where a typed-backend outage must not walk
frozen rows toward `dead`. But `index_after_commit` catches **every** exception,
so a *permanent* per-row Bigtable failure parked forever: it never reached a
terminal status so it never hit the ALERT path; with the retention invariant now
structural (#339) it kept `terminal_at` NULL on its reservation and gateway
authorization indefinitely; and the drain re-did the full apply every cycle.

Bounded at 6 hours of continuous unrepaired activity, then the row goes `dead`.

**`dead`, not `done`.** `mark(done=True)` NULLs `settle_body`, and for a
gateway/typed request that payload is normally the only repair evidence: typed
finalize skips the generic `generation` / `generation_by_workspace` entity
writes, and `POST /internal/reconcile/generation-activity` repairs by scanning
`generation_by_workspace`. That endpoint would have rewritten **zero** rows for
exactly the rows the alert fired on. `dead` preserves the payload, is the
existing human-review terminal, and still stops the 60s churn. Retention stays
pinned — correctly: those records are the evidence a human needs.

## 2. The repair window was measured wrong, twice

First it came from `row.created_at`, so a row that sat behind a typed-store
outage for six hours and then failed its index **once** escalated immediately.
Moved into the park note (`last_error` = `bigtable activity index pending
since=<ts>`), no DDL.

Then nothing bounded it: a typed-unavailable park clobbered the stamp and
`park()` never burns attempts, so "Bigtable fails under six hours → one
transient typed failure → repeat" reset the window forever. A typed park now
**preserves** the stamp, so typed-outage time counts toward the window and six
hours is a genuine bound. Future timestamps are clamped.

## 3. A zero-cost row lost its payload on the next cycle

Pre-existing on main, and the reason the bound never applied to those rows. A
zero-cost settle whose index fails parks; on the next drain apply takes the
`ALREADY_SETTLED` path, reads `actual_micro == 0`, and returns
`RESOLVED_ZERO_COST_ELSEWHERE` **without retrying Bigtable** — the drain marks it
`done` and NULLs `settle_body`. Reproduced: body PRESENT → NULL, zero Bigtable
writes.

My first fix gated the retry on the park note. That was unsound — inline settle,
a lost lease before `park()`, and the operator re-arm all leave a repairable row
without the note, and each reproduced the same data loss. The index is now
attempted whenever a generation exists. No billing state moves (the reservation
already returned `ALREADY_SETTLED`); the benchmark and analytics-outbox writes it
also performs are non-billing, at-least-once by design, with stable ids.

## 4. `finish` could unpause a workspace that never resharded

`ready` only means "nothing blocks a reshard", and `inspect_credit_reshard` never
compared current to target. A drained, paused, healthy **one-shard** workspace
inspected with `--shards 16` reports `ready=True`, and `run_finish` gated the
unpause on `ready` alone — resuming traffic while printing `unpaused with 16
credit shards` for a ledger still at one. Added `at_target`, required by `finish`
and by key verification. It must stay separate from `ready`: before a reshard
`current != target` by definition, so the preflight cannot require it.

## Runbook

New section for a workspace left paused between reshard `prepare` and `finish`,
the missing `activity_pending` and `resolved_zero_cost_elsewhere` cheat-sheet
rows, and the dead-row repair procedure (scoped with
`last_error='activity_repair_expired'` so a mistyped id cannot resurrect an
`already_released_free` row). Ten factual errors found across the review rounds
are corrected, including that a paused workspace does **not** always drain to
zero holds — a `pending`/`dead` outbox row excludes its reservation from the
reaper, so waiting can never succeed until that row is resolved.

## Deferred

Two pre-existing defects the reviews found are filed rather than widened into
this PR, and the reviews confirmed this diff makes neither worse:
- #355 — `mark()`/`park()` accept a stale worker when the current owner is NULL.
- #356 — a sibling refund dead-letters as `invalid_row` when its settle charged.

## Verification

`uv run ruff check .` · `uv run mypy` · `uv run pytest -q` → 2173 passed, 76 skipped.

Every regression test was **verified by mutation** — reverting the specific
behavior must fail its specific test:

| Mutation | Tests killed |
| --- | --- |
| escalate to `done` instead of `dead` | payload-preserved, retention-pinned |
| clock from `row.created_at` | old-row-fresh-window (+2) |
| window restarts every cycle | second-cycle-preserves-since (+2) |
| never escalate / always escalate | both escalation tests / under-bound |
| malformed or future `since` mishandled | malformed, naive, clamp |
| restore the park-note discriminator | both no-note zero-cost tests |
| typed park clobbers the stamp | window-preservation |
| alert without checking `mark()` | lost-lease false-alert |
| remove `at_target` (credit or key) | reproduces `unpaused with 16 credit shards` |

The retention test runs the **real** apply path with
`_index_generation_after_commit` forced to fail, then asserts `terminal_at` stays
NULL on both the reservation and the gateway authorization. The alert test
asserts the message does **not** contain `reconcile/generation-activity`, so the
endpoint that cannot repair these rows cannot creep back into the instructions.