### PR TITLE
Add Inkling Small with fail-closed pricing

### DIFF
--- a/scripts/pricing/manifest.py
+++ b/scripts/pricing/manifest.py
@@ -131,6 +131,9 @@ def write_discovered_chat_manifest(
 
         price = result.prices.get(model_id)
         if price is not None:
+            if row.get("routable_reason") == "price-unavailable":
+                row.pop("routable", None)
+                row.pop("routable_reason", None)
             tier = price.tiers[0]
             row["input_token_price_per_m"] = tier.prompt_micro_per_m
             row["output_token_price_per_m"] = tier.completion_micro_per_m
@@ -139,9 +142,15 @@ def write_discovered_chat_manifest(
             else:
                 row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
             updated.append(model_id)
-        elif existing is None:
-            row["routable"] = False
-            row["routable_reason"] = "price-unavailable"
+        else:
+            row.pop("input_token_price_per_m", None)
+            row.pop("output_token_price_per_m", None)
+            row.pop("cached_input_token_price_per_m", None)
+            if row.get("routable") is not False or row.get(
+                "routable_reason"
+            ) == "price-unavailable":
+                row["routable"] = False
+                row["routable_reason"] = "price-unavailable"
         present_rows[model_id] = row
 
     rebuilt = reconcile_manifest_tombstones(

--- a/scripts/pricing/openai_catalog.py
+++ b/scripts/pricing/openai_catalog.py
@@ -65,7 +65,11 @@ def discover_openai_chat_catalog(
     upstream_id_map: dict[str, str],
     include: Callable[[dict[str, Any]], bool] | None = None,
 ) -> tuple[dict[str, ModelPrice], dict[str, dict[str, Any]]]:
-    """Normalize priced text-chat rows while preserving exact upstream IDs."""
+    """Normalize text-chat rows while preserving exact upstream IDs.
+
+    All-zero prices remain in ``discovered`` so manifest writers can disable
+    an existing route immediately, but never enter ``prices`` as billable.
+    """
 
     prices: dict[str, ModelPrice] = {}
     discovered: dict[str, dict[str, Any]] = {}
@@ -111,7 +115,8 @@ def discover_openai_chat_catalog(
             if isinstance(value, list):
                 row[field] = [str(item) for item in value]
         discovered[model_id] = row
-        prices[model_id] = price
+        if price.prompt_micro_per_m > 0 or price.completion_micro_per_m > 0:
+            prices[model_id] = price
     return prices, discovered
 
 

--- a/scripts/pricing/parsers/thinkingmachines.py
+++ b/scripts/pricing/parsers/thinkingmachines.py
@@ -7,8 +7,16 @@ from decimal import ROUND_HALF_UP, Decimal
 
 from bs4 import BeautifulSoup, Tag
 
-_INKLING_256K_ID = "thinkingmachines/Inkling:peft:262144"
-_CANONICAL_ID = "thinkingmachines/inkling"
+_SERVERLESS_IDS = {
+    "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4": (
+        "thinkingmachines/inkling-small"
+    ),
+    "thinkingmachines/Inkling:peft:262144:sampling-nvfp4": (
+        "thinkingmachines/inkling"
+    ),
+}
+_LEGACY_INKLING_256K_ID = "thinkingmachines/Inkling:peft:262144"
+_LEGACY_CANONICAL_ID = "thinkingmachines/inkling"
 
 
 def _microdollars_per_million(text: str) -> int:
@@ -43,9 +51,44 @@ def parse(html: str) -> dict[str, dict[str, int]]:
     active = soup.select_one("#pricing-toggle button.active")
     mode = str(active.get("data-mode")) if isinstance(active, Tag) else "old"
 
+    prices: dict[str, dict[str, int]] = {}
+    for row in soup.select("#serverless-tbody tr"):
+        model_cell = row.select_one("td.tinker-id")
+        if model_cell is None:
+            continue
+        canonical_id = _SERVERLESS_IDS.get(model_cell.get_text(strip=True))
+        if canonical_id is None:
+            continue
+        cells = row.find_all("td", recursive=False)
+        if len(cells) < 5:
+            continue
+        input_span = _price_span(cells[3], mode)
+        output_span = _price_span(cells[4], mode)
+        cache_span = input_span.select_one(".price-cached")
+        if cache_span is None:
+            cache_span = cells[3].select_one(".price-cached")
+        if cache_span is None:
+            raise ValueError(f"{canonical_id} serverless row has no cached-input rate")
+        prices[canonical_id] = {
+            "prompt_micro_per_m": _microdollars_per_million(
+                input_span.get_text(" ", strip=True)
+            ),
+            "completion_micro_per_m": _microdollars_per_million(
+                output_span.get_text(" ", strip=True)
+            ),
+            "prompt_cached_micro_per_m": _microdollars_per_million(
+                cache_span.get_text(" ", strip=True)
+            ),
+        }
+    if prices:
+        return prices
+
     for row in soup.select("#model-tbody tr"):
         model_cell = row.select_one("td.tinker-id")
-        if model_cell is None or model_cell.get_text(strip=True) != _INKLING_256K_ID:
+        if (
+            model_cell is None
+            or model_cell.get_text(strip=True) != _LEGACY_INKLING_256K_ID
+        ):
             continue
         cells = row.find_all("td", recursive=False)
         if len(cells) < 8:
@@ -58,7 +101,7 @@ def parse(html: str) -> dict[str, dict[str, int]]:
         if cache_span is None:
             raise ValueError("Inkling 256K pricing row has no cached-input rate")
         return {
-            _CANONICAL_ID: {
+            _LEGACY_CANONICAL_ID: {
                 "prompt_micro_per_m": _microdollars_per_million(
                     input_span.get_text(" ", strip=True)
                 ),

--- a/scripts/pricing/providers/baseten.py
+++ b/scripts/pricing/providers/baseten.py
@@ -59,6 +59,7 @@ _NATIVE_TO_OR_ID = {
     "zai-org/GLM-5.2-Fast": "z-ai/glm-5.2-fast",
     "moonshotai/Kimi-K2.7-Code": "moonshotai/kimi-k2.7-code",
     "thinkingmachines/inkling": "thinkingmachines/inkling-1m",
+    "thinkingmachines/inkling-small": "thinkingmachines/inkling-small",
 }
 
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}

--- a/scripts/pricing/providers/thinkingmachines.py
+++ b/scripts/pricing/providers/thinkingmachines.py
@@ -10,7 +10,10 @@ from scripts.pricing.base import ProviderPricingResult, fetch_provider
 
 SLUG = "thinkingmachines"
 URL = "https://tinker-docs.thinkingmachines.ai/tinker/models/"
-EXPECTED_MODELS = ["thinkingmachines/inkling"]
+EXPECTED_MODELS = [
+    "thinkingmachines/inkling",
+    "thinkingmachines/inkling-small",
+]
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -63,4 +66,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    return ["thinkingmachines: refreshed provider_models/thinkingmachines.json (1 priced row)"]
+    return [
+        "thinkingmachines: refreshed provider_models/thinkingmachines.json "
+        f"({len(updated)} priced rows)"
+    ]

--- a/src/trusted_router/data/provider_models/baseten.json
+++ b/src/trusted_router/data/provider_models/baseten.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native Baseten Model API routes, capabilities, context windows, and account-billable prices refreshed hourly from Baseten's authenticated /v1/models feed.",
   "provider": "baseten",
   "source": "https://inference.baseten.co/v1/models",
-  "generated_at": "2026-07-31T00:04:46Z",
+  "generated_at": "2026-07-31T02:10:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 17,
   "models": [
@@ -458,9 +458,8 @@
         "temperature",
         "stop"
       ],
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
-      "cached_input_token_price_per_m": 0
+      "routable": false,
+      "routable_reason": "price-unavailable"
     },
     {
       "display_name": "SID-1",
@@ -489,9 +488,8 @@
         "temperature",
         "stop"
       ],
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
-      "cached_input_token_price_per_m": 0
+      "routable": false,
+      "routable_reason": "price-unavailable"
     },
     {
       "display_name": "Inkling Small",
@@ -521,9 +519,8 @@
         "temperature",
         "stop"
       ],
-      "input_token_price_per_m": 0,
-      "output_token_price_per_m": 0,
-      "cached_input_token_price_per_m": 0
+      "routable": false,
+      "routable_reason": "price-unavailable"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/thinkingmachines.json
+++ b/src/trusted_router/data/provider_models/thinkingmachines.json
@@ -1,22 +1,48 @@
 {
   "source": "https://tinker-docs.thinkingmachines.ai/tinker/models/",
-  "generated_at": "2026-07-31T00:04:46Z",
+  "generated_at": "2026-07-31T02:10:22Z",
   "provider": "thinkingmachines",
   "currency": "USD",
   "price_unit": "microdollars_per_million_tokens",
-  "model_count": 1,
+  "model_count": 2,
   "models": [
     {
       "id": "thinkingmachines/inkling",
-      "upstream_id": "thinkingmachines/Inkling:peft:262144",
+      "upstream_id": "thinkingmachines/Inkling:peft:262144:sampling-nvfp4",
       "display_name": "Thinking Machines Inkling 256K",
       "context_length": 262144,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
       "endpoints": [
         "chat/completions"
       ],
-      "input_token_price_per_m": 3740000,
-      "output_token_price_per_m": 9360000,
-      "cached_input_token_price_per_m": 748000
+      "input_token_price_per_m": 1000000,
+      "output_token_price_per_m": 4050000,
+      "cached_input_token_price_per_m": 170000
+    },
+    {
+      "id": "thinkingmachines/inkling-small",
+      "upstream_id": "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4",
+      "display_name": "Thinking Machines Inkling Small 256K",
+      "context_length": 262144,
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 60000
     }
   ]
 }

--- a/tests/test_baseten_wafer_pricing.py
+++ b/tests/test_baseten_wafer_pricing.py
@@ -95,6 +95,129 @@ def test_baseten_fetch_discovers_prices_without_float_drift(monkeypatch) -> None
     assert baseten.UPSTREAM_ID_MAP["thinkingmachines/inkling-1m"] == "thinkingmachines/inkling"
 
 
+def test_baseten_zero_price_discovery_is_immediately_disabled(
+    tmp_path: Path, monkeypatch
+) -> None:  # noqa: ANN001
+    payload = {
+        "data": [
+            {
+                "id": "thinkingmachines/inkling-small",
+                "context_length": 1_048_576,
+                "pricing": {"prompt": "0", "completion": "0"},
+            },
+            {
+                "id": "zai-org/GLM-5.2",
+                "pricing": {
+                    "prompt": "0.0000014",
+                    "completion": "0.0000044",
+                },
+            },
+            {
+                "id": "zai-org/GLM-5.2-Fast",
+                "pricing": {
+                    "prompt": "0.0000021",
+                    "completion": "0.0000066",
+                },
+            },
+            {
+                "id": "moonshotai/Kimi-K2.7-Code",
+                "pricing": {
+                    "prompt": "0.00000095",
+                    "completion": "0.000004",
+                },
+            },
+            {
+                "id": "thinkingmachines/inkling",
+                "pricing": {
+                    "prompt": "0.000001",
+                    "completion": "0.00000405",
+                },
+            },
+        ]
+    }
+
+    class FakeClient:
+        def __init__(self, **_kwargs) -> None:  # noqa: ANN003
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args, **_kwargs) -> FakeResponse:  # noqa: ANN002, ANN003
+            return FakeResponse(payload)
+
+    manifest_path = tmp_path / "baseten.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "baseten",
+                "models": [
+                    {
+                        "id": "thinkingmachines/inkling-small",
+                        "upstream_id": "thinkingmachines/inkling-small",
+                        "input_token_price_per_m": 10_000,
+                        "output_token_price_per_m": 10_000,
+                    },
+                    {
+                        "id": "z-ai/glm-5.2",
+                        "upstream_id": "zai-org/GLM-5.2",
+                    },
+                    {
+                        "id": "z-ai/glm-5.2-fast",
+                        "upstream_id": "zai-org/GLM-5.2-Fast",
+                    },
+                    {
+                        "id": "moonshotai/kimi-k2.7-code",
+                        "upstream_id": "moonshotai/Kimi-K2.7-Code",
+                    },
+                    {
+                        "id": "thinkingmachines/inkling-1m",
+                        "upstream_id": "thinkingmachines/inkling",
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(baseten.httpx, "Client", FakeClient)
+    monkeypatch.setattr(baseten, "MANIFEST_PATH", manifest_path)
+
+    result = baseten.fetch()
+    assert "thinkingmachines/inkling-small" not in result.prices
+    assert "thinkingmachines/inkling-small" in baseten._DISCOVERED_MANIFEST_ROWS
+
+    baseten.write_provider_manifest(result)
+    rows = {
+        row["id"]: row
+        for row in json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    }
+    assert rows["thinkingmachines/inkling-small"]["routable"] is False
+    assert (
+        rows["thinkingmachines/inkling-small"]["routable_reason"]
+        == "price-unavailable"
+    )
+
+    payload["data"][0]["pricing"] = {
+        "prompt": "0.0000003",
+        "completion": "0.0000012",
+    }
+    recovered = baseten.fetch()
+    baseten.write_provider_manifest(recovered)
+    recovered_rows = {
+        row["id"]: row
+        for row in json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    }
+    recovered_small = recovered_rows["thinkingmachines/inkling-small"]
+    assert "routable" not in recovered_small
+    assert "routable_reason" not in recovered_small
+    assert recovered_small["input_token_price_per_m"] == 300_000
+    assert recovered_small["output_token_price_per_m"] == 1_200_000
+
+
 def test_baseten_provider_appends_new_priced_models_to_manifest(
     tmp_path: Path, monkeypatch
 ) -> None:  # noqa: ANN001

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1124,6 +1124,28 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
         (endpoint.provider, endpoint.upstream_id) for endpoint in endpoints_for_model(inkling_1m.id)
     } == {("baseten", "thinkingmachines/inkling")}
 
+    inkling_small = MODELS["thinkingmachines/inkling-small"]
+    inkling_small_shape = model_to_openrouter_shape(inkling_small)
+    assert inkling_small.context_length == 262_144
+    assert inkling_small_shape["trustedrouter"]["open_weights"] is True
+    assert (
+        inkling_small.prompt_price_microdollars_per_million_tokens
+        == 315_000
+    )
+    assert (
+        inkling_small.completion_price_microdollars_per_million_tokens
+        == 1_260_000
+    )
+    assert {
+        (endpoint.provider, endpoint.upstream_id)
+        for endpoint in endpoints_for_model(inkling_small.id)
+    } == {
+        (
+            "thinkingmachines",
+            "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4",
+        )
+    }
+
 
 def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() -> None:
     model_id = "nvidia/nemotron-3-ultra-550b-a55b"

--- a/tests/test_thinkingmachines_pricing.py
+++ b/tests/test_thinkingmachines_pricing.py
@@ -26,6 +26,42 @@ def _pricing_html(*, active: str = "old") -> str:
     """
 
 
+def _serverless_pricing_html() -> str:
+    return """
+    <table><tbody id="serverless-tbody">
+      <tr>
+        <td>Inkling-Small</td>
+        <td class="tinker-id">thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4</td>
+        <td>256K</td>
+        <td class="price">$0.30<span class="price-cached">$0.06 (cached)</span></td>
+        <td class="price">$1.20</td>
+      </tr>
+      <tr>
+        <td>Inkling</td>
+        <td class="tinker-id">thinkingmachines/Inkling:peft:262144:sampling-nvfp4</td>
+        <td>256K</td>
+        <td class="price">$1.00<span class="price-cached">$0.17 (cached)</span></td>
+        <td class="price">$4.05</td>
+      </tr>
+    </tbody></table>
+    """
+
+
+def test_parser_reads_all_serverless_inference_models() -> None:
+    assert parse(_serverless_pricing_html()) == {
+        "thinkingmachines/inkling-small": {
+            "prompt_micro_per_m": 300_000,
+            "completion_micro_per_m": 1_200_000,
+            "prompt_cached_micro_per_m": 60_000,
+        },
+        "thinkingmachines/inkling": {
+            "prompt_micro_per_m": 1_000_000,
+            "completion_micro_per_m": 4_050_000,
+            "prompt_cached_micro_per_m": 170_000,
+        },
+    }
+
+
 def test_parser_uses_currently_active_pricing_version() -> None:
     assert parse(_pricing_html()) == {
         "thinkingmachines/inkling": {
@@ -73,6 +109,11 @@ def test_manifest_writer_updates_integer_rates(tmp_path, monkeypatch) -> None:  
                         "id": "thinkingmachines/inkling",
                         "input_token_price_per_m": 1,
                         "output_token_price_per_m": 1,
+                    },
+                    {
+                        "id": "thinkingmachines/inkling-small",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
                     }
                 ]
             }
@@ -84,17 +125,31 @@ def test_manifest_writer_updates_integer_rates(tmp_path, monkeypatch) -> None:  
         slug="thinkingmachines",
         prices={
             "thinkingmachines/inkling": ModelPrice(
-                prompt_micro_per_m=3_740_000,
-                completion_micro_per_m=9_360_000,
-                prompt_cached_micro_per_m=748_000,
-            )
+                prompt_micro_per_m=1_000_000,
+                completion_micro_per_m=4_050_000,
+                prompt_cached_micro_per_m=170_000,
+            ),
+            "thinkingmachines/inkling-small": ModelPrice(
+                prompt_micro_per_m=300_000,
+                completion_micro_per_m=1_200_000,
+                prompt_cached_micro_per_m=60_000,
+            ),
         },
         source="deterministic",
     )
 
     thinkingmachines.write_provider_manifest(result)
 
-    row = json.loads(manifest.read_text(encoding="utf-8"))["models"][0]
-    assert row["input_token_price_per_m"] == 3_740_000
-    assert row["output_token_price_per_m"] == 9_360_000
-    assert row["cached_input_token_price_per_m"] == 748_000
+    rows = {
+        row["id"]: row
+        for row in json.loads(manifest.read_text(encoding="utf-8"))["models"]
+    }
+    assert rows["thinkingmachines/inkling"]["input_token_price_per_m"] == 1_000_000
+    assert rows["thinkingmachines/inkling"]["output_token_price_per_m"] == 4_050_000
+    assert rows["thinkingmachines/inkling"]["cached_input_token_price_per_m"] == 170_000
+    assert rows["thinkingmachines/inkling-small"]["input_token_price_per_m"] == 300_000
+    assert rows["thinkingmachines/inkling-small"]["output_token_price_per_m"] == 1_200_000
+    assert (
+        rows["thinkingmachines/inkling-small"]["cached_input_token_price_per_m"]
+        == 60_000
+    )


### PR DESCRIPTION
Adds the verified Thinking Machines Inkling Small serverless route and current native prices.

Also fixes discovered provider rows that report $0/$0: they are now retained for lifecycle tracking but disabled immediately instead of becoming a $0.01/M billable route.

Validation:
- 2,266 passed, 86 skipped
- ruff clean
- mypy clean
- live Tinker parser returned both Inkling models
- direct Inkling Small call returned HTTP 200