### PR TITLE
Fix Cloud Run memory alert aggregation

### DIFF
--- a/scripts/deploy/gateway-alerts/control-plane-memory.yaml
+++ b/scripts/deploy/gateway-alerts/control-plane-memory.yaml
@@ -14,7 +14,9 @@ conditions:
       filter: 'resource.type = "cloud_run_revision" AND resource.labels.service_name = "trusted-router" AND metric.type = "run.googleapis.com/container/memory/utilizations"'
       aggregations:
         - alignmentPeriod: 60s
-          perSeriesAligner: ALIGN_MAX
+          # Cloud Run publishes this metric as a DELTA DISTRIBUTION. Reduce
+          # each minute to a scalar percentile before taking the regional max.
+          perSeriesAligner: ALIGN_PERCENTILE_99
           crossSeriesReducer: REDUCE_MAX
           groupByFields:
             - resource.label.location

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -49,7 +49,8 @@ def test_control_plane_memory_alert_warns_before_oom() -> None:
     assert 'displayName: "TR Control Plane: memory pressure"' in policy
     assert 'resource.labels.service_name = "trusted-router"' in policy
     assert 'metric.type = "run.googleapis.com/container/memory/utilizations"' in policy
-    assert "perSeriesAligner: ALIGN_MAX" in policy
+    assert "perSeriesAligner: ALIGN_PERCENTILE_99" in policy
+    assert "perSeriesAligner: ALIGN_MAX" not in policy
     assert "crossSeriesReducer: REDUCE_MAX" in policy
     assert "resource.label.location" in policy
     assert "thresholdValue: 0.8" in policy


### PR DESCRIPTION
## Summary
- use `ALIGN_PERCENTILE_99` for Cloud Run memory utilization, which is a DELTA DISTRIBUTION metric
- keep the regional max reduction and five-minute 80% threshold
- prevent regression to the invalid `ALIGN_MAX` configuration

## Root cause
GCP rejected the previously merged policy because `ALIGN_MAX` cannot align a distribution metric. The invalid policy therefore never existed in production.

## Verification
- `uv run ruff check tests/test_gateway_reliability_deploy.py`
- `uv run pytest -q tests/test_gateway_reliability_deploy.py` (5 passed)
- live `gcloud monitoring policies create` succeeded
- policy `17363841345491360096` is enabled with the verified `security@trustedrouter.com` channel