### PR TITLE
Retry transient Data Manager authorization failures

### DIFF
--- a/src/trusted_router/google_ads_conversions.py
+++ b/src/trusted_router/google_ads_conversions.py
@@ -34,6 +34,9 @@ GOOGLE_ADS_DIRECT_DELIVERY_ACTIONS = frozenset(
         GOOGLE_ADS_PURCHASE_ACTION,
     }
 )
+LEGACY_GOOGLE_DATA_MANAGER_403_ERROR = (
+    "Google Data Manager returned HTTP 403"
+)
 
 GOOGLE_ADS_CSV_COLUMNS = (
     "conversion_action",
@@ -93,6 +96,18 @@ def build_google_ads_conversion(
 
 def is_google_ads_direct_delivery(conversion: GoogleAdsConversion) -> bool:
     return conversion.conversion_action in GOOGLE_ADS_DIRECT_DELIVERY_ACTIONS
+
+
+def should_repair_legacy_google_data_manager_403(
+    conversion: GoogleAdsConversion,
+) -> bool:
+    """Repair only rows dead-lettered by the first API-propagation smoke."""
+    return (
+        is_google_ads_direct_delivery(conversion)
+        and conversion.delivery_status == "dead"
+        and conversion.delivery_attempts == 1
+        and conversion.last_error == LEGACY_GOOGLE_DATA_MANAGER_403_ERROR
+    )
 
 
 def google_ads_conversion_kind(occurred_at: str) -> str:

--- a/src/trusted_router/google_data_manager_cli.py
+++ b/src/trusted_router/google_data_manager_cli.py
@@ -16,12 +16,12 @@ from trusted_router.services.google_data_manager import (
 from trusted_router.storage_gcp_google_ads import create_google_ads_delivery_store
 
 
-def main() -> None:
+def main() -> int:
     logging.basicConfig(level=logging.INFO)
     settings = get_settings()
     if not settings.google_data_manager_enabled:
         logging.getLogger(__name__).info("google_data_manager.disabled")
-        return
+        return 0
 
     store = create_google_ads_delivery_store(settings)
     config = GoogleDataManagerConfig.from_settings(settings)
@@ -37,16 +37,16 @@ def main() -> None:
             ),
         )
     logging.getLogger(__name__).info(
-        "google_data_manager.run_complete",
-        extra={
-            "claimed": result.claimed,
-            "submitted": result.submitted,
-            "failed": result.failed,
-            "repaired": result.repaired,
-            "google_request_id": result.request_id,
-        },
+        "google_data_manager.run_complete claimed=%d submitted=%d "
+        "failed=%d repaired=%d google_request_id=%s",
+        result.claimed,
+        result.submitted,
+        result.failed,
+        result.repaired,
+        result.request_id or "",
     )
+    return 1 if result.failed else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/trusted_router/services/google_data_manager.py
+++ b/src/trusted_router/services/google_data_manager.py
@@ -221,8 +221,10 @@ class GoogleDataManagerClient:
                 retryable=True,
             ) from exc
         if not 200 <= response.status_code < 300:
+            detail = _google_error_detail(response)
+            suffix = f" ({detail})" if detail else ""
             raise GoogleDataManagerUploadError(
-                f"Google Data Manager returned HTTP {response.status_code}",
+                f"Google Data Manager returned HTTP {response.status_code}{suffix}",
                 retryable=_is_retryable_status(response.status_code),
             )
         try:
@@ -337,12 +339,12 @@ def run_google_data_manager_once(
             max_attempts=settings.google_data_manager_max_attempts,
         )
         log.warning(
-            "google_data_manager.upload_failed",
-            extra={
-                "conversion_count": len(conversions),
-                "retryable": exc.retryable,
-                "marked_failed": failed,
-            },
+            "google_data_manager.upload_failed error=%s "
+            "conversion_count=%d retryable=%s marked_failed=%d",
+            exc,
+            len(conversions),
+            exc.retryable,
+            failed,
         )
         return GoogleDataManagerRunResult(
             claimed=len(conversions),
@@ -487,5 +489,41 @@ def _numeric_id(value: str | None, label: str) -> str:
     return normalized
 
 
+def _google_error_detail(response: httpx.Response) -> str:
+    """Extract safe diagnostic codes without logging Google's raw response."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return ""
+
+    details: list[str] = []
+    status = error.get("status")
+    if isinstance(status, str) and status:
+        details.append(f"status={status[:80]}")
+
+    raw_details = error.get("details")
+    if isinstance(raw_details, list):
+        for item in raw_details:
+            if not isinstance(item, dict):
+                continue
+            detail_type = str(item.get("@type", ""))
+            if detail_type.endswith("ErrorInfo"):
+                reason = item.get("reason")
+                if isinstance(reason, str) and reason:
+                    details.append(f"reason={reason[:80]}")
+            elif detail_type.endswith("RequestInfo"):
+                request_id = item.get("requestId")
+                if isinstance(request_id, str) and request_id:
+                    details.append(f"request_id={request_id[:128]}")
+    return " ".join(details)
+
+
 def _is_retryable_status(status_code: int) -> bool:
-    return status_code in {408, 409, 425, 429} or status_code >= 500
+    # Google documents propagation-time SERVICE_DISABLED as a 403. Retry is
+    # still bounded by google_data_manager_max_attempts.
+    return status_code in {403, 408, 409, 425, 429} or status_code >= 500

--- a/src/trusted_router/storage_attribution.py
+++ b/src/trusted_router/storage_attribution.py
@@ -7,6 +7,7 @@ import uuid
 from trusted_router.google_ads_conversions import (
     build_google_ads_conversion,
     is_google_ads_direct_delivery,
+    should_repair_legacy_google_data_manager_403,
 )
 from trusted_router.storage_models import (
     AcquisitionAttribution,
@@ -250,10 +251,16 @@ class InMemoryAcquisitionAttribution:
                     continue
                 if (
                     is_google_ads_direct_delivery(conversion)
-                    and conversion.delivery_status == "not_scheduled"
+                    and (
+                        conversion.delivery_status == "not_scheduled"
+                        or should_repair_legacy_google_data_manager_403(
+                            conversion
+                        )
+                    )
                 ):
                     conversion.delivery_status = "pending"
                     conversion.next_attempt_at = iso_now()
+                    conversion.last_error = None
                     conversion.updated_at = conversion.next_attempt_at
                     repaired += 1
         return repaired

--- a/src/trusted_router/storage_gcp_attribution.py
+++ b/src/trusted_router/storage_gcp_attribution.py
@@ -11,6 +11,7 @@ from trusted_router.google_ads_conversions import (
     google_ads_conversion_kinds_since,
     is_google_ads_direct_delivery,
     parse_utc_timestamp,
+    should_repair_legacy_google_data_manager_403,
 )
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
 from trusted_router.storage_models import (
@@ -391,9 +392,15 @@ class SpannerAcquisitionAttribution:
                     )
                     if conversion is None:
                         return 0
-                    if conversion.delivery_status == "not_scheduled":
+                    if (
+                        conversion.delivery_status == "not_scheduled"
+                        or should_repair_legacy_google_data_manager_403(
+                            conversion
+                        )
+                    ):
                         conversion.delivery_status = "pending"
                         conversion.next_attempt_at = iso_now()
+                        conversion.last_error = None
                         conversion.updated_at = conversion.next_attempt_at
                         self._io.write_entity_tx(
                             transaction,

--- a/tests/test_google_data_manager.py
+++ b/tests/test_google_data_manager.py
@@ -343,7 +343,7 @@ def test_worker_uses_spanner_only_outbox_store() -> None:
     ("status_code", "retryable"),
     [
         (400, False),
-        (403, False),
+        (403, True),
         (408, True),
         (429, True),
         (500, True),
@@ -369,6 +369,47 @@ def test_http_failure_classification_does_not_echo_response_body(
             client.ingest([_conversion()])
     assert raised.value.retryable is retryable
     assert private_response_body not in str(raised.value)
+
+
+def test_google_error_codes_are_logged_without_raw_message() -> None:
+    private_message = "click-id-secret-must-not-be-logged"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={
+                "error": {
+                    "status": "PERMISSION_DENIED",
+                    "message": private_message,
+                    "details": [
+                        {
+                            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                            "reason": "SERVICE_DISABLED",
+                        },
+                        {
+                            "@type": "type.googleapis.com/google.rpc.RequestInfo",
+                            "requestId": "google-request-123",
+                        },
+                    ],
+                }
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = GoogleDataManagerClient(
+            config=_config(),
+            client=http,
+            token_provider=lambda: "token",
+        )
+        with pytest.raises(GoogleDataManagerUploadError) as raised:
+            client.ingest([_conversion()])
+
+    message = str(raised.value)
+    assert "status=PERMISSION_DENIED" in message
+    assert "reason=SERVICE_DISABLED" in message
+    assert "request_id=google-request-123" in message
+    assert private_message not in message
+    assert raised.value.retryable is True
 
 
 def test_success_without_request_id_is_retried() -> None:
@@ -516,6 +557,56 @@ def test_legacy_direct_conversion_is_repaired_once() -> None:
     assert len(
         store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
     ) == 1
+
+
+def test_first_production_403_dead_letter_is_repaired_once() -> None:
+    store = InMemoryStore()
+    conversion = _conversion()
+    conversion.delivery_status = "dead"
+    conversion.delivery_attempts = 1
+    conversion.last_error = "Google Data Manager returned HTTP 403"
+    store.acquisition_store.google_ads_conversions[conversion.order_id] = conversion
+
+    assert store.repair_google_ads_delivery_queue(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    ) == 1
+    assert conversion.delivery_status == "pending"
+    assert conversion.last_error is None
+    assert store.repair_google_ads_delivery_queue(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    ) == 0
+
+
+def test_spanner_repairs_first_production_403_dead_letter() -> None:
+    store, _database, _table = make_fake_store()
+    assert store.create_acquisition_attribution(
+        _attribution(workspace_id="ws-spanner-repair")
+    )
+    claimed = store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    assert len(claimed) == 1
+    conversion = claimed[0]
+    assert conversion.lease_owner
+
+    dead = store.mark_google_ads_delivery_failed(
+        order_id=conversion.order_id,
+        occurred_at=conversion.occurred_at,
+        lease_owner=conversion.lease_owner,
+        error="Google Data Manager returned HTTP 403",
+        retryable=False,
+        max_attempts=3,
+    )
+    assert dead is not None
+    assert dead.delivery_status == "dead"
+
+    assert store.repair_google_ads_delivery_queue(
+        since="2000-01-01T00:00:00Z",
+        limit=10,
+    ) == 1
+    retried = store.claim_google_ads_deliveries(limit=10, lease_seconds=60)
+    assert len(retried) == 1
+    assert retried[0].last_error is None
 
 
 def test_spanner_conversion_and_due_pointer_commit_together() -> None:


### PR DESCRIPTION
## Production smoke finding
The first Data Manager request reached Google with the expected scoped Cloud Run token, but Google returned 403 shortly after the API was enabled. The worker incorrectly dead-lettered the batch and exited successfully.

## Fix
- retry bounded 403 failures, including API/IAM propagation
- extract only safe Google status, reason, and request ID fields; never log the raw response body
- make failed upload runs exit nonzero
- repair the exact first-smoke 403 dead-letter once
- cover in-memory and Spanner repair paths

## Verification
- 70 focused tests pass
- ruff passes
- mypy passes