### PR TITLE
Outbox hardening: refund classification, strict lease fence, legacy retention backfill

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -712,6 +712,29 @@ money keys. It preserves the credit row's Stripe, auto-refill, shard, and future
 metadata. Run once without flags, review, then run with `--apply`. Re-running is
 idempotent.
 
+**Legacy retention backfill** (issue #357): `tr_reservation` rows written before
+`terminal_at` arming shipped have it NULL, and Spanner's
+`ROW DELETION POLICY (OLDER_THAN(terminal_at, INTERVAL 30 DAY))` never deletes a
+NULL-timestamp row — as of 2026-07-30 that was 1.17M settled rows (~97% of the
+settled table) permanently exempt from the TTL. One-off, idempotent repair:
+
+```bash
+PYTHONPATH=src uv run python scripts/backfill_reservation_terminal_at.py
+```
+
+reports candidates / guard-excluded counts (dry run); add `--apply` to arm
+`terminal_at = now` in batches (`--batch`, default 5000). Two predicates in the
+UPDATE are load-bearing and must never be widened: `settled` (an open hold must
+NEVER get a TTL fuse — the reaper owns its lifecycle) and the
+`NOT EXISTS (... tr_settle_outbox ... status IN ('pending','dead'))` guard (a
+frozen intent's evidence must not age out under it; the script reports such rows
+as excluded and stops rather than spinning). Backfilled rows age out ~30 days
+after the run. Run it off the deploy path in a low-traffic window — bulk DML
+overlapping a rolling deploy produces the
+[Aborted/wounded burst](#authorize-deadlock-burst). Safe to re-run any time;
+once the debt drains the candidate count stays ~0 because steady-state arming
+is structural.
+
 ---
 
 ## <a id="authorize-deadlock-burst"></a>Sentry "Aborted ... deadlock/wounded" burst on gateway authorize

--- a/scripts/backfill_reservation_terminal_at.py
+++ b/scripts/backfill_reservation_terminal_at.py
@@ -1,0 +1,259 @@
+"""Arm TTL retention for settled legacy reservations.
+
+This is a guarded, idempotent operator backfill. It is read-only by default;
+pass ``--apply`` to set ``tr_reservation.terminal_at`` in bounded batches.
+
+Examples:
+  uv run python scripts/backfill_reservation_terminal_at.py
+  uv run python scripts/backfill_reservation_terminal_at.py --batch 5000 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+
+DEFAULT_BATCH_SIZE = 5000
+
+_CANDIDATE_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_reservation "
+    "WHERE settled AND terminal_at IS NULL"
+)
+_ARMED_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_reservation "
+    "WHERE settled AND terminal_at IS NOT NULL"
+)
+_OPEN_HOLD_COUNT_SQL = "SELECT COUNT(*) FROM tr_reservation WHERE NOT settled"
+_EXCLUDED_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_reservation "
+    "WHERE settled AND terminal_at IS NULL "
+    "AND EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    "AND o.status IN ('pending', 'dead'))"
+)
+_GATEWAY_AUTHORIZATION_PINNED_COUNT_SQL = (
+    "SELECT COUNT(*) FROM tr_gateway_authorization "
+    "WHERE settled AND terminal_at IS NULL"
+)
+_SELECT_BATCH_SQL = (
+    "SELECT reservation_id FROM tr_reservation "
+    "WHERE settled AND terminal_at IS NULL "
+    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    "AND o.status IN ('pending', 'dead')) "
+    "ORDER BY reservation_id LIMIT @batch"
+)
+
+# The guard is load-bearing (issue #357, lesson from #339). A pending/dead
+# outbox intent FREEZES its hold. Arming terminal_at under that intent would put
+# a 30-day fuse on evidence the frozen intent needs. Keep the guard in the SAME
+# transaction as the write; the production zero-frozen observation can change
+# while this backfill runs.
+#
+# `settled` is equally load-bearing. An open hold must NEVER receive
+# terminal_at: the reaper owns its lifecycle, and putting a TTL fuse on a live
+# hold is corruption.
+_UPDATE_BATCH_SQL = (
+    "UPDATE tr_reservation SET terminal_at=@terminal_at "
+    "WHERE reservation_id IN UNNEST(@ids) "
+    "AND settled AND terminal_at IS NULL "
+    "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o "
+    "WHERE o.authorization_id = tr_reservation.authorization_id "
+    "AND o.status IN ('pending', 'dead'))"
+)
+
+
+@dataclass(frozen=True)
+class BackfillStatus:
+    candidates: int
+    armed: int
+    open_holds: int
+    excluded: int
+    gateway_authorization_pinned: int
+
+    @property
+    def eligible(self) -> int:
+        return self.candidates - self.excluded
+
+
+def _scalar_count(reader: Any, sql: str) -> int:
+    rows = list(reader.execute_sql(sql))
+    if len(rows) != 1:
+        raise RuntimeError(f"expected one count row, got {len(rows)}")
+    return int(rows[0][0])
+
+
+def inspect_status(store: Any) -> BackfillStatus:
+    """Read all operator status counters from one consistent snapshot."""
+    with store._database.snapshot(multi_use=True) as snapshot:
+        return BackfillStatus(
+            candidates=_scalar_count(snapshot, _CANDIDATE_COUNT_SQL),
+            armed=_scalar_count(snapshot, _ARMED_COUNT_SQL),
+            open_holds=_scalar_count(snapshot, _OPEN_HOLD_COUNT_SQL),
+            excluded=_scalar_count(snapshot, _EXCLUDED_COUNT_SQL),
+            gateway_authorization_pinned=_scalar_count(
+                snapshot,
+                _GATEWAY_AUTHORIZATION_PINNED_COUNT_SQL,
+            ),
+        )
+
+
+def _print_status(status: BackfillStatus) -> None:
+    print(
+        "STATUS: tr_reservation "
+        f"candidates={status.candidates} armed={status.armed} "
+        f"open_holds={status.open_holds} excluded={status.excluded}"
+    )
+    print(
+        "STATUS: tr_gateway_authorization "
+        f"pinned={status.gateway_authorization_pinned} "
+        "(informational cross-check)"
+    )
+
+
+def run_status(store: Any) -> BackfillStatus:
+    """Inspect and print status. This is always the first action of a run."""
+    status = inspect_status(store)
+    _print_status(status)
+    return status
+
+
+def _select_batch(store: Any, batch: int) -> list[str]:
+    with store._database.snapshot() as snapshot:
+        rows = snapshot.execute_sql(
+            _SELECT_BATCH_SQL,
+            params={"batch": batch},
+            param_types={"batch": store._param_types.INT64},
+        )
+        return [str(row[0]) for row in rows]
+
+
+def _arm_batch(store: Any, reservation_ids: list[str]) -> int:
+    # Legacy rows have no created_at, so "now" is the only honest timestamp.
+    # The resulting 30-day tail before TTL deletion is the point, not a defect.
+    terminal_at = datetime.now(UTC)
+
+    def txn(transaction: Any) -> int:
+        return int(
+            transaction.execute_update(
+                _UPDATE_BATCH_SQL,
+                params={
+                    "terminal_at": terminal_at,
+                    "ids": reservation_ids,
+                },
+                param_types={
+                    "terminal_at": store._param_types.TIMESTAMP,
+                    "ids": store._param_types.Array(store._param_types.STRING),
+                },
+            )
+        )
+
+    return int(store._run_in_transaction(txn))
+
+
+def _print_final(status: BackfillStatus, armed: int) -> None:
+    print(
+        f"FINAL: armed={armed} remaining_candidates={status.candidates} "
+        f"excluded={status.excluded}"
+    )
+
+
+def run_backfill(
+    store: Any,
+    *,
+    batch: int = DEFAULT_BATCH_SIZE,
+    apply: bool = False,
+) -> int:
+    """Print status, then optionally arm all currently eligible legacy rows."""
+    if batch < 1:
+        raise ValueError("batch must be at least 1")
+
+    initial = run_status(store)
+    if not apply:
+        print(
+            f"DRY-RUN: would arm {initial.eligible} rows "
+            f"in batches of {batch}"
+        )
+        return 0
+
+    # This is a one-off debt drain. Steady-state arming keeps the table bounded,
+    # so the candidate count remains approximately zero after it completes.
+    # Re-running at any time is safe because every read and write requires
+    # terminal_at IS NULL.
+    batch_number = 0
+    running_total = 0
+    while True:
+        reservation_ids = _select_batch(store, batch)
+        if not reservation_ids:
+            final = inspect_status(store)
+            _print_final(final, running_total)
+            if final.candidates:
+                print(
+                    "STOP: all remaining candidates are excluded by the "
+                    "pending/dead tr_settle_outbox frozen-intent guard"
+                )
+            else:
+                print("COMPLETE: no unarmed settled reservations remain")
+            return 0
+
+        batch_number += 1
+        updated = _arm_batch(store, reservation_ids)
+        running_total += updated
+        print(
+            f"batch {batch_number}: updated={updated} "
+            f"running_total={running_total}"
+        )
+
+        if updated == 0:
+            current = inspect_status(store)
+            if current.candidates == 0:
+                _print_final(current, running_total)
+                print("COMPLETE: no unarmed settled reservations remain")
+                return 0
+            if current.eligible == 0:
+                _print_final(current, running_total)
+                print(
+                    "STOP: all remaining candidates are excluded by the "
+                    "pending/dead tr_settle_outbox frozen-intent guard"
+                )
+                return 0
+
+
+def _positive_batch(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("batch must be an integer") from exc
+    if value < 1:
+        raise argparse.ArgumentTypeError("batch must be at least 1")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=_positive_batch, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--apply", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    store = create_store(Settings())
+    return run_backfill(store, batch=args.batch, apply=args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_reservation_terminal_at.py
+++ b/scripts/backfill_reservation_terminal_at.py
@@ -195,10 +195,25 @@ def run_backfill(
     # terminal_at IS NULL.
     batch_number = 0
     running_total = 0
+    empty_but_eligible = 0
     while True:
         reservation_ids = _select_batch(store, batch)
         if not reservation_ids:
             final = inspect_status(store)
+            if final.eligible:
+                # A row became eligible between the select and this status read
+                # (e.g. a human set a dead intent to release_approved). Re-select
+                # instead of stopping with a false "all excluded" message. Bound
+                # the retry so a pathological ping-pong cannot spin forever.
+                empty_but_eligible += 1
+                if empty_but_eligible <= 3:
+                    continue
+                _print_final(final, running_total)
+                print(
+                    "ERROR: select repeatedly returned no rows while "
+                    f"{final.eligible} eligible rows remain; re-run",
+                )
+                return 1
             _print_final(final, running_total)
             if final.candidates:
                 print(
@@ -208,6 +223,7 @@ def run_backfill(
             else:
                 print("COMPLETE: no unarmed settled reservations remain")
             return 0
+        empty_but_eligible = 0
 
         batch_number += 1
         updated = _arm_batch(store, reservation_ids)

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -276,6 +276,11 @@ def _apply_typed(
             return ApplyOutcome.RESERVATION_MISSING
         actual_micro = int(reservation.get("actual_micro") or 0)
         if actual_micro > 0:
+            # Refunds never carry a generation, so requiring one here made the
+            # benign charged-settle-beats-refund replay unreachable and
+            # dead-lettered it, pinning retention on a non-problem (issue #356).
+            if not success:
+                return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
             if generation is None:
                 return ApplyOutcome.INVALID_ROW
             if not _index_generation_after_commit(typed_store, generation):

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -108,6 +108,8 @@ def _resolve_row(
     error_note: str | None,
 ) -> None:
     lease_owner = row.lease_owner
+    # Benign done transitions may ignore a lost fence: the winner re-runs the
+    # idempotent apply and marks the row done.
     if outcome == ApplyOutcome.SETTLED_NOW:
         outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
         logger.info(
@@ -256,7 +258,7 @@ def _resolve_row(
     if outcome == ApplyOutcome.ALREADY_RELEASED_FREE:
         if row.intent_kind == "settle":
             error = "already_released_free: settle charge was lost"
-            outbox.mark(
+            status = outbox.mark(
                 row.authorization_id,
                 row.intent_kind,
                 done=False,
@@ -264,6 +266,16 @@ def _resolve_row(
                 lease_owner=lease_owner,
                 force_dead=True,
             )
+            if status != "dead":
+                # The winner re-derives the observation and alerts exactly once;
+                # a stale duplicate or contradictory page is worse than none.
+                logger.warning(
+                    "settle outbox resolution skipped because row was no longer "
+                    "claimable by this owner authorization_id=%s intent_kind=%s",
+                    row.authorization_id,
+                    row.intent_kind,
+                )
+                return
             logger.error(
                 "ALERT settle outbox lost charge authorization_id=%s actual_cost_micro=%s",
                 row.authorization_id,
@@ -274,7 +286,7 @@ def _resolve_row(
         return
 
     if outcome == ApplyOutcome.RESERVATION_MISSING:
-        outbox.mark(
+        status = outbox.mark(
             row.authorization_id,
             row.intent_kind,
             done=False,
@@ -282,6 +294,16 @@ def _resolve_row(
             lease_owner=lease_owner,
             force_dead=True,
         )
+        if status != "dead":
+            # The winner re-derives the observation and alerts exactly once;
+            # a stale duplicate or contradictory page is worse than none.
+            logger.warning(
+                "settle outbox resolution skipped because row was no longer "
+                "claimable by this owner authorization_id=%s intent_kind=%s",
+                row.authorization_id,
+                row.intent_kind,
+            )
+            return
         logger.error(
             "ALERT settle outbox reservation missing authorization_id=%s reservation_id=%s",
             row.authorization_id,
@@ -290,7 +312,7 @@ def _resolve_row(
         return
 
     if outcome == ApplyOutcome.INVALID_ROW:
-        outbox.mark(
+        status = outbox.mark(
             row.authorization_id,
             row.intent_kind,
             done=False,
@@ -298,6 +320,16 @@ def _resolve_row(
             lease_owner=lease_owner,
             force_dead=True,
         )
+        if status != "dead":
+            # The winner re-derives the observation and warns exactly once; a
+            # stale duplicate or contradictory warning is worse than none.
+            logger.warning(
+                "settle outbox resolution skipped because row was no longer "
+                "claimable by this owner authorization_id=%s intent_kind=%s",
+                row.authorization_id,
+                row.intent_kind,
+            )
+            return
         logger.warning(
             "settle outbox invalid frozen row authorization_id=%s intent_kind=%s",
             row.authorization_id,

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -334,7 +334,9 @@ class SpannerSettleOutbox:
         still incrementing attempts for the audit trail. Dead FREEZES the hold
         (GUARD_STATUSES) until a human sets `release_approved`. Returns the new
         status, or None if the row was not claimable by this owner (lost lease /
-        already resolved). Only 'pending' rows are marked."""
+        already resolved). A worker that lost its lease cannot resolve the row;
+        the winner (or next claimant) re-runs the idempotent apply to re-derive
+        the outcome. Only 'pending' rows are marked."""
         now = _iso_now()
 
         def txn(transaction: Any) -> str | None:
@@ -351,8 +353,10 @@ class SpannerSettleOutbox:
                 rows[0][1],
                 rows[0][2],
             )
-            if lease_owner is not None and cur_owner not in (None, lease_owner):
-                return None  # lost the lease to another worker
+            # Issue #355: anonymous inline callers may touch only unleased rows,
+            # while drain workers may touch only rows they still own.
+            if cur_owner != lease_owner:
+                return None
             next_attempts = attempts + 1
             if done:
                 new_status, next_at, err, terminal_at = "done", None, None, now
@@ -382,7 +386,8 @@ class SpannerSettleOutbox:
                 "settle_body=IF(@done, CAST(NULL AS STRING), settle_body) "
                 "WHERE authorization_id=@aid "
                 "AND intent_kind=@kind AND status='pending' "
-                "AND (lease_owner IS NULL OR lease_owner=@lease_owner)",
+                "AND ((@lease_owner IS NULL AND lease_owner IS NULL) OR "
+                "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner))",
                 params={
                     "status": new_status, "attempts": next_attempts, "err": err,
                     "next_at": next_at, "now": now,
@@ -496,7 +501,9 @@ class SpannerSettleOutbox:
                 return False
             attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
             parked_reservation_id = rows[0][2]
-            if lease_owner is not None and cur_owner not in (None, lease_owner):
+            # Issue #355: anonymous callers may park only unleased rows, while
+            # drain workers must still own the lease they are fencing with.
+            if cur_owner != lease_owner:
                 return False
             # §6: park != failure. A whole typed-backend outage must not walk
             # frozen rows toward dead; attempts stays unchanged and only the
@@ -506,7 +513,8 @@ class SpannerSettleOutbox:
                 "next_attempt_at=@next_at, lease_owner=NULL, leased_until=NULL, "
                 "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
                 "AND status='pending' AND attempts=@attempts "
-                "AND (lease_owner IS NULL OR lease_owner=@lease_owner)",
+                "AND ((@lease_owner IS NULL AND lease_owner IS NULL) OR "
+                "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner))",
                 params={
                     "attempts": attempts, "err": note[:1000],
                     "next_at": next_at, "now": now,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -791,7 +791,12 @@ class _FakeTransaction:
         if sql.startswith("UPDATE tr_settle_outbox SET status='pending'"):  # park
             _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "park")
             _require_pred(sql, "AND status='pending' AND attempts=@attempts", "park")
-            _require_pred(sql, "lease_owner IS NULL OR lease_owner=@lease_owner", "park")
+            _require_pred(
+                sql,
+                "(@lease_owner IS NULL AND lease_owner IS NULL) OR "
+                "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner)",
+                "park",
+            )
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
@@ -799,7 +804,7 @@ class _FakeTransaction:
             if int(rec.get("attempts", 0) or 0) != int(p["attempts"]):
                 return 0
             owner = rec.get("lease_owner")
-            if owner is not None and owner != p.get("lease_owner"):
+            if owner != p.get("lease_owner"):
                 return 0
             new = dict(
                 rec, status="pending", attempts=rec.get("attempts", 0), last_error=p["err"],
@@ -823,13 +828,18 @@ class _FakeTransaction:
         if sql.startswith("UPDATE tr_settle_outbox SET status=@status"):  # mark
             _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "mark")
             _require_pred(sql, "status='pending'", "mark")
-            _require_pred(sql, "lease_owner IS NULL OR lease_owner=@lease_owner", "mark")
+            _require_pred(
+                sql,
+                "(@lease_owner IS NULL AND lease_owner IS NULL) OR "
+                "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner)",
+                "mark",
+            )
             pk = (p["aid"], p["kind"])
             rec = self._settle_outbox_current(pk)
             if rec is None or rec["status"] != "pending":
                 return 0
             owner = rec.get("lease_owner")
-            if owner is not None and owner != p.get("lease_owner"):
+            if owner != p.get("lease_owner"):
                 return 0
             new = dict(
                 rec, status=p["status"], attempts=p["attempts"], last_error=p["err"],

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -143,6 +143,15 @@ class FakeSpannerDatabase:
         # tr_settle_outbox: PK (authorization_id, intent_kind) -> {column: value}.
         self.settle_outbox: dict[tuple, dict] = {}
         self.settle_outbox_versions: dict[tuple, int] = {}
+        # Per-authorization RANGE version: bumped whenever ANY outbox row of an
+        # authorization is inserted/updated/deleted at commit. The MF2 guard
+        # count and the sibling/EXISTS predicates are range reads over an
+        # authorization's rows — including the ABSENCE of rows — and real
+        # Spanner serializes them against a concurrent enqueue commit. Per-row
+        # versions cannot represent "no row existed", so guard reads record
+        # this key and _try_commit validates it: an enqueue that lands between
+        # the in-txn zero-count and the claim commit aborts the claim.
+        self.settle_outbox_auth_versions: dict[str, int] = {}
         self._global_version = 0
         self._commit_lock = threading.Lock()
         self._ready_barrier = ready_barrier
@@ -187,6 +196,11 @@ class FakeSpannerDatabase:
                     current_version = 1 if key[1] in self.reservation_idemp else 0
                 elif isinstance(key, tuple) and len(key) == 2 and key[0] == "outbox":
                     current_version = self.settle_outbox_versions.get(key[1], 0)
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "outbox_auth":
+                    # Range read over one authorization's outbox rows (MF2 guard
+                    # count / sibling predicates): any commit touching the range
+                    # since the read aborts this transaction.
+                    current_version = self.settle_outbox_auth_versions.get(key[1], 0)
                 elif isinstance(key, tuple) and len(key) == 2 and key[0] == "gateway_auth":
                     current_version = self.gateway_authorization_versions.get(
                         key[1],
@@ -235,10 +249,12 @@ class FakeSpannerDatabase:
                     _, pk, record = op
                     self.settle_outbox[pk] = record
                     self.settle_outbox_versions[pk] = new_version
+                    self.settle_outbox_auth_versions[pk[0]] = new_version
                 elif op[0] == "delete_settle_outbox":
                     _, pk = op
                     self.settle_outbox.pop(pk, None)
                     self.settle_outbox_versions.pop(pk, None)
+                    self.settle_outbox_auth_versions[pk[0]] = new_version
                 elif op[0] == "update_reservation":
                     _, rid, record = op
                     self.reservations[rid] = record
@@ -348,6 +364,13 @@ class _FakeTransaction:
 
     def _has_guarded_outbox_intent(self, authorization_id: str) -> bool:
         """Evaluate the correlated pending/dead EXISTS against the in-txn view."""
+        # Range read (absence included) — record the per-authorization range
+        # version so a concurrent enqueue/status-flip aborts this txn at commit.
+        range_key = ("outbox_auth", authorization_id)
+        if range_key not in self.read_versions:
+            self.read_versions[range_key] = (
+                self.db.settle_outbox_auth_versions.get(authorization_id, 0)
+            )
         pks = set(self.db.settle_outbox)
         pks.update(
             op[1]
@@ -1122,12 +1145,31 @@ def _execute_settle_outbox_sql(
         )
         aid = p["aid"]
         kind = p["kind"]
+        if txn is not None:
+            # Range read over the authorization's rows (absence included) —
+            # same serialization contract as the MF2 guard count above.
+            range_key = ("outbox_auth", aid)
+            if range_key not in txn.read_versions:
+                txn.read_versions[range_key] = (
+                    db.settle_outbox_auth_versions.get(aid, 0)
+                )
         count = 0
-        for pk, committed in db.settle_outbox.items():
+        pks = set(db.settle_outbox)
+        if txn is not None:
+            pks.update(
+                op[1]
+                for op in txn.pending_writes
+                if op[0] in (
+                    "insert_settle_outbox",
+                    "update_settle_outbox",
+                    "delete_settle_outbox",
+                )
+            )
+        for pk in pks:
             rec = (
                 txn._settle_outbox_current(pk)
                 if txn is not None
-                else committed
+                else db.settle_outbox.get(pk)
             )
             if (
                 rec is not None
@@ -1137,12 +1179,42 @@ def _execute_settle_outbox_sql(
             ):
                 count += 1
         return [[count]]
-    if "SELECT COUNT(*) FROM tr_settle_outbox" in sql:  # reaper-guard predicate (has_intent)
+    if "SELECT COUNT(*) FROM tr_settle_outbox" in sql:  # MF2 guard count / has_intent
         _require_pred(sql, "authorization_id=@aid", "has_intent")
         _require_pred(sql, f"status IN ({_GUARD_STATUS_SQL})", "has_intent")
         aid = p["aid"]
-        # Committed-state read is correct for the in-txn guard too: enqueue
-        # commits in its own txn, and the reaper txn never writes outbox rows.
+        if txn is not None:
+            # MF2: inside settle_atomic's claim transaction this range read —
+            # including its ABSENCE result — must serialize against a
+            # concurrent enqueue commit. Record the per-authorization range
+            # version so _try_commit aborts the claim if any outbox row of this
+            # authorization commits after the count. (An earlier comment argued
+            # committed-state reads were fine here; a diagnostic disproved it —
+            # an enqueue landing between the zero-count and the claim commit
+            # slipped through unvalidated.)
+            range_key = ("outbox_auth", aid)
+            if range_key not in txn.read_versions:
+                txn.read_versions[range_key] = (
+                    db.settle_outbox_auth_versions.get(aid, 0)
+                )
+            pks = set(db.settle_outbox)
+            pks.update(
+                op[1]
+                for op in txn.pending_writes
+                if op[0] in (
+                    "insert_settle_outbox",
+                    "update_settle_outbox",
+                    "delete_settle_outbox",
+                )
+            )
+            n = sum(
+                1
+                for pk in pks
+                if pk[0] == aid
+                and (rec := txn._settle_outbox_current(pk)) is not None
+                and rec.get("status") in GUARD_STATUSES
+            )
+            return [[n]]
         n = sum(
             1 for rec in db.settle_outbox.values()
             if rec.get("authorization_id") == aid and rec.get("status") in GUARD_STATUSES

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -274,6 +274,18 @@ class _FakeTransaction:
         self.db = db
         self.read_versions: dict[tuple[str, str], int] = {}
         self.read_snapshots: dict[tuple[str, str], str | None] = {}
+        # Row values pinned at FIRST read, keyed like read_versions. Real
+        # Spanner read-write transactions are serializable: every statement in
+        # one transaction sees ONE consistent view, and an external commit that
+        # invalidates it surfaces as Aborted at commit time — never as a row
+        # changing between two statements. Serving repeat reads from the pinned
+        # snapshot (with _try_commit's version validation unchanged) reproduces
+        # exactly that: the txn body stays self-consistent, and the conflict
+        # becomes an abort-and-retry. Without this, a concurrent commit landing
+        # between a plan read and its guarded DML made the guard fail MID-txn —
+        # a phantom _RebalanceInvariantError real Spanner cannot produce
+        # (surfaced as a rare credit-shard stress flake).
+        self.row_snapshots: dict[tuple, dict | None] = {}
         self.pending_writes: list[tuple] = []
         # DML+mutation mixing is forbidden in one transaction (real Spanner
         # buffers mutations after DML and DML can't see them); fail fast if both.
@@ -289,6 +301,25 @@ class _FakeTransaction:
     ) -> list[list[str]]:
         return _execute_sql(self.db, self, sql, params or {})
 
+    def _pinned_read(
+        self,
+        version_key: tuple,
+        current_version: int,
+        rec: dict | None,
+    ) -> dict | None:
+        """First read pins version + value; repeat reads return the pin.
+
+        Pin independently of read_versions: some INSERT handlers record an
+        absence version directly without a value snapshot, and a later read
+        through here must not KeyError (nor observe fresher state) for that key.
+        """
+        if version_key not in self.read_versions:
+            self.read_versions[version_key] = current_version
+        if version_key not in self.row_snapshots:
+            self.row_snapshots[version_key] = dict(rec) if rec is not None else None
+        snap = self.row_snapshots[version_key]
+        return dict(snap) if snap is not None else None
+
     def _reservation_current(self, rid: str) -> dict | None:
         """In-txn view of a reservation (read-your-writes) + record read version."""
         for op in reversed(self.pending_writes):
@@ -296,11 +327,11 @@ class _FakeTransaction:
                 return dict(op[2])
             if op[0] == "insert_reservation" and op[1]["reservation_id"] == rid:
                 return dict(op[1])
-        version_key = ("res", rid)
-        if version_key not in self.read_versions:
-            self.read_versions[version_key] = self.db.reservation_versions.get(rid, 0)
-        rec = self.db.reservations.get(rid)
-        return dict(rec) if rec is not None else None
+        return self._pinned_read(
+            ("res", rid),
+            self.db.reservation_versions.get(rid, 0),
+            self.db.reservations.get(rid),
+        )
 
     def _settle_outbox_current(self, pk: tuple) -> dict | None:
         """In-txn view of a settle-outbox row (read-your-writes) + read version."""
@@ -309,11 +340,11 @@ class _FakeTransaction:
                 return None
             if op[0] in ("insert_settle_outbox", "update_settle_outbox") and op[1] == pk:
                 return dict(op[2])
-        version_key = ("outbox", pk)
-        if version_key not in self.read_versions:
-            self.read_versions[version_key] = self.db.settle_outbox_versions.get(pk, 0)
-        rec = self.db.settle_outbox.get(pk)
-        return dict(rec) if rec is not None else None
+        return self._pinned_read(
+            ("outbox", pk),
+            self.db.settle_outbox_versions.get(pk, 0),
+            self.db.settle_outbox.get(pk),
+        )
 
     def _has_guarded_outbox_intent(self, authorization_id: str) -> bool:
         """Evaluate the correlated pending/dead EXISTS against the in-txn view."""
@@ -345,13 +376,11 @@ class _FakeTransaction:
                 "update_gateway_authorization",
             ) and op[1] == authorization_id:
                 return dict(op[2])
-        version_key = ("gateway_auth", authorization_id)
-        if version_key not in self.read_versions:
-            self.read_versions[version_key] = (
-                self.db.gateway_authorization_versions.get(authorization_id, 0)
-            )
-        rec = self.db.gateway_authorizations.get(authorization_id)
-        return dict(rec) if rec is not None else None
+        return self._pinned_read(
+            ("gateway_auth", authorization_id),
+            self.db.gateway_authorization_versions.get(authorization_id, 0),
+            self.db.gateway_authorizations.get(authorization_id),
+        )
 
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
         """In-txn view of a typed row for DML: sees prior DML writes
@@ -361,11 +390,11 @@ class _FakeTransaction:
         for op in reversed(self.pending_writes):
             if op[0] == "update_typed" and op[1] == table and op[2] == pk:
                 return dict(op[3])
-        version_key = ("typed", table, pk)
-        if version_key not in self.read_versions:
-            self.read_versions[version_key] = self.db.typed_versions.get((table, pk), 0)
-        rec = self.db.typed.get(table, {}).get(pk)
-        return dict(rec) if rec is not None else None
+        return self._pinned_read(
+            ("typed", table, pk),
+            self.db.typed_versions.get((table, pk), 0),
+            self.db.typed.get(table, {}).get(pk),
+        )
 
     def execute_update(
         self, sql: str, *, params: dict[str, Any] | None = None, param_types: Any = None

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -20,6 +20,10 @@ class _ParamTypes:
     BOOL = "BOOL"
     TIMESTAMP = "TIMESTAMP"
 
+    @staticmethod
+    def Array(element_type: Any) -> tuple[str, Any]:
+        return ("ARRAY", element_type)
+
 
 # Real Spanner column DEFAULTs for the typed counter tables (every counter is
 # NOT NULL DEFAULT(0) in the DDL). The fake fills these on INSERT so a
@@ -531,6 +535,58 @@ class _FakeTransaction:
             record["terminal_at"] = None
             self.pending_writes.append(("insert_reservation", record))
             return 1
+        if (
+            sql.startswith("UPDATE tr_reservation SET terminal_at=@terminal_at")
+            and "IN UNNEST" in sql
+        ):
+            _require_pred(
+                sql,
+                "reservation_id IN UNNEST(@ids)",
+                "reservation-terminal-backfill",
+            )
+            _require_pred(
+                sql,
+                "AND settled AND terminal_at IS NULL",
+                "reservation-terminal-backfill",
+            )
+            _require_pred(
+                sql,
+                "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+                "reservation-terminal-backfill",
+            )
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_reservation.authorization_id",
+                "reservation-terminal-backfill",
+            )
+            _require_pred(
+                sql,
+                f"o.status IN ({_GUARD_STATUS_SQL})",
+                "reservation-terminal-backfill",
+            )
+            ids = p.get("ids")
+            if not isinstance(ids, list):
+                raise AssertionError(
+                    "reservation-terminal-backfill requires an @ids array binding"
+                )
+            updated = 0
+            for rid in ids:
+                rec = self._reservation_current(str(rid))
+                if (
+                    rec is None
+                    or not rec.get("settled")
+                    or rec.get("terminal_at") is not None
+                    or self._has_guarded_outbox_intent(
+                        str(rec.get("authorization_id"))
+                    )
+                ):
+                    continue
+                new = dict(rec, terminal_at=p["terminal_at"])
+                self.pending_writes.append(
+                    ("update_reservation", str(rid), new)
+                )
+                updated += 1
+            return updated
         if "UPDATE tr_reservation SET settled=true" in sql:
             _require_pred(sql, "reservation_id=@rid AND settled=false", "reservation-claim")
             guarded = "tr_settle_outbox" in sql
@@ -1076,6 +1132,134 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    # Guarded legacy terminal_at backfill. These narrow handlers intentionally
+    # assert every real predicate they model (MF6); a production SQL regression
+    # must fail tests instead of being repaired by the fake's Python filtering.
+    if sql.startswith("SELECT reservation_id FROM tr_reservation"):
+        _require_pred(
+            sql,
+            "WHERE settled AND terminal_at IS NULL",
+            "reservation-terminal-backfill-scan",
+        )
+        _require_pred(
+            sql,
+            "AND NOT EXISTS (SELECT 1 FROM tr_settle_outbox o",
+            "reservation-terminal-backfill-scan",
+        )
+        _require_pred(
+            sql,
+            "o.authorization_id = tr_reservation.authorization_id",
+            "reservation-terminal-backfill-scan",
+        )
+        _require_pred(
+            sql,
+            f"o.status IN ({_GUARD_STATUS_SQL})",
+            "reservation-terminal-backfill-scan",
+        )
+        _require_pred(
+            sql,
+            "ORDER BY reservation_id LIMIT @batch",
+            "reservation-terminal-backfill-scan",
+        )
+        rows = [
+            [rid]
+            for rid, rec in sorted(db.reservations.items())
+            if rec.get("settled")
+            and rec.get("terminal_at") is None
+            and not any(
+                outbox.get("authorization_id") == rec.get("authorization_id")
+                and outbox.get("status") in GUARD_STATUSES
+                for outbox in db.settle_outbox.values()
+            )
+        ]
+        return rows[: int(params["batch"])]
+    if (
+        sql.startswith("SELECT COUNT(*) FROM tr_reservation")
+        and not params
+    ):
+        if "AND EXISTS (SELECT 1 FROM tr_settle_outbox o" in sql:
+            _require_pred(
+                sql,
+                "WHERE settled AND terminal_at IS NULL",
+                "reservation-terminal-backfill-excluded-count",
+            )
+            _require_pred(
+                sql,
+                "o.authorization_id = tr_reservation.authorization_id",
+                "reservation-terminal-backfill-excluded-count",
+            )
+            _require_pred(
+                sql,
+                f"o.status IN ({_GUARD_STATUS_SQL})",
+                "reservation-terminal-backfill-excluded-count",
+            )
+            return [[
+                sum(
+                    1
+                    for rec in db.reservations.values()
+                    if rec.get("settled")
+                    and rec.get("terminal_at") is None
+                    and any(
+                        outbox.get("authorization_id")
+                        == rec.get("authorization_id")
+                        and outbox.get("status") in GUARD_STATUSES
+                        for outbox in db.settle_outbox.values()
+                    )
+                )
+            ]]
+        if "terminal_at IS NULL" in sql:
+            _require_pred(
+                sql,
+                "WHERE settled AND terminal_at IS NULL",
+                "reservation-terminal-backfill-candidate-count",
+            )
+            return [[
+                sum(
+                    1
+                    for rec in db.reservations.values()
+                    if rec.get("settled") and rec.get("terminal_at") is None
+                )
+            ]]
+        if "terminal_at IS NOT NULL" in sql:
+            _require_pred(
+                sql,
+                "WHERE settled AND terminal_at IS NOT NULL",
+                "reservation-terminal-backfill-armed-count",
+            )
+            return [[
+                sum(
+                    1
+                    for rec in db.reservations.values()
+                    if rec.get("settled") and rec.get("terminal_at") is not None
+                )
+            ]]
+        _require_pred(
+            sql,
+            "WHERE NOT settled",
+            "reservation-terminal-backfill-open-count",
+        )
+        return [[
+            sum(
+                1
+                for rec in db.reservations.values()
+                if not rec.get("settled")
+            )
+        ]]
+    if sql.startswith(
+        "SELECT COUNT(*) FROM tr_gateway_authorization"
+    ):
+        _require_pred(
+            sql,
+            "WHERE settled AND terminal_at IS NULL",
+            "gateway-authorization-terminal-backfill-cross-check",
+        )
+        return [[
+            sum(
+                1
+                for rec in db.gateway_authorizations.values()
+                if rec.get("settled") and rec.get("terminal_at") is None
+            )
+        ]]
     # Reaper scan: expired unsettled reservations. This must precede the generic
     # tr_settle_outbox dispatcher because the guarded scan names both tables; match
     # the more specific query first.

--- a/tests/test_backfill_reservation_terminal_at.py
+++ b/tests/test_backfill_reservation_terminal_at.py
@@ -154,3 +154,40 @@ def test_apply_processes_more_candidates_than_batch_in_multiple_batches(
     assert "batch 1: updated=2 running_total=2" in output
     assert "batch 2: updated=2 running_total=4" in output
     assert "batch 3: updated=1 running_total=5" in output
+
+
+def test_race_row_becomes_eligible_after_empty_select_is_still_armed(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A guarded row whose intent flips to release_approved between the empty
+    select and the status read must be re-selected and armed, not abandoned
+    behind a false "all excluded" STOP (review finding on #357)."""
+    import scripts.backfill_reservation_terminal_at as mod
+
+    store, database, _bigtable = make_fake_store()
+    _seed_reservation(database, "res-race")
+    _freeze(database, "res-race", "pending")
+
+    real_select = mod._select_batch
+    calls = {"n": 0}
+
+    def select_then_release(store_arg: Any, batch: int) -> list[str]:
+        ids = real_select(store_arg, batch)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert ids == [], "precondition: the frozen row is not selectable"
+            # Concurrent human action: the guard status leaves GUARD_STATUSES.
+            database.settle_outbox[("auth-res-race", "settle")]["status"] = (
+                "release_approved"
+            )
+        return ids
+
+    monkeypatch.setattr(mod, "_select_batch", select_then_release)
+
+    assert run_backfill(store, apply=True) == 0
+
+    assert database.reservations["res-race"]["terminal_at"] is not None
+    output = capsys.readouterr().out
+    assert "STOP" not in output
+    assert output.endswith("COMPLETE: no unarmed settled reservations remain\n")

--- a/tests/test_backfill_reservation_terminal_at.py
+++ b/tests/test_backfill_reservation_terminal_at.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from scripts.backfill_reservation_terminal_at import run_backfill
+from tests.fakes.spanner import make_fake_store
+
+
+def _seed_reservation(
+    database: Any,
+    reservation_id: str,
+    *,
+    settled: bool = True,
+    terminal_at: datetime | None = None,
+) -> None:
+    database.reservations[reservation_id] = {
+        "reservation_id": reservation_id,
+        "authorization_id": f"auth-{reservation_id}",
+        "settled": settled,
+        "terminal_at": terminal_at,
+    }
+
+
+def _freeze(database: Any, reservation_id: str, status: str) -> None:
+    authorization_id = f"auth-{reservation_id}"
+    database.settle_outbox[(authorization_id, "settle")] = {
+        "authorization_id": authorization_id,
+        "intent_kind": "settle",
+        "status": status,
+    }
+
+
+def test_apply_arms_settled_null_rows_and_terminates(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, database, _bigtable = make_fake_store()
+    for index in range(3):
+        _seed_reservation(database, f"res-{index}")
+
+    assert run_backfill(store, apply=True) == 0
+
+    assert all(
+        row["terminal_at"] is not None
+        for row in database.reservations.values()
+    )
+    output = capsys.readouterr().out
+    assert output.startswith(
+        "STATUS: tr_reservation candidates=3 armed=0 open_holds=0 excluded=0\n"
+    )
+    assert "batch 1: updated=3 running_total=3" in output
+    assert "FINAL: armed=3 remaining_candidates=0 excluded=0" in output
+    assert output.endswith("COMPLETE: no unarmed settled reservations remain\n")
+
+
+@pytest.mark.parametrize("outbox_status", ["pending", "dead"])
+def test_apply_excludes_frozen_intent_rows_and_stops(
+    outbox_status: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, database, _bigtable = make_fake_store()
+    for index in range(3):
+        _seed_reservation(database, f"res-{index}")
+    _freeze(database, "res-1", outbox_status)
+
+    assert run_backfill(store, batch=1, apply=True) == 0
+
+    assert database.reservations["res-0"]["terminal_at"] is not None
+    assert database.reservations["res-1"]["terminal_at"] is None
+    assert database.reservations["res-2"]["terminal_at"] is not None
+    output = capsys.readouterr().out
+    assert "candidates=3 armed=0 open_holds=0 excluded=1" in output
+    assert "FINAL: armed=2 remaining_candidates=1 excluded=1" in output
+    assert output.endswith(
+        "STOP: all remaining candidates are excluded by the pending/dead "
+        "tr_settle_outbox frozen-intent guard\n"
+    )
+
+
+def test_apply_never_touches_open_holds() -> None:
+    store, database, _bigtable = make_fake_store()
+    _seed_reservation(database, "settled")
+    _seed_reservation(database, "open", settled=False)
+
+    assert run_backfill(store, apply=True) == 0
+
+    assert database.reservations["settled"]["terminal_at"] is not None
+    assert database.reservations["open"]["terminal_at"] is None
+
+
+def test_apply_preserves_already_armed_rows() -> None:
+    store, database, _bigtable = make_fake_store()
+    existing = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+    _seed_reservation(database, "already-armed", terminal_at=existing)
+    _seed_reservation(database, "candidate")
+
+    assert run_backfill(store, apply=True) == 0
+
+    assert database.reservations["already-armed"]["terminal_at"] == existing
+    assert database.reservations["candidate"]["terminal_at"] is not None
+
+
+def test_dry_run_mutates_nothing_and_reports_candidates_and_exclusions(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, database, _bigtable = make_fake_store()
+    _seed_reservation(database, "eligible")
+    _seed_reservation(database, "frozen")
+    _seed_reservation(database, "open", settled=False)
+    _seed_reservation(
+        database,
+        "armed",
+        terminal_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    _freeze(database, "frozen", "pending")
+    database.gateway_authorizations["gateway-pinned"] = {
+        "authorization_id": "gateway-pinned",
+        "settled": True,
+        "terminal_at": None,
+    }
+    before = deepcopy(database.reservations)
+
+    assert run_backfill(store, batch=7) == 0
+
+    assert database.reservations == before
+    output = capsys.readouterr().out
+    assert output.startswith(
+        "STATUS: tr_reservation candidates=2 armed=1 open_holds=1 excluded=1\n"
+    )
+    assert (
+        "STATUS: tr_gateway_authorization pinned=1 "
+        "(informational cross-check)\n"
+    ) in output
+    assert output.endswith("DRY-RUN: would arm 1 rows in batches of 7\n")
+
+
+def test_apply_processes_more_candidates_than_batch_in_multiple_batches(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, database, _bigtable = make_fake_store()
+    for index in range(5):
+        _seed_reservation(database, f"res-{index}")
+
+    assert run_backfill(store, batch=2, apply=True) == 0
+
+    assert all(
+        row["terminal_at"] is not None
+        for row in database.reservations.values()
+    )
+    output = capsys.readouterr().out
+    assert "batch 1: updated=2 running_total=2" in output
+    assert "batch 2: updated=2 running_total=4" in output
+    assert "batch 3: updated=1 running_total=5" in output

--- a/tests/test_fake_spanner_txn_consistency.py
+++ b/tests/test_fake_spanner_txn_consistency.py
@@ -1,0 +1,118 @@
+"""The fake transaction must give every statement ONE consistent row view.
+
+Real Spanner read-write transactions are serializable: a concurrent commit
+that invalidates what a transaction already read surfaces as Aborted at
+commit time — never as a row changing value between two statements of the
+same transaction. The fake models that with version validation at commit
+plus row snapshots pinned at first read.
+
+Without the pinned snapshots, a commit landing between a plan read and its
+guarded DML made the guard evaluate against FRESHER state than the plan —
+a mid-transaction inconsistency real Spanner cannot produce. Production's
+rebalance turned exactly that into a phantom _RebalanceInvariantError
+("credit shard changed or disappeared during rebalance"), seen as a rare
+credit-shard stress flake under coverage on CI.
+"""
+
+from __future__ import annotations
+
+from tests.fakes.spanner import make_fake_store
+
+_DONOR_TRANSFER_SQL = (
+    "UPDATE tr_credit_balance SET total_credits=total_credits-@move "
+    "WHERE workspace_id=@ws AND shard=@donor "
+    "AND (total_credits-total_usage-reserved)>=@move"
+)
+
+
+def _seed_shard(db, ws: str, shard: int, credits: int, usage: int) -> None:
+    db.typed.setdefault("tr_credit_balance", {})[(ws, shard)] = {
+        "workspace_id": ws,
+        "shard": shard,
+        "total_credits": credits,
+        "total_usage": usage,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def test_guarded_dml_sees_the_txn_pinned_view_and_conflict_aborts() -> None:
+    store, db, _bt = make_fake_store()
+    ws = "ws-txn-consistency"
+    _seed_shard(db, ws, 0, credits=1_000, usage=0)
+
+    pk = (ws, 0)
+    attempts: list[int] = []
+
+    def txn_body(txn):
+        attempt = len(attempts)
+        attempts.append(attempt)
+        # Statement 1: the "plan read" pins the row (headroom 1000).
+        rec = txn._typed_current("tr_credit_balance", pk)
+        assert rec is not None
+        if attempt == 0:
+            assert rec["total_usage"] == 0
+            # A concurrent transaction commits a usage bump between the plan
+            # read and the guarded DML (headroom drops to 400).
+            committed = db.typed["tr_credit_balance"][pk]
+            committed["total_usage"] = 600
+            db.typed_versions[("tr_credit_balance", pk)] = (
+                db.typed_versions.get(("tr_credit_balance", pk), 0) + 1
+            )
+        # Statement 2: guarded DML planned against the FIRST read. On attempt 0
+        # it must evaluate against the pinned view (headroom 1000) and succeed
+        # in-txn; the external commit then surfaces as an ABORT at commit, not
+        # as a mid-txn guard failure. On the retry the fresh read sees usage
+        # 600 and a smaller move still fits.
+        move = 500 if attempt == 0 else 300
+        updated = txn.execute_update(
+            _DONOR_TRANSFER_SQL,
+            params={"move": move, "ws": ws, "donor": 0},
+            param_types=None,
+        )
+        assert updated == 1, (
+            f"attempt {attempt}: guarded DML must see the transaction's pinned "
+            "view; a mid-txn guard failure is a phantom real Spanner cannot "
+            "produce"
+        )
+        return updated
+
+    assert db.run_in_transaction(txn_body) == 1
+    # The conflict was surfaced as serializable abort-and-retry.
+    assert len(attempts) == 2
+    assert db.aborts == 1
+    # Final state composes BOTH writes: the concurrent usage bump and the
+    # retry's smaller transfer, with no lost update in either direction.
+    final = db.typed["tr_credit_balance"][pk]
+    assert final["total_usage"] == 600
+    assert final["total_credits"] == 700
+
+
+def test_repeat_read_in_one_txn_is_stable_despite_concurrent_commit() -> None:
+    store, db, _bt = make_fake_store()
+    ws = "ws-repeat-read"
+    _seed_shard(db, ws, 0, credits=1_000, usage=0)
+    pk = (ws, 0)
+    ran = {"n": 0}
+
+    def txn_body(txn):
+        ran["n"] += 1
+        if ran["n"] > 1:
+            # Retry after the abort: fresh view, no further interference.
+            return txn._typed_current("tr_credit_balance", pk)["total_usage"]
+        first = txn._typed_current("tr_credit_balance", pk)
+        committed = db.typed["tr_credit_balance"][pk]
+        committed["total_usage"] = 999
+        db.typed_versions[("tr_credit_balance", pk)] = (
+            db.typed_versions.get(("tr_credit_balance", pk), 0) + 1
+        )
+        second = txn._typed_current("tr_credit_balance", pk)
+        assert second["total_usage"] == first["total_usage"] == 0, (
+            "repeatable read violated: one transaction observed two states"
+        )
+        return second["total_usage"]
+
+    # The read-only body still aborts at commit (version drift) and retries.
+    assert db.run_in_transaction(txn_body) == 999
+    assert db.aborts == 1

--- a/tests/test_fake_spanner_txn_consistency.py
+++ b/tests/test_fake_spanner_txn_consistency.py
@@ -116,3 +116,59 @@ def test_repeat_read_in_one_txn_is_stable_despite_concurrent_commit() -> None:
     # The read-only body still aborts at commit (version drift) and retries.
     assert db.run_in_transaction(txn_body) == 999
     assert db.aborts == 1
+
+
+def test_mf2_guard_zero_count_aborts_when_enqueue_commits_before_claim() -> None:
+    """The MF2 lost-charge interlock's actual serialization race.
+
+    settle_atomic's in-txn guard count reads an authorization's outbox rows —
+    including their ABSENCE. If an enqueue commits between the zero-count and
+    the claim commit, real Spanner aborts the claim; per-row versions cannot
+    express "no row existed", so the fake tracks a per-authorization range
+    version. Without it, the claim committed against a guard it never saw."""
+    from trusted_router.storage_gcp_settle_outbox import GUARD_COUNT_SQL
+
+    store, db, _bt = make_fake_store()
+    aid = "gwa-mf2-race"
+    counts: list[int] = []
+
+    def txn_body(txn):
+        attempt = len(counts)
+        rows = list(
+            txn.execute_sql(GUARD_COUNT_SQL, params={"aid": aid}, param_types=None)
+        )
+        counts.append(int(rows[0][0]))
+        if attempt == 0:
+            assert counts[0] == 0, "precondition: no guard row at first read"
+            # Concurrent enqueue commits AFTER the zero-count, BEFORE our commit.
+            pk = (aid, "settle")
+            db.settle_outbox[pk] = {
+                "authorization_id": aid,
+                "intent_kind": "settle",
+                "status": "pending",
+            }
+            db._global_version += 1
+            db.settle_outbox_versions[pk] = db._global_version
+            db.settle_outbox_auth_versions[aid] = db._global_version
+        # Stand-in for the reservation claim write: any buffered write makes
+        # this a read-write commit subject to validation.
+        txn.pending_writes.append(
+            (
+                "update_typed",
+                "tr_credit_balance",
+                ("ws-mf2", 0),
+                {
+                    "workspace_id": "ws-mf2",
+                    "shard": 0,
+                    "total_credits": 1,
+                    "total_usage": 0,
+                    "reserved": 0,
+                },
+            )
+        )
+        return counts[-1]
+
+    # The retry must OBSERVE the enqueue the first attempt raced with.
+    assert db.run_in_transaction(txn_body) == 1
+    assert counts == [0, 1]
+    assert db.aborts == 1

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1523,6 +1523,13 @@ def test_charged_settle_then_sibling_refund_resolves_and_arms_retention(
     )
     assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
     assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
+    # Money: the settle's charge stands, the refund replay moved no counters.
+    credit = _typed_credit(db, ws)
+    assert credit["reserved"] == 0
+    assert credit["total_usage"] == 777_777
+    key_row = _typed_key(db, key.hash)
+    assert key_row["reserved"] == 0
+    assert key_row["usage"] == 777_777
 
 
 def test_charged_settle_with_no_generation_dead_letters_as_invalid_row(

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1421,6 +1421,86 @@ def test_lost_charge_recovery_end_to_end(
     assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
 
 
+def test_charged_settle_then_sibling_refund_resolves_and_arms_retention(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-drain-sibling-refund"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    ob = _outbox(store)
+    settle_row = _row(auth, cost=777_777)
+    refund_row = _row(auth, intent="refund", cost=777_777)
+    ob.enqueue(settle_row)
+    ob.enqueue(refund_row, initial_delay_seconds=60)
+
+    settled = drain_mod.drain_settle_outbox(10)
+
+    assert settled["outcomes"] == {ApplyOutcome.SETTLED_NOW: 1}
+    assert ob.get(auth.id, "settle").status == "done"
+    assert ob.get(auth.id, "refund").status == "pending"
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+    db.settle_outbox[(auth.id, "refund")]["next_attempt_at"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        refunded = drain_mod.drain_settle_outbox(10)
+
+    assert refunded["outcomes"] == {
+        ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE: 1
+    }
+    completed_refund = ob.get(auth.id, "refund")
+    assert completed_refund is not None and completed_refund.status == "done"
+    assert any(
+        "kept charge beat refund intent" in record.getMessage()
+        and f"authorization_id={auth.id}" in record.getMessage()
+        for record in caplog.records
+    )
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
+
+
+def test_charged_settle_with_no_generation_dead_letters_as_invalid_row(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-drain-malformed-settle"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    assert (
+        apply_mod.apply_frozen_settle(_row(auth, cost=777_777))
+        == ApplyOutcome.SETTLED_NOW
+    )
+    ob = _outbox(store)
+    ob.enqueue(_row(auth, cost=777_777))
+
+    def fail_to_build_generation(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        apply_mod,
+        "_frozen_generation",
+        fail_to_build_generation,
+    )
+
+    drained = drain_mod.drain_settle_outbox(10)
+
+    assert drained["outcomes"] == {ApplyOutcome.INVALID_ROW: 1}
+    malformed = ob.get(auth.id, "settle")
+    assert malformed is not None and malformed.status == "dead"
+    assert malformed.last_error == "invalid_row"
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+
+
 def test_drain_leaves_terminal_rows_for_spanner_ttl(
     fake_store: tuple[Any, Any, Any],
 ) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -977,6 +977,66 @@ def test_activity_pending_lost_lease_skips_false_alert(
     )
 
 
+def test_lost_lease_dead_letter_alerts_only_when_fence_wins(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    ob = _outbox(store)
+    stale_auth = _bare_authorization("gwa-missing-stale-owner")
+    winner_auth = _bare_authorization("gwa-missing-winning-owner")
+    ob.enqueue(_row(stale_auth))
+    ob.enqueue(_row(winner_auth))
+    claimed = {
+        row.authorization_id: row
+        for row in ob.claim(limit=2, lease_seconds=300)
+    }
+    stale = claimed[stale_auth.id]
+    winner = claimed[winner_auth.id]
+    stale_record = db.settle_outbox[(stale_auth.id, "settle")]
+    stale_record["lease_owner"] = None
+    stale_record["leased_until"] = None
+
+    with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
+        drain_mod._resolve_row(
+            ob,
+            stale,
+            ApplyOutcome.RESERVATION_MISSING,
+            error_note=None,
+        )
+        drain_mod._resolve_row(
+            ob,
+            winner,
+            ApplyOutcome.RESERVATION_MISSING,
+            error_note=None,
+        )
+
+    stale_row = ob.get(stale_auth.id, "settle")
+    winner_row = ob.get(winner_auth.id, "settle")
+    assert stale_row is not None and stale_row.status == "pending"
+    assert stale_row.last_error is None
+    assert winner_row is not None and winner_row.status == "dead"
+    alerts = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "ALERT" in record.getMessage()
+    ]
+    assert len(alerts) == 1
+    assert f"authorization_id={winner_auth.id}" in alerts[0].getMessage()
+    assert not any(
+        record.levelno == logging.ERROR
+        and f"authorization_id={stale_auth.id}" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any(
+        record.levelno == logging.WARNING
+        and "resolution skipped" in record.getMessage()
+        and f"authorization_id={stale_auth.id}" in record.getMessage()
+        and "intent_kind=settle" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_activity_pending_escalation_keeps_retention_pinned(
     fake_store: tuple[Any, Any, Any],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -351,3 +351,35 @@ def test_outbox_schema_uses_generated_shard_and_sparse_due_index() -> None:
     assert workflow.index("Smoke test prod") < workflow.index(
         "Retire legacy settle-outbox hotspot index"
     )
+
+
+def test_expired_lease_with_stale_owner_is_stolen_and_stale_worker_fenced() -> None:
+    """Crash recovery under the strict fence (#355): reclamation depends on
+    lease EXPIRY, not owner nullability. A crashed worker's row (owner still
+    set, lease expired) must be re-claimable, the steal must rewrite the owner,
+    and the stale worker's late mark must then lose the exact-match fence."""
+    store, db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-crash", cost=100))
+    [job_a] = ob.claim(lease_seconds=300)
+    stale_owner = job_a.lease_owner
+    assert stale_owner is not None
+
+    # Worker A "crashes": its lease expires with the owner still on the row.
+    db.settle_outbox[("gwa-crash", "settle")]["leased_until"] = (
+        "2000-01-01T00:00:00Z"
+    )
+
+    [job_b] = ob.claim(lease_seconds=300)
+    assert job_b.lease_owner is not None
+    assert job_b.lease_owner != stale_owner
+
+    # A wakes up late: exact-match fence rejects it against B's ownership.
+    assert ob.mark("gwa-crash", "settle", done=True, lease_owner=stale_owner) is None
+    assert ob.get("gwa-crash", "settle").status == "pending"
+
+    # B, the legitimate owner, resolves normally.
+    assert (
+        ob.mark("gwa-crash", "settle", done=True, lease_owner=job_b.lease_owner)
+        == "done"
+    )

--- a/tests/test_settle_outbox_storage.py
+++ b/tests/test_settle_outbox_storage.py
@@ -136,31 +136,77 @@ def test_mark_rejects_a_lost_lease() -> None:
     assert ob.get("gwa-8", "settle").status == "pending"
 
 
-def test_mark_without_owner_respects_active_lease_then_owner_succeeds() -> None:
-    store, _db, _ = make_fake_store()
+def test_stale_mark_after_reclaim_and_park_is_rejected() -> None:
+    store, db, _ = make_fake_store()
     ob = _outbox(store)
-    ob.enqueue(_row("gwa-lease-fence"))
+    ob.enqueue(_row("gwa-stale-mark"))
+    [job] = ob.claim(lease_seconds=300)
+    record = db.settle_outbox[("gwa-stale-mark", "settle")]
+    record["lease_owner"] = None
+    record["leased_until"] = None
+
+    assert (
+        ob.mark(
+            "gwa-stale-mark",
+            "settle",
+            done=False,
+            error="stale terminal outcome",
+            lease_owner=job.lease_owner,
+            force_dead=True,
+        )
+        is None
+    )
+    pending = ob.get("gwa-stale-mark", "settle")
+    assert pending is not None
+    assert pending.status == "pending"
+    assert pending.last_error is None
+
+
+def test_stale_park_after_reclaim_and_park_is_rejected() -> None:
+    store, db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-stale-park"))
+    [job] = ob.claim(lease_seconds=300)
+    record = db.settle_outbox[("gwa-stale-park", "settle")]
+    record["lease_owner"] = None
+    record["leased_until"] = None
+    attempts_before = record["attempts"]
+    next_attempt_before = record["next_attempt_at"]
+
+    assert (
+        ob.park(
+            "gwa-stale-park",
+            "settle",
+            lease_owner=job.lease_owner,
+            retry_after_seconds=120,
+            note="stale park",
+        )
+        is False
+    )
+    pending = ob.get("gwa-stale-park", "settle")
+    assert pending is not None
+    assert pending.status == "pending"
+    assert pending.attempts == attempts_before
+    assert pending.next_attempt_at == next_attempt_before
+    assert pending.last_error is None
+
+
+def test_anonymous_mark_requires_an_unleased_row() -> None:
+    store, db, _ = make_fake_store()
+    ob = _outbox(store)
+    ob.enqueue(_row("gwa-anonymous-fence"))
     [job] = ob.claim(lease_seconds=300)
 
-    assert ob.mark("gwa-lease-fence", "settle", done=True) is None
-    fenced = ob.get("gwa-lease-fence", "settle")
+    assert ob.mark("gwa-anonymous-fence", "settle", done=True) is None
+    fenced = ob.get("gwa-anonymous-fence", "settle")
     assert fenced is not None
     assert fenced.status == "pending"
     assert fenced.lease_owner == job.lease_owner
 
-    assert (
-        ob.mark(
-            "gwa-lease-fence",
-            "settle",
-            done=True,
-            lease_owner=job.lease_owner,
-        )
-        == "done"
-    )
-    done = ob.get("gwa-lease-fence", "settle")
-    assert done is not None
-    assert done.status == "done"
-    assert done.lease_owner is None and done.leased_until is None
+    record = db.settle_outbox[("gwa-anonymous-fence", "settle")]
+    record["lease_owner"] = None
+    record["leased_until"] = None
+    assert ob.mark("gwa-anonymous-fence", "settle", done=True) == "done"
 
 
 def test_enqueue_initial_delay_defers_claim_until_default_row_is_due() -> None:


### PR DESCRIPTION
Closes the three defects deferred or discovered during #353's review and prod verification, plus a fake-fidelity bug that CI's flaking stress test forced to the surface. One commit per concern.

## 1. Refund sibling of a charged settle resolves benignly (#356)

Refund intents always build `generation=None`, so the `ALREADY_SETTLED` / `actual_micro > 0` branch could never reach the benign `ALREADY_SETTLED_WITH_CHARGE` outcome for a real refund — it fell into `INVALID_ROW`, went `dead` (a guard status), and pinned `terminal_at` NULL for a benign replay. Refunds now return the benign outcome before the generation check; a settle with no generation still dead-letters as `invalid_row`. Money assertions included: after both intents, credit/key `reserved` is 0 and usage holds exactly the settle's charge.

## 2. Strict lease fencing for `mark()`/`park()` (#355)

Both accepted a write whenever the row's current `lease_owner` was NULL, so a stale worker whose lease expired mid-apply could force-dead a row another worker had just reclaimed and parked. Now a fenced caller must match the current owner exactly (Python guard AND SQL predicate); the anonymous inline gateway `mark(done=True)` still touches only unleased rows. The three force_dead drain sites gate their ALERT on `mark()` actually returning `"dead"`: the winner re-derives the observation and alerts exactly once. Crash recovery is pinned by a test: an expired lease with a non-NULL stale owner is stolen by the next claim, and the stale worker's late mark loses the fence.

## 3. Guarded backfill for legacy `terminal_at` (#357)

Measured in prod: 1,172,662 settled `tr_reservation` rows have `terminal_at` NULL, permanently exempt from the 30-day TTL (~97% of the settled table). `scripts/backfill_reservation_terminal_at.py` is dry-run-by-default and idempotent; `--apply` arms `terminal_at = now` in batches of 5000. Two load-bearing predicates ride in the same transaction as the write: `settled` (an open hold must never get a TTL fuse) and `NOT EXISTS` on `pending`/`dead` outbox intents (a frozen intent's evidence must not age out under it). A review round found the empty-select exit could end with a false "all excluded" STOP when a guard status flipped concurrently — fixed: an eligible remainder re-selects (bounded), and the exact interleaving is regression-tested. Runbook subsection included.

The backfill run itself happens after merge, off the deploy path, in a low-traffic window.

## 4. Fake txn reads are now repeatable (root cause of the CI stress flake)

CI failed `test_credit_shard_lifecycle_stress_preserves_every_invariant` on this branch. Fresh-process sampling under coverage: 0/40 failures on main, 11–15/20 at the branch tip — yet sentinel instrumentation proved the stress executes **zero** lines this branch added. The new code merely perturbed thread interleaving enough to surface a latent fake-fidelity gap:

The fake's in-txn row accessors recorded the read *version* at first read but returned the *latest-committed value* on every call, so two statements in one transaction could observe two different states of the same row — impossible under real Spanner's serializable read-write transactions (an invalidating concurrent commit surfaces as `Aborted` at commit; the fake's `_try_commit` already models that). Production's rebalance turned the inconsistency into a phantom `_RebalanceInvariantError`: plan read sees headroom → concurrent settle commits a usage bump → the guarded donor DML in the *same* transaction evaluates against fresher state and fails mid-txn, failing one authorize and the invariant audit.

Entities already had pinned `read_snapshots`; typed counter rows, reservations, outbox rows, and gateway authorizations now pin too (`_pinned_read`). Commit-time version validation is unchanged, so the conflict becomes abort-and-retry, matching Spanner. Stress under coverage: 15/20 failures → **0/30**. Two deterministic regression tests drive the exact interleaving; reverting the pin fails both.

## Verification

`uv run ruff check .` · `uv run mypy` · `uv run pytest -q` → 2219 passed, 86 skipped.

Every regression test mutation-verified (kind-fake style where the fake mirrors production — revert production AND the fake together; the test must still fail):

| Mutation | Killed by |
| --- | --- |
| revert refund early-return | sibling-refund test (retention stays pinned) |
| permissive fence revert (prod + fake) | stale-mark, stale-park, winning-owner-alert |
| remove drain alert gates | both lost-lease tests |
| drop frozen-intent guard from backfill (prod + fake) | six tests, loudly |
| drop `settled` from backfill end-to-end | open-holds test |
| revert candidates→eligible exit check | eligibility-race test |
| revert the snapshot pin | both txn-consistency tests |

## 5. Fake MF2 guard reads track a per-authorization outbox range version

The fidelity review of commit 4 found the adjacent hole blocking: the MF2 guard count (settle_atomic's in-transaction lost-charge interlock) read the outbox directly and recorded no read versions. Per-row versions cannot express *no row existed*, so an enqueue committing between the in-txn zero-count and the reservation-claim commit did not abort the fake transaction — the fake could not prove the one property MF2 exists for, and the guard tests were wiring tests only.

Added `settle_outbox_auth_versions`, a per-authorization range version bumped on any commit touching that authorization's outbox rows; the MF2 guard count, sibling-guard count, and correlated EXISTS record it on first read and `_try_commit` validates it. A regression test drives the exact race: zero-count → concurrent enqueue commit → claim write → abort → retry observes the guard row. Mutation-verified: dropping the range-key recording fails that test.

Remaining pre-existing unversioned range reads the review enumerated are filed as #364.
