### PR TITLE
Publish verified model modalities

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -659,8 +659,13 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
             "modality": (
                 "text->embedding"
                 if model.supports_embeddings and not model.supports_chat
-                else "text->text"
+                else (
+                    f"{'+'.join(model.input_modalities)}"
+                    f"->{'+'.join(model.output_modalities)}"
+                )
             ),
+            "input_modalities": list(model.input_modalities),
+            "output_modalities": list(model.output_modalities),
             "tokenizer": "unknown",
             "instruct_type": None,
         },

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -188,6 +188,8 @@ class Model:
     supports_chat: bool = True
     supports_messages: bool = False
     supports_embeddings: bool = False
+    input_modalities: tuple[str, ...] = ("text",)
+    output_modalities: tuple[str, ...] = ("text",)
     prepaid_available: bool = False
     byok_available: bool = True
     # Headline (low-tier) rates: what /v1/models displays. For

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -10,6 +10,7 @@ merge). No dependency on catalog.py, so no import cycle.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,26 @@ def _positive_float(value: object) -> float | None:
         return None
     parsed = float(value)
     return parsed if parsed > 0 else None
+
+
+_SUPPORTED_GATEWAY_MODALITIES = frozenset({"text", "image"})
+
+
+def _modalities(value: object, *, default: tuple[str, ...]) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return default
+    normalized = tuple(
+        dict.fromkeys(
+            item.strip().lower()
+            for item in value
+            if (
+                isinstance(item, str)
+                and item.strip()
+                and item.strip().lower() in _SUPPORTED_GATEWAY_MODALITIES
+            )
+        )
+    )
+    return normalized or default
 
 
 def _endpoint(
@@ -597,6 +618,9 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
         # not supported even if Claude-on-OpenRouter etc. exist. Drive
         # the supports_messages flag off the publisher.
         supports_messages = publisher == "anthropic"
+        architecture = raw_model.get("architecture")
+        if not isinstance(architecture, dict):
+            architecture = {}
         prepaid_available = any(
             slug in GATEWAY_PREPAID_PROVIDER_SLUGS for _p, _c, _t, slug, _ep in per_endpoint_prices
         )
@@ -607,6 +631,14 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
             context_length=context_length,
             supports_chat=True,
             supports_messages=supports_messages,
+            input_modalities=_modalities(
+                architecture.get("input_modalities"),
+                default=("text",),
+            ),
+            output_modalities=_modalities(
+                architecture.get("output_modalities"),
+                default=("text",),
+            ),
             prepaid_available=prepaid_available,
             byok_available=any(
                 PROVIDERS[slug].supports_byok
@@ -782,6 +814,14 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                 upstream_id=upstream_id,
                 supports_chat=True,
                 supports_messages=publisher == "anthropic",
+                input_modalities=_modalities(
+                    raw_model.get("input_modalities"),
+                    default=("text",),
+                ),
+                output_modalities=_modalities(
+                    raw_model.get("output_modalities"),
+                    default=("text",),
+                ),
                 # Availability comes from the explicit provider-native
                 # endpoints below. Do not let _build_endpoints synthesize
                 # publisher-direct routes for supplemental-only models
@@ -795,7 +835,19 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                 price_tiers=tiers,
                 published_price_tiers=tiers,
             )
-            models.setdefault(model_id, model)
+            existing = models.get(model_id)
+            if existing is None:
+                models[model_id] = model
+            else:
+                models[model_id] = replace(
+                    existing,
+                    input_modalities=tuple(
+                        dict.fromkeys((*existing.input_modalities, *model.input_modalities))
+                    ),
+                    output_modalities=tuple(
+                        dict.fromkeys((*existing.output_modalities, *model.output_modalities))
+                    ),
+                )
 
             if provider_slug in GATEWAY_PREPAID_PROVIDER_SLUGS:
                 credits_id = f"{model_id}@{provider_slug}/prepaid"

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -11,6 +11,8 @@ catalog_data / catalog_ingest / pricing leaves."""
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-compat
     _EMBEDDING_SPECS,
     _MODEL_PROVIDER_PRIVACY_OVERRIDES,
@@ -767,7 +769,26 @@ _SUPPLEMENTAL_MODELS, _SUPPLEMENTAL_ENDPOINTS = _supplemental_provider_models_an
 # through the same `cost × 1.05, $0.01/M floor` formula.
 MODELS.update(_INGESTED_MODELS)
 for _model_id, _model in _SUPPLEMENTAL_MODELS.items():
-    MODELS.setdefault(_model_id, _model)
+    _existing_model = MODELS.get(_model_id)
+    if _existing_model is None:
+        MODELS[_model_id] = _model
+        continue
+    # A provider-native catalog may advertise a capability before the shared
+    # snapshot does. Preserve the primary catalog's pricing/name while taking
+    # the union of capabilities verified by callable provider routes.
+    MODELS[_model_id] = replace(
+        _existing_model,
+        input_modalities=tuple(
+            dict.fromkeys(
+                (*_existing_model.input_modalities, *_model.input_modalities)
+            )
+        ),
+        output_modalities=tuple(
+            dict.fromkeys(
+                (*_existing_model.output_modalities, *_model.output_modalities)
+            )
+        ),
+    )
 # Embedding models override any snapshot/supplemental collision: the
 # hand-curated embedding entry (input-only pricing, supports_embeddings) is
 # authoritative for these IDs. Merge BEFORE `_build_endpoints` so each gets

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -78,6 +78,7 @@ from trusted_router.catalog import (
     orchestration_role,
     provider_privacy_tier,
 )
+from trusted_router.catalog_ingest import _modalities
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.routing import chat_route_candidates, chat_route_endpoint_candidates
@@ -1127,6 +1128,13 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
     inkling_small = MODELS["thinkingmachines/inkling-small"]
     inkling_small_shape = model_to_openrouter_shape(inkling_small)
     assert inkling_small.context_length == 262_144
+    assert inkling_small.input_modalities == ("text", "image")
+    assert inkling_small.output_modalities == ("text",)
+    assert inkling_small_shape["architecture"]["modality"] == "text+image->text"
+    assert inkling_small_shape["architecture"]["input_modalities"] == [
+        "text",
+        "image",
+    ]
     assert inkling_small_shape["trustedrouter"]["open_weights"] is True
     assert (
         inkling_small.prompt_price_microdollars_per_million_tokens
@@ -1145,6 +1153,14 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
             "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4",
         )
     }
+
+
+def test_catalog_modalities_publish_only_gateway_supported_capabilities() -> None:
+    assert _modalities(
+        ["Text", "image", "audio", "image", "", 7],
+        default=("text",),
+    ) == ("text", "image")
+    assert _modalities(["audio"], default=("text",)) == ("text",)
 
 
 def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() -> None:


### PR DESCRIPTION
## Summary
- propagate verified text/image modalities from provider catalogs into the public model catalog
- union capabilities across callable provider routes while preserving primary pricing metadata
- advertise Inkling Small as text+image to text without overclaiming unsupported audio

## Verification
- `uv run pytest -q` (2269 passed, 86 skipped)
- `uv run pytest -q tests/test_catalog_routing_contracts.py` (89 passed)
- `uv run ruff check .`
- `uv run mypy`
- `git diff --check`