### PR TITLE
Retain Google Ads conversions during access propagation

### DIFF
--- a/scripts/deploy/google_data_manager.sh
+++ b/scripts/deploy/google_data_manager.sh
@@ -37,7 +37,10 @@ ENV_VARS=(
   "TR_GOOGLE_DATA_MANAGER_PURCHASE_ACTION_ID=${GOOGLE_ADS_PURCHASE_ACTION_ID}"
   "TR_GOOGLE_DATA_MANAGER_BATCH_SIZE=500"
   "TR_GOOGLE_DATA_MANAGER_LEASE_SECONDS=300"
-  "TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS=8"
+  # Google Ads documents that newly granted account access can take about
+  # 24 hours to propagate. Twenty bounded, exponentially backed-off attempts
+  # retain the conversion for roughly three days without creating a tight loop.
+  "TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS=20"
   "TR_GOOGLE_DATA_MANAGER_REPAIR_LOOKBACK_DAYS=90"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"

--- a/tests/test_google_data_manager.py
+++ b/tests/test_google_data_manager.py
@@ -303,6 +303,7 @@ def test_deploy_worker_does_not_receive_application_secrets() -> None:
 
     assert "TR_ENVIRONMENT=worker" in deploy_script
     assert "tr-google-data-manager@" in deploy_script
+    assert "TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS=20" in deploy_script
     assert "TR_STRIPE_SECRET_KEY=" not in deploy_script
     assert "TR_STRIPE_WEBHOOK_SECRET=" not in deploy_script
     assert "TR_INTERNAL_GATEWAY_TOKEN=" not in deploy_script


### PR DESCRIPTION
## Summary
- extend production Data Manager retries from 8 to 20 attempts
- retain conversion events for roughly three days while newly granted Google Ads access propagates
- preserve bounded exponential backoff and the six-hour cap
- lock the production setting with a regression assertion

## Verification
- `uv run pytest -q tests/test_google_data_manager.py`
- `uv run ruff check tests/test_google_data_manager.py`
- `bash -n scripts/deploy/google_data_manager.sh`
- `git diff --check`