### PR TITLE
Remove Quill Feather homepage promotion

### DIFF
--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -275,24 +275,6 @@ response = client.chat.completions.create(
       </div>
     </section>
 
-    <section class="home-section">
-      <div class="home-wrap">
-        <aside class="quill-ad" aria-label="Sponsored: Quill Feather">
-          <div class="quill-ad-inner">
-            <a class="quill-ad-mark" href="https://quill.lorehex.co" aria-label="Open Quill Feather">
-              <img src="/static/quill-feather.png" alt="Quill Feather private AI device" loading="lazy" decoding="async" width="320" height="291">
-            </a>
-            <div>
-              <span class="quill-ad-eyebrow">Sponsored · Quill Feather</span>
-              <h2 class="quill-ad-title">A private agent that fits in your hand.</h2>
-              <p class="quill-ad-lead">A personal LLM device for local and private AI workflows. Run an agent around the clock on hardware you control.</p>
-            </div>
-            <div class="quill-ad-cta"><a class="btn primary" href="https://quill.lorehex.co">Buy Quill Feather</a></div>
-          </div>
-        </aside>
-      </div>
-    </section>
-
     <section class="home-section band-dim">
       <div class="home-wrap narrow">
         <div class="kicker centered">Questions</div>

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -53,7 +53,6 @@
       <a href="/support">Support</a>
       <a href="/legal">Legal</a>
       <a href="/terms">Terms</a>
-      <a href="https://quill.lorehex.co">Quill hardware</a>
     </div>
   </div>
   <div class="site-footer-base">

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -189,7 +189,8 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert "trustedrouter/auto" in dashboard.text  # routing model
     assert "$25 USDC" not in dashboard.text
     assert "Stripe Crypto" not in dashboard.text
-    assert "https://quill.lorehex.co" in dashboard.text
+    assert "Quill Feather" not in dashboard.text
+    assert "https://quill.lorehex.co" not in dashboard.text
     assert 'href="/status"' in dashboard.text
     assert "https://github.com/Lore-Hex/trusted-router-py" in dashboard.text
     assert 'href="/providers"' in dashboard.text


### PR DESCRIPTION
Summary:
- Remove the sponsored Quill Feather block from the homepage.
- Remove the Quill hardware link from the shared footer.
- Assert the homepage no longer contains the promotion or destination URL.

Tests:
- Focused homepage and SEO tests: 2 passed.