### PR TITLE
Run router test suite once in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,11 @@ jobs:
         run: npx eslint frontend/src
       - name: Stylelint
         run: npx stylelint "src/trusted_router/static/*.css"
-      - name: Tests
-        run: uv run pytest -q
-      - name: Coverage
-        run: uv run pytest --cov=trusted_router --cov-report=term-missing --cov-fail-under=70
+      # The coverage invocation executes the complete test suite. Running a
+      # separate plain pytest pass doubled CI time and delayed every guarded
+      # production rollout without checking any additional behavior.
+      - name: Tests and coverage
+        run: uv run pytest -q --cov=trusted_router --cov-report=term-missing --cov-fail-under=70
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
       - name: Browser smoke

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_runs_python_suite_once_with_coverage() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("uv run pytest") == 1
+    assert (
+        "uv run pytest -q --cov=trusted_router --cov-report=term-missing "
+        "--cov-fail-under=70"
+    ) in workflow


### PR DESCRIPTION
## Summary
- combine the complete pytest and coverage gates into one invocation
- preserve quiet output and the 70% coverage threshold
- add a regression test that prevents duplicate full-suite invocations

## Validation
- `ruff check tests/test_ci_workflow.py`
- `mypy tests/test_ci_workflow.py`
- `pytest -q tests/test_ci_workflow.py tests/test_refresh_workflow_dispatch.py` (4 passed)
- parsed `.github/workflows/ci.yml` with PyYAML

This is workflow-only and does not trigger a control-plane deployment.