### PR TITLE
Enable Alibaba Cloud Model Studio routes

### DIFF
--- a/scripts/pricing/providers/alibaba.py
+++ b/scripts/pricing/providers/alibaba.py
@@ -8,7 +8,11 @@ intentionally skipped instead of published at a guessed or zero price.
 
 from __future__ import annotations
 
+import json
 import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -17,7 +21,10 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_TRANSPORT_RETRIES,
     PROVIDER_FETCH_UA,
     ModelPrice,
+    PriceTier,
     ProviderPricingResult,
+    guard_manifest_prune,
+    reconcile_manifest_tombstones,
     validate,
 )
 from scripts.pricing.model_ids import remember_upstream_id
@@ -27,12 +34,21 @@ URL = (
     os.environ.get("ALIBABA_BASE_URL")
     or "https://ws-el6e4bpnggpx7g88.eu-central-1.maas.aliyuncs.com/compatible-mode/v1"
 ) + "/models"
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "trusted_router"
+    / "data"
+    / "provider_models"
+    / "alibaba.json"
+)
 
 EXPECTED_MODELS = [
     "z-ai/glm-5.2",
     "moonshotai/kimi-k2.7-code",
     "deepseek/deepseek-v4-flash",
     "deepseek/deepseek-v4-pro",
+    "qwen/qwen3.7-flash",
     "qwen/qwen3.7-max",
     "qwen/qwen3.7-plus",
 ]
@@ -62,6 +78,46 @@ def _canonical_model_id(native_id: str) -> str | None:
 
 def _price(native_id: str) -> ModelPrice | None:
     model = native_id.lower()
+    if model.startswith("qwen3.7-flash"):
+        return ModelPrice(
+            tiers=[
+                PriceTier(
+                    max_prompt_tokens=32_000,
+                    prompt_micro_per_m=_micro(0.03),
+                    completion_micro_per_m=_micro(0.13),
+                    prompt_cached_micro_per_m=_micro(0.006),
+                ),
+                PriceTier(
+                    max_prompt_tokens=256_000,
+                    prompt_micro_per_m=_micro(0.10),
+                    completion_micro_per_m=_micro(0.40),
+                    prompt_cached_micro_per_m=_micro(0.02),
+                ),
+                PriceTier(
+                    max_prompt_tokens=None,
+                    prompt_micro_per_m=_micro(0.20),
+                    completion_micro_per_m=_micro(0.80),
+                    prompt_cached_micro_per_m=_micro(0.04),
+                ),
+            ]
+        )
+    if model.startswith("qwen3.7-plus"):
+        return ModelPrice(
+            tiers=[
+                PriceTier(
+                    max_prompt_tokens=256_000,
+                    prompt_micro_per_m=_micro(0.40),
+                    completion_micro_per_m=_micro(1.60),
+                    prompt_cached_micro_per_m=_micro(0.04),
+                ),
+                PriceTier(
+                    max_prompt_tokens=None,
+                    prompt_micro_per_m=_micro(1.20),
+                    completion_micro_per_m=_micro(4.80),
+                    prompt_cached_micro_per_m=_micro(0.12),
+                ),
+            ]
+        )
     prompt = completion = cached = None
     if model.startswith("glm-5."):
         prompt, completion, cached = 1.40, 4.40, 0.26
@@ -75,8 +131,6 @@ def _price(native_id: str) -> ModelPrice | None:
         prompt, completion, cached = 2.40, 4.80, 0.24
     elif model.startswith("qwen3.7-max"):
         prompt, completion, cached = 2.50, 7.50, 0.25
-    elif model.startswith("qwen3.7-plus"):
-        prompt, completion, cached = 0.40, 1.60, 0.04
     elif model.startswith("qwen3.6-plus"):
         prompt, completion, cached = 0.50, 3.00, 0.05
     elif model.startswith("qwen3.6-flash"):
@@ -147,9 +201,37 @@ def _price(native_id: str) -> ModelPrice | None:
 
 
 UPSTREAM_ID_MAP: dict[str, str] = {}
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
+
+
+def _manifest_row(
+    *,
+    model_id: str,
+    native_id: str,
+    source_row: dict[str, Any],
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": model_id,
+        "upstream_id": native_id,
+        "display_name": native_id.replace("-", " ").title(),
+        "title": native_id,
+        "model_type": "chat",
+        "endpoints": ["chat/completions"],
+    }
+    created = source_row.get("created")
+    if isinstance(created, int) and not isinstance(created, bool) and created > 0:
+        row["created"] = created
+    if native_id.startswith("qwen3.7-"):
+        row["context_length"] = 1_048_576
+    if native_id.startswith("qwen3.7-flash"):
+        row["input_modalities"] = ["text", "image"]
+        row["output_modalities"] = ["text"]
+    return row
 
 
 def fetch() -> ProviderPricingResult:
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+
     api_key = (
         os.environ.get("ALIBABA_API_KEY")
         or os.environ.get("DASHSCOPE_API_KEY")
@@ -173,6 +255,7 @@ def fetch() -> ProviderPricingResult:
         rows = []
 
     prices: dict[str, ModelPrice] = {}
+    manifest_rows: dict[str, dict[str, Any]] = {}
     UPSTREAM_ID_MAP.clear()
     for row in rows:
         if not isinstance(row, dict):
@@ -183,12 +266,18 @@ def fetch() -> ProviderPricingResult:
         model_id = _canonical_model_id(native_id)
         if model_id is None:
             continue
+        manifest_rows[model_id] = _manifest_row(
+            model_id=model_id,
+            native_id=native_id,
+            source_row=row,
+        )
         price = _price(native_id)
         if price is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, model_id, native_id)
         prices[model_id] = price
 
+    _DISCOVERED_MANIFEST_ROWS = manifest_rows
     errors = validate(prices, EXPECTED_MODELS)
     if errors:
         raise RuntimeError("; ".join(errors))
@@ -199,3 +288,106 @@ def fetch() -> ProviderPricingResult:
         fetched_url=URL,
         notes=["Alibaba /models does not include prices; family rates come from published Model Studio pricing."],
     )
+
+
+def _apply_price(row: dict[str, Any], price: ModelPrice) -> None:
+    first = price.tiers[0]
+    row["input_token_price_per_m"] = first.prompt_micro_per_m
+    row["output_token_price_per_m"] = first.completion_micro_per_m
+    if first.prompt_cached_micro_per_m is not None:
+        row["cached_input_token_price_per_m"] = first.prompt_cached_micro_per_m
+    else:
+        row.pop("cached_input_token_price_per_m", None)
+
+    if len(price.tiers) == 1:
+        # Several older Alibaba families have hand-verified context tiers in
+        # the committed manifest while the public source parser currently
+        # exposes only the headline rate. Do not erase those safer tiers.
+        return
+    row["price_tiers"] = [
+        {
+            "max_prompt_tokens": tier.max_prompt_tokens,
+            "input_token_price_per_m": tier.prompt_micro_per_m,
+            "output_token_price_per_m": tier.completion_micro_per_m,
+            **(
+                {"cached_input_token_price_per_m": tier.prompt_cached_micro_per_m}
+                if tier.prompt_cached_micro_per_m is not None
+                else {}
+            ),
+        }
+        for tier in price.tiers
+    ]
+
+
+def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
+    """Refresh Alibaba routes from the workspace's authoritative model feed."""
+
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError("alibaba manifest has no models list")
+    if not _DISCOVERED_MANIFEST_ROWS:
+        guarded = guard_manifest_prune(rows, [], provider_slug=SLUG)
+        if guarded is rows:
+            return ["alibaba: kept old manifest (mass-prune guard)"]
+        raise RuntimeError("alibaba discovery returned no supported model rows")
+
+    existing_by_id = {
+        row["id"]: row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    present_rows: dict[str, dict[str, Any]] = {}
+    updated: list[str] = []
+    for model_id, discovered in sorted(_DISCOVERED_MANIFEST_ROWS.items()):
+        existing = existing_by_id.get(model_id)
+        if existing is None:
+            row = dict(discovered)
+        else:
+            # The live /models feed carries only id/object/created. Preserve
+            # richer curated metadata while refreshing route identity and
+            # availability from the authoritative feed.
+            row = dict(existing)
+            row["id"] = discovered["id"]
+            row["upstream_id"] = discovered["upstream_id"]
+            if "created" in discovered:
+                row["created"] = discovered["created"]
+        price = result.prices.get(model_id)
+        if price is not None:
+            _apply_price(row, price)
+            updated.append(model_id)
+        present_rows[model_id] = row
+
+    refreshed_rows = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+    guarded = guard_manifest_prune(rows, refreshed_rows, provider_slug=SLUG)
+    if guarded is rows:
+        return ["alibaba: kept old manifest (mass-prune guard)"]
+
+    previous_ids = set(existing_by_id)
+    current_ids = {
+        row["id"]
+        for row in guarded
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    appended = sorted(current_ids - previous_ids)
+    raw["models"] = guarded
+    raw["source"] = URL
+    raw["price_source"] = "https://www.alibabacloud.com/help/en/model-studio/model-pricing"
+    raw["generated_at"] = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    raw["model_count"] = len(guarded)
+    MANIFEST_PATH.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    suffix = f", appended {len(appended)}" if appended else ""
+    return [
+        f"alibaba: refreshed provider_models/alibaba.json "
+        f"({len(updated)} priced rows{suffix})"
+    ]

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -875,7 +875,7 @@ PROVIDERS: dict[str, Provider] = {
     "alibaba": Provider(
         slug="alibaba",
         name="Alibaba Cloud Model Studio",
-        supports_prepaid=False,
+        supports_prepaid=True,
         supports_byok=False,
         provider_policy=(
             "No provider-ZDR claim is tracked here. Alibaba Cloud Model Studio "
@@ -987,6 +987,10 @@ GATEWAY_PREPAID_PROVIDER_SLUGS = frozenset(
         "neurometric",
         "nebius",
         "minimax",
+        # Alibaba Cloud Model Studio — Frankfurt workspace. The production
+        # key is entitled to inference and its provider-native catalog is
+        # refreshed from the workspace-scoped /models endpoint.
+        "alibaba",
         # Cohere — embeddings only for now (native /v2/embed in the enclave).
         "cohere",
         # Voyage — embeddings only (OpenAI-shaped /v1/embeddings in the enclave).

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -712,6 +712,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "zai",
         "tinfoil",
         "xiaomi",
+        "alibaba",
         "meta",
     ):
         path = _PROVIDER_MODELS_DIR / f"{provider_slug}.json"

--- a/src/trusted_router/data/provider_models/alibaba.json
+++ b/src/trusted_router/data/provider_models/alibaba.json
@@ -3,9 +3,9 @@
   "provider": "alibaba",
   "source": "https://ws-el6e4bpnggpx7g88.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/models",
   "price_source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
-  "generated_at": "2026-07-01T00:00:00Z",
+  "generated_at": "2026-07-30T21:15:39Z",
   "price_scale": "microdollars_per_million",
-  "model_count": 72,
+  "model_count": 75,
   "models": [
     {
       "id": "z-ai/glm-5.2",
@@ -870,7 +870,7 @@
       "created": 1773662064,
       "context_length": 131072,
       "input_token_price_per_m": 50000,
-      "output_token_price_per_m": 200000,
+      "output_token_price_per_m": 400000,
       "cached_input_token_price_per_m": 5000,
       "model_type": "chat",
       "endpoints": [
@@ -891,7 +891,7 @@
       "created": 1773661748,
       "context_length": 131072,
       "input_token_price_per_m": 50000,
-      "output_token_price_per_m": 200000,
+      "output_token_price_per_m": 400000,
       "cached_input_token_price_per_m": 5000,
       "model_type": "chat",
       "endpoints": [
@@ -912,7 +912,7 @@
       "created": 1773661631,
       "context_length": 131072,
       "input_token_price_per_m": 50000,
-      "output_token_price_per_m": 200000,
+      "output_token_price_per_m": 400000,
       "cached_input_token_price_per_m": 5000,
       "model_type": "chat",
       "endpoints": [
@@ -933,7 +933,7 @@
       "created": 1773661512,
       "context_length": 131072,
       "input_token_price_per_m": 50000,
-      "output_token_price_per_m": 200000,
+      "output_token_price_per_m": 400000,
       "cached_input_token_price_per_m": 5000,
       "model_type": "chat",
       "endpoints": [
@@ -2127,6 +2127,104 @@
       ],
       "output_modalities": [
         "text"
+      ]
+    },
+    {
+      "id": "qwen/qwen-plus-character",
+      "upstream_id": "qwen-plus-character",
+      "display_name": "Qwen Plus Character",
+      "title": "qwen-plus-character",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "created": 1784556825,
+      "input_token_price_per_m": 400000,
+      "output_token_price_per_m": 4000000,
+      "cached_input_token_price_per_m": 40000
+    },
+    {
+      "id": "qwen/qwen3.7-flash",
+      "upstream_id": "qwen3.7-flash",
+      "display_name": "Qwen3.7 Flash",
+      "title": "qwen3.7-flash",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "created": 1785220431,
+      "context_length": 1048576,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "input_token_price_per_m": 30000,
+      "output_token_price_per_m": 130000,
+      "cached_input_token_price_per_m": 6000,
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 32000,
+          "input_token_price_per_m": 30000,
+          "output_token_price_per_m": 130000,
+          "cached_input_token_price_per_m": 6000
+        },
+        {
+          "max_prompt_tokens": 256000,
+          "input_token_price_per_m": 100000,
+          "output_token_price_per_m": 400000,
+          "cached_input_token_price_per_m": 20000
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 200000,
+          "output_token_price_per_m": 800000,
+          "cached_input_token_price_per_m": 40000
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-flash-2026-07-15",
+      "upstream_id": "qwen3.7-flash-2026-07-15",
+      "display_name": "Qwen3.7 Flash 2026 07 15",
+      "title": "qwen3.7-flash-2026-07-15",
+      "model_type": "chat",
+      "endpoints": [
+        "chat/completions"
+      ],
+      "created": 1785220365,
+      "context_length": 1048576,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "input_token_price_per_m": 30000,
+      "output_token_price_per_m": 130000,
+      "cached_input_token_price_per_m": 6000,
+      "price_tiers": [
+        {
+          "max_prompt_tokens": 32000,
+          "input_token_price_per_m": 30000,
+          "output_token_price_per_m": 130000,
+          "cached_input_token_price_per_m": 6000
+        },
+        {
+          "max_prompt_tokens": 256000,
+          "input_token_price_per_m": 100000,
+          "output_token_price_per_m": 400000,
+          "cached_input_token_price_per_m": 20000
+        },
+        {
+          "max_prompt_tokens": null,
+          "input_token_price_per_m": 200000,
+          "output_token_price_per_m": 800000,
+          "cached_input_token_price_per_m": 40000
+        }
       ]
     }
   ]

--- a/tests/test_alibaba_pricing.py
+++ b/tests/test_alibaba_pricing.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.pricing.providers import alibaba
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def _expected_model_rows() -> list[dict[str, object]]:
+    return [
+        {"id": "glm-5.2", "created": 1},
+        {"id": "kimi-k2.7-code", "created": 2},
+        {"id": "deepseek-v4-flash", "created": 3},
+        {"id": "deepseek-v4-pro", "created": 4},
+        {"id": "qwen3.7-flash", "created": 5},
+        {"id": "qwen3.7-flash-2026-07-15", "created": 6},
+        {"id": "qwen3.7-max", "created": 7},
+        {"id": "qwen3.7-plus", "created": 8},
+    ]
+
+
+def test_qwen_37_flash_uses_published_context_price_tiers() -> None:
+    price = alibaba._price("qwen3.7-flash")  # noqa: SLF001
+
+    assert price is not None
+    assert [
+        (
+            tier.max_prompt_tokens,
+            tier.prompt_micro_per_m,
+            tier.completion_micro_per_m,
+            tier.prompt_cached_micro_per_m,
+        )
+        for tier in price.tiers
+    ] == [
+        (32_000, 30_000, 130_000, 6_000),
+        (256_000, 100_000, 400_000, 20_000),
+        (None, 200_000, 800_000, 40_000),
+    ]
+
+
+def test_fetch_discovers_qwen_37_flash_alias_and_snapshot(monkeypatch) -> None:  # noqa: ANN001
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # noqa: ANN003
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args, **_kwargs) -> FakeResponse:  # noqa: ANN002, ANN003
+            return FakeResponse({"data": _expected_model_rows()})
+
+    monkeypatch.setattr(alibaba.httpx, "Client", FakeClient)
+
+    result = alibaba.fetch()
+
+    assert "qwen/qwen3.7-flash" in result.prices
+    assert alibaba.UPSTREAM_ID_MAP["qwen/qwen3.7-flash"] == "qwen3.7-flash"
+    assert (
+        alibaba.UPSTREAM_ID_MAP["qwen/qwen3.7-flash-2026-07-15"]
+        == "qwen3.7-flash-2026-07-15"
+    )
+    assert alibaba._DISCOVERED_MANIFEST_ROWS["qwen/qwen3.7-flash"][  # noqa: SLF001
+        "context_length"
+    ] == 1_048_576
+
+
+def test_manifest_refresh_appends_new_models_with_tiered_prices(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "alibaba.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "alibaba",
+                "models": [
+                    {
+                        "id": "qwen/qwen3.7-plus",
+                        "upstream_id": "qwen3.7-plus",
+                        "display_name": "Qwen3.7 Plus",
+                        "endpoints": ["chat/completions"],
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                        "price_tiers": [
+                            {
+                                "max_prompt_tokens": 256_000,
+                                "input_token_price_per_m": 400_000,
+                                "output_token_price_per_m": 1_600_000,
+                            },
+                            {
+                                "max_prompt_tokens": None,
+                                "input_token_price_per_m": 1_200_000,
+                                "output_token_price_per_m": 4_800_000,
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # noqa: ANN003
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args, **_kwargs) -> FakeResponse:  # noqa: ANN002, ANN003
+            return FakeResponse({"data": _expected_model_rows()})
+
+    monkeypatch.setattr(alibaba, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(alibaba.httpx, "Client", FakeClient)
+
+    result = alibaba.fetch()
+    notes = alibaba.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    flash = by_id["qwen/qwen3.7-flash"]
+    assert notes == [
+        "alibaba: refreshed provider_models/alibaba.json "
+        "(8 priced rows, appended 7)"
+    ]
+    assert flash["upstream_id"] == "qwen3.7-flash"
+    assert flash["input_token_price_per_m"] == 30_000
+    assert flash["output_token_price_per_m"] == 130_000
+    assert flash["price_tiers"][-1] == {
+        "max_prompt_tokens": None,
+        "input_token_price_per_m": 200_000,
+        "output_token_price_per_m": 800_000,
+        "cached_input_token_price_per_m": 40_000,
+    }
+    assert by_id["qwen/qwen3.7-plus"]["display_name"] == "Qwen3.7 Plus"
+    assert len(by_id["qwen/qwen3.7-plus"]["price_tiers"]) == 2

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1079,7 +1079,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
         "alibaba",
     }.issubset(provider_flags)
     assert provider_flags["openai"]["supports_prepaid"] is True
-    assert provider_flags["alibaba"]["supports_prepaid"] is False
+    assert provider_flags["alibaba"]["supports_prepaid"] is True
     assert provider_flags["alibaba"]["supports_byok"] is False
     assert provider_flags["deepseek"]["supports_byok"] is True
     assert provider_flags["kimi"]["supports_byok"] is True

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -49,8 +49,9 @@ def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) ->
     assert "phala" not in glm_providers
     assert glm_providers
     assert "phala" not in qwen_providers
-    # Phala is currently the only live route for this exact Qwen revision.
-    assert not qwen_providers
+    # Retirement is provider-scoped: Alibaba still serves this exact Qwen
+    # revision after Phala's route is removed.
+    assert qwen_providers == {"alibaba"}
 
 
 def test_non_confidential_phala_qwen_route_is_not_published() -> None:

--- a/tests/test_provider_contracts.py
+++ b/tests/test_provider_contracts.py
@@ -709,22 +709,29 @@ def test_baseten_catalog_exposes_glm_52_fast_router() -> None:
     } == {220_500}
 
 
-def test_alibaba_catalog_is_staged_but_not_routable_until_entitled() -> None:
+def test_alibaba_catalog_is_routable_after_workspace_entitlement() -> None:
     from trusted_router.catalog import GATEWAY_PREPAID_PROVIDER_SLUGS, PROVIDERS
 
-    # Alibaba /models works, but the current workspace key returns
-    # AccessDenied.Unpurchased for sampled chat calls. Keep the provider and
-    # manifest staged, but do not publish user-routable endpoints until the
-    # Model Studio workspace is entitled to the selected models.
     assert "alibaba" in PROVIDERS
-    assert PROVIDERS["alibaba"].supports_prepaid is False
+    assert PROVIDERS["alibaba"].supports_prepaid is True
     assert PROVIDERS["alibaba"].supports_byok is False
-    assert "alibaba" not in GATEWAY_PREPAID_PROVIDER_SLUGS
-    assert not [
+    assert "alibaba" in GATEWAY_PREPAID_PROVIDER_SLUGS
+    endpoints = [
         endpoint
-        for endpoint in endpoints_for_model("qwen/qwen3.5-397b-a17b")
+        for endpoint in endpoints_for_model("qwen/qwen3.7-flash")
         if endpoint.provider == "alibaba"
     ]
+    assert {endpoint.usage_type for endpoint in endpoints} == {"Credits"}
+    assert {endpoint.upstream_id for endpoint in endpoints} == {"qwen3.7-flash"}
+    snapshot_endpoints = [
+        endpoint
+        for endpoint in endpoints_for_model("qwen/qwen3.7-flash-2026-07-15")
+        if endpoint.provider == "alibaba"
+    ]
+    assert {endpoint.usage_type for endpoint in snapshot_endpoints} == {"Credits"}
+    assert {endpoint.upstream_id for endpoint in snapshot_endpoints} == {
+        "qwen3.7-flash-2026-07-15"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- enable Alibaba Cloud Model Studio as a prepaid provider after workspace billing activation
- refresh the authenticated Frankfurt model catalog hourly and publish Qwen 3.7 Flash with tier-aware pricing
- ingest Alibaba's provider-native manifest at runtime and preserve curated metadata during refreshes

## Verification
- direct Qwen 3.7 Flash non-streaming PONG: passed
- direct Qwen 3.7 Flash SSE: passed
- direct Qwen 3.7 Flash image input: passed
- `uv run ruff check .`: passed
- `uv run mypy`: passed
- `uv run pytest -q`: 2200 passed, 76 skipped
