### PR TITLE
storage: reserve/settle/refund on PostgresStore — the inference gate

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -166,6 +166,11 @@ def _aws_dsql_token_provider(hostname: str, region: str) -> Callable[[], str]:
     return generate_token
 
 
+_RESERVATION_KIND = "reservation"
+_RESERVATION_IDEMPOTENCY_KIND = "reservation_idempotency"
+_RESERVATION_FINALIZATION_KIND = "reservation_finalization"
+
+
 def _split_sql_statements(schema: str) -> list[str]:
     """Split a schema file into statements, ignoring semicolons in comments.
 
@@ -1510,17 +1515,125 @@ class PostgresStore:
         *,
         idempotency_key: str | None = None,
     ) -> Reservation:
-        self._not_implemented("reserve")
+        reservation = Reservation(
+            id=str(uuid.uuid4()),
+            workspace_id=workspace_id,
+            key_hash=key_hash,
+            amount_microdollars=int(amount_microdollars),
+            idempotency_key=idempotency_key,
+        )
+
+        def reserve_credit(conn: Any) -> Reservation:
+            if idempotency_key is not None:
+                won = self._insert_entity_once_tx(
+                    conn,
+                    _RESERVATION_IDEMPOTENCY_KIND,
+                    idempotency_key,
+                    reservation,
+                )
+                if not won:
+                    existing = self._read_entity_tx(
+                        conn,
+                        _RESERVATION_IDEMPOTENCY_KIND,
+                        idempotency_key,
+                        Reservation,
+                    )
+                    if existing is None:
+                        raise RuntimeError(
+                            "reservation idempotency row disappeared after conflict"
+                        )
+                    return existing
+
+            inserted = self._insert_entity_once_tx(
+                conn,
+                _RESERVATION_KIND,
+                reservation.id,
+                reservation,
+            )
+            if not inserted:
+                raise RuntimeError("reservation id collision")
+
+            cursor = conn.execute(
+                "UPDATE tr_credit_balance "
+                "SET reserved = reserved + %s, updated_at = CURRENT_TIMESTAMP "
+                "WHERE workspace_id = %s AND shard = 0 "
+                "AND total_credits - total_usage - reserved >= %s",
+                (
+                    reservation.amount_microdollars,
+                    workspace_id,
+                    reservation.amount_microdollars,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("insufficient credits")
+            return reservation
+
+        return self._run_transaction(reserve_credit)
 
     def settle(
         self,
         reservation_id: str,
         actual_microdollars: int,
     ) -> None:
-        self._not_implemented("settle")
+        self._finalize_reservation(
+            reservation_id,
+            actual_microdollars=int(actual_microdollars),
+            operation="settle",
+        )
 
     def refund(self, reservation_id: str) -> None:
-        self._not_implemented("refund")
+        self._finalize_reservation(
+            reservation_id,
+            actual_microdollars=0,
+            operation="refund",
+        )
+
+    def _finalize_reservation(
+        self,
+        reservation_id: str,
+        *,
+        actual_microdollars: int,
+        operation: str,
+    ) -> None:
+        def finalize(conn: Any) -> None:
+            reservation = self._read_entity_tx(
+                conn,
+                _RESERVATION_KIND,
+                reservation_id,
+                Reservation,
+            )
+            if reservation is None:
+                raise KeyError(reservation_id)
+
+            won = self._insert_entity_once_tx(
+                conn,
+                _RESERVATION_FINALIZATION_KIND,
+                reservation_id,
+                {
+                    "actual_microdollars": actual_microdollars,
+                    "operation": operation,
+                },
+            )
+            if not won:
+                return
+
+            cursor = conn.execute(
+                "UPDATE tr_credit_balance "
+                "SET reserved = reserved - %s, "
+                "total_usage = total_usage + %s, "
+                "updated_at = CURRENT_TIMESTAMP "
+                "WHERE workspace_id = %s AND shard = 0 AND reserved >= %s",
+                (
+                    reservation.amount_microdollars,
+                    actual_microdollars,
+                    reservation.workspace_id,
+                    reservation.amount_microdollars,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("reservation release row-count != 1")
+
+        self._run_transaction(finalize)
 
     def update_auto_refill_settings(
         self,

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -13,25 +13,22 @@ conformance test and fails these.
 
 Known limits of this suite — read before trusting it
 ----------------------------------------------------
-* **Sequential, not concurrent.** "Single use" is really a claim about an
-  atomic take, and these tests exercise it one caller at a time. A backend
-  that implements consume as a non-atomic read-then-write would pass here and
-  still double-redeem under two concurrent callers. Concurrent conformance
-  needs real backends (an emulator or container), so it lands with that
-  wiring rather than being faked against the in-memory store.
-* **Credit is asserted through its return contract, not a balance.** The
-  `Store` protocol exposes no backend-neutral balance read: `CreditAccount`
+* Most single-use-secret tests are sequential. Credit reservation is the
+  exception: its oversubscription test uses real threads against the same
+  store, which means separate pooled connections on server-backed backends.
+* The `Store` protocol exposes no backend-neutral balance read: `CreditAccount`
   became metadata-only, and the money snapshot lives on backend-specific
-  methods (`credit_money_snapshot`, `typed_credit_snapshot`). So a backend
-  that returns `(True, False)` while crediting the wrong amount would pass.
-  Closing that hole means putting a neutral money read on the protocol — a
-  real portability gap, tracked in docs/storage-portability/README.md rather
-  than papered over here.
+  methods (`credit_money_snapshot`, `typed_credit_snapshot`). The reservation
+  tests therefore assert balances through observable capacity: reserve the
+  exact expected remainder, then prove one more microdollar is rejected.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import threading
+
+import pytest
 
 from trusted_router.store_protocol import Store
 
@@ -70,6 +67,161 @@ def test_credit_workspace_once_distinguishes_events(
     assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-A") is True
     assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-A") is False
     assert store.credit_workspace_once(workspace_id, 5_000, f"evt-{unique}-B") is True
+
+
+def _credit_and_key(
+    store: Store,
+    workspace_id: str,
+    unique: str,
+    amount_microdollars: int,
+) -> str:
+    assert store.credit_workspace_once(
+        workspace_id,
+        amount_microdollars,
+        f"evt-reservation-{unique}",
+    ) is True
+    _raw_key, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name=f"reservation-{unique}",
+        creator_user_id=None,
+    )
+    return key.hash
+
+
+def _assert_exact_available_capacity(
+    store: Store,
+    workspace_id: str,
+    key_hash: str,
+    amount_microdollars: int,
+    unique: str,
+) -> None:
+    store.reserve(
+        workspace_id,
+        key_hash,
+        amount_microdollars,
+        idempotency_key=f"capacity-{unique}",
+    )
+    with pytest.raises(ValueError, match="insufficient credits"):
+        store.reserve(workspace_id, key_hash, 1)
+
+
+def test_reserve_then_settle_less_releases_unused_hold(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """A 60 microdollar hold settled at 20 leaves exactly 80 of 100."""
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    reservation = store.reserve(workspace_id, key_hash, 60)
+
+    store.settle(reservation.id, 20)
+
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 80, unique)
+
+
+def test_reserve_then_settle_more_books_full_actual(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """Settlement may exceed the hold and can make available credit negative."""
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    reservation = store.reserve(workspace_id, key_hash, 60)
+
+    store.settle(reservation.id, 120)
+
+    # Correct state is credits=100, usage=120, reserved=0: a 20 top-up only
+    # reaches zero, and the next microdollar creates exactly one of capacity.
+    assert store.credit_workspace_once(
+        workspace_id, 20, f"evt-overage-zero-{unique}"
+    ) is True
+    with pytest.raises(ValueError, match="insufficient credits"):
+        store.reserve(workspace_id, key_hash, 1)
+    assert store.credit_workspace_once(
+        workspace_id, 1, f"evt-overage-positive-{unique}"
+    ) is True
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 1, unique)
+
+
+def test_reserve_then_refund_restores_exact_balance(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    reservation = store.reserve(workspace_id, key_hash, 60)
+
+    store.refund(reservation.id)
+
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 100, unique)
+
+
+def test_settle_is_idempotent(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """A replay releases and charges once, even after the first call returned."""
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    reservation = store.reserve(workspace_id, key_hash, 60)
+
+    store.settle(reservation.id, 20)
+    store.settle(reservation.id, 20)
+
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 80, unique)
+
+
+def test_refund_is_idempotent(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """A refund replay releases the recorded hold exactly once."""
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    reservation = store.reserve(workspace_id, key_hash, 60)
+
+    store.refund(reservation.id)
+    store.refund(reservation.id)
+
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 100, unique)
+
+
+def test_concurrent_reserves_cannot_oversubscribe(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """Two simultaneous full-balance holds cannot both pass the predicate."""
+    key_hash = _credit_and_key(store, workspace_id, unique, 100)
+    ready = threading.Barrier(3)
+    result_lock = threading.Lock()
+    reservations: list[object] = []
+    errors: list[Exception] = []
+
+    def reserve_once() -> None:
+        ready.wait()
+        try:
+            reservation = store.reserve(workspace_id, key_hash, 100)
+        except Exception as exc:
+            with result_lock:
+                errors.append(exc)
+        else:
+            with result_lock:
+                reservations.append(reservation)
+
+    threads = [threading.Thread(target=reserve_once) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    ready.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads), "reserve threads hung"
+    assert len(reservations) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert str(errors[0]) == "insufficient credits"
+    with pytest.raises(ValueError, match="insufficient credits"):
+        store.reserve(workspace_id, key_hash, 1)
+
+
+def test_insufficient_reserve_does_not_mutate_balance(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    key_hash = _credit_and_key(store, workspace_id, unique, 50)
+
+    with pytest.raises(ValueError, match="insufficient credits"):
+        store.reserve(workspace_id, key_hash, 51)
+
+    _assert_exact_available_capacity(store, workspace_id, key_hash, 50, unique)
 
 
 def test_record_sns_message_once_is_idempotent(store: Store, unique: str) -> None:


### PR DESCRIPTION
The gate for inference on every non-GCP cloud. AWS-EU and Azure have been live control planes that could not route a single token, because these three methods raised `NotImplementedError`.

## Money rules, held

**No read-modify-write anywhere.** Reserve enforces sufficiency inside the `WHERE` clause of a conditional `UPDATE`, so `rowcount = 0` *means* "insufficient" — concurrent reserves are safe by construction, not by luck. Settle and refund share a finalization marker keyed on the reservation, so a replay after a crash charges or releases exactly once, and a settle racing a refund cannot double-release.

## Conformance: 24 semantics tests × 3 backends

Now pinned on `memory`, `postgres` and `spanner-pg`:

- settle under reserve releases the difference
- settle over reserve charges the actual amount — **matching both reference backends** rather than an invented rule
- refund restores exactly
- **settle is idempotent**; **refund is idempotent**
- insufficient reserve mutates nothing
- **two real threads racing one balance → exactly one reservation, one failure**

That last one is the test worth having and the easiest to fake. It spawns actual threads and asserts a single winner, rather than calling reserve twice in sequence and proving nothing.

## Verification

Written by codex-cli from a money-grade spec. Re-run here independently: **73 passed** across the three backends, ruff and mypy clean over 198 files.

Codex was straight that **Aurora DSQL and Citus were not verified** — running conformance against the live DSQL pair is the next step, not a claim made here. That matters: running it against real DSQL previously surfaced three incompatibilities that "Postgres-wire compatible" had hidden.