### PR TITLE
Scale ClickHouse analytics for long-term reliability

### DIFF
--- a/clickhouse/002_provider_analytics_rollups.sql
+++ b/clickhouse/002_provider_analytics_rollups.sql
@@ -1,0 +1,88 @@
+-- TrustedRouter analytics schema, increment 2: durable aggregate tiers.
+--
+-- These are rebuilt from `provider_benchmark_samples FINAL`; they are not
+-- additive materialized views because the ingestion contract is at-least-once.
+-- The rollup worker builds one partition in a staging table, verifies that
+-- sum(attempts) equals the source row count, and atomically replaces the live
+-- partition. Hourly detail is retained for three years. Daily and monthly
+-- aggregates are intentionally retained without a TTL.
+
+CREATE TABLE IF NOT EXISTS provider_analytics_hourly
+(
+    period_start                 DateTime('UTC'),
+    provider                     LowCardinality(String),
+    model                        LowCardinality(String),
+    source                       LowCardinality(String),
+    region                       LowCardinality(String),
+    usage_type                   LowCardinality(String),
+    status                       LowCardinality(String),
+    error_type                   LowCardinality(String),
+    error_status                 UInt16,
+    streamed                     UInt8,
+    attempts                     UInt64,
+    completed                    UInt64,
+    failed                       UInt64,
+    input_tokens                 UInt64,
+    output_tokens                UInt64,
+    total_cost_microdollars      Int64,
+    p50_elapsed_milliseconds     Nullable(Float64),
+    p95_elapsed_milliseconds     Nullable(Float64),
+    p50_first_token_milliseconds Nullable(Float64),
+    p95_first_token_milliseconds Nullable(Float64),
+    p50_ttfb_milliseconds        Nullable(Float64),
+    p95_ttfb_milliseconds        Nullable(Float64),
+    p50_tokens_per_second        Nullable(Float64),
+    p95_tokens_per_second        Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+)
+TTL period_start + INTERVAL 3 YEAR;
+
+CREATE TABLE IF NOT EXISTS provider_analytics_daily
+AS provider_analytics_hourly
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);
+
+CREATE TABLE IF NOT EXISTS provider_analytics_monthly
+AS provider_analytics_hourly
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);
+
+CREATE TABLE IF NOT EXISTS provider_analytics_hourly_staging
+AS provider_analytics_hourly
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);
+
+CREATE TABLE IF NOT EXISTS provider_analytics_daily_staging
+AS provider_analytics_daily
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);
+
+CREATE TABLE IF NOT EXISTS provider_analytics_monthly_staging
+AS provider_analytics_monthly
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);

--- a/clickhouse/003_provider_benchmark_replicated.sql
+++ b/clickhouse/003_provider_benchmark_replicated.sql
@@ -1,0 +1,39 @@
+-- Staging table used to migrate the single local analytics table to one shard
+-- with three ClickHouse replicas. The migration script creates this table on
+-- every replica, verifies full fingerprints, then renames it to the canonical
+-- `provider_benchmark_samples` name. The Keeper path is intentionally stable
+-- across table renames.
+
+CREATE TABLE IF NOT EXISTS provider_benchmark_samples_replicated
+(
+    id                       String,
+    created_at               DateTime64(3, 'UTC'),
+    provider                 LowCardinality(String),
+    model                    LowCardinality(String),
+    provider_name            LowCardinality(String),
+    status                   LowCardinality(String),
+    usage_type               LowCardinality(String),
+    source                   LowCardinality(String),
+    streamed                 UInt8,
+    input_tokens             UInt32,
+    output_tokens            UInt32,
+    total_cost_microdollars  Int64,
+    speed_tokens_per_second  Nullable(Float32),
+    elapsed_milliseconds     Nullable(UInt32),
+    first_token_milliseconds Nullable(UInt32),
+    ttfb_milliseconds        Nullable(UInt32),
+    finish_reason            LowCardinality(Nullable(String)),
+    error_type               LowCardinality(Nullable(String)),
+    error_status             Nullable(UInt16),
+    error_message            Nullable(String),
+    region                   LowCardinality(Nullable(String)),
+    app                      String
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/provider_benchmark_samples-v1',
+    '{replica}',
+    created_at
+)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (provider, model, created_at, id)
+TTL toDateTime(created_at) + INTERVAL 400 DAY;

--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -1,0 +1,578 @@
+"""Archive closed ClickHouse analytics days as verified, immutable Parquet.
+
+The manifest pointer is advanced only after the exported Parquet has been read
+back and its row/content fingerprint matches the deduplicated ClickHouse source.
+Reruns are cheap when the source fingerprint is unchanged and create a new,
+immutable revision when reconciliation adds late rows.
+"""
+
+# ruff: noqa: S608
+# SQL identifiers are allowlist-validated and all remaining query fragments are
+# generated from typed dates, integer shard indexes, and a fixed column list.
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Protocol
+
+PROJECT = "quill-cloud-proxy"
+DATABASE = "tr"
+TABLE = "provider_benchmark_samples"
+ARCHIVE_BUCKET = "quill-cloud-proxy-tr-clickhouse-archive"
+ARCHIVE_SCHEMA_VERSION = 1
+ROWS_PER_PART = 5_000_000
+UINT64_MODULUS = 1 << 64
+
+log = logging.getLogger("trusted_router.analytics_archive")
+
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_COLUMNS = (
+    "id",
+    "created_at",
+    "provider",
+    "model",
+    "provider_name",
+    "status",
+    "usage_type",
+    "source",
+    "streamed",
+    "input_tokens",
+    "output_tokens",
+    "total_cost_microdollars",
+    "speed_tokens_per_second",
+    "elapsed_milliseconds",
+    "first_token_milliseconds",
+    "ttfb_milliseconds",
+    "finish_reason",
+    "error_type",
+    "error_status",
+    "error_message",
+    "region",
+    "app",
+)
+
+
+def _identifier(value: str, *, label: str) -> str:
+    if _IDENTIFIER.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a ClickHouse identifier")
+    return value
+
+
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _day_bounds(day: dt.date) -> tuple[str, str]:
+    start = dt.datetime.combine(day, dt.time(), tzinfo=dt.UTC)
+    return (
+        start.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        (start + dt.timedelta(days=1))
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
+    )
+
+
+def _row_hash_expression() -> str:
+    return "cityHash64(toJSONString(tuple(" + ", ".join(_COLUMNS) + ")))"
+
+
+@dataclasses.dataclass(frozen=True)
+class SourceFingerprint:
+    rows: int
+    hash_sum: int
+    hash_xor: int
+    min_created_at: str | None
+    max_created_at: str | None
+
+    @property
+    def revision(self) -> str:
+        return (
+            f"v{ARCHIVE_SCHEMA_VERSION}-{self.rows}-"
+            f"{self.hash_sum:016x}-{self.hash_xor:016x}"
+        )
+
+    def matches(self, other: SourceFingerprint) -> bool:
+        return (
+            self.rows == other.rows
+            and self.hash_sum == other.hash_sum
+            and self.hash_xor == other.hash_xor
+        )
+
+    def as_dict(self) -> dict[str, int | str | None]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> SourceFingerprint:
+        return cls(
+            rows=int(value["rows"]),
+            hash_sum=int(value["hash_sum"]),
+            hash_xor=int(value["hash_xor"]),
+            min_created_at=_nullable_string(value.get("min_created_at")),
+            max_created_at=_nullable_string(value.get("max_created_at")),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ExportedPart:
+    path: Path
+    rows: int
+    hash_sum: int
+    hash_xor: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ArchiveResult:
+    day: dt.date
+    rows: int
+    revision: str
+    skipped: bool
+    manifest_key: str
+
+
+class DailyExporter(Protocol):
+    def source_fingerprint(self, day: dt.date) -> SourceFingerprint: ...
+
+    def export_parts(
+        self,
+        day: dt.date,
+        destination: Path,
+        *,
+        part_count: int,
+    ) -> list[Path]: ...
+
+    def verify_part(self, path: Path) -> ExportedPart: ...
+
+
+class ArchiveStore(Protocol):
+    def read_json(self, key: str) -> dict[str, Any] | None: ...
+
+    def put_file_if_absent(
+        self,
+        key: str,
+        path: Path,
+        *,
+        sha256: str,
+        metadata: dict[str, str],
+    ) -> None: ...
+
+    def put_json_if_absent(self, key: str, value: dict[str, Any]) -> None: ...
+
+    def put_json_pointer(self, key: str, value: dict[str, Any]) -> None: ...
+
+
+class ClickHouseDailyExporter:
+    def __init__(
+        self,
+        *,
+        password: str,
+        database: str = DATABASE,
+        table: str = TABLE,
+    ) -> None:
+        self._password = password
+        self._database = _identifier(database, label="database")
+        self._table = _identifier(table, label="table")
+
+    @property
+    def qualified_table(self) -> str:
+        return f"{self._database}.{self._table}"
+
+    def _client(self, query: str, *, stdout: Any = subprocess.PIPE) -> bytes:
+        env = os.environ.copy()
+        env["CLICKHOUSE_PASSWORD"] = self._password
+        result = subprocess.run(  # noqa: S603 - fixed executable and argv, no shell
+            [
+                "/usr/bin/clickhouse-client",
+                "--user",
+                "tr",
+                "--database",
+                self._database,
+                "--query",
+                query,
+            ],
+            env=env,
+            stdout=stdout,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace")[:2000]
+            raise RuntimeError(f"ClickHouse archive query failed: {detail}")
+        return result.stdout if isinstance(result.stdout, bytes) else b""
+
+    def source_fingerprint(self, day: dt.date) -> SourceFingerprint:
+        start, end = _day_bounds(day)
+        query = _fingerprint_query(
+            self.qualified_table,
+            where=(
+                f"created_at >= toDateTime64({_sql_string(start)}, 3, 'UTC') "
+                f"AND created_at < toDateTime64({_sql_string(end)}, 3, 'UTC')"
+            ),
+            final=True,
+        )
+        return _parse_fingerprint(self._client(query))
+
+    def earliest_day(self) -> dt.date | None:
+        payload = self._client(
+            f"SELECT if(count() = 0, '', toString(toDate(min(created_at)))) "
+            f"FROM {self.qualified_table} FINAL"
+        )
+        value = payload.decode("utf-8").strip().splitlines()[-1]
+        return dt.date.fromisoformat(value) if value else None
+
+    def export_parts(
+        self,
+        day: dt.date,
+        destination: Path,
+        *,
+        part_count: int,
+    ) -> list[Path]:
+        destination.mkdir(parents=True, exist_ok=True)
+        start, end = _day_bounds(day)
+        paths: list[Path] = []
+        for part in range(part_count):
+            path = destination / f"part-{part:05d}-of-{part_count:05d}.parquet"
+            where = (
+                f"created_at >= toDateTime64({_sql_string(start)}, 3, 'UTC') "
+                f"AND created_at < toDateTime64({_sql_string(end)}, 3, 'UTC') "
+                f"AND cityHash64(id) % {part_count} = {part}"
+            )
+            query = (  # noqa: S608 - identifiers are validated; values are generated.
+                f"SELECT {', '.join(_COLUMNS)} FROM {self.qualified_table} FINAL "
+                f"WHERE {where} ORDER BY created_at, id FORMAT Parquet"
+            )
+            with path.open("wb") as stream:
+                self._client(query, stdout=stream)
+            paths.append(path)
+        return paths
+
+    def verify_part(self, path: Path) -> ExportedPart:
+        query = _fingerprint_query(
+            f"file({_sql_string(str(path))}, Parquet)",
+            where=None,
+            final=False,
+        )
+        fingerprint = _parse_fingerprint(_run_clickhouse_local(query))
+        return ExportedPart(
+            path=path,
+            rows=fingerprint.rows,
+            hash_sum=fingerprint.hash_sum,
+            hash_xor=fingerprint.hash_xor,
+        )
+
+
+class GCSArchiveStore:
+    def __init__(self, *, project: str, bucket: str) -> None:
+        from google.cloud import storage
+
+        self._bucket = storage.Client(project=project).bucket(bucket)
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        blob = self._bucket.blob(key)
+        if not blob.exists():
+            return None
+        value = json.loads(blob.download_as_text())
+        if not isinstance(value, dict):
+            raise RuntimeError(f"archive object {key} is not a JSON object")
+        return value
+
+    def put_file_if_absent(
+        self,
+        key: str,
+        path: Path,
+        *,
+        sha256: str,
+        metadata: dict[str, str],
+    ) -> None:
+        from google.api_core.exceptions import PreconditionFailed
+
+        blob = self._bucket.blob(key)
+        blob.metadata = {**metadata, "sha256": sha256}
+        try:
+            blob.upload_from_filename(
+                str(path),
+                content_type="application/vnd.apache.parquet",
+                if_generation_match=0,
+            )
+        except PreconditionFailed:
+            blob.reload()
+            if (blob.metadata or {}).get("sha256") != sha256:
+                raise RuntimeError(
+                    f"immutable archive object differs: gs://{self._bucket.name}/{key}"
+                ) from None
+
+    def put_json_if_absent(self, key: str, value: dict[str, Any]) -> None:
+        from google.api_core.exceptions import PreconditionFailed
+
+        encoded = _json_bytes(value)
+        blob = self._bucket.blob(key)
+        try:
+            blob.upload_from_string(
+                encoded,
+                content_type="application/json",
+                if_generation_match=0,
+            )
+        except PreconditionFailed:
+            if blob.download_as_bytes() != encoded:
+                raise RuntimeError(
+                    f"immutable archive manifest differs: gs://{self._bucket.name}/{key}"
+                ) from None
+
+    def put_json_pointer(self, key: str, value: dict[str, Any]) -> None:
+        blob = self._bucket.blob(key)
+        generation = 0
+        if blob.exists():
+            blob.reload()
+            generation = int(blob.generation or 0)
+        blob.upload_from_string(
+            _json_bytes(value),
+            content_type="application/json",
+            if_generation_match=generation,
+        )
+
+
+def _nullable_string(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _fingerprint_query(table_expression: str, *, where: str | None, final: bool) -> str:
+    suffix = " FINAL" if final else ""
+    where_clause = f" WHERE {where}" if where else ""
+    row_hash = _row_hash_expression()
+    return (  # noqa: S608 - table expressions are validated or locally generated.
+        "SELECT count() AS rows, "
+        f"sum({row_hash}) AS hash_sum, "
+        f"groupBitXor({row_hash}) AS hash_xor, "
+        "if(count() = 0, NULL, toString(min(created_at))) AS min_created_at, "
+        "if(count() = 0, NULL, toString(max(created_at))) AS max_created_at "
+        f"FROM {table_expression}{suffix}{where_clause} FORMAT JSONEachRow"
+    )
+
+
+def _parse_fingerprint(payload: bytes) -> SourceFingerprint:
+    value = json.loads(payload.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError("ClickHouse fingerprint response was not an object")
+    return SourceFingerprint.from_dict(value)
+
+
+def _run_clickhouse_local(query: str) -> bytes:
+    result = subprocess.run(  # noqa: S603 - fixed executable and argv, no shell
+        ["/usr/bin/clickhouse-local", "--query", query],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace")[:2000]
+        raise RuntimeError(f"Parquet verification failed: {detail}")
+    return result.stdout
+
+
+def _json_bytes(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _combine_parts(parts: Sequence[ExportedPart]) -> SourceFingerprint:
+    rows = sum(part.rows for part in parts)
+    hash_sum = sum(part.hash_sum for part in parts) % UINT64_MODULUS
+    hash_xor = 0
+    for part in parts:
+        hash_xor ^= part.hash_xor
+    return SourceFingerprint(
+        rows=rows,
+        hash_sum=hash_sum,
+        hash_xor=hash_xor,
+        min_created_at=None,
+        max_created_at=None,
+    )
+
+
+def archive_day(
+    exporter: DailyExporter,
+    store: ArchiveStore,
+    day: dt.date,
+    *,
+    rows_per_part: int = ROWS_PER_PART,
+    now: dt.datetime | None = None,
+) -> ArchiveResult:
+    if rows_per_part < 1:
+        raise ValueError("rows_per_part must be positive")
+    source = exporter.source_fingerprint(day)
+    date_prefix = f"raw/provider_benchmark_samples/day={day.isoformat()}"
+    pointer_key = f"{date_prefix}/_latest.json"
+    latest = store.read_json(pointer_key)
+    if latest is not None:
+        prior = SourceFingerprint.from_dict(dict(latest["source_fingerprint"]))
+        if source.matches(prior):
+            return ArchiveResult(
+                day=day,
+                rows=source.rows,
+                revision=str(latest["revision"]),
+                skipped=True,
+                manifest_key=str(latest["manifest"]),
+            )
+
+    part_count = math.ceil(source.rows / rows_per_part) if source.rows else 0
+    revision = source.revision
+    revision_prefix = f"{date_prefix}/revisions/{revision}"
+    manifest_key = f"{revision_prefix}/manifest.json"
+    exported_at = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+    manifest_parts: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix=f"tr-archive-{day.isoformat()}-") as temporary:
+        paths = exporter.export_parts(day, Path(temporary), part_count=part_count)
+        if len(paths) != part_count:
+            raise RuntimeError(f"expected {part_count} Parquet parts, exporter returned {len(paths)}")
+        verified = [exporter.verify_part(path) for path in paths]
+        actual = _combine_parts(verified)
+        if not source.matches(actual):
+            raise RuntimeError(
+                "archive parity mismatch: "
+                f"source rows/hash={source.rows}/{source.hash_sum}/{source.hash_xor}, "
+                f"parquet rows/hash={actual.rows}/{actual.hash_sum}/{actual.hash_xor}"
+            )
+        for index, part in enumerate(verified):
+            sha256 = _sha256(part.path)
+            key = f"{revision_prefix}/{part.path.name}"
+            store.put_file_if_absent(
+                key,
+                part.path,
+                sha256=sha256,
+                metadata={
+                    "archive-day": day.isoformat(),
+                    "archive-revision": revision,
+                    "rows": str(part.rows),
+                    "part": str(index),
+                },
+            )
+            manifest_parts.append(
+                {
+                    "key": key,
+                    "rows": part.rows,
+                    "bytes": part.path.stat().st_size,
+                    "sha256": sha256,
+                    "hash_sum": part.hash_sum,
+                    "hash_xor": part.hash_xor,
+                }
+            )
+
+    manifest: dict[str, Any] = {
+        "schema_version": ARCHIVE_SCHEMA_VERSION,
+        "dataset": TABLE,
+        "day": day.isoformat(),
+        "revision": revision,
+        "exported_at": exported_at.isoformat().replace("+00:00", "Z"),
+        "source_fingerprint": source.as_dict(),
+        "parts": manifest_parts,
+        "parquet_rows": sum(int(part["rows"]) for part in manifest_parts),
+    }
+    store.put_json_if_absent(manifest_key, manifest)
+    store.put_json_pointer(
+        pointer_key,
+        {
+            "schema_version": ARCHIVE_SCHEMA_VERSION,
+            "day": day.isoformat(),
+            "revision": revision,
+            "manifest": manifest_key,
+            "source_fingerprint": source.as_dict(),
+            "updated_at": exported_at.isoformat().replace("+00:00", "Z"),
+        },
+    )
+    return ArchiveResult(
+        day=day,
+        rows=source.rows,
+        revision=revision,
+        skipped=False,
+        manifest_key=manifest_key,
+    )
+
+
+def _days_to_archive(
+    *,
+    date: dt.date | None,
+    lookback_days: int,
+    backfill_start: dt.date | None = None,
+) -> list[dt.date]:
+    if date is not None:
+        return [date]
+    if backfill_start is None and lookback_days < 1:
+        raise ValueError("lookback_days must be positive")
+    today = dt.datetime.now(dt.UTC).date()
+    if backfill_start is not None:
+        if backfill_start >= today:
+            return []
+        return [
+            backfill_start + dt.timedelta(days=offset)
+            for offset in range((today - backfill_start).days)
+        ]
+    return [today - dt.timedelta(days=offset) for offset in range(lookback_days, 0, -1)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
+    parser.add_argument("--database", default=DATABASE)
+    parser.add_argument("--table", default=TABLE)
+    parser.add_argument("--date", type=dt.date.fromisoformat)
+    parser.add_argument("--lookback-days", type=int, default=7)
+    parser.add_argument("--backfill", action="store_true")
+    parser.add_argument("--rows-per-part", type=int, default=ROWS_PER_PART)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    exporter = ClickHouseDailyExporter(
+        password=os.environ["CH_PASSWORD"],
+        database=args.database,
+        table=args.table,
+    )
+    store = GCSArchiveStore(project=args.project, bucket=args.bucket)
+    backfill_start = exporter.earliest_day() if args.backfill and args.date is None else None
+    for day in _days_to_archive(
+        date=args.date,
+        lookback_days=args.lookback_days,
+        backfill_start=backfill_start,
+    ):
+        result = archive_day(
+            exporter,
+            store,
+            day,
+            rows_per_part=args.rows_per_part,
+        )
+        log.info(
+            "analytics_archive.completed day=%s rows=%d revision=%s skipped=%s manifest=gs://%s/%s",
+            result.day,
+            result.rows,
+            result.revision,
+            result.skipped,
+            args.bucket,
+            result.manifest_key,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/requirements-live.txt
+++ b/clickhouse/requirements-live.txt
@@ -1,2 +1,3 @@
 google-cloud-bigtable>=2.26.0
 google-cloud-spanner>=3.50.0
+google-cloud-storage>=2.18.0

--- a/clickhouse/rollup_analytics.py
+++ b/clickhouse/rollup_analytics.py
@@ -1,0 +1,354 @@
+"""Recompute verified hourly, daily, and monthly ClickHouse rollups."""
+
+# ruff: noqa: S608
+# SQL identifiers are allowlist-validated and all other fragments are generated
+# from typed UTC boundaries and a closed granularity allowlist.
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import logging
+import os
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+from typing import Protocol
+
+DATABASE = "tr"
+RAW_TABLE = "provider_benchmark_samples"
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_GRANULARITIES = ("hourly", "daily", "monthly")
+
+log = logging.getLogger("trusted_router.analytics_rollup")
+
+
+def _identifier(value: str, *, label: str) -> str:
+    if _IDENTIFIER.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a ClickHouse identifier")
+    return value
+
+
+def _sql_datetime(value: dt.datetime) -> str:
+    utc = value.astimezone(dt.UTC)
+    text = utc.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return f"toDateTime64('{text}', 3, 'UTC')"
+
+
+def _month_start(value: dt.date) -> dt.date:
+    return value.replace(day=1)
+
+
+def _shift_month(value: dt.date, months: int) -> dt.date:
+    absolute = value.year * 12 + value.month - 1 + months
+    return dt.date(absolute // 12, absolute % 12 + 1, 1)
+
+
+@dataclasses.dataclass(frozen=True)
+class RollupPartition:
+    granularity: str
+    start: dt.datetime
+    end: dt.datetime
+    partition_id: str
+
+    def __post_init__(self) -> None:
+        if self.granularity not in _GRANULARITIES:
+            raise ValueError(f"unsupported granularity: {self.granularity}")
+        if self.start.tzinfo is None or self.end.tzinfo is None:
+            raise ValueError("rollup boundaries must be timezone-aware")
+        if self.end < self.start:
+            raise ValueError("rollup end cannot precede start")
+
+
+class QueryExecutor(Protocol):
+    def execute(self, query: str) -> bytes: ...
+
+
+class ClickHouseExecutor:
+    def __init__(self, *, password: str, database: str = DATABASE) -> None:
+        self._password = password
+        self._database = _identifier(database, label="database")
+
+    def execute(self, query: str) -> bytes:
+        env = os.environ.copy()
+        env["CLICKHOUSE_PASSWORD"] = self._password
+        result = subprocess.run(  # noqa: S603 - fixed executable and argv, no shell
+            [
+                "/usr/bin/clickhouse-client",
+                "--user",
+                "tr",
+                "--database",
+                self._database,
+                "--multiquery",
+                "--query",
+                query,
+            ],
+            env=env,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace")[:2000]
+            raise RuntimeError(f"ClickHouse rollup query failed: {detail}")
+        return result.stdout
+
+
+def planned_partitions(
+    granularity: str,
+    *,
+    now: dt.datetime,
+    backfill_start: dt.date | None = None,
+) -> list[RollupPartition]:
+    if granularity not in _GRANULARITIES:
+        raise ValueError(f"unsupported granularity: {granularity}")
+    now = now.astimezone(dt.UTC)
+    today = now.date()
+    if granularity == "hourly":
+        first = backfill_start or today - dt.timedelta(days=2)
+        dates = _date_range(first, today)
+        result: list[RollupPartition] = []
+        closed_hour = now.replace(minute=0, second=0, microsecond=0)
+        for day in dates:
+            start = dt.datetime.combine(day, dt.time(), tzinfo=dt.UTC)
+            end = min(start + dt.timedelta(days=1), closed_hour)
+            if end > start:
+                result.append(RollupPartition("hourly", start, end, day.strftime("%Y%m%d")))
+        return result
+
+    current_month = _month_start(today)
+    first_month = _month_start(backfill_start) if backfill_start else _shift_month(current_month, -1)
+    months = _month_range(first_month, current_month)
+    if granularity == "daily":
+        start_of_today = dt.datetime.combine(today, dt.time(), tzinfo=dt.UTC)
+        return [
+            RollupPartition(
+                "daily",
+                dt.datetime.combine(month, dt.time(), tzinfo=dt.UTC),
+                min(
+                    dt.datetime.combine(_shift_month(month, 1), dt.time(), tzinfo=dt.UTC),
+                    start_of_today,
+                ),
+                month.strftime("%Y%m"),
+            )
+            for month in months
+            if dt.datetime.combine(month, dt.time(), tzinfo=dt.UTC) < start_of_today
+        ]
+
+    # Monthly rows are published only after a complete calendar month closes.
+    complete_months = [month for month in months if month < current_month]
+    return [
+        RollupPartition(
+            "monthly",
+            dt.datetime.combine(month, dt.time(), tzinfo=dt.UTC),
+            dt.datetime.combine(_shift_month(month, 1), dt.time(), tzinfo=dt.UTC),
+            month.strftime("%Y%m"),
+        )
+        for month in complete_months
+    ]
+
+
+def _date_range(first: dt.date, last: dt.date) -> list[dt.date]:
+    if first > last:
+        return []
+    return [first + dt.timedelta(days=offset) for offset in range((last - first).days + 1)]
+
+
+def _month_range(first: dt.date, last: dt.date) -> list[dt.date]:
+    if first > last:
+        return []
+    result: list[dt.date] = []
+    value = first
+    while value <= last:
+        result.append(value)
+        value = _shift_month(value, 1)
+    return result
+
+
+def _bucket_expression(granularity: str) -> str:
+    return {
+        "hourly": "toStartOfHour(created_at, 'UTC')",
+        "daily": "toStartOfDay(created_at, 'UTC')",
+        "monthly": "toStartOfMonth(created_at, 'UTC')",
+    }[granularity]
+
+
+def _nullable_quantile(column: str, quantile: float) -> str:
+    return (
+        f"if(countIf({column} IS NOT NULL) = 0, NULL, "
+        f"quantileTDigestIf({quantile})({column}, {column} IS NOT NULL))"
+    )
+
+
+def _rollup_select(
+    partition: RollupPartition,
+    *,
+    raw_table: str,
+) -> str:
+    raw_table = _identifier(raw_table, label="raw table")
+    bucket = _bucket_expression(partition.granularity)
+    where = (
+        f"created_at >= {_sql_datetime(partition.start)} "
+        f"AND created_at < {_sql_datetime(partition.end)}"
+    )
+    return f"""
+SELECT
+  {bucket} AS period_start,
+  provider,
+  model,
+  source,
+  ifNull(region, '') AS region,
+  usage_type,
+  status,
+  ifNull(error_type, '') AS error_type,
+  ifNull(error_status, 0) AS error_status,
+  streamed,
+  count() AS attempts,
+  countIf(status = 'success') AS completed,
+  countIf(status != 'success') AS failed,
+  sum(toUInt64(input_tokens)) AS input_tokens,
+  sum(toUInt64(output_tokens)) AS output_tokens,
+  sum(total_cost_microdollars) AS total_cost_microdollars,
+  {_nullable_quantile('elapsed_milliseconds', 0.50)} AS p50_elapsed_milliseconds,
+  {_nullable_quantile('elapsed_milliseconds', 0.95)} AS p95_elapsed_milliseconds,
+  {_nullable_quantile('first_token_milliseconds', 0.50)} AS p50_first_token_milliseconds,
+  {_nullable_quantile('first_token_milliseconds', 0.95)} AS p95_first_token_milliseconds,
+  {_nullable_quantile('ttfb_milliseconds', 0.50)} AS p50_ttfb_milliseconds,
+  {_nullable_quantile('ttfb_milliseconds', 0.95)} AS p95_ttfb_milliseconds,
+  {_nullable_quantile('speed_tokens_per_second', 0.50)} AS p50_tokens_per_second,
+  {_nullable_quantile('speed_tokens_per_second', 0.95)} AS p95_tokens_per_second
+FROM {raw_table} FINAL
+WHERE {where}
+GROUP BY
+  period_start, provider, model, source, region, usage_type, status,
+  error_type, error_status, streamed
+""".strip()
+
+
+def _scalar_uint(payload: bytes) -> int:
+    text = payload.decode("utf-8").strip()
+    if not text:
+        raise RuntimeError("ClickHouse scalar query returned no value")
+    return int(text.splitlines()[-1])
+
+
+def recompute_partition(
+    executor: QueryExecutor,
+    partition: RollupPartition,
+    *,
+    raw_table: str = RAW_TABLE,
+) -> int:
+    target = f"provider_analytics_{partition.granularity}"
+    staging = f"{target}_staging"
+    select = _rollup_select(partition, raw_table=raw_table)
+    where = (
+        f"created_at >= {_sql_datetime(partition.start)} "
+        f"AND created_at < {_sql_datetime(partition.end)}"
+    )
+    source_rows = _scalar_uint(
+        executor.execute(f"SELECT count() FROM {_identifier(raw_table, label='raw table')} FINAL WHERE {where}")
+    )
+    executor.execute(f"TRUNCATE TABLE {staging}")
+    if source_rows == 0:
+        executor.execute(f"ALTER TABLE {target} DROP PARTITION ID '{partition.partition_id}'")
+        return 0
+    executor.execute(f"INSERT INTO {staging} {select}")
+    staged_rows = _scalar_uint(executor.execute(f"SELECT sum(attempts) FROM {staging}"))
+    if staged_rows != source_rows:
+        raise RuntimeError(
+            f"{partition.granularity} rollup parity mismatch for {partition.partition_id}: "
+            f"source={source_rows} staged={staged_rows}"
+        )
+    executor.execute(
+        f"ALTER TABLE {target} REPLACE PARTITION ID '{partition.partition_id}' FROM {staging}"
+    )
+    live_rows = _scalar_uint(
+        executor.execute(
+            f"SELECT sum(attempts) FROM {target} "
+            f"WHERE _partition_id = '{partition.partition_id}'"
+        )
+    )
+    if live_rows != source_rows:
+        raise RuntimeError(
+            f"{partition.granularity} live parity mismatch for {partition.partition_id}: "
+            f"source={source_rows} live={live_rows}"
+        )
+    return source_rows
+
+
+def _raw_start(executor: QueryExecutor, raw_table: str) -> dt.date | None:
+    table = _identifier(raw_table, label="raw table")
+    payload = executor.execute(
+        f"SELECT if(count() = 0, '', toString(toDate(min(created_at)))) FROM {table} FINAL"
+    )
+    value = payload.decode("utf-8").strip().splitlines()[-1]
+    return dt.date.fromisoformat(value) if value else None
+
+
+def run_rollups(
+    executor: QueryExecutor,
+    granularities: Iterable[str],
+    *,
+    now: dt.datetime,
+    raw_table: str = RAW_TABLE,
+    backfill: bool = False,
+) -> list[tuple[RollupPartition, int]]:
+    start = _raw_start(executor, raw_table) if backfill else None
+    if backfill and start is None:
+        return []
+    results: list[tuple[RollupPartition, int]] = []
+    for granularity in granularities:
+        for partition in planned_partitions(
+            granularity,
+            now=now,
+            backfill_start=start,
+        ):
+            rows = recompute_partition(executor, partition, raw_table=raw_table)
+            results.append((partition, rows))
+    return results
+
+
+def _parse_granularities(value: str) -> Sequence[str]:
+    if value == "all":
+        return _GRANULARITIES
+    if value not in _GRANULARITIES:
+        raise argparse.ArgumentTypeError("granularity must be hourly, daily, monthly, or all")
+    return (value,)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--database", default=DATABASE)
+    parser.add_argument("--raw-table", default=RAW_TABLE)
+    parser.add_argument("--granularity", default="all", type=_parse_granularities)
+    parser.add_argument("--backfill", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    executor = ClickHouseExecutor(
+        password=os.environ["CH_PASSWORD"],
+        database=args.database,
+    )
+    results = run_rollups(
+        executor,
+        args.granularity,
+        now=dt.datetime.now(dt.UTC),
+        raw_table=args.raw_table,
+        backfill=args.backfill,
+    )
+    for partition, rows in results:
+        log.info(
+            "analytics_rollup.completed granularity=%s partition=%s start=%s end=%s rows=%d",
+            partition.granularity,
+            partition.partition_id,
+            partition.start.isoformat(),
+            partition.end.isoformat(),
+            rows,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/tr-clickhouse-archive.service
+++ b/clickhouse/tr-clickhouse-archive.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=TrustedRouter verified daily ClickHouse Parquet archive
+After=network-online.target clickhouse-server.service
+Wants=network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+Environment=GCP_PROJECT_ID=quill-cloud-proxy
+Environment=ARCHIVE_BUCKET=quill-cloud-proxy-tr-clickhouse-archive
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.archive_daily --lookback-days 7
+TimeoutStartSec=6h
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-archive.timer
+++ b/clickhouse/tr-clickhouse-archive.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily TrustedRouter verified analytics archive
+
+[Timer]
+OnCalendar=*-*-* 04:20:00 UTC
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/tr-clickhouse-rollup-daily.service
+++ b/clickhouse/tr-clickhouse-rollup-daily.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=TrustedRouter daily and monthly analytics rollups
+After=clickhouse-server.service
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_analytics --granularity daily
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_analytics --granularity monthly
+TimeoutStartSec=4h
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict

--- a/clickhouse/tr-clickhouse-rollup-daily.timer
+++ b/clickhouse/tr-clickhouse-rollup-daily.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily TrustedRouter long-term analytics rollups
+
+[Timer]
+OnCalendar=*-*-* 03:35:00 UTC
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/tr-clickhouse-rollup-hourly.service
+++ b/clickhouse/tr-clickhouse-rollup-hourly.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=TrustedRouter hourly analytics rollup
+After=clickhouse-server.service
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_analytics --granularity hourly
+TimeoutStartSec=2h
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict

--- a/clickhouse/tr-clickhouse-rollup-hourly.timer
+++ b/clickhouse/tr-clickhouse-rollup-hourly.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly TrustedRouter analytics rollup
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/clickhouse-reliability.md
+++ b/docs/clickhouse-reliability.md
@@ -1,0 +1,218 @@
+# ClickHouse reliability and long-term analytics
+
+This is the canonical production runbook for TrustedRouter provider analytics.
+It supersedes the single-node and shadow-read descriptions in
+`docs/storage-portability/`.
+
+## Scope and data policy
+
+ClickHouse stores bounded request metadata used by provider dashboards,
+leaderboards, and route-health analysis. It does not store prompts, model
+outputs, API keys, BYOK secrets, authorization headers, or workspace IDs.
+Spanner remains the source of truth for billing and the durable analytics
+outbox. A ClickHouse failure must not fail inference or settlement.
+
+Long-term analytics uses tiers instead of retaining every hot row forever:
+
+| Tier | Retention | Purpose |
+|---|---:|---|
+| Replicated raw ClickHouse rows | 400 days | Recent investigation and exact re-aggregation |
+| Hourly ClickHouse rollups | 3 years | Detailed trends and provider operations |
+| Daily and monthly ClickHouse rollups | No TTL | Long-term product and provider analytics |
+| Verified Parquet archive in GCS | 7 years | Immutable, portable raw history and disaster recovery |
+| Persistent-disk snapshots | 30 daily snapshots | Fast node recovery |
+
+The 400-day raw TTL has not been shortened. Changing it requires a separate
+retention decision after archive restore drills and rollup consumers are
+verified.
+
+## Production topology
+
+The GCP deployment is one logical shard with three synchronous ClickHouse
+replicas and a three-voter embedded Keeper quorum:
+
+| Node | Zone | Disk |
+|---|---|---:|
+| `tr-clickhouse-1` | `us-central1-a` | 500 GB SSD |
+| `tr-clickhouse-2` | `us-central1-b` | 500 GB SSD |
+| `tr-clickhouse-3` | `us-central1-c` | 500 GB SSD |
+
+All nodes have no external IP, VM deletion protection, non-auto-deleting boot
+disks, the Google Ops Agent, and the daily snapshot policy. The canonical raw
+table uses `ReplicatedReplacingMergeTree`; exact readers use `FINAL` because
+the Spanner outbox is at-least-once.
+
+Customer-facing readers use the regional internal passthrough load balancer:
+
+```text
+tr-clickhouse-ilb (10.128.0.96:8123)
+  -> tr-clickhouse-1
+  -> tr-clickhouse-2
+  -> tr-clickhouse-3
+```
+
+The forwarding rule allows global VPC access so all control-plane regions can
+reach it. The read-only `tr_provider_read` account can select only the raw and
+rollup tables. Ingestion, reconciliation, archive, and rollup workers run on
+node 1. Their durable input remains in Spanner if node 1 is temporarily down.
+
+The pre-migration local node-1 table is retained as
+`provider_benchmark_samples_local_backup`. Do not delete it until a later,
+explicitly reviewed cleanup.
+
+## Durable archive
+
+`clickhouse/archive_daily.py` exports each closed UTC day from the canonical
+raw table with `FINAL`. It computes a full row-set fingerprint, writes Parquet,
+reads the Parquet back with `clickhouse-local`, and compares row count, hash
+sum, and hash XOR before publishing a manifest.
+
+Objects are immutable and revisioned:
+
+```text
+gs://quill-cloud-proxy-tr-clickhouse-archive/
+  raw/provider_benchmark_samples/day=YYYY-MM-DD/
+    _latest.json
+    revisions/<fingerprint>/manifest.json
+    revisions/<fingerprint>/part-*.parquet
+```
+
+A rerun with unchanged data is a no-op. Late reconciled rows produce a new
+immutable revision and atomically advance `_latest.json`. Bucket versioning,
+uniform access, and public-access prevention are enabled. The daily service
+rechecks seven closed days so late rows are captured.
+
+## Aggregate tiers
+
+`clickhouse/rollup_analytics.py` builds hourly, daily, and monthly tables from
+raw `FINAL` rows. It never uses an additive materialized view because replayed
+outbox events would double-count.
+
+For each partition, the worker:
+
+1. Recomputes into a staging table.
+2. Verifies `sum(attempts)` equals the exact source row count.
+3. Atomically replaces the live partition.
+4. Verifies the published partition again.
+
+The hourly timer rebuilds recent closed hours. The daily timer rebuilds daily
+partitions and publishes monthly rows only after a complete calendar month
+closes. Backfills are idempotent.
+
+## Deployment
+
+Run each script without `--apply` first. The mutation order is:
+
+```bash
+scripts/deploy/clickhouse_reliability.sh --apply
+scripts/deploy/clickhouse_resize_disk.sh --apply
+scripts/deploy/clickhouse_cluster.sh --apply
+scripts/deploy/clickhouse_live_ingestion.sh
+scripts/deploy/rollout.sh
+```
+
+`clickhouse_cluster.sh` stages all Keeper configs before restarts, starts the
+two new voters together, migrates only after full-fingerprint parity, pauses
+the ingester for the final delta, and exposes the load balancer only after the
+canonical replicated table is healthy. Routine control-plane rollouts discover
+the internal load-balancer address dynamically.
+
+Never restart or deploy all three ClickHouse nodes together. Change one zone,
+wait for replica queue and load-balancer health to recover, then continue.
+
+## Health checks
+
+Check load-balancer backends:
+
+```bash
+gcloud compute backend-services get-health tr-clickhouse-http \
+  --project quill-cloud-proxy --region us-central1
+```
+
+On every replica, require no queue, no delay, and no read-only replica:
+
+```sql
+SYSTEM SYNC REPLICA provider_benchmark_samples;
+SELECT queue_size, absolute_delay, is_readonly
+FROM system.replicas
+WHERE database = 'tr' AND table = 'provider_benchmark_samples';
+```
+
+Use a fixed cutoff at least five minutes in the past when comparing live
+fingerprints, otherwise concurrent ingestion can make healthy replicas appear
+different. Compare this on all three nodes:
+
+```sql
+SELECT
+  count(),
+  sum(cityHash64(tuple(*))),
+  groupBitXor(cityHash64(tuple(*)))
+FROM provider_benchmark_samples FINAL
+WHERE created_at < toDateTime64('<fixed UTC cutoff>', 3, 'UTC');
+```
+
+The controlled zone-failure test is:
+
+```bash
+scripts/deploy/clickhouse_failover_smoke.sh
+scripts/deploy/clickhouse_failover_smoke.sh --apply
+```
+
+The apply mode arms a remote automatic restart before stopping one node, runs
+20 SQL reads through the load balancer with two zones healthy, restores the
+node, waits for 3/3 health, and synchronizes the replica.
+
+## Restore procedures
+
+### Replace one failed replica
+
+1. Remove or drain only the failed backend. Keep two healthy nodes serving.
+2. Preserve the failed disk for investigation.
+3. Provision a replacement VM in the same zone with the same private identity.
+4. Install the cluster config and canonical replicated table.
+5. Let ClickHouse fetch parts from a healthy replica.
+6. Require queue zero, fixed-cutoff fingerprint parity, and healthy load-balancer state.
+7. Re-enable the backend.
+
+### Restore from a disk snapshot
+
+1. Create a new disk from the newest valid `tr-clickhouse-daily-snapshots` snapshot.
+2. Attach it to an isolated replacement VM with no external IP.
+3. Start ClickHouse without registering it in the load balancer.
+4. Verify table metadata and a fixed-cutoff fingerprint against a healthy replica.
+5. Rejoin it as a replica, synchronize, then add it to the backend group.
+
+### Restore from Parquet
+
+1. Read each day's `_latest.json` and its immutable manifest.
+2. Verify every object's SHA256 and the manifest's row-set fingerprint.
+3. Load parts into a new staging table with the current schema.
+4. Compare per-day fingerprints with the manifests.
+5. Replicate the staged data, verify all replicas, then rename it into service.
+6. Replay the remaining Spanner outbox and run reconciliation.
+
+Parquet is the cross-version and cross-cloud recovery source. Disk snapshots
+are the faster same-platform recovery source.
+
+## Alerts and capacity
+
+Cloud Monitoring pages on node unavailability and disk use at 75 percent.
+The ClickHouse server, archive timer, rollup timers, and ingester must also be
+checked during incident response. Alert delivery uses the verified
+TrustedRouter infrastructure notification channel.
+
+At 75 percent disk use, do not merely expand forever. Measure rows per second,
+compressed bytes per row, parts, merge backlog, query latency, Keeper latency,
+and archive lag. The current topology scales reads across three replicas but
+has one logical write shard. Before sustained load approaches one shard's
+tested limit:
+
+1. Add time-first projections or purpose-built rollups for expensive scans.
+2. Benchmark the expected row rate with the real schema and query mix.
+3. Add shards with three replicas per shard and route inserts by stable event hash.
+4. Keep provider/model queries distributed so a hot model cannot own one shard.
+5. Validate rebalancing and restore procedures before raising production traffic.
+
+The GCS Parquet archive separates long-term history from hot disk capacity.
+It can later be queried with ClickHouse, BigQuery external tables, or DuckDB
+without expanding the production cluster just to retain old rows.

--- a/docs/storage-portability/HANDOFF.md
+++ b/docs/storage-portability/HANDOFF.md
@@ -1,9 +1,15 @@
 # HANDOFF — multi-cloud + ClickHouse analytics
 
-**Last updated 2026-07-30.** Written for an agent taking this over cold. Read
+**Last updated 2026-07-31.** Written for an agent taking this over cold. Read
 [`multi-cloud-separation.md`](multi-cloud-separation.md) and
 [`analytics-ingestion.md`](analytics-ingestion.md) for the *why*; this document is the *where
 we are and what is next*.
+
+> **Production topology update:** the canonical operational document is now
+> [`../clickhouse-reliability.md`](../clickhouse-reliability.md). ClickHouse is
+> no longer a single shadow node. Provider analytics reads use a private,
+> three-zone replicated cluster. Historical stage descriptions below remain
+> useful design context but are not the current runbook.
 
 ---
 
@@ -24,12 +30,13 @@ operational wide-column store and was never a columnar warehouse.
 | Separation decision | **Decided**, #307 |
 | `PostgresStore` | **Merged**, #310 — passes conformance |
 | `PostgresStore` on Spanner PG dialect | **Proven**, #322 — 14/14 |
-| ClickHouse node on GCP | **Live** — `tr-clickhouse-1` |
+| ClickHouse cluster on GCP | **Live**: three zones, three Keeper voters, 500 GB SSD per replica |
 | Backfill (historical) | **Done** — 200k+ rows, per-day parity with Bigtable |
-| Live ingestion (stage 1 shadow) | **Live and verified**, #340 + #347 |
+| Live ingestion | **Live and verified**, durable Spanner outbox plus hourly repair |
 | Route-health differential proof (stage 2 gate) | **Passes**, #350 |
-| Route-health read cutover | **Not started** |
-| Leaderboard proof + cutover | **Not started** |
+| Provider portal read cutover | **Live** through private regional load balancer |
+| Immutable Parquet archive | **Live**, verified daily revisions in GCS, seven-year retention |
+| Hour/day/month rollups | **Live**, parity-gated atomic partition replacement |
 | AWS deployment | **Not started** |
 | Azure deployment | **Not started** |
 
@@ -55,16 +62,17 @@ the "different money code per backend" risk — there is one implementation.
 
 ## 3. What is running in production right now
 
-### ClickHouse node — `tr-clickhouse-1`
+### ClickHouse cluster
 
-* `us-central1-a`, `e2-standard-4`, 200GB pd-ssd, ClickHouse 26.7.1, database `tr`.
-* **No external IP.** Egress via Cloud NAT; access via IAP only.
-* Table `provider_benchmark_samples`, `ReplacingMergeTree`. **Raw only — there is deliberately
-  no `AggregatingMergeTree` view**, because a materialized view runs per INSERT *block* before
-  source replacement and therefore double-counts on every replay. Use `FINAL` for exact counts.
-* Password: Secret Manager `trustedrouter-clickhouse-password`, and on the node at
-  `/etc/tr-clickhouse-ingest.env` as `CH_PASSWORD`. **Prefer the node's file** — Secret
-  Manager's `latest` has drifted from what is deployed.
+* `tr-clickhouse-1/2/3` run in `us-central1-a/b/c`, each on `e2-standard-4`
+  with a 500 GB SSD and no external IP.
+* One logical shard has three `ReplicatedReplacingMergeTree` replicas and a
+  three-voter embedded Keeper quorum.
+* Provider analytics readers use private load balancer `tr-clickhouse-ilb`.
+* Exact raw queries use `FINAL`. Recomputed hourly, daily, and monthly tables
+  replace verified partitions instead of using replay-unsafe additive views.
+* Daily disk snapshots retain 30 days. Verified immutable Parquet retains raw
+  history for seven years. See the canonical runbook linked above.
 
 ### Live ingestion
 
@@ -84,7 +92,9 @@ Verified 2026-07-30: rows flowed, outbox depth held at **0**, `drain_lag_seconds
 `clickhouse_insert_errors_total=0`, and the ingester's `rows_ingested_total` matched the
 ClickHouse row delta exactly.
 
-**It is still a SHADOW. Nothing reads from ClickHouse.** Bigtable remains authoritative.
+Provider portal analytics now read ClickHouse through the private load
+balancer. Spanner remains authoritative for billing, and ClickHouse remains
+off the inference and settlement critical path.
 
 ### Keyless cross-cloud identity (provisioned, currently unused)
 

--- a/docs/storage-portability/README.md
+++ b/docs/storage-portability/README.md
@@ -3,20 +3,24 @@
 Handoff document. Goal: run the control plane end-to-end on AWS (then Azure)
 without a risky rewrite of the billing core.
 
-Status as of 2026-07-26:
+Status as of 2026-07-31:
 
 | Phase | State |
 |---|---|
 | 0. Behavioural storage conformance suite | **landed** (#288) |
 | 1. ClickHouse analytics — proof on real data | **done, exact match on 500 routes** |
 | 4. Leak closures — cloud SDKs behind ports | **landed** (#289) |
-| 2. ClickHouse in parallel on GCP (dual-write + verify) | **next** |
+| 2. ClickHouse on GCP | **live**: durable outbox, three replicas, archive, rollups, private reads |
 | 3. AWS test cluster (ClickHouse + remote Spanner) | tooling already exists — mostly a re-run |
 | 5. Azure | spike done for attestation; Entra→GCP WIF outstanding |
 | — Postgres/`PostgresStore` port | **deliberately NOT on the path** |
 
 Ordering note: phase 4 landed before phase 2 because it is a pure decoupling
 with no deployment risk, and it is what lets a non-GCP process start at all.
+
+Current production operations are documented in
+[`../clickhouse-reliability.md`](../clickhouse-reliability.md). Later sections
+describing phase 2 as future work are retained as historical design context.
 
 ---
 
@@ -243,7 +247,13 @@ typed-billing contract (leak #3) is explicitly *not* being touched yet.
 
 ---
 
-## Phase 2 (next): ClickHouse in parallel on GCP
+## Phase 2 (complete): ClickHouse on GCP
+
+The production implementation now uses a durable Spanner outbox, three
+replicated zonal nodes behind a private load balancer, verified immutable
+Parquet archives, daily disk snapshots, and recomputed aggregate tiers. The
+steps below are the original plan and should be read as history; use the
+canonical runbook for current commands and recovery procedures.
 
 Goal: ClickHouse running alongside the live stack, continuously verified,
 before anything depends on it.

--- a/docs/storage-portability/analytics-ingestion.md
+++ b/docs/storage-portability/analytics-ingestion.md
@@ -4,6 +4,13 @@ Companion to `README.md`. One question: **how analytics rows get from the
 control plane into ClickHouse** at 1T tokens/month within ~2 months and 100T
 soon after.
 
+> **Implementation update, 2026-07-31:** the durable Spanner outbox, a
+> three-zone replicated ClickHouse cluster, verified Parquet archives, and
+> recomputed hour/day/month rollups are live. See
+> [`../clickhouse-reliability.md`](../clickhouse-reliability.md) for current
+> topology and operations. This document preserves the design analysis and
+> historical staging plan.
+
 > **Revision history.** v1 of this document proposed a Bigtable high-water-mark
 > replay feeding an additive materialized view, justified by a
 > `parts/s = N/T` argument. An adversarial review found that design cannot

--- a/scripts/deploy/clickhouse-alerts/disk-capacity.yaml
+++ b/scripts/deploy/clickhouse-alerts/disk-capacity.yaml
@@ -1,0 +1,27 @@
+displayName: "TR ClickHouse: disk capacity"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    A TrustedRouter ClickHouse filesystem has remained above 75 percent used.
+    Expand the persistent disk online before ingestion or archive verification
+    loses working space. Runbook: docs/clickhouse-reliability.md.
+conditions:
+  - displayName: "ClickHouse disk above 75 percent for 15 minutes"
+    conditionThreshold:
+      filter: 'resource.type = "gce_instance" AND (__INSTANCE_FILTER__) AND metric.type = "agent.googleapis.com/disk/percent_used" AND metric.labels.state = "used"'
+      aggregations:
+        - alignmentPeriod: 300s
+          perSeriesAligner: ALIGN_MAX
+          crossSeriesReducer: REDUCE_MAX
+      comparison: COMPARISON_GT
+      thresholdValue: 75
+      duration: 900s
+      trigger:
+        count: 1
+alertStrategy:
+  autoClose: 86400s
+  notificationPrompts:
+    - OPENED
+    - CLOSED

--- a/scripts/deploy/clickhouse-alerts/node-availability.yaml
+++ b/scripts/deploy/clickhouse-alerts/node-availability.yaml
@@ -1,0 +1,24 @@
+displayName: "TR ClickHouse: node availability"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    The production ClickHouse node stopped publishing VM uptime. Provider
+    analytics may be unavailable even though inference remains unaffected.
+    Runbook: docs/clickhouse-reliability.md.
+conditions:
+  - displayName: "ClickHouse VM uptime absent for 3 minutes"
+    conditionAbsent:
+      filter: 'resource.type = "gce_instance" AND (__INSTANCE_FILTER__) AND metric.type = "compute.googleapis.com/instance/uptime"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_MEAN
+      duration: 180s
+      trigger:
+        count: 1
+alertStrategy:
+  autoClose: 86400s
+  notificationPrompts:
+    - OPENED
+    - CLOSED

--- a/scripts/deploy/clickhouse-archive-lifecycle.json
+++ b/scripts/deploy/clickhouse-archive-lifecycle.json
@@ -1,0 +1,12 @@
+{
+  "rule": [
+    {
+      "action": {"type": "Delete"},
+      "condition": {"age": 2555, "isLive": true}
+    },
+    {
+      "action": {"type": "Delete"},
+      "condition": {"age": 30, "isLive": false}
+    }
+  ]
+}

--- a/scripts/deploy/clickhouse_cluster.sh
+++ b/scripts/deploy/clickhouse_cluster.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# Build and migrate the TrustedRouter three-replica ClickHouse cluster.
+#
+# Safety order:
+#   1. Provision two new private nodes and a three-voter Keeper quorum.
+#   2. Backfill a replicated staging table and compare full fingerprints.
+#   3. Stop the durable outbox ingester and replay once more.
+#   4. Rename replicas 2/3 first; rename node 1 last in one atomic statement.
+#   5. Resume ingestion, then expose only the private internal load balancer.
+# The original node-1 table remains as provider_benchmark_samples_local_backup.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+KEEPER_IDS=(1 2 3)
+CLUSTER_SERVICE_ACCOUNT_NAME="${TR_CLICKHOUSE_CLUSTER_SA:-tr-clickhouse}"
+CLUSTER_SERVICE_ACCOUNT="${CLUSTER_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+SECRET="${TR_CLICKHOUSE_SECRET:-trustedrouter-clickhouse-password}"
+SNAPSHOT_POLICY="${TR_CLICKHOUSE_SNAPSHOT_POLICY:-tr-clickhouse-daily-snapshots}"
+MIGRATION_SCHEMA="${SCRIPT_DIR}/../../clickhouse/003_provider_benchmark_replicated.sql"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would provision tr-clickhouse-2/3 in zones b/c with 500 GB disks"
+  log "dry-run: would form a three-voter Keeper quorum and verify all replicas"
+  log "dry-run: would retain the current local table and cut over only after fingerprint parity"
+  exit 0
+fi
+
+node_ssh() {
+  local index="$1"
+  shift
+  gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+node_query() {
+  local index="$1"
+  local query="$2"
+  printf '%s\n' "$query" | node_ssh "$index" --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr --multiquery
+  '"
+}
+
+node_scalar() {
+  node_query "$1" "$2" | tail -1 | tr -d '\r'
+}
+
+ensure_service_account() {
+  local attempt
+  log "ensuring least-privilege ClickHouse replica identity"
+  if ! gc iam service-accounts describe "$CLUSTER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
+    gc iam service-accounts create "$CLUSTER_SERVICE_ACCOUNT_NAME" \
+      --display-name="TrustedRouter ClickHouse replicas"
+  fi
+  for attempt in {1..24}; do
+    if gc iam service-accounts describe "$CLUSTER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$attempt" -eq 24 ]; then
+      echo "service account did not become visible: ${CLUSTER_SERVICE_ACCOUNT}" >&2
+      exit 1
+    fi
+    sleep 5
+  done
+  for attempt in {1..12}; do
+    if gc secrets add-iam-policy-binding "$SECRET" \
+        --member="serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" \
+        --role=roles/secretmanager.secretAccessor \
+        --quiet >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$attempt" -eq 12 ]; then
+      echo "could not grant Secret Manager access to ${CLUSTER_SERVICE_ACCOUNT}" >&2
+      exit 1
+    fi
+    sleep 5
+  done
+  ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/monitoring.metricWriter
+  ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/logging.logWriter
+}
+
+ensure_network() {
+  log "ensuring private ClickHouse and Keeper network rules"
+  gc compute firewall-rules update tr-clickhouse-internal \
+    --allow=tcp:8123,tcp:9000,tcp:9181,tcp:9234 \
+    --source-ranges=10.128.0.0/9 \
+    --quiet
+  if gc compute firewall-rules describe tr-clickhouse-health-check >/dev/null 2>&1; then
+    gc compute firewall-rules update tr-clickhouse-health-check \
+      --allow=tcp:8123 \
+      --source-ranges=35.191.0.0/16,130.211.0.0/22 \
+      --quiet
+  else
+    gc compute firewall-rules create tr-clickhouse-health-check \
+      --network=default \
+      --allow=tcp:8123 \
+      --source-ranges=35.191.0.0/16,130.211.0.0/22 \
+      --target-tags=tr-clickhouse \
+      --description="GCP health checks for private ClickHouse ILB"
+  fi
+}
+
+provision_nodes() {
+  local index
+  for index in 1 2; do
+    log "ensuring ${NAMES[$index]} in ${ZONES[$index]}"
+    PROJECT="$PROJECT_ID" \
+      ZONE="${ZONES[$index]}" \
+      NAME="${NAMES[$index]}" \
+      DISK_GB=500 \
+      SERVICE_ACCOUNT="$CLUSTER_SERVICE_ACCOUNT" \
+      SNAPSHOT_POLICY="$SNAPSHOT_POLICY" \
+      SECRET="$SECRET" \
+      "${SCRIPT_DIR}/clickhouse_node.sh"
+  done
+}
+
+wait_for_nodes() {
+  local index attempt
+  for index in 0 1 2; do
+    for attempt in {1..40}; do
+      if node_ssh "$index" --command="sudo systemctl is-active clickhouse-server" \
+          >/dev/null 2>&1; then
+        break
+      fi
+      if [ "$attempt" -eq 40 ]; then
+        echo "${NAMES[$index]} did not become ready" >&2
+        exit 1
+      fi
+      sleep 15
+    done
+  done
+}
+
+install_password_envs() {
+  local password index
+  password="$(gc secrets versions access latest --secret="$SECRET")"
+  for index in 0 1 2; do
+    printf 'CH_PASSWORD=%s\n' "$password" | node_ssh "$index" --command="sudo sh -c '
+      umask 077
+      cat > /etc/tr-clickhouse-ingest.env
+    '"
+  done
+  unset password
+}
+
+load_ips() {
+  IPS=()
+  local index ip
+  for index in 0 1 2; do
+    ip="$(gc compute instances describe "${NAMES[$index]}" \
+      --zone="${ZONES[$index]}" \
+      --format='value(networkInterfaces[0].networkIP)')"
+    if [ -z "$ip" ]; then
+      echo "missing private IP for ${NAMES[$index]}" >&2
+      exit 1
+    fi
+    IPS+=("$ip")
+  done
+}
+
+render_cluster_config() {
+  local index="$1"
+  cat <<XML
+<clickhouse>
+  <keeper_server>
+    <tcp_port>9181</tcp_port>
+    <server_id>${KEEPER_IDS[$index]}</server_id>
+    <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+    <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+    <coordination_settings>
+      <operation_timeout_ms>10000</operation_timeout_ms>
+      <session_timeout_ms>30000</session_timeout_ms>
+      <raft_logs_level>warning</raft_logs_level>
+    </coordination_settings>
+    <raft_configuration>
+      <server><id>1</id><hostname>${IPS[0]}</hostname><port>9234</port></server>
+      <server><id>2</id><hostname>${IPS[1]}</hostname><port>9234</port></server>
+      <server><id>3</id><hostname>${IPS[2]}</hostname><port>9234</port></server>
+    </raft_configuration>
+  </keeper_server>
+  <zookeeper>
+    <node><host>${IPS[0]}</host><port>9181</port></node>
+    <node><host>${IPS[1]}</host><port>9181</port></node>
+    <node><host>${IPS[2]}</host><port>9181</port></node>
+  </zookeeper>
+  <remote_servers>
+    <trustedrouter>
+      <shard>
+        <internal_replication>true</internal_replication>
+        <replica><host>${IPS[0]}</host><port>9000</port></replica>
+        <replica><host>${IPS[1]}</host><port>9000</port></replica>
+        <replica><host>${IPS[2]}</host><port>9000</port></replica>
+      </shard>
+    </trustedrouter>
+  </remote_servers>
+  <macros>
+    <shard>01</shard>
+    <replica>${NAMES[$index]}</replica>
+  </macros>
+</clickhouse>
+XML
+}
+
+install_cluster_config() {
+  local index ready pid_two pid_three
+  # Stage every config before restarting anything. The two new Keeper voters
+  # restart concurrently so neither blocks forever waiting for the other to
+  # form quorum; node 1 joins only after that pair is active.
+  for index in 0 1 2; do
+    log "configuring Keeper and replica macros on ${NAMES[$index]}"
+    render_cluster_config "$index" | node_ssh "$index" --command="sudo sh -c '
+      set -eu
+      temporary=\$(mktemp)
+      cat > \"\$temporary\"
+      if ! cmp -s \"\$temporary\" /etc/clickhouse-server/config.d/tr-cluster.xml; then
+        install -o clickhouse -g clickhouse -m 0644 \"\$temporary\" \
+          /etc/clickhouse-server/config.d/tr-cluster.xml
+        touch /run/tr-clickhouse-cluster-restart-needed
+      fi
+      rm -f \"\$temporary\"
+    '"
+  done
+  node_ssh 1 --command="sudo sh -c 'if [ -e /run/tr-clickhouse-cluster-restart-needed ]; then rm -f /run/tr-clickhouse-cluster-restart-needed; systemctl restart clickhouse-server; fi'" &
+  pid_two=$!
+  node_ssh 2 --command="sudo sh -c 'if [ -e /run/tr-clickhouse-cluster-restart-needed ]; then rm -f /run/tr-clickhouse-cluster-restart-needed; systemctl restart clickhouse-server; fi'" &
+  pid_three=$!
+  wait "$pid_two"
+  wait "$pid_three"
+  node_ssh 0 --command="sudo sh -c 'if [ -e /run/tr-clickhouse-cluster-restart-needed ]; then rm -f /run/tr-clickhouse-cluster-restart-needed; systemctl restart clickhouse-server; fi'"
+
+  for index in 1 2 0; do
+    ready=0
+    for _ in {1..60}; do
+      if node_ssh "$index" --command="sudo systemctl is-active clickhouse-server" \
+          >/dev/null 2>&1; then
+        ready=1
+        break
+      fi
+      sleep 2
+    done
+    if [ "$ready" -ne 1 ]; then
+      echo "clickhouse-server did not restart on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+  node_scalar 0 "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null
+}
+
+install_ops_agents() {
+  local index
+  for index in 1 2; do
+    node_ssh "$index" --command="sudo sh -c '
+      set -eu
+      if ! dpkg-query -W google-cloud-ops-agent >/dev/null 2>&1; then
+        tmp=\$(mktemp)
+        curl -fsSL https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh -o \"\$tmp\"
+        bash \"\$tmp\" --also-install
+        rm -f \"\$tmp\"
+      fi
+      systemctl enable --now google-cloud-ops-agent
+    '"
+  done
+}
+
+replicated_table_name() {
+  local index="$1"
+  local engine
+  engine="$(node_scalar "$index" \
+    "SELECT engine FROM system.tables WHERE database='tr' AND name='provider_benchmark_samples'")"
+  if [ "$engine" = "ReplicatedReplacingMergeTree" ]; then
+    printf 'provider_benchmark_samples\n'
+  else
+    printf 'provider_benchmark_samples_replicated\n'
+  fi
+}
+
+ensure_replicated_tables() {
+  local schema index canonical_engine
+  schema="$(cat "$MIGRATION_SCHEMA")"
+  canonical_engine="$(node_scalar 0 \
+    "SELECT engine FROM system.tables WHERE database='tr' AND name='provider_benchmark_samples'")"
+  if [ "$canonical_engine" = "ReplicatedReplacingMergeTree" ]; then
+    log "canonical table is already replicated"
+    return
+  fi
+  if [ "$canonical_engine" != "ReplacingMergeTree" ]; then
+    echo "refusing migration: unexpected node-1 engine ${canonical_engine}" >&2
+    exit 1
+  fi
+  for index in 0 1 2; do
+    node_query "$index" "CREATE DATABASE IF NOT EXISTS tr; ${schema}"
+  done
+}
+
+fingerprint_sql() {
+  local table="$1"
+  local cutoff="${2:-}"
+  local columns
+  local where=""
+  columns="id,created_at,provider,model,provider_name,status,usage_type,source,streamed,input_tokens,output_tokens,total_cost_microdollars,speed_tokens_per_second,elapsed_milliseconds,first_token_milliseconds,ttfb_milliseconds,finish_reason,error_type,error_status,error_message,region,app"
+  if [ -n "$cutoff" ]; then
+    where=" WHERE created_at < toDateTime64('${cutoff}', 3, 'UTC')"
+  fi
+  printf '%s\n' "SELECT count(), sum(cityHash64(toJSONString(tuple(${columns})))), groupBitXor(cityHash64(toJSONString(tuple(${columns})))) FROM ${table} FINAL${where} FORMAT TSVRaw"
+}
+
+sync_replicas() {
+  local index table
+  for index in 0 1 2; do
+    table="$(replicated_table_name "$index")"
+    node_query "$index" "SYSTEM SYNC REPLICA ${table}"
+  done
+}
+
+assert_replica_parity() {
+  local cutoff="${1:-}"
+  local source expected index table actual
+  source="$(node_scalar 0 "$(fingerprint_sql provider_benchmark_samples "$cutoff")")"
+  expected=""
+  for index in 0 1 2; do
+    table="$(replicated_table_name "$index")"
+    actual="$(node_scalar "$index" "$(fingerprint_sql "$table" "$cutoff")")"
+    if [ -z "$expected" ]; then
+      expected="$actual"
+    elif [ "$actual" != "$expected" ]; then
+      echo "replica fingerprint mismatch on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+  if [ "$source" != "$expected" ]; then
+    echo "source and replicated fingerprints differ" >&2
+    exit 1
+  fi
+}
+
+migrate_raw_table() {
+  local engine index table cutoff
+  engine="$(node_scalar 0 \
+    "SELECT engine FROM system.tables WHERE database='tr' AND name='provider_benchmark_samples'")"
+  if [ "$engine" = "ReplicatedReplacingMergeTree" ]; then
+    sync_replicas
+    cutoff="$(python3 -c 'import datetime as d; print((d.datetime.now(d.UTC)-d.timedelta(minutes=5)).isoformat(timespec="milliseconds").replace("+00:00","Z"))')"
+    assert_replica_parity "$cutoff"
+    return
+  fi
+
+  log "performing first replay-safe backfill"
+  node_query 0 "INSERT INTO provider_benchmark_samples_replicated SELECT * FROM provider_benchmark_samples FINAL"
+  sync_replicas
+
+  log "pausing the outbox ingester for final parity and atomic rename"
+  node_ssh 0 --command="sudo systemctl stop tr-clickhouse-ingest.service"
+  trap 'node_ssh 0 --command="sudo systemctl start tr-clickhouse-ingest.service" >/dev/null 2>&1 || true' EXIT
+  node_query 0 "INSERT INTO provider_benchmark_samples_replicated SELECT * FROM provider_benchmark_samples FINAL"
+  sync_replicas
+  assert_replica_parity
+
+  for index in 1 2; do
+    table="$(replicated_table_name "$index")"
+    if [ "$table" = "provider_benchmark_samples_replicated" ]; then
+      node_query "$index" \
+        "RENAME TABLE provider_benchmark_samples_replicated TO provider_benchmark_samples"
+    fi
+  done
+  if [ "$(node_scalar 0 "SELECT count() FROM system.tables WHERE database='tr' AND name='provider_benchmark_samples_local_backup'")" != "0" ]; then
+    echo "refusing node-1 rename: local backup table already exists" >&2
+    exit 1
+  fi
+  node_query 0 \
+    "RENAME TABLE provider_benchmark_samples TO provider_benchmark_samples_local_backup, provider_benchmark_samples_replicated TO provider_benchmark_samples"
+
+  for index in 0 1 2; do
+    engine="$(node_scalar "$index" \
+      "SELECT engine FROM system.tables WHERE database='tr' AND name='provider_benchmark_samples'")"
+    if [ "$engine" != "ReplicatedReplacingMergeTree" ]; then
+      echo "canonical table is not replicated on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+  node_ssh 0 --command="sudo systemctl start tr-clickhouse-ingest.service"
+  trap - EXIT
+  assert_replica_parity
+}
+
+install_provider_readers() {
+  local index
+  for index in 0 1 2; do
+    PROJECT="$PROJECT_ID" ZONE="${ZONES[$index]}" NAME="${NAMES[$index]}" \
+      bash "${SCRIPT_DIR}/clickhouse_provider_reader.sh"
+  done
+}
+
+ensure_internal_load_balancer() {
+  local index group address ip
+  log "ensuring private regional ClickHouse load balancer"
+  for index in 0 1 2; do
+    group="tr-clickhouse-${KEEPER_IDS[$index]}"
+    if ! gc compute instance-groups unmanaged describe "$group" \
+        --zone="${ZONES[$index]}" >/dev/null 2>&1; then
+      gc compute instance-groups unmanaged create "$group" --zone="${ZONES[$index]}"
+    fi
+    if ! gc compute instance-groups unmanaged list-instances "$group" \
+        --zone="${ZONES[$index]}" --format='value(instance.basename())' \
+        | grep -Fxq "${NAMES[$index]}"; then
+      gc compute instance-groups unmanaged add-instances "$group" \
+        --zone="${ZONES[$index]}" \
+        --instances="${NAMES[$index]}"
+    fi
+    gc compute instance-groups unmanaged set-named-ports "$group" \
+      --zone="${ZONES[$index]}" \
+      --named-ports=http:8123
+  done
+
+  if ! gc compute health-checks describe tr-clickhouse-http --region="$REGION" >/dev/null 2>&1; then
+    gc compute health-checks create tcp tr-clickhouse-http \
+      --region="$REGION" \
+      --port=8123 \
+      --check-interval=10s \
+      --timeout=5s \
+      --healthy-threshold=2 \
+      --unhealthy-threshold=2
+  fi
+  if ! gc compute backend-services describe tr-clickhouse-http \
+      --region="$REGION" >/dev/null 2>&1; then
+    gc compute backend-services create tr-clickhouse-http \
+      --region="$REGION" \
+      --load-balancing-scheme=INTERNAL \
+      --protocol=TCP \
+      --health-checks=tr-clickhouse-http \
+      --health-checks-region="$REGION"
+  fi
+  for index in 0 1 2; do
+    group="tr-clickhouse-${KEEPER_IDS[$index]}"
+    if ! gc compute backend-services describe tr-clickhouse-http \
+        --region="$REGION" --format='value(backends[].group.basename())' \
+        | grep -Fxq "$group"; then
+      gc compute backend-services add-backend tr-clickhouse-http \
+        --region="$REGION" \
+        --instance-group="$group" \
+        --instance-group-zone="${ZONES[$index]}"
+    fi
+  done
+  address=tr-clickhouse-ilb
+  if ! gc compute addresses describe "$address" --region="$REGION" >/dev/null 2>&1; then
+    gc compute addresses create "$address" \
+      --region="$REGION" \
+      --subnet=default
+  fi
+  ip="$(gc compute addresses describe "$address" --region="$REGION" --format='value(address)')"
+  if ! gc compute forwarding-rules describe tr-clickhouse-http \
+      --region="$REGION" >/dev/null 2>&1; then
+    gc compute forwarding-rules create tr-clickhouse-http \
+      --region="$REGION" \
+      --load-balancing-scheme=INTERNAL \
+      --network=default \
+      --subnet=default \
+      --address="$ip" \
+      --ports=8123 \
+      --backend-service=tr-clickhouse-http \
+      --backend-service-region="$REGION" \
+      --allow-global-access
+  fi
+  if [ "$(node_scalar 0 "SELECT 1")" != "1" ]; then
+    echo "node query validation failed before load-balancer smoke" >&2
+    exit 1
+  fi
+  if [ "$(node_ssh 0 --command="curl -fsS --max-time 5 http://${ip}:8123/ping")" != "Ok." ]; then
+    echo "private ClickHouse load balancer /ping failed" >&2
+    exit 1
+  fi
+  log "private ClickHouse load balancer is healthy at ${ip}:8123"
+}
+
+ensure_service_account
+ensure_network
+provision_nodes
+wait_for_nodes
+install_password_envs
+load_ips
+install_cluster_config
+install_ops_agents
+ensure_replicated_tables
+migrate_raw_table
+install_provider_readers
+ensure_internal_load_balancer
+log "three-replica ClickHouse cluster is healthy; local node-1 backup was retained"

--- a/scripts/deploy/clickhouse_failover_smoke.sh
+++ b/scripts/deploy/clickhouse_failover_smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Prove one ClickHouse zone can fail without interrupting private reader traffic.
+#
+# Safety is intentionally redundant: a remote transient systemd timer is armed
+# before the target is stopped, and a local EXIT trap restores it immediately.
+# Losing the operator shell or IAP connection therefore cannot leave a replica
+# stopped indefinitely.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+TARGET="${TR_CLICKHOUSE_FAILOVER_NODE:-tr-clickhouse-3}"
+LB_NAME="${TR_CLICKHOUSE_LB_NAME:-tr-clickhouse-http}"
+LB_ADDRESS="${TR_CLICKHOUSE_LB_ADDRESS:-tr-clickhouse-ilb}"
+RESTORE_AFTER="${TR_CLICKHOUSE_RESTORE_AFTER:-5m}"
+RESTORE_UNIT="tr-clickhouse-failover-restore-$(date -u +%s)-$$"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+TARGET_INDEX=-1
+for index in "${!NAMES[@]}"; do
+  if [ "${NAMES[$index]}" = "$TARGET" ]; then
+    TARGET_INDEX="$index"
+    break
+  fi
+done
+if [ "$TARGET_INDEX" -lt 0 ]; then
+  echo "unknown ClickHouse replica: ${TARGET}" >&2
+  exit 2
+fi
+
+target_ssh() {
+  gc compute ssh "$TARGET" \
+    --zone="${ZONES[$TARGET_INDEX]}" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+health_counts() {
+  gc compute backend-services get-health "$LB_NAME" \
+    --region="$REGION" \
+    --format=json \
+    | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+groups = payload if isinstance(payload, list) else [payload]
+states = [
+    endpoint.get("healthState")
+    for group in groups
+    for endpoint in group.get("status", {}).get("healthStatus", [])
+]
+print(sum(state == "HEALTHY" for state in states), len(states))
+'
+}
+
+wait_for_health() {
+  local wanted_healthy="$1"
+  local wanted_total="$2"
+  local mode="$3"
+  local healthy total
+  for _ in {1..30}; do
+    read -r healthy total < <(health_counts)
+    if [ "$total" -eq "$wanted_total" ]; then
+      if [ "$mode" = exact ] && [ "$healthy" -eq "$wanted_healthy" ]; then
+        return 0
+      fi
+      if [ "$mode" = at-least ] && [ "$healthy" -ge "$wanted_healthy" ]; then
+        return 0
+      fi
+    fi
+    sleep 5
+  done
+  echo "load balancer did not reach expected health: healthy=${healthy:-?} total=${total:-?}" >&2
+  return 1
+}
+
+restore_target() {
+  target_ssh --command="sudo sh -c '
+    systemctl start clickhouse-server
+    systemctl stop ${RESTORE_UNIT}.timer >/dev/null 2>&1 || true
+    systemctl reset-failed ${RESTORE_UNIT}.service >/dev/null 2>&1 || true
+  '" >/dev/null 2>&1 || true
+}
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would arm a ${RESTORE_AFTER} remote restart for ${TARGET}"
+  log "dry-run: would stop ${TARGET}, require 2/3 healthy backends, and run 20 SQL reads"
+  log "dry-run: would restore ${TARGET}, require 3/3 healthy backends, and sync its replica"
+  exit 0
+fi
+
+trap restore_target EXIT INT TERM HUP
+
+lb_ip="$(gc compute addresses describe "$LB_ADDRESS" \
+  --region="$REGION" --format='value(address)')"
+source_index=$(((TARGET_INDEX + 1) % ${#NAMES[@]}))
+
+log "arming remote fail-safe restart on ${TARGET}"
+target_ssh --command="sudo sh -c '
+  systemd-run --unit=${RESTORE_UNIT} \
+    --on-active=${RESTORE_AFTER} /bin/systemctl start clickhouse-server
+  systemctl stop clickhouse-server
+'"
+
+log "waiting for the load balancer to remove ${TARGET}"
+wait_for_health 2 3 exact
+
+log "running SQL reads through the private load balancer"
+gc compute ssh "${NAMES[$source_index]}" \
+  --zone="${ZONES[$source_index]}" \
+  --tunnel-through-iap \
+  --quiet \
+  --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    config=\$(mktemp)
+    trap \"rm -f \\\"\$config\\\"\" EXIT
+    chmod 0600 \"\$config\"
+    printf \"user = \\\"tr:%s\\\"\\n\" \"\$CH_PASSWORD\" >\"\$config\"
+    for _ in \$(seq 1 20); do
+      result=\$(curl --config \"\$config\" -fsS --max-time 5 \
+        --data-binary \"SELECT 1\" http://${lb_ip}:8123/)
+      [ \"\$result\" = 1 ]
+    done
+  '"
+
+log "restoring ${TARGET}"
+restore_target
+wait_for_health 3 3 exact
+target_ssh --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --query \"SYSTEM SYNC REPLICA provider_benchmark_samples\"
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --query \"SELECT throwIf(sum(queue_size) != 0 OR sum(absolute_delay) != 0 OR sum(is_readonly) != 0) FROM system.replicas\"
+'"
+
+trap - EXIT INT TERM HUP
+log "failover smoke passed: reads survived one zone down and all replicas recovered"

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -61,17 +61,37 @@ ssh_node --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-reconcile.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-reconcile.timer \
     /etc/systemd/system/tr-clickhouse-reconcile.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.service \
+    /etc/systemd/system/tr-clickhouse-archive.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.timer \
+    /etc/systemd/system/tr-clickhouse-archive.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-hourly.service \
+    /etc/systemd/system/tr-clickhouse-rollup-hourly.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-hourly.timer \
+    /etc/systemd/system/tr-clickhouse-rollup-hourly.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-daily.service \
+    /etc/systemd/system/tr-clickhouse-rollup-daily.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-daily.timer \
+    /etc/systemd/system/tr-clickhouse-rollup-daily.timer
   set -a
   . /etc/tr-clickhouse-ingest.env
   set +a
   clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
     --multiquery < /opt/tr-clickhouse/clickhouse/001_provider_benchmark_samples.sql
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --multiquery < /opt/tr-clickhouse/clickhouse/002_provider_analytics_rollups.sql
   systemctl daemon-reload
   systemctl enable tr-clickhouse-ingest.service
   systemctl restart tr-clickhouse-ingest.service
   systemctl enable --now tr-clickhouse-reconcile.timer
+  systemctl enable --now tr-clickhouse-archive.timer
+  systemctl enable --now tr-clickhouse-rollup-hourly.timer
+  systemctl enable --now tr-clickhouse-rollup-daily.timer
   systemctl is-active tr-clickhouse-ingest.service
   systemctl is-active tr-clickhouse-reconcile.timer
+  systemctl is-active tr-clickhouse-archive.timer
+  systemctl is-active tr-clickhouse-rollup-hourly.timer
+  systemctl is-active tr-clickhouse-rollup-daily.timer
 '"
 
 echo "deployed through IAP; TR_ANALYTICS_OUTBOX_ENABLED was not changed"

--- a/scripts/deploy/clickhouse_node.sh
+++ b/scripts/deploy/clickhouse_node.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 # Provision the analytics ClickHouse node.
 #
-# Stage 0 of docs/storage-portability/analytics-ingestion.md: a single
-# internal-only node. Deliberately small — today's volume is ~280 rows/hour and
-# the row rate at scale is unknown within 450x, so sizing now would be guessing.
-# Stage 3 revisits this with measured numbers.
+# The default 500 GB disk preserves comfortable headroom at the measured row
+# density while immutable Parquet remains the long-term raw source of truth.
 #
 # NETWORKING: no public IP. Under the Bigtable-replay ingestion design only the
 # ingester talks to ClickHouse, and the ingester runs on this same host, so
@@ -19,9 +17,11 @@ PROJECT="${PROJECT:-quill-cloud-proxy}"
 ZONE="${ZONE:-us-central1-a}"          # colocated with Bigtable/Spanner to keep the ingest scan local
 NAME="${NAME:-tr-clickhouse-1}"
 MACHINE="${MACHINE:-e2-standard-4}"    # 4 vCPU / 16 GB
-DISK_GB="${DISK_GB:-200}"
+DISK_GB="${DISK_GB:-500}"
 DISK_TYPE="${DISK_TYPE:-pd-ssd}"
 SECRET="${SECRET:-trustedrouter-clickhouse-password}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-}"
+SNAPSHOT_POLICY="${SNAPSHOT_POLICY:-tr-clickhouse-daily-snapshots}"
 
 log() { printf '\n=== %s\n' "$*"; }
 
@@ -83,7 +83,10 @@ if gcloud compute instances describe "$NAME" --zone "$ZONE" --project "$PROJECT"
   log "instance $NAME already exists — skipping create"
 else
   log "creating instance (no external IP)"
-  PASSWORD=$(gcloud secrets versions access latest --secret "$SECRET" --project "$PROJECT")
+  service_account_args=()
+  if [ -n "$SERVICE_ACCOUNT" ]; then
+    service_account_args=(--service-account "$SERVICE_ACCOUNT")
+  fi
   gcloud compute instances create "$NAME" \
     --project "$PROJECT" --zone "$ZONE" \
     --machine-type "$MACHINE" \
@@ -93,9 +96,10 @@ else
     --deletion-protection \
     --tags tr-clickhouse \
     --no-address \
+    "${service_account_args[@]}" \
     --scopes https://www.googleapis.com/auth/cloud-platform \
     --metadata-from-file startup-script="$STARTUP_FILE" \
-    --metadata ch-password="$PASSWORD"
+    --metadata clickhouse-password-secret="$SECRET"
 fi
 
 # Keep the analytics volume if an existing VM is accidentally deleted. The
@@ -106,6 +110,18 @@ gcloud compute instances set-disk-auto-delete "$NAME" \
 gcloud compute instances update "$NAME" \
   --project "$PROJECT" --zone "$ZONE" \
   --deletion-protection
+
+if gcloud compute resource-policies describe "$SNAPSHOT_POLICY" \
+    --project "$PROJECT" --region "${ZONE%-*}" >/dev/null 2>&1; then
+  attached_policies="$(gcloud compute disks describe "$NAME" \
+    --project "$PROJECT" --zone "$ZONE" \
+    --format='value(resourcePolicies.basename())')"
+  if ! grep -Fxq "$SNAPSHOT_POLICY" <<<"$attached_policies"; then
+    gcloud compute disks add-resource-policies "$NAME" \
+      --project "$PROJECT" --zone "$ZONE" \
+      --resource-policies="$SNAPSHOT_POLICY"
+  fi
+fi
 
 log "done. tail provisioning with:"
 echo "  gcloud compute ssh $NAME --zone $ZONE --project $PROJECT --tunnel-through-iap --command 'sudo tail -f /var/log/tr-clickhouse-startup.log'"

--- a/scripts/deploy/clickhouse_provider_reader.sh
+++ b/scripts/deploy/clickhouse_provider_reader.sh
@@ -49,6 +49,9 @@ sed "s/__PASSWORD_SHA256__/${reader_hash}/g" >"$config" <<'XML'
       <quota>default</quota>
       <grants>
         <query>GRANT SELECT ON tr.provider_benchmark_samples</query>
+        <query>GRANT SELECT ON tr.provider_analytics_hourly</query>
+        <query>GRANT SELECT ON tr.provider_analytics_daily</query>
+        <query>GRANT SELECT ON tr.provider_analytics_monthly</query>
       </grants>
     </tr_provider_read>
   </users>
@@ -61,7 +64,7 @@ gcloud compute ssh "$NAME" \
   --zone="$ZONE" \
   --tunnel-through-iap \
   --quiet \
-  --command="sudo sh -c 'umask 077; cat > /etc/clickhouse-server/users.d/tr-provider-reader.xml; chown clickhouse:clickhouse /etc/clickhouse-server/users.d/tr-provider-reader.xml; systemctl restart clickhouse-server'" \
+  --command="sudo sh -c 'set -eu; umask 077; temporary=\$(mktemp); cat > \"\$temporary\"; if ! cmp -s \"\$temporary\" /etc/clickhouse-server/users.d/tr-provider-reader.xml; then install -o clickhouse -g clickhouse -m 0640 \"\$temporary\" /etc/clickhouse-server/users.d/tr-provider-reader.xml; systemctl restart clickhouse-server; fi; rm -f \"\$temporary\"'" \
   <"$config"
 
 # Validate the account with the raw password locally, but never put it in argv:

--- a/scripts/deploy/clickhouse_reliability.sh
+++ b/scripts/deploy/clickhouse_reliability.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Provision durable ClickHouse archives, snapshots, monitoring, and disk policy.
+# Idempotent. Without --apply it only prints mutations.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ZONE="${TR_CLICKHOUSE_ZONE:-us-central1-a}"
+NAME="${TR_CLICKHOUSE_NAME:-tr-clickhouse-1}"
+DISK="${TR_CLICKHOUSE_DISK:-${NAME}}"
+ARCHIVE_BUCKET="${TR_CLICKHOUSE_ARCHIVE_BUCKET:-${PROJECT_ID}-tr-clickhouse-archive}"
+SNAPSHOT_POLICY="${TR_CLICKHOUSE_SNAPSHOT_POLICY:-tr-clickhouse-daily-snapshots}"
+NODE_SERVICE_ACCOUNT="${TR_CLICKHOUSE_SERVICE_ACCOUNT:-${PROJECT_NUMBER}-compute@developer.gserviceaccount.com}"
+ALERT_CHANNEL_DISPLAY_NAME="${TR_CLICKHOUSE_ALERT_CHANNEL_DISPLAY_NAME:-TrustedRouter Spanner on-call}"
+ALERT_EMAIL="${TR_CLICKHOUSE_ALERT_EMAIL:-security@trustedrouter.com}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+ensure_archive_bucket() {
+  log "ensuring private multi-region Parquet archive bucket"
+  run gc services enable storage.googleapis.com
+  if ! gc storage buckets describe "gs://${ARCHIVE_BUCKET}" >/dev/null 2>&1; then
+    run gc storage buckets create "gs://${ARCHIVE_BUCKET}" \
+      --location=US \
+      --uniform-bucket-level-access \
+      --public-access-prevention
+  fi
+  run gc storage buckets update "gs://${ARCHIVE_BUCKET}" \
+    --uniform-bucket-level-access \
+    --public-access-prevention \
+    --versioning \
+    --lifecycle-file="${SCRIPT_DIR}/clickhouse-archive-lifecycle.json"
+  run gc storage buckets add-iam-policy-binding "gs://${ARCHIVE_BUCKET}" \
+    --member="serviceAccount:${NODE_SERVICE_ACCOUNT}" \
+    --role=roles/storage.objectUser
+}
+
+ensure_snapshot_policy() {
+  log "ensuring daily 30-day persistent-disk snapshots"
+  if ! gc compute resource-policies describe "$SNAPSHOT_POLICY" \
+      --region="$REGION" >/dev/null 2>&1; then
+    run gc compute resource-policies create snapshot-schedule "$SNAPSHOT_POLICY" \
+      --region="$REGION" \
+      --daily-schedule \
+      --start-time=05:00 \
+      --max-retention-days=30 \
+      --on-source-disk-delete=keep-auto-snapshots \
+      --storage-location=us
+  fi
+  local policies
+  policies="$(gc compute disks describe "$DISK" --zone="$ZONE" \
+    --format='value(resourcePolicies.basename())')"
+  if ! grep -Fxq "$SNAPSHOT_POLICY" <<<"$policies"; then
+    run gc compute disks add-resource-policies "$DISK" \
+      --zone="$ZONE" \
+      --resource-policies="$SNAPSHOT_POLICY"
+  fi
+}
+
+ensure_ops_agent() {
+  log "ensuring Ops Agent host metrics for disk-capacity alerts"
+  run ensure_project_role "serviceAccount:${NODE_SERVICE_ACCOUNT}" roles/monitoring.metricWriter
+  if [ "$APPLY" -eq 0 ]; then
+    run gc compute ssh "$NAME" --zone="$ZONE" --tunnel-through-iap \
+      --command="install Google Cloud Ops Agent if absent"
+    return
+  fi
+  gc compute ssh "$NAME" --zone="$ZONE" --tunnel-through-iap --quiet --command="sudo sh -c '
+    set -eu
+    if ! dpkg-query -W google-cloud-ops-agent >/dev/null 2>&1; then
+      tmp=\$(mktemp)
+      curl -fsSL https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh -o \"\$tmp\"
+      bash \"\$tmp\" --also-install
+      rm -f \"\$tmp\"
+    fi
+    systemctl enable --now google-cloud-ops-agent
+    systemctl is-active google-cloud-ops-agent
+  '"
+}
+
+ensure_channel() {
+  local channel
+  channel="$(gc beta monitoring channels list \
+    --filter="displayName=\"${ALERT_CHANNEL_DISPLAY_NAME}\"" \
+    --format='value(name)' | head -1)"
+  if [ -n "$channel" ]; then
+    printf '%s\n' "$channel"
+    return
+  fi
+  if [ "$APPLY" -eq 0 ]; then
+    run gc beta monitoring channels create \
+      --display-name="$ALERT_CHANNEL_DISPLAY_NAME" \
+      --description="TrustedRouter infrastructure reliability incidents" \
+      --type=email \
+      --channel-labels="email_address=${ALERT_EMAIL}"
+    printf 'projects/%s/notificationChannels/DRY_RUN\n' "$PROJECT_ID"
+    return
+  fi
+  gc beta monitoring channels create \
+    --display-name="$ALERT_CHANNEL_DISPLAY_NAME" \
+    --description="TrustedRouter infrastructure reliability incidents" \
+    --type=email \
+    --channel-labels="email_address=${ALERT_EMAIL}" \
+    --format='value(name)'
+}
+
+ensure_alerts() {
+  local channel="$1"
+  local instance_filter template rendered display_name policy_name instance_id
+  instance_filter=""
+  while read -r instance_id; do
+    [ -n "$instance_id" ] || continue
+    if [ -n "$instance_filter" ]; then
+      instance_filter="${instance_filter} OR "
+    fi
+    instance_filter="${instance_filter}resource.labels.instance_id = \"${instance_id}\""
+  done < <(gc compute instances list \
+    --filter='name~^tr-clickhouse-[0-9]+$' \
+    --format='value(id)')
+  if [ -z "$instance_filter" ]; then
+    echo "no ClickHouse instances found for alert policy" >&2
+    exit 1
+  fi
+  for template in "${SCRIPT_DIR}"/clickhouse-alerts/*.yaml; do
+    rendered="$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-alert.XXXXXX.yaml")"
+    sed "s|__INSTANCE_FILTER__|${instance_filter}|g" "$template" >"$rendered"
+    display_name="$(sed -n 's/^displayName: "\(.*\)"$/\1/p' "$rendered")"
+    policy_name="$(gc monitoring policies list \
+      --filter="displayName=\"${display_name}\"" \
+      --format='value(name)' | head -1)"
+    if [ -z "$policy_name" ]; then
+      run gc monitoring policies create \
+        --policy-from-file="$rendered" \
+        --notification-channels="$channel"
+    else
+      run gc monitoring policies update "$policy_name" \
+        --policy-from-file="$rendered" \
+        --set-notification-channels="$channel"
+    fi
+    rm -f "$rendered"
+  done
+}
+
+ensure_archive_bucket
+ensure_snapshot_policy
+ensure_ops_agent
+channel="$(ensure_channel)"
+ensure_alerts "$channel"
+log "ClickHouse reliability safeguards are configured"

--- a/scripts/deploy/clickhouse_resize_disk.sh
+++ b/scripts/deploy/clickhouse_resize_disk.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Expand the ClickHouse persistent boot disk and root filesystem online.
+# ClickHouse ingestion pauses only while a pre-resize snapshot is initiated;
+# the durable Spanner outbox buffers rows during that interval.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ZONE="${TR_CLICKHOUSE_ZONE:-us-central1-a}"
+NAME="${TR_CLICKHOUSE_NAME:-tr-clickhouse-1}"
+DISK="${TR_CLICKHOUSE_DISK:-${NAME}}"
+TARGET_GB="${TR_CLICKHOUSE_DISK_GB:-500}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+current_gb="$(gc compute disks describe "$DISK" --zone="$ZONE" --format='value(sizeGb)')"
+if [ "$TARGET_GB" -lt 500 ]; then
+  echo "refusing: production ClickHouse target must be at least 500 GB" >&2
+  exit 1
+fi
+resize_needed=1
+if [ "$current_gb" -ge "$TARGET_GB" ]; then
+  resize_needed=0
+fi
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: disk=${current_gb} GB target=${TARGET_GB} GB; would ensure / uses all available space"
+  exit 0
+fi
+
+snapshot="not-needed"
+ingester_stopped=0
+resume_ingester() {
+  if [ "$ingester_stopped" -eq 1 ]; then
+    gc compute ssh "$NAME" --zone="$ZONE" --tunnel-through-iap --quiet \
+      --command="sudo systemctl start tr-clickhouse-ingest.service" >/dev/null || true
+  fi
+}
+trap resume_ingester EXIT
+
+if [ "$resize_needed" -eq 1 ]; then
+  snapshot="${NAME}-pre-resize-$(date -u +%Y%m%d-%H%M%S)"
+  log "pausing analytics ingestion and syncing the filesystem"
+  gc compute ssh "$NAME" --zone="$ZONE" --tunnel-through-iap --quiet --command="sudo sh -c '
+    set -eu
+    systemctl stop tr-clickhouse-ingest.service
+    sync
+  '"
+  ingester_stopped=1
+
+  log "creating pre-resize snapshot ${snapshot}"
+  gc compute snapshots create "$snapshot" \
+    --source-disk="$DISK" \
+    --source-disk-zone="$ZONE" \
+    --storage-location=us \
+    --description="TrustedRouter ClickHouse pre-resize snapshot"
+
+  log "resuming analytics ingestion"
+  resume_ingester
+  ingester_stopped=0
+
+  log "expanding persistent disk to ${TARGET_GB} GB"
+  gc compute disks resize "$DISK" --zone="$ZONE" --size="${TARGET_GB}GB" --quiet
+else
+  log "persistent disk is already ${current_gb} GB; resuming at filesystem growth"
+fi
+
+log "growing the root partition and filesystem online"
+gc compute ssh "$NAME" --zone="$ZONE" --tunnel-through-iap --quiet --command="sudo sh -c '
+  set -eu
+  apt-get update -y >/dev/null
+  apt-get install -y cloud-guest-utils >/dev/null
+  root_source=\$(findmnt -n -o SOURCE /)
+  parent=\$(lsblk -no PKNAME \"\$root_source\" | head -1)
+  root_device=\$(basename \"\$(readlink -f \"\$root_source\")\")
+  part=\$(cat \"/sys/class/block/\$root_device/partition\")
+  if [ -n \"\$parent\" ] && [ -n \"\$part\" ]; then
+    growpart \"/dev/\$parent\" \"\$part\" || true
+  fi
+  filesystem=\$(findmnt -n -o FSTYPE /)
+  case \"\$filesystem\" in
+    ext2|ext3|ext4) resize2fs \"\$root_source\" ;;
+    xfs) xfs_growfs / ;;
+    btrfs) btrfs filesystem resize max / ;;
+    *) echo \"unsupported root filesystem: \$filesystem\" >&2; exit 1 ;;
+  esac
+  actual=\$(df -B1 --output=size / | tail -1 | xargs)
+  minimum=$((TARGET_GB * 1000 * 1000 * 1000 * 95 / 100))
+  if [ \"\$actual\" -lt \"\$minimum\" ]; then
+    echo \"root filesystem did not grow: \$actual bytes\" >&2
+    exit 1
+  fi
+  systemctl is-active clickhouse-server
+  systemctl is-active tr-clickhouse-ingest.service
+  df -h /
+'"
+
+new_gb="$(gc compute disks describe "$DISK" --zone="$ZONE" --format='value(sizeGb)')"
+if [ "$new_gb" -lt "$TARGET_GB" ]; then
+  echo "disk resize validation failed: ${new_gb} GB" >&2
+  exit 1
+fi
+log "ClickHouse disk expansion complete: ${current_gb} GB -> ${new_gb} GB; snapshot=${snapshot}"

--- a/scripts/deploy/clickhouse_startup.sh
+++ b/scripts/deploy/clickhouse_startup.sh
@@ -18,8 +18,19 @@ echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://package
   > /etc/apt/sources.list.d/clickhouse.list
 apt-get update -y
 
-PASSWORD=$(curl -fsSL -H 'Metadata-Flavor: Google' \
-  "http://metadata.google.internal/computeMetadata/v1/instance/attributes/ch-password")
+# Resolve the password directly from Secret Manager using the VM identity. The
+# raw credential never enters instance metadata, serial output, or argv.
+METADATA=http://metadata.google.internal/computeMetadata/v1
+PROJECT_ID=$(curl -fsSL -H 'Metadata-Flavor: Google' "$METADATA/project/project-id")
+SECRET_NAME=$(curl -fsSL -H 'Metadata-Flavor: Google' \
+  "$METADATA/instance/attributes/clickhouse-password-secret")
+ACCESS_TOKEN=$(curl -fsSL -H 'Metadata-Flavor: Google' \
+  "$METADATA/instance/service-accounts/default/token" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+PASSWORD=$(curl -fsSL -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://secretmanager.googleapis.com/v1/projects/${PROJECT_ID}/secrets/${SECRET_NAME}/versions/latest:access" \
+  | python3 -c 'import base64,json,sys; print(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode(), end="")')
+unset ACCESS_TOKEN
 debconf-set-selections <<< "clickhouse-server clickhouse-server/default-password password ${PASSWORD}"
 apt-get install -y clickhouse-server clickhouse-client
 

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -105,6 +105,20 @@ case "$REQUEST_RECORD_WRITE_MODE" in
     ;;
 esac
 
+# Prefer the private three-replica ClickHouse load balancer once provisioned.
+# The direct node-1 address remains only as a migration fallback for projects
+# that have not run clickhouse_cluster.sh yet.
+PROVIDER_ANALYTICS_CLICKHOUSE_URL="${TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL:-}"
+if [ -z "$PROVIDER_ANALYTICS_CLICKHOUSE_URL" ]; then
+  clickhouse_ilb_ip="$(gc compute addresses describe tr-clickhouse-ilb \
+    --region=us-central1 --format='value(address)' 2>/dev/null || true)"
+  if [ -n "$clickhouse_ilb_ip" ]; then
+    PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://${clickhouse_ilb_ip}:8123"
+  else
+    PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://10.128.15.214:8123"
+  fi
+fi
+
 ENV_VARS=(
   "TR_ENVIRONMENT=production"
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
@@ -151,22 +165,21 @@ ENV_VARS=(
   # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
   # flag-off settle path is byte-identical.
   "TR_SETTLE_OUTBOX_ENABLED=true"
-  # Analytics outbox → ClickHouse (docs/storage-portability/analytics-ingestion.md
-  # stage 1). Enqueue is a SEPARATE transaction from settle and is best-effort:
+  # Analytics outbox -> ClickHouse (docs/clickhouse-reliability.md). Enqueue is
+  # a SEPARATE transaction from settle and is best-effort:
   # analytics is not worth destabilising money code for, and
   # clickhouse/reconcile_benchmark_samples.py replays from Bigtable to repair
   # anything dropped. Table DDL applied 2026-07-28 with a 7-day ROW DELETION
   # POLICY, so a dead drainer cannot grow it without bound the way
   # tr_settle_outbox and tr_entities did (#334). Ingester + reconciler run on
-  # tr-clickhouse-1 under systemd.
-  #
-  # This is a SHADOW: nothing reads from ClickHouse. Remove this line to
-  # revert — the flag-off path does not touch the outbox at all.
+  # tr-clickhouse-1 under systemd. Provider analytics reads use the private
+  # three-replica load balancer below; inference and billing never depend on
+  # ClickHouse. Remove this line to stop enqueueing new analytics rows.
   "TR_ANALYTICS_OUTBOX_ENABLED=true"
   # Private provider operations portal. Direct VPC egress below reaches this
   # RFC1918 address; ClickHouse has no public IP and the credential is a
   # SELECT-only account scoped to the benchmark table.
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=http://10.128.15.214:8123"
+  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}"
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read"
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_DATABASE=tr"
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_TABLE=provider_benchmark_samples"

--- a/tests/test_clickhouse_archive.py
+++ b/tests/test_clickhouse_archive.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clickhouse.archive_daily import (
+    ArchiveStore,
+    ExportedPart,
+    SourceFingerprint,
+    _combine_parts,
+    _days_to_archive,
+    archive_day,
+)
+
+
+class FakeExporter:
+    def __init__(self, fingerprint: SourceFingerprint) -> None:
+        self.fingerprint = fingerprint
+        self.export_calls = 0
+        self.parity_delta = 0
+
+    def source_fingerprint(self, _day: dt.date) -> SourceFingerprint:
+        return self.fingerprint
+
+    def export_parts(
+        self,
+        _day: dt.date,
+        destination: Path,
+        *,
+        part_count: int,
+    ) -> list[Path]:
+        self.export_calls += 1
+        paths: list[Path] = []
+        rows_left = self.fingerprint.rows
+        hash_sum_left = self.fingerprint.hash_sum + self.parity_delta
+        hash_xor_left = self.fingerprint.hash_xor
+        for index in range(part_count):
+            remaining_parts = part_count - index
+            rows = rows_left // remaining_parts
+            hash_sum = hash_sum_left // remaining_parts
+            hash_xor = hash_xor_left if index == 0 else 0
+            path = destination / f"part-{index:05d}-of-{part_count:05d}.parquet"
+            path.write_text(json.dumps({"rows": rows, "hash_sum": hash_sum, "hash_xor": hash_xor}))
+            paths.append(path)
+            rows_left -= rows
+            hash_sum_left -= hash_sum
+        return paths
+
+    def verify_part(self, path: Path) -> ExportedPart:
+        value = json.loads(path.read_text())
+        return ExportedPart(
+            path=path,
+            rows=int(value["rows"]),
+            hash_sum=int(value["hash_sum"]),
+            hash_xor=int(value["hash_xor"]),
+        )
+
+
+class MemoryStore(ArchiveStore):
+    def __init__(self) -> None:
+        self.json: dict[str, dict[str, Any]] = {}
+        self.files: dict[str, bytes] = {}
+        self.pointer_writes = 0
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        return self.json.get(key)
+
+    def put_file_if_absent(
+        self,
+        key: str,
+        path: Path,
+        *,
+        sha256: str,
+        metadata: dict[str, str],
+    ) -> None:
+        del sha256, metadata
+        value = path.read_bytes()
+        if key in self.files and self.files[key] != value:
+            raise RuntimeError("immutable file differs")
+        self.files[key] = value
+
+    def put_json_if_absent(self, key: str, value: dict[str, Any]) -> None:
+        if key in self.json and self.json[key] != value:
+            raise RuntimeError("immutable manifest differs")
+        self.json[key] = value
+
+    def put_json_pointer(self, key: str, value: dict[str, Any]) -> None:
+        self.pointer_writes += 1
+        self.json[key] = value
+
+
+def _fingerprint(*, rows: int = 7, hash_sum: int = 42, hash_xor: int = 17) -> SourceFingerprint:
+    return SourceFingerprint(
+        rows=rows,
+        hash_sum=hash_sum,
+        hash_xor=hash_xor,
+        min_created_at="2026-07-01 00:00:01.000",
+        max_created_at="2026-07-01 23:59:59.000",
+    )
+
+
+def test_archive_publishes_manifest_only_after_verified_parts() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+
+    result = archive_day(
+        exporter,
+        store,
+        dt.date(2026, 7, 1),
+        rows_per_part=3,
+        now=dt.datetime(2026, 7, 3, tzinfo=dt.UTC),
+    )
+
+    assert result.skipped is False
+    assert exporter.export_calls == 1
+    assert len(store.files) == 3
+    manifest = store.json[result.manifest_key]
+    assert manifest["parquet_rows"] == 7
+    assert len(manifest["parts"]) == 3
+    assert all(len(part["sha256"]) == 64 for part in manifest["parts"])
+    pointer = store.json["raw/provider_benchmark_samples/day=2026-07-01/_latest.json"]
+    assert pointer["manifest"] == result.manifest_key
+    assert store.pointer_writes == 1
+
+
+def test_unchanged_source_skips_export_and_pointer_write() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    first = archive_day(exporter, store, dt.date(2026, 7, 1), rows_per_part=10)
+    second = archive_day(exporter, store, dt.date(2026, 7, 1), rows_per_part=10)
+
+    assert first.revision == second.revision
+    assert second.skipped is True
+    assert exporter.export_calls == 1
+    assert store.pointer_writes == 1
+
+
+def test_late_rows_create_new_revision_without_overwriting_old_one() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    first = archive_day(exporter, store, dt.date(2026, 7, 1), rows_per_part=10)
+    exporter.fingerprint = _fingerprint(rows=8, hash_sum=99, hash_xor=31)
+    second = archive_day(exporter, store, dt.date(2026, 7, 1), rows_per_part=10)
+
+    assert first.revision != second.revision
+    assert first.manifest_key in store.json
+    assert second.manifest_key in store.json
+    assert store.pointer_writes == 2
+
+
+def test_parity_failure_never_publishes_manifest_or_pointer() -> None:
+    exporter = FakeExporter(_fingerprint())
+    exporter.parity_delta = 1
+    store = MemoryStore()
+
+    with pytest.raises(RuntimeError, match="archive parity mismatch"):
+        archive_day(exporter, store, dt.date(2026, 7, 1), rows_per_part=10)
+
+    assert store.json == {}
+    assert store.files == {}
+
+
+def test_empty_day_publishes_a_zero_row_manifest_without_parts() -> None:
+    exporter = FakeExporter(_fingerprint(rows=0, hash_sum=0, hash_xor=0))
+    store = MemoryStore()
+    result = archive_day(exporter, store, dt.date(2026, 7, 1))
+
+    assert result.rows == 0
+    assert store.json[result.manifest_key]["parts"] == []
+    assert store.files == {}
+
+
+def test_combined_part_hash_uses_uint64_overflow_and_xor() -> None:
+    parts = [
+        ExportedPart(Path("a"), 2, (1 << 64) - 1, 0b1010),
+        ExportedPart(Path("b"), 3, 4, 0b1100),
+    ]
+    combined = _combine_parts(parts)
+    assert combined.rows == 5
+    assert combined.hash_sum == 3
+    assert combined.hash_xor == 0b0110
+
+
+def test_archive_date_selection_never_includes_open_current_day() -> None:
+    explicit = dt.date(2026, 7, 9)
+    assert _days_to_archive(date=explicit, lookback_days=0) == [explicit]
+    with pytest.raises(ValueError, match="positive"):
+        _days_to_archive(date=None, lookback_days=0)
+
+
+def test_backfill_date_selection_includes_every_closed_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FrozenDateTime(dt.datetime):
+        @classmethod
+        def now(cls, tz: dt.tzinfo | None = None) -> FrozenDateTime:
+            value = cls(2026, 7, 5, tzinfo=dt.UTC)
+            return value if tz is None else value.astimezone(tz)
+
+    monkeypatch.setattr("clickhouse.archive_daily.dt.datetime", FrozenDateTime)
+    assert _days_to_archive(
+        date=None,
+        lookback_days=0,
+        backfill_start=dt.date(2026, 7, 2),
+    ) == [dt.date(2026, 7, 2), dt.date(2026, 7, 3), dt.date(2026, 7, 4)]

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -12,3 +12,60 @@ def test_clickhouse_node_preserves_disk_and_blocks_accidental_vm_deletion() -> N
     assert "set-disk-auto-delete" in script
     assert "--no-auto-delete" in script
     assert script.count("--deletion-protection") >= 2
+    assert 'DISK_GB="${DISK_GB:-500}"' in script
+
+
+def test_clickhouse_password_never_enters_instance_metadata() -> None:
+    node = (ROOT / "scripts/deploy/clickhouse_node.sh").read_text()
+    startup = (ROOT / "scripts/deploy/clickhouse_startup.sh").read_text()
+
+    assert "--metadata ch-password=" not in node
+    assert "clickhouse-password-secret" in node
+    assert "secretmanager.googleapis.com" in startup
+    assert "instance/attributes/ch-password" not in startup
+
+
+def test_live_deploy_installs_archive_and_rollup_timers() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
+
+    assert "002_provider_analytics_rollups.sql" in script
+    assert "tr-clickhouse-archive.timer" in script
+    assert "tr-clickhouse-rollup-hourly.timer" in script
+    assert "tr-clickhouse-rollup-daily.timer" in script
+
+
+def test_cluster_migration_is_parity_gated_and_keeps_local_backup() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_cluster.sh").read_text()
+
+    assert "tr-clickhouse-2" in script
+    assert "tr-clickhouse-3" in script
+    assert "us-central1-b" in script
+    assert "us-central1-c" in script
+    assert "<keeper_server>" in script
+    assert "pid_two" in script
+    assert "pid_three" in script
+    assert "SYSTEM SYNC REPLICA" in script
+    assert "source and replicated fingerprints differ" in script
+    assert "timedelta(minutes=5)" in script
+    assert "service account did not become visible" in script
+    assert "provider_benchmark_samples_local_backup" in script
+    assert "RENAME TABLE provider_benchmark_samples TO" in script
+    assert "DROP TABLE provider_benchmark_samples_local_backup" not in script
+
+
+def test_cluster_load_balancer_is_private_global_access_and_three_backend() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_cluster.sh").read_text()
+
+    assert "--load-balancing-scheme=INTERNAL" in script
+    assert "--allow-global-access" in script
+    assert "--ports=8123" in script
+    assert "tr-clickhouse-health-check" in script
+    assert "35.191.0.0/16,130.211.0.0/22" in script
+    assert "http://${ip}:8123/ping" in script
+
+
+def test_rollout_prefers_private_clickhouse_load_balancer() -> None:
+    script = (ROOT / "scripts/deploy/rollout.sh").read_text()
+
+    assert "compute addresses describe tr-clickhouse-ilb" in script
+    assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}' in script

--- a/tests/test_clickhouse_reliability_deploy.py
+++ b/tests/test_clickhouse_reliability_deploy.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_archive_lifecycle_keeps_live_raw_objects_for_seven_years() -> None:
+    lifecycle = json.loads(
+        (ROOT / "scripts/deploy/clickhouse-archive-lifecycle.json").read_text()
+    )
+    rules = lifecycle["rule"]
+    assert any(
+        rule["action"]["type"] == "Delete"
+        and rule["condition"] == {"age": 2555, "isLive": True}
+        for rule in rules
+    )
+    assert any(rule["condition"] == {"age": 30, "isLive": False} for rule in rules)
+
+
+def test_reliability_script_provisions_private_archive_and_snapshots() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_reliability.sh").read_text()
+
+    assert "--uniform-bucket-level-access" in script
+    assert "--public-access-prevention" in script
+    assert "--versioning" in script
+    assert "roles/storage.objectUser" in script
+    assert "create snapshot-schedule" in script
+    assert "--max-retention-days=30" in script
+    assert "--on-source-disk-delete=keep-auto-snapshots" in script
+    assert "disks add-resource-policies" in script
+
+
+def test_reliability_script_installs_disk_metrics_and_idempotent_alerts() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_reliability.sh").read_text()
+    disk_policy = (ROOT / "scripts/deploy/clickhouse-alerts/disk-capacity.yaml").read_text()
+    uptime_policy = (
+        ROOT / "scripts/deploy/clickhouse-alerts/node-availability.yaml"
+    ).read_text()
+
+    assert "google-cloud-ops-agent" in script
+    assert "roles/monitoring.metricWriter" in script
+    assert "monitoring policies create" in script
+    assert "monitoring policies update" in script
+    assert "agent.googleapis.com/disk/percent_used" in disk_policy
+    assert "thresholdValue: 75" in disk_policy
+    assert "compute.googleapis.com/instance/uptime" in uptime_policy
+    assert "__INSTANCE_FILTER__" in disk_policy
+    assert "__INSTANCE_FILTER__" in uptime_policy
+    assert "name~^tr-clickhouse-[0-9]+$" in script
+
+
+def test_online_resize_snapshots_resumes_ingestion_and_validates_filesystem() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_resize_disk.sh").read_text()
+
+    assert 'TR_CLICKHOUSE_DISK_GB:-500' in script
+    assert "compute snapshots create" in script
+    assert "systemctl stop tr-clickhouse-ingest.service" in script
+    assert "trap resume_ingester EXIT" in script
+    assert "compute disks resize" in script
+    assert "growpart" in script
+    assert "resize2fs" in script
+    assert "xfs_growfs" in script
+    assert "resuming at filesystem growth" in script
+    assert "systemctl is-active tr-clickhouse-ingest.service" in script
+
+
+def test_failover_smoke_has_remote_and_local_restore_guards() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_failover_smoke.sh").read_text()
+
+    assert 'RESTORE_UNIT="tr-clickhouse-failover-restore-' in script
+    assert "systemd-run --unit=${RESTORE_UNIT}" in script
+    assert "--on-active=${RESTORE_AFTER}" in script
+    assert "trap restore_target EXIT INT TERM HUP" in script
+    assert "systemctl start clickhouse-server" in script
+    assert "wait_for_health 2 3 exact" in script
+    assert "wait_for_health 3 3 exact" in script
+    assert "for _ in \\$(seq 1 20)" in script
+    assert "SYSTEM SYNC REPLICA provider_benchmark_samples" in script

--- a/tests/test_clickhouse_replay_functional.py
+++ b/tests/test_clickhouse_replay_functional.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 import uuid
 from pathlib import Path
@@ -11,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from clickhouse.backfill_benchmark_samples import normalise
+from clickhouse.rollup_analytics import RollupPartition, recompute_partition
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("TR_RUN_CLICKHOUSE_FUNCTIONAL") != "1",
@@ -38,66 +41,66 @@ def test_replayed_batch_collapses_under_final() -> None:
         pytest.skip("docker executable is unavailable")
     name = f"tr-clickhouse-replay-{uuid.uuid4().hex[:12]}"
     image = os.environ.get("TR_CLICKHOUSE_TEST_IMAGE", "clickhouse/clickhouse-server:latest")
-    _docker(docker, "run", "--rm", "-d", "--name", name, image)
-    try:
-        for _ in range(60):
-            ready = _docker(
+    with tempfile.TemporaryDirectory(prefix="tr-clickhouse-keeper-") as temporary:
+        keeper_config = Path(temporary) / "keeper.xml"
+        keeper_config.write_text(
+            """<clickhouse>
+  <keeper_server>
+    <tcp_port>9181</tcp_port>
+    <server_id>1</server_id>
+    <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+    <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+    <raft_configuration>
+      <server><id>1</id><hostname>127.0.0.1</hostname><port>9234</port></server>
+    </raft_configuration>
+  </keeper_server>
+  <zookeeper><node><host>127.0.0.1</host><port>9181</port></node></zookeeper>
+  <macros><shard>01</shard><replica>functional-1</replica></macros>
+</clickhouse>
+"""
+        )
+        _docker(
+            docker,
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            name,
+            "-v",
+            f"{keeper_config}:/etc/clickhouse-server/config.d/keeper.xml:ro",
+            image,
+        )
+        try:
+            for _ in range(60):
+                ready = _docker(
+                    docker,
+                    "exec",
+                    name,
+                    "clickhouse-client",
+                    "--query",
+                    "SELECT 1",
+                    check=False,
+                )
+                if ready.returncode == 0:
+                    break
+                time.sleep(0.25)
+            else:
+                pytest.fail("ClickHouse container did not become ready")
+
+            database = f"replay_{uuid.uuid4().hex}"
+            _docker(
                 docker,
                 "exec",
                 name,
                 "clickhouse-client",
                 "--query",
-                "SELECT 1",
-                check=False,
+                f"CREATE DATABASE {database}",
             )
-            if ready.returncode == 0:
-                break
-            time.sleep(0.25)
-        else:
-            pytest.fail("ClickHouse container did not become ready")
-
-        database = f"replay_{uuid.uuid4().hex}"
-        _docker(
-            docker,
-            "exec",
-            name,
-            "clickhouse-client",
-            "--query",
-            f"CREATE DATABASE {database}",
-        )
-        schema = (
-            Path(__file__).parents[1] / "clickhouse" / "001_provider_benchmark_samples.sql"
-        ).read_bytes()
-        _docker(
-            docker,
-            "exec",
-            "-i",
-            name,
-            "clickhouse-client",
-            "--database",
-            database,
-            "--multiquery",
-            input_bytes=schema,
-        )
-
-        raw = {
-            "id": "bench-functional-replay",
-            "created_at": "2026-07-28T12:34:56.789Z",
-            "provider": "anthropic",
-            "model": "anthropic/claude-haiku-4.5",
-            "provider_name": "Anthropic",
-            "status": "success",
-            "usage_type": "Credits",
-            "source": "organic",
-            "streamed": True,
-            "input_tokens": 12,
-            "output_tokens": 3,
-            "total_cost_microdollars": 9,
-        }
-        canonical = normalise(raw)
-        assert canonical is not None
-        payload = (json.dumps(canonical) + "\n").encode()
-        for _ in range(2):
+            schema = (
+                Path(__file__).parents[1]
+                / "clickhouse"
+                / "001_provider_benchmark_samples.sql"
+            ).read_bytes()
             _docker(
                 docker,
                 "exec",
@@ -106,20 +109,156 @@ def test_replayed_batch_collapses_under_final() -> None:
                 "clickhouse-client",
                 "--database",
                 database,
-                "--query",
-                "INSERT INTO provider_benchmark_samples FORMAT JSONEachRow",
-                input_bytes=payload,
+                "--multiquery",
+                input_bytes=schema,
             )
-        count = _docker(
-            docker,
-            "exec",
-            name,
-            "clickhouse-client",
-            "--database",
-            database,
-            "--query",
-            "SELECT count() FROM provider_benchmark_samples FINAL",
-        )
-        assert count.stdout.decode().strip() == "1"
-    finally:
-        _docker(docker, "rm", "-f", name, check=False)
+
+            raw = {
+                "id": "bench-functional-replay",
+                "created_at": "2026-07-28T12:34:56.789Z",
+                "provider": "anthropic",
+                "model": "anthropic/claude-haiku-4.5",
+                "provider_name": "Anthropic",
+                "status": "success",
+                "usage_type": "Credits",
+                "source": "organic",
+                "streamed": True,
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "total_cost_microdollars": 9,
+            }
+            canonical = normalise(raw)
+            assert canonical is not None
+            payload = (json.dumps(canonical) + "\n").encode()
+            for _ in range(2):
+                _docker(
+                    docker,
+                    "exec",
+                    "-i",
+                    name,
+                    "clickhouse-client",
+                    "--database",
+                    database,
+                    "--query",
+                    "INSERT INTO provider_benchmark_samples FORMAT JSONEachRow",
+                    input_bytes=payload,
+                )
+            count = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT count() FROM provider_benchmark_samples FINAL",
+            )
+            assert count.stdout.decode().strip() == "1"
+
+            rollup_schema = (
+                Path(__file__).parents[1]
+                / "clickhouse"
+                / "002_provider_analytics_rollups.sql"
+            ).read_bytes()
+            _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--multiquery",
+                input_bytes=rollup_schema,
+            )
+
+            class DockerExecutor:
+                def execute(self, query: str) -> bytes:
+                    result = _docker(
+                        docker,
+                        "exec",
+                        name,
+                        "clickhouse-client",
+                        "--database",
+                        database,
+                        "--query",
+                        query,
+                    )
+                    return result.stdout
+
+            rolled = recompute_partition(
+                DockerExecutor(),
+                RollupPartition(
+                    "hourly",
+                    dt.datetime(2026, 7, 28, tzinfo=dt.UTC),
+                    dt.datetime(2026, 7, 29, tzinfo=dt.UTC),
+                    "20260728",
+                ),
+            )
+            assert rolled == 1
+            rollup_count = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT sum(attempts) FROM provider_analytics_hourly",
+            )
+            assert rollup_count.stdout.decode().strip() == "1"
+
+            daily_ddl = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SHOW CREATE TABLE provider_analytics_daily",
+            ).stdout.decode()
+            hourly_ddl = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SHOW CREATE TABLE provider_analytics_hourly",
+            ).stdout.decode()
+            assert "TTL" not in daily_ddl
+            assert "TTL" in hourly_ddl
+
+            replicated_schema = (
+                Path(__file__).parents[1]
+                / "clickhouse"
+                / "003_provider_benchmark_replicated.sql"
+            ).read_bytes()
+            _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--multiquery",
+                input_bytes=replicated_schema,
+            )
+            engine = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT engine FROM system.tables "
+                "WHERE database=currentDatabase() "
+                "AND name='provider_benchmark_samples_replicated'",
+            )
+            assert engine.stdout.decode().strip() == "ReplicatedReplacingMergeTree"
+        finally:
+            _docker(docker, "rm", "-f", name, check=False)

--- a/tests/test_clickhouse_rollups.py
+++ b/tests/test_clickhouse_rollups.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from clickhouse.rollup_analytics import (
+    RollupPartition,
+    _parse_granularities,
+    planned_partitions,
+    recompute_partition,
+)
+
+
+class FakeExecutor:
+    def __init__(self, responses: list[bytes]) -> None:
+        self.responses = responses
+        self.queries: list[str] = []
+
+    def execute(self, query: str) -> bytes:
+        self.queries.append(query)
+        return self.responses.pop(0) if self.responses else b""
+
+
+def test_hourly_planner_excludes_open_hour_and_rebuilds_recent_days() -> None:
+    now = dt.datetime(2026, 7, 31, 12, 34, tzinfo=dt.UTC)
+    partitions = planned_partitions("hourly", now=now)
+
+    assert [part.partition_id for part in partitions] == ["20260729", "20260730", "20260731"]
+    assert partitions[-1].end == dt.datetime(2026, 7, 31, 12, tzinfo=dt.UTC)
+
+
+def test_daily_planner_rebuilds_previous_and_current_month_but_not_today() -> None:
+    now = dt.datetime(2026, 7, 2, 12, 34, tzinfo=dt.UTC)
+    partitions = planned_partitions("daily", now=now)
+
+    assert [part.partition_id for part in partitions] == ["202606", "202607"]
+    assert partitions[-1].end == dt.datetime(2026, 7, 2, tzinfo=dt.UTC)
+
+
+def test_monthly_planner_only_publishes_complete_months() -> None:
+    now = dt.datetime(2026, 7, 2, 12, 34, tzinfo=dt.UTC)
+    partitions = planned_partitions("monthly", now=now)
+
+    assert [part.partition_id for part in partitions] == ["202606"]
+    assert partitions[0].start == dt.datetime(2026, 6, 1, tzinfo=dt.UTC)
+    assert partitions[0].end == dt.datetime(2026, 7, 1, tzinfo=dt.UTC)
+
+
+def test_backfill_planner_covers_every_historical_partition() -> None:
+    now = dt.datetime(2026, 7, 31, 12, 34, tzinfo=dt.UTC)
+    daily = planned_partitions(
+        "daily",
+        now=now,
+        backfill_start=dt.date(2025, 11, 18),
+    )
+    monthly = planned_partitions(
+        "monthly",
+        now=now,
+        backfill_start=dt.date(2025, 11, 18),
+    )
+
+    assert daily[0].partition_id == "202511"
+    assert daily[-1].partition_id == "202607"
+    assert monthly[0].partition_id == "202511"
+    assert monthly[-1].partition_id == "202606"
+
+
+def test_recompute_verifies_staging_before_atomic_replace_and_live_after() -> None:
+    executor = FakeExecutor([b"17\n", b"", b"", b"17\n", b"", b"17\n"])
+    partition = RollupPartition(
+        "hourly",
+        dt.datetime(2026, 7, 30, tzinfo=dt.UTC),
+        dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        "20260730",
+    )
+
+    assert recompute_partition(executor, partition) == 17
+    assert executor.queries[1] == "TRUNCATE TABLE provider_analytics_hourly_staging"
+    assert executor.queries[2].startswith("INSERT INTO provider_analytics_hourly_staging SELECT")
+    assert "REPLACE PARTITION ID '20260730'" in executor.queries[4]
+    assert "FROM provider_analytics_hourly_staging" in executor.queries[4]
+
+
+def test_recompute_does_not_publish_a_parity_mismatch() -> None:
+    executor = FakeExecutor([b"17\n", b"", b"", b"16\n"])
+    partition = RollupPartition(
+        "daily",
+        dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        "202607",
+    )
+
+    with pytest.raises(RuntimeError, match="rollup parity mismatch"):
+        recompute_partition(executor, partition)
+    assert all("REPLACE PARTITION" not in query for query in executor.queries)
+
+
+def test_empty_source_removes_stale_partition_without_insert() -> None:
+    executor = FakeExecutor([b"0\n", b""])
+    partition = RollupPartition(
+        "monthly",
+        dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        "202606",
+    )
+
+    assert recompute_partition(executor, partition) == 0
+    assert executor.queries[-1] == "ALTER TABLE provider_analytics_monthly DROP PARTITION ID '202606'"
+
+
+def test_granularity_parser_is_fail_closed() -> None:
+    assert tuple(_parse_granularities("all")) == ("hourly", "daily", "monthly")
+    with pytest.raises(Exception, match="granularity"):
+        _parse_granularities("weekly")

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -129,7 +129,9 @@ def test_provider_portal_uses_private_vpc_and_dedicated_clickhouse_reader() -> N
         ROOT / "scripts/deploy/clickhouse_provider_reader.sh"
     ).read_text(encoding="utf-8")
 
-    assert "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=http://10.128.15.214:8123" in rollout
+    assert "compute addresses describe tr-clickhouse-ilb" in rollout
+    assert 'PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://${clickhouse_ilb_ip}:8123"' in rollout
+    assert 'PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://10.128.15.214:8123"' in rollout
     assert "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read" in rollout
     assert "--vpc-egress private-ranges-only" in rollout
     assert '--network "${TR_CLOUD_RUN_NETWORK:-default}"' in rollout
@@ -143,6 +145,9 @@ def test_provider_portal_uses_private_vpc_and_dedicated_clickhouse_reader() -> N
     assert "<max_memory_usage>536870912</max_memory_usage>" in reader
     assert "<max_result_bytes>536870912</max_result_bytes>" in reader
     assert "GRANT SELECT ON tr.provider_benchmark_samples" in reader
+    assert "GRANT SELECT ON tr.provider_analytics_hourly" in reader
+    assert "GRANT SELECT ON tr.provider_analytics_daily" in reader
+    assert "GRANT SELECT ON tr.provider_analytics_monthly" in reader
     assert "refusing configuration: $NAME has external IP" in reader
     assert (
         "TR_PROVIDER_ANALYTICS_CLICKHOUSE_PASSWORD: "


### PR DESCRIPTION
## Summary
- archive closed raw analytics days as parity-verified immutable Parquet with seven-year GCS retention
- add verified hourly, daily, and monthly aggregate tiers
- migrate the customer-facing raw analytics table to three zonal replicas behind a private load balancer
- expand every replica to 500 GB SSD, attach daily snapshots, and add node/disk alerts
- add a cleanup-safe one-zone failover smoke and a canonical operations/restore runbook

## Production verification
- all three replicas healthy with zero queue, zero delay, and identical fixed-cutoff fingerprints
- authenticated SQL reads succeeded through the private load balancer with one zone stopped
- all four Cloud Run regions now use the load-balancer endpoint
- 26 closed days archived with immutable latest manifests
- ingestion, reconciliation, archive, and rollup timers active

## Tests
- `uv run ruff check .`
- `uv run mypy`
- `.venv/bin/pytest -q` (2325 passed, 86 skipped)
- `TR_RUN_CLICKHOUSE_FUNCTIONAL=1 .venv/bin/pytest -q tests/test_clickhouse_replay_functional.py`
- `bash -n` on all changed deployment scripts