### PR TITLE
Limit priority metadata to priced models

### DIFF
--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -80,10 +80,12 @@ def _openai_service_tier_metadata(
 ) -> dict[str, Any]:
     if provider != "openai":
         return {}
-    metadata: dict[str, Any] = {"service_tiers": list(OPENAI_SERVICE_TIERS)}
     if pricing := openai_priority_pricing(model_id):
-        metadata["priority_pricing"] = pricing.public_payload()
-    return metadata
+        return {
+            "service_tiers": list(OPENAI_SERVICE_TIERS),
+            "priority_pricing": pricing.public_payload(),
+        }
+    return {"service_tiers": ["default"]}
 
 
 def _public_model_matches_filters(shape: dict[str, Any], request: Request) -> bool:

--- a/tests/test_openai_service_tier.py
+++ b/tests/test_openai_service_tier.py
@@ -299,3 +299,15 @@ def test_catalog_advertises_openai_priority_pricing() -> None:
         "completion_microdollars_per_million_tokens": 63_000_000,
         "max_prompt_tokens": 272_000,
     }
+
+
+def test_catalog_does_not_advertise_unpriced_priority_tiers() -> None:
+    client, _key = _client_and_key()
+    response = client.get("/v1/models/openai/gpt-4o-mini/endpoints")
+    assert response.status_code == 200
+    openai_endpoint = next(
+        item for item in response.json()["data"] if item["provider"] == "openai"
+    )
+
+    assert openai_endpoint["trustedrouter"]["service_tiers"] == ["default"]
+    assert "priority_pricing" not in openai_endpoint["trustedrouter"]


### PR DESCRIPTION
Only advertise auto/priority for OpenAI models with authoritative Priority prices. Other OpenAI models expose default only. Regression test failed before the fix and passes after it; all service-tier tests are green.