### PR TITLE
marketing: put the AWS and Azure deployments on the region map

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -235,8 +235,16 @@ class Settings(BaseSettings):
     marketing_regions: str = (
         "us-central1,europe-west4,us-east4,"
         "asia-northeast1,asia-east2,asia-southeast1,"
-        "southamerica-east1"
+        "southamerica-east1,"
+        # Standalone deployments on other clouds (multi-cloud-separation.md).
+        "aws-eu-west-1,aws-eu-north-1,azure-australiaeast"
     )
+    # Non-GCP deployments that have PASSED their own end-to-end smoke
+    # (verify_deployment.sh --expect-monitor). Listing here turns the map dot
+    # from "staged" to "live", so an entry is a factual claim, not decoration.
+    # Stockholm (aws-eu-north-1) is deliberately absent: it replicates the
+    # AWS-EU database but has no compute yet.
+    external_live_regions: str = "aws-eu-west-1,azure-australiaeast"
     primary_region: str = "us-central1"
     regional_api_hostname_template: str = "api-{region}.quillrouter.com"
     synthetic_monitor_region: str | None = None

--- a/src/trusted_router/regions.py
+++ b/src/trusted_router/regions.py
@@ -52,8 +52,26 @@ GCP_REGION_GEO: dict[str, RegionGeo] = {
 
 
 def _lookup_region_geo(region: str) -> RegionGeo | None:
-    """Return geo info for a configured GCP region."""
-    return GCP_REGION_GEO.get(region)
+    """Return geo info for a configured region on any cloud."""
+    return GCP_REGION_GEO.get(region) or MULTICLOUD_REGION_GEO.get(region)
+
+
+# Standalone deployments on other clouds. These are SEPARATE TrustedRouter
+# products — own database, own credits, own status page (see
+# docs/storage-portability/multi-cloud-separation.md) — so their ids are
+# namespaced by cloud rather than pretending to be GCP regions. A dot here
+# must correspond to a deployment that actually serves; the live/staged
+# split is settings.external_live_regions, not this table.
+MULTICLOUD_REGION_GEO: dict[str, RegionGeo] = {
+    "aws-eu-west-1": RegionGeo("aws-eu-west-1", "Dublin", 53.349, -6.260, cloud="aws"),
+    # Stockholm is the DSQL replication peer of the AWS-EU deployment. It
+    # holds live data but no compute yet, so it defaults to "staged" on the
+    # map until compute lands there.
+    "aws-eu-north-1": RegionGeo("aws-eu-north-1", "Stockholm", 59.329, 18.068, cloud="aws"),
+    "azure-australiaeast": RegionGeo(
+        "azure-australiaeast", "Sydney", -33.868, 151.209, cloud="azure"
+    ),
+}
 
 
 def configured_regions(settings: Settings) -> list[str]:
@@ -148,6 +166,16 @@ def region_map_payload(settings: Settings) -> list[dict[str, Any]]:
     intentionally trivial so unit tests can re-derive it."""
     primary = choose_region(settings)
     serving_regions = set(configured_regions(settings))
+    # Standalone deployments on other clouds serve their own traffic, so the
+    # GCP serving list can't know about them. They are declared live
+    # explicitly — and must only be listed once their own smoke
+    # (scripts/deploy/verify_deployment.sh) passes, because this flag is the
+    # difference between a "live" and a "staged" dot on the marketing page.
+    serving_regions |= {
+        item.strip()
+        for item in settings.external_live_regions.split(",")
+        if item.strip()
+    }
     out: list[dict[str, Any]] = []
     for region in configured_marketing_regions(settings):
         geo = _lookup_region_geo(region)

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -234,14 +234,14 @@ response = client.chat.completions.create(
               {% for region in map_regions %}
               <g class="region-dot {% if region.primary %}primary{% endif %} {% if region.serving %}live{% else %}edge{% endif %}" transform="translate({{ '%.1f'|format(region.x) }} {{ '%.1f'|format(region.y) }})">
                 <circle r="{% if region.primary %}9{% else %}7{% endif %}"></circle>
-                <text x="12" y="-8">{{ region.city }}</text>
+                <text x="12" y="-8">{{ region.city }}{% if region.cloud == "aws" %} · AWS{% elif region.cloud == "azure" %} · Azure{% endif %}</text>
               </g>
               {% endfor %}
             </svg>
           </div>
           <div class="region-map-copy">
-            <strong>{{ map_regions|length }} region footprint</strong>
-            <span>{{ api_region_count }} live regions with additional capacity staged.</span>
+            <strong>{{ map_regions|length }} regions across three clouds</strong>
+            <span>{{ api_region_count }} live GCP regions, plus standalone EU (AWS) and APAC (Azure) deployments. Additional capacity staged.</span>
           </div>
         </div>
       </div>

--- a/tests/test_region_map_projection.py
+++ b/tests/test_region_map_projection.py
@@ -94,7 +94,8 @@ def test_default_region_map_shows_gcp_region_marketing_footprint() -> None:
     settings = Settings(environment="local", regions="us-central1,europe-west4")
     rendered = region_map_payload(settings)
 
-    assert [r["id"] for r in rendered] == [
+    gcp = [r for r in rendered if r["cloud"] == "gcp"]
+    assert [r["id"] for r in gcp] == [
         "us-central1",
         "europe-west4",
         "us-east4",
@@ -103,8 +104,8 @@ def test_default_region_map_shows_gcp_region_marketing_footprint() -> None:
         "asia-southeast1",
         "southamerica-east1",
     ]
-    assert [r["status_label"] for r in rendered[:2]] == ["live", "live"]
-    assert all(r["status_label"] == "edge" for r in rendered[2:])
+    assert [r["status_label"] for r in gcp[:2]] == ["live", "live"]
+    assert all(r["status_label"] == "edge" for r in gcp[2:])
     assert next(r for r in rendered if r["id"] == "asia-east2")["city"] == "Hong Kong"
 
 
@@ -139,3 +140,31 @@ def test_region_map_payload_orders_primary_first() -> None:
     rendered = region_map_payload(settings)
     if rendered:
         assert rendered[0]["id"] == settings.primary_region
+
+
+def test_map_shows_multicloud_deployments_with_honest_serving_flags() -> None:
+    """The marketing map now carries the standalone AWS and Azure deployments.
+
+    The serving flag is a factual claim — external_live_regions must only list
+    deployments whose own smoke passes — so this pins the shipped default:
+    Dublin and Sydney live, Stockholm (database peer, no compute) staged.
+    """
+    settings = Settings(environment="local")
+    rows = {row["id"]: row for row in region_map_payload(settings)}
+
+    assert rows["aws-eu-west-1"]["city"] == "Dublin"
+    assert rows["aws-eu-west-1"]["cloud"] == "aws"
+    assert rows["aws-eu-west-1"]["serving"] is True
+
+    assert rows["azure-australiaeast"]["cloud"] == "azure"
+    assert rows["azure-australiaeast"]["serving"] is True
+
+    # Stockholm replicates the AWS-EU database but has no compute yet. If this
+    # assertion starts failing because someone flipped it live, that flip must
+    # come with compute actually serving there.
+    assert rows["aws-eu-north-1"]["serving"] is False
+
+    # No duplicate cities on the map (Joseph's rule): the Azure Sydney entry
+    # must not coexist with GCP's australia-southeast1 Sydney dot.
+    cities = [row["city"] for row in region_map_payload(settings)]
+    assert len(cities) == len(set(cities)), f"duplicate city dots: {cities}"


### PR DESCRIPTION
The map was GCP-only. `RegionGeo` already carried a `cloud` field marked *"for future portability"*, so this fills it in rather than inventing a parallel mechanism.

## What renders now

**Dublin · Stockholm · Sydney** alongside the GCP dots, each labelled with its cloud — which matters, because credits do not move between deployments and a reader should be able to tell which one a city belongs to.

Ids are namespaced by cloud (`aws-eu-west-1`, `azure-australiaeast`) because these are **standalone deployments** — own database, own credits, own status page — not GCP regions wearing a different hat.

## The serving flag is a factual claim

GCP's own serving list cannot know about other clouds, so non-GCP deployments are declared live explicitly via `external_live_regions`. **An entry there means that deployment's own smoke passes** (`verify_deployment.sh --expect-monitor`).

- **Dublin — live.** 6/6 today.
- **Sydney — live.** 6/6 today.
- **Stockholm — staged, deliberately.** It replicates the AWS-EU database but has no compute yet. A test pins this, so flipping it live requires compute actually serving there.

A second test pins that no two dots share a city.

## Not claimed

Neither new deployment serves inference (`reserve`/`settle`/`refund` are still stubs), and neither has a TEE yet — so nothing here implies attested routing outside GCP.