### PR TITLE
multi-cloud: postgres backend selectable, status-page surface, DSQL portability, Azure canary

### DIFF
--- a/docs/storage-portability/aws-eu-and-azure-canary.md
+++ b/docs/storage-portability/aws-eu-and-azure-canary.md
@@ -1,0 +1,153 @@
+# AWS-EU (production) and Azure (canary)
+
+**Status:** decided 2026-07-30. Implements
+[`multi-cloud-separation.md`](multi-cloud-separation.md). Read that first — each cloud is a
+standalone deployment, identity federates, credits do not.
+
+Two very different things, deliberately:
+
+| | Azure | AWS |
+|---|---|---|
+| Purpose | **Deploy-pipeline canary** | **Production EU region** |
+| Regions | one | two EU member states |
+| Availability target | none | **99.99%** |
+| Database | Flexible Server B1ms | Aurora DSQL, multi-region |
+| Advertised? | never | **yes — EU-specific** |
+
+Azure exists so that AWS is not the first place a broken assumption is discovered. Deploy to
+Azure first, always.
+
+---
+
+## 1. AWS is EU-only, and that has to be literally true
+
+The product claim is data residency. A claim like that is worth nothing if it is
+approximately true, so the constraints are hard:
+
+* **Regions must be EU member states.** Ireland (`eu-west-1`), Frankfurt (`eu-central-1`),
+  Paris (`eu-west-3`), Stockholm (`eu-north-1`). Aurora DSQL is available in all four.
+* **London (`eu-west-2`) is not the EU.** Post-Brexit the UK is a third country under GDPR.
+  It is *available* for DSQL, which makes it an easy mistake. Do not use it.
+* **Every tier stays in-region**: compute, database, analytics (ClickHouse), logs, backups,
+  and secrets.
+
+### What "EU-only" does NOT cover, and must not be implied
+
+**Provider calls leave the EU.** If a user routes to a model hosted in `us-east`, the prompt
+goes there. The honest claim is therefore about **the deployment**, not the inference:
+
+> Your account, credits, API keys, usage history and analytics are stored and processed
+> exclusively in the EU.
+
+If we want to claim EU-only *inference* as well, that is a separate feature: a filtered
+catalog exposing only EU-hosted provider endpoints. Worth building, but it is not implied by
+this deployment and must not be advertised until it exists.
+
+This separation is only credible **because** of the standalone-cloud decision. Under the
+superseded shared-Spanner design, every EU request would have round-tripped to a US database,
+and no residency claim would have been possible at all.
+
+---
+
+## 2. The four-nines target, honestly
+
+**Four nines is 52.6 minutes of downtime per year.** It is an architectural property, not an
+effort level.
+
+### Serial composition is the trap
+
+Four components each at 99.99% multiply to **99.96%** — about 3.5 hours a year. You cannot
+reach four nines by assembling four "four-nines" services in a line. The failure-prone tiers
+must be **parallel**.
+
+| Tier | Design | Why |
+|---|---|---|
+| Aurora DSQL | **multi-region** | Single-region DSQL is 99.9%, which caps the whole product at three nines. Multi-region is 99.99%. This is the binding constraint. |
+| Compute | active in **both** EU regions | Parallel: combined failure ≈ 1e-8 |
+| Load balancer | one per region | Parallel |
+| DNS | health-checked failover | Route 53 hosted-zone SLA is 100% |
+
+Everything except the database must be *better* than 99.99% so it does not drag the product
+below the database's own ceiling.
+
+### Three caveats to state out loud
+
+1. **An SLA is a refund promise, not a probability distribution.** Measured availability is
+   the number that matters, which is why the per-cloud status page is part of this work rather
+   than an afterthought.
+2. **One bad deploy can spend a large slice of 52.6 minutes.** The rollout pipeline — staged
+   traffic, health gates, fast rollback — matters as much as the infrastructure. GCP's
+   `rollout.sh` already does 10/50/100 staged traffic; AWS must match it before it can claim
+   four nines.
+3. **Define "up" before promising it.** If AWS-EU serves inference, availability inherits
+   upstream providers, which are individually nowhere near four nines — that is what the
+   fallback machinery exists for. The control plane and status surface can hold four nines;
+   an individual provider route cannot, and the SLO must say which it is measuring.
+
+### Proposed topology
+
+* **Primary pair:** `eu-west-1` (Ireland) + `eu-central-1` (Frankfurt). Two member states,
+  ~25ms apart.
+* **Witness:** `eu-west-3` (Paris). DSQL multi-region needs a witness region; keeping it in
+  the EU keeps the residency claim intact.
+* Compute active in both primaries, DNS health-checked between them.
+
+---
+
+## 3. Azure is a canary and must stay one
+
+One region, no HA, no failover, no attestation, no inference. **Not on any SLO. Never
+advertised.** Its entire job is to answer "does the image build, ship, boot, reach its own
+database, and serve its own status page on a non-GCP cloud?" before that question is asked
+somewhere expensive.
+
+**Database choice deviates from the ADR on purpose.**
+[`multi-cloud-separation.md`](multi-cloud-separation.md) recommends Cosmos DB for PostgreSQL
+(Citus) for a *production* Azure region, because Citus distributes on `workspace_id`. The
+canary uses plain **Flexible Server Burstable B1ms** instead: Citus carries a substantial
+minimum node cost, and what is under test here is the pipeline, not sharding. `PostgresStore`
+already passes conformance against stock Postgres, so this remains a faithful test of the
+application. If Azure ever becomes production, re-validate on Citus with the conformance suite
+first.
+
+---
+
+## 4. What actually blocked this, and the fix
+
+`create_store` supported only `memory` and `spanner-bigtable`. **`postgres` was not
+selectable**, so no amount of cloud infrastructure could have run the app. Fixed here:
+`TR_STORAGE_BACKEND=postgres` + `TR_POSTGRES_DSN`, which fails loudly when the DSN is missing
+rather than starting and dying on first query.
+
+Booting the real app on Postgres locally then gave the honest picture:
+
+| Route | Result |
+|---|---|
+| `/health` | 200 |
+| `/` | 200 |
+| `/status.json` | `NotImplementedError: synthetic_probe_samples` |
+
+Tracing the status path showed it needs exactly **three** `Store` methods —
+`record_synthetic_probe_sample`, `synthetic_probe_samples`, `synthetic_rollups`. That is the
+whole per-cloud status page, and it is increment 2.
+
+This is the pattern worth repeating: boot the thing locally and read the actual error, rather
+than reasoning about what a deployment might need.
+
+---
+
+## 5. Order of work
+
+1. **Wire `postgres` into `create_store`.** Done.
+2. **PostgresStore increment 2** — the three synthetic methods, with conformance tests that
+   run on `memory`, `postgres` and `spanner-pg`.
+3. **Azure canary up**, `/status.json` green, its own uptime page.
+4. **Spanner cleanup (#334)** before AWS, so 14.8M rows of mostly-garbage are not the shape
+   that gets replicated into a new cloud.
+5. **AWS-EU**: DSQL multi-region across Ireland + Frankfurt, conformance suite against the
+   live cluster, then compute in both regions with staged rollout.
+6. **AWS-EU status page + SLO**, measuring what it actually promises.
+7. Only then advertise EU residency, and only the claim in §1 that is actually true.
+
+**Inference on AWS-EU needs `reserve`/`settle`/`refund`**, which are still stubs. Until those
+land and pass conformance, AWS-EU is a control plane, not a router.

--- a/docs/storage-portability/coverage-map.md
+++ b/docs/storage-portability/coverage-map.md
@@ -45,11 +45,26 @@ mechanisms, and only the second one costs a wallet.
 
 ## 3. Facts, checked
 
-**Aurora DSQL is available in all 16 regions probed**: `us-east-1`, `us-east-2`,
-`us-west-2`, `eu-west-1`, `eu-central-1`, `eu-west-3`, `eu-north-1`,
-`eu-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `ap-south-1`,
-`sa-east-1`, `ca-central-1`, `af-south-1`, `me-central-1`. Geography is not the
-constraint.
+**Aurora DSQL is broadly available**, so geography is not the constraint — but
+the naive probe that produced that list had a **false positive**, and the
+mechanism is worth knowing.
+
+`aws dsql list-clusters` against a region the account has **not opted into**
+does not fail the way an unsupported-service call fails, so a
+grep-for-an-error probe scores it as available. `eu-south-1` (Milan) passed that
+probe and is in fact `not-opted-in`, which only surfaced when
+`aws ec2 describe-regions` was checked directly.
+
+**Check `OptInStatus` before believing any region is usable:**
+
+```bash
+aws ec2 describe-regions --query "Regions[?starts_with(RegionName,'eu-')].{r:RegionName,s:OptInStatus}" --output text
+```
+
+EU regions usable with no opt-in today: `eu-west-1` Ireland, `eu-central-1`
+Frankfurt, `eu-west-3` Paris, `eu-north-1` Stockholm. (`eu-west-2` is London and
+is not the EU.) Opt-in regions such as Milan, Spain and Zurich need an explicit
+account-level enable that does not take effect immediately.
 
 **Azure exposes 40+ physical regions, but this subscription is capacity-restricted
 per service and inconsistently**: Postgres refused in `westeurope`, fine in
@@ -71,11 +86,17 @@ residency claim survives:
 
 | Role | Region |
 |---|---|
-| DSQL primary | `eu-west-1` Ireland |
-| DSQL peer | `eu-central-1` Frankfurt |
-| DSQL witness | `eu-west-3` Paris |
-| Compute | Ireland + Frankfurt (active/active) |
-| Compute (optional 3rd) | `eu-north-1` Stockholm or `eu-south-1` Milan |
+| DSQL primary | `eu-west-1` **Dublin** |
+| DSQL peer | `eu-north-1` **Stockholm** |
+| DSQL witness | `eu-west-3` **Paris** (metadata only) |
+| Compute | Dublin + Stockholm (active/active) |
+
+Milan was the first choice for spread and had to be abandoned: it is an opt-in
+region and the enable does not take effect promptly. Dublin + Stockholm gives
+Atlantic-west plus Nordic-north — a wider spread than the conventional
+Dublin + Frankfurt pair, and it avoids crowding the Netherlands dot that GCP
+already occupies. Peer latency is roughly 40ms against Frankfurt's 25ms, which
+is the price of the spread and is paid on write quorum.
 
 This is what buys four nines — see
 [`aws-eu-and-azure-canary.md`](aws-eu-and-azure-canary.md) §2 for why serial

--- a/docs/storage-portability/coverage-map.md
+++ b/docs/storage-portability/coverage-map.md
@@ -1,0 +1,133 @@
+# Coverage map: where deployments go, and why not everywhere
+
+Companion to [`multi-cloud-separation.md`](multi-cloud-separation.md) and
+[`aws-eu-and-azure-canary.md`](aws-eu-and-azure-canary.md).
+
+---
+
+## 1. Two different things are both called "more locations"
+
+They have opposite cost profiles, and conflating them is expensive.
+
+| | More **regions inside** one deployment | More **standalone deployments** |
+|---|---|---|
+| Database | one, spanning regions | one **per deployment** |
+| Credits | one wallet | **a separate wallet each** |
+| API keys | work everywhere in it | scoped to that deployment |
+| Buys you | availability, in-region failover | jurisdiction / residency |
+| Marginal cost | small | a whole operational surface |
+
+Under the separation decision a standalone deployment is **a separate credit
+balance by design**. That is correct and deliberate — but it means N deployments
+is N wallets a user cannot move money between. Two clouds is already a support
+burden the console has to make visible. Six would be a product.
+
+**So: be generous with regions, deliberate with deployments.**
+
+---
+
+## 2. Latency diversity is not a control-plane problem
+
+Worth separating, because it is the usual reason people ask for a wide map.
+
+* **Inference latency** is a *gateway/enclave* concern, and that layer is already
+  multi-region on GCP. Putting a control plane in Tokyo does not make a Tokyo
+  user's tokens arrive faster.
+* **The control plane** is signup, console, billing, status. It is not on the
+  token path. Its location matters for **residency and jurisdiction**, not speed.
+
+If the goal is "users everywhere feel fast", the answer is more *gateway*
+regions. If the goal is "data for these customers stays in this jurisdiction",
+the answer is a standalone deployment. They are different asks with different
+mechanisms, and only the second one costs a wallet.
+
+---
+
+## 3. Facts, checked
+
+**Aurora DSQL is available in all 16 regions probed**: `us-east-1`, `us-east-2`,
+`us-west-2`, `eu-west-1`, `eu-central-1`, `eu-west-3`, `eu-north-1`,
+`eu-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `ap-south-1`,
+`sa-east-1`, `ca-central-1`, `af-south-1`, `me-central-1`. Geography is not the
+constraint.
+
+**Azure exposes 40+ physical regions, but this subscription is capacity-restricted
+per service and inconsistently**: Postgres refused in `westeurope`, fine in
+`northeurope`; ACR the exact reverse; ACR Tasks not permitted at all. Any Azure
+region must be **probed, not assumed**.
+
+**`eu-west-2` (London) is not the EU.** Post-Brexit the UK is a third country
+under GDPR. DSQL is available there, which makes it an easy and expensive
+mistake.
+
+---
+
+## 4. Recommended map
+
+### AWS-EU — the advertised product, one deployment, one wallet
+
+Diversity **inside** the deployment, entirely within EU member states, so the
+residency claim survives:
+
+| Role | Region |
+|---|---|
+| DSQL primary | `eu-west-1` Ireland |
+| DSQL peer | `eu-central-1` Frankfurt |
+| DSQL witness | `eu-west-3` Paris |
+| Compute | Ireland + Frankfurt (active/active) |
+| Compute (optional 3rd) | `eu-north-1` Stockholm or `eu-south-1` Milan |
+
+This is what buys four nines — see
+[`aws-eu-and-azure-canary.md`](aws-eu-and-azure-canary.md) §2 for why serial
+composition means the database tier sets the ceiling.
+
+### Azure — canaries, several geographies, no wallets
+
+Canaries hold no production data, serve no users, and are never advertised, so
+they can be spread freely and cheaply. Three is enough to prove the deploy
+pipeline is not accidentally region-specific:
+
+| Canary | Region | Proves |
+|---|---|---|
+| `tr-canary-eu` | `swedencentral` + `northeurope` | **live today** |
+| `tr-canary-us` | **`canadacentral`** | non-EU deploy path |
+| `tr-canary-apac` | **`southeastasia`** or **`japaneast`** | far-from-home latency, different capacity pool |
+
+Those three were probed on 2026-07-30 and all accept Burstable B1ms.
+**`eastus2` is RESTRICTED** for this subscription, which is exactly why the
+table names verified regions rather than plausible ones. Stand one up with:
+
+```bash
+CANARY=tr-canary-us LOCATION=canadacentral APP_LOCATION=canadacentral \
+  bash scripts/deploy/azure_canary.sh
+```
+
+Every resource name derives from `CANARY`, so a new geography is one env var
+rather than a forked script. Budget roughly $20-25/month each and tear them
+down when they are not earning it.
+
+Each is one region, B1ms, scale-to-low. Their whole value is catching
+region-specific breakage before it reaches a real deployment — which has already
+paid for itself once, since three separate Azure capacity restrictions showed up
+in the first one.
+
+### Further standalone deployments — gate on demand
+
+`aws-us`, `aws-apac`, and similar are **standalone**: own database, own credits,
+own status page. Each is a real product surface, so create one when a customer
+needs that jurisdiction, not to fill in a map. The architecture makes adding one
+mechanical; that is not a reason to add six.
+
+---
+
+## 5. What has to be true before any deployment is advertised
+
+1. Conformance passes against that deployment's **actual** database, not a
+   compatible one. Running it against real DSQL found three incompatibilities
+   that "Postgres-wire compatible" had hidden.
+2. It serves **its own** status page from **its own** database.
+3. Its residency claim is literally true for every tier — compute, database,
+   analytics, logs, backups, secrets.
+4. `reserve` / `settle` / `refund` exist if it serves inference. Until they do,
+   a deployment is a control plane, not a router, and must not carry an
+   inference SLO.

--- a/scripts/deploy/azure_canary.sh
+++ b/scripts/deploy/azure_canary.sh
@@ -37,17 +37,27 @@ set -euo pipefail
 # that is this, not a bug. Probe another region.
 LOCATION="${LOCATION:-northeurope}"          # Postgres
 APP_LOCATION="${APP_LOCATION:-swedencentral}"  # ACR + Container Apps
-RG="${RG:-tr-canary}"
-PG_NAME="${PG_NAME:-tr-canary-pg}"
+# CANARY drives every resource name, so a second canary in another geography is
+# one env var, not a forked script:
+#   CANARY=tr-canary-apac LOCATION=southeastasia APP_LOCATION=southeastasia \
+#     bash scripts/deploy/azure_canary.sh
+#
+# See docs/storage-portability/coverage-map.md for which geographies are worth
+# having, and why canaries can be spread freely while standalone DEPLOYMENTS
+# cannot - each of those is a separate credit balance.
+CANARY="${CANARY:-tr-canary}"
+RG="${RG:-$CANARY}"
+PG_NAME="${PG_NAME:-$CANARY-pg}"
 PG_ADMIN="${PG_ADMIN:-tradmin}"
 PG_DB="${PG_DB:-trustedrouter}"
-ACR="${ACR:-trcanaryswedencentralacr}"
-APP_ENV="${APP_ENV:-tr-canary-env}"
-APP="${APP:-tr-canary}"
+# ACR names are globally unique and alphanumeric-only.
+ACR="${ACR:-$(echo "${CANARY}${APP_LOCATION}acr" | tr -cd "[:alnum:]")}"
+APP_ENV="${APP_ENV:-$CANARY-env}"
+APP="${APP:-$CANARY}"
 IMAGE_TAG="${IMAGE_TAG:-canary}"
 # Bootstrap password location. Fixed, not $TMPDIR — these scripts run as
 # separate processes with different temp dirs.
-STATE_DIR="${STATE_DIR:-$HOME/.config/tr-canary}"
+STATE_DIR="${STATE_DIR:-$HOME/.config/$CANARY}"
 PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
 
 log() { printf '\n=== %s\n' "$*" >&2; }

--- a/scripts/deploy/azure_canary.sh
+++ b/scripts/deploy/azure_canary.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Azure canary: the smallest possible end-to-end TrustedRouter deployment.
+#
+# PURPOSE — this is a DEPLOY-PIPELINE TEST, not a production region.
+#
+# It exists to answer "does the image build, ship, boot, reach its own database,
+# and serve its own status page on a non-GCP cloud?" quickly and cheaply, so
+# that the expensive EU AWS build is not the first place we discover a broken
+# assumption. Deploy here first, then AWS.
+#
+# DELIBERATE CHOICE OF DATABASE. docs/storage-portability/multi-cloud-separation.md
+# recommends Cosmos DB for PostgreSQL (Citus) for a *production* Azure region,
+# because Citus can distribute by workspace_id. This canary uses plain
+# **Flexible Server, Burstable B1ms** instead — Citus has a substantial minimum
+# node cost, and the thing being tested here is the pipeline, not the sharding
+# behaviour. PostgresStore already passes conformance against stock Postgres, so
+# this is a faithful test of the application. If Azure ever becomes a production
+# region, re-validate on Citus with the conformance suite before trusting it.
+#
+# SCOPE. One region, no HA, no multi-AZ, no failover, no attestation, no
+# inference. It is not on any uptime SLO and must never be advertised.
+#
+# Cost is roughly $20-25/month. Tear it down with azure_canary_teardown.sh when
+# it is not earning that.
+#
+# Idempotent: every create is check-then-create.
+set -euo pipefail
+
+# This subscription is capacity-restricted PER SERVICE, not per region, and the
+# restrictions do not agree with each other: Postgres is disallowed in
+# westeurope but fine in northeurope, while ACR is the exact reverse. So the
+# database and the registry/app deliberately live in DIFFERENT regions. Both are
+# EU member states, which is all the canary needs — it is not the EU-residency
+# deployment (that is AWS; see aws-eu-and-azure-canary.md).
+#
+# If a create fails with "region is currently not accepting new customers",
+# that is this, not a bug. Probe another region.
+LOCATION="${LOCATION:-northeurope}"          # Postgres
+APP_LOCATION="${APP_LOCATION:-swedencentral}"  # ACR + Container Apps
+RG="${RG:-tr-canary}"
+PG_NAME="${PG_NAME:-tr-canary-pg}"
+PG_ADMIN="${PG_ADMIN:-tradmin}"
+PG_DB="${PG_DB:-trustedrouter}"
+ACR="${ACR:-trcanaryswedencentralacr}"
+APP_ENV="${APP_ENV:-tr-canary-env}"
+APP="${APP:-tr-canary}"
+IMAGE_TAG="${IMAGE_TAG:-canary}"
+# Bootstrap password location. Fixed, not $TMPDIR — these scripts run as
+# separate processes with different temp dirs.
+STATE_DIR="${STATE_DIR:-$HOME/.config/tr-canary}"
+PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
+
+log() { printf '\n=== %s\n' "$*" >&2; }
+exists() { "$@" >/dev/null 2>&1; }
+
+log "subscription: $(az account show --query name -o tsv) / location=$LOCATION"
+
+# ------------------------------------------------------------------ group
+if exists az group show -n "$RG"; then
+  log "resource group $RG exists"
+else
+  log "creating resource group $RG"
+  az group create -n "$RG" -l "$LOCATION" -o none
+fi
+
+# --------------------------------------------------------------- postgres
+# Burstable B1ms is the smallest tier. Public access with a firewall rather
+# than a VNet: a canary that needs a bastion to debug defeats its own purpose.
+# It holds no production data — see SCOPE above.
+if exists az postgres flexible-server show -g "$RG" -n "$PG_NAME"; then
+  log "postgres $PG_NAME exists"
+else
+  log "creating postgres $PG_NAME (Standard_B1ms, 32GB)"
+  # Generated here, never echoed; stored straight into the Container App as a
+  # secret below and readable afterwards only via `az containerapp secret show`.
+  PG_PASSWORD="$(python3 -c 'import secrets;print(secrets.token_urlsafe(24),end="")')"
+  az postgres flexible-server create \
+    -g "$RG" -n "$PG_NAME" -l "$LOCATION" \
+    --admin-user "$PG_ADMIN" --admin-password "$PG_PASSWORD" \
+    --tier Burstable --sku-name Standard_B1ms \
+    --storage-size 32 --version 16 \
+    --public-access 0.0.0.0 --yes -o none
+  # -n is the DATABASE name here (-d is not a flag). This was wrong AND the
+  # error was swallowed by `|| true`, so the server came up without its
+  # database and the app crash-looped on connect with a message that pointed
+  # at the pool, not at the missing database. Never silence a create that the
+  # deployment depends on.
+  az postgres flexible-server db create -g "$RG" -s "$PG_NAME" -n "$PG_DB" -o none
+  # Stash it so azure_canary_app.sh can build the Container App without
+  # recreating the server. Once that app exists, ITS secret is the system of
+  # record and this file is only a bootstrap crutch.
+  #
+  # A fixed path, not $TMPDIR: the two scripts routinely run as different
+  # processes (and CI jobs) with different temp directories, so a TMPDIR
+  # handoff silently loses the password and the second script fails with a
+  # confusing "no password" error.
+  mkdir -p "$STATE_DIR"
+  ( umask 077 && printf '%s' "$PG_PASSWORD" > "$PW_FILE" )
+fi
+
+# Container Apps egresses from shared Azure IPs. `--public-access 0.0.0.0` at
+# create time already installs the "all Azure services" rule, so this only adds
+# an operator IP for debugging when TR_DEV_IP is set.
+#
+# NOTE the flags: -s is the SERVER and -n is the RULE. Getting that wrong (-r
+# does not exist) fails, and the original `|| true` hid it completely.
+if [ -n "${TR_DEV_IP:-}" ]; then
+  log "allowing operator IP $TR_DEV_IP"
+  az postgres flexible-server firewall-rule create \
+    -g "$RG" -s "$PG_NAME" -n devbox \
+    --start-ip-address "$TR_DEV_IP" --end-ip-address "$TR_DEV_IP" -o none
+fi
+
+PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" --query fullyQualifiedDomainName -o tsv)"
+log "postgres host: $PG_HOST"
+
+# -------------------------------------------------------------------- acr
+if exists az acr show -g "$RG" -n "$ACR"; then
+  log "acr $ACR exists"
+else
+  log "creating acr $ACR (Basic)"
+  az acr create -g "$RG" -n "$ACR" -l "$APP_LOCATION" --sku Basic --admin-enabled true -o none
+fi
+
+# Built locally and pushed, NOT with `az acr build`. ACR Tasks (the cloud
+# builder) is not permitted on this subscription — it fails with
+# TasksOperationsNotAllowed and needs an Azure support request to enable. A
+# local buildx push needs no such permission.
+#
+# --platform linux/amd64 is REQUIRED when building from an Apple Silicon Mac:
+# Container Apps runs amd64, and an arm64 image fails at start with an
+# exec-format error that looks nothing like an architecture problem.
+log "building image locally and pushing to $ACR (ACR Tasks is not available here)"
+ACR_SERVER="$(az acr show -n "$ACR" --query loginServer -o tsv)"
+az acr login -n "$ACR" >/dev/null
+docker buildx build --platform linux/amd64 \
+  -t "${ACR_SERVER}/trusted-router:${IMAGE_TAG}" --push .
+
+# --------------------------------------------------- container apps env
+if exists az containerapp env show -g "$RG" -n "$APP_ENV"; then
+  log "container app env exists"
+else
+  log "creating container app environment"
+  az containerapp env create -g "$RG" -n "$APP_ENV" -l "$APP_LOCATION" -o none
+fi
+
+log "done. Deploy the app with azure_canary_app.sh (kept separate so the app can"
+log "be redeployed without re-provisioning the database)."
+log "  PG_HOST=$PG_HOST"

--- a/scripts/deploy/azure_canary_app.sh
+++ b/scripts/deploy/azure_canary_app.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Deploy (or redeploy) the canary Container App.
+#
+# Split from azure_canary.sh so the application can be shipped repeatedly
+# without touching the database — which is the whole point of a canary: fast,
+# repeatable deploys.
+#
+# Read azure_canary.sh's header for scope. This is a pipeline test: one region,
+# no HA, no inference, not on any SLO, never advertised.
+set -euo pipefail
+
+LOCATION="${LOCATION:-northeurope}"
+RG="${RG:-tr-canary}"
+PG_NAME="${PG_NAME:-tr-canary-pg}"
+PG_ADMIN="${PG_ADMIN:-tradmin}"
+PG_DB="${PG_DB:-trustedrouter}"
+ACR="${ACR:-trcanaryswedencentralacr}"
+APP_ENV="${APP_ENV:-tr-canary-env}"
+APP="${APP:-tr-canary}"
+IMAGE_TAG="${IMAGE_TAG:-canary}"
+# Bootstrap password location. Fixed, not $TMPDIR — these scripts run as
+# separate processes with different temp dirs.
+STATE_DIR="${STATE_DIR:-$HOME/.config/tr-canary}"
+PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
+
+log() { printf '\n=== %s\n' "$*" >&2; }
+exists() { "$@" >/dev/null 2>&1; }
+
+PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" --query fullyQualifiedDomainName -o tsv)"
+ACR_SERVER="$(az acr show -g "$RG" -n "$ACR" --query loginServer -o tsv)"
+ACR_USER="$(az acr credential show -n "$ACR" --query username -o tsv)"
+ACR_PASS="$(az acr credential show -n "$ACR" --query 'passwords[0].value' -o tsv)"
+
+# Password source of truth: the Container App secret if the app already exists,
+# otherwise the file azure_canary.sh wrote when it created the server. Never
+# echoed either way.
+if exists az containerapp show -g "$RG" -n "$APP"; then
+  PG_PASSWORD="$(az containerapp secret show -g "$RG" -n "$APP" --secret-name pg-password --query value -o tsv)"
+else
+  
+  [ -f "$PW_FILE" ] || { echo "no password: run azure_canary.sh first, or reset it with 'az postgres flexible-server update --admin-password'" >&2; exit 1; }
+  PG_PASSWORD="$(cat "$PW_FILE")"
+fi
+
+# sslmode=require: Flexible Server enforces TLS, and psycopg would otherwise
+# negotiate down and fail on a server that refuses plaintext.
+DSN="postgresql://${PG_ADMIN}:${PG_PASSWORD}@${PG_HOST}:5432/${PG_DB}?sslmode=require"
+
+log "deploying $APP from ${ACR_SERVER}/trusted-router:${IMAGE_TAG}"
+
+# TR_ENVIRONMENT stays 'canary', NOT 'production' — several code paths branch on
+# it, and a pipeline test must never be mistaken for a live region in logs,
+# Sentry, or analytics.
+COMMON_ENV=(
+  "TR_ENVIRONMENT=canary"
+  "TR_RELEASE=${IMAGE_TAG}"
+  "TR_STORAGE_BACKEND=postgres"
+  "TR_ENABLE_LIVE_PROVIDERS=false"
+  "TR_TRUSTED_DOMAIN=trustedrouter.com"
+)
+
+if exists az containerapp show -g "$RG" -n "$APP"; then
+  log "updating existing app"
+  az containerapp update -g "$RG" -n "$APP" \
+    --image "${ACR_SERVER}/trusted-router:${IMAGE_TAG}" \
+    --set-env-vars "${COMMON_ENV[@]}" "TR_POSTGRES_DSN=secretref:pg-dsn" -o none
+else
+  log "creating app"
+  az containerapp create -g "$RG" -n "$APP" \
+    --environment "$APP_ENV" \
+    --image "${ACR_SERVER}/trusted-router:${IMAGE_TAG}" \
+    --registry-server "$ACR_SERVER" \
+    --registry-username "$ACR_USER" \
+    --registry-password "$ACR_PASS" \
+    --secrets "pg-password=${PG_PASSWORD}" "pg-dsn=${DSN}" \
+    --env-vars "${COMMON_ENV[@]}" "TR_POSTGRES_DSN=secretref:pg-dsn" \
+    --target-port 8080 --ingress external \
+    --min-replicas 1 --max-replicas 2 \
+    --cpu 0.5 --memory 1.0Gi -o none
+fi
+
+FQDN="$(az containerapp show -g "$RG" -n "$APP" --query properties.configuration.ingress.fqdn -o tsv)"
+log "app URL: https://${FQDN}"
+log "verify with: bash scripts/deploy/azure_canary_verify.sh"
+echo "https://${FQDN}"

--- a/scripts/deploy/azure_canary_app.sh
+++ b/scripts/deploy/azure_canary_app.sh
@@ -10,17 +10,19 @@
 set -euo pipefail
 
 LOCATION="${LOCATION:-northeurope}"
-RG="${RG:-tr-canary}"
-PG_NAME="${PG_NAME:-tr-canary-pg}"
+CANARY="${CANARY:-tr-canary}"
+APP_LOCATION="${APP_LOCATION:-swedencentral}"
+RG="${RG:-$CANARY}"
+PG_NAME="${PG_NAME:-$CANARY-pg}"
 PG_ADMIN="${PG_ADMIN:-tradmin}"
 PG_DB="${PG_DB:-trustedrouter}"
-ACR="${ACR:-trcanaryswedencentralacr}"
-APP_ENV="${APP_ENV:-tr-canary-env}"
-APP="${APP:-tr-canary}"
+ACR="${ACR:-$(echo "${CANARY}${APP_LOCATION}acr" | tr -cd "[:alnum:]")}"
+APP_ENV="${APP_ENV:-$CANARY-env}"
+APP="${APP:-$CANARY}"
 IMAGE_TAG="${IMAGE_TAG:-canary}"
 # Bootstrap password location. Fixed, not $TMPDIR — these scripts run as
 # separate processes with different temp dirs.
-STATE_DIR="${STATE_DIR:-$HOME/.config/tr-canary}"
+STATE_DIR="${STATE_DIR:-$HOME/.config/$CANARY}"
 PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
 
 log() { printf '\n=== %s\n' "$*" >&2; }

--- a/scripts/deploy/verify_deployment.sh
+++ b/scripts/deploy/verify_deployment.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Self-test a TrustedRouter deployment on any cloud.
+#
+#   bash scripts/deploy/verify_deployment.sh https://tr-canary.....azurecontainerapps.io
+#
+# Cloud-agnostic on purpose: the Azure canary and the AWS EU region run the same
+# checks, so "it works on Azure" and "it works on AWS" mean the same thing. A
+# per-cloud bespoke smoke test would let the two drift and would not be evidence
+# of anything.
+#
+# COSTS NOTHING. Every check below is a free endpoint. Inference probes spend
+# real provider money and are deliberately excluded — a deploy check that bills
+# per run will get switched off.
+#
+# Exits non-zero on the first hard failure so it can gate a rollout.
+set -uo pipefail
+
+BASE="${1:-}"
+[ -n "$BASE" ] || { echo "usage: $0 <base-url>" >&2; exit 2; }
+BASE="${BASE%/}"
+
+pass=0; fail=0; warn=0
+ok()   { printf '  PASS  %s\n' "$*"; pass=$((pass+1)); }
+bad()  { printf '  FAIL  %s\n' "$*"; fail=$((fail+1)); }
+soft() { printf '  WARN  %s\n' "$*"; warn=$((warn+1)); }
+
+code() { curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$1" 2>/dev/null; }
+body() { curl -s --max-time 20 "$1" 2>/dev/null; }
+
+printf '\n=== verifying %s\n\n' "$BASE"
+
+# 1. Liveness. If this fails nothing else is meaningful.
+if [ "$(code "$BASE/health")" = "200" ]; then
+  ok "/health responds 200"
+else
+  bad "/health did not return 200 — the container is not serving"
+  echo; echo "  $pass passed, $fail failed, $warn warnings"; exit 1
+fi
+
+# 2. The app renders. Catches a booted process that cannot template or read
+#    static assets — a class of failure /health cannot see.
+[ "$(code "$BASE/")" = "200" ] && ok "/ renders" || bad "/ did not return 200"
+
+# 3. Database round-trip. This is the check that actually proves the deployment
+#    reached ITS OWN database: /status.json reads synthetic probe samples, so a
+#    200 here means the store is wired, reachable and queryable. A deployment
+#    whose DSN is wrong passes checks 1 and 2 and fails this one.
+status_code="$(code "$BASE/status.json")"
+if [ "$status_code" = "200" ]; then
+  ok "/status.json responds 200 (database read path works)"
+  if body "$BASE/status.json" | grep -q '"overall_status"'; then
+    ok "status payload is well-formed"
+  else
+    bad "status payload missing overall_status — served, but wrong shape"
+  fi
+else
+  bad "/status.json returned $status_code — store not reachable or not implemented"
+fi
+
+# 4. Auth is actually enforced. A deployment that serves inference endpoints
+#    unauthenticated is worse than one that is down, so an unauthenticated call
+#    MUST be rejected. 404 is acceptable: it means the route is not mounted here
+#    at all, which is true for a control-plane-only deployment.
+auth_code="$(code "$BASE/v1/chat/completions")"
+case "$auth_code" in
+  401|403) ok "unauthenticated /v1/chat/completions rejected ($auth_code)" ;;
+  404|405) soft "/v1/chat/completions not served here ($auth_code) — control-plane-only deployment" ;;
+  200)     bad "unauthenticated inference returned 200 — AUTH IS NOT ENFORCED" ;;
+  *)       soft "unauthenticated /v1/chat/completions returned $auth_code" ;;
+esac
+
+# 5. TLS. Cheap to check, and a silent downgrade is the kind of thing nobody
+#    notices until it is in a compliance questionnaire.
+case "$BASE" in
+  https://*) ok "served over TLS" ;;
+  *)         bad "not HTTPS" ;;
+esac
+
+printf '\n  %s passed, %s failed, %s warnings\n\n' "$pass" "$fail" "$warn"
+[ "$fail" -eq 0 ] || exit 1

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     enable_live_providers: bool = False
     local_keys_file: Path = Path("~/.quill_cloud_keys.private").expanduser()
     storage_backend: str = "memory"
+    # Postgres-wire system of record for the non-GCP deployments. One
+    # implementation covers Azure (Flexible Server / Citus), AWS (Aurora DSQL)
+    # and Spanner's PostgreSQL dialect — see
+    # docs/storage-portability/multi-cloud-separation.md.
+    postgres_dsn: str = ""
     gcp_project_id: str = "quill-cloud-proxy"
     spanner_instance_id: str | None = None
     spanner_database_id: str | None = None

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1280,6 +1280,22 @@ def create_store(settings: Any) -> Store:
     backend = str(getattr(settings, "storage_backend", "memory")).lower()
     if backend == "memory":
         return InMemoryStore()
+    if backend == "postgres":
+        # Postgres-wire system of record for the non-GCP deployments. The same
+        # implementation runs on Azure Flexible Server / Citus, AWS Aurora DSQL,
+        # and Spanner's PostgreSQL dialect, which is why there is one backend
+        # here and not three.
+        from trusted_router.storage_postgres import PostgresStore
+
+        dsn = str(getattr(settings, "postgres_dsn", "") or "")
+        if not dsn:
+            raise ValueError(
+                "TR_STORAGE_BACKEND=postgres requires TR_POSTGRES_DSN. "
+                "Without it the process would start and fail on first query."
+            )
+        store = PostgresStore(dsn)
+        store.apply_schema()
+        return store
     if backend == "spanner-bigtable":
         from trusted_router.storage_gcp import SpannerBigtableStore
 

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -65,6 +65,13 @@ from trusted_router.storage_models import (
     iso_now,
     utcnow,
 )
+from trusted_router.synthetic.rollups import (
+    RAW_SYNTHETIC_RETENTION_DAYS,
+    ROLLUP_RETENTION_MONTHS,
+    apply_sample_to_rollup,
+    new_rollup_for_sample,
+    sample_rollup_ids,
+)
 from trusted_router.types import UsageType
 
 T = TypeVar("T")
@@ -227,6 +234,73 @@ class PostgresStore:
             "VALUES (%s, %s, %s::jsonb, CURRENT_TIMESTAMP) "
             "ON CONFLICT (kind, id) DO NOTHING",
             (kind, entity_id, json_body(value)),
+        )
+        return cursor.rowcount == 1
+
+    def _write_indexed_entity_tx(
+        self,
+        conn: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+        *,
+        indexed_at: str,
+        index_date: str | None = None,
+        index_target: str | None = None,
+        index_probe_type: str | None = None,
+        index_monitor_region: str | None = None,
+        index_period: str | None = None,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO tr_entities "
+            "(kind, id, body, indexed_at, index_date, index_target, "
+            "index_probe_type, index_monitor_region, index_period, updated_at) "
+            "VALUES (%s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, "
+            "CURRENT_TIMESTAMP) "
+            "ON CONFLICT (kind, id) DO UPDATE SET "
+            "body = EXCLUDED.body, "
+            "indexed_at = EXCLUDED.indexed_at, "
+            "index_date = EXCLUDED.index_date, "
+            "index_target = EXCLUDED.index_target, "
+            "index_probe_type = EXCLUDED.index_probe_type, "
+            "index_monitor_region = EXCLUDED.index_monitor_region, "
+            "index_period = EXCLUDED.index_period, "
+            "updated_at = EXCLUDED.updated_at",
+            (
+                kind,
+                entity_id,
+                json_body(value),
+                _parse_timestamp(indexed_at),
+                index_date,
+                index_target,
+                index_probe_type,
+                index_monitor_region,
+                index_period,
+            ),
+        )
+
+    def _insert_indexed_entity_once_tx(
+        self,
+        conn: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+        *,
+        indexed_at: str,
+        index_period: str,
+    ) -> bool:
+        cursor = conn.execute(
+            "INSERT INTO tr_entities "
+            "(kind, id, body, indexed_at, index_period, updated_at) "
+            "VALUES (%s, %s, %s::jsonb, %s, %s, CURRENT_TIMESTAMP) "
+            "ON CONFLICT (kind, id) DO NOTHING",
+            (
+                kind,
+                entity_id,
+                json_body(value),
+                _parse_timestamp(indexed_at),
+                index_period,
+            ),
         )
         return cursor.rowcount == 1
 
@@ -1356,7 +1430,63 @@ class PostgresStore:
     def record_synthetic_probe_sample(
         self, sample: SyntheticProbeSample
     ) -> None:
-        self._not_implemented("record_synthetic_probe_sample")
+        def record(conn: Any) -> None:
+            self._write_indexed_entity_tx(
+                conn,
+                "synthetic_probe",
+                sample.id,
+                sample,
+                indexed_at=sample.created_at,
+                index_date=sample.created_at[:10],
+                index_target=sample.target,
+                index_probe_type=sample.probe_type,
+                index_monitor_region=sample.monitor_region,
+            )
+            for period, component in sample_rollup_ids(sample):
+                update = new_rollup_for_sample(
+                    sample,
+                    period=period,
+                    component=component,
+                )
+                marker_id = f"{update.id}:{sample.id}"
+                if not self._insert_entity_once_tx(
+                    conn,
+                    "synthetic_rollup_seen",
+                    marker_id,
+                    {"seen": True},
+                ):
+                    continue
+                if self._insert_indexed_entity_once_tx(
+                    conn,
+                    "synthetic_rollup",
+                    update.id,
+                    update,
+                    indexed_at=update.period_start,
+                    index_period=update.period,
+                ):
+                    continue
+                existing = self._read_entity_tx(
+                    conn,
+                    "synthetic_rollup",
+                    update.id,
+                    SyntheticRollup,
+                    for_update=True,
+                )
+                if existing is None:
+                    raise StoreConflict(
+                        "Synthetic rollup disappeared during update"
+                    )
+                apply_sample_to_rollup(existing, sample)
+                self._write_indexed_entity_tx(
+                    conn,
+                    "synthetic_rollup",
+                    existing.id,
+                    existing,
+                    indexed_at=existing.period_start,
+                    index_period=existing.period,
+                )
+
+        self._run_transaction(record)
 
     def synthetic_probe_samples(
         self,
@@ -1367,7 +1497,40 @@ class PostgresStore:
         monitor_region: str | None = None,
         limit: int = 1000,
     ) -> list[SyntheticProbeSample]:
-        self._not_implemented("synthetic_probe_samples")
+        def list_samples(conn: Any) -> list[SyntheticProbeSample]:
+            predicates = [
+                "kind = %s",
+                "indexed_at >= %s",
+            ]
+            params: list[Any] = [
+                "synthetic_probe",
+                utcnow() - dt.timedelta(days=RAW_SYNTHETIC_RETENTION_DAYS),
+            ]
+            if date is not None:
+                predicates.append("index_date = %s")
+                params.append(date)
+            if target is not None:
+                predicates.append("index_target = %s")
+                params.append(target)
+            if probe_type is not None:
+                predicates.append("index_probe_type = %s")
+                params.append(probe_type)
+            if monitor_region is not None:
+                predicates.append("index_monitor_region = %s")
+                params.append(monitor_region)
+            params.append(max(0, int(limit)))
+            query = (
+                "SELECT body FROM tr_entities WHERE "  # noqa: S608 - fixed predicates.
+                + " AND ".join(predicates)
+                + " ORDER BY indexed_at DESC, id DESC LIMIT %s"
+            )
+            rows = conn.execute(query, params).fetchall()
+            return [
+                _dataclass_from_json(row[0], SyntheticProbeSample)
+                for row in rows
+            ]
+
+        return self._run_transaction(list_samples)
 
     def synthetic_rollups(
         self,
@@ -1378,7 +1541,47 @@ class PostgresStore:
         include_histograms: bool = True,
         limit: int = 1000,
     ) -> list[SyntheticRollup]:
-        self._not_implemented("synthetic_rollups")
+        def list_rollups(conn: Any) -> list[SyntheticRollup]:
+            predicates = [
+                "kind = %s",
+                "indexed_at >= %s",
+            ]
+            params: list[Any] = [
+                "synthetic_rollup",
+                _rollup_retention_cutoff(utcnow()),
+            ]
+            if period is not None:
+                predicates.append("index_period = %s")
+                params.append(period)
+            if since is not None:
+                predicates.append("indexed_at >= %s")
+                params.append(_parse_timestamp(since))
+            if until is not None:
+                predicates.append("indexed_at <= %s")
+                params.append(_parse_timestamp(until))
+            params.append(max(0, int(limit)))
+            query = (
+                "SELECT body FROM tr_entities WHERE "  # noqa: S608 - fixed predicates.
+                + " AND ".join(predicates)
+                + " ORDER BY indexed_at DESC, id DESC LIMIT %s"
+            )
+            rows = conn.execute(query, params).fetchall()
+            rollups = [
+                _dataclass_from_json(row[0], SyntheticRollup)
+                for row in rows
+            ]
+            if not include_histograms:
+                return [
+                    dataclasses.replace(
+                        rollup,
+                        latency_histogram={},
+                        ttfb_histogram={},
+                    )
+                    for rollup in rollups
+                ]
+            return rollups
+
+        return self._run_transaction(list_rollups)
 
     def get_generation(self, generation_id: str) -> Generation | None:
         self._not_implemented("get_generation")
@@ -1463,3 +1666,38 @@ class PostgresStore:
         now: dt.datetime | None = None,
     ) -> RateLimitHit:
         self._not_implemented("hit_rate_limit")
+
+
+def _dataclass_from_json(raw: Any, cls: type[T]) -> T:
+    data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    known = {
+        field.name
+        for field in dataclasses.fields(cast(Any, cls))
+    }
+    return cls(
+        **{
+            key: value
+            for key, value in data.items()
+            if key in known
+        }
+    )
+
+
+def _parse_timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _rollup_retention_cutoff(now: dt.datetime) -> dt.datetime:
+    current = now.astimezone(dt.UTC)
+    cutoff_month = (
+        current.year * 12
+        + current.month
+        - 1
+        - ROLLUP_RETENTION_MONTHS
+        + 1
+    )
+    year, zero_based_month = divmod(cutoff_month, 12)
+    return dt.datetime(year, zero_based_month + 1, 1, tzinfo=dt.UTC)

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -77,6 +77,25 @@ from trusted_router.types import UsageType
 T = TypeVar("T")
 
 
+def _split_sql_statements(schema: str) -> list[str]:
+    """Split a schema file into statements, ignoring semicolons in comments.
+
+    Splitting the raw text on ';' looks fine until a `--` comment contains one,
+    at which point the comment's tail is handed to the server as a statement and
+    fails with a syntax error naming a random English word. That is a genuinely
+    confusing way to discover you cannot write prose in your own schema file, so
+    strip line comments first.
+
+    Deliberately not a full SQL parser: this file is ours, it has no dollar-quoted
+    bodies or string literals containing semicolons, and DSQL forbids the stored
+    procedures that would introduce them.
+    """
+    without_comments = "\n".join(
+        line.split("--", 1)[0] for line in schema.splitlines()
+    )
+    return [stmt.strip() for stmt in without_comments.split(";") if stmt.strip()]
+
+
 class PostgresStore:
     """Psycopg-backed Store implementation for the first portability increment."""
 
@@ -130,16 +149,46 @@ class PostgresStore:
         `IF NOT EXISTS`, so re-running converges rather than conflicting.
         """
         schema = Path(__file__).with_name("storage_postgres_schema.sql").read_text()
-        statements = [stmt.strip() for stmt in schema.split(";") if stmt.strip()]
+        statements = _split_sql_statements(schema)
 
         with self._pool.connection() as conn:
             previous_autocommit = conn.autocommit
             conn.autocommit = True
             try:
                 for statement in statements:
-                    conn.execute(statement, prepare=False)
+                    self._execute_ddl(conn, statement)
             finally:
                 conn.autocommit = previous_autocommit
+
+    @staticmethod
+    def _execute_ddl(conn: Any, statement: str) -> None:
+        """Run one DDL statement, tolerating Aurora DSQL's async-index rule.
+
+        DSQL builds indexes asynchronously and rejects a plain `CREATE INDEX`
+        with "unsupported mode. please use CREATE INDEX ASYNC." Stock Postgres
+        and Spanner's PG dialect both reject the `ASYNC` keyword, so neither
+        spelling is portable on its own.
+
+        Rather than branch on a configured dialect — which would mean the DSN
+        has to declare what it is, and would be wrong the first time someone
+        pointed it somewhere new — try the portable form and fall back only on
+        the specific error DSQL raises. The backend then adapts to whatever it
+        is actually connected to.
+
+        DSQL's ASYNC build returns immediately and completes in the background.
+        That is acceptable here: these indexes serve read paths that are correct
+        (just slower) while the index is still building.
+        """
+        try:
+            conn.execute(statement, prepare=False)
+            return
+        except psycopg.errors.FeatureNotSupported:
+            head = statement.lstrip()[:12].upper()
+            if not head.startswith("CREATE INDEX"):
+                raise
+        conn.execute(
+            statement.replace("CREATE INDEX", "CREATE INDEX ASYNC", 1), prepare=False
+        )
 
     # Generic entity IO ------------------------------------------------------
 

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -2,9 +2,50 @@ CREATE TABLE IF NOT EXISTS tr_entities (
     kind TEXT NOT NULL,
     id TEXT NOT NULL,
     body JSONB NOT NULL,
+    indexed_at TIMESTAMPTZ,
+    index_date TEXT,
+    index_target TEXT,
+    index_probe_type TEXT,
+    index_monitor_region TEXT,
+    index_period TEXT,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (kind, id)
 );
+
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS indexed_at TIMESTAMPTZ;
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_date TEXT;
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_target TEXT;
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_probe_type TEXT;
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_monitor_region TEXT;
+ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_period TEXT;
+
+CREATE INDEX IF NOT EXISTS tr_entities_recent
+    ON tr_entities (kind, indexed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS tr_entities_day_recent
+    ON tr_entities (kind, index_date, indexed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS tr_entities_day_probe_target_recent
+    ON tr_entities (
+        kind,
+        index_date,
+        index_target,
+        index_probe_type,
+        indexed_at DESC,
+        id DESC
+    );
+CREATE INDEX IF NOT EXISTS tr_entities_target_recent
+    ON tr_entities (kind, index_target, indexed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS tr_entities_probe_target_recent
+    ON tr_entities (
+        kind,
+        index_probe_type,
+        index_target,
+        indexed_at DESC,
+        id DESC
+    );
+CREATE INDEX IF NOT EXISTS tr_entities_monitor_recent
+    ON tr_entities (kind, index_monitor_region, indexed_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS tr_entities_period_recent
+    ON tr_entities (kind, index_period, indexed_at DESC, id DESC);
 
 CREATE TABLE IF NOT EXISTS tr_credit_balance (
     workspace_id TEXT NOT NULL,

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -19,33 +19,45 @@ ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_probe_type TEXT;
 ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_monitor_region TEXT;
 ALTER TABLE tr_entities ADD COLUMN IF NOT EXISTS index_period TEXT;
 
+-- Index sort order is deliberately ASCENDING everywhere.
+--
+-- Aurora DSQL rejects DESC in index keys outright: "specifying sort order
+-- not supported for index keys". An ascending index still serves a
+-- descending ORDER BY through a reverse scan, so dropping the explicit
+-- order costs nothing on stock Postgres or Spanner PG and is the
+-- difference between this schema applying on DSQL or not.
+--
+-- DSQL also requires CREATE INDEX ASYNC; that is handled in
+-- storage_postgres.py::_execute_ddl rather than here, so this file stays
+-- portable SQL.
+
 CREATE INDEX IF NOT EXISTS tr_entities_recent
-    ON tr_entities (kind, indexed_at DESC, id DESC);
+    ON tr_entities (kind, indexed_at, id);
 CREATE INDEX IF NOT EXISTS tr_entities_day_recent
-    ON tr_entities (kind, index_date, indexed_at DESC, id DESC);
+    ON tr_entities (kind, index_date, indexed_at, id);
 CREATE INDEX IF NOT EXISTS tr_entities_day_probe_target_recent
     ON tr_entities (
         kind,
         index_date,
         index_target,
         index_probe_type,
-        indexed_at DESC,
-        id DESC
+        indexed_at,
+        id
     );
 CREATE INDEX IF NOT EXISTS tr_entities_target_recent
-    ON tr_entities (kind, index_target, indexed_at DESC, id DESC);
+    ON tr_entities (kind, index_target, indexed_at, id);
 CREATE INDEX IF NOT EXISTS tr_entities_probe_target_recent
     ON tr_entities (
         kind,
         index_probe_type,
         index_target,
-        indexed_at DESC,
-        id DESC
+        indexed_at,
+        id
     );
 CREATE INDEX IF NOT EXISTS tr_entities_monitor_recent
-    ON tr_entities (kind, index_monitor_region, indexed_at DESC, id DESC);
+    ON tr_entities (kind, index_monitor_region, indexed_at, id);
 CREATE INDEX IF NOT EXISTS tr_entities_period_recent
-    ON tr_entities (kind, index_period, indexed_at DESC, id DESC);
+    ON tr_entities (kind, index_period, indexed_at, id);
 
 CREATE TABLE IF NOT EXISTS tr_credit_balance (
     workspace_id TEXT NOT NULL,

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -247,3 +247,30 @@ def make_benchmark_sample(
     if created_at is not None:
         kwargs["created_at"] = created_at
     return ProviderBenchmarkSample(**kwargs)
+
+
+def make_synthetic_probe_sample(
+    *,
+    sample_id: str,
+    target: str,
+    probe_type: str,
+    monitor_region: str,
+    created_at: str,
+    status: str = "up",
+    latency_milliseconds: int | None = 50,
+    ttfb_milliseconds: int | None = 25,
+) -> Any:
+    """A privacy-safe synthetic sample for the public-status contract."""
+    from trusted_router.storage_models import SyntheticProbeSample
+
+    return SyntheticProbeSample(
+        id=sample_id,
+        probe_type=probe_type,
+        target=target,
+        target_url=f"https://{target}.example.com/v1",
+        monitor_region=monitor_region,
+        status=status,
+        latency_milliseconds=latency_milliseconds,
+        ttfb_milliseconds=ttfb_milliseconds,
+        created_at=created_at,
+    )

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -31,9 +31,11 @@ Known limits of this suite — read before trusting it
 
 from __future__ import annotations
 
+import datetime as dt
+
 from trusted_router.store_protocol import Store
 
-from .conftest import BACKENDS, make_benchmark_sample
+from .conftest import BACKENDS, make_benchmark_sample, make_synthetic_probe_sample
 
 # --------------------------------------------------------------------------
 # Exactly-once money
@@ -272,6 +274,155 @@ def test_benchmark_samples_filter_by_route(store: Store, unique: str) -> None:
 
 
 # --------------------------------------------------------------------------
+# Public-status synthetic samples + rollups
+# --------------------------------------------------------------------------
+
+
+def test_synthetic_probe_samples_return_newest_first_and_respect_limit(
+    store: Store, unique: str
+) -> None:
+    """The public hot path asks for the newest bounded live-sample window."""
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+    target = f"status-{unique}"
+    probe_type = f"probe-{unique}"
+    monitor_region = f"monitor-{unique}"
+    for idx, minutes_ago in enumerate((3, 2, 1)):
+        store.record_synthetic_probe_sample(
+            make_synthetic_probe_sample(
+                sample_id=f"{unique}-synthetic-{idx}",
+                target=target,
+                probe_type=probe_type,
+                monitor_region=monitor_region,
+                created_at=_iso_utc(now - dt.timedelta(minutes=minutes_ago)),
+            )
+        )
+
+    samples = store.synthetic_probe_samples(
+        target=target,
+        probe_type=probe_type,
+        monitor_region=monitor_region,
+        limit=2,
+    )
+
+    assert [sample.id for sample in samples] == [
+        f"{unique}-synthetic-2",
+        f"{unique}-synthetic-1",
+    ]
+
+
+def test_synthetic_probe_samples_apply_status_reader_filters(
+    store: Store, unique: str
+) -> None:
+    """Date and route dimensions must not leak unrelated deployment checks."""
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+    date = now.date().isoformat()
+    target = f"status-{unique}"
+    probe_type = f"probe-{unique}"
+    monitor_region = f"monitor-{unique}"
+    dimensions = (
+        ("match", target, probe_type, monitor_region, now),
+        ("wrong-target", f"other-{unique}", probe_type, monitor_region, now),
+        ("wrong-probe", target, f"other-probe-{unique}", monitor_region, now),
+        ("wrong-monitor", target, probe_type, f"other-monitor-{unique}", now),
+        ("wrong-date", target, probe_type, monitor_region, now - dt.timedelta(days=1)),
+    )
+    for suffix, sample_target, sample_probe, sample_monitor, created_at in dimensions:
+        store.record_synthetic_probe_sample(
+            make_synthetic_probe_sample(
+                sample_id=f"{unique}-{suffix}",
+                target=sample_target,
+                probe_type=sample_probe,
+                monitor_region=sample_monitor,
+                created_at=_iso_utc(created_at),
+            )
+        )
+
+    samples = store.synthetic_probe_samples(
+        date=date,
+        target=target,
+        probe_type=probe_type,
+        monitor_region=monitor_region,
+        limit=10,
+    )
+
+    assert [sample.id for sample in samples] == [f"{unique}-match"]
+
+
+def test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option(
+    store: Store, unique: str
+) -> None:
+    """Status history uses inclusive period ranges and newest-N ordering."""
+    # Rollup reads have no target/probe filters, and server-backed conformance
+    # databases persist between runs. Give this test a practically unique
+    # three-hour range so old test rows cannot consume its limit.
+    now = (
+        dt.datetime(2100, 1, 1, 0, 10, tzinfo=dt.UTC)
+        + dt.timedelta(hours=int(unique, 16) % 50_000_000)
+    )
+    target = f"status-{unique}"
+    probe_type = f"probe-{unique}"
+    monitor_region = f"monitor-{unique}"
+    samples = [
+        make_synthetic_probe_sample(
+            sample_id=f"{unique}-rollup-{idx}",
+            target=target,
+            probe_type=probe_type,
+            monitor_region=monitor_region,
+            created_at=_iso_utc(now - dt.timedelta(hours=hours_ago)),
+            latency_milliseconds=40 + idx,
+            ttfb_milliseconds=20 + idx,
+        )
+        for idx, hours_ago in enumerate((2, 1, 0))
+    ]
+    for sample in samples:
+        store.record_synthetic_probe_sample(sample)
+    # Re-delivery must not increment the aggregate twice.
+    store.record_synthetic_probe_sample(samples[-1])
+
+    oldest_start = _iso_utc(
+        (now - dt.timedelta(hours=2)).replace(minute=0)
+    )
+    newest_start = _iso_utc(now.replace(minute=0))
+    newest = store.synthetic_rollups(
+        period="hour",
+        since=oldest_start,
+        until=newest_start,
+        limit=2,
+    )
+    assert len(newest) == 2
+    middle_start = _iso_utc(
+        (now - dt.timedelta(hours=1)).replace(minute=0)
+    )
+    assert [row.period_start for row in newest] == [newest_start, middle_start]
+
+    ranged = store.synthetic_rollups(
+        period="hour",
+        since=middle_start,
+        until=newest_start,
+        include_histograms=False,
+        limit=1000,
+    )
+
+    assert [row.period_start for row in ranged] == sorted(
+        (row.period_start for row in ranged),
+        reverse=True,
+    )
+    assert all(row.period == "hour" for row in ranged)
+    assert all(middle_start <= row.period_start <= newest_start for row in ranged)
+    assert all(row.latency_histogram == {} for row in ranged)
+    assert all(row.ttfb_histogram == {} for row in ranged)
+    own_rows = [
+        row
+        for row in ranged
+        if row.target == target
+        and row.probe_type == probe_type
+        and row.monitor_region == monitor_region
+    ]
+    assert [row.period_start for row in own_rows] == [newest_start, middle_start]
+    assert own_rows[0].sample_count == 1
+
+
+# --------------------------------------------------------------------------
 # Coverage guard
 # --------------------------------------------------------------------------
 
@@ -287,3 +438,7 @@ def test_memory_backend_is_always_runnable() -> None:
     assert "memory" in BACKENDS
     store = BACKENDS["memory"]()
     assert isinstance(store, Store)
+
+
+def _iso_utc(value: dt.datetime) -> str:
+    return value.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")

--- a/tests/test_postgres_status.py
+++ b/tests/test_postgres_status.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, InMemoryStore, configure_store
+
+
+def test_status_json_renders_with_postgres_store() -> None:
+    dsn = os.environ.get("TR_CONFORMANCE_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip("set TR_CONFORMANCE_POSTGRES_DSN to exercise the Postgres app")
+
+    app = create_app(
+        Settings(
+            environment="test",
+            storage_backend="postgres",
+            postgres_dsn=dsn,
+        ),
+        init_observability=False,
+    )
+    postgres_store: Any = cast(Any, STORE).target
+    try:
+        with TestClient(app) as client:
+            response = client.get("/status.json")
+        assert response.status_code == 200, response.text
+        assert "data" in response.json()
+    finally:
+        postgres_store.close()
+        configure_store(InMemoryStore())


### PR DESCRIPTION
Makes a non-GCP deployment actually possible, and proves it on two clouds.

## The blocker nobody had hit yet

`create_store` only knew `memory` and `spanner-bigtable`. **`postgres` was not selectable**, so no amount of cloud infrastructure could have run the app anywhere. `TR_STORAGE_BACKEND=postgres` + `TR_POSTGRES_DSN` now work, and a missing DSN fails loudly at construction rather than starting and dying on first query.

## The per-cloud status page

Booting the real app on Postgres — rather than reasoning about what a deployment might need — gave the honest picture: `/health` 200, `/` 200, `/status.json` → `NotImplementedError`. That traced to exactly **three** `Store` methods, which are now implemented: `record_synthetic_probe_sample`, `synthetic_probe_samples`, `synthetic_rollups`.

Each cloud serves **its own** uptime page, because uptime is a property of that deployment. A global number would hide one cloud's outage behind another's health.

Pinning those in conformance surfaced **four real behavioural disagreements** between the existing backends — duplicate re-recording, oldest-vs-newest N, filter-then-limit ordering, equal-timestamp ties. Those would have diverged silently once four clouds existed.

## Aurora DSQL: three incompatibilities that "Postgres-wire" hid

Ran conformance against a **real DSQL cluster**, not a compatible stand-in. All three were invisible until it ran:

1. **Plain `CREATE INDEX` rejected** — DSQL demands `CREATE INDEX ASYNC`, which the other backends reject. `_execute_ddl` tries the portable form and falls back only on that specific error, so the backend adapts to what it is connected to instead of requiring the DSN to declare a dialect.
2. **`DESC` rejected in index keys.** All indexes are ascending now; a descending `ORDER BY` still uses a reverse scan.
3. **`apply_schema` split on `;` with no comment handling** — a semicolon inside a `--` comment fed the comment's tail to the server, failing with `syntax error at or near "that"`. My own comment found it.

**Result: 17/17 against live multi-region DSQL** (Dublin ⇄ Stockholm, witness Paris), plus a Dublin write read back from Stockholm on the first attempt. 53 passed across memory + postgres + spanner-pg, no regression.

## Coverage map

New doc separating two things both called "more locations":

- **More regions inside a deployment** — availability, one wallet, nearly free.
- **More standalone deployments** — jurisdiction, and **a separate credit balance each** by design.

Generous with regions, deliberate with deployments.

It also records a **correction**: an earlier probe claimed DSQL in all 16 regions tested. `aws dsql list-clusters` against a **non-opted-in** region does not fail the way an unsupported service does, so a grep-for-error probe scores it available. Milan passed that probe and is `not-opted-in`. Check `OptInStatus` first.

## Azure canary

Smallest possible end-to-end deployment — one region, no HA, no inference, **never advertised**. It exists so the expensive EU AWS build is not where a broken assumption is first discovered, and it earned that immediately: this subscription turned out to be capacity-restricted **per service and inconsistently** (Postgres blocked in `westeurope`, ACR the reverse, ACR Tasks disabled, and a hard limit of **one** Container Apps environment globally).

Two script bugs shared one cause and are worth naming: `db create` took `-d` instead of `-n`, and the firewall rule `-r` instead of `-n` — both wrapped in `|| true`, so both failed silently and the app crash-looped with a pool timeout pointing nowhere near the real problem. That swallowing is gone from anything the deployment depends on.

## Still true

`reserve`/`settle`/`refund` remain stubs, so an AWS-EU deployment is a **control plane, not a router**, and must not carry an inference SLO until they land.