### PR TITLE
Fix Google Data Manager quota project header

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -81,6 +81,10 @@ library. Its Cloud Run service identity requests only the
 2,000 events per request; TrustedRouter uses bounded 500-row batches and a
 five-minute schedule.
 
+REST uploads also send `x-goog-user-project` using `TR_GCP_PROJECT_ID`, as
+required by Google's Data Manager REST setup. The uploader service account
+must have `roles/serviceusage.serviceUsageConsumer` on that project.
+
 Delivery state is durable:
 
 - `pending`: eligible for a worker lease

--- a/src/trusted_router/services/google_data_manager.py
+++ b/src/trusted_router/services/google_data_manager.py
@@ -48,6 +48,7 @@ _NUMERIC_ID_RE = re.compile(r"^[0-9]+$")
 
 @dataclass(frozen=True)
 class GoogleDataManagerConfig:
+    project_id: str
     account_id: str
     signup_action_id: str
     activated_action_id: str
@@ -57,6 +58,7 @@ class GoogleDataManagerConfig:
     @classmethod
     def from_settings(cls, settings: Settings) -> GoogleDataManagerConfig:
         return cls(
+            project_id=settings.gcp_project_id.strip(),
             account_id=_numeric_id(
                 settings.google_data_manager_account_id,
                 "Google Ads account ID",
@@ -218,6 +220,7 @@ class GoogleDataManagerClient:
                     "Authorization": f"Bearer {self._token_provider()}",
                     "Content-Type": "application/json",
                     "User-Agent": "TrustedRouter-DataManager/1",
+                    "x-goog-user-project": self._config.project_id,
                 },
             )
         except GoogleDataManagerUploadError:

--- a/tests/test_google_data_manager.py
+++ b/tests/test_google_data_manager.py
@@ -41,6 +41,7 @@ def _now() -> str:
 
 def _config() -> GoogleDataManagerConfig:
     return GoogleDataManagerConfig(
+        project_id="test-project",
         account_id="1234567890",
         signup_action_id="111",
         activated_action_id="333",
@@ -52,6 +53,7 @@ def _config() -> GoogleDataManagerConfig:
 def _settings(**overrides: Any) -> Settings:
     values: dict[str, Any] = {
         "environment": "test",
+        "gcp_project_id": "test-project",
         "google_data_manager_enabled": True,
         "google_data_manager_account_id": "123-456-7890",
         "google_data_manager_signup_action_id": "111",
@@ -295,6 +297,7 @@ def test_raw_http_client_posts_to_data_manager_without_google_sdk() -> None:
     assert str(requests[0].url) == DATA_MANAGER_INGEST_URL
     assert requests[0].headers["authorization"] == "Bearer scoped-access-token"
     assert requests[0].headers["content-type"] == "application/json"
+    assert requests[0].headers["x-goog-user-project"] == "test-project"
 
 
 def test_metadata_identity_token_is_scoped_and_cached() -> None:


### PR DESCRIPTION
## Summary
- send the required x-goog-user-project header on Data Manager REST uploads
- derive the quota project from TR_GCP_PROJECT_ID
- add a regression assertion and document the IAM requirement

## Verification
- uv run pytest -q tests/test_google_data_manager.py (32 passed)
- uv run ruff check src/trusted_router/services/google_data_manager.py tests/test_google_data_manager.py
- uv run mypy

## Production impact
This fixes the authenticated HTTP 403 currently backing off signup, activation, and purchase conversion uploads. The durable queue retains all pending events.