### PR TITLE
Bound control-plane runtime caches

### DIFF
--- a/scripts/deploy/gateway-alerts/control-plane-memory.yaml
+++ b/scripts/deploy/gateway-alerts/control-plane-memory.yaml
@@ -1,0 +1,31 @@
+displayName: "TR Control Plane: memory pressure"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    A TrustedRouter control-plane instance has used more than 80 percent of
+    its configured memory for five minutes. Inspect the affected region,
+    in-process cache cardinality, background queues, and recent deploys before
+    the instance reaches its hard Cloud Run memory limit.
+conditions:
+  - displayName: "Cloud Run memory above 80 percent for 5 minutes"
+    conditionThreshold:
+      filter: 'resource.type = "cloud_run_revision" AND resource.labels.service_name = "trusted-router" AND metric.type = "run.googleapis.com/container/memory/utilizations"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_MAX
+          crossSeriesReducer: REDUCE_MAX
+          groupByFields:
+            - resource.label.location
+      comparison: COMPARISON_GT
+      thresholdValue: 0.8
+      duration: 300s
+      evaluationMissingData: EVALUATION_MISSING_DATA_INACTIVE
+      trigger:
+        count: 1
+alertStrategy:
+  autoClose: 1800s
+  notificationPrompts:
+    - OPENED
+    - CLOSED

--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -3,7 +3,9 @@ prompt content."""
 
 from __future__ import annotations
 
+import threading
 import time
+from collections import OrderedDict
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query
@@ -24,7 +26,55 @@ USAGE_RANGE_PRESETS: dict[str, tuple[int, str]] = {
     "90d": (129600, "day"),
 }
 _UsageCacheKey = tuple[str, str, bool, str | None]
-_USAGE_CACHE: dict[_UsageCacheKey, tuple[float, dict[str, Any]]] = {}
+_USAGE_CACHE_MAX_ENTRIES = 256
+
+
+class _UsageCache:
+    """Small bounded TTL cache for expensive console usage queries."""
+
+    def __init__(self, *, max_entries: int = _USAGE_CACHE_MAX_ENTRIES) -> None:
+        if max_entries < 1:
+            raise ValueError("usage cache max_entries must be positive")
+        self._max_entries = max_entries
+        self._entries: OrderedDict[
+            _UsageCacheKey, tuple[float, dict[str, Any]]
+        ] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: _UsageCacheKey, *, now: float) -> dict[str, Any] | None:
+        with self._lock:
+            cached = self._entries.get(key)
+            if cached is None:
+                return None
+            if cached[0] <= now:
+                self._entries.pop(key, None)
+                return None
+            self._entries.move_to_end(key)
+            return cached[1]
+
+    def put(
+        self,
+        key: _UsageCacheKey,
+        value: dict[str, Any],
+        *,
+        expires_at: float,
+    ) -> None:
+        with self._lock:
+            self._entries[key] = (expires_at, value)
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+_USAGE_CACHE = _UsageCache()
 
 
 def register(app: FastAPI) -> None:
@@ -61,9 +111,9 @@ def register(app: FastAPI) -> None:
             api_key_hash,
         )
         now = time.monotonic()
-        cached = _USAGE_CACHE.get(cache_key)
-        if cached is not None and cached[0] > now:
-            return cached[1]
+        cached = _USAGE_CACHE.get(cache_key, now=now)
+        if cached is not None:
+            return cached
         result = STORE.usage_series(
             ctx.workspace.id,
             window_minutes=window_minutes,
@@ -81,5 +131,9 @@ def register(app: FastAPI) -> None:
         result["latest_activity_at"] = latest[0].get("created_at") if latest else None
         # A shared cache (Redis) is deferred; this per-worker TTL covers
         # occasional console reads and protects Bigtable from refresh bursts.
-        _USAGE_CACHE[cache_key] = (now + _USAGE_CACHE_TTL_SECONDS, result)
+        _USAGE_CACHE.put(
+            cache_key,
+            result,
+            expires_at=now + _USAGE_CACHE_TTL_SECONDS,
+        )
         return result

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -7,6 +7,7 @@ import logging
 import re
 import threading
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -116,6 +117,8 @@ STATUS_MONTH_ROLLUP_LIMIT = 50
 STATUS_ROLLUP_RETENTION_MONTHS = 24
 STATUS_RESPONSE_CACHE_SECONDS = 60
 STATUS_RESPONSE_STALE_SECONDS = 600
+PUBLIC_RESPONSE_CACHE_MAX_ENTRIES = 32
+PUBLIC_RESPONSE_REFRESH_MAX_THREADS = 2
 STATUS_HISTORY_CACHE_SECONDS = 300
 STATUS_HISTORY_STALE_SECONDS = 1_800
 LEADERBOARD_SAMPLE_LIMIT = PUBLIC_BENCHMARK_SAMPLE_LIMIT
@@ -135,9 +138,12 @@ INDEXNOW_KEY = "360a02e48445d297f9612a4c3fef878b"
 _STATUS_CACHE: tuple[float, dict[str, Any]] | None = None
 _LEADERBOARD_CACHE: tuple[float, dict[str, Any]] | None = None
 _APPS_CACHE: tuple[float, dict[str, Any]] | None = None
-_STATUS_RESPONSE_CACHE: dict[str, _CachedPublicBody] = {}
+_STATUS_RESPONSE_CACHE: OrderedDict[str, _CachedPublicBody] = OrderedDict()
 _STATUS_RESPONSE_REFRESHING: set[str] = set()
 _STATUS_RESPONSE_CACHE_LOCK = threading.RLock()
+_STATUS_RESPONSE_REFRESH_SLOTS = threading.BoundedSemaphore(
+    PUBLIC_RESPONSE_REFRESH_MAX_THREADS
+)
 
 
 @dataclass(frozen=True)
@@ -187,7 +193,8 @@ if not _leads_log.handlers:
 # form. Not a substitute for an edge WAF, but enough to blunt casual abuse of
 # an unauthenticated POST that fans out to email. Keyed by client IP.
 _INQUIRY_RATE_LOCK = threading.Lock()
-_INQUIRY_HITS: dict[str, list[float]] = {}
+_INQUIRY_MAX_CLIENTS = 4096
+_INQUIRY_HITS: OrderedDict[str, list[float]] = OrderedDict()
 _INQUIRY_WINDOW_SECONDS = 3600.0
 _INQUIRY_MAX_PER_WINDOW = 5
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
@@ -200,14 +207,28 @@ def _inquiry_rate_ok(client_ip: str, *, now: float | None = None) -> bool:
         hits = [t for t in _INQUIRY_HITS.get(client_ip, ()) if t > cutoff]
         if len(hits) >= _INQUIRY_MAX_PER_WINDOW:
             _INQUIRY_HITS[client_ip] = hits
+            _INQUIRY_HITS.move_to_end(client_ip)
+            _bound_inquiry_clients(cutoff)
             return False
         hits.append(now)
         _INQUIRY_HITS[client_ip] = hits
-        # Opportunistic cleanup so the dict can't grow unbounded.
-        if len(_INQUIRY_HITS) > 4096:
-            for key in [k for k, v in _INQUIRY_HITS.items() if not any(t > cutoff for t in v)]:
-                _INQUIRY_HITS.pop(key, None)
+        _INQUIRY_HITS.move_to_end(client_ip)
+        _bound_inquiry_clients(cutoff)
     return True
+
+
+def _bound_inquiry_clients(cutoff: float) -> None:
+    if len(_INQUIRY_HITS) <= _INQUIRY_MAX_CLIENTS:
+        return
+    stale = [
+        key
+        for key, hits in _INQUIRY_HITS.items()
+        if not any(hit > cutoff for hit in hits)
+    ]
+    for key in stale:
+        _INQUIRY_HITS.pop(key, None)
+    while len(_INQUIRY_HITS) > _INQUIRY_MAX_CLIENTS:
+        _INQUIRY_HITS.popitem(last=False)
 
 
 async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSONResponse:
@@ -908,9 +929,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @public_html_route("/leaderboard")
     async def leaderboard_page(request: Request, background_tasks: BackgroundTasks) -> Response:
+        _ = request
         return _cached_public_response(
             settings,
-            key=f"leaderboard:page:{request.headers.get('host', '')}",
+            key="leaderboard:page",
             media_type="text/html",
             ttl_seconds=LEADERBOARD_RESPONSE_CACHE_SECONDS,
             stale_seconds=LEADERBOARD_RESPONSE_STALE_SECONDS,
@@ -959,16 +981,17 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 background_tasks=background_tasks,
                 build=lambda: _json_body({"data": _status_history_payload(window)}),
             )
+        render_host = _status_render_host(settings, request.headers.get("host", ""))
         return _cached_public_response(
             settings,
-            key=f"status:history:{window}:html:{request.headers.get('host', '')}",
+            key=f"status:history:{window}:html:{render_host}",
             media_type="text/html",
             ttl_seconds=STATUS_HISTORY_CACHE_SECONDS,
             stale_seconds=STATUS_HISTORY_STALE_SECONDS,
             background_tasks=background_tasks,
             build=lambda: _status_history_page_html(
                 settings,
-                host=request.headers.get("host", ""),
+                host=render_host,
                 window=window,
                 history=_status_history_payload(window),
             ).encode(),
@@ -1151,15 +1174,24 @@ def _cached_status_page_response(
     host: str,
     background_tasks: BackgroundTasks,
 ) -> Response:
+    render_host = _status_render_host(settings, host)
     return _cached_public_response(
         settings,
-        key=f"status:page:{host}",
+        key=f"status:page:{render_host}",
         media_type="text/html",
         ttl_seconds=STATUS_RESPONSE_CACHE_SECONDS,
         stale_seconds=STATUS_RESPONSE_STALE_SECONDS,
         background_tasks=background_tasks,
-        build=lambda: _status_page_html(settings, host=host).encode(),
+        build=lambda: _status_page_html(settings, host=render_host).encode(),
     )
+
+
+def _status_render_host(settings: Settings, host: str) -> str:
+    """Collapse arbitrary Host headers to the two rendered page variants."""
+    hostname = host.partition(":")[0].strip().lower()
+    if hostname == "status.trustedrouter.com":
+        return hostname
+    return settings.trusted_domain
 
 
 def _cached_public_response(
@@ -1186,8 +1218,10 @@ def _cached_public_response(
         if cached is not None:
             age = now - cached.cached_at
             if age < ttl_seconds:
+                _STATUS_RESPONSE_CACHE.move_to_end(key)
                 return _cached_body_response(cached, cache_state="hit")
             if age < ttl_seconds + stale_seconds:
+                _STATUS_RESPONSE_CACHE.move_to_end(key)
                 _schedule_cached_response_refresh(
                     key=key,
                     media_type=media_type,
@@ -1206,6 +1240,9 @@ def _cached_public_response(
     )
     with _STATUS_RESPONSE_CACHE_LOCK:
         _STATUS_RESPONSE_CACHE[key] = cached
+        _STATUS_RESPONSE_CACHE.move_to_end(key)
+        while len(_STATUS_RESPONSE_CACHE) > PUBLIC_RESPONSE_CACHE_MAX_ENTRIES:
+            _STATUS_RESPONSE_CACHE.popitem(last=False)
     return _cached_body_response(cached, cache_state="miss")
 
 
@@ -1221,13 +1258,21 @@ def _schedule_cached_response_refresh(
     with _STATUS_RESPONSE_CACHE_LOCK:
         if key in _STATUS_RESPONSE_REFRESHING:
             return
+        if not _STATUS_RESPONSE_REFRESH_SLOTS.acquire(blocking=False):
+            return
         _STATUS_RESPONSE_REFRESHING.add(key)
     refresh_thread = threading.Thread(
         target=_refresh_cached_response,
         args=(key, media_type, cache_control, build),
         daemon=True,
     )
-    refresh_thread.start()
+    try:
+        refresh_thread.start()
+    except Exception:
+        with _STATUS_RESPONSE_CACHE_LOCK:
+            _STATUS_RESPONSE_REFRESHING.discard(key)
+        _STATUS_RESPONSE_REFRESH_SLOTS.release()
+        raise
 
 
 def _refresh_cached_response(
@@ -1245,9 +1290,15 @@ def _refresh_cached_response(
                 media_type=media_type,
                 cache_control=cache_control,
             )
+            _STATUS_RESPONSE_CACHE.move_to_end(key)
+            while len(_STATUS_RESPONSE_CACHE) > PUBLIC_RESPONSE_CACHE_MAX_ENTRIES:
+                _STATUS_RESPONSE_CACHE.popitem(last=False)
+    except Exception:
+        log.exception("public_cache_refresh_failed key=%s", key)
     finally:
         with _STATUS_RESPONSE_CACHE_LOCK:
             _STATUS_RESPONSE_REFRESHING.discard(key)
+        _STATUS_RESPONSE_REFRESH_SLOTS.release()
 
 
 def _cached_body_response(cached: _CachedPublicBody, *, cache_state: str) -> Response:

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -139,6 +139,22 @@ def _trustedos_payload(*, company: str, message: str) -> dict[str, str]:
     }
 
 
+def test_trustedos_inquiry_rate_state_has_a_hard_client_bound() -> None:
+    with public_routes._INQUIRY_RATE_LOCK:
+        public_routes._INQUIRY_HITS.clear()
+    try:
+        for index in range(public_routes._INQUIRY_MAX_CLIENTS + 1):
+            client_ip = f"198.51.{index // 256}.{index % 256}"
+            assert public_routes._inquiry_rate_ok(client_ip, now=100.0)
+
+        with public_routes._INQUIRY_RATE_LOCK:
+            assert len(public_routes._INQUIRY_HITS) == public_routes._INQUIRY_MAX_CLIENTS
+            assert "198.51.0.0" not in public_routes._INQUIRY_HITS
+    finally:
+        with public_routes._INQUIRY_RATE_LOCK:
+            public_routes._INQUIRY_HITS.clear()
+
+
 def _scrubbed_trustedos_messages(
     caplog: pytest.LogCaptureFixture,
     event_name: str,

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -41,6 +41,22 @@ def test_gateway_pressure_alert_only_tracks_the_billing_path() -> None:
     assert "duration: 600s" in original
 
 
+def test_control_plane_memory_alert_warns_before_oom() -> None:
+    policy = (DEPLOY / "gateway-alerts" / "control-plane-memory.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'displayName: "TR Control Plane: memory pressure"' in policy
+    assert 'resource.labels.service_name = "trusted-router"' in policy
+    assert 'metric.type = "run.googleapis.com/container/memory/utilizations"' in policy
+    assert "perSeriesAligner: ALIGN_MAX" in policy
+    assert "crossSeriesReducer: REDUCE_MAX" in policy
+    assert "resource.label.location" in policy
+    assert "thresholdValue: 0.8" in policy
+    assert "duration: 300s" in policy
+    assert "EVALUATION_MISSING_DATA_INACTIVE" in policy
+
+
 def test_gateway_alert_deploy_is_idempotent_and_dry_run_by_default() -> None:
     script = (DEPLOY / "gateway_reliability.sh").read_text(encoding="utf-8")
 

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -5,6 +5,7 @@ import base64
 import datetime as dt
 import json
 import random
+import threading
 import time
 from dataclasses import asdict
 from pathlib import Path
@@ -295,6 +296,105 @@ def test_public_status_response_cache_reuses_rendered_body() -> None:
     assert second.body == b"payload-1"
     assert second.headers["x-tr-cache"] == "hit"
     assert calls == 1
+
+
+def test_public_response_cache_is_bounded() -> None:
+    import trusted_router.routes.public as public_routes
+
+    with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+        public_routes._STATUS_RESPONSE_CACHE.clear()
+        public_routes._STATUS_RESPONSE_REFRESHING.clear()
+    try:
+        for index in range(public_routes.PUBLIC_RESPONSE_CACHE_MAX_ENTRIES + 5):
+            public_routes._cached_public_response(
+                Settings(environment="local"),
+                key=f"bounded-cache-{index}",
+                media_type="application/json",
+                ttl_seconds=60,
+                stale_seconds=300,
+                background_tasks=BackgroundTasks(),
+                build=lambda index=index: f"payload-{index}".encode(),
+            )
+
+        with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+            assert (
+                len(public_routes._STATUS_RESPONSE_CACHE)
+                == public_routes.PUBLIC_RESPONSE_CACHE_MAX_ENTRIES
+            )
+            assert "bounded-cache-0" not in public_routes._STATUS_RESPONSE_CACHE
+            assert (
+                f"bounded-cache-{public_routes.PUBLIC_RESPONSE_CACHE_MAX_ENTRIES + 4}"
+                in public_routes._STATUS_RESPONSE_CACHE
+            )
+    finally:
+        with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+            public_routes._STATUS_RESPONSE_CACHE.clear()
+            public_routes._STATUS_RESPONSE_REFRESHING.clear()
+
+
+def test_status_cache_host_collapses_untrusted_host_headers() -> None:
+    import trusted_router.routes.public as public_routes
+
+    settings = Settings(environment="local", trusted_domain="trustedrouter.com")
+
+    assert (
+        public_routes._status_render_host(settings, "STATUS.TRUSTEDROUTER.COM:443")
+        == "status.trustedrouter.com"
+    )
+    assert (
+        public_routes._status_render_host(settings, "attacker-controlled.example")
+        == "trustedrouter.com"
+    )
+
+
+def test_stale_public_refreshes_are_concurrency_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trusted_router.routes.public as public_routes
+
+    started = threading.Event()
+    unblock = threading.Event()
+    finished = threading.Event()
+    monkeypatch.setattr(
+        public_routes,
+        "_STATUS_RESPONSE_REFRESH_SLOTS",
+        threading.BoundedSemaphore(1),
+    )
+
+    def blocking_build() -> bytes:
+        started.set()
+        assert unblock.wait(timeout=2)
+        finished.set()
+        return b"refreshed"
+
+    public_routes._schedule_cached_response_refresh(
+        key="refresh-first",
+        media_type="text/plain",
+        cache_control="public, max-age=1",
+        build=blocking_build,
+        background_tasks=BackgroundTasks(),
+    )
+    assert started.wait(timeout=2)
+    public_routes._schedule_cached_response_refresh(
+        key="refresh-second",
+        media_type="text/plain",
+        cache_control="public, max-age=1",
+        build=lambda: b"should-not-run",
+        background_tasks=BackgroundTasks(),
+    )
+
+    with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+        assert public_routes._STATUS_RESPONSE_REFRESHING == {"refresh-first"}
+    unblock.set()
+    assert finished.wait(timeout=2)
+    for _ in range(100):
+        with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+            if not public_routes._STATUS_RESPONSE_REFRESHING:
+                break
+        time.sleep(0.01)
+    with public_routes._STATUS_RESPONSE_CACHE_LOCK:
+        assert not public_routes._STATUS_RESPONSE_REFRESHING
+        public_routes._STATUS_RESPONSE_CACHE.pop("refresh-first", None)
 
 
 def test_status_history_monthly_uses_public_rollups(client: TestClient) -> None:

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from tests.fakes.spanner import make_fake_store
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.routes.console.activity import _USAGE_CACHE
+from trusted_router.routes.console.activity import _USAGE_CACHE, _UsageCache
 from trusted_router.storage import STORE, Generation, InMemoryStore
 from trusted_router.storage_activity import summarize_activity, usage_bucket_key
 from trusted_router.storage_gcp_activity_index import usage_series, write_generation
@@ -542,6 +542,33 @@ def test_console_usage_series_endpoint_returns_json_and_uses_cache(
     assert first.json()["latest_activity_at"] is None
     assert first.json() == second.json()
     assert calls == [(workspace.id, 60, "minute", "key_a", True)]
+
+
+def test_console_usage_cache_is_bounded_and_evicts_lru() -> None:
+    cache = _UsageCache(max_entries=2)
+    first = ("ws-1", "1h", False, None)
+    second = ("ws-2", "1h", False, None)
+    third = ("ws-3", "1h", False, None)
+
+    cache.put(first, {"value": 1}, expires_at=100.0)
+    cache.put(second, {"value": 2}, expires_at=100.0)
+    assert cache.get(first, now=1.0) == {"value": 1}
+
+    cache.put(third, {"value": 3}, expires_at=100.0)
+
+    assert len(cache) == 2
+    assert cache.get(first, now=1.0) == {"value": 1}
+    assert cache.get(second, now=1.0) is None
+    assert cache.get(third, now=1.0) == {"value": 3}
+
+
+def test_console_usage_cache_removes_expired_entries() -> None:
+    cache = _UsageCache(max_entries=2)
+    key = ("ws-1", "30d", True, "key-hash")
+    cache.put(key, {"value": 1}, expires_at=10.0)
+
+    assert cache.get(key, now=10.0) is None
+    assert len(cache) == 0
 
 
 def test_console_usage_series_empty_window_reports_latest_activity(


### PR DESCRIPTION
Bounds high-cardinality in-process caches and stale refresh concurrency. Collapses untrusted Host variants, hard-bounds inquiry rate-limit state, and adds LRU/TTL/concurrency regression coverage. Adds a regional Cloud Run memory-pressure alert at 80% for five minutes.\n\nValidated locally: ruff, mypy, 2276 tests passed (86 skipped), plus alert-policy tests and YAML parsing. The policy is committed but the configured service accounts lack monitoring policy write permission, so its one-time production creation still requires an IAM-capable operator identity.