### PR TITLE
Fix leaderboard deadline metrics and synthetic blind spot

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -114,12 +114,19 @@ IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
 monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
+  regional_ingest_base="https://${SERVICE}-${PROJECT_NUMBER}.${monitor_region}.run.app"
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
   scheduler_name="${job_name}-every-five-minutes"
   legacy_scheduler_name="${job_name}-every-minute"
   env_vars=(
     "${BASE_ENV_VARS[@]}"
     "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}"
+    # Probe the public control-plane domain, but ingest through the regional
+    # Cloud Run URL. Otherwise an apex TLS/DNS incident prevents the monitor
+    # from recording the very failure it observed.
+    "TR_SYNTHETIC_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/samples"
+    "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/benchmark"
+    "TR_SYNTHETIC_ROUTE_HEALTH_URL=${regional_ingest_base}/v1/internal/synthetic/route-health"
     "TR_SYNTHETIC_BILLING_CONCURRENCY=2"
     "TR_SYNTHETIC_START_DELAY_SECONDS=$((monitor_index * 20))"
     # Short random provider/model probes feed uptime and TTFT. Sustained
@@ -168,6 +175,7 @@ done
 # has a separate Cloud Run Job so a slow 512-token stream cannot delay or
 # overlap TLS, attestation, billing, fallback, or short provider probes.
 throughput_region="us-central1"
+throughput_ingest_base="https://${SERVICE}-${PROJECT_NUMBER}.${throughput_region}.run.app"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
 throughput_scheduler_name="${throughput_job_name}-every-five-minutes"
 legacy_throughput_scheduler_names=(
@@ -177,6 +185,9 @@ legacy_throughput_scheduler_names=(
 throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
+  "TR_SYNTHETIC_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/benchmark"
+  "TR_SYNTHETIC_ROUTE_HEALTH_URL=${throughput_ingest_base}/v1/internal/synthetic/route-health"
   "TR_SYNTHETIC_BILLING_CONCURRENCY=1"
   "TR_SYNTHETIC_START_DELAY_SECONDS=45"
   "TR_SYNTHETIC_ROTATION_ENABLED=false"
@@ -230,11 +241,13 @@ done
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.
 image_region="us-central1"
+image_ingest_base="https://${SERVICE}-${PROJECT_NUMBER}.${image_region}.run.app"
 image_job_name="trusted-router-image-generation-${image_region}"
 image_scheduler_name="${image_job_name}-every-six-hours"
 image_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${image_region}"
+  "TR_SYNTHETIC_INGEST_URL=${image_ingest_base}/v1/internal/synthetic/samples"
   "TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"
   "TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"
   "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS=120"

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -418,11 +418,16 @@ def aggregate_leaderboard(
         if attribution.counts_toward_provider_availability:
             stats.provider_sample_count += 1
             stats.capacity_attempt_count += 1
-            stats.deadline_sample_count += 1
             if sample.status == "success":
                 stats.provider_success_count += 1
             if attribution.capacity_rejected:
                 stats.capacity_rejection_count += 1
+            # Failed provider attempts missed the first-token deadline even
+            # when no byte arrived. Successful non-streaming observations may
+            # not carry TTFT at all; excluding those unmeasured successes keeps
+            # the denominator honest instead of reporting them as late.
+            if sample.status != "success" or sample.first_token_milliseconds is not None:
+                stats.deadline_sample_count += 1
         if sample.first_token_milliseconds is not None:
             ttft[key].append(sample.first_token_milliseconds)
             provider_ttft[sample.provider].append(sample.first_token_milliseconds)

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -141,6 +141,24 @@ def test_failed_partial_stream_counts_once_against_first_token_deadline() -> Non
     assert model["availability_within_deadline"] == 0.5
 
 
+def test_success_without_ttft_is_not_counted_as_missed_deadline() -> None:
+    samples = [
+        _sample(provider="p", model="p/model", ttft=100),
+        _sample(
+            provider="p",
+            model="p/model",
+            ttft=None,
+            created_at="2026-06-04T00:00:01Z",
+        ),
+    ]
+
+    model = aggregate_leaderboard(samples)["models"][0]
+
+    assert model["provider_availability"] == 1
+    assert model["deadline_sample_count"] == 1
+    assert model["availability_within_deadline"] == 1
+
+
 def test_models_sorted_fastest_first_unmeasured_last() -> None:
     samples = [
         _sample(provider="slow", model="slow/m", ttft=500),

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2411,6 +2411,30 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"${throughput_job_name}-every-minute"' in body
     assert '"${throughput_job_name}-every-two-minutes"' in body
     assert 'image_job_name="trusted-router-image-generation-${image_region}"' in body
+    assert (
+        'regional_ingest_base="https://${SERVICE}-${PROJECT_NUMBER}.${monitor_region}.run.app"'
+        in body
+    )
+    assert (
+        '"TR_SYNTHETIC_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/samples"'
+        in body
+    )
+    assert (
+        '"TR_SYNTHETIC_BENCHMARK_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/benchmark"'
+        in body
+    )
+    assert (
+        '"TR_SYNTHETIC_ROUTE_HEALTH_URL=${regional_ingest_base}/v1/internal/synthetic/route-health"'
+        in body
+    )
+    assert (
+        '"TR_SYNTHETIC_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/samples"'
+        in body
+    )
+    assert (
+        '"TR_SYNTHETIC_INGEST_URL=${image_ingest_base}/v1/internal/synthetic/samples"'
+        in body
+    )
     assert '"TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"' in body
     assert '"TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"' in body
     assert '--args="-m,trusted_router.synthetic.image_generation"' in body


### PR DESCRIPTION
## Summary
- exclude successful requests without measured TTFT from the within-deadline denominator
- keep failed provider attempts in the deadline denominator
- ingest synthetic and benchmark results through each regional Cloud Run URL while continuing to probe the public domain
- preserve image and throughput ingestion during apex TLS/DNS failures

## Production evidence
- old apex certificate expired while bundled trust.trustedrouter.com validation was FAILED_NOT_VISIBLE
- replacement apex-only certificate is ACTIVE and attached
- during the certificate gap, probes could not upload failures because probe and ingest shared trustedrouter.com
- live OpenAI metric changes from the false 19.63% to 100% over 59 measured TTFT samples, with p95 TTFT 4.33s

## Validation
- `uv run ruff check ...`
- `uv run mypy`
- `uv run pytest -q`: 2290 passed, 86 skipped
- authenticated empty ingest checks returned 200 in us-central1 and europe-west4
- `bash -n scripts/deploy/synthetic.sh`