### PR TITLE
Add server-side Google Ads conversion delivery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -315,11 +315,13 @@ jobs:
         run: |
           set -euo pipefail
           deploy_synthetic_monitor="false"
+          deploy_google_data_manager="false"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.deploy_synthetic_monitor }}" = "true" ]; then
               deploy_synthetic_monitor="true"
             fi
+            deploy_google_data_manager="true"
           fi
 
           changed=""
@@ -337,10 +339,15 @@ jobs:
             if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/|scripts/deploy/synthetic\.sh$|\.github/workflows/deploy\.yml$)'; then
               deploy_synthetic_monitor="true"
             fi
+            if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/|scripts/deploy/google_data_manager\.sh$|\.github/workflows/deploy\.yml$)'; then
+              deploy_google_data_manager="true"
+            fi
           fi
 
           echo "deploy_synthetic_monitor=${deploy_synthetic_monitor}" >> "$GITHUB_OUTPUT"
           echo "deploy_synthetic_monitor=${deploy_synthetic_monitor}"
+          echo "deploy_google_data_manager=${deploy_google_data_manager}" >> "$GITHUB_OUTPUT"
+          echo "deploy_google_data_manager=${deploy_google_data_manager}"
 
       - name: Deploy us-central1 (no-traffic)
         env:
@@ -494,6 +501,13 @@ jobs:
         # not user-serving traffic.
         continue-on-error: true
         run: bash scripts/deploy/synthetic.sh
+
+      - name: Deploy Google Data Manager conversion uploader
+        if: ${{ steps.optional.outputs.deploy_google_data_manager == 'true' }}
+        # Server-to-server conversion upload is outside the request path.
+        # The script safely skips until its dedicated service account exists.
+        continue-on-error: true
+        run: bash scripts/deploy/google_data_manager.sh
 
       # No cross-region "final watchdog" step. Each region's health is
       # gated by its own per-region canary above (us-central1, then

--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -67,16 +67,40 @@ settlement, payment acknowledgement, or streaming.
 
 ## Google Ads Data Manager
 
-Google Ads imports attributed outcomes from:
+Signup and settled credit-purchase conversions are sent directly from a
+scheduled Cloud Run job to Google's Data Manager REST endpoint:
+
+```text
+POST https://datamanager.googleapis.com/v1/events:ingest
+```
+
+The job calls raw HTTPS and does not load a Google browser tag or Google client
+library. Its Cloud Run service identity requests only the
+`https://www.googleapis.com/auth/datamanager` scope. Google accepts at most
+2,000 events per request; TrustedRouter uses bounded 500-row batches and a
+five-minute schedule.
+
+Delivery state is durable:
+
+- `pending`: eligible for a worker lease
+- `submitted`: Google accepted the request and returned a request ID
+- `dead`: a permanent failure or the retry limit was reached
+
+Leases prevent concurrent workers from claiming the same row. Transient
+network, `408`, `409`, `425`, `429`, and `5xx` failures use bounded exponential
+backoff. The deterministic transaction ID lets Google deduplicate an upload if
+the worker crashes after Google accepts it but before Spanner records the
+request ID.
+
+Activation and seven-day retention remain available in the authenticated CSV
+recovery feed:
 
 ```text
 GET /v1/internal/marketing/google-ads-conversions.csv
 ```
 
-The HTTPS feed requires a dedicated HTTP Basic username and a 32-character or
-longer secret from Secret Manager. It is private, uncached, and excluded from
-indexing. The feed covers the last 90 days and fails with `503` rather than
-silently truncating if it reaches the configured row ceiling.
+The feed is private, uncached, excluded from indexing, and fails with `503`
+rather than silently truncating at its configured row ceiling.
 
 Each Google-attributed milestone creates an idempotent, month-partitioned
 Spanner row:
@@ -99,6 +123,44 @@ idempotency check wins. A protected backfill endpoint reconstructs historic
 signup, activation, and retention rows; it deliberately does not synthesize
 historic individual purchases from aggregate totals.
 
+### Production Setup
+
+The production Google Ads resources are:
+
+```text
+operating account: 8424034078
+signup conversion action: 7701333837
+purchase conversion action: 7701333966
+```
+
+These identifiers are ordinary deployment configuration, not credentials. They
+can be overridden with `TR_GOOGLE_DATA_MANAGER_*`. When a manager account makes
+the call, also configure:
+
+```text
+TR_GOOGLE_DATA_MANAGER_LOGIN_ACCOUNT_ID
+```
+
+Authorize
+`tr-google-data-manager@quill-cloud-proxy.iam.gserviceaccount.com` with Standard
+access to Google Ads account `8424034078`. The worker has only Spanner database
+access and Service Usage Consumer in GCP. It has no application secrets,
+provider keys, BYOK decrypt permission, or prompt-path Bigtable access. It
+retrieves a short-lived access token from the Cloud Run metadata server with
+only the Data Manager OAuth scope; no service-account key is created or stored.
+The worker initializes a Spanner-only outbox adapter and never constructs the
+application's Bigtable client.
+
+`scripts/deploy/infra.sh` creates the dedicated identity.
+`scripts/deploy/google_data_manager.sh` deploys the uploader job and scheduler,
+and skips safely until the identity exists.
+
+Google reference:
+
+- [Data Manager event ingestion](https://developers.google.com/data-manager/api/reference/rest/v1/events/ingest)
+- [Data Manager access setup](https://developers.google.com/data-manager/api/devguides/quickstart/set-up-access)
+- [Data Manager request status](https://developers.google.com/data-manager/api/reference/rest/v1/requestStatus/retrieve)
+
 ## Campaign Conventions
 
 Every paid destination must set:
@@ -113,6 +175,28 @@ utm_content=<creative_name>
 Google and X click identifiers can be appended by their respective auto-tagging
 features. Creative-specific `utm_content` values are required so Axiom can
 compare privacy, migration, and reliability messages within one campaign.
+
+## First-Party Funnel Report
+
+Google does not need TrustedRouter conversion data for internal measurement.
+TrustedRouter records the metadata-only funnel and can compare campaigns and
+creative cells through signup, first successful API call, payment, and
+seven-day retained usage:
+
+```bash
+uv run python scripts/marketing_funnel_report.py \
+  --source google \
+  --campaign high_intent_search_20260725 \
+  --days 30
+```
+
+Use `--format json` for analysis or dashboards. Add `--creative <utm_content>`
+to inspect one creative cell. Revenue remains integer microdollars until the
+final display conversion.
+
+One `utm_content` value is one measurable creative cell. Multiple headlines
+inside one responsive search ad share that cell, so create separately tagged
+ads when headline-level downstream measurement is required.
 
 ## Initial Optimization Policy
 

--- a/scripts/deploy/google_data_manager.sh
+++ b/scripts/deploy/google_data_manager.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Deploy the metadata-only Google Ads Data Manager uploader. The job runs
+# outside request handling and uses the Cloud Run service identity for a
+# scoped OAuth token; no Google client SDK or browser tag is loaded.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+# These are Google Ads resource identifiers, not credentials. Keep them in
+# deployment config so CI can deploy the worker without copying unrelated
+# application secrets into its environment.
+GOOGLE_ADS_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_ACCOUNT_ID:-8424034078}"
+GOOGLE_ADS_SIGNUP_ACTION_ID="${TR_GOOGLE_DATA_MANAGER_SIGNUP_ACTION_ID:-7701333837}"
+GOOGLE_ADS_PURCHASE_ACTION_ID="${TR_GOOGLE_DATA_MANAGER_PURCHASE_ACTION_ID:-7701333966}"
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT:-tr-google-data-manager@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+if ! gc iam service-accounts describe \
+  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
+  log "Google Data Manager service account is missing; run infra.sh as an owner"
+  exit 0
+fi
+
+ENV_VARS=(
+  # This is a one-shot worker, not an HTTP production process. It deliberately
+  # does not load Stripe, Sentry, gateway, BYOK, or provider credentials.
+  "TR_ENVIRONMENT=worker"
+  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  "TR_GCP_PROJECT_ID=${PROJECT_ID}"
+  "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
+  "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+  "TR_GOOGLE_DATA_MANAGER_ENABLED=true"
+  "TR_GOOGLE_DATA_MANAGER_ACCOUNT_ID=${GOOGLE_ADS_ACCOUNT_ID}"
+  "TR_GOOGLE_DATA_MANAGER_SIGNUP_ACTION_ID=${GOOGLE_ADS_SIGNUP_ACTION_ID}"
+  "TR_GOOGLE_DATA_MANAGER_PURCHASE_ACTION_ID=${GOOGLE_ADS_PURCHASE_ACTION_ID}"
+  "TR_GOOGLE_DATA_MANAGER_BATCH_SIZE=500"
+  "TR_GOOGLE_DATA_MANAGER_LEASE_SECONDS=300"
+  "TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS=8"
+  "TR_GOOGLE_DATA_MANAGER_REPAIR_LOOKBACK_DAYS=90"
+)
+SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
+
+if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
+  echo "ERROR: image ${IMAGE} does not exist. Run scripts/deploy/image.sh first." >&2
+  exit 1
+fi
+
+job_name="trusted-router-google-data-manager"
+scheduler_name="${job_name}-every-five-minutes"
+region="us-central1"
+run_uri="https://${region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"
+
+log "deploying Google Data Manager Cloud Run job"
+gc run jobs deploy "$job_name" \
+  --region "$region" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.google_data_manager_cli" \
+  --service-account "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
+  --set-env-vars "$SET_ENV_VARS" \
+  --max-retries 0 \
+  --task-timeout 120s \
+  --cpu 1 \
+  --memory 512Mi \
+  --quiet >/dev/null
+
+gc run jobs add-iam-policy-binding "$job_name" \
+  --region "$region" \
+  --member="serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  --role="roles/run.invoker" \
+  --quiet >/dev/null
+
+if gc scheduler jobs describe "$scheduler_name" \
+  --location "$region" >/dev/null 2>&1; then
+  gc scheduler jobs update http "$scheduler_name" \
+    --location "$region" \
+    --schedule "*/5 * * * *" \
+    --uri "$run_uri" \
+    --http-method POST \
+    --oauth-service-account-email "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
+    --quiet >/dev/null
+else
+  gc scheduler jobs create http "$scheduler_name" \
+    --location "$region" \
+    --schedule "*/5 * * * *" \
+    --uri "$run_uri" \
+    --http-method POST \
+    --oauth-service-account-email "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
+    --quiet >/dev/null
+fi
+
+log "Google Data Manager uploader is deployed"

--- a/scripts/deploy/infra.sh
+++ b/scripts/deploy/infra.sh
@@ -13,6 +13,7 @@ gc services enable \
   secretmanager.googleapis.com \
   cloudscheduler.googleapis.com \
   cloudkms.googleapis.com \
+  datamanager.googleapis.com \
   spanner.googleapis.com \
   bigtableadmin.googleapis.com \
   cloudbuild.googleapis.com
@@ -109,3 +110,33 @@ ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager
 ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/spanner.databaseUser"
 ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/bigtable.user"
 ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/aiplatform.user"
+
+# Metadata-only Google Ads conversion worker. It has no access to application
+# secrets, provider keys, BYOK decrypt permission, or prompt-path Bigtable
+# access. Google
+# Ads account access is granted separately after this identity exists.
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID:-tr-google-data-manager}"
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+if ! gc iam service-accounts describe \
+  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
+  gc iam service-accounts create "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID" \
+    --display-name="TrustedRouter Google Data Manager" \
+    --description="Uploads metadata-only signup and settled-purchase conversions to Google Ads" \
+    --quiet
+fi
+ensure_project_role \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseUser"
+ensure_project_role \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/serviceusage.serviceUsageConsumer"
+gc iam service-accounts add-iam-policy-binding \
+  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+  --role="roles/iam.serviceAccountUser" \
+  --quiet >/dev/null
+gc iam service-accounts add-iam-policy-binding \
+  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@serverless-robot-prod.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --quiet >/dev/null

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -93,6 +93,19 @@ class Settings(BaseSettings):
     google_ads_conversion_feed_password: str | None = None
     google_ads_conversion_feed_retention_days: int = 90
     google_ads_conversion_feed_max_rows: int = 100_000
+    # Direct server-to-server Google Ads Data Manager reporting. The control
+    # plane leaves this disabled; a scheduled Cloud Run job enables it and
+    # uploads only metadata-only signup and settled-purchase rows.
+    google_data_manager_enabled: bool = False
+    google_data_manager_account_id: str | None = None
+    google_data_manager_login_account_id: str | None = None
+    google_data_manager_signup_action_id: str | None = None
+    google_data_manager_purchase_action_id: str | None = None
+    google_data_manager_batch_size: int = 500
+    google_data_manager_lease_seconds: int = 300
+    google_data_manager_max_attempts: int = 8
+    google_data_manager_timeout_seconds: float = 20.0
+    google_data_manager_repair_lookback_days: int = 90
     enable_sentry_test_route: bool = False
     sentry_floodgate_enabled: bool = True
     sentry_floodgate_window_seconds: int = 60 * 60
@@ -307,6 +320,50 @@ class Settings(BaseSettings):
             )
         if self.google_ads_conversion_feed_max_rows < 1:
             raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_MAX_ROWS must be positive")
+        if not 1 <= self.google_data_manager_batch_size <= 2_000:
+            raise ValueError(
+                "TR_GOOGLE_DATA_MANAGER_BATCH_SIZE must be between 1 and 2000"
+            )
+        if self.google_data_manager_lease_seconds < 30:
+            raise ValueError(
+                "TR_GOOGLE_DATA_MANAGER_LEASE_SECONDS must be at least 30"
+            )
+        if not 1 <= self.google_data_manager_max_attempts <= 20:
+            raise ValueError(
+                "TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS must be between 1 and 20"
+            )
+        if not 1.0 <= self.google_data_manager_timeout_seconds <= 120.0:
+            raise ValueError(
+                "TR_GOOGLE_DATA_MANAGER_TIMEOUT_SECONDS must be between 1 and 120"
+            )
+        if not 1 <= self.google_data_manager_repair_lookback_days <= 90:
+            raise ValueError(
+                "TR_GOOGLE_DATA_MANAGER_REPAIR_LOOKBACK_DAYS must be between 1 and 90"
+            )
+        if self.google_data_manager_enabled:
+            missing_google_data_manager = [
+                name
+                for name, value in (
+                    (
+                        "TR_GOOGLE_DATA_MANAGER_ACCOUNT_ID",
+                        self.google_data_manager_account_id,
+                    ),
+                    (
+                        "TR_GOOGLE_DATA_MANAGER_SIGNUP_ACTION_ID",
+                        self.google_data_manager_signup_action_id,
+                    ),
+                    (
+                        "TR_GOOGLE_DATA_MANAGER_PURCHASE_ACTION_ID",
+                        self.google_data_manager_purchase_action_id,
+                    ),
+                )
+                if not value
+            ]
+            if missing_google_data_manager:
+                raise ValueError(
+                    "Google Data Manager is enabled but missing "
+                    + ", ".join(missing_google_data_manager)
+                )
         if ":" in self.google_ads_conversion_feed_username:
             raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_USERNAME cannot contain ':'")
         if (
@@ -422,6 +479,10 @@ _LOCAL_KEY_FALLBACKS: tuple[str, ...] = (
     "sentry_dsn",
     "google_ads_conversion_feed_username",
     "google_ads_conversion_feed_password",
+    "google_data_manager_account_id",
+    "google_data_manager_login_account_id",
+    "google_data_manager_signup_action_id",
+    "google_data_manager_purchase_action_id",
     "bootstrap_management_key",
     "byok_kms_key_name",
     "byok_envelope_key_b64",

--- a/src/trusted_router/google_ads_conversions.py
+++ b/src/trusted_router/google_ads_conversions.py
@@ -28,6 +28,13 @@ GOOGLE_ADS_ACTION_BY_EVENT = {
     "credit_purchase_completed": GOOGLE_ADS_PURCHASE_ACTION,
 }
 
+GOOGLE_ADS_DIRECT_DELIVERY_ACTIONS = frozenset(
+    {
+        GOOGLE_ADS_SIGNUP_ACTION,
+        GOOGLE_ADS_PURCHASE_ACTION,
+    }
+)
+
 GOOGLE_ADS_CSV_COLUMNS = (
     "conversion_action",
     "gclid",
@@ -69,7 +76,7 @@ def build_google_ads_conversion(
         )
     )
     order_id = hashlib.sha256(seed.encode("utf-8")).hexdigest()
-    return GoogleAdsConversion(
+    conversion = GoogleAdsConversion(
         order_id=order_id,
         conversion_action=action,
         occurred_at=occurred_at,
@@ -78,6 +85,14 @@ def build_google_ads_conversion(
         wbraid=touch.get("wbraid"),
         value_microdollars=value_microdollars,
     )
+    if is_google_ads_direct_delivery(conversion):
+        conversion.delivery_status = "pending"
+        conversion.next_attempt_at = conversion.created_at
+    return conversion
+
+
+def is_google_ads_direct_delivery(conversion: GoogleAdsConversion) -> bool:
+    return conversion.conversion_action in GOOGLE_ADS_DIRECT_DELIVERY_ACTIONS
 
 
 def google_ads_conversion_kind(occurred_at: str) -> str:

--- a/src/trusted_router/google_data_manager_cli.py
+++ b/src/trusted_router/google_data_manager_cli.py
@@ -1,0 +1,52 @@
+"""One-shot scheduled Google Ads Data Manager uploader."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from trusted_router.config import get_settings
+from trusted_router.services.google_data_manager import (
+    GoogleDataManagerClient,
+    GoogleDataManagerConfig,
+    MetadataAccessTokenProvider,
+    run_google_data_manager_once,
+)
+from trusted_router.storage_gcp_google_ads import create_google_ads_delivery_store
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    settings = get_settings()
+    if not settings.google_data_manager_enabled:
+        logging.getLogger(__name__).info("google_data_manager.disabled")
+        return
+
+    store = create_google_ads_delivery_store(settings)
+    config = GoogleDataManagerConfig.from_settings(settings)
+    timeout = httpx.Timeout(settings.google_data_manager_timeout_seconds)
+    with httpx.Client(timeout=timeout) as client:
+        result = run_google_data_manager_once(
+            store=store,
+            settings=settings,
+            client=GoogleDataManagerClient(
+                config=config,
+                client=client,
+                token_provider=MetadataAccessTokenProvider(client),
+            ),
+        )
+    logging.getLogger(__name__).info(
+        "google_data_manager.run_complete",
+        extra={
+            "claimed": result.claimed,
+            "submitted": result.submitted,
+            "failed": result.failed,
+            "repaired": result.repaired,
+            "google_request_id": result.request_id,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trusted_router/services/google_data_manager.py
+++ b/src/trusted_router/services/google_data_manager.py
@@ -1,0 +1,491 @@
+"""Direct, metadata-only Google Ads Data Manager conversion delivery.
+
+This module deliberately uses raw HTTPS instead of a Google SDK. Uploads carry
+only Google's click identifier, event time, integer-derived dollar value,
+currency, and TrustedRouter's opaque transaction ID. They never carry email,
+workspace, account, prompt, output, API-key, or inference data.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from trusted_router.config import Settings
+from trusted_router.google_ads_conversions import (
+    GOOGLE_ADS_PURCHASE_ACTION,
+    GOOGLE_ADS_SIGNUP_ACTION,
+    is_google_ads_direct_delivery,
+)
+from trusted_router.storage_models import GoogleAdsConversion
+
+log = logging.getLogger(__name__)
+
+DATA_MANAGER_INGEST_URL = "https://datamanager.googleapis.com/v1/events:ingest"
+DATA_MANAGER_SCOPE = "https://www.googleapis.com/auth/datamanager"
+METADATA_IDENTITY_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/"
+    "instance/service-accounts/default/token"
+)
+MAX_EVENTS_PER_REQUEST = 2_000
+
+_DESTINATION_REFERENCE_BY_ACTION = {
+    GOOGLE_ADS_SIGNUP_ACTION: "signup",
+    GOOGLE_ADS_PURCHASE_ACTION: "purchase",
+}
+_NUMERIC_ID_RE = re.compile(r"^[0-9]+$")
+
+
+@dataclass(frozen=True)
+class GoogleDataManagerConfig:
+    account_id: str
+    signup_action_id: str
+    purchase_action_id: str
+    login_account_id: str | None = None
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> GoogleDataManagerConfig:
+        return cls(
+            account_id=_numeric_id(
+                settings.google_data_manager_account_id,
+                "Google Ads account ID",
+            ),
+            signup_action_id=_numeric_id(
+                settings.google_data_manager_signup_action_id,
+                "signup conversion action ID",
+            ),
+            purchase_action_id=_numeric_id(
+                settings.google_data_manager_purchase_action_id,
+                "purchase conversion action ID",
+            ),
+            login_account_id=(
+                _numeric_id(
+                    settings.google_data_manager_login_account_id,
+                    "login account ID",
+                )
+                if settings.google_data_manager_login_account_id
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GoogleDataManagerIngestResult:
+    request_id: str
+    warning_count: int
+
+
+@dataclass(frozen=True)
+class GoogleDataManagerRunResult:
+    claimed: int
+    submitted: int
+    failed: int
+    repaired: int
+    request_id: str | None = None
+
+
+class GoogleDataManagerUploadError(RuntimeError):
+    def __init__(self, message: str, *, retryable: bool) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class GoogleAdsDeliveryStore(Protocol):
+    """Narrow storage surface available to the conversion worker."""
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int: ...
+
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]: ...
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None: ...
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None: ...
+
+
+class MetadataAccessTokenProvider:
+    """Fetch and cache a scoped Cloud Run service-identity access token."""
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+        self._token: str | None = None
+        self._expires_at = 0.0
+
+    def __call__(self) -> str:
+        if self._token and time.monotonic() < self._expires_at:
+            return self._token
+        try:
+            response = self._client.get(
+                METADATA_IDENTITY_URL,
+                params={
+                    "scopes": DATA_MANAGER_SCOPE,
+                    "enforce_scopes": "true",
+                },
+                headers={"Metadata-Flavor": "Google"},
+            )
+        except httpx.HTTPError as exc:
+            raise GoogleDataManagerUploadError(
+                "Cloud Run identity token request failed",
+                retryable=True,
+            ) from exc
+        if response.status_code != 200:
+            raise GoogleDataManagerUploadError(
+                f"Cloud Run identity token request returned HTTP {response.status_code}",
+                retryable=_is_retryable_status(response.status_code),
+            )
+        try:
+            payload = response.json()
+            token = str(payload["access_token"])
+            expires_in = max(int(payload.get("expires_in", 300)), 1)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise GoogleDataManagerUploadError(
+                "Cloud Run identity token response was invalid",
+                retryable=True,
+            ) from exc
+        self._token = token
+        self._expires_at = time.monotonic() + max(expires_in - 60, 1)
+        return token
+
+
+class GoogleDataManagerClient:
+    def __init__(
+        self,
+        *,
+        config: GoogleDataManagerConfig,
+        client: httpx.Client,
+        token_provider: Callable[[], str],
+        ingest_url: str = DATA_MANAGER_INGEST_URL,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._token_provider = token_provider
+        self._ingest_url = ingest_url
+
+    def ingest(
+        self,
+        conversions: list[GoogleAdsConversion],
+    ) -> GoogleDataManagerIngestResult:
+        if not conversions:
+            raise ValueError("at least one Google Ads conversion is required")
+        if len(conversions) > MAX_EVENTS_PER_REQUEST:
+            raise ValueError(
+                f"Google Data Manager accepts at most {MAX_EVENTS_PER_REQUEST} events"
+            )
+        body = encode_google_data_manager_request(
+            conversions,
+            config=self._config,
+        )
+        try:
+            response = self._client.post(
+                self._ingest_url,
+                content=body,
+                headers={
+                    "Authorization": f"Bearer {self._token_provider()}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "TrustedRouter-DataManager/1",
+                },
+            )
+        except GoogleDataManagerUploadError:
+            raise
+        except httpx.HTTPError as exc:
+            raise GoogleDataManagerUploadError(
+                "Google Data Manager request failed",
+                retryable=True,
+            ) from exc
+        if not 200 <= response.status_code < 300:
+            raise GoogleDataManagerUploadError(
+                f"Google Data Manager returned HTTP {response.status_code}",
+                retryable=_is_retryable_status(response.status_code),
+            )
+        try:
+            payload = response.json()
+            request_id = str(payload["requestId"]).strip()
+            warnings = payload.get("fieldWarnings", [])
+            warning_count = len(warnings) if isinstance(warnings, list) else 0
+        except (KeyError, TypeError, ValueError) as exc:
+            raise GoogleDataManagerUploadError(
+                "Google Data Manager response did not contain a request ID",
+                retryable=True,
+            ) from exc
+        if not request_id:
+            raise GoogleDataManagerUploadError(
+                "Google Data Manager response did not contain a request ID",
+                retryable=True,
+            )
+        return GoogleDataManagerIngestResult(
+            request_id=request_id,
+            warning_count=warning_count,
+        )
+
+
+def encode_google_data_manager_request(
+    conversions: list[GoogleAdsConversion],
+    *,
+    config: GoogleDataManagerConfig,
+) -> bytes:
+    """Encode exact microdollar values as JSON numbers without binary floats."""
+    if not conversions:
+        raise ValueError("at least one Google Ads conversion is required")
+    if len(conversions) > MAX_EVENTS_PER_REQUEST:
+        raise ValueError(
+            f"Google Data Manager accepts at most {MAX_EVENTS_PER_REQUEST} events"
+        )
+    for conversion in conversions:
+        if not is_google_ads_direct_delivery(conversion):
+            raise ValueError(
+                f"conversion action is not eligible for direct delivery: "
+                f"{conversion.conversion_action}"
+            )
+
+    references = {
+        _destination_reference(conversion)
+        for conversion in conversions
+    }
+    destinations = [
+        _destination(reference, config=config)
+        for reference in ("signup", "purchase")
+        if reference in references
+    ]
+    event_json = [
+        _encode_event(conversion)
+        for conversion in conversions
+    ]
+    destination_json = json.dumps(
+        destinations,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return (
+        '{"destinations":'
+        + destination_json
+        + ',"events":['
+        + ",".join(event_json)
+        + "]}"
+    ).encode("utf-8")
+
+
+def run_google_data_manager_once(
+    *,
+    store: GoogleAdsDeliveryStore,
+    settings: Settings,
+    client: GoogleDataManagerClient,
+) -> GoogleDataManagerRunResult:
+    if not settings.google_data_manager_enabled:
+        return GoogleDataManagerRunResult(
+            claimed=0,
+            submitted=0,
+            failed=0,
+            repaired=0,
+        )
+
+    since = (
+        dt.datetime.now(dt.UTC).replace(microsecond=0)
+        - dt.timedelta(days=settings.google_data_manager_repair_lookback_days)
+    ).isoformat().replace("+00:00", "Z")
+    repaired = store.repair_google_ads_delivery_queue(
+        since=since,
+        limit=settings.google_data_manager_batch_size,
+    )
+    conversions = store.claim_google_ads_deliveries(
+        limit=settings.google_data_manager_batch_size,
+        lease_seconds=settings.google_data_manager_lease_seconds,
+    )
+    if not conversions:
+        return GoogleDataManagerRunResult(
+            claimed=0,
+            submitted=0,
+            failed=0,
+            repaired=repaired,
+        )
+
+    try:
+        result = client.ingest(conversions)
+    except GoogleDataManagerUploadError as exc:
+        failed = _mark_batch_failed(
+            store,
+            conversions,
+            error=str(exc),
+            retryable=exc.retryable,
+            max_attempts=settings.google_data_manager_max_attempts,
+        )
+        log.warning(
+            "google_data_manager.upload_failed",
+            extra={
+                "conversion_count": len(conversions),
+                "retryable": exc.retryable,
+                "marked_failed": failed,
+            },
+        )
+        return GoogleDataManagerRunResult(
+            claimed=len(conversions),
+            submitted=0,
+            failed=failed,
+            repaired=repaired,
+        )
+
+    submitted = 0
+    for conversion in conversions:
+        lease_owner = conversion.lease_owner
+        if not lease_owner:
+            continue
+        marked = store.mark_google_ads_delivery_submitted(
+            order_id=conversion.order_id,
+            occurred_at=conversion.occurred_at,
+            lease_owner=lease_owner,
+            request_id=result.request_id,
+        )
+        if marked is not None:
+            submitted += 1
+    log.info(
+        "google_data_manager.upload_submitted",
+        extra={
+            "conversion_count": len(conversions),
+            "submitted_count": submitted,
+            "warning_count": result.warning_count,
+            "google_request_id": result.request_id,
+        },
+    )
+    return GoogleDataManagerRunResult(
+        claimed=len(conversions),
+        submitted=submitted,
+        failed=0,
+        repaired=repaired,
+        request_id=result.request_id,
+    )
+
+
+def _mark_batch_failed(
+    store: GoogleAdsDeliveryStore,
+    conversions: list[GoogleAdsConversion],
+    *,
+    error: str,
+    retryable: bool,
+    max_attempts: int,
+) -> int:
+    failed = 0
+    for conversion in conversions:
+        lease_owner = conversion.lease_owner
+        if not lease_owner:
+            continue
+        marked = store.mark_google_ads_delivery_failed(
+            order_id=conversion.order_id,
+            occurred_at=conversion.occurred_at,
+            lease_owner=lease_owner,
+            error=error,
+            retryable=retryable,
+            max_attempts=max_attempts,
+        )
+        if marked is not None:
+            failed += 1
+    return failed
+
+
+def _destination(
+    reference: str,
+    *,
+    config: GoogleDataManagerConfig,
+) -> dict[str, Any]:
+    action_id = {
+        "signup": config.signup_action_id,
+        "purchase": config.purchase_action_id,
+    }[reference]
+    destination: dict[str, Any] = {
+        "reference": reference,
+        "operatingAccount": {
+            "accountId": config.account_id,
+            "accountType": "GOOGLE_ADS",
+        },
+        "productDestinationId": action_id,
+    }
+    if config.login_account_id:
+        destination["loginAccount"] = {
+            "accountId": config.login_account_id,
+            "accountType": "GOOGLE_ADS",
+        }
+    return destination
+
+
+def _encode_event(conversion: GoogleAdsConversion) -> str:
+    click_name, click_value = _one_click_identifier(conversion)
+    event = {
+        "adIdentifiers": {click_name: click_value},
+        "currency": conversion.currency_code,
+        "destinationReferences": [_destination_reference(conversion)],
+        "eventSource": "WEB",
+        "eventTimestamp": conversion.occurred_at,
+        "transactionId": conversion.order_id,
+    }
+    encoded = json.dumps(event, separators=(",", ":"), sort_keys=True)
+    return (
+        encoded[:-1]
+        + ',"conversionValue":'
+        + _microdollars_json_number(conversion.value_microdollars)
+        + "}"
+    )
+
+
+def _one_click_identifier(
+    conversion: GoogleAdsConversion,
+) -> tuple[str, str]:
+    for name in ("gclid", "gbraid", "wbraid"):
+        value = getattr(conversion, name)
+        if value:
+            return name, value
+    raise ValueError("Google Ads conversion has no click identifier")
+
+
+def _destination_reference(conversion: GoogleAdsConversion) -> str:
+    try:
+        return _DESTINATION_REFERENCE_BY_ACTION[conversion.conversion_action]
+    except KeyError as exc:
+        raise ValueError(
+            f"unsupported direct conversion action: {conversion.conversion_action}"
+        ) from exc
+
+
+def _microdollars_json_number(value: int) -> str:
+    if value < 0:
+        raise ValueError("Google Ads conversion value cannot be negative")
+    whole, fractional = divmod(value, 1_000_000)
+    if not fractional:
+        return str(whole)
+    return f"{whole}.{fractional:06d}".rstrip("0")
+
+
+def _numeric_id(value: str | None, label: str) -> str:
+    normalized = (value or "").replace("-", "").strip()
+    if not _NUMERIC_ID_RE.fullmatch(normalized):
+        raise ValueError(f"{label} must contain only digits")
+    return normalized
+
+
+def _is_retryable_status(status_code: int) -> bool:
+    return status_code in {408, 409, 425, 429} or status_code >= 500

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -272,6 +272,57 @@ class InMemoryStore:
     def backfill_google_ads_conversions(self, *, limit: int) -> int:
         return self.acquisition_store.backfill_google_ads_conversions(limit=limit)
 
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        return self.acquisition_store.claim_google_ads_deliveries(
+            limit=limit,
+            lease_seconds=lease_seconds,
+        )
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        return self.acquisition_store.mark_google_ads_delivery_submitted(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            request_id=request_id,
+        )
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        return self.acquisition_store.mark_google_ads_delivery_failed(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            error=error,
+            retryable=retryable,
+            max_attempts=max_attempts,
+        )
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        return self.acquisition_store.repair_google_ads_delivery_queue(
+            since=since,
+            limit=limit,
+        )
+
     # Auth sessions delegate to storage_auth_sessions.InMemoryAuthSessions.
     def create_auth_session(
         self,

--- a/src/trusted_router/storage_attribution.py
+++ b/src/trusted_router/storage_attribution.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import datetime as dt
 import threading
+import uuid
 
-from trusted_router.google_ads_conversions import build_google_ads_conversion
+from trusted_router.google_ads_conversions import (
+    build_google_ads_conversion,
+    is_google_ads_direct_delivery,
+)
 from trusted_router.storage_models import (
     AcquisitionAttribution,
     GoogleAdsConversion,
@@ -143,6 +147,117 @@ class InMemoryAcquisitionAttribution:
                         created += 1
         return created
 
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        now = iso_now()
+        owner = f"gdm_{uuid.uuid4().hex}"
+        leased_until = _iso_after_seconds(lease_seconds)
+        with self._lock:
+            rows = [
+                conversion
+                for conversion in self.google_ads_conversions.values()
+                if _google_delivery_is_due(conversion, now)
+            ]
+            rows.sort(
+                key=lambda item: (
+                    item.next_attempt_at,
+                    item.occurred_at,
+                    item.order_id,
+                )
+            )
+            claimed = rows[:limit]
+            for conversion in claimed:
+                conversion.lease_owner = owner
+                conversion.leased_until = leased_until
+                conversion.updated_at = now
+            return claimed
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        del occurred_at
+        with self._lock:
+            conversion = self.google_ads_conversions.get(order_id)
+            if conversion is None or conversion.lease_owner != lease_owner:
+                return None
+            conversion.delivery_status = "submitted"
+            conversion.delivery_attempts += 1
+            conversion.last_error = None
+            conversion.lease_owner = None
+            conversion.leased_until = None
+            conversion.google_request_id = request_id
+            conversion.submitted_at = iso_now()
+            conversion.updated_at = conversion.submitted_at
+            return conversion
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        del occurred_at
+        with self._lock:
+            conversion = self.google_ads_conversions.get(order_id)
+            if conversion is None or conversion.lease_owner != lease_owner:
+                return None
+            conversion.delivery_attempts += 1
+            conversion.last_error = error[:500]
+            conversion.lease_owner = None
+            conversion.leased_until = None
+            conversion.google_request_id = None
+            conversion.submitted_at = None
+            conversion.updated_at = iso_now()
+            if retryable and conversion.delivery_attempts < max_attempts:
+                conversion.delivery_status = "pending"
+                conversion.next_attempt_at = _iso_after_seconds(
+                    _google_delivery_backoff_seconds(
+                        conversion.delivery_attempts
+                    )
+                )
+            else:
+                conversion.delivery_status = "dead"
+            return conversion
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        since_at = dt.datetime.fromisoformat(since.replace("Z", "+00:00"))
+        repaired = 0
+        with self._lock:
+            rows = sorted(
+                self.google_ads_conversions.values(),
+                key=lambda item: (item.occurred_at, item.order_id),
+            )
+            for conversion in rows:
+                if repaired >= limit:
+                    break
+                occurred_at = dt.datetime.fromisoformat(
+                    conversion.occurred_at.replace("Z", "+00:00")
+                )
+                if occurred_at < since_at:
+                    continue
+                if (
+                    is_google_ads_direct_delivery(conversion)
+                    and conversion.delivery_status == "not_scheduled"
+                ):
+                    conversion.delivery_status = "pending"
+                    conversion.next_attempt_at = iso_now()
+                    conversion.updated_at = conversion.next_attempt_at
+                    repaired += 1
+        return repaired
+
     def _record_google_conversion(
         self,
         record: AcquisitionAttribution,
@@ -161,3 +276,25 @@ class InMemoryAcquisitionAttribution:
         )
         if conversion is not None:
             self.google_ads_conversions.setdefault(conversion.order_id, conversion)
+
+
+def _google_delivery_backoff_seconds(attempts: int) -> int:
+    return min(6 * 60 * 60, 30 * (2 ** max(attempts - 1, 0)))
+
+
+def _iso_after_seconds(seconds: int) -> str:
+    return (
+        dt.datetime.now(dt.UTC).replace(microsecond=0)
+        + dt.timedelta(seconds=seconds)
+    ).isoformat().replace("+00:00", "Z")
+
+
+def _google_delivery_is_due(
+    conversion: GoogleAdsConversion,
+    now: str,
+) -> bool:
+    if conversion.delivery_status != "pending":
+        return False
+    if conversion.next_attempt_at > now:
+        return False
+    return not conversion.leased_until or conversion.leased_until <= now

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -333,6 +333,57 @@ class SpannerBigtableStore:
     def backfill_google_ads_conversions(self, *, limit: int) -> int:
         return self.acquisition_store.backfill_google_ads_conversions(limit=limit)
 
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        return self.acquisition_store.claim_google_ads_deliveries(
+            limit=limit,
+            lease_seconds=lease_seconds,
+        )
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        return self.acquisition_store.mark_google_ads_delivery_submitted(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            request_id=request_id,
+        )
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        return self.acquisition_store.mark_google_ads_delivery_failed(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            error=error,
+            retryable=retryable,
+            max_attempts=max_attempts,
+        )
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        return self.acquisition_store.repair_google_ads_delivery_queue(
+            since=since,
+            limit=limit,
+        )
+
     def ensure_user(
         self,
         user_id: str,

--- a/src/trusted_router/storage_gcp_attribution.py
+++ b/src/trusted_router/storage_gcp_attribution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+import uuid
 from typing import Any
 
 from trusted_router.google_ads_conversions import (
@@ -7,6 +9,7 @@ from trusted_router.google_ads_conversions import (
     google_ads_conversion_entity_id,
     google_ads_conversion_kind,
     google_ads_conversion_kinds_since,
+    is_google_ads_direct_delivery,
     parse_utc_timestamp,
 )
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
@@ -17,6 +20,7 @@ from trusted_router.storage_models import (
 )
 
 _KIND = "acquisition_attribution"
+_GOOGLE_DELIVERY_DUE_KIND = "google_ads_conversion_due"
 
 
 class SpannerAcquisitionAttribution:
@@ -207,6 +211,221 @@ class SpannerAcquisitionAttribution:
             created += run_in_transaction_with_retry(self._io.database, txn)
         return created
 
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        pointers = self._io.list_entities(
+            _GOOGLE_DELIVERY_DUE_KIND,
+            prefix="pending#",
+            cls=dict,
+            limit=max(limit * 20, limit),
+        )
+        now = iso_now()
+        candidates = [
+            pointer
+            for pointer in pointers
+            if str(pointer.get("next_attempt_at", "")) <= now
+        ]
+        owner = f"gdm_{uuid.uuid4().hex}"
+        leased_until = _iso_after_seconds(lease_seconds)
+        claimed: list[GoogleAdsConversion] = []
+        for pointer in candidates:
+            if len(claimed) >= limit:
+                break
+            conversion = self._claim_google_ads_delivery(
+                conversion_kind=str(pointer.get("conversion_kind", "")),
+                conversion_id=str(pointer.get("conversion_id", "")),
+                owner=owner,
+                leased_until=leased_until,
+                now=now,
+            )
+            if conversion is not None:
+                claimed.append(conversion)
+        return claimed
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        conversion_kind = google_ads_conversion_kind(occurred_at)
+        conversion_id = _google_conversion_id_from_values(
+            order_id=order_id,
+            occurred_at=occurred_at,
+        )
+
+        def txn(transaction: Any) -> GoogleAdsConversion | None:
+            conversion = self._io.read_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                GoogleAdsConversion,
+            )
+            if conversion is None or conversion.lease_owner != lease_owner:
+                return None
+            old_due_id = _google_delivery_due_id(conversion)
+            submitted_at = iso_now()
+            conversion.delivery_status = "submitted"
+            conversion.delivery_attempts += 1
+            conversion.last_error = None
+            conversion.lease_owner = None
+            conversion.leased_until = None
+            conversion.google_request_id = request_id
+            conversion.submitted_at = submitted_at
+            conversion.updated_at = submitted_at
+            self._io.write_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                conversion,
+            )
+            self._io.delete_entities_tx(
+                transaction,
+                _GOOGLE_DELIVERY_DUE_KIND,
+                [old_due_id],
+            )
+            return conversion
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        conversion_kind = google_ads_conversion_kind(occurred_at)
+        conversion_id = _google_conversion_id_from_values(
+            order_id=order_id,
+            occurred_at=occurred_at,
+        )
+
+        def txn(transaction: Any) -> GoogleAdsConversion | None:
+            conversion = self._io.read_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                GoogleAdsConversion,
+            )
+            if conversion is None or conversion.lease_owner != lease_owner:
+                return None
+            old_due_id = _google_delivery_due_id(conversion)
+            conversion.delivery_attempts += 1
+            conversion.last_error = error[:500]
+            conversion.lease_owner = None
+            conversion.leased_until = None
+            conversion.google_request_id = None
+            conversion.submitted_at = None
+            conversion.updated_at = iso_now()
+            if retryable and conversion.delivery_attempts < max_attempts:
+                conversion.delivery_status = "pending"
+                conversion.next_attempt_at = _iso_after_seconds(
+                    _google_delivery_backoff_seconds(
+                        conversion.delivery_attempts
+                    )
+                )
+            else:
+                conversion.delivery_status = "dead"
+            self._io.write_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                conversion,
+            )
+            self._io.delete_entities_tx(
+                transaction,
+                _GOOGLE_DELIVERY_DUE_KIND,
+                [old_due_id],
+            )
+            if conversion.delivery_status == "pending":
+                self._write_google_delivery_pointer_tx(
+                    transaction,
+                    conversion_kind=conversion_kind,
+                    conversion_id=conversion_id,
+                    conversion=conversion,
+                )
+            return conversion
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        since_at = parse_utc_timestamp(since)
+        repaired = 0
+        for kind in google_ads_conversion_kinds_since(since_at):
+            if repaired >= limit:
+                break
+            rows = self._io.list_entities(
+                kind,
+                cls=GoogleAdsConversion,
+                limit=max(limit - repaired, 1),
+            )
+            for candidate in rows:
+                if repaired >= limit:
+                    break
+                if parse_utc_timestamp(candidate.occurred_at) < since_at:
+                    continue
+                if not is_google_ads_direct_delivery(candidate):
+                    continue
+                conversion_id = google_ads_conversion_entity_id(candidate)
+
+                def txn(
+                    transaction: Any,
+                    conversion_kind: str = kind,
+                    conversion_id: str = conversion_id,
+                ) -> int:
+                    conversion = self._io.read_entity_tx(
+                        transaction,
+                        conversion_kind,
+                        conversion_id,
+                        GoogleAdsConversion,
+                    )
+                    if conversion is None:
+                        return 0
+                    if conversion.delivery_status == "not_scheduled":
+                        conversion.delivery_status = "pending"
+                        conversion.next_attempt_at = iso_now()
+                        conversion.updated_at = conversion.next_attempt_at
+                        self._io.write_entity_tx(
+                            transaction,
+                            conversion_kind,
+                            conversion_id,
+                            conversion,
+                        )
+                    if conversion.delivery_status != "pending":
+                        return 0
+                    due_id = _google_delivery_due_id(conversion)
+                    existing_pointer = self._io.read_entity_tx(
+                        transaction,
+                        _GOOGLE_DELIVERY_DUE_KIND,
+                        due_id,
+                        dict,
+                    )
+                    if existing_pointer is not None:
+                        return 0
+                    self._write_google_delivery_pointer_tx(
+                        transaction,
+                        conversion_kind=conversion_kind,
+                        conversion_id=conversion_id,
+                        conversion=conversion,
+                    )
+                    return 1
+
+                repaired += run_in_transaction_with_retry(
+                    self._io.database,
+                    txn,
+                )
+        return repaired
+
     def _write_google_conversion_tx(
         self,
         transaction: Any,
@@ -226,9 +445,120 @@ class SpannerAcquisitionAttribution:
         )
         if conversion is None:
             return
+        conversion_kind = google_ads_conversion_kind(conversion.occurred_at)
+        conversion_id = google_ads_conversion_entity_id(conversion)
+        existing = self._io.read_entity_tx(
+            transaction,
+            conversion_kind,
+            conversion_id,
+            GoogleAdsConversion,
+        )
+        if existing is not None:
+            return
         self._io.write_entity_tx(
             transaction,
-            google_ads_conversion_kind(conversion.occurred_at),
-            google_ads_conversion_entity_id(conversion),
+            conversion_kind,
+            conversion_id,
             conversion,
         )
+        if conversion.delivery_status == "pending":
+            self._write_google_delivery_pointer_tx(
+                transaction,
+                conversion_kind=conversion_kind,
+                conversion_id=conversion_id,
+                conversion=conversion,
+            )
+
+    def _claim_google_ads_delivery(
+        self,
+        *,
+        conversion_kind: str,
+        conversion_id: str,
+        owner: str,
+        leased_until: str,
+        now: str,
+    ) -> GoogleAdsConversion | None:
+        if not conversion_kind or not conversion_id:
+            return None
+
+        def txn(transaction: Any) -> GoogleAdsConversion | None:
+            conversion = self._io.read_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                GoogleAdsConversion,
+            )
+            if conversion is None or not _google_delivery_is_due(
+                conversion,
+                now,
+            ):
+                return None
+            conversion.lease_owner = owner
+            conversion.leased_until = leased_until
+            conversion.updated_at = now
+            self._io.write_entity_tx(
+                transaction,
+                conversion_kind,
+                conversion_id,
+                conversion,
+            )
+            return conversion
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def _write_google_delivery_pointer_tx(
+        self,
+        transaction: Any,
+        *,
+        conversion_kind: str,
+        conversion_id: str,
+        conversion: GoogleAdsConversion,
+    ) -> None:
+        self._io.write_entity_tx(
+            transaction,
+            _GOOGLE_DELIVERY_DUE_KIND,
+            _google_delivery_due_id(conversion),
+            {
+                "conversion_kind": conversion_kind,
+                "conversion_id": conversion_id,
+                "next_attempt_at": conversion.next_attempt_at,
+            },
+        )
+
+
+def _google_conversion_id_from_values(
+    *,
+    order_id: str,
+    occurred_at: str,
+) -> str:
+    timestamp = parse_utc_timestamp(occurred_at)
+    return f"{timestamp:%Y%m%dT%H%M%SZ}#{order_id}"
+
+
+def _google_delivery_due_id(conversion: GoogleAdsConversion) -> str:
+    return (
+        f"{conversion.delivery_status}#"
+        f"{conversion.next_attempt_at}#{conversion.order_id}"
+    )
+
+
+def _google_delivery_backoff_seconds(attempts: int) -> int:
+    return min(6 * 60 * 60, 30 * (2 ** max(attempts - 1, 0)))
+
+
+def _iso_after_seconds(seconds: int) -> str:
+    return (
+        dt.datetime.now(dt.UTC).replace(microsecond=0)
+        + dt.timedelta(seconds=seconds)
+    ).isoformat().replace("+00:00", "Z")
+
+
+def _google_delivery_is_due(
+    conversion: GoogleAdsConversion,
+    now: str,
+) -> bool:
+    if conversion.delivery_status != "pending":
+        return False
+    if conversion.next_attempt_at > now:
+        return False
+    return not conversion.leased_until or conversion.leased_until <= now

--- a/src/trusted_router/storage_gcp_google_ads.py
+++ b/src/trusted_router/storage_gcp_google_ads.py
@@ -1,0 +1,278 @@
+"""Spanner-only storage adapter for the Google Ads conversion worker."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any, TypeVar
+
+from trusted_router.config import Settings
+from trusted_router.services.google_data_manager import GoogleAdsDeliveryStore
+from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_io import SpannerIO
+from trusted_router.storage_models import GoogleAdsConversion
+
+T = TypeVar("T")
+
+
+class SpannerGoogleAdsDeliveryStore:
+    """Expose only the durable conversion queue, without creating Bigtable."""
+
+    entity_table = "tr_entities"
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        spanner_instance_id: str,
+        spanner_database_id: str,
+    ) -> None:
+        if not spanner_instance_id or not spanner_database_id:
+            raise ValueError("Spanner instance and database IDs are required")
+        try:
+            from google.cloud import spanner
+            from google.cloud.spanner_v1 import FixedSizePool, param_types
+        except ImportError as exc:  # pragma: no cover - production image dependency.
+            raise RuntimeError(
+                "Install google-cloud-spanner for the Google Data Manager worker"
+            ) from exc
+
+        self._spanner = spanner
+        self._param_types = param_types
+        self._database = (
+            spanner.Client(
+                project=project_id,
+                disable_builtin_metrics=True,
+            )
+            .instance(spanner_instance_id)
+            .database(
+                spanner_database_id,
+                pool=FixedSizePool(size=2),
+            )
+        )
+        io = SpannerIO(
+            database=self._database,
+            spanner_module=self._spanner,
+            write_entity_batch=self._write_entity_batch,
+            read_entity_tx=self._read_entity_tx,
+            write_entity_tx=self._write_entity_tx,
+            write_entity=self._write_entity,
+            read_entity=self._read_entity,
+            list_entities=self._list_entities,
+            delete_entities=self._delete_entities,
+            delete_entities_tx=self._delete_entities_tx,
+        )
+        self._attribution = SpannerAcquisitionAttribution(io)
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        return self._attribution.repair_google_ads_delivery_queue(
+            since=since,
+            limit=limit,
+        )
+
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        return self._attribution.claim_google_ads_deliveries(
+            limit=limit,
+            lease_seconds=lease_seconds,
+        )
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        return self._attribution.mark_google_ads_delivery_submitted(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            request_id=request_id,
+        )
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        return self._attribution.mark_google_ads_delivery_failed(
+            order_id=order_id,
+            occurred_at=occurred_at,
+            lease_owner=lease_owner,
+            error=error,
+            retryable=retryable,
+            max_attempts=max_attempts,
+        )
+
+    def _read_entity(
+        self,
+        kind: str,
+        entity_id: str,
+        cls: type[T],
+    ) -> T | None:
+        with self._database.snapshot() as snapshot:
+            return self._read_entity_from(snapshot, kind, entity_id, cls)
+
+    def _read_entity_tx(
+        self,
+        transaction: Any,
+        kind: str,
+        entity_id: str,
+        cls: type[T],
+    ) -> T | None:
+        return self._read_entity_from(transaction, kind, entity_id, cls)
+
+    def _read_entity_from(
+        self,
+        reader: Any,
+        kind: str,
+        entity_id: str,
+        cls: type[T],
+    ) -> T | None:
+        rows = list(
+            reader.execute_sql(
+                "SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+                params={"kind": kind, "id": entity_id},
+                param_types={
+                    "kind": self._param_types.STRING,
+                    "id": self._param_types.STRING,
+                },
+            )
+        )
+        if not rows:
+            return None
+        data = json.loads(rows[0][0])
+        if cls is dict:
+            return data
+        if dataclasses.is_dataclass(cls):
+            known = {field.name for field in dataclasses.fields(cls)}
+            data = {key: value for key, value in data.items() if key in known}
+        return cls(**data)
+
+    def _list_entities(
+        self,
+        kind: str,
+        *,
+        cls: type[T],
+        prefix: str | None = None,
+        suffix: str | None = None,
+        limit: int | None = None,
+    ) -> list[T]:
+        where = "kind=@kind"
+        params: dict[str, Any] = {"kind": kind}
+        param_types: dict[str, Any] = {"kind": self._param_types.STRING}
+        if prefix is not None:
+            where += " AND STARTS_WITH(id, @prefix)"
+            params["prefix"] = prefix
+            param_types["prefix"] = self._param_types.STRING
+        if suffix is not None:
+            where += " AND ENDS_WITH(id, @suffix)"
+            params["suffix"] = suffix
+            param_types["suffix"] = self._param_types.STRING
+        tail = " ORDER BY id"
+        if limit is not None:
+            tail += " LIMIT @limit"
+            params["limit"] = int(limit)
+            param_types["limit"] = self._param_types.INT64
+        with self._database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                f"SELECT body FROM tr_entities WHERE {where}{tail}",  # noqa: S608
+                params=params,
+                param_types=param_types,
+            )
+            return [self._decode_entity(row[0], cls) for row in rows]
+
+    def _decode_entity(self, body: str, cls: type[T]) -> T:
+        data = json.loads(body)
+        if cls is dict:
+            return data
+        if dataclasses.is_dataclass(cls):
+            known = {field.name for field in dataclasses.fields(cls)}
+            data = {key: value for key, value in data.items() if key in known}
+        return cls(**data)
+
+    def _write_entity(self, kind: str, entity_id: str, value: Any) -> None:
+        with self._database.batch() as batch:
+            self._write_entity_batch(batch, kind, entity_id, value)
+
+    def _write_entity_batch(
+        self,
+        batch: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> None:
+        batch.insert_or_update(
+            table=self.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    kind,
+                    entity_id,
+                    json_body(value),
+                    self._spanner.COMMIT_TIMESTAMP,
+                )
+            ],
+        )
+
+    def _write_entity_tx(
+        self,
+        transaction: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> None:
+        transaction.insert_or_update(
+            table=self.entity_table,
+            columns=("kind", "id", "body", "updated_at"),
+            values=[
+                (
+                    kind,
+                    entity_id,
+                    json_body(value),
+                    self._spanner.COMMIT_TIMESTAMP,
+                )
+            ],
+        )
+
+    def _delete_entities(self, kind: str, entity_ids: list[str]) -> None:
+        with self._database.batch() as batch:
+            batch.delete(
+                self.entity_table,
+                self._spanner.KeySet(
+                    keys=[(kind, entity_id) for entity_id in entity_ids]
+                ),
+            )
+
+    def _delete_entities_tx(
+        self,
+        transaction: Any,
+        kind: str,
+        entity_ids: list[str],
+    ) -> None:
+        transaction.delete(
+            self.entity_table,
+            self._spanner.KeySet(
+                keys=[(kind, entity_id) for entity_id in entity_ids]
+            ),
+        )
+
+
+def create_google_ads_delivery_store(settings: Settings) -> GoogleAdsDeliveryStore:
+    return SpannerGoogleAdsDeliveryStore(
+        project_id=settings.gcp_project_id,
+        spanner_instance_id=settings.spanner_instance_id or "",
+        spanner_database_id=settings.spanner_database_id or "",
+    )

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -916,6 +916,15 @@ class GoogleAdsConversion:
     value_microdollars: int = 0
     currency_code: str = "USD"
     created_at: str = field(default_factory=iso_now)
+    delivery_status: str = "not_scheduled"
+    delivery_attempts: int = 0
+    next_attempt_at: str = field(default_factory=iso_now)
+    last_error: str | None = None
+    lease_owner: str | None = None
+    leased_until: str | None = None
+    google_request_id: str | None = None
+    submitted_at: str | None = None
+    updated_at: str = field(default_factory=iso_now)
 
 
 @dataclass

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -618,6 +618,39 @@ class PostgresStore:
     def backfill_google_ads_conversions(self, *, limit: int) -> int:
         self._not_implemented("backfill_google_ads_conversions")
 
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]:
+        self._not_implemented("claim_google_ads_deliveries")
+
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None:
+        self._not_implemented("mark_google_ads_delivery_submitted")
+
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None:
+        self._not_implemented("mark_google_ads_delivery_failed")
+
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int:
+        self._not_implemented("repair_google_ads_delivery_queue")
+
     def create_workspace(
         self,
         owner_user_id: str,

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -97,6 +97,31 @@ class Store(Protocol):
         limit: int,
     ) -> list[GoogleAdsConversion]: ...
     def backfill_google_ads_conversions(self, *, limit: int) -> int: ...
+    def claim_google_ads_deliveries(
+        self,
+        *,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[GoogleAdsConversion]: ...
+    def mark_google_ads_delivery_submitted(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        request_id: str,
+    ) -> GoogleAdsConversion | None: ...
+    def mark_google_ads_delivery_failed(
+        self,
+        *,
+        order_id: str,
+        occurred_at: str,
+        lease_owner: str,
+        error: str,
+        retryable: bool,
+        max_attempts: int,
+    ) -> GoogleAdsConversion | None: ...
+    def repair_google_ads_delivery_queue(self, *, since: str, limit: int) -> int: ...
     def create_workspace(
         self,
         owner_user_id: str,

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -37,6 +37,7 @@ ALLOWED = {
     # what these exist to do.
     "storage_gcp.py",
     "storage_gcp_authorize.py",
+    "storage_gcp_google_ads.py",
     "storage_gcp_io.py",
     "storage_gcp_settle_outbox.py",
     "storage_gcp_synthetic_rollups.py",

--- a/tests/test_google_data_manager.py
+++ b/tests/test_google_data_manager.py
@@ -1,0 +1,538 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.google_ads_conversions import (
+    GOOGLE_ADS_ACTIVATED_ACTION,
+    GOOGLE_ADS_PURCHASE_ACTION,
+    GOOGLE_ADS_SIGNUP_ACTION,
+)
+from trusted_router.services.google_data_manager import (
+    DATA_MANAGER_INGEST_URL,
+    DATA_MANAGER_SCOPE,
+    GoogleDataManagerClient,
+    GoogleDataManagerConfig,
+    GoogleDataManagerIngestResult,
+    GoogleDataManagerUploadError,
+    MetadataAccessTokenProvider,
+    encode_google_data_manager_request,
+    run_google_data_manager_once,
+)
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_models import AcquisitionAttribution, GoogleAdsConversion
+
+
+def _now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace(
+        "+00:00",
+        "Z",
+    )
+
+
+def _config() -> GoogleDataManagerConfig:
+    return GoogleDataManagerConfig(
+        account_id="1234567890",
+        signup_action_id="111",
+        purchase_action_id="222",
+        login_account_id="9998887776",
+    )
+
+
+def _settings(**overrides: Any) -> Settings:
+    values: dict[str, Any] = {
+        "environment": "test",
+        "google_data_manager_enabled": True,
+        "google_data_manager_account_id": "123-456-7890",
+        "google_data_manager_signup_action_id": "111",
+        "google_data_manager_purchase_action_id": "222",
+        "google_data_manager_batch_size": 50,
+        "google_data_manager_lease_seconds": 60,
+        "google_data_manager_max_attempts": 3,
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def _conversion(
+    *,
+    action: str = GOOGLE_ADS_PURCHASE_ACTION,
+    order_id: str = "a" * 64,
+    value_microdollars: int = 12_345_678,
+    gclid: str | None = "google-click",
+    gbraid: str | None = None,
+    wbraid: str | None = None,
+) -> GoogleAdsConversion:
+    now = _now()
+    return GoogleAdsConversion(
+        order_id=order_id,
+        conversion_action=action,
+        occurred_at=now,
+        gclid=gclid,
+        gbraid=gbraid,
+        wbraid=wbraid,
+        value_microdollars=value_microdollars,
+        delivery_status="pending",
+        next_attempt_at=now,
+    )
+
+
+def _attribution(*, workspace_id: str = "ws-google") -> AcquisitionAttribution:
+    now = _now()
+    touch = {
+        "utm_source": "google",
+        "gclid": "google-click",
+        "captured_at": now,
+    }
+    return AcquisitionAttribution(
+        workspace_id=workspace_id,
+        anonymous_id="anonymous-random-id",
+        first_touch=touch,
+        last_touch=touch,
+        signup_provider="email",
+        signup_at=now,
+    )
+
+
+def test_request_is_exact_metadata_only_json() -> None:
+    signup = _conversion(
+        action=GOOGLE_ADS_SIGNUP_ACTION,
+        order_id="s" * 64,
+        value_microdollars=0,
+    )
+    purchase = _conversion(
+        order_id="p" * 64,
+        value_microdollars=12_345_678,
+    )
+
+    encoded = encode_google_data_manager_request(
+        [signup, purchase],
+        config=_config(),
+    )
+    payload = json.loads(encoded, parse_float=Decimal)
+
+    assert payload["destinations"] == [
+        {
+            "loginAccount": {
+                "accountId": "9998887776",
+                "accountType": "GOOGLE_ADS",
+            },
+            "operatingAccount": {
+                "accountId": "1234567890",
+                "accountType": "GOOGLE_ADS",
+            },
+            "productDestinationId": "111",
+            "reference": "signup",
+        },
+        {
+            "loginAccount": {
+                "accountId": "9998887776",
+                "accountType": "GOOGLE_ADS",
+            },
+            "operatingAccount": {
+                "accountId": "1234567890",
+                "accountType": "GOOGLE_ADS",
+            },
+            "productDestinationId": "222",
+            "reference": "purchase",
+        },
+    ]
+    assert payload["events"][0]["conversionValue"] == 0
+    assert payload["events"][1]["conversionValue"] == Decimal("12.345678")
+    assert payload["events"][1]["adIdentifiers"] == {"gclid": "google-click"}
+    assert payload["events"][1]["eventSource"] == "WEB"
+    assert payload["events"][1]["transactionId"] == "p" * 64
+
+    lowered = encoded.decode().lower()
+    for forbidden in (
+        "email",
+        "workspace",
+        "prompt",
+        "output",
+        "api_key",
+        "request_body",
+        "user_id",
+    ):
+        assert forbidden not in lowered
+
+
+@pytest.mark.parametrize(
+    ("value_microdollars", "expected"),
+    [
+        (0, 0),
+        (1, Decimal("0.000001")),
+        (10, Decimal("0.00001")),
+        (1_000_000, 1),
+        (1_000_001, Decimal("1.000001")),
+        (999_999_999_999, Decimal("999999.999999")),
+    ],
+)
+def test_request_never_rounds_microdollars(
+    value_microdollars: int,
+    expected: int | Decimal,
+) -> None:
+    payload = json.loads(
+        encode_google_data_manager_request(
+            [_conversion(value_microdollars=value_microdollars)],
+            config=_config(),
+        ),
+        parse_float=Decimal,
+    )
+    assert payload["events"][0]["conversionValue"] == expected
+
+
+def test_request_sends_exactly_one_click_identifier() -> None:
+    payload = json.loads(
+        encode_google_data_manager_request(
+            [
+                _conversion(
+                    gclid="gclid",
+                    gbraid="gbraid",
+                    wbraid="wbraid",
+                )
+            ],
+            config=_config(),
+        )
+    )
+    assert payload["events"][0]["adIdentifiers"] == {"gclid": "gclid"}
+
+
+def test_request_rejects_non_direct_events_and_missing_click_ids() -> None:
+    with pytest.raises(ValueError, match="not eligible"):
+        encode_google_data_manager_request(
+            [_conversion(action=GOOGLE_ADS_ACTIVATED_ACTION)],
+            config=_config(),
+        )
+    with pytest.raises(ValueError, match="no click identifier"):
+        encode_google_data_manager_request(
+            [_conversion(gclid=None)],
+            config=_config(),
+        )
+
+
+def test_request_enforces_google_batch_limit() -> None:
+    conversion = _conversion()
+    with pytest.raises(ValueError, match="at most 2000"):
+        encode_google_data_manager_request(
+            [conversion] * 2_001,
+            config=_config(),
+        )
+
+
+def test_config_normalizes_google_ads_ids() -> None:
+    settings = _settings(
+        google_data_manager_account_id="123-456-7890",
+        google_data_manager_login_account_id="999-888-7776",
+    )
+    assert GoogleDataManagerConfig.from_settings(settings) == _config()
+
+
+def test_config_fails_closed_when_enabled_without_destination_ids() -> None:
+    with pytest.raises(ValueError, match="SIGNUP_ACTION_ID"):
+        Settings(
+            environment="test",
+            google_data_manager_enabled=True,
+            google_data_manager_account_id="123",
+            google_data_manager_purchase_action_id="222",
+        )
+
+
+def test_raw_http_client_posts_to_data_manager_without_google_sdk() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "requestId": "request-123",
+                "fieldWarnings": [{"fieldPath": "events[0]"}],
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        result = GoogleDataManagerClient(
+            config=_config(),
+            client=http,
+            token_provider=lambda: "scoped-access-token",
+        ).ingest([_conversion()])
+
+    assert result == GoogleDataManagerIngestResult(
+        request_id="request-123",
+        warning_count=1,
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == DATA_MANAGER_INGEST_URL
+    assert requests[0].headers["authorization"] == "Bearer scoped-access-token"
+    assert requests[0].headers["content-type"] == "application/json"
+
+
+def test_metadata_identity_token_is_scoped_and_cached() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"access_token": "metadata-token", "expires_in": 3600},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        provider = MetadataAccessTokenProvider(http)
+        assert provider() == "metadata-token"
+        assert provider() == "metadata-token"
+
+    assert len(requests) == 1
+    assert requests[0].headers["metadata-flavor"] == "Google"
+    assert requests[0].url.params["scopes"] == DATA_MANAGER_SCOPE
+    assert requests[0].url.params["enforce_scopes"] == "true"
+
+
+def test_deploy_worker_does_not_receive_application_secrets() -> None:
+    deploy_script = (
+        Path(__file__).parents[1] / "scripts/deploy/google_data_manager.sh"
+    ).read_text()
+
+    assert "TR_ENVIRONMENT=worker" in deploy_script
+    assert "tr-google-data-manager@" in deploy_script
+    assert "TR_STRIPE_SECRET_KEY=" not in deploy_script
+    assert "TR_STRIPE_WEBHOOK_SECRET=" not in deploy_script
+    assert "TR_INTERNAL_GATEWAY_TOKEN=" not in deploy_script
+    assert "TR_SENTRY_DSN=" not in deploy_script
+    assert "TR_BIGTABLE_" not in deploy_script
+    assert "TR_BYOK_" not in deploy_script
+    assert "--update-secrets" not in deploy_script
+
+
+def test_uploader_uses_raw_https_without_google_client_library() -> None:
+    source = (
+        Path(__file__).parents[1]
+        / "src/trusted_router/services/google_data_manager.py"
+    ).read_text()
+
+    assert "import google" not in source
+    assert "from google" not in source
+    assert DATA_MANAGER_INGEST_URL in source
+
+
+def test_worker_uses_spanner_only_outbox_store() -> None:
+    root = Path(__file__).parents[1]
+    cli_source = (
+        root / "src/trusted_router/google_data_manager_cli.py"
+    ).read_text()
+    store_source = (
+        root / "src/trusted_router/storage_gcp_google_ads.py"
+    ).read_text()
+
+    assert "create_google_ads_delivery_store" in cli_source
+    assert "create_store" not in cli_source
+    assert "google.cloud import spanner" in store_source
+    assert "google.cloud import bigtable" not in store_source
+    assert "bigtable.Client" not in store_source
+
+
+@pytest.mark.parametrize(
+    ("status_code", "retryable"),
+    [
+        (400, False),
+        (403, False),
+        (408, True),
+        (429, True),
+        (500, True),
+        (503, True),
+    ],
+)
+def test_http_failure_classification_does_not_echo_response_body(
+    status_code: int,
+    retryable: bool,
+) -> None:
+    private_response_body = "private-click-id-that-must-not-reach-errors"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, text=private_response_body)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = GoogleDataManagerClient(
+            config=_config(),
+            client=http,
+            token_provider=lambda: "token",
+        )
+        with pytest.raises(GoogleDataManagerUploadError) as raised:
+            client.ingest([_conversion()])
+    assert raised.value.retryable is retryable
+    assert private_response_body not in str(raised.value)
+
+
+def test_success_without_request_id_is_retried() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = GoogleDataManagerClient(
+            config=_config(),
+            client=http,
+            token_provider=lambda: "token",
+        )
+        with pytest.raises(GoogleDataManagerUploadError) as raised:
+            client.ingest([_conversion()])
+    assert raised.value.retryable is True
+
+
+class _SuccessfulClient:
+    def ingest(
+        self,
+        conversions: list[GoogleAdsConversion],
+    ) -> GoogleDataManagerIngestResult:
+        assert {
+            item.conversion_action for item in conversions
+        } == {
+            GOOGLE_ADS_SIGNUP_ACTION,
+            GOOGLE_ADS_PURCHASE_ACTION,
+        }
+        return GoogleDataManagerIngestResult(
+            request_id="accepted-request",
+            warning_count=0,
+        )
+
+
+class _FailingClient:
+    def __init__(self, *, retryable: bool) -> None:
+        self.retryable = retryable
+
+    def ingest(
+        self,
+        conversions: list[GoogleAdsConversion],
+    ) -> GoogleDataManagerIngestResult:
+        raise GoogleDataManagerUploadError(
+            "sanitized failure",
+            retryable=self.retryable,
+        )
+
+
+def test_worker_submits_signup_and_settled_purchase_only() -> None:
+    store = InMemoryStore()
+    record = _attribution()
+    assert store.create_acquisition_attribution(record)
+    store.claim_acquisition_milestones(
+        record.workspace_id,
+        ["first_successful_api_call"],
+        occurred_at=_now(),
+    )
+    store.record_acquisition_purchase(
+        record.workspace_id,
+        amount_microdollars=25_000_001,
+        occurred_at=_now(),
+    )
+
+    result = run_google_data_manager_once(
+        store=store,
+        settings=_settings(),
+        client=_SuccessfulClient(),  # type: ignore[arg-type]
+    )
+
+    assert result.claimed == 2
+    assert result.submitted == 2
+    conversions = store.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )
+    by_action = {item.conversion_action: item for item in conversions}
+    assert by_action[GOOGLE_ADS_SIGNUP_ACTION].delivery_status == "submitted"
+    assert by_action[GOOGLE_ADS_PURCHASE_ACTION].delivery_status == "submitted"
+    assert by_action[GOOGLE_ADS_ACTIVATED_ACTION].delivery_status == "not_scheduled"
+    assert {
+        by_action[GOOGLE_ADS_SIGNUP_ACTION].google_request_id,
+        by_action[GOOGLE_ADS_PURCHASE_ACTION].google_request_id,
+    } == {"accepted-request"}
+    assert store.claim_google_ads_deliveries(limit=10, lease_seconds=60) == []
+
+
+def test_retryable_failure_requeues_and_permanent_failure_dead_letters() -> None:
+    retry_store = InMemoryStore()
+    assert retry_store.create_acquisition_attribution(_attribution())
+    retry_result = run_google_data_manager_once(
+        store=retry_store,
+        settings=_settings(),
+        client=_FailingClient(retryable=True),  # type: ignore[arg-type]
+    )
+    retry_conversion = retry_store.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )[0]
+    assert retry_result.failed == 1
+    assert retry_conversion.delivery_status == "pending"
+    assert retry_conversion.delivery_attempts == 1
+    assert retry_conversion.lease_owner is None
+
+    dead_store = InMemoryStore()
+    assert dead_store.create_acquisition_attribution(
+        _attribution(workspace_id="ws-dead")
+    )
+    dead_result = run_google_data_manager_once(
+        store=dead_store,
+        settings=_settings(),
+        client=_FailingClient(retryable=False),  # type: ignore[arg-type]
+    )
+    dead_conversion = dead_store.list_google_ads_conversions(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    )[0]
+    assert dead_result.failed == 1
+    assert dead_conversion.delivery_status == "dead"
+    assert dead_conversion.delivery_attempts == 1
+
+
+def test_delivery_lease_prevents_double_claim() -> None:
+    store = InMemoryStore()
+    assert store.create_acquisition_attribution(_attribution())
+    first = store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    second = store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    assert len(first) == 1
+    assert second == []
+
+
+def test_legacy_direct_conversion_is_repaired_once() -> None:
+    store = InMemoryStore()
+    conversion = _conversion()
+    conversion.delivery_status = "not_scheduled"
+    store.acquisition_store.google_ads_conversions[conversion.order_id] = conversion
+
+    assert store.repair_google_ads_delivery_queue(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    ) == 1
+    assert store.repair_google_ads_delivery_queue(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    ) == 0
+    assert len(
+        store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    ) == 1
+
+
+def test_spanner_conversion_and_due_pointer_commit_together() -> None:
+    store, _database, _table = make_fake_store()
+    record = _attribution(workspace_id="ws-spanner-google")
+    assert store.create_acquisition_attribution(record)
+
+    claimed = store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    assert len(claimed) == 1
+    conversion = claimed[0]
+    assert conversion.lease_owner
+    marked = store.mark_google_ads_delivery_submitted(
+        order_id=conversion.order_id,
+        occurred_at=conversion.occurred_at,
+        lease_owner=conversion.lease_owner,
+        request_id="spanner-request",
+    )
+    assert marked is not None
+    assert marked.delivery_status == "submitted"
+    assert store.claim_google_ads_deliveries(limit=10, lease_seconds=60) == []


### PR DESCRIPTION
## Summary
- upload signup and settled-purchase conversions directly to Google Ads Data Manager over raw HTTPS
- keep activation and retention CSV-only
- add durable Spanner queue leases, retries, repair, and deterministic transaction IDs
- deploy a least-privilege Cloud Run job on a five-minute schedule

## Privacy
- no Google browser tag or client SDK
- no prompt/output, email, user/workspace IDs, request bodies, or keys
- payload contains one click identifier, event time, integer-derived value, currency, destination reference, and opaque transaction ID

## Verification
- 2,253 tests passed, 86 skipped
- ruff passed
- mypy passed