### PR TITLE
Use canonical provider portal URLs

### DIFF
--- a/src/trusted_router/routes/provider_portal.py
+++ b/src/trusted_router/routes/provider_portal.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 
 from trusted_router.auth import SESSION_COOKIE_NAME
 from trusted_router.config import Settings
@@ -82,13 +82,11 @@ def _client(settings: Settings) -> ProviderAnalyticsClient:
 def register_provider_portal_routes(app: FastAPI) -> None:
     settings: Settings = app.state.settings
 
-    @app.get("/provider", response_class=HTMLResponse, include_in_schema=False)
-    async def provider_portal(
-        context: ProviderPortalDep,
-        provider: str | None = Query(default=None),
-        days: int = Query(default=7, ge=1, le=MAX_PROVIDER_EXPORT_DAYS),
+    async def _render_provider_portal(
+        context: ProviderPortalContext,
+        grant: ProviderAccessGrant,
+        days: int,
     ) -> HTMLResponse:
-        grant = context.selected_grant(provider)
         try:
             summary = await _client(settings).summary(grant.provider, days=days)
         except (httpx.HTTPError, RuntimeError, ValueError):
@@ -112,7 +110,7 @@ def register_provider_portal_routes(app: FastAPI) -> None:
             user_email=context.user.email,
             workspaces=[],
             current_workspace_id="",
-            console_next_path="/provider",
+            console_next_path=f"/provider/{grant.provider}",
             provider_mode=True,
             grants=context.grants,
             selected_provider=grant.provider,
@@ -123,6 +121,23 @@ def register_provider_portal_routes(app: FastAPI) -> None:
         )
         return HTMLResponse(
             html,
+            headers={
+                "Cache-Control": "private, no-store",
+                "X-Robots-Tag": "noindex, nofollow",
+            },
+        )
+
+    @app.get("/provider", response_class=RedirectResponse, include_in_schema=False)
+    async def provider_portal_redirect(
+        context: ProviderPortalDep,
+        provider: str | None = Query(default=None),
+        days: int = Query(default=7, ge=1, le=MAX_PROVIDER_EXPORT_DAYS),
+    ) -> RedirectResponse:
+        grant = context.selected_grant(provider)
+        suffix = f"?days={days}" if days != 7 else ""
+        return RedirectResponse(
+            url=f"/provider/{grant.provider}{suffix}",
+            status_code=302,
             headers={
                 "Cache-Control": "private, no-store",
                 "X-Robots-Tag": "noindex, nofollow",
@@ -166,3 +181,12 @@ def register_provider_portal_routes(app: FastAPI) -> None:
                 "X-Robots-Tag": "noindex, nofollow",
             },
         )
+
+    @app.get("/provider/{provider}", response_class=HTMLResponse, include_in_schema=False)
+    async def provider_portal(
+        provider: str,
+        context: ProviderPortalDep,
+        days: int = Query(default=7, ge=1, le=MAX_PROVIDER_EXPORT_DAYS),
+    ) -> HTMLResponse:
+        grant = context.selected_grant(provider)
+        return await _render_provider_portal(context, grant, days)

--- a/src/trusted_router/templates/console/_layout.html
+++ b/src/trusted_router/templates/console/_layout.html
@@ -30,7 +30,7 @@
 </head>
 <body class="console">
   <header class="console-topbar">
-    <a class="brand" href="{{ '/provider' if provider_mode else '/console/api-keys' }}">{% include "_brand.html" %}</a>
+    <a class="brand" href="{{ '/provider/' ~ selected_provider if provider_mode else '/console/api-keys' }}">{% include "_brand.html" %}</a>
     <nav class="console-topnav">
       <a href="/models">Models</a>
       <a href="https://trust.trustedrouter.com">Trust</a>
@@ -67,7 +67,7 @@
       {% if provider_mode %}
       <div class="sidebar-group">
         <div class="sidebar-label">Provider operations</div>
-        <a href="/provider?provider={{ selected_provider }}" class="sidebar-link active">Overview</a>
+        <a href="/provider/{{ selected_provider }}" class="sidebar-link active">Overview</a>
         <a href="#request-export" class="sidebar-link">Request export</a>
         <a href="/providers/marketplace" class="sidebar-link">Reliability contract</a>
       </div>

--- a/src/trusted_router/templates/provider/overview.html
+++ b/src/trusted_router/templates/provider/overview.html
@@ -51,8 +51,7 @@
       <h2>Request window</h2>
       <p>Aggregated provider metadata for the selected period.</p>
     </div>
-    <form method="get" action="/provider">
-      <input type="hidden" name="provider" value="{{ selected_provider }}">
+    <form method="get" action="/provider/{{ selected_provider }}">
       <label>
         Period
         <select name="days" onchange="this.form.requestSubmit()">

--- a/tests/test_provider_portal.py
+++ b/tests/test_provider_portal.py
@@ -84,7 +84,16 @@ def test_provider_portal_renders_only_granted_provider(
         lambda _settings: _FakeAnalytics(),
     )
 
-    response = client.get("/provider?provider=neurometric&days=30")
+    redirect = client.get(
+        "/provider?provider=neurometric&days=30",
+        follow_redirects=False,
+    )
+
+    assert redirect.status_code == 302
+    assert redirect.headers["location"] == "/provider/neurometric?days=30"
+    assert redirect.headers["cache-control"] == "private, no-store"
+
+    response = client.get("/provider/neurometric?days=30")
 
     assert response.status_code == 200
     assert response.headers["cache-control"] == "private, no-store"
@@ -94,7 +103,20 @@ def test_provider_portal_renders_only_granted_provider(
     assert "25.00%" in response.text
     assert "Offered share" in response.text
     assert "Prompts, outputs, customer identities" in response.text
-    assert client.get("/provider?provider=together").status_code == 403
+    assert 'href="/provider/neurometric"' in response.text
+    assert client.get("/provider/together").status_code == 403
+
+
+def test_provider_portal_entry_redirects_to_only_granted_provider(
+    client: TestClient,
+) -> None:
+    user_id = _login(client)
+    STORE.grant_provider_access(user_id, "neurometric")
+
+    response = client.get("/provider", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/provider/neurometric"
 
 
 def test_provider_csv_download_is_private_and_bounded(


### PR DESCRIPTION
## Summary
- redirect the grant-aware `/provider` entry point to `/provider/{provider}`
- keep provider authorization enforced server-side on canonical URLs
- update portal navigation and period controls to preserve the canonical path

## Tests
- `uv run pytest -q tests/test_provider_portal.py tests/test_provider_onboarding_page.py`
- `uv run ruff check src/trusted_router/routes/provider_portal.py tests/test_provider_portal.py`
- `uv run mypy src/trusted_router/routes/provider_portal.py`