### PR TITLE
Harden Alibaba hourly model refresh

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -238,7 +238,9 @@ def _alibaba_model_id(native_id: str) -> str | None:
         return f"qwen/{lowered}"
     if lowered.startswith("minimax-"):
         return f"minimax/{lowered}"
-    return None
+    if "/" in lowered:
+        return lowered
+    return f"alibaba/{lowered}"
 
 
 def _kimi_model_id(native_id: str) -> str | None:

--- a/scripts/pricing/parsers/thinkingmachines.py
+++ b/scripts/pricing/parsers/thinkingmachines.py
@@ -19,7 +19,16 @@ def _microdollars_per_million(text: str) -> int:
 
 
 def _price_span(cell: Tag, mode: str) -> Tag:
-    span = cell.select_one(f".price-{mode}") or cell.select_one(".price-old")
+    # Discounted rows use ``<s class=price-original>`` for the crossed-out
+    # list price and ``.price-current`` for the amount actually charged.
+    # Prefer the explicit current value before consulting the legacy toggle
+    # classes; otherwise parsing the whole cell picks the struck-through
+    # amount first and creates a false 2x price spike.
+    span = (
+        cell.select_one(".price-current")
+        or cell.select_one(f".price-{mode}")
+        or cell.select_one(".price-old")
+    )
     if isinstance(span, Tag):
         return span
     # The current server-rendered table puts the active dollar price directly
@@ -43,7 +52,9 @@ def parse(html: str) -> dict[str, dict[str, int]]:
             continue
         input_span = _price_span(cells[6], mode)
         output_span = _price_span(cells[7], mode)
-        cache_span = input_span.select_one(".price-cached")
+        cache_span = input_span.select_one(".price-cached") or cells[6].select_one(
+            ".price-cached"
+        )
         if cache_span is None:
             raise ValueError("Inkling 256K pricing row has no cached-input rate")
         return {

--- a/scripts/pricing/providers/alibaba.py
+++ b/scripts/pricing/providers/alibaba.py
@@ -73,7 +73,14 @@ def _canonical_model_id(native_id: str) -> str | None:
         return f"qwen/{lowered}"
     if lowered.startswith("minimax-"):
         return f"minimax/{lowered}"
-    return None
+    # Keep every model returned by Alibaba's authenticated OpenAI-compatible
+    # catalog visible to the refresh system. Unknown families are namespaced
+    # to Alibaba and enter the manifest as non-routable ``awaiting-price``
+    # rows until a reviewed price rule exists; they must never be silently
+    # ignored or accidentally exposed as zero-cost routes.
+    if "/" in lowered:
+        return lowered
+    return f"alibaba/{lowered}"
 
 
 def _price(native_id: str) -> ModelPrice | None:

--- a/tests/fixtures/pricing/thinkingmachines.html
+++ b/tests/fixtures/pricing/thinkingmachines.html
@@ -8,9 +8,14 @@
       <td class="tinker-id">thinkingmachines/Inkling:peft:262144</td>
       <td>Hybrid</td><td>MoE</td><td>Large</td><td>256K</td>
       <td class="price">
-        <span class="price-old">$3.74 <span class="price-cached">$0.748 (cached)</span></span>
+        <s class="price-original">$7.48</s>
+        <span class="price-current">$3.74</span>
+        <span class="price-cached">$0.748 (cached)</span>
       </td>
-      <td class="price"><span class="price-old">$9.36</span></td>
+      <td class="price">
+        <s class="price-original">$18.72</s>
+        <span class="price-current">$9.36</span>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/tests/test_alibaba_pricing.py
+++ b/tests/test_alibaba_pricing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from scripts.pricing import refresh
 from scripts.pricing.providers import alibaba
 
 
@@ -152,3 +153,60 @@ def test_manifest_refresh_appends_new_models_with_tiered_prices(
     }
     assert by_id["qwen/qwen3.7-plus"]["display_name"] == "Qwen3.7 Plus"
     assert len(by_id["qwen/qwen3.7-plus"]["price_tiers"]) == 2
+
+
+def test_unknown_live_model_is_discovered_but_held_until_priced(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "alibaba.json"
+    manifest_path.write_text(
+        json.dumps({"provider": "alibaba", "models": []}) + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # noqa: ANN003
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args, **_kwargs) -> FakeResponse:  # noqa: ANN002, ANN003
+            return FakeResponse(
+                {
+                    "data": [
+                        *_expected_model_rows(),
+                        {"id": "new-frontier-model", "created": 9},
+                    ]
+                }
+            )
+
+    monkeypatch.setattr(alibaba, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(alibaba.httpx, "Client", FakeClient)
+
+    result = alibaba.fetch()
+    alibaba.write_provider_manifest(result)
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    unresolved = by_id["alibaba/new-frontier-model"]
+    assert unresolved["upstream_id"] == "new-frontier-model"
+    assert unresolved["routable"] is False
+    assert unresolved["routable_reason"] == "awaiting-price"
+    assert unresolved["unresolved_since"]
+    assert "input_token_price_per_m" not in unresolved
+    assert "output_token_price_per_m" not in unresolved
+
+
+def test_alibaba_is_wired_to_hourly_refresh() -> None:
+    workflow = (
+        Path(__file__).parents[1] / ".github" / "workflows" / "refresh-prices.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "alibaba" in refresh.PROVIDER_SLUGS
+    assert 'cron: "0 * * * *"' in workflow
+    assert "ALIBABA_API_KEY:trustedrouter-alibaba-api-key" in workflow

--- a/tests/test_pricing_fixtures.py
+++ b/tests/test_pricing_fixtures.py
@@ -205,6 +205,19 @@ def _row_tiers(row: dict) -> list[tuple[float, float]]:
     ]
 
 
+def test_thinkingmachines_discount_uses_current_not_struck_original() -> None:
+    fixture = (FIXTURE_DIR / "thinkingmachines.html").read_text(encoding="utf-8")
+    module = importlib.import_module("scripts.pricing.parsers.thinkingmachines")
+
+    row = module.parse(fixture)["thinkingmachines/inkling"]
+
+    assert row == {
+        "prompt_micro_per_m": 3_740_000,
+        "completion_micro_per_m": 9_360_000,
+        "prompt_cached_micro_per_m": 748_000,
+    }
+
+
 def test_novita_fixture_keeps_qwen_235b_prices_in_true_microdollars() -> None:
     """Novita's `/models` feed reports prices 100x smaller than its public
     pricing table. The parser source of truth must preserve true


### PR DESCRIPTION
## Summary
- guarantee every Alibaba `/models` row is discovered; unfamiliar unpriced families are quarantined as `awaiting-price`
- lock Alibaba into the hourly authenticated refresh with a regression test
- repair the Thinking Machines discount parser that was blocking the global hourly commit by reading a crossed-out list price

## Verification
- live Alibaba catalog: 75 models; committed manifest: 75; no missing or stale IDs
- live Thinking Machines parser: $3.74 input / $9.36 output / $0.748 cached
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2203 passed, 76 skipped)