### PR TITLE
Add OpenAI priority service tier billing

### DIFF
--- a/scripts/pricing/providers/openai.py
+++ b/scripts/pricing/providers/openai.py
@@ -26,11 +26,13 @@ from scripts.pricing.base import ProviderPricingResult, fetch_provider
 SLUG = "openai"
 URL = "https://developers.openai.com/api/docs/pricing"
 
-# Models we expect to see on the page. Strict floor — parser must
-# extract these or validation triggers self-heal. Today the page
-# headlines GPT-5.5 / 5.4 family; if OpenAI replaces those with a
-# 5.6 family this list needs updating.
+# Models we expect to see on the page. This strict floor makes the hourly
+# refresh self-heal or fail closed if a current flagship disappears from the
+# parser output instead of silently retaining stale prices.
 EXPECTED_MODELS = [
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
     "openai/gpt-5.5",
     "openai/gpt-5.4",
     "openai/gpt-5.4-mini",

--- a/src/trusted_router/openai_service_tiers.py
+++ b/src/trusted_router/openai_service_tiers.py
@@ -1,0 +1,120 @@
+"""OpenAI request service tiers and their customer-visible prices.
+
+The provider catalog has one OpenAI endpoint per usage type, while OpenAI
+selects Standard versus Priority processing per request. Keep that second
+pricing dimension here so authorization, settlement, and public endpoint
+metadata use the same values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trusted_router.money import token_cost_microdollars
+from trusted_router.pricing import _customer_price
+
+OPENAI_SERVICE_TIERS = ("default", "auto", "priority")
+OPENAI_PRIORITY_MAX_PROMPT_TOKENS = 272_000
+
+
+@dataclass(frozen=True)
+class OpenAIPriorityPricing:
+    prompt_microdollars_per_million_tokens: int
+    cached_prompt_microdollars_per_million_tokens: int
+    completion_microdollars_per_million_tokens: int
+    cache_write_microdollars_per_million_tokens: int
+
+    def public_payload(self) -> dict[str, int]:
+        return {
+            "prompt_microdollars_per_million_tokens": (self.prompt_microdollars_per_million_tokens),
+            "cached_prompt_microdollars_per_million_tokens": (
+                self.cached_prompt_microdollars_per_million_tokens
+            ),
+            "completion_microdollars_per_million_tokens": (
+                self.completion_microdollars_per_million_tokens
+            ),
+            "max_prompt_tokens": OPENAI_PRIORITY_MAX_PROMPT_TOKENS,
+        }
+
+
+def _customer_priority_pricing(
+    prompt_upstream_microdollars: int,
+    cached_prompt_upstream_microdollars: int,
+    completion_upstream_microdollars: int,
+) -> OpenAIPriorityPricing:
+    return OpenAIPriorityPricing(
+        prompt_microdollars_per_million_tokens=_customer_price(prompt_upstream_microdollars),
+        cached_prompt_microdollars_per_million_tokens=_customer_price(
+            cached_prompt_upstream_microdollars
+        ),
+        completion_microdollars_per_million_tokens=_customer_price(
+            completion_upstream_microdollars
+        ),
+        cache_write_microdollars_per_million_tokens=_customer_price(
+            prompt_upstream_microdollars * 5 // 4
+        ),
+    )
+
+
+OPENAI_PRIORITY_PRICING: dict[str, OpenAIPriorityPricing] = {
+    "openai/gpt-5.6-sol": _customer_priority_pricing(
+        10_000_000,
+        1_000_000,
+        60_000_000,
+    ),
+    "openai/gpt-5.6-terra": _customer_priority_pricing(
+        5_000_000,
+        500_000,
+        30_000_000,
+    ),
+    "openai/gpt-5.6-luna": _customer_priority_pricing(
+        2_000_000,
+        200_000,
+        12_000_000,
+    ),
+}
+
+
+def openai_priority_pricing(model_id: str) -> OpenAIPriorityPricing | None:
+    return OPENAI_PRIORITY_PRICING.get(model_id)
+
+
+def openai_priority_cost_microdollars(
+    model_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> int:
+    pricing = openai_priority_pricing(model_id)
+    if pricing is None:
+        raise ValueError(f"OpenAI Priority processing is unavailable for {model_id}")
+    cost = (
+        token_cost_microdollars(
+            input_tokens,
+            pricing.prompt_microdollars_per_million_tokens,
+        )
+        + token_cost_microdollars(
+            cache_read_tokens,
+            pricing.cached_prompt_microdollars_per_million_tokens,
+        )
+        + token_cost_microdollars(
+            cache_creation_tokens,
+            pricing.cache_write_microdollars_per_million_tokens,
+        )
+        + token_cost_microdollars(
+            output_tokens,
+            pricing.completion_microdollars_per_million_tokens,
+        )
+    )
+    has_positive_charge = any(
+        count > 0
+        for count in (
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+        )
+    )
+    return max(cost, 1) if has_positive_charge else 0

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -24,6 +24,10 @@ from trusted_router.catalog import (
     providers_for_display,
 )
 from trusted_router.money import microdollars_per_million_tokens_to_token_decimal
+from trusted_router.openai_service_tiers import (
+    OPENAI_SERVICE_TIERS,
+    openai_priority_pricing,
+)
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.routing import catalog_endpoint_candidates, provider_route_preferences
 
@@ -56,6 +60,30 @@ def _provider_query_body(request: Request) -> dict[str, Any]:
 
 def _truthy_query(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _endpoint_supported_parameters(provider: str) -> list[str]:
+    parameters = [
+        "messages",
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "stream",
+    ]
+    if provider == "openai":
+        parameters.append("service_tier")
+    return parameters
+
+
+def _openai_service_tier_metadata(
+    provider: str, model_id: str
+) -> dict[str, Any]:
+    if provider != "openai":
+        return {}
+    metadata: dict[str, Any] = {"service_tiers": list(OPENAI_SERVICE_TIERS)}
+    if pricing := openai_priority_pricing(model_id):
+        metadata["priority_pricing"] = pricing.public_payload()
+    return metadata
 
 
 def _public_model_matches_filters(shape: dict[str, Any], request: Request) -> bool:
@@ -165,13 +193,9 @@ def register_catalog_routes(router: APIRouter) -> None:
                     "completion_price_microdollars_per_million_tokens": (
                         endpoint.completion_price_microdollars_per_million_tokens
                     ),
-                    "supported_parameters": [
-                        "messages",
-                        "temperature",
-                        "top_p",
-                        "max_tokens",
-                        "stream",
-                    ],
+                    "supported_parameters": _endpoint_supported_parameters(
+                        endpoint.provider
+                    ),
                     "trustedrouter": {
                         "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
                         "stores_content": endpoint_stores_content(endpoint),
@@ -200,6 +224,10 @@ def register_catalog_routes(router: APIRouter) -> None:
                         "usage_type": endpoint.usage_type,
                         "prepaid_available": endpoint.usage_type == "Credits",
                         "byok_available": endpoint.usage_type == "BYOK",
+                        **_openai_service_tier_metadata(
+                            endpoint.provider,
+                            endpoint.model_id,
+                        ),
                     },
                 }
                 for _model, endpoint in catalog_endpoint_candidates(model, prefs)

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -38,6 +38,12 @@ from trusted_router.catalog import (
 from trusted_router.config import Settings
 from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import money_pair, token_cost_microdollars
+from trusted_router.openai_service_tiers import (
+    OPENAI_PRIORITY_MAX_PROMPT_TOKENS,
+    OPENAI_SERVICE_TIERS,
+    openai_priority_cost_microdollars,
+    openai_priority_pricing,
+)
 from trusted_router.partner_billing import (
     PARASAIL_LIBERTY_2_0_MODEL_ID,
     PARTNER_OPERATOR_COST_SETTLE_FIELD,
@@ -99,6 +105,7 @@ _SETTLE_REPAIR_FIELDS = frozenset(
         "output_tokens",
         "cache_read_input_tokens",
         "cache_creation_input_tokens",
+        "service_tier",
         "request_id",
         "finish_reason",
         "status",
@@ -255,6 +262,15 @@ def _authorize_gateway_sync(
     endpoint_candidates = _eligible_gateway_endpoint_candidates(
         endpoint_candidates, workspace.id
     )
+    input_tokens = body.estimated_input_tokens
+    if custom_model is not None and custom_model.hidden_prompt.strip():
+        input_tokens += estimate_tokens_from_text(custom_model.hidden_prompt)
+    service_tier = _requested_service_tier_or_error(body.service_tier)
+    endpoint_candidates = _service_tier_endpoint_candidates_or_error(
+        endpoint_candidates,
+        service_tier=service_tier,
+        estimated_input_tokens=input_tokens,
+    )
     additional_cost_reservation = body.additional_cost_reservation_microdollars
     if additional_cost_reservation:
         if body.route_type != "responses.web_search.planner":
@@ -279,9 +295,6 @@ def _authorize_gateway_sync(
     model, endpoint = endpoint_candidates[0]
     region = choose_region(settings, body.region or None)
 
-    input_tokens = body.estimated_input_tokens
-    if custom_model is not None and custom_model.hidden_prompt.strip():
-        input_tokens += estimate_tokens_from_text(custom_model.hidden_prompt)
     output_tokens = body.output_estimate
     model_estimate = (
         partner_cost_microdollars(
@@ -291,7 +304,13 @@ def _authorize_gateway_sync(
         )
         if partner_mode is not None
         else max(
-            _endpoint_cost_microdollars(candidate_endpoint, input_tokens, output_tokens)
+            _endpoint_cost_microdollars(
+                candidate_endpoint,
+                input_tokens,
+                output_tokens,
+                service_tier=service_tier,
+                reserve_auto=True,
+            )
             for _candidate_model, candidate_endpoint in endpoint_candidates
         )
     )
@@ -1002,6 +1021,7 @@ def _settle_gateway_authorization(
     auth_ms = (perf_counter() - timing_start) * 1000
 
     output_tokens = body.output_count
+    service_tier = _actual_service_tier_or_error(body.service_tier)
     uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
         selected_endpoint.provider, body
     )
@@ -1033,6 +1053,7 @@ def _settle_gateway_authorization(
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_creation,
             effective_at=authorization.created_at,
+            service_tier=service_tier,
         )
     )
     operator_cost = (
@@ -1043,6 +1064,7 @@ def _settle_gateway_authorization(
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_creation,
             effective_at=authorization.created_at,
+            service_tier=service_tier,
         )
         if partner_mode == PartnerBillingMode.INTERNAL
         else None
@@ -1543,6 +1565,69 @@ def _endpoint_for_id_compat(endpoint_id: str) -> ModelEndpoint | None:
     return endpoint_for_id(f"{model_id}@{provider}/{usage_suffix}")
 
 
+def _requested_service_tier_or_error(service_tier: str | None) -> str | None:
+    if service_tier is None:
+        return None
+    normalized = service_tier.strip().lower()
+    if normalized not in OPENAI_SERVICE_TIERS:
+        raise api_error(
+            400,
+            "service_tier must be default, auto, or priority",
+            ErrorType.BAD_REQUEST,
+        )
+    return normalized
+
+
+def _actual_service_tier_or_error(service_tier: str | None) -> str | None:
+    if service_tier is None:
+        return None
+    normalized = service_tier.strip().lower()
+    if normalized not in {"default", "priority"}:
+        raise api_error(
+            400,
+            "settlement service_tier must be the actual default or priority tier",
+            ErrorType.BAD_REQUEST,
+        )
+    return normalized
+
+
+def _service_tier_endpoint_candidates_or_error(
+    candidates: list[tuple[Model, ModelEndpoint]],
+    *,
+    service_tier: str | None,
+    estimated_input_tokens: int,
+) -> list[tuple[Model, ModelEndpoint]]:
+    if service_tier is None:
+        return candidates
+    openai_candidates = [
+        (model, endpoint)
+        for model, endpoint in candidates
+        if endpoint.provider == "openai"
+    ]
+    if service_tier in {"auto", "priority"}:
+        openai_candidates = [
+            (model, endpoint)
+            for model, endpoint in openai_candidates
+            if openai_priority_pricing(endpoint.model_id) is not None
+        ]
+    if (
+        service_tier == "priority"
+        and estimated_input_tokens > OPENAI_PRIORITY_MAX_PROMPT_TOKENS
+    ):
+        raise api_error(
+            400,
+            "OpenAI Priority processing does not support prompts over 272000 tokens",
+            ErrorType.BAD_REQUEST,
+        )
+    if not openai_candidates:
+        raise api_error(
+            400,
+            f"OpenAI {service_tier} processing is unavailable for the requested model",
+            ErrorType.MODEL_NOT_SUPPORTED,
+        )
+    return openai_candidates
+
+
 def _endpoint_cost_microdollars(
     endpoint: ModelEndpoint,
     input_tokens: int,
@@ -1551,11 +1636,23 @@ def _endpoint_cost_microdollars(
     cache_read_tokens: int = 0,
     cache_creation_tokens: int = 0,
     effective_at: datetime | str | None = None,
+    service_tier: str | None = None,
+    reserve_auto: bool = False,
 ) -> int:
     """input_tokens must be the UNCACHED prompt tokens when cache counts
     are passed — cached reads/writes bill at the provider-specific
     multiple of the prompt price (see catalog.cache_token_prices_microdollars)."""
     endpoint = effective_endpoint(endpoint, at=effective_at)
+    if service_tier == "priority" or (service_tier == "auto" and reserve_auto):
+        if endpoint.provider != "openai":
+            raise ValueError("OpenAI service tiers require an OpenAI endpoint")
+        return openai_priority_cost_microdollars(
+            endpoint.model_id,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+        )
     total_prompt = input_tokens + cache_read_tokens + cache_creation_tokens
     rates = resolve_request_rates(
         getattr(endpoint, "price_tiers", ()) or (),

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -200,6 +200,7 @@ class GatewayAuthorizeRequest(_Lenient):
     max_output_tokens: int | None = Field(default=None, ge=1)
     max_completion_tokens: int | None = Field(default=None, ge=1)
     max_tokens: int | None = Field(default=None, ge=1)
+    service_tier: str | None = Field(default=None, min_length=1, max_length=20)
     region: str | None = None
     user: str | None = Field(default=None, max_length=256)
     session_id: str | None = Field(default=None, max_length=256)
@@ -284,6 +285,7 @@ class GatewaySettleRequest(_Lenient):
     # and Gemini prompt counts INCLUDE the cached subset.
     cache_read_input_tokens: int | None = Field(default=None, ge=0)
     cache_creation_input_tokens: int | None = Field(default=None, ge=0)
+    service_tier: str | None = Field(default=None, min_length=1, max_length=20)
     request_id: str | None = None
     finish_reason: str | None = None
     status: str | None = None

--- a/tests/test_openai_service_tier.py
+++ b/tests/test_openai_service_tier.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from scripts.pricing.parsers.openai import parse as parse_openai_pricing
+from trusted_router.catalog import endpoint_for_id
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.money import token_cost_microdollars
+
+
+def _client_and_key() -> tuple[TestClient, dict[str, object]]:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    client = TestClient(app)
+    created = client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "openai-priority@example.com"},
+        json={"name": "openai priority"},
+    )
+    assert created.status_code == 201, created.text
+    return client, created.json()["data"]
+
+
+def _authorize(
+    client: TestClient,
+    key: dict[str, object],
+    *,
+    model: str = "openai/gpt-5.6-sol",
+    service_tier: str = "priority",
+    input_tokens: int = 1_000,
+    output_tokens: int = 1_000,
+    idempotency_key: str | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "api_key_hash": key["hash"],
+        "model": model,
+        "service_tier": service_tier,
+        "estimated_input_tokens": input_tokens,
+        "max_output_tokens": output_tokens,
+    }
+    if idempotency_key is not None:
+        body["idempotency_key"] = idempotency_key
+    response = client.post("/v1/internal/gateway/authorize", json=body)
+    assert response.status_code == 200, response.text
+    return response.json()["data"]
+
+
+def test_hourly_openai_parser_captures_announced_standard_price_cuts() -> None:
+    parsed = parse_openai_pricing(
+        "\n".join(
+            (
+                "| Model | Input | Cached input | Cache writes | Output | "
+                "Input | Cached input | Cache writes | Output |",
+                "| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | $0.40 | $0.04 | $0.50 | $1.80 |",
+                "| gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 | "
+                "$4.00 | $0.40 | $5.00 | $18.00 |",
+                "| gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 | "
+                "$10.00 | $1.00 | $12.50 | $45.00 |",
+            )
+        )
+    )
+
+    assert parsed["openai/gpt-5.6-luna"]["tiers"][0] == {
+        "max_prompt_tokens": 272_000,
+        "prompt_micro_per_m": 200_000,
+        "completion_micro_per_m": 1_200_000,
+        "prompt_cached_micro_per_m": 20_000,
+    }
+    assert parsed["openai/gpt-5.6-terra"]["tiers"][0] == {
+        "max_prompt_tokens": 272_000,
+        "prompt_micro_per_m": 2_000_000,
+        "completion_micro_per_m": 12_000_000,
+        "prompt_cached_micro_per_m": 200_000,
+    }
+
+
+def test_priority_authorization_uses_only_openai_and_reserves_priority_price() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(client, key)
+
+    assert auth["provider"] == "openai"
+    assert {route["provider"] for route in auth["route_candidates"]} == {"openai"}
+    expected = token_cost_microdollars(1_000, 10_500_000) + token_cost_microdollars(
+        1_000, 63_000_000
+    )
+    assert auth["estimated_cost_microdollars"] == expected
+
+
+def test_priority_settlement_bills_actual_returned_tier() -> None:
+    client, key = _client_and_key()
+
+    downgraded = _authorize(client, key, idempotency_key="priority-downgraded")
+    default_settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": downgraded["authorization_id"],
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 1_000,
+            "service_tier": "default",
+            "request_id": "priority-downgraded",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert default_settle.status_code == 200, default_settle.text
+    endpoint = endpoint_for_id(str(downgraded["endpoint_id"]))
+    assert endpoint is not None
+    expected_default = token_cost_microdollars(
+        1_000, endpoint.prompt_price_microdollars_per_million_tokens
+    ) + token_cost_microdollars(1_000, endpoint.completion_price_microdollars_per_million_tokens)
+    assert default_settle.json()["data"]["cost_microdollars"] == expected_default
+
+    priority = _authorize(client, key, idempotency_key="priority-served")
+    priority_settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": priority["authorization_id"],
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 1_000,
+            "service_tier": "priority",
+            "request_id": "priority-served",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert priority_settle.status_code == 200, priority_settle.text
+    expected_priority = token_cost_microdollars(1_000, 10_500_000) + token_cost_microdollars(
+        1_000, 63_000_000
+    )
+    assert priority_settle.json()["data"]["cost_microdollars"] == expected_priority
+    assert expected_priority > expected_default
+
+
+def test_priority_cached_tokens_use_priority_cached_rate() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(client, key, idempotency_key="priority-cache")
+    settled = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            # OpenAI prompt_tokens includes its cached subset.
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 100,
+            "cache_read_input_tokens": 900,
+            "service_tier": "priority",
+            "request_id": "priority-cache",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settled.status_code == 200, settled.text
+    expected = (
+        token_cost_microdollars(100, 10_500_000)
+        + token_cost_microdollars(900, 1_050_000)
+        + token_cost_microdollars(100, 63_000_000)
+    )
+    assert settled.json()["data"]["cost_microdollars"] == expected
+
+
+def test_priority_rejects_unsupported_models_and_long_context() -> None:
+    client, key = _client_and_key()
+    unsupported = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "anthropic/claude-haiku-4.5",
+            "service_tier": "priority",
+            "estimated_input_tokens": 10,
+            "max_output_tokens": 10,
+        },
+    )
+    assert unsupported.status_code == 400
+
+    too_long = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "openai/gpt-5.6-sol",
+            "service_tier": "priority",
+            "estimated_input_tokens": 272_001,
+            "max_output_tokens": 10,
+        },
+    )
+    assert too_long.status_code == 400
+
+
+def test_priority_limit_includes_custom_model_hidden_prompt() -> None:
+    client, key = _client_and_key()
+    created = client.post(
+        "/v1/custom-models",
+        headers={"x-trustedrouter-user": "openai-priority@example.com"},
+        json={
+            "name": "Priority prompt",
+            "base_model_id": "openai/gpt-5.6-sol",
+            "hidden_prompt": "12345678",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    too_long = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": created.json()["data"]["id"],
+            "service_tier": "priority",
+            "estimated_input_tokens": 271_999,
+            "max_output_tokens": 1,
+        },
+    )
+    assert too_long.status_code == 400
+    assert "272000" in too_long.text
+
+
+def test_auto_reserves_priority_but_settles_reported_default() -> None:
+    client, key = _client_and_key()
+    auth = _authorize(
+        client,
+        key,
+        service_tier="auto",
+        idempotency_key="auto-downgrade",
+    )
+    priority_estimate = token_cost_microdollars(1_000, 10_500_000) + token_cost_microdollars(
+        1_000, 63_000_000
+    )
+    assert auth["estimated_cost_microdollars"] == priority_estimate
+
+    settled = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 1_000,
+            "service_tier": "default",
+            "request_id": "auto-downgrade",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settled.status_code == 200, settled.text
+    assert settled.json()["data"]["cost_microdollars"] < priority_estimate
+
+
+def test_invalid_requested_and_actual_service_tiers_are_rejected() -> None:
+    client, key = _client_and_key()
+    invalid_request = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "openai/gpt-5.6-sol",
+            "service_tier": "flex",
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+        },
+    )
+    assert invalid_request.status_code == 400
+
+    auth = _authorize(client, key, idempotency_key="invalid-settle-tier")
+    invalid_settlement = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            "actual_input_tokens": 1,
+            "actual_output_tokens": 1,
+            "service_tier": "auto",
+            "request_id": "invalid-settle-tier",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert invalid_settlement.status_code == 400
+
+
+def test_service_tier_is_part_of_idempotency_fingerprint() -> None:
+    client, key = _client_and_key()
+    _authorize(client, key, idempotency_key="tier-fingerprint")
+    mismatch = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "openai/gpt-5.6-sol",
+            "service_tier": "default",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 1_000,
+            "idempotency_key": "tier-fingerprint",
+        },
+    )
+    assert mismatch.status_code == 409
+
+
+def test_catalog_advertises_openai_priority_pricing() -> None:
+    client, _key = _client_and_key()
+    response = client.get("/v1/models/openai/gpt-5.6-sol/endpoints")
+    assert response.status_code == 200
+    openai_endpoint = next(item for item in response.json()["data"] if item["provider"] == "openai")
+    assert "service_tier" in openai_endpoint["supported_parameters"]
+    assert openai_endpoint["trustedrouter"]["service_tiers"] == [
+        "default",
+        "auto",
+        "priority",
+    ]
+    assert openai_endpoint["trustedrouter"]["priority_pricing"] == {
+        "prompt_microdollars_per_million_tokens": 10_500_000,
+        "cached_prompt_microdollars_per_million_tokens": 1_050_000,
+        "completion_microdollars_per_million_tokens": 63_000_000,
+        "max_prompt_tokens": 272_000,
+    }


### PR DESCRIPTION
Implements OpenAI service_tier routing and actual-tier billing for GPT-5.6. Priority and auto requests are restricted to OpenAI endpoints, auto reserves the worst case, settlement bills the provider-reported actual tier, cached tokens use tier-specific rates, and the catalog advertises supported tiers. Also strengthens the hourly OpenAI pricing parser floor for all GPT-5.6 variants.\n\nValidation: 2,233 Python tests passed, 86 skipped; ruff and mypy clean; 10 focused service-tier tests pass.