### PR TITLE
deploy: AWS-EU control plane on App Runner + DSQL IAM auth + per-cloud synthetics

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Deploy the AWS-EU control plane: App Runner (Dublin) on Aurora DSQL.
+#
+# Mirrors azure_canary*.sh in shape — build locally, push, deploy, verify with
+# the same cloud-agnostic scripts/deploy/verify_deployment.sh. App Runner over
+# ECS+ALB for the same reason Container Apps won on Azure: an HTTPS URL with no
+# cert/LB ceremony, so the e2e loop closes fast. The four-nines active/active
+# topology (Dublin + Stockholm behind health-checked DNS) comes after
+# reserve/settle land; this is deliberately the single-region first rung.
+#
+# Auth to the database is IAM: the instance role tr-eu-app holds
+# dsql:DbConnectAdmin on the Dublin cluster, and TR_POSTGRES_IAM_AUTH=aws-dsql
+# makes PostgresStore mint a fresh token per physical connection (DSQL tokens
+# expire in minutes — a static password dies within the hour). The DSN
+# deliberately carries NO password.
+set -euo pipefail
+
+REGION="${REGION:-eu-west-1}"
+ACCOUNT="${ACCOUNT:-330422590279}"
+CLUSTER_ID="${CLUSTER_ID:-7rt62n5uiz6xjdsoi2ahypz3cq}"
+ECR="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/trusted-router"
+TAG="${TAG:-eu}"
+SVC="${SVC:-tr-eu}"
+DSQL_HOST="${CLUSTER_ID}.dsql.${REGION}.on.aws"
+
+log(){ printf '\n=== %s\n' "$*" >&2; }
+
+log "building linux/amd64 image and pushing to ${ECR}:${TAG}"
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com" >/dev/null
+docker buildx build --platform linux/amd64 -t "${ECR}:${TAG}" --push .
+
+CONFIG=$(cat <<JSON
+{
+  "ImageRepository": {
+    "ImageIdentifier": "${ECR}:${TAG}",
+    "ImageRepositoryType": "ECR",
+    "ImageConfiguration": {
+      "Port": "8080",
+      "RuntimeEnvironmentVariables": {
+        "TR_ENVIRONMENT": "canary",
+        "TR_RELEASE": "${TAG}",
+        "TR_STORAGE_BACKEND": "postgres",
+        "TR_POSTGRES_DSN": "host=${DSQL_HOST} port=5432 user=admin dbname=postgres sslmode=require",
+        "TR_POSTGRES_IAM_AUTH": "aws-dsql",
+        "TR_ENABLE_LIVE_PROVIDERS": "false",
+        "TR_SYNTHETIC_MONITOR_REGION": "${REGION}"
+      }
+    }
+  },
+  "AuthenticationConfiguration": {
+    "AccessRoleArn": "arn:aws:iam::${ACCOUNT}:role/tr-eu-ecr-access"
+  },
+  "AutoDeploymentsEnabled": false
+}
+JSON
+)
+
+if aws apprunner list-services --region "$REGION" --query "ServiceSummaryList[?ServiceName=='${SVC}'].ServiceArn" --output text | grep -q arn; then
+  ARN=$(aws apprunner list-services --region "$REGION" --query "ServiceSummaryList[?ServiceName=='${SVC}'].ServiceArn" --output text)
+  log "updating existing service $ARN"
+  aws apprunner update-service --region "$REGION" --service-arn "$ARN" --source-configuration "$CONFIG" >/dev/null
+else
+  log "creating service $SVC"
+  ARN=$(aws apprunner create-service --region "$REGION" --service-name "$SVC" \
+    --source-configuration "$CONFIG" \
+    --instance-configuration "Cpu=1024,Memory=2048,InstanceRoleArn=arn:aws:iam::${ACCOUNT}:role/tr-eu-app" \
+    --health-check-configuration "Protocol=HTTP,Path=/health,Interval=10,Timeout=5,HealthyThreshold=2,UnhealthyThreshold=3" \
+    --query 'Service.ServiceArn' --output text)
+fi
+
+log "waiting for RUNNING"
+for _ in $(seq 1 60); do
+  S=$(aws apprunner describe-service --region "$REGION" --service-arn "$ARN" --query 'Service.Status' --output text)
+  [ "$S" = "RUNNING" ] && break
+  [ "$S" = "CREATE_FAILED" ] || [ "$S" = "UPDATE_FAILED" ] && { echo "FAILED: $S" >&2; exit 1; }
+  sleep 20
+done
+URL=$(aws apprunner describe-service --region "$REGION" --service-arn "$ARN" --query 'Service.ServiceUrl' --output text)
+log "service: https://${URL}"
+echo "https://${URL}"

--- a/scripts/deploy/verify_deployment.sh
+++ b/scripts/deploy/verify_deployment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Self-test a TrustedRouter deployment on any cloud.
 #
-#   bash scripts/deploy/verify_deployment.sh https://tr-canary.....azurecontainerapps.io
+#   bash scripts/deploy/verify_deployment.sh [--expect-monitor] https://tr-canary.....azurecontainerapps.io
 #
 # Cloud-agnostic on purpose: the Azure canary and the AWS EU region run the same
 # checks, so "it works on Azure" and "it works on AWS" mean the same thing. A
@@ -15,8 +15,25 @@
 # Exits non-zero on the first hard failure so it can gate a rollout.
 set -uo pipefail
 
-BASE="${1:-}"
-[ -n "$BASE" ] || { echo "usage: $0 <base-url>" >&2; exit 2; }
+BASE=""
+EXPECT_MONITOR=0
+for arg in "$@"; do
+  case "$arg" in
+    --expect-monitor) EXPECT_MONITOR=1 ;;
+    -*) echo "unknown option: $arg" >&2; exit 2 ;;
+    *)
+      [ -z "$BASE" ] || {
+        echo "usage: $0 [--expect-monitor] <base-url>" >&2
+        exit 2
+      }
+      BASE="$arg"
+      ;;
+  esac
+done
+[ -n "$BASE" ] || {
+  echo "usage: $0 [--expect-monitor] <base-url>" >&2
+  exit 2
+}
 BASE="${BASE%/}"
 
 pass=0; fail=0; warn=0
@@ -48,10 +65,84 @@ fi
 status_code="$(code "$BASE/status.json")"
 if [ "$status_code" = "200" ]; then
   ok "/status.json responds 200 (database read path works)"
-  if body "$BASE/status.json" | grep -q '"overall_status"'; then
+  status_payload="$(body "$BASE/status.json")"
+  if printf '%s' "$status_payload" | grep -q '"overall_status"'; then
     ok "status payload is well-formed"
   else
     bad "status payload missing overall_status — served, but wrong shape"
+  fi
+  if [ "$EXPECT_MONITOR" -eq 1 ]; then
+    monitor_result="$(
+      printf '%s' "$status_payload" | python3 -c '
+import datetime as dt
+import json
+import sys
+
+MAX_AGE_SECONDS = 30 * 60
+
+
+def parse_time(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+try:
+    payload = json.load(sys.stdin)
+except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    print(f"invalid status JSON: {exc}")
+    raise SystemExit(1)
+
+data = payload.get("data", payload)
+if not isinstance(data, dict):
+    print("status payload has no data object")
+    raise SystemExit(1)
+
+now = dt.datetime.now(dt.timezone.utc)
+candidates = []
+freshness = data.get("monitor_freshness")
+if isinstance(freshness, dict):
+    latest = parse_time(freshness.get("latest_sample_at"))
+    if latest is not None:
+        candidates.append(latest)
+    else:
+        age = freshness.get("latest_sample_age_seconds")
+        if isinstance(age, (int, float)) and not isinstance(age, bool) and age >= 0:
+            candidates.append(now - dt.timedelta(seconds=age))
+
+current = data.get("current")
+checks = current.get("checks") if isinstance(current, dict) else None
+if isinstance(checks, list):
+    for check in checks:
+        if isinstance(check, dict):
+            created_at = parse_time(check.get("created_at"))
+            if created_at is not None:
+                candidates.append(created_at)
+
+if not candidates:
+    print("no synthetic sample timestamp found")
+    raise SystemExit(1)
+
+latest = max(candidates)
+age_seconds = max((now - latest).total_seconds(), 0)
+if age_seconds > MAX_AGE_SECONDS:
+    print(f"newest sample is {int(age_seconds)}s old (limit {MAX_AGE_SECONDS}s)")
+    raise SystemExit(1)
+
+print(f"newest sample is {int(age_seconds)}s old")
+'
+    )"
+    if [ "$?" -eq 0 ]; then
+      ok "synthetic monitor is fresh ($monitor_result)"
+    else
+      bad "synthetic monitor is stale or missing — $monitor_result"
+    fi
   fi
 else
   bad "/status.json returned $status_code — store not reachable or not implemented"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -40,6 +40,13 @@ class Settings(BaseSettings):
     # and Spanner's PostgreSQL dialect — see
     # docs/storage-portability/multi-cloud-separation.md.
     postgres_dsn: str = ""
+    # Aurora DSQL passwords are short-lived IAM tokens. ``aws-dsql`` refreshes
+    # the token for every physical pool connection; empty preserves ordinary
+    # static-password Postgres behaviour.
+    postgres_iam_auth: str = ""
+    # Normally inferred from ``<id>.dsql.<region>.on.aws``. This override is
+    # available for endpoints whose hostname does not encode the AWS region.
+    postgres_iam_region: str = ""
     gcp_project_id: str = "quill-cloud-proxy"
     spanner_instance_id: str | None = None
     spanner_database_id: str | None = None

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1337,7 +1337,15 @@ def create_store(settings: Any) -> Store:
                 "TR_STORAGE_BACKEND=postgres requires TR_POSTGRES_DSN. "
                 "Without it the process would start and fail on first query."
             )
-        store = PostgresStore(dsn)
+        store = PostgresStore(
+            dsn,
+            postgres_iam_auth=str(
+                getattr(settings, "postgres_iam_auth", "") or ""
+            ),
+            postgres_iam_region=str(
+                getattr(settings, "postgres_iam_region", "") or ""
+            ),
+        )
         store.apply_schema()
         return store
     if backend == "spanner-bigtable":

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 import json
+import re
 import secrets
 import uuid
 from collections.abc import Callable
@@ -79,6 +80,91 @@ from trusted_router.types import UsageType
 
 T = TypeVar("T")
 
+_AWS_DSQL_IAM_AUTH = "aws-dsql"
+_AWS_DSQL_HOST_RE = re.compile(
+    r"^[^.]+\.dsql\.(?P<region>[a-z0-9-]+)\.on\.aws$",
+    re.IGNORECASE,
+)
+
+
+class _IamTokenConnectionPool(ConnectionPool):
+    """Connection pool that obtains a new password for every connection.
+
+    ``psycopg_pool`` resolves ``self.kwargs`` immediately before opening each
+    physical connection. Updating the password here therefore covers initial
+    fill, growth, idle replacement, and reconnects without reaching into
+    psycopg internals.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        token_provider: Callable[[], str],
+        **kwargs: Any,
+    ) -> None:
+        self._token_provider = token_provider
+        connection_kwargs = kwargs.get("kwargs")
+        if connection_kwargs is None:
+            kwargs["kwargs"] = {}
+        elif not isinstance(connection_kwargs, dict):
+            raise TypeError("IAM token pool requires static connection kwargs")
+        else:
+            kwargs["kwargs"] = dict(connection_kwargs)
+        super().__init__(*args, **kwargs)
+
+    def _connect(self, timeout: float | None = None) -> Any:
+        if not isinstance(self.kwargs, dict):  # Defensive: fixed in __init__.
+            raise TypeError("IAM token pool requires mutable connection kwargs")
+        self.kwargs["password"] = self._token_provider()
+        return super()._connect(timeout)
+
+
+def _aws_dsql_connection_details(
+    dsn: str,
+    *,
+    region_override: str = "",
+) -> tuple[str, str]:
+    params = psycopg.conninfo.conninfo_to_dict(dsn)
+    hostname = str(params.get("host") or "").rstrip(".")
+    if not hostname:
+        raise ValueError("AWS DSQL IAM auth requires a hostname in TR_POSTGRES_DSN")
+    if params.get("password"):
+        raise ValueError(
+            "TR_POSTGRES_DSN must not contain a password when "
+            "TR_POSTGRES_IAM_AUTH=aws-dsql"
+        )
+
+    region = region_override.strip()
+    if not region:
+        match = _AWS_DSQL_HOST_RE.fullmatch(hostname)
+        if match is None:
+            raise ValueError(
+                "Could not infer the AWS region from TR_POSTGRES_DSN host "
+                f"{hostname!r}; set TR_POSTGRES_IAM_REGION"
+            )
+        region = match.group("region")
+    return hostname, region
+
+
+def _aws_dsql_token_provider(hostname: str, region: str) -> Callable[[], str]:
+    # Infrastructure SDK imports stay inside the selected adapter path so
+    # ordinary Postgres deployments do not import or initialize boto3.
+    import boto3
+
+    client = boto3.client("dsql", region_name=region)
+
+    def generate_token() -> str:
+        return cast(
+            str,
+            client.generate_db_connect_admin_auth_token(
+                Hostname=hostname,
+                Region=region,
+                ExpiresIn=900,
+            ),
+        )
+
+    return generate_token
+
 
 def _split_sql_statements(schema: str) -> list[str]:
     """Split a schema file into statements, ignoring semicolons in comments.
@@ -111,18 +197,38 @@ class PostgresStore:
         pool_min_size: int = 0,
         pool_max_size: int = 4,
         transaction_attempts: int = 8,
+        postgres_iam_auth: str = "",
+        postgres_iam_region: str = "",
     ) -> None:
         if not dsn:
             raise ValueError("Postgres DSN is required")
         if transaction_attempts < 1:
             raise ValueError("transaction_attempts must be positive")
         self._transaction_attempts = transaction_attempts
-        self._pool = ConnectionPool(
-            conninfo=dsn,
-            min_size=pool_min_size,
-            max_size=pool_max_size,
-            open=True,
-        )
+        if not postgres_iam_auth:
+            self._pool = ConnectionPool(
+                conninfo=dsn,
+                min_size=pool_min_size,
+                max_size=pool_max_size,
+                open=True,
+            )
+        elif postgres_iam_auth == _AWS_DSQL_IAM_AUTH:
+            hostname, region = _aws_dsql_connection_details(
+                dsn,
+                region_override=postgres_iam_region,
+            )
+            self._pool = _IamTokenConnectionPool(
+                conninfo=dsn,
+                token_provider=_aws_dsql_token_provider(hostname, region),
+                min_size=pool_min_size,
+                max_size=pool_max_size,
+                open=True,
+            )
+        else:
+            raise ValueError(
+                "Unsupported TR_POSTGRES_IAM_AUTH value "
+                f"{postgres_iam_auth!r}; expected 'aws-dsql' or empty"
+            )
 
     def close(self) -> None:
         """Close the connection pool."""

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -45,6 +45,9 @@ ALLOWED = {
     # need not install the Google libraries at all.
     "storage_errors.py",
     "key_management.py",
+    # The portable Postgres adapter lazily imports boto3 only when its explicit
+    # Aurora DSQL IAM-auth mode is selected.
+    "storage_postgres.py",
     # VENDOR PRODUCT APIs, not infrastructure — see the module docstring.
     # google.auth here mints an access token for Vertex AI as an upstream LLM
     # PROVIDER. Routing to Vertex requires Google credentials no matter which

--- a/tests/test_postgres_iam_auth.py
+++ b/tests/test_postgres_iam_auth.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from psycopg_pool import ConnectionPool
+
+import trusted_router.storage_postgres as storage_postgres
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+from trusted_router.storage_postgres import (
+    PostgresStore,
+    _aws_dsql_connection_details,
+    _aws_dsql_token_provider,
+    _IamTokenConnectionPool,
+)
+
+
+def test_iam_pool_refreshes_token_before_every_physical_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = 0
+    observed: list[tuple[str, float | None]] = []
+
+    def token_provider() -> str:
+        nonlocal generated
+        generated += 1
+        return f"token-{generated}"
+
+    def fake_connect(self: ConnectionPool[Any], timeout: float | None = None) -> object:
+        assert isinstance(self.kwargs, dict)
+        observed.append((str(self.kwargs["password"]), timeout))
+        return object()
+
+    monkeypatch.setattr(ConnectionPool, "_connect", fake_connect)
+    pool = _IamTokenConnectionPool(
+        conninfo="postgresql://admin@cluster.example/postgres",
+        token_provider=token_provider,
+        min_size=0,
+        max_size=1,
+        open=False,
+    )
+
+    pool._connect()
+    pool._connect(2.5)
+
+    assert generated == 2
+    assert observed == [("token-1", None), ("token-2", 2.5)]
+
+
+def test_empty_iam_auth_does_not_import_boto3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakePool:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.delitem(sys.modules, "boto3", raising=False)
+    monkeypatch.setattr(storage_postgres, "ConnectionPool", FakePool)
+
+    store = PostgresStore("postgresql://postgres.example/test")
+    try:
+        assert "boto3" not in sys.modules
+        assert isinstance(store._pool, FakePool)
+    finally:
+        store.close()
+
+
+def test_dsql_token_provider_uses_expected_client_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeClient:
+        def generate_db_connect_admin_auth_token(self, **kwargs: Any) -> str:
+            calls.append(kwargs)
+            return f"token-{len(calls)}"
+
+    fake_boto3 = types.ModuleType("boto3")
+
+    def client(service: str, *, region_name: str) -> FakeClient:
+        assert service == "dsql"
+        assert region_name == "us-west-2"
+        return FakeClient()
+
+    fake_boto3.client = client  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    provider = _aws_dsql_token_provider(
+        "cluster.dsql.us-west-2.on.aws",
+        "us-west-2",
+    )
+
+    assert provider() == "token-1"
+    assert provider() == "token-2"
+    assert calls == [
+        {
+            "Hostname": "cluster.dsql.us-west-2.on.aws",
+            "Region": "us-west-2",
+            "ExpiresIn": 900,
+        },
+        {
+            "Hostname": "cluster.dsql.us-west-2.on.aws",
+            "Region": "us-west-2",
+            "ExpiresIn": 900,
+        },
+    ]
+
+
+def test_dsql_connection_details_infer_region_and_reject_password() -> None:
+    dsn = (
+        "postgresql://admin@cluster.dsql.eu-west-1.on.aws/postgres"
+        "?sslmode=require"
+    )
+
+    assert _aws_dsql_connection_details(dsn) == (
+        "cluster.dsql.eu-west-1.on.aws",
+        "eu-west-1",
+    )
+    assert _aws_dsql_connection_details(
+        "postgresql://admin@custom.example/postgres",
+        region_override="ap-southeast-2",
+    ) == ("custom.example", "ap-southeast-2")
+
+    with pytest.raises(ValueError, match="must not contain a password"):
+        _aws_dsql_connection_details(
+            "postgresql://admin:secret@cluster.dsql.us-east-1.on.aws/postgres"
+        )
+
+
+def test_settings_and_create_store_pass_iam_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeStore:
+        def __init__(self, dsn: str, **kwargs: Any) -> None:
+            captured["dsn"] = dsn
+            captured.update(kwargs)
+
+        def apply_schema(self) -> None:
+            captured["schema_applied"] = True
+
+    monkeypatch.setenv("TR_POSTGRES_IAM_AUTH", "aws-dsql")
+    monkeypatch.setenv("TR_POSTGRES_IAM_REGION", "us-east-2")
+    settings = Settings(_env_file=None)
+    assert settings.postgres_iam_auth == "aws-dsql"
+    assert settings.postgres_iam_region == "us-east-2"
+
+    monkeypatch.setattr(storage_postgres, "PostgresStore", FakeStore)
+    result = create_store(
+        SimpleNamespace(
+            storage_backend="postgres",
+            postgres_dsn="postgresql://admin@cluster.example/postgres",
+            postgres_iam_auth="aws-dsql",
+            postgres_iam_region="us-east-2",
+        )
+    )
+
+    assert isinstance(result, FakeStore)
+    assert captured == {
+        "dsn": "postgresql://admin@cluster.example/postgres",
+        "postgres_iam_auth": "aws-dsql",
+        "postgres_iam_region": "us-east-2",
+        "schema_applied": True,
+    }

--- a/tests/test_verify_deployment.py
+++ b/tests/test_verify_deployment.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deploy" / "verify_deployment.sh"
+
+
+def _iso_at_age(minutes: int) -> str:
+    value = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=minutes)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _status_payload(
+    *,
+    monitor_age_minutes: int | None = None,
+    check_age_minutes: int | None = None,
+) -> str:
+    data: dict[str, Any] = {"overall_status": "up"}
+    if monitor_age_minutes is not None:
+        data["monitor_freshness"] = {
+            "latest_sample_at": _iso_at_age(monitor_age_minutes),
+        }
+    if check_age_minutes is not None:
+        data["current"] = {
+            "checks": [{"created_at": _iso_at_age(check_age_minutes)}]
+        }
+    return json.dumps({"data": data})
+
+
+def _run_verifier(
+    tmp_path: Path,
+    payload: str,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+url="${!#}"
+if [[ "$*" == *"%{http_code}"* ]]; then
+  case "$url" in
+    */v1/chat/completions) printf '401' ;;
+    *) printf '200' ;;
+  esac
+elif [[ "$url" == */status.json ]]; then
+  printf '%s' "$VERIFY_STATUS_JSON"
+fi
+"""
+    )
+    fake_curl.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+    env["VERIFY_STATUS_JSON"] = payload
+    return subprocess.run(  # noqa: S603 - checked-in script and test-owned fake curl.
+        ["/bin/bash", str(SCRIPT), *args, "https://deployment.example"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_verify_deployment_without_expect_monitor_accepts_stale_data(
+    tmp_path: Path,
+) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=90),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "synthetic monitor is" not in result.stdout
+
+
+def test_verify_deployment_expect_monitor_accepts_fresh_monitor_freshness(
+    tmp_path: Path,
+) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=5),
+        "--expect-monitor",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS  synthetic monitor is fresh" in result.stdout
+
+
+def test_verify_deployment_expect_monitor_falls_back_to_current_checks(
+    tmp_path: Path,
+) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(check_age_minutes=10),
+        "--expect-monitor",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS  synthetic monitor is fresh" in result.stdout
+
+
+def test_verify_deployment_expect_monitor_rejects_stale_data(
+    tmp_path: Path,
+) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=31),
+        "--expect-monitor",
+    )
+
+    assert result.returncode == 1
+    assert "FAIL  synthetic monitor is stale or missing" in result.stdout


### PR DESCRIPTION
Closes the end-to-end loop on both non-GCP clouds. **Identical smoke, both green.**

| | Azure Sydney | AWS Dublin |
|---|---|---|
| `verify_deployment.sh --expect-monitor` | **6/6** | **6/6** |
| Synthetic freshness | 66s | **0s** |
| Database | own Postgres | **Aurora DSQL (multi-region pair)** |
| Scheduler | Container Apps cron job | EventBridge → API destination |

## The AWS blocker was auth lifetime, not infrastructure

**Aurora DSQL tokens expire in minutes.** A static-password `ConnectionPool` works at deploy time and then dies within the hour, and the failure surfaces as assorted `OperationalError`s that look nothing like auth — a genuinely nasty way to find out.

`TR_POSTGRES_IAM_AUTH=aws-dsql` installs a pool subclass that mints a fresh token before **every physical connection**, from the ambient instance role. The DSN carries no password and there is no key in config. Empty setting leaves the static path byte-identical, and `boto3` stays lazily imported so `tests/test_cloud_sdk_boundary.py` still holds.

## A trap that would have produced convincing wrong data

`TR_API_BASE_URL` defaults to GCP prod. Without pointing each deployment at **itself**, both clouds' synthetics would have probed GCP and recorded *the wrong cloud's health* on their own status pages — green dashboards proving nothing. Both are now self-targeted.

## `--expect-monitor`

`verify_deployment.sh` gains a check requiring a synthetic sample under 30 minutes old. That is the difference between "the status page serves" and "the synthetics are actually running", and it is what upgrades both clouds from 5/6 to 6/6.

## Honest about the attestation probe

The attestation synthetic runs on both clouds and reports **`trust_degraded`** — correctly, because no TEE exists there yet. It goes green when an enclave answers, not before. Nitro work for Dublin is in progress separately.

## Verification

Codex wrote the pool + smoke extension to spec and was straight that its sandbox blocked localhost TCP, so the live-backend runs are mine: **52 conformance passed** (memory + postgres + spanner-pg), ruff and mypy clean across 194 files.

## Still gating inference

`reserve`/`settle`/`refund` remain stubs, so both deployments are control planes, not routers.