### PR TITLE
Measure gateway latency phases and lay dark quota-lease foundation

### DIFF
--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -1,0 +1,114 @@
+# Regional quota leases
+
+Status: **dark foundation, not production authority**
+
+The current typed Spanner counter path remains TrustedRouter's only prepaid
+billing authority. Regional quota leases are the planned way to remove a
+cross-continent Spanner transaction from first-token latency without changing
+the invariant that a workspace cannot spend more credit than it owns.
+
+## Safety model
+
+The global ledger grants a region a bounded amount of already-reserved credit.
+Creating a lease and increasing the workspace's global `reserved` total happen
+in one exact Spanner transaction. A region can authorize only against its local
+durable lease. The maximum unreconciled exposure is therefore the sum of active
+lease grants, which the global ledger has already removed from spendable
+balance.
+
+This is escrow, not an eventually consistent copy of account balance.
+
+Every lease has:
+
+- one workspace and one region;
+- a monotonically increasing fencing token;
+- an exact integer microdollar grant;
+- a short expiration;
+- durable reservation, settlement, and refund records;
+- `active`, `draining`, `closed`, or `quarantined` state.
+
+The regional ledger rejects stale fencing tokens, expired leases, duplicate
+request IDs with changed fingerprints, settlement above the exact reservation,
+and all work after drain begins. It fails closed if its durable store is
+unavailable. In-memory quota is never authoritative.
+
+## Intended flow
+
+1. A global Spanner transaction computes a bounded grant and adds that amount
+   to the workspace's exact global reserved counter.
+2. The signed lease is written to a durable regional ledger with its fencing
+   token. The gateway does not authorize from it until both records exist.
+3. Regional authorization reserves against the lease in one local transaction.
+4. Regional settlement or refund is idempotent and uses the same request ID.
+5. A reconciler drains the lease, imports settled spend to Spanner, releases the
+   unused global reservation, and closes the lease in one fenced operation.
+6. Ambiguous or inconsistent leases are quarantined. They are never guessed
+   back into service.
+
+## Initial eligibility
+
+The first pilot is limited to explicitly allowlisted workspaces using uncapped
+prepaid API keys. BYOK, capped keys, hard workspace budgets, custom billing
+arrangements, orchestration fan-out, and x402 funding stay on the exact global
+path until each has an explicit accounting proof.
+
+The grant is the minimum of:
+
+- requested regional capacity;
+- an operator-configured per-lease cap;
+- a small percentage of current globally available credit.
+
+All values are integer microdollars. No floating-point money enters this path.
+
+## Durable schema sketch
+
+The production implementation should use a regional strongly consistent store,
+not process memory. A representative schema is:
+
+```sql
+CREATE TABLE tr_regional_quota_lease (
+  lease_id STRING(64) NOT NULL,
+  workspace_id STRING(64) NOT NULL,
+  region STRING(32) NOT NULL,
+  fencing_token INT64 NOT NULL,
+  granted_micro INT64 NOT NULL,
+  state STRING(16) NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)
+) PRIMARY KEY (lease_id);
+
+CREATE TABLE tr_regional_quota_hold (
+  lease_id STRING(64) NOT NULL,
+  hold_id STRING(64) NOT NULL,
+  fingerprint STRING(64) NOT NULL,
+  reserved_micro INT64 NOT NULL,
+  actual_micro INT64,
+  state STRING(16) NOT NULL,
+  updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)
+) PRIMARY KEY (lease_id, hold_id),
+  INTERLEAVE IN PARENT tr_regional_quota_lease ON DELETE CASCADE;
+```
+
+The final regional store choice must preserve conditional writes and fencing.
+Redis without durable, strongly consistent persistence is not acceptable.
+
+## Rollout gates
+
+`TR_REGIONAL_QUOTA_LEASES_ENABLED` defaults to false and production startup
+currently rejects true. Ordinary deploys explicitly set it false so stale
+configuration cannot activate a second billing authority.
+
+Production activation requires all of the following:
+
+1. Durable regional schema and transactional adapter.
+2. Global grant and close transactions that escrow and release exact credit.
+3. Reconciliation worker with drift, orphan, and stuck-lease repair.
+4. Property tests proving aggregate spend never exceeds the escrowed grant.
+5. Crash tests at every boundary, including grant-write ambiguity and regional
+   settlement before reconciliation.
+6. Fencing tests for region replacement and split-brain workers.
+7. Shadow accounting with zero drift on a pilot workspace.
+8. A one-workspace rollout with a hard exposure cap and automatic rollback.
+
+Until those gates pass, the latency work in this change improves connection,
+TLS, health, and region selection while billing remains exact in Spanner.

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -175,6 +175,9 @@ ENV_VARS=(
   # operator overrides it. This prevents routine rollouts from reopening the
   # unbounded generic write path.
   "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
+  # Dark foundation only. Do not let a stale service-level env var activate a
+  # second billing authority during an ordinary production rollout.
+  "TR_REGIONAL_QUOTA_LEASES_ENABLED=false"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -198,6 +198,16 @@ class Settings(BaseSettings):
     x402_settle_rate_limit_per_window: int = 30
     x402_settle_workspace_per_window: int = 120
     multi_region_enabled: bool = True
+    # Regional quota leases are a future latency optimization for prepaid
+    # authorization. The state machine and design are intentionally dark: the
+    # exact typed Spanner counters remain the only production authority until
+    # a durable regional ledger and reconciliation worker have passed the
+    # rollout gates in docs/design/regional-quota-leases.md.
+    regional_quota_leases_enabled: bool = False
+    regional_quota_lease_pilot_workspace_ids: str = ""
+    regional_quota_lease_ttl_seconds: int = 60
+    regional_quota_lease_max_microdollars: int = 10_000_000
+    regional_quota_lease_max_available_basis_points: int = 1_000
     # Operational read-only flag. When set, write paths (credit
     # reservations, gateway authorize, signup, etc.) return 503 with
     # `Retry-After`; reads keep working. Used for the Spanner →
@@ -334,6 +344,30 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'"
             )
+        if not 5 <= self.regional_quota_lease_ttl_seconds <= 300:
+            raise ValueError(
+                "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS must be between 5 and 300"
+            )
+        if self.regional_quota_lease_max_microdollars <= 0:
+            raise ValueError(
+                "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS must be positive"
+            )
+        if not 1 <= self.regional_quota_lease_max_available_basis_points <= 5_000:
+            raise ValueError(
+                "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS must be "
+                "between 1 and 5000"
+            )
+        if self.regional_quota_leases_enabled:
+            if environment not in {"local", "test"}:
+                raise ValueError(
+                    "TR_REGIONAL_QUOTA_LEASES_ENABLED is not production-ready; "
+                    "the durable regional ledger and reconciliation gates are incomplete"
+                )
+            if not self.regional_quota_lease_pilot_workspace_ids.strip():
+                raise ValueError(
+                    "TR_REGIONAL_QUOTA_LEASES_ENABLED requires "
+                    "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
+                )
         if self.google_ads_conversion_feed_max_rows < 1:
             raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_MAX_ROWS must be positive")
         if not 1 <= self.google_data_manager_batch_size <= 2_000:
@@ -466,6 +500,14 @@ class Settings(BaseSettings):
     @property
     def paypal_enabled(self) -> bool:
         return bool(self.paypal_client_id and self.paypal_client_secret)
+
+    @property
+    def regional_quota_lease_pilot_workspaces(self) -> frozenset[str]:
+        return frozenset(
+            workspace_id.strip()
+            for workspace_id in self.regional_quota_lease_pilot_workspace_ids.split(",")
+            if workspace_id.strip()
+        )
 
     @property
     def ses_enabled(self) -> bool:

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -137,6 +137,16 @@ def _sample_from_body(body: Any) -> SyntheticProbeSample:
         "status": str(body.get("status") or ""),
         "latency_milliseconds": _optional_int(body.get("latency_milliseconds")),
         "ttfb_milliseconds": _optional_int(body.get("ttfb_milliseconds")),
+        "dns_milliseconds": _optional_int(body.get("dns_milliseconds")),
+        "tcp_connect_milliseconds": _optional_int(body.get("tcp_connect_milliseconds")),
+        "tls_handshake_milliseconds": _optional_int(body.get("tls_handshake_milliseconds")),
+        "gateway_processing_milliseconds": _optional_int(
+            body.get("gateway_processing_milliseconds")
+        ),
+        "connection_reused": body.get("connection_reused")
+        if isinstance(body.get("connection_reused"), bool)
+        else None,
+        "protocol": _optional_str(body.get("protocol")),
         "http_status": _optional_int(body.get("http_status")),
         "error_type": _optional_str(body.get("error_type")),
         "provider": _optional_str(body.get("provider")),

--- a/src/trusted_router/services/regional_quota_leases.py
+++ b/src/trusted_router/services/regional_quota_leases.py
@@ -1,0 +1,292 @@
+"""Pure, dark state machine for future regional prepaid quota leases.
+
+This module is deliberately not connected to gateway authorization. It models
+the invariants that a durable regional ledger must enforce before the exact
+typed Spanner billing path can safely delegate bounded spend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from enum import StrEnum
+
+
+class LeaseState(StrEnum):
+    ACTIVE = "active"
+    DRAINING = "draining"
+    CLOSED = "closed"
+    QUARANTINED = "quarantined"
+
+
+class HoldState(StrEnum):
+    RESERVED = "reserved"
+    SETTLED = "settled"
+    REFUNDED = "refunded"
+
+
+class RegionalQuotaLeaseError(ValueError):
+    """Base class for deterministic lease-state failures."""
+
+
+class LeaseUnavailableError(RegionalQuotaLeaseError):
+    pass
+
+
+class LeaseExhaustedError(RegionalQuotaLeaseError):
+    pass
+
+
+class LeaseFenceMismatchError(RegionalQuotaLeaseError):
+    pass
+
+
+class LeaseIdempotencyConflictError(RegionalQuotaLeaseError):
+    pass
+
+
+class LeaseSettlementError(RegionalQuotaLeaseError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaLeaseHold:
+    hold_id: str
+    fingerprint: str
+    reserved_microdollars: int
+    state: HoldState = HoldState.RESERVED
+    actual_microdollars: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.hold_id or not self.fingerprint:
+            raise RegionalQuotaLeaseError("hold_id and fingerprint are required")
+        if self.reserved_microdollars <= 0:
+            raise RegionalQuotaLeaseError("reserved_microdollars must be positive")
+        if self.state == HoldState.RESERVED and self.actual_microdollars is not None:
+            raise RegionalQuotaLeaseError("reserved hold cannot have an actual amount")
+        if self.state == HoldState.SETTLED and not (
+            self.actual_microdollars is not None
+            and 0 <= self.actual_microdollars <= self.reserved_microdollars
+        ):
+            raise RegionalQuotaLeaseError(
+                "settled hold actual amount must fit inside its reservation"
+            )
+        if self.state == HoldState.REFUNDED and self.actual_microdollars != 0:
+            raise RegionalQuotaLeaseError("refunded hold actual amount must be zero")
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseTransition:
+    lease: RegionalQuotaLease
+    hold: QuotaLeaseHold
+    replayed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RegionalQuotaLease:
+    lease_id: str
+    workspace_id: str
+    region: str
+    fencing_token: int
+    granted_microdollars: int
+    expires_at: datetime
+    state: LeaseState = LeaseState.ACTIVE
+    holds: tuple[QuotaLeaseHold, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.lease_id or not self.workspace_id or not self.region:
+            raise RegionalQuotaLeaseError(
+                "lease_id, workspace_id, and region are required"
+            )
+        if self.fencing_token <= 0:
+            raise RegionalQuotaLeaseError("fencing_token must be positive")
+        if self.granted_microdollars <= 0:
+            raise RegionalQuotaLeaseError("granted_microdollars must be positive")
+        if self.expires_at.tzinfo is None:
+            raise RegionalQuotaLeaseError("expires_at must be timezone-aware")
+        if len({hold.hold_id for hold in self.holds}) != len(self.holds):
+            raise RegionalQuotaLeaseError("hold IDs must be unique within a lease")
+        if self.accounted_microdollars > self.granted_microdollars:
+            raise RegionalQuotaLeaseError("lease accounting exceeds its grant")
+
+    @property
+    def reserved_microdollars(self) -> int:
+        return sum(
+            hold.reserved_microdollars
+            for hold in self.holds
+            if hold.state == HoldState.RESERVED
+        )
+
+    @property
+    def spent_microdollars(self) -> int:
+        return sum(
+            hold.actual_microdollars or 0
+            for hold in self.holds
+            if hold.state == HoldState.SETTLED
+        )
+
+    @property
+    def accounted_microdollars(self) -> int:
+        return self.reserved_microdollars + self.spent_microdollars
+
+    @property
+    def available_microdollars(self) -> int:
+        return self.granted_microdollars - self.accounted_microdollars
+
+    def reserve(
+        self,
+        *,
+        hold_id: str,
+        fingerprint: str,
+        amount_microdollars: int,
+        fencing_token: int,
+        now: datetime | None = None,
+    ) -> LeaseTransition:
+        now = _utc_now() if now is None else now
+        self._require_fence(fencing_token)
+        self._require_aware(now)
+        existing = self._hold(hold_id)
+        if existing is not None:
+            if (
+                existing.fingerprint != fingerprint
+                or existing.reserved_microdollars != amount_microdollars
+            ):
+                raise LeaseIdempotencyConflictError(
+                    "hold ID was reused with different reservation inputs"
+                )
+            return LeaseTransition(self, existing, True)
+        if self.state != LeaseState.ACTIVE:
+            raise LeaseUnavailableError(f"lease is {self.state}")
+        if now >= self.expires_at:
+            raise LeaseUnavailableError("lease has expired")
+        if amount_microdollars <= 0:
+            raise RegionalQuotaLeaseError("reservation must be positive")
+        if amount_microdollars > self.available_microdollars:
+            raise LeaseExhaustedError("regional lease has insufficient quota")
+        hold = QuotaLeaseHold(
+            hold_id=hold_id,
+            fingerprint=fingerprint,
+            reserved_microdollars=amount_microdollars,
+        )
+        lease = replace(self, holds=(*self.holds, hold))
+        return LeaseTransition(lease, hold, False)
+
+    def settle(
+        self,
+        *,
+        hold_id: str,
+        actual_microdollars: int,
+        fencing_token: int,
+    ) -> LeaseTransition:
+        self._require_fence(fencing_token)
+        hold = self._required_hold(hold_id)
+        if hold.state == HoldState.SETTLED:
+            if hold.actual_microdollars != actual_microdollars:
+                raise LeaseIdempotencyConflictError(
+                    "settlement replay changed the actual amount"
+                )
+            return LeaseTransition(self, hold, True)
+        if hold.state == HoldState.REFUNDED:
+            raise LeaseSettlementError("refunded hold cannot be settled")
+        if not 0 <= actual_microdollars <= hold.reserved_microdollars:
+            raise LeaseSettlementError(
+                "actual amount must fit inside the exact regional reservation"
+            )
+        settled = replace(
+            hold,
+            state=HoldState.SETTLED,
+            actual_microdollars=actual_microdollars,
+        )
+        lease = self._replace_hold(settled)
+        return LeaseTransition(lease, settled, False)
+
+    def refund(self, *, hold_id: str, fencing_token: int) -> LeaseTransition:
+        self._require_fence(fencing_token)
+        hold = self._required_hold(hold_id)
+        if hold.state == HoldState.REFUNDED:
+            return LeaseTransition(self, hold, True)
+        if hold.state == HoldState.SETTLED:
+            raise LeaseSettlementError("settled hold cannot be refunded")
+        refunded = replace(hold, state=HoldState.REFUNDED, actual_microdollars=0)
+        lease = self._replace_hold(refunded)
+        return LeaseTransition(lease, refunded, False)
+
+    def begin_drain(self, *, fencing_token: int) -> RegionalQuotaLease:
+        self._require_fence(fencing_token)
+        if self.state == LeaseState.DRAINING:
+            return self
+        if self.state != LeaseState.ACTIVE:
+            raise LeaseUnavailableError(f"lease is {self.state}")
+        return replace(self, state=LeaseState.DRAINING)
+
+    def close(self, *, fencing_token: int) -> RegionalQuotaLease:
+        self._require_fence(fencing_token)
+        if self.state == LeaseState.CLOSED:
+            return self
+        if self.state != LeaseState.DRAINING:
+            raise LeaseUnavailableError("lease must drain before close")
+        if self.reserved_microdollars:
+            raise LeaseUnavailableError("lease still has open reservations")
+        return replace(self, state=LeaseState.CLOSED)
+
+    def quarantine(self, *, fencing_token: int) -> RegionalQuotaLease:
+        self._require_fence(fencing_token)
+        if self.state == LeaseState.CLOSED:
+            raise LeaseUnavailableError("closed lease cannot be quarantined")
+        return replace(self, state=LeaseState.QUARANTINED)
+
+    def _require_fence(self, fencing_token: int) -> None:
+        if fencing_token != self.fencing_token:
+            raise LeaseFenceMismatchError("stale regional lease fencing token")
+
+    @staticmethod
+    def _require_aware(value: datetime) -> None:
+        if value.tzinfo is None:
+            raise RegionalQuotaLeaseError("now must be timezone-aware")
+
+    def _hold(self, hold_id: str) -> QuotaLeaseHold | None:
+        return next((hold for hold in self.holds if hold.hold_id == hold_id), None)
+
+    def _required_hold(self, hold_id: str) -> QuotaLeaseHold:
+        hold = self._hold(hold_id)
+        if hold is None:
+            raise LeaseSettlementError("unknown regional reservation")
+        return hold
+
+    def _replace_hold(self, replacement: QuotaLeaseHold) -> RegionalQuotaLease:
+        return replace(
+            self,
+            holds=tuple(
+                replacement if hold.hold_id == replacement.hold_id else hold
+                for hold in self.holds
+            ),
+        )
+
+
+def bounded_lease_grant_microdollars(
+    *,
+    available_microdollars: int,
+    requested_microdollars: int,
+    per_lease_cap_microdollars: int,
+    max_available_basis_points: int,
+) -> int:
+    """Return a bounded grant; the global transaction must escrow this amount."""
+
+    if min(
+        available_microdollars,
+        requested_microdollars,
+        per_lease_cap_microdollars,
+    ) < 0:
+        raise RegionalQuotaLeaseError("lease grant inputs cannot be negative")
+    if not 1 <= max_available_basis_points <= 10_000:
+        raise RegionalQuotaLeaseError(
+            "max_available_basis_points must be between 1 and 10000"
+        )
+    fraction_cap = (
+        available_microdollars * max_available_basis_points // 10_000
+    )
+    return min(requested_microdollars, per_lease_cap_microdollars, fraction_cap)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/src/trusted_router/storage_gcp_synthetic_rollups.py
+++ b/src/trusted_router/storage_gcp_synthetic_rollups.py
@@ -139,6 +139,10 @@ def _rollups_from_rows(
             if not include_histograms:
                 payload["latency_histogram"] = {}
                 payload["ttfb_histogram"] = {}
+                payload["dns_histogram"] = {}
+                payload["tcp_connect_histogram"] = {}
+                payload["tls_handshake_histogram"] = {}
+                payload["gateway_processing_histogram"] = {}
             rollups.append(SyntheticRollup(**payload))
         except (TypeError, ValueError):
             continue

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -803,6 +803,12 @@ class SyntheticProbeSample:
     target_region: str | None = None
     latency_milliseconds: int | None = None
     ttfb_milliseconds: int | None = None
+    dns_milliseconds: int | None = None
+    tcp_connect_milliseconds: int | None = None
+    tls_handshake_milliseconds: int | None = None
+    gateway_processing_milliseconds: int | None = None
+    connection_reused: bool | None = None
+    protocol: str | None = None
     http_status: int | None = None
     error_type: str | None = None
     provider: str | None = None
@@ -827,6 +833,12 @@ class SyntheticProbeSample:
             "status": self.status,
             "latency_milliseconds": self.latency_milliseconds,
             "ttfb_milliseconds": self.ttfb_milliseconds,
+            "dns_milliseconds": self.dns_milliseconds,
+            "tcp_connect_milliseconds": self.tcp_connect_milliseconds,
+            "tls_handshake_milliseconds": self.tls_handshake_milliseconds,
+            "gateway_processing_milliseconds": self.gateway_processing_milliseconds,
+            "connection_reused": self.connection_reused,
+            "protocol": self.protocol,
             "http_status": self.http_status,
             "error_type": self.error_type,
             "provider": self.provider,
@@ -868,6 +880,10 @@ class SyntheticRollup:
     unknown_count: int = 0
     latency_histogram: dict[str, int] = field(default_factory=dict)
     ttfb_histogram: dict[str, int] = field(default_factory=dict)
+    dns_histogram: dict[str, int] = field(default_factory=dict)
+    tcp_connect_histogram: dict[str, int] = field(default_factory=dict)
+    tls_handshake_histogram: dict[str, int] = field(default_factory=dict)
+    gateway_processing_histogram: dict[str, int] = field(default_factory=dict)
     error_counts: dict[str, int] = field(default_factory=dict)
     last_checked_at: str | None = None
     cost_microdollars: int = 0

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -1814,6 +1814,10 @@ class PostgresStore:
                         rollup,
                         latency_histogram={},
                         ttfb_histogram={},
+                        dns_histogram={},
+                        tcp_connect_histogram={},
+                        tls_handshake_histogram={},
+                        gateway_processing_histogram={},
                     )
                     for rollup in rollups
                 ]

--- a/src/trusted_router/storage_synthetic.py
+++ b/src/trusted_router/storage_synthetic.py
@@ -89,7 +89,15 @@ class InMemorySyntheticChecks:
         rows.sort(key=lambda rollup: rollup.period_start, reverse=True)
         if not include_histograms:
             rows = [
-                replace(rollup, latency_histogram={}, ttfb_histogram={})
+                replace(
+                    rollup,
+                    latency_histogram={},
+                    ttfb_histogram={},
+                    dns_histogram={},
+                    tcp_connect_histogram={},
+                    tls_handshake_histogram={},
+                    gateway_processing_histogram={},
+                )
                 for rollup in rows
             ]
         return rows[:limit]

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -7,6 +7,12 @@ from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
 REGIONAL_GATEWAY_PROBES = {"tls_health", "attestation_nonce"}
 CONTROL_PLANE_PROBES = {"control_plane_health"}
 IMAGE_GENERATION_PROBES = {"image_generation"}
+BILLING_PROBES = {
+    "gateway_authorize",
+    "gateway_settle",
+    # Retained so existing 24-month rollups remain visible after the split.
+    "gateway_authorize_settle",
+}
 MONITOR_CONFIGURATION_ERROR_TYPES = frozenset(
     {
         "monitor_account_unavailable",
@@ -20,7 +26,7 @@ COMPONENT_PROBES: dict[str, set[str]] = {
     "us_east4_regional_api": REGIONAL_GATEWAY_PROBES,
     "eu_regional_api": REGIONAL_GATEWAY_PROBES,
     "attestation": {"attestation_nonce"},
-    "billing_settlement": {"gateway_authorize_settle"},
+    "billing_settlement": BILLING_PROBES,
     "provider_fallback": {"provider_fallback"},
     "image_generation": IMAGE_GENERATION_PROBES,
 }
@@ -99,7 +105,7 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("eu_regional_api")
     if sample.probe_type == "attestation_nonce":
         ids.append("attestation")
-    if sample.target == "control-plane" and sample.probe_type == "gateway_authorize_settle":
+    if sample.target == "control-plane" and sample.probe_type in BILLING_PROBES:
         ids.append("billing_settlement")
     if sample.target == "control-plane" and sample.probe_type == "provider_fallback":
         ids.append("provider_fallback")
@@ -135,6 +141,8 @@ def rollup_slo_class_ids(rollup: SyntheticRollup) -> list[str]:
     expected_component = {
         "tls_health": "canonical_api",
         "attestation_nonce": "canonical_api",
+        "gateway_authorize": "billing_settlement",
+        "gateway_settle": "billing_settlement",
         "gateway_authorize_settle": "billing_settlement",
         "provider_fallback": "provider_fallback",
     }.get(rollup.probe_type)
@@ -149,7 +157,7 @@ def _slo_class_ids(*, probe_type: str, target: str) -> list[str]:
         (target == "canonical" and probe_type in REGIONAL_GATEWAY_PROBES)
         or (
             target == "control-plane"
-            and probe_type in {"gateway_authorize_settle", "provider_fallback"}
+            and probe_type in BILLING_PROBES | {"provider_fallback"}
         )
     ):
         ids.append("router_core")

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -6,13 +6,15 @@ import binascii
 import json
 import random
 import secrets
+import socket
+import ssl
 import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 
@@ -140,6 +142,7 @@ async def _run_target_synthetic_probes(
     probes = [
         tls_health_probe(client, target, monitor_region=monitor_region),
         attestation_nonce_probe(client, target, monitor_region=monitor_region),
+        gateway_latency_phase_probes(target, monitor_region=monitor_region),
     ]
     # Per-region control plane health via Cloud Run direct URL.
     # tls_health above probes target.api_base_url which is the
@@ -172,7 +175,16 @@ async def _run_target_synthetic_probes(
                 ),
             ]
         )
-    return list(await asyncio.gather(*probes))
+    results = await asyncio.gather(*probes)
+    samples: list[SyntheticProbeSample] = []
+    for result in results:
+        if isinstance(result, list):
+            samples.extend(result)
+        elif isinstance(result, SyntheticProbeSample):
+            samples.append(result)
+        else:
+            raise TypeError(f"unexpected synthetic probe result: {type(result).__name__}")
+    return samples
 
 
 async def _run_billing_probe(
@@ -224,6 +236,276 @@ async def tls_health_probe(
             latency_milliseconds=_elapsed_ms(started),
             error_type=exc.__class__.__name__,
         )
+
+
+async def gateway_latency_phase_probes(
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    timeout_seconds: float = 10.0,
+) -> list[SyntheticProbeSample]:
+    """Measure a fresh TLS request and an immediate request on that connection.
+
+    This probe is diagnostic, not an uptime signal. It uses an HTTP/1.1-only
+    connection so DNS, TCP, TLS, and application processing can be timed
+    independently without relying on private httpx/httpcore trace APIs.
+    """
+
+    url = _root_url(target.api_base_url, "/health")
+    parsed = urlsplit(url)
+    host = parsed.hostname
+    if parsed.scheme != "https" or not host:
+        return _failed_latency_phase_samples(
+            target,
+            monitor_region=monitor_region,
+            url=url,
+            error_type="invalid_health_url",
+        )
+    port = parsed.port or 443
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    writer: asyncio.StreamWriter | None = None
+    raw_socket: socket.socket | None = None
+    started = time.perf_counter()
+    try:
+        loop = asyncio.get_running_loop()
+        dns_started = time.perf_counter()
+        addresses = await asyncio.wait_for(
+            loop.getaddrinfo(host, port, type=socket.SOCK_STREAM),
+            timeout=_remaining_probe_seconds(started, timeout_seconds),
+        )
+        dns_ms = _elapsed_ms(dns_started)
+        tcp_ms: int | None = None
+        last_connect_error: OSError | TimeoutError | None = None
+        for family, socktype, protocol, _canonical_name, address in addresses:
+            candidate_socket = socket.socket(family, socktype, protocol)
+            candidate_socket.setblocking(False)
+            tcp_started = time.perf_counter()
+            try:
+                await asyncio.wait_for(
+                    loop.sock_connect(candidate_socket, address),
+                    timeout=_remaining_probe_seconds(started, timeout_seconds),
+                )
+            except (OSError, TimeoutError) as exc:
+                candidate_socket.close()
+                last_connect_error = exc
+                continue
+            raw_socket = candidate_socket
+            tcp_ms = _elapsed_ms(tcp_started)
+            break
+        if raw_socket is None or tcp_ms is None:
+            raise last_connect_error or OSError("no resolved address accepted TCP")
+
+        tls_context = ssl.create_default_context()
+        tls_context.set_alpn_protocols(["http/1.1"])
+        tls_started = time.perf_counter()
+        reader, stream_writer = await asyncio.wait_for(
+            asyncio.open_connection(
+                sock=raw_socket,
+                ssl=tls_context,
+                server_hostname=host,
+            ),
+            timeout=_remaining_probe_seconds(started, timeout_seconds),
+        )
+        writer = stream_writer
+        raw_socket = None
+        tls_ms = _elapsed_ms(tls_started)
+        ssl_object = stream_writer.get_extra_info("ssl_object")
+        negotiated_protocol = (
+            ssl_object.selected_alpn_protocol() if ssl_object is not None else None
+        ) or "http/1.1"
+
+        first_started = time.perf_counter()
+        first_status, first_headers, first_body, first_ttfb = await _health_http11_request(
+            reader,
+            stream_writer,
+            host=host,
+            path=path,
+            timeout_seconds=_remaining_probe_seconds(started, timeout_seconds),
+        )
+        first_total_ms = _elapsed_ms(started)
+        first_ok = first_status == 200 and first_body == b'{"status":"ok"}'
+        cold = _sample(
+            "gateway_cold_path",
+            target,
+            monitor_region,
+            url,
+            status="up" if first_ok else "down",
+            latency_milliseconds=first_total_ms,
+            ttfb_milliseconds=first_ttfb,
+            dns_milliseconds=dns_ms,
+            tcp_connect_milliseconds=tcp_ms,
+            tls_handshake_milliseconds=tls_ms,
+            gateway_processing_milliseconds=_server_timing_gateway(first_headers),
+            connection_reused=False,
+            protocol=negotiated_protocol,
+            http_status=first_status,
+            error_type=None if first_ok else "bad_health_response",
+        )
+
+        reusable = first_headers.get("connection", "").casefold() != "close"
+        if not reusable or not first_ok:
+            return [
+                cold,
+                _sample(
+                    "gateway_reused_path",
+                    target,
+                    monitor_region,
+                    url,
+                    status="down",
+                    latency_milliseconds=_elapsed_ms(first_started),
+                    connection_reused=False,
+                    protocol=negotiated_protocol,
+                    error_type="connection_not_reusable",
+                ),
+            ]
+
+        reused_started = time.perf_counter()
+        second_status, second_headers, second_body, second_ttfb = (
+            await _health_http11_request(
+                reader,
+                stream_writer,
+                host=host,
+                path=path,
+                timeout_seconds=_remaining_probe_seconds(started, timeout_seconds),
+            )
+        )
+        second_total_ms = _elapsed_ms(reused_started)
+        second_ok = second_status == 200 and second_body == b'{"status":"ok"}'
+        return [
+            cold,
+            _sample(
+                "gateway_reused_path",
+                target,
+                monitor_region,
+                url,
+                status="up" if second_ok else "down",
+                latency_milliseconds=second_total_ms,
+                ttfb_milliseconds=second_ttfb,
+                gateway_processing_milliseconds=_server_timing_gateway(second_headers),
+                connection_reused=True,
+                protocol=negotiated_protocol,
+                http_status=second_status,
+                error_type=None if second_ok else "bad_health_response",
+            ),
+        ]
+    except (EOFError, OSError, TimeoutError, ssl.SSLError, ValueError) as exc:
+        return _failed_latency_phase_samples(
+            target,
+            monitor_region=monitor_region,
+            url=url,
+            error_type=exc.__class__.__name__,
+            latency_milliseconds=_elapsed_ms(started),
+        )
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (OSError, ssl.SSLError):
+                pass
+        if raw_socket is not None:
+            raw_socket.close()
+
+
+async def _health_http11_request(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    host: str,
+    path: str,
+    timeout_seconds: float,
+) -> tuple[int, dict[str, str], bytes, int]:
+    request = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}\r\n"
+        "Accept: application/json\r\n"
+        "User-Agent: TrustedRouter-Synthetic/1\r\n"
+        "Connection: keep-alive\r\n\r\n"
+    ).encode("ascii")
+    started = time.perf_counter()
+    writer.write(request)
+    await asyncio.wait_for(
+        writer.drain(), timeout=_remaining_probe_seconds(started, timeout_seconds)
+    )
+    status_line = await asyncio.wait_for(
+        reader.readline(), timeout=_remaining_probe_seconds(started, timeout_seconds)
+    )
+    ttfb_ms = _elapsed_ms(started)
+    parts = status_line.decode("ascii", "replace").strip().split(" ", 2)
+    if len(parts) < 2 or not parts[1].isdigit():
+        raise ValueError("invalid HTTP status line")
+    status = int(parts[1])
+    headers: dict[str, str] = {}
+    header_bytes = len(status_line)
+    while True:
+        line = await asyncio.wait_for(
+            reader.readline(), timeout=_remaining_probe_seconds(started, timeout_seconds)
+        )
+        header_bytes += len(line)
+        if header_bytes > 64 * 1024:
+            raise ValueError("health response headers too large")
+        if line in {b"\r\n", b"\n"}:
+            break
+        name, separator, value = line.decode("latin-1").partition(":")
+        if not separator:
+            raise ValueError("invalid HTTP header")
+        headers[name.strip().casefold()] = value.strip()
+    content_length = int(headers.get("content-length", "0"))
+    if content_length < 0 or content_length > 4096:
+        raise ValueError("invalid health response length")
+    body = await asyncio.wait_for(
+        reader.readexactly(content_length),
+        timeout=_remaining_probe_seconds(started, timeout_seconds),
+    )
+    return status, headers, body, ttfb_ms
+
+
+def _server_timing_gateway(headers: dict[str, str]) -> int | None:
+    for metric in headers.get("server-timing", "").split(","):
+        name, *parameters = metric.split(";")
+        if name.strip().casefold() != "gateway":
+            continue
+        for parameter in parameters:
+            key, separator, value = parameter.strip().partition("=")
+            if separator and key.casefold() == "dur":
+                try:
+                    return max(0, int(round(float(value))))
+                except ValueError:
+                    return None
+    return None
+
+
+def _remaining_probe_seconds(started: float, timeout_seconds: float) -> float:
+    remaining = timeout_seconds - (time.perf_counter() - started)
+    if remaining <= 0:
+        raise TimeoutError("gateway latency probe deadline exceeded")
+    return remaining
+
+
+def _failed_latency_phase_samples(
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    url: str,
+    error_type: str,
+    latency_milliseconds: int | None = None,
+) -> list[SyntheticProbeSample]:
+    return [
+        _sample(
+            probe_type,
+            target,
+            monitor_region,
+            url,
+            status="down",
+            latency_milliseconds=latency_milliseconds,
+            connection_reused=probe_type == "gateway_reused_path",
+            error_type=error_type,
+        )
+        for probe_type in ("gateway_cold_path", "gateway_reused_path")
+    ]
 
 
 async def control_plane_health_probe(
@@ -634,8 +916,10 @@ async def gateway_billing_probe(
     authorize_url = f"{base}/v1/internal/gateway/authorize"
     settle_url = f"{base}/v1/internal/gateway/settle"
     headers = {"x-trustedrouter-internal-token": internal_token}
-    started = time.perf_counter()
     target = SyntheticTarget("control-plane", control_plane_base_url, None)
+    samples: list[SyntheticProbeSample] = []
+    stage = "authorize"
+    started = time.perf_counter()
     try:
         authorize = await client.post(
             authorize_url,
@@ -651,7 +935,7 @@ async def gateway_billing_probe(
         if authorize.status_code != 200:
             return [
                 _sample(
-                    "gateway_authorize_settle",
+                    "gateway_authorize",
                     target,
                     monitor_region,
                     authorize_url,
@@ -663,6 +947,22 @@ async def gateway_billing_probe(
                 )
             ]
         data = authorize.json()["data"]
+        samples.append(
+            _sample(
+                "gateway_authorize",
+                target,
+                monitor_region,
+                authorize_url,
+                status="up",
+                latency_milliseconds=_elapsed_ms(started),
+                http_status=authorize.status_code,
+                model=model,
+                selected_model=data.get("model"),
+                selected_provider=data.get("provider"),
+            )
+        )
+        stage = "settle"
+        started = time.perf_counter()
         settle = await client.post(
             settle_url,
             headers=headers,
@@ -692,9 +992,9 @@ async def gateway_billing_probe(
                 else "settle_failed"
             )
         )
-        return [
+        samples.append(
             _sample(
-                "gateway_authorize_settle",
+                "gateway_settle",
                 target,
                 monitor_region,
                 settle_url,
@@ -708,20 +1008,22 @@ async def gateway_billing_probe(
                 generation_id=settle_data.get("generation_id"),
                 cost_microdollars=int(settle_data.get("cost_microdollars") or 0),
             )
-        ]
+        )
+        return samples
     except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
-        return [
+        samples.append(
             _sample(
-                "gateway_authorize_settle",
+                f"gateway_{stage}",
                 target,
                 monitor_region,
-                authorize_url,
+                authorize_url if stage == "authorize" else settle_url,
                 status="down",
                 latency_milliseconds=_elapsed_ms(started),
                 error_type=exc.__class__.__name__,
                 model=model,
             )
-        ]
+        )
+        return samples
 
 
 async def gateway_fallback_probe(
@@ -1589,6 +1891,12 @@ def _sample(
     status: str,
     latency_milliseconds: int | None = None,
     ttfb_milliseconds: int | None = None,
+    dns_milliseconds: int | None = None,
+    tcp_connect_milliseconds: int | None = None,
+    tls_handshake_milliseconds: int | None = None,
+    gateway_processing_milliseconds: int | None = None,
+    connection_reused: bool | None = None,
+    protocol: str | None = None,
     http_status: int | None = None,
     error_type: str | None = None,
     provider: str | None = None,
@@ -1611,6 +1919,12 @@ def _sample(
         status=status,
         latency_milliseconds=latency_milliseconds,
         ttfb_milliseconds=ttfb_milliseconds,
+        dns_milliseconds=dns_milliseconds,
+        tcp_connect_milliseconds=tcp_connect_milliseconds,
+        tls_handshake_milliseconds=tls_handshake_milliseconds,
+        gateway_processing_milliseconds=gateway_processing_milliseconds,
+        connection_reused=connection_reused,
+        protocol=protocol,
         http_status=http_status,
         error_type=error_type,
         provider=provider,

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -82,6 +82,17 @@ def apply_sample_to_rollup(rollup: SyntheticRollup, sample: SyntheticProbeSample
         _increment_histogram(rollup.latency_histogram, sample.latency_milliseconds)
     if sample.ttfb_milliseconds is not None:
         _increment_histogram(rollup.ttfb_histogram, sample.ttfb_milliseconds)
+    if sample.dns_milliseconds is not None:
+        _increment_histogram(rollup.dns_histogram, sample.dns_milliseconds)
+    if sample.tcp_connect_milliseconds is not None:
+        _increment_histogram(rollup.tcp_connect_histogram, sample.tcp_connect_milliseconds)
+    if sample.tls_handshake_milliseconds is not None:
+        _increment_histogram(rollup.tls_handshake_histogram, sample.tls_handshake_milliseconds)
+    if sample.gateway_processing_milliseconds is not None:
+        _increment_histogram(
+            rollup.gateway_processing_histogram,
+            sample.gateway_processing_milliseconds,
+        )
     if sample.error_type:
         rollup.error_counts[sample.error_type] = rollup.error_counts.get(sample.error_type, 0) + 1
     rollup.cost_microdollars += sample.cost_microdollars
@@ -125,6 +136,10 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
     }
     latency_histogram: dict[str, int] = {}
     ttfb_histogram: dict[str, int] = {}
+    dns_histogram: dict[str, int] = {}
+    tcp_connect_histogram: dict[str, int] = {}
+    tls_handshake_histogram: dict[str, int] = {}
+    gateway_processing_histogram: dict[str, int] = {}
     error_counts: Counter[str] = Counter()
     cost_microdollars = 0
     sample_count = 0
@@ -139,6 +154,13 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
         status_counts["unknown"] += rollup.unknown_count
         _merge_histograms(latency_histogram, rollup.latency_histogram)
         _merge_histograms(ttfb_histogram, rollup.ttfb_histogram)
+        _merge_histograms(dns_histogram, rollup.dns_histogram)
+        _merge_histograms(tcp_connect_histogram, rollup.tcp_connect_histogram)
+        _merge_histograms(tls_handshake_histogram, rollup.tls_handshake_histogram)
+        _merge_histograms(
+            gateway_processing_histogram,
+            rollup.gateway_processing_histogram,
+        )
         error_counts.update(rollup.error_counts)
         cost_microdollars += rollup.cost_microdollars
         if rollup.last_checked_at and (last_checked_at is None or rollup.last_checked_at > last_checked_at):
@@ -150,6 +172,26 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
         "p95_latency_milliseconds": percentile_from_histogram(latency_histogram, 95),
         "p50_ttfb_milliseconds": percentile_from_histogram(ttfb_histogram, 50),
         "p95_ttfb_milliseconds": percentile_from_histogram(ttfb_histogram, 95),
+        "p50_dns_milliseconds": percentile_from_histogram(dns_histogram, 50),
+        "p95_dns_milliseconds": percentile_from_histogram(dns_histogram, 95),
+        "p50_tcp_connect_milliseconds": percentile_from_histogram(
+            tcp_connect_histogram, 50
+        ),
+        "p95_tcp_connect_milliseconds": percentile_from_histogram(
+            tcp_connect_histogram, 95
+        ),
+        "p50_tls_handshake_milliseconds": percentile_from_histogram(
+            tls_handshake_histogram, 50
+        ),
+        "p95_tls_handshake_milliseconds": percentile_from_histogram(
+            tls_handshake_histogram, 95
+        ),
+        "p50_gateway_processing_milliseconds": percentile_from_histogram(
+            gateway_processing_histogram, 50
+        ),
+        "p95_gateway_processing_milliseconds": percentile_from_histogram(
+            gateway_processing_histogram, 95
+        ),
         "top_error": error_counts.most_common(1)[0][0] if error_counts else None,
         "last_checked_at": last_checked_at,
         "cost_microdollars": cost_microdollars,

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -159,6 +159,14 @@ def _headline_metrics(samples: list[SyntheticProbeSample], *, now: dt.datetime) 
     global_latencies = _gateway_latency_values(samples, now=now)
     canonical_latencies = _gateway_latency_values(samples, now=now, target="canonical")
     primary_latencies = in_region_latencies or global_latencies
+    cutoff = now - dt.timedelta(seconds=WINDOW_SECONDS["5m"])
+    phase_samples = [
+        sample
+        for sample in samples
+        if sample.probe_type in {"gateway_cold_path", "gateway_reused_path"}
+        and sample.status == "up"
+        and _parse_time(sample.created_at) >= cutoff
+    ]
     return {
         "gateway_overhead_p50_milliseconds": _percentile(primary_latencies, 50),
         "gateway_overhead_sample_count": len(primary_latencies),
@@ -169,6 +177,7 @@ def _headline_metrics(samples: list[SyntheticProbeSample], *, now: dt.datetime) 
         "global_gateway_overhead_sample_count": len(global_latencies),
         "canonical_gateway_overhead_p50_milliseconds": _percentile(canonical_latencies, 50),
         "canonical_gateway_overhead_sample_count": len(canonical_latencies),
+        "latency_anatomy": _sample_group_breakdown(phase_samples),
         # Human-friendly label for the headline-metric subtitle; the
         # actual rollup window stays at WINDOW_SECONDS["5m"] above.
         "window": "last 5 min",
@@ -809,6 +818,26 @@ def _sample_group_breakdown(
             for sample in probe_samples
             if sample.ttfb_milliseconds is not None
         ]
+        dns_values = [
+            sample.dns_milliseconds
+            for sample in probe_samples
+            if sample.dns_milliseconds is not None
+        ]
+        tcp_values = [
+            sample.tcp_connect_milliseconds
+            for sample in probe_samples
+            if sample.tcp_connect_milliseconds is not None
+        ]
+        tls_values = [
+            sample.tls_handshake_milliseconds
+            for sample in probe_samples
+            if sample.tls_handshake_milliseconds is not None
+        ]
+        gateway_values = [
+            sample.gateway_processing_milliseconds
+            for sample in probe_samples
+            if sample.gateway_processing_milliseconds is not None
+        ]
         statuses = [sample.status for sample in probe_samples]
         row = {
             "target": target,
@@ -823,6 +852,14 @@ def _sample_group_breakdown(
             "p95_latency_milliseconds": _percentile(latencies, 95),
             "p50_ttfb_milliseconds": _percentile(ttfbs, 50),
             "p95_ttfb_milliseconds": _percentile(ttfbs, 95),
+            "p50_dns_milliseconds": _percentile(dns_values, 50),
+            "p95_dns_milliseconds": _percentile(dns_values, 95),
+            "p50_tcp_connect_milliseconds": _percentile(tcp_values, 50),
+            "p95_tcp_connect_milliseconds": _percentile(tcp_values, 95),
+            "p50_tls_handshake_milliseconds": _percentile(tls_values, 50),
+            "p95_tls_handshake_milliseconds": _percentile(tls_values, 95),
+            "p50_gateway_processing_milliseconds": _percentile(gateway_values, 50),
+            "p95_gateway_processing_milliseconds": _percentile(gateway_values, 95),
             "last_checked_at": max(sample.created_at for sample in probe_samples),
         }
         if include_component:
@@ -871,6 +908,22 @@ def _rollup_group_breakdown(
             "p95_latency_milliseconds": merged["p95_latency_milliseconds"],
             "p50_ttfb_milliseconds": merged["p50_ttfb_milliseconds"],
             "p95_ttfb_milliseconds": merged["p95_ttfb_milliseconds"],
+            "p50_dns_milliseconds": merged["p50_dns_milliseconds"],
+            "p95_dns_milliseconds": merged["p95_dns_milliseconds"],
+            "p50_tcp_connect_milliseconds": merged["p50_tcp_connect_milliseconds"],
+            "p95_tcp_connect_milliseconds": merged["p95_tcp_connect_milliseconds"],
+            "p50_tls_handshake_milliseconds": merged[
+                "p50_tls_handshake_milliseconds"
+            ],
+            "p95_tls_handshake_milliseconds": merged[
+                "p95_tls_handshake_milliseconds"
+            ],
+            "p50_gateway_processing_milliseconds": merged[
+                "p50_gateway_processing_milliseconds"
+            ],
+            "p95_gateway_processing_milliseconds": merged[
+                "p95_gateway_processing_milliseconds"
+            ],
             "last_checked_at": merged["last_checked_at"],
             "top_error": merged["top_error"],
         }

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -61,6 +61,36 @@
     {% endfor %}
   </section>
 
+  {% if snapshot.headline_metrics.latency_anatomy %}
+  <section class="status-section">
+    <div class="status-section-head">
+      <div>
+        <h2>Gateway latency anatomy</h2>
+        <p>Fresh connections include DNS, TCP, and TLS setup. Reused connections show the request path after that setup is paid once.</p>
+      </div>
+    </div>
+    <div class="leaderboard-table-wrap">
+      <table class="activity-table status-table">
+        <thead><tr><th>Path</th><th>Region path</th><th>Total p50</th><th>DNS</th><th>TCP</th><th>TLS</th><th>Gateway</th><th>Samples</th></tr></thead>
+        <tbody>
+          {% for row in snapshot.headline_metrics.latency_anatomy %}
+          <tr>
+            <td>{% if row.probe_type == "gateway_reused_path" %}Reused connection{% else %}Fresh connection{% endif %}</td>
+            <td>{{ row.region_pair }}</td>
+            <td>{% if row.p50_latency_milliseconds is not none %}{{ row.p50_latency_milliseconds }} ms{% else %}n/a{% endif %}</td>
+            <td>{% if row.p50_dns_milliseconds is not none %}{{ row.p50_dns_milliseconds }} ms{% else %}paid once{% endif %}</td>
+            <td>{% if row.p50_tcp_connect_milliseconds is not none %}{{ row.p50_tcp_connect_milliseconds }} ms{% else %}paid once{% endif %}</td>
+            <td>{% if row.p50_tls_handshake_milliseconds is not none %}{{ row.p50_tls_handshake_milliseconds }} ms{% else %}paid once{% endif %}</td>
+            <td>{% if row.p50_gateway_processing_milliseconds is not none %}{{ row.p50_gateway_processing_milliseconds }} ms{% else %}n/a{% endif %}</td>
+            <td>{{ row.sample_count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+  {% endif %}
+
   {% if provider_health %}
   <section class="status-section">
     <div class="status-section-head">

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -411,6 +411,10 @@ def test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option(
     assert all(middle_start <= row.period_start <= newest_start for row in ranged)
     assert all(row.latency_histogram == {} for row in ranged)
     assert all(row.ttfb_histogram == {} for row in ranged)
+    assert all(row.dns_histogram == {} for row in ranged)
+    assert all(row.tcp_connect_histogram == {} for row in ranged)
+    assert all(row.tls_handshake_histogram == {} for row in ranged)
+    assert all(row.gateway_processing_histogram == {} for row in ranged)
     own_rows = [
         row
         for row in ranged

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -15,6 +15,24 @@ def test_deploy_pins_ten_cent_signup_credit_policy() -> None:
     assert '"TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=100000"' in rollout
 
 
+def test_all_attested_control_plane_regions_remain_warm() -> None:
+    library = (ROOT / "scripts/deploy/_lib.sh").read_text()
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+
+    assert 'TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4}"' in library
+    assert (
+        'TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4}"'
+        in library
+    )
+    assert '--min-instances "$min_instances"' in rollout
+
+
+def test_production_deploy_keeps_regional_quota_leases_dark() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+
+    assert '"TR_REGIONAL_QUOTA_LEASES_ENABLED=false"' in rollout
+
+
 def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 

--- a/tests/test_regional_quota_leases.py
+++ b/tests/test_regional_quota_leases.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from trusted_router.config import Settings
+from trusted_router.services.regional_quota_leases import (
+    HoldState,
+    LeaseExhaustedError,
+    LeaseFenceMismatchError,
+    LeaseIdempotencyConflictError,
+    LeaseSettlementError,
+    LeaseState,
+    LeaseUnavailableError,
+    RegionalQuotaLease,
+    RegionalQuotaLeaseError,
+    bounded_lease_grant_microdollars,
+)
+
+NOW = datetime(2026, 7, 31, tzinfo=UTC)
+
+
+def _lease(*, grant: int = 1_000, expires_in: int = 60) -> RegionalQuotaLease:
+    return RegionalQuotaLease(
+        lease_id="lease-1",
+        workspace_id="workspace-1",
+        region="us-east4",
+        fencing_token=7,
+        granted_microdollars=grant,
+        expires_at=NOW + timedelta(seconds=expires_in),
+    )
+
+
+def test_reserve_settle_and_refund_preserve_exact_integer_accounting() -> None:
+    first = _lease().reserve(
+        hold_id="a",
+        fingerprint="fp-a",
+        amount_microdollars=400,
+        fencing_token=7,
+        now=NOW,
+    ).lease
+    second = first.reserve(
+        hold_id="b",
+        fingerprint="fp-b",
+        amount_microdollars=300,
+        fencing_token=7,
+        now=NOW,
+    ).lease
+
+    settled = second.settle(
+        hold_id="a", actual_microdollars=275, fencing_token=7
+    ).lease
+    refunded = settled.refund(hold_id="b", fencing_token=7).lease
+
+    assert refunded.spent_microdollars == 275
+    assert refunded.reserved_microdollars == 0
+    assert refunded.available_microdollars == 725
+    assert refunded.holds[0].state == HoldState.SETTLED
+    assert refunded.holds[1].state == HoldState.REFUNDED
+
+
+def test_reservation_and_terminal_transitions_are_idempotent() -> None:
+    transition = _lease().reserve(
+        hold_id="a",
+        fingerprint="fp",
+        amount_microdollars=400,
+        fencing_token=7,
+        now=NOW,
+    )
+    replay = transition.lease.reserve(
+        hold_id="a",
+        fingerprint="fp",
+        amount_microdollars=400,
+        fencing_token=7,
+        now=NOW,
+    )
+    assert replay.replayed is True
+    assert replay.lease is transition.lease
+
+    settled = replay.lease.settle(
+        hold_id="a", actual_microdollars=250, fencing_token=7
+    )
+    settled_replay = settled.lease.settle(
+        hold_id="a", actual_microdollars=250, fencing_token=7
+    )
+    assert settled_replay.replayed is True
+    assert settled_replay.lease is settled.lease
+
+
+@pytest.mark.parametrize(
+    ("fingerprint", "amount"),
+    [("different", 400), ("fp", 401)],
+)
+def test_idempotency_reuse_with_changed_inputs_fails(
+    fingerprint: str, amount: int
+) -> None:
+    lease = _lease().reserve(
+        hold_id="a",
+        fingerprint="fp",
+        amount_microdollars=400,
+        fencing_token=7,
+        now=NOW,
+    ).lease
+    with pytest.raises(LeaseIdempotencyConflictError):
+        lease.reserve(
+            hold_id="a",
+            fingerprint=fingerprint,
+            amount_microdollars=amount,
+            fencing_token=7,
+            now=NOW,
+        )
+
+
+def test_lease_fails_closed_on_expiry_exhaustion_and_stale_fence() -> None:
+    with pytest.raises(LeaseUnavailableError, match="expired"):
+        _lease(expires_in=0).reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=1,
+            fencing_token=7,
+            now=NOW,
+        )
+    with pytest.raises(LeaseExhaustedError):
+        _lease(grant=100).reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=101,
+            fencing_token=7,
+            now=NOW,
+        )
+    with pytest.raises(LeaseFenceMismatchError):
+        _lease().reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=1,
+            fencing_token=6,
+            now=NOW,
+        )
+
+
+def test_settlement_cannot_exceed_hold_or_cross_refund_boundary() -> None:
+    lease = _lease().reserve(
+        hold_id="a",
+        fingerprint="fp",
+        amount_microdollars=100,
+        fencing_token=7,
+        now=NOW,
+    ).lease
+    with pytest.raises(LeaseSettlementError, match="fit inside"):
+        lease.settle(hold_id="a", actual_microdollars=101, fencing_token=7)
+    refunded = lease.refund(hold_id="a", fencing_token=7).lease
+    with pytest.raises(LeaseSettlementError, match="refunded"):
+        refunded.settle(hold_id="a", actual_microdollars=50, fencing_token=7)
+
+
+def test_drain_blocks_new_work_and_close_waits_for_open_holds() -> None:
+    lease = _lease().reserve(
+        hold_id="a",
+        fingerprint="fp",
+        amount_microdollars=100,
+        fencing_token=7,
+        now=NOW,
+    ).lease
+    draining = lease.begin_drain(fencing_token=7)
+    assert draining.state == LeaseState.DRAINING
+    with pytest.raises(LeaseUnavailableError, match="draining"):
+        draining.reserve(
+            hold_id="b",
+            fingerprint="fp-b",
+            amount_microdollars=1,
+            fencing_token=7,
+            now=NOW,
+        )
+    with pytest.raises(LeaseUnavailableError, match="open reservations"):
+        draining.close(fencing_token=7)
+    closed = draining.refund(hold_id="a", fencing_token=7).lease.close(
+        fencing_token=7
+    )
+    assert closed.state == LeaseState.CLOSED
+
+
+def test_bounded_grant_is_integer_only_and_caps_global_exposure() -> None:
+    assert (
+        bounded_lease_grant_microdollars(
+            available_microdollars=10_000_003,
+            requested_microdollars=5_000_000,
+            per_lease_cap_microdollars=3_000_000,
+            max_available_basis_points=1_000,
+        )
+        == 1_000_000
+    )
+    assert (
+        bounded_lease_grant_microdollars(
+            available_microdollars=100,
+            requested_microdollars=1,
+            per_lease_cap_microdollars=50,
+            max_available_basis_points=1_000,
+        )
+        == 1
+    )
+
+
+def test_many_independent_reservations_never_exceed_grant() -> None:
+    lease = _lease(grant=10_000)
+    for index in range(100):
+        lease = lease.reserve(
+            hold_id=f"hold-{index}",
+            fingerprint=f"fp-{index}",
+            amount_microdollars=100,
+            fencing_token=7,
+            now=NOW,
+        ).lease
+    assert lease.accounted_microdollars == 10_000
+    with pytest.raises(LeaseExhaustedError):
+        lease.reserve(
+            hold_id="overflow",
+            fingerprint="overflow",
+            amount_microdollars=1,
+            fencing_token=7,
+            now=NOW,
+        )
+
+
+@given(
+    grant=st.integers(min_value=1, max_value=1_000_000),
+    requested=st.lists(
+        st.integers(min_value=1, max_value=100_000),
+        min_size=0,
+        max_size=50,
+    ),
+)
+def test_arbitrary_reservation_sequences_never_exceed_escrow(
+    grant: int,
+    requested: list[int],
+) -> None:
+    lease = _lease(grant=grant)
+    for index, amount in enumerate(requested):
+        if amount > lease.available_microdollars:
+            with pytest.raises(LeaseExhaustedError):
+                lease.reserve(
+                    hold_id=f"hold-{index}",
+                    fingerprint=f"fp-{index}",
+                    amount_microdollars=amount,
+                    fencing_token=7,
+                    now=NOW,
+                )
+        else:
+            lease = lease.reserve(
+                hold_id=f"hold-{index}",
+                fingerprint=f"fp-{index}",
+                amount_microdollars=amount,
+                fencing_token=7,
+                now=NOW,
+            ).lease
+        assert 0 <= lease.accounted_microdollars <= grant
+        assert lease.available_microdollars == grant - lease.accounted_microdollars
+
+
+def test_pure_transitions_are_safe_to_compute_concurrently() -> None:
+    lease = _lease(grant=10_000)
+
+    def reserve(index: int) -> RegionalQuotaLease:
+        return lease.reserve(
+            hold_id=f"hold-{index}",
+            fingerprint=f"fp-{index}",
+            amount_microdollars=100,
+            fencing_token=7,
+            now=NOW,
+        ).lease
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        candidates = list(pool.map(reserve, range(32)))
+
+    assert all(candidate.accounted_microdollars == 100 for candidate in candidates)
+    assert lease.accounted_microdollars == 0
+
+
+def test_invalid_construction_and_grant_inputs_fail_closed() -> None:
+    with pytest.raises(RegionalQuotaLeaseError, match="timezone-aware"):
+        RegionalQuotaLease(
+            lease_id="lease",
+            workspace_id="workspace",
+            region="us-east4",
+            fencing_token=1,
+            granted_microdollars=1,
+            expires_at=datetime(2026, 7, 31),
+        )
+    with pytest.raises(RegionalQuotaLeaseError, match="cannot be negative"):
+        bounded_lease_grant_microdollars(
+            available_microdollars=-1,
+            requested_microdollars=1,
+            per_lease_cap_microdollars=1,
+            max_available_basis_points=1_000,
+        )
+
+
+def test_regional_leases_are_dark_and_fail_closed_outside_tests() -> None:
+    assert Settings(environment="test").regional_quota_leases_enabled is False
+    with pytest.raises(ValidationError, match="PILOT_WORKSPACE_IDS"):
+        Settings(environment="test", regional_quota_leases_enabled=True)
+    with pytest.raises(ValidationError, match="not production-ready"):
+        Settings(
+            environment="staging",
+            regional_quota_leases_enabled=True,
+            regional_quota_lease_pilot_workspace_ids="workspace-1",
+        )
+    settings = Settings(
+        environment="test",
+        regional_quota_leases_enabled=True,
+        regional_quota_lease_pilot_workspace_ids=" workspace-1,workspace-2 ",
+    )
+    assert settings.regional_quota_lease_pilot_workspaces == {
+        "workspace-1",
+        "workspace-2",
+    }

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -51,8 +51,10 @@ from trusted_router.synthetic.probes import (
     IMAGE_GENERATION_MODEL,
     IMAGE_GENERATION_PROVIDER,
     SyntheticTarget,
+    _remaining_probe_seconds,
     _rotation_max_tokens,
     _rotation_omits_temperature,
+    _server_timing_gateway,
     _sse_line_error,
     _sse_line_finish_reason,
     _sse_line_has_content,
@@ -60,6 +62,7 @@ from trusted_router.synthetic.probes import (
     choose_rotation_target,
     gateway_billing_probe,
     gateway_fallback_probe,
+    gateway_latency_phase_probes,
     image_generation_probe,
     openai_chat_pong_probe,
     provider_rotation_probe,
@@ -252,6 +255,49 @@ def test_status_snapshot_calls_out_stale_monitor_data() -> None:
     assert snapshot["summary"]["headline"] == "Monitor Data Stale"
     assert snapshot["monitor_freshness"]["is_stale"] is True
     assert snapshot["monitor_freshness"]["latest_sample_age_seconds"] >= 12 * 60
+
+
+def test_status_snapshot_reports_cold_and_reused_latency_anatomy_without_affecting_slo() -> None:
+    now = utcnow()
+    created_at = (now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z")
+    samples = [
+        _sample(
+            id="tls",
+            probe_type="tls_health",
+            status="up",
+            latency_milliseconds=57,
+            created_at=created_at,
+        ),
+        _sample(
+            id="cold",
+            probe_type="gateway_cold_path",
+            status="up",
+            latency_milliseconds=57,
+            dns_milliseconds=3,
+            tcp_connect_milliseconds=12,
+            tls_handshake_milliseconds=26,
+            gateway_processing_milliseconds=1,
+            created_at=created_at,
+        ),
+        _sample(
+            id="reused",
+            probe_type="gateway_reused_path",
+            status="up",
+            latency_milliseconds=15,
+            gateway_processing_milliseconds=1,
+            created_at=created_at,
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now)
+    anatomy = {
+        row["probe_type"]: row for row in snapshot["headline_metrics"]["latency_anatomy"]
+    }
+
+    assert anatomy["gateway_cold_path"]["p50_dns_milliseconds"] == 3
+    assert anatomy["gateway_cold_path"]["p50_tls_handshake_milliseconds"] == 26
+    assert anatomy["gateway_reused_path"]["p50_latency_milliseconds"] == 15
+    assert snapshot["windows"]["5m"]["sample_count"] == 1
 
 
 def test_public_status_response_cache_reuses_rendered_body() -> None:
@@ -1290,6 +1336,27 @@ def test_synthetic_rollups_are_idempotent_and_monthly_queryable() -> None:
     assert canonical.latency_histogram == {"123": 1}
 
 
+def test_synthetic_rollup_retains_latency_phase_histograms() -> None:
+    sample = _sample(
+        id="syn_latency_phases",
+        probe_type="gateway_cold_path",
+        status="up",
+        latency_milliseconds=57,
+        dns_milliseconds=3,
+        tcp_connect_milliseconds=12,
+        tls_handshake_milliseconds=26,
+        gateway_processing_milliseconds=1,
+    )
+
+    rollup = new_rollup_for_sample(sample, period="hour", component="uncategorized")
+
+    assert rollup.latency_histogram == {"57": 1}
+    assert rollup.dns_histogram == {"3": 1}
+    assert rollup.tcp_connect_histogram == {"12": 1}
+    assert rollup.tls_handshake_histogram == {"26": 1}
+    assert rollup.gateway_processing_histogram == {"1": 1}
+
+
 def test_gcp_synthetic_rollups_use_period_start_range() -> None:
     old = _sample(
         id="syn_rollup_old_range",
@@ -1917,6 +1984,10 @@ def _sample(
     output_match: bool | None = None,
     created_at: str | None = None,
     latency_milliseconds: int | None = None,
+    dns_milliseconds: int | None = None,
+    tcp_connect_milliseconds: int | None = None,
+    tls_handshake_milliseconds: int | None = None,
+    gateway_processing_milliseconds: int | None = None,
     error_type: str | None = None,
     http_status: int | None = None,
 ) -> SyntheticProbeSample:
@@ -1932,6 +2003,10 @@ def _sample(
         provider=provider,
         output_match=output_match,
         latency_milliseconds=latency_milliseconds,
+        dns_milliseconds=dns_milliseconds,
+        tcp_connect_milliseconds=tcp_connect_milliseconds,
+        tls_handshake_milliseconds=tls_handshake_milliseconds,
+        gateway_processing_milliseconds=gateway_processing_milliseconds,
         error_type=error_type,
         http_status=http_status,
         created_at=created_at or iso_now(),
@@ -2043,6 +2118,26 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
     monkeypatch.setattr(probe_module, "configured_targets", lambda _settings: targets)
     monkeypatch.setattr(probe_module, "tls_health_probe", fake_probe("tls_health"))
     monkeypatch.setattr(probe_module, "attestation_nonce_probe", fake_probe("attestation_nonce"))
+
+    async def fake_phase_probes(
+        target: SyntheticTarget,
+        *,
+        monitor_region: str,
+        **_kwargs: Any,
+    ) -> list[SyntheticProbeSample]:
+        return [
+            _sample(
+                id=f"{probe_type}-{target.name}",
+                probe_type=probe_type,
+                status="up",
+                target=target.name,
+                target_region=target.region,
+                monitor_region=monitor_region,
+            )
+            for probe_type in ("gateway_cold_path", "gateway_reused_path")
+        ]
+
+    monkeypatch.setattr(probe_module, "gateway_latency_phase_probes", fake_phase_probes)
     monkeypatch.setattr(
         probe_module, "control_plane_health_probe", fake_probe("control_plane_health")
     )
@@ -2061,7 +2156,7 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
     )
     elapsed = time.perf_counter() - started
 
-    assert len(samples) == 13
+    assert len(samples) == 19
     assert {sample.target for sample in samples} == {"canonical", "us-east4", "europe-west4"}
     # Serial execution would take about 13 * 30ms. Keep enough slack for busy CI
     # while still proving a single slow target no longer blocks the whole pass.
@@ -2119,6 +2214,17 @@ async def test_run_synthetic_once_bounds_credit_bearing_probe_concurrency(
     monkeypatch.setattr(probe_module, "configured_targets", lambda _settings: targets)
     monkeypatch.setattr(probe_module, "tls_health_probe", fake_health_probe)
     monkeypatch.setattr(probe_module, "attestation_nonce_probe", fake_health_probe)
+
+    async def no_phase_probes(
+        _target: SyntheticTarget,
+        *,
+        monitor_region: str,
+        **_kwargs: Any,
+    ) -> list[SyntheticProbeSample]:
+        assert monitor_region == "us-central1"
+        return []
+
+    monkeypatch.setattr(probe_module, "gateway_latency_phase_probes", no_phase_probes)
     monkeypatch.setattr(probe_module, "openai_chat_pong_probe", fake_billing_probe)
     monkeypatch.setattr(probe_module, "responses_pong_probe", fake_billing_probe)
 
@@ -2666,6 +2772,82 @@ def test_sse_line_error_distinguishes_router_failure_from_provider_failure() -> 
     ) == ("router_database_contention", 503, "transient database contention")
 
 
+def test_gateway_server_timing_parser_is_bounded_and_optional() -> None:
+    assert _server_timing_gateway({"server-timing": "cache;dur=4, gateway;dur=0.7"}) == 1
+    assert _server_timing_gateway({"server-timing": "gateway;dur=invalid"}) is None
+    assert _server_timing_gateway({}) is None
+
+
+def test_gateway_latency_phase_probe_uses_one_total_deadline() -> None:
+    with pytest.raises(TimeoutError, match="deadline exceeded"):
+        _remaining_probe_seconds(time.perf_counter() - 2.0, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_gateway_latency_phase_probe_rejects_non_https_without_network() -> None:
+    samples = await gateway_latency_phase_probes(
+        SyntheticTarget("bad", "http://api.example/v1", "us-central1"),
+        monitor_region="us-central1",
+    )
+
+    assert [sample.probe_type for sample in samples] == [
+        "gateway_cold_path",
+        "gateway_reused_path",
+    ]
+    assert all(sample.status == "down" for sample in samples)
+    assert all(sample.error_type == "invalid_health_url" for sample in samples)
+    assert all(sample_slo_class_ids(sample) == [] for sample in samples)
+
+
+@pytest.mark.asyncio
+async def test_gateway_billing_probe_reports_authorize_and_settle_separately() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/authorize"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "authorization_id": "auth-1",
+                        "model": "deepseek/deepseek-v4-flash",
+                        "provider": "deepseek",
+                        "endpoint_id": "deepseek-primary",
+                    }
+                },
+            )
+        assert request.url.path.endswith("/settle")
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "settled": True,
+                    "model": "deepseek/deepseek-v4-flash",
+                    "provider": "deepseek",
+                    "generation_id": "gen-1",
+                    "cost_microdollars": 1,
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        samples = await gateway_billing_probe(
+            client,
+            control_plane_base_url="https://trustedrouter.com",
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            internal_token="internal-test",  # noqa: S106 - test placeholder.
+            model="trustedrouter/monitor",
+        )
+
+    assert [sample.probe_type for sample in samples] == [
+        "gateway_authorize",
+        "gateway_settle",
+    ]
+    assert all(sample.status == "up" for sample in samples)
+    assert all(sample.latency_milliseconds is not None for sample in samples)
+    assert all(sample_slo_class_ids(sample) == ["router_core"] for sample in samples)
+    assert samples[1].cost_microdollars == 1
+
+
 @pytest.mark.asyncio
 async def test_gateway_billing_probe_classifies_monitor_workspace_pause() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2692,6 +2874,7 @@ async def test_gateway_billing_probe_classifies_monitor_workspace_pause() -> Non
             model="trustedrouter/monitor",
         )
 
+    assert samples[0].probe_type == "gateway_authorize"
     assert samples[0].error_type == "monitor_workspace_paused"
     assert sample_slo_class_ids(samples[0]) == []
     assert {component for _period, component in sample_rollup_ids(samples[0])} == {


### PR DESCRIPTION
## Summary
- measure fresh and reused gateway paths with DNS, TCP, TLS, TTFB, and enclave processing phases
- split synthetic authorization and settlement latency and expose phase rollups on status
- document and test a bounded regional quota-lease state machine while keeping it disabled and rejected in production

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2320 passed, 86 skipped)