### PR TITLE
Protect ClickHouse analytics disk from accidental deletion

### DIFF
--- a/scripts/deploy/clickhouse_node.sh
+++ b/scripts/deploy/clickhouse_node.sh
@@ -89,12 +89,23 @@ else
     --machine-type "$MACHINE" \
     --image-family debian-12 --image-project debian-cloud \
     --boot-disk-size "${DISK_GB}GB" --boot-disk-type "$DISK_TYPE" \
+    --no-boot-disk-auto-delete \
+    --deletion-protection \
     --tags tr-clickhouse \
     --no-address \
     --scopes https://www.googleapis.com/auth/cloud-platform \
     --metadata-from-file startup-script="$STARTUP_FILE" \
     --metadata ch-password="$PASSWORD"
 fi
+
+# Keep the analytics volume if an existing VM is accidentally deleted. The
+# explicit update also repairs nodes created before these flags were added.
+gcloud compute instances set-disk-auto-delete "$NAME" \
+  --project "$PROJECT" --zone "$ZONE" \
+  --disk "$NAME" --no-auto-delete
+gcloud compute instances update "$NAME" \
+  --project "$PROJECT" --zone "$ZONE" \
+  --deletion-protection
 
 log "done. tail provisioning with:"
 echo "  gcloud compute ssh $NAME --zone $ZONE --project $PROJECT --tunnel-through-iap --command 'sudo tail -f /var/log/tr-clickhouse-startup.log'"

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_clickhouse_node_preserves_disk_and_blocks_accidental_vm_deletion() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_node.sh").read_text()
+
+    assert "--no-boot-disk-auto-delete" in script
+    assert "set-disk-auto-delete" in script
+    assert "--no-auto-delete" in script
+    assert script.count("--deletion-protection") >= 2


### PR DESCRIPTION
## Summary
- create the ClickHouse node with VM deletion protection enabled
- keep its persistent boot and analytics disk if the VM is deleted
- repair both settings when the idempotent provisioning script is rerun
- add a regression test for the durability flags

## Production
Applied both settings in place to `tr-clickhouse-1`; the VM remained running.

## Verification
- `bash -n scripts/deploy/clickhouse_node.sh`
- `uv run ruff check tests/test_clickhouse_node_provisioning.py`
- `uv run pytest -q tests/test_clickhouse_node_provisioning.py`