### PR TITLE
Move operational analytics toward ClickHouse

### DIFF
--- a/clickhouse/004_operational_analytics_replicated.sql
+++ b/clickhouse/004_operational_analytics_replicated.sql
@@ -1,0 +1,125 @@
+-- Replicated operational metadata tables. These tables never contain prompts,
+-- outputs, raw workspace IDs, API keys, BYOK secrets, or authorization headers.
+
+CREATE TABLE IF NOT EXISTS activity_generations
+(
+    generation_id               String,
+    request_id                  String,
+    tenant_id                   FixedString(64),
+    key_id                      FixedString(64),
+    model                       LowCardinality(String),
+    provider                    LowCardinality(String),
+    provider_name               LowCardinality(String),
+    app                         String,
+    tokens_prompt               UInt64,
+    tokens_completion           UInt64,
+    cached_input_tokens         UInt64,
+    reasoning_tokens            UInt64,
+    total_cost_microdollars     Int64,
+    usage_type                  LowCardinality(String),
+    speed_tokens_per_second     Float64,
+    finish_reason               LowCardinality(String),
+    status                      LowCardinality(String),
+    streamed                    UInt8,
+    usage_estimated             UInt8,
+    elapsed_milliseconds        Nullable(UInt64),
+    first_token_milliseconds    Nullable(UInt64),
+    ttfb_milliseconds           Nullable(UInt64),
+    region                      LowCardinality(Nullable(String)),
+    user                        Nullable(String),
+    session_id                  Nullable(String),
+    http_referer                Nullable(String),
+    app_categories              Array(String),
+    tags                        Map(String, String),
+    created_at                  DateTime64(3, 'UTC'),
+    ingest_version              DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/activity-generations-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (tenant_id, created_at, generation_id)
+TTL toDateTime(created_at) + INTERVAL 400 DAY;
+
+CREATE TABLE IF NOT EXISTS synthetic_probe_samples
+(
+    id                              String,
+    probe_type                      LowCardinality(String),
+    target                          LowCardinality(String),
+    target_url                      String,
+    monitor_region                  LowCardinality(String),
+    status                          LowCardinality(String),
+    target_region                   LowCardinality(Nullable(String)),
+    latency_milliseconds            Nullable(UInt64),
+    ttfb_milliseconds               Nullable(UInt64),
+    dns_milliseconds                Nullable(UInt64),
+    tcp_connect_milliseconds        Nullable(UInt64),
+    tls_handshake_milliseconds      Nullable(UInt64),
+    gateway_processing_milliseconds Nullable(UInt64),
+    connection_reused               Nullable(UInt8),
+    protocol                        LowCardinality(Nullable(String)),
+    http_status                     Nullable(UInt16),
+    error_type                      LowCardinality(Nullable(String)),
+    provider                        LowCardinality(Nullable(String)),
+    model                           LowCardinality(Nullable(String)),
+    selected_provider               LowCardinality(Nullable(String)),
+    selected_model                  LowCardinality(Nullable(String)),
+    generation_id                   Nullable(String),
+    attestation_digest              Nullable(String),
+    source_commit                   Nullable(String),
+    cost_microdollars               Int64,
+    output_match                    Nullable(UInt8),
+    created_at                      DateTime64(3, 'UTC'),
+    ingest_version                  DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/synthetic-probe-samples-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMMDD(created_at)
+ORDER BY (target, probe_type, monitor_region, created_at, id)
+TTL toDateTime(created_at) + INTERVAL 14 DAY;
+
+CREATE TABLE IF NOT EXISTS synthetic_status_rollups
+(
+    id                           String,
+    period                       LowCardinality(String),
+    period_start                 DateTime('UTC'),
+    component                    LowCardinality(String),
+    target                       LowCardinality(String),
+    probe_type                   LowCardinality(String),
+    monitor_region               LowCardinality(String),
+    target_region                LowCardinality(String),
+    sample_count                 UInt64,
+    up_count                     UInt64,
+    down_count                   UInt64,
+    degraded_count               UInt64,
+    routing_degraded_count       UInt64,
+    trust_degraded_count         UInt64,
+    unknown_count                UInt64,
+    latency_histogram            Map(String, UInt64),
+    ttfb_histogram               Map(String, UInt64),
+    dns_histogram                Map(String, UInt64),
+    tcp_connect_histogram        Map(String, UInt64),
+    tls_handshake_histogram      Map(String, UInt64),
+    gateway_processing_histogram Map(String, UInt64),
+    error_counts                 Map(String, UInt64),
+    last_checked_at              Nullable(DateTime64(3, 'UTC')),
+    cost_microdollars            Int64,
+    updated_at                   DateTime64(3, 'UTC'),
+    ingest_version               DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/synthetic-status-rollups-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period, period_start, component, target, probe_type, monitor_region,
+    target_region, id
+)
+TTL period_start + INTERVAL 24 MONTH;

--- a/clickhouse/005_provider_rollups_replicated.sql
+++ b/clickhouse/005_provider_rollups_replicated.sql
@@ -1,0 +1,64 @@
+-- Three-replica provider analytics rollups. Temporary staging tables remain
+-- local to the rollup worker; only published aggregates need replication.
+
+CREATE TABLE IF NOT EXISTS provider_analytics_hourly_replicated
+(
+    period_start                 DateTime('UTC'),
+    provider                     LowCardinality(String),
+    model                        LowCardinality(String),
+    source                       LowCardinality(String),
+    region                       LowCardinality(String),
+    usage_type                   LowCardinality(String),
+    status                       LowCardinality(String),
+    error_type                   LowCardinality(String),
+    error_status                 UInt16,
+    streamed                     UInt8,
+    attempts                     UInt64,
+    completed                    UInt64,
+    failed                       UInt64,
+    input_tokens                 UInt64,
+    output_tokens                UInt64,
+    total_cost_microdollars      Int64,
+    p50_elapsed_milliseconds     Nullable(Float64),
+    p95_elapsed_milliseconds     Nullable(Float64),
+    p50_first_token_milliseconds Nullable(Float64),
+    p95_first_token_milliseconds Nullable(Float64),
+    p50_ttfb_milliseconds        Nullable(Float64),
+    p95_ttfb_milliseconds        Nullable(Float64),
+    p50_tokens_per_second        Nullable(Float64),
+    p95_tokens_per_second        Nullable(Float64)
+)
+ENGINE = ReplicatedMergeTree(
+    '/trustedrouter/tables/{shard}/provider-analytics-hourly-v1',
+    '{replica}'
+)
+PARTITION BY toYYYYMMDD(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+)
+TTL period_start + INTERVAL 3 YEAR;
+
+CREATE TABLE IF NOT EXISTS provider_analytics_daily_replicated
+AS provider_analytics_hourly_replicated
+ENGINE = ReplicatedMergeTree(
+    '/trustedrouter/tables/{shard}/provider-analytics-daily-v1',
+    '{replica}'
+)
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);
+
+CREATE TABLE IF NOT EXISTS provider_analytics_monthly_replicated
+AS provider_analytics_hourly_replicated
+ENGINE = ReplicatedMergeTree(
+    '/trustedrouter/tables/{shard}/provider-analytics-monthly-v1',
+    '{replica}'
+)
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (
+    period_start, provider, model, source, region, usage_type, status,
+    error_type, error_status, streamed
+);

--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -1,0 +1,270 @@
+"""Replay bounded Bigtable operational metadata into replicated ClickHouse."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Iterator
+from typing import Any, TypeVar
+
+from google.cloud import bigtable
+from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
+
+from clickhouse.ingest_operational_outbox import (
+    CanonicalOperationalEvent,
+    ClickHouseOperationalWriter,
+    OperationalOutboxRow,
+    normalise_operational_event,
+)
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    activity_payload,
+    synthetic_payload,
+)
+from trusted_router.storage_models import Generation, SyntheticProbeSample, SyntheticRollup
+
+PROJECT = "quill-cloud-proxy"
+INSTANCE = "trusted-router-logs"
+TABLE = "trustedrouter-generations"
+DATABASE = "tr"
+FAMILIES = {
+    "activity": ("activity", "m"),
+    "synthetic": ("synthetic", "m"),
+    "rollup": ("rollup", "m"),
+}
+T = TypeVar("T")
+
+
+class ClickHouse:
+    def __init__(self, *, password: str) -> None:
+        self._password = password
+
+    def query(
+        self,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        external_ids: bool = False,
+    ) -> str:
+        env = os.environ.copy()
+        env["CLICKHOUSE_PASSWORD"] = self._password
+        command = [
+            "/usr/bin/clickhouse-client",
+            "--user",
+            "tr",
+            "--database",
+            DATABASE,
+        ]
+        if external_ids:
+            command.extend(
+                [
+                    "--external",
+                    "--file",
+                    "-",
+                    "--name",
+                    "wanted",
+                    "--structure",
+                    "id String",
+                    "--format",
+                    "TabSeparated",
+                ]
+            )
+        command.extend(["--query", sql])
+        result = subprocess.run(  # noqa: S603 - fixed executable and SQL below.
+            command,
+            input=input_bytes,
+            env=env,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode(errors="replace")[:1000]
+            raise RuntimeError(f"ClickHouse query failed: {detail}")
+        return result.stdout.decode()
+
+
+def _body(row: Any, families: Iterable[str]) -> dict[str, Any] | None:
+    for family in families:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if not cells:
+            continue
+        try:
+            payload = json.loads(cells[0].value.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            return None
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _parse(cls: type[T], payload: dict[str, Any] | None) -> T | None:
+    if payload is None:
+        return None
+    try:
+        return cls(**payload)
+    except (TypeError, ValueError):
+        return None
+
+
+def _created_at(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def iter_activity_events(table: Any) -> Iterator[CanonicalOperationalEvent]:
+    rows = table.read_rows(
+        start_key=b"ws_recent#",
+        end_key=b"ws_recent#~",
+        filter_=CellsColumnLimitFilter(1),
+    )
+    for row in rows:
+        generation = _parse(Generation, _body(row, FAMILIES["activity"]))
+        if generation is None:
+            continue
+        yield normalise_operational_event(
+            OperationalOutboxRow(
+                shard=0,
+                commit_ts=_created_at(generation.created_at),
+                event_kind="activity",
+                event_id=generation.id,
+                payload=json.dumps(activity_payload(generation)),
+            )
+        )
+
+
+def iter_synthetic_events(table: Any) -> Iterator[CanonicalOperationalEvent]:
+    rows = table.read_rows(
+        start_key=b"synthetic_recent#",
+        end_key=b"synthetic_recent#~",
+        filter_=CellsColumnLimitFilter(1),
+    )
+    for row in rows:
+        sample = _parse(SyntheticProbeSample, _body(row, FAMILIES["synthetic"]))
+        if sample is None:
+            continue
+        yield normalise_operational_event(
+            OperationalOutboxRow(
+                shard=0,
+                commit_ts=_created_at(sample.created_at),
+                event_kind="synthetic",
+                event_id=sample.id,
+                payload=json.dumps(synthetic_payload(sample)),
+            )
+        )
+
+
+def iter_rollups(table: Any) -> Iterator[SyntheticRollup]:
+    rows = table.read_rows(
+        start_key=b"synthetic_rollup#",
+        end_key=b"synthetic_rollup#~",
+        filter_=CellsColumnLimitFilter(1),
+    )
+    for row in rows:
+        rollup = _parse(SyntheticRollup, _body(row, FAMILIES["rollup"]))
+        if rollup is not None:
+            yield rollup
+
+
+def _batches(items: Iterable[T], size: int) -> Iterator[list[T]]:
+    batch: list[T] = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def insert_rollups(clickhouse: ClickHouse, rollups: list[SyntheticRollup]) -> None:
+    if not rollups:
+        return
+    version = dt.datetime.now(dt.UTC).isoformat()
+    payload = b"\n".join(
+        json.dumps(
+            {
+                **dataclasses.asdict(rollup),
+                "target_region": rollup.target_region or "",
+                "ingest_version": version,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        for rollup in rollups
+    )
+    clickhouse.query(
+        "INSERT INTO synthetic_status_rollups FORMAT JSONEachRow",
+        input_bytes=payload,
+    )
+
+
+def _count(clickhouse: ClickHouse, table: str) -> int:
+    allowed = {
+        "activity_generations",
+        "synthetic_probe_samples",
+        "synthetic_status_rollups",
+    }
+    if table not in allowed:
+        raise ValueError("unsupported table")
+    return int(clickhouse.query(f"SELECT count() FROM {table} FINAL").strip())  # noqa: S608
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--batch", type=int, default=5000)
+    args = parser.parse_args()
+    if args.batch < 1:
+        raise SystemExit("--batch must be positive")
+
+    table = (
+        bigtable.Client(project=PROJECT, admin=False)
+        .instance(INSTANCE)
+        .table(TABLE)
+    )
+    password = os.environ.get("CH_PASSWORD", "")
+    if args.apply and not password:
+        raise SystemExit("CH_PASSWORD is required with --apply")
+
+    clickhouse = ClickHouse(password=password) if args.apply else None
+    writer = (
+        ClickHouseOperationalWriter(password=password, database=DATABASE)
+        if args.apply
+        else None
+    )
+    counts = {"activity": 0, "synthetic": 0, "rollup": 0}
+
+    for kind, events in (
+        ("activity", iter_activity_events(table)),
+        ("synthetic", iter_synthetic_events(table)),
+    ):
+        for batch in _batches(events, args.batch):
+            counts[kind] += len(batch)
+            if writer is not None:
+                writer.insert(batch)
+            print(f"{kind}: {counts[kind]} rows", file=sys.stderr, flush=True)
+
+    for rollup_batch in _batches(iter_rollups(table), args.batch):
+        counts["rollup"] += len(rollup_batch)
+        if clickhouse is not None:
+            insert_rollups(clickhouse, rollup_batch)
+        print(f"rollup: {counts['rollup']} rows", file=sys.stderr, flush=True)
+
+    result: dict[str, Any] = {"mode": "apply" if args.apply else "dry-run", **counts}
+    if clickhouse is not None:
+        result["clickhouse"] = {
+            "activity": _count(clickhouse, "activity_generations"),
+            "synthetic": _count(clickhouse, "synthetic_probe_samples"),
+            "rollup": _count(clickhouse, "synthetic_status_rollups"),
+        }
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -116,10 +116,15 @@ def _created_at(value: str) -> dt.datetime:
     return parsed.astimezone(dt.UTC)
 
 
-def iter_activity_events(table: Any) -> Iterator[CanonicalOperationalEvent]:
+def iter_activity_events(
+    table: Any,
+    *,
+    limit: int | None = None,
+) -> Iterator[CanonicalOperationalEvent]:
     rows = table.read_rows(
         start_key=b"ws_recent#",
         end_key=b"ws_recent#~",
+        limit=limit,
         filter_=CellsColumnLimitFilter(1),
     )
     for row in rows:
@@ -137,10 +142,15 @@ def iter_activity_events(table: Any) -> Iterator[CanonicalOperationalEvent]:
         )
 
 
-def iter_synthetic_events(table: Any) -> Iterator[CanonicalOperationalEvent]:
+def iter_synthetic_events(
+    table: Any,
+    *,
+    limit: int | None = None,
+) -> Iterator[CanonicalOperationalEvent]:
     rows = table.read_rows(
         start_key=b"synthetic_recent#",
         end_key=b"synthetic_recent#~",
+        limit=limit,
         filter_=CellsColumnLimitFilter(1),
     )
     for row in rows:
@@ -218,9 +228,15 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--batch", type=int, default=5000)
+    parser.add_argument("--recent-limit", type=int)
+    parser.add_argument("--skip-activity", action="store_true")
+    parser.add_argument("--skip-synthetic", action="store_true")
+    parser.add_argument("--skip-rollups", action="store_true")
     args = parser.parse_args()
     if args.batch < 1:
         raise SystemExit("--batch must be positive")
+    if args.recent_limit is not None and args.recent_limit < 1:
+        raise SystemExit("--recent-limit must be positive")
 
     table = (
         bigtable.Client(project=PROJECT, admin=False)
@@ -239,21 +255,28 @@ def main() -> int:
     )
     counts = {"activity": 0, "synthetic": 0, "rollup": 0}
 
-    for kind, events in (
-        ("activity", iter_activity_events(table)),
-        ("synthetic", iter_synthetic_events(table)),
-    ):
+    sources = []
+    if not args.skip_activity:
+        sources.append(
+            ("activity", iter_activity_events(table, limit=args.recent_limit))
+        )
+    if not args.skip_synthetic:
+        sources.append(
+            ("synthetic", iter_synthetic_events(table, limit=args.recent_limit))
+        )
+    for kind, events in sources:
         for batch in _batches(events, args.batch):
             counts[kind] += len(batch)
             if writer is not None:
                 writer.insert(batch)
             print(f"{kind}: {counts[kind]} rows", file=sys.stderr, flush=True)
 
-    for rollup_batch in _batches(iter_rollups(table), args.batch):
-        counts["rollup"] += len(rollup_batch)
-        if clickhouse is not None:
-            insert_rollups(clickhouse, rollup_batch)
-        print(f"rollup: {counts['rollup']} rows", file=sys.stderr, flush=True)
+    if not args.skip_rollups:
+        for rollup_batch in _batches(iter_rollups(table), args.batch):
+            counts["rollup"] += len(rollup_batch)
+            if clickhouse is not None:
+                insert_rollups(clickhouse, rollup_batch)
+            print(f"rollup: {counts['rollup']} rows", file=sys.stderr, flush=True)
 
     result: dict[str, Any] = {"mode": "apply" if args.apply else "dry-run", **counts}
     if clickhouse is not None:

--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -1,0 +1,350 @@
+"""Drain tenant activity and synthetic metadata from Spanner to ClickHouse."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import math
+import os
+import subprocess
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+PROJECT = "quill-cloud-proxy"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+OUTBOX_TABLE = "tr_operational_analytics_outbox"
+OUTBOX_SHARDS = 32
+
+ACTIVITY_COLUMNS = (
+    "generation_id",
+    "request_id",
+    "tenant_id",
+    "key_id",
+    "model",
+    "provider",
+    "provider_name",
+    "app",
+    "tokens_prompt",
+    "tokens_completion",
+    "cached_input_tokens",
+    "reasoning_tokens",
+    "total_cost_microdollars",
+    "usage_type",
+    "speed_tokens_per_second",
+    "finish_reason",
+    "status",
+    "streamed",
+    "usage_estimated",
+    "elapsed_milliseconds",
+    "first_token_milliseconds",
+    "ttfb_milliseconds",
+    "region",
+    "user",
+    "session_id",
+    "http_referer",
+    "app_categories",
+    "tags",
+    "created_at",
+)
+SYNTHETIC_COLUMNS = (
+    "id",
+    "probe_type",
+    "target",
+    "target_url",
+    "monitor_region",
+    "status",
+    "target_region",
+    "latency_milliseconds",
+    "ttfb_milliseconds",
+    "dns_milliseconds",
+    "tcp_connect_milliseconds",
+    "tls_handshake_milliseconds",
+    "gateway_processing_milliseconds",
+    "connection_reused",
+    "protocol",
+    "http_status",
+    "error_type",
+    "provider",
+    "model",
+    "selected_provider",
+    "selected_model",
+    "generation_id",
+    "attestation_digest",
+    "source_commit",
+    "cost_microdollars",
+    "output_match",
+    "created_at",
+)
+
+EVENT_TABLES = {
+    "activity": "activity_generations",
+    "synthetic": "synthetic_probe_samples",
+}
+
+log = logging.getLogger("trusted_router.operational_analytics_ingest")
+
+
+@dataclass(frozen=True)
+class OperationalOutboxRow:
+    shard: int
+    commit_ts: dt.datetime
+    event_kind: str
+    event_id: str
+    payload: str
+
+    @property
+    def key(self) -> tuple[int, dt.datetime, str, str]:
+        return (self.shard, self.commit_ts, self.event_kind, self.event_id)
+
+
+@dataclass(frozen=True)
+class CanonicalOperationalEvent:
+    event_kind: str
+    row: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    fetched: int
+    inserted: int
+    rows_per_second: float
+
+
+class OutboxSource(Protocol):
+    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]: ...
+
+    def delete(self, rows: list[OperationalOutboxRow]) -> None: ...
+
+    def oldest_commit_ts(self) -> dt.datetime | None: ...
+
+
+class BatchWriter(Protocol):
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None: ...
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+class SpannerOperationalOutboxSource:
+    def __init__(
+        self,
+        *,
+        project: str,
+        instance: str,
+        database: str,
+        shard_count: int = OUTBOX_SHARDS,
+    ) -> None:
+        from google.cloud import spanner
+        from google.cloud.spanner_v1 import param_types
+
+        self._database = (
+            spanner.Client(project=project, disable_builtin_metrics=True)
+            .instance(instance)
+            .database(database)
+        )
+        self._pt = param_types
+        self._shard_count = shard_count
+
+    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
+        if limit < 1:
+            return []
+        per_shard = max(1, math.ceil(limit / self._shard_count) * 2)
+        rows: list[OperationalOutboxRow] = []
+        with self._database.snapshot(multi_use=True) as snapshot:
+            for shard in range(self._shard_count):
+                values = snapshot.execute_sql(
+                    "SELECT shard, commit_ts, event_kind, event_id, payload "
+                    "FROM tr_operational_analytics_outbox "
+                    "WHERE shard=@shard ORDER BY commit_ts, event_kind, event_id "
+                    "LIMIT @limit",
+                    params={"shard": shard, "limit": per_shard},
+                    param_types={"shard": self._pt.INT64, "limit": self._pt.INT64},
+                )
+                rows.extend(
+                    OperationalOutboxRow(
+                        shard=int(row[0]),
+                        commit_ts=_utc(row[1]),
+                        event_kind=str(row[2]),
+                        event_id=str(row[3]),
+                        payload=str(row[4]),
+                    )
+                    for row in values
+                )
+        rows.sort(
+            key=lambda row: (
+                row.commit_ts,
+                row.shard,
+                row.event_kind,
+                row.event_id,
+            )
+        )
+        return rows[:limit]
+
+    def delete(self, rows: list[OperationalOutboxRow]) -> None:
+        if not rows:
+            return
+        from google.cloud.spanner_v1 import KeySet
+
+        with self._database.batch() as batch:
+            batch.delete(OUTBOX_TABLE, KeySet(keys=[list(row.key) for row in rows]))
+
+    def oldest_commit_ts(self) -> dt.datetime | None:
+        oldest: dt.datetime | None = None
+        with self._database.snapshot(multi_use=True) as snapshot:
+            for shard in range(self._shard_count):
+                values = list(
+                    snapshot.execute_sql(
+                        "SELECT commit_ts FROM tr_operational_analytics_outbox "
+                        "WHERE shard=@shard ORDER BY commit_ts LIMIT 1",
+                        params={"shard": shard},
+                        param_types={"shard": self._pt.INT64},
+                    )
+                )
+                if values:
+                    candidate = _utc(values[0][0])
+                    oldest = candidate if oldest is None else min(oldest, candidate)
+        return oldest
+
+
+class ClickHouseOperationalWriter:
+    def __init__(self, *, password: str, database: str = "tr") -> None:
+        self._password = password
+        self._database = database
+
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None:
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for event in events:
+            grouped[event.event_kind].append(event.row)
+        for event_kind, rows in grouped.items():
+            table = EVENT_TABLES.get(event_kind)
+            if table is None:
+                raise ValueError(f"unsupported operational event kind: {event_kind}")
+            payload = "\n".join(
+                json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows
+            ).encode("utf-8")
+            command = [
+                "/usr/bin/clickhouse-client",
+                "--user",
+                "tr",
+                "--database",
+                self._database,
+                "--query",
+                f"INSERT INTO {table} FORMAT JSONEachRow",
+            ]
+            env = os.environ.copy()
+            env["CLICKHOUSE_PASSWORD"] = self._password
+            result = subprocess.run(  # noqa: S603 - fixed executable and table allowlist.
+                command,
+                input=payload,
+                env=env,
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = result.stderr.decode("utf-8", errors="replace")[:1000]
+                raise RuntimeError(f"ClickHouse {event_kind} insert failed: {detail}")
+
+
+def normalise_operational_event(row: OperationalOutboxRow) -> CanonicalOperationalEvent:
+    raw = json.loads(row.payload)
+    if not isinstance(raw, dict):
+        raise ValueError("operational outbox payload is not a JSON object")
+    allowed: tuple[str, ...]
+    if row.event_kind == "activity":
+        allowed = ACTIVITY_COLUMNS
+    elif row.event_kind == "synthetic":
+        allowed = SYNTHETIC_COLUMNS
+    else:
+        raise ValueError(f"unsupported operational event kind: {row.event_kind}")
+    missing = [column for column in allowed if column not in raw]
+    if missing:
+        raise ValueError(
+            f"{row.event_kind} payload missing required fields: {', '.join(missing)}"
+        )
+    canonical = {column: raw[column] for column in allowed}
+    canonical["ingest_version"] = _utc(row.commit_ts).isoformat()
+    return CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)
+
+
+def drain_once(
+    source: OutboxSource,
+    writer: BatchWriter,
+    *,
+    batch_size: int,
+) -> DrainResult:
+    rows = source.fetch(limit=batch_size)
+    if not rows:
+        return DrainResult(fetched=0, inserted=0, rows_per_second=0.0)
+    events = [normalise_operational_event(row) for row in rows]
+    started = time.monotonic()
+    writer.insert(events)
+    source.delete(rows)
+    elapsed = max(time.monotonic() - started, 0.000_001)
+    return DrainResult(
+        fetched=len(rows),
+        inserted=len(events),
+        rows_per_second=len(events) / elapsed,
+    )
+
+
+def _lag_seconds(oldest: dt.datetime | None) -> float:
+    if oldest is None:
+        return 0.0
+    return max(0.0, (dt.datetime.now(dt.UTC) - _utc(oldest)).total_seconds())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
+    )
+    parser.add_argument("--shards", type=int, default=OUTBOX_SHARDS)
+    parser.add_argument("--batch-size", type=int, default=5000)
+    parser.add_argument("--poll-seconds", type=float, default=2.0)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    source = SpannerOperationalOutboxSource(
+        project=args.project,
+        instance=args.spanner_instance,
+        database=args.spanner_database,
+        shard_count=args.shards,
+    )
+    writer = ClickHouseOperationalWriter(password=password)
+    while True:
+        result = drain_once(source, writer, batch_size=max(1, args.batch_size))
+        log.info(
+            "operational_analytics_outbox.metrics rows=%d rows_per_second=%.3f "
+            "drain_lag_seconds=%.3f",
+            result.inserted,
+            result.rows_per_second,
+            _lag_seconds(source.oldest_commit_ts()),
+        )
+        if args.once:
+            return 0
+        if result.fetched == 0:
+            time.sleep(max(0.1, args.poll_seconds))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -1,0 +1,331 @@
+"""Recompute synthetic hour/day/month rollups from replicated raw rows."""
+
+# ruff: noqa: S608
+# Every SQL timestamp is rendered from a typed datetime and table names are
+# module constants, so no request-controlled fragment reaches these queries.
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import subprocess
+from typing import Any
+
+from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
+from trusted_router.synthetic.rollups import (
+    apply_sample_to_rollup,
+    new_rollup_for_sample,
+    rollup_id,
+    sample_rollup_ids,
+)
+
+RAW_TABLE = "synthetic_probe_samples"
+ROLLUP_TABLE = "synthetic_status_rollups"
+
+
+class ClickHouseExecutor:
+    def __init__(self, *, password: str, database: str = "tr") -> None:
+        self._password = password
+        self._database = database
+
+    def query(self, sql: str, *, input_bytes: bytes | None = None) -> bytes:
+        result = subprocess.run(  # noqa: S603 - fixed executable and argv.
+            [
+                "/usr/bin/clickhouse-client",
+                "--user",
+                "tr",
+                "--password",
+                self._password,
+                "--database",
+                self._database,
+                "--query",
+                sql,
+            ],
+            input=input_bytes,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.decode(errors="replace")[:1000])
+        return result.stdout
+
+
+def fetch_samples(
+    executor: ClickHouseExecutor,
+    *,
+    start: dt.datetime,
+    end: dt.datetime,
+) -> list[SyntheticProbeSample]:
+    rows = executor.query(
+        "SELECT * EXCEPT ingest_version FROM synthetic_probe_samples FINAL "
+        f"WHERE created_at >= toDateTime64('{_ch_time(start)}', 3, 'UTC') "
+        f"AND created_at < toDateTime64('{_ch_time(end)}', 3, 'UTC') "
+        "ORDER BY created_at FORMAT JSONEachRow"
+    )
+    return [
+        _sample_from_dict(json.loads(line))
+        for line in rows.decode().splitlines()
+        if line.strip()
+    ]
+
+
+def build_raw_rollups(
+    samples: list[SyntheticProbeSample],
+    *,
+    periods: set[str],
+) -> list[SyntheticRollup]:
+    rollups: dict[str, SyntheticRollup] = {}
+    for sample in samples:
+        for period, component in sample_rollup_ids(sample):
+            if period not in periods:
+                continue
+            update = new_rollup_for_sample(
+                sample,
+                period=period,
+                component=component,
+            )
+            existing = rollups.get(update.id)
+            if existing is None:
+                rollups[update.id] = update
+            else:
+                apply_sample_to_rollup(existing, sample)
+    return list(rollups.values())
+
+
+def complete_window_rollups(
+    rollups: list[SyntheticRollup],
+    *,
+    raw_start: dt.datetime,
+) -> list[SyntheticRollup]:
+    """Exclude the oldest partial period after raw TTL has started expiring."""
+    safe_starts = {
+        "hour": _ceil_period(raw_start, "hour"),
+        "day": _ceil_period(raw_start, "day"),
+    }
+    result: list[SyntheticRollup] = []
+    for rollup in rollups:
+        safe_start = safe_starts.get(rollup.period)
+        if safe_start is None:
+            continue
+        period_start = dt.datetime.fromisoformat(
+            rollup.period_start.replace("Z", "+00:00")
+        )
+        if _utc(period_start) >= safe_start:
+            result.append(rollup)
+    return result
+
+
+def fetch_daily_rollups(
+    executor: ClickHouseExecutor,
+    *,
+    start: dt.datetime,
+    end: dt.datetime,
+) -> list[SyntheticRollup]:
+    rows = executor.query(
+        "SELECT * EXCEPT ingest_version FROM synthetic_status_rollups FINAL "
+        "WHERE period = 'day' "
+        f"AND period_start >= toDateTime('{_ch_time(start)}', 'UTC') "
+        f"AND period_start < toDateTime('{_ch_time(end)}', 'UTC') "
+        "FORMAT JSONEachRow"
+    )
+    return [
+        _rollup_from_dict(json.loads(line))
+        for line in rows.decode().splitlines()
+        if line.strip()
+    ]
+
+
+def monthly_from_daily(daily: list[SyntheticRollup]) -> list[SyntheticRollup]:
+    grouped: dict[tuple[str, ...], SyntheticRollup] = {}
+    for source in daily:
+        month_start = source.period_start[:7] + "-01T00:00:00Z"
+        key = (
+            month_start,
+            source.component,
+            source.target,
+            source.probe_type,
+            source.monitor_region,
+            source.target_region or "",
+        )
+        target = grouped.get(key)
+        if target is None:
+            target = SyntheticRollup(
+                id=rollup_id(
+                    period="month",
+                    period_start=month_start,
+                    component=source.component,
+                    target=source.target,
+                    probe_type=source.probe_type,
+                    monitor_region=source.monitor_region,
+                    target_region=source.target_region,
+                ),
+                period="month",
+                period_start=month_start,
+                component=source.component,
+                target=source.target,
+                probe_type=source.probe_type,
+                monitor_region=source.monitor_region,
+                target_region=source.target_region,
+            )
+            grouped[key] = target
+        _merge_rollup(target, source)
+    return list(grouped.values())
+
+
+def insert_rollups(
+    executor: ClickHouseExecutor,
+    rollups: list[SyntheticRollup],
+    *,
+    ingest_version: dt.datetime,
+) -> None:
+    if not rollups:
+        return
+    payload = b"\n".join(
+        json.dumps(
+            {
+                **dataclasses.asdict(rollup),
+                "target_region": rollup.target_region or "",
+                "ingest_version": ingest_version.isoformat(),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        for rollup in rollups
+    )
+    executor.query(
+        f"INSERT INTO {ROLLUP_TABLE} FORMAT JSONEachRow",
+        input_bytes=payload,
+    )
+
+
+def recompute(executor: ClickHouseExecutor, *, now: dt.datetime) -> dict[str, int]:
+    now = _utc(now)
+    raw_start = now - dt.timedelta(days=14)
+    samples = fetch_samples(executor, start=raw_start, end=now)
+    raw_rollups = complete_window_rollups(
+        build_raw_rollups(samples, periods={"hour", "day"}),
+        raw_start=raw_start,
+    )
+    version = dt.datetime.now(dt.UTC)
+    insert_rollups(executor, raw_rollups, ingest_version=version)
+
+    previous_month = _month_start(_month_start(now) - dt.timedelta(days=1))
+    next_month = _next_month(_month_start(now))
+    daily = fetch_daily_rollups(executor, start=previous_month, end=next_month)
+    monthly = monthly_from_daily(daily)
+    insert_rollups(executor, monthly, ingest_version=version)
+    return {
+        "samples": len(samples),
+        "hourly_daily_rollups": len(raw_rollups),
+        "monthly_rollups": len(monthly),
+    }
+
+
+def _merge_rollup(target: SyntheticRollup, source: SyntheticRollup) -> None:
+    for field in (
+        "sample_count",
+        "up_count",
+        "down_count",
+        "degraded_count",
+        "routing_degraded_count",
+        "trust_degraded_count",
+        "unknown_count",
+        "cost_microdollars",
+    ):
+        setattr(target, field, getattr(target, field) + getattr(source, field))
+    for field in (
+        "latency_histogram",
+        "ttfb_histogram",
+        "dns_histogram",
+        "tcp_connect_histogram",
+        "tls_handshake_histogram",
+        "gateway_processing_histogram",
+        "error_counts",
+    ):
+        destination = getattr(target, field)
+        for key, count in getattr(source, field).items():
+            destination[key] = destination.get(key, 0) + count
+    if source.last_checked_at and (
+        target.last_checked_at is None
+        or source.last_checked_at > target.last_checked_at
+    ):
+        target.last_checked_at = source.last_checked_at
+    target.updated_at = iso_now()
+
+
+def _sample_from_dict(payload: dict[str, Any]) -> SyntheticProbeSample:
+    payload = dict(payload)
+    payload["created_at"] = _iso(payload["created_at"])
+    for key in ("connection_reused", "output_match"):
+        if payload.get(key) is not None:
+            payload[key] = bool(payload[key])
+    return SyntheticProbeSample(**payload)
+
+
+def _rollup_from_dict(payload: dict[str, Any]) -> SyntheticRollup:
+    payload = dict(payload)
+    for key in ("period_start", "updated_at", "last_checked_at"):
+        if payload.get(key) is not None:
+            payload[key] = _iso(payload[key])
+    if payload.get("target_region") == "":
+        payload["target_region"] = None
+    return SyntheticRollup(**payload)
+
+
+def _iso(value: Any) -> str:
+    text = str(value).replace(" ", "T")
+    return text if text.endswith("Z") else text + "Z"
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _month_start(value: dt.datetime) -> dt.datetime:
+    return _utc(value).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _next_month(value: dt.datetime) -> dt.datetime:
+    value = _month_start(value)
+    return (value.replace(day=28) + dt.timedelta(days=4)).replace(day=1)
+
+
+def _ceil_period(value: dt.datetime, period: str) -> dt.datetime:
+    value = _utc(value)
+    if period == "hour":
+        floor = value.replace(minute=0, second=0, microsecond=0)
+        return floor if value == floor else floor + dt.timedelta(hours=1)
+    if period == "day":
+        floor = value.replace(hour=0, minute=0, second=0, microsecond=0)
+        return floor if value == floor else floor + dt.timedelta(days=1)
+    raise ValueError(f"unsupported period: {period}")
+
+
+def _ch_time(value: dt.datetime) -> str:
+    return _utc(value).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--at", help="UTC ISO timestamp; defaults to now")
+    args = parser.parse_args()
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    now = (
+        dt.datetime.fromisoformat(args.at.replace("Z", "+00:00"))
+        if args.at
+        else dt.datetime.now(dt.UTC)
+    )
+    result = recompute(ClickHouseExecutor(password=password), now=now)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/tr-clickhouse-operational-ingest.service
+++ b/clickhouse/tr-clickhouse-operational-ingest.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=TrustedRouter operational analytics ClickHouse ingester
+After=network-online.target clickhouse-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.ingest_operational_outbox
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-operational-parity.service
+++ b/clickhouse/tr-clickhouse-operational-parity.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TrustedRouter Bigtable and ClickHouse operational parity check
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_operational_parity
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest

--- a/clickhouse/tr-clickhouse-operational-parity.timer
+++ b/clickhouse/tr-clickhouse-operational-parity.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sample Bigtable and ClickHouse parity every 30 minutes
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=30m
+RandomizedDelaySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/tr-clickhouse-synthetic-rollup.service
+++ b/clickhouse/tr-clickhouse-synthetic-rollup.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TrustedRouter synthetic ClickHouse rollup rebuild
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+

--- a/clickhouse/tr-clickhouse-synthetic-rollup.timer
+++ b/clickhouse/tr-clickhouse-synthetic-rollup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Rebuild TrustedRouter synthetic ClickHouse rollups
+
+[Timer]
+OnBootSec=3m
+OnUnitActiveSec=5m
+RandomizedDelaySec=20s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -1,0 +1,277 @@
+"""Compare bounded Bigtable samples with their ClickHouse replicas."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, TypeVar
+
+from google.cloud import bigtable
+from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
+
+from clickhouse.backfill_benchmark_samples import normalise as normalise_benchmark
+from clickhouse.backfill_operational_analytics import ClickHouse
+from clickhouse.ingest_operational_outbox import (
+    OperationalOutboxRow,
+    normalise_operational_event,
+)
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    activity_payload,
+    synthetic_payload,
+)
+from trusted_router.storage_models import (
+    Generation,
+    ProviderBenchmarkSample,
+    SyntheticProbeSample,
+    SyntheticRollup,
+)
+
+PROJECT = "quill-cloud-proxy"
+INSTANCE = "trusted-router-logs"
+TABLE = "trustedrouter-generations"
+SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+T = TypeVar("T")
+
+
+def _body(row: Any, families: tuple[str, ...]) -> dict[str, Any] | None:
+    for family in families:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if not cells:
+            continue
+        try:
+            payload = json.loads(cells[0].value.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            return None
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _parse(cls: type[T], payload: dict[str, Any] | None) -> T | None:
+    if payload is None:
+        return None
+    try:
+        return cls(**payload)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iso(value: Any) -> str:
+    text = str(value).replace(" ", "T")
+    return text if text.endswith("Z") else text + "Z"
+
+
+def _canonical(payload: dict[str, Any], *, surface: str) -> str:
+    payload = dict(payload)
+    payload.pop("ingest_version", None)
+    payload.pop("updated_at", None)
+    for field in ("created_at", "period_start", "last_checked_at"):
+        if payload.get(field) is not None:
+            payload[field] = _iso(payload[field])
+    if surface == "synthetic":
+        for field in ("connection_reused", "output_match"):
+            if payload.get(field) is not None:
+                payload[field] = bool(payload[field])
+    if surface == "activity":
+        for field in ("streamed", "usage_estimated"):
+            if payload.get(field) is not None:
+                payload[field] = bool(payload[field])
+    if surface == "rollup" and payload.get("target_region") is None:
+        payload["target_region"] = ""
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    ).hexdigest()
+
+
+def _clickhouse_rows(
+    clickhouse: ClickHouse,
+    *,
+    table: str,
+    id_column: str,
+    ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    allowed = {
+        ("provider_benchmark_samples", "id"),
+        ("activity_generations", "generation_id"),
+        ("synthetic_probe_samples", "id"),
+        ("synthetic_status_rollups", "id"),
+    }
+    if (table, id_column) not in allowed:
+        raise ValueError("unsupported parity table")
+    if not ids:
+        return {}
+    if any(SAFE_ID.fullmatch(item) is None for item in ids):
+        raise ValueError("source contains an invalid record ID")
+    payload = ("\n".join(ids) + "\n").encode()
+    result = clickhouse.query(
+        f"SELECT * EXCEPT ingest_version FROM {table} FINAL "  # noqa: S608
+        f"WHERE {id_column} IN (SELECT id FROM wanted) "
+        "FORMAT JSONEachRow",
+        input_bytes=payload,
+        external_ids=True,
+    )
+    rows: dict[str, dict[str, Any]] = {}
+    for line in result.splitlines():
+        row = json.loads(line)
+        if isinstance(row, dict):
+            rows[str(row[id_column])] = row
+    return rows
+
+
+def _source_rows(table: Any, *, surface: str, limit: int) -> dict[str, dict[str, Any]]:
+    config = {
+        "benchmark": (b"benchmark_recent#", ("benchmark", "m")),
+        "activity": (b"ws_recent#", ("activity", "m")),
+        "synthetic": (b"synthetic_recent#", ("synthetic", "m")),
+        "rollup": (b"synthetic_rollup#", ("rollup", "m")),
+    }
+    prefix, families = config[surface]
+    rows = table.read_rows(
+        start_key=prefix,
+        end_key=prefix + b"~",
+        limit=limit,
+        filter_=CellsColumnLimitFilter(1),
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        raw = _body(row, families)
+        if surface == "benchmark":
+            benchmark_sample = _parse(ProviderBenchmarkSample, raw)
+            if benchmark_sample is None:
+                continue
+            normalized = normalise_benchmark(dataclasses.asdict(benchmark_sample))
+            if normalized is not None:
+                result[benchmark_sample.id] = normalized
+        elif surface == "activity":
+            generation = _parse(Generation, raw)
+            if generation is None:
+                continue
+            event = normalise_operational_event(
+                OperationalOutboxRow(
+                    shard=0,
+                    commit_ts=dt.datetime.now(dt.UTC),
+                    event_kind="activity",
+                    event_id=generation.id,
+                    payload=json.dumps(activity_payload(generation)),
+                )
+            )
+            event.row.pop("ingest_version", None)
+            result[generation.id] = event.row
+        elif surface == "synthetic":
+            synthetic_sample = _parse(SyntheticProbeSample, raw)
+            if synthetic_sample is not None:
+                result[synthetic_sample.id] = synthetic_payload(synthetic_sample)
+        else:
+            rollup = _parse(SyntheticRollup, raw)
+            if rollup is not None:
+                result[rollup.id] = dataclasses.asdict(rollup)
+    return result
+
+
+def compare_surface(
+    clickhouse: ClickHouse,
+    table: Any,
+    *,
+    surface: str,
+    limit: int,
+) -> dict[str, Any]:
+    destinations = {
+        "benchmark": ("provider_benchmark_samples", "id"),
+        "activity": ("activity_generations", "generation_id"),
+        "synthetic": ("synthetic_probe_samples", "id"),
+        "rollup": ("synthetic_status_rollups", "id"),
+    }
+    source = _source_rows(table, surface=surface, limit=limit)
+    ch_table, id_column = destinations[surface]
+    destination = _clickhouse_rows(
+        clickhouse,
+        table=ch_table,
+        id_column=id_column,
+        ids=list(source),
+    )
+    missing = 0
+    mismatched = 0
+    for record_id, source_row in source.items():
+        destination_row = destination.get(record_id)
+        if destination_row is None:
+            missing += 1
+        elif _canonical(source_row, surface=surface) != _canonical(
+            destination_row,
+            surface=surface,
+        ):
+            mismatched += 1
+    return {
+        "sampled": len(source),
+        "found": len(destination),
+        "missing": missing,
+        "mismatched": mismatched,
+        "ok": missing == 0 and mismatched == 0,
+    }
+
+
+def _write_history(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=16)
+    history: list[dict[str, Any]] = []
+    if path.exists():
+        for line in path.read_text().splitlines():
+            try:
+                row = json.loads(line)
+                created = dt.datetime.fromisoformat(
+                    str(row["checked_at"]).replace("Z", "+00:00")
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+            if created >= cutoff:
+                history.append(row)
+    history.append(result)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in history))
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=5000)
+    parser.add_argument(
+        "--history-file",
+        default="/var/lib/tr-clickhouse-ingest/operational-parity.jsonl",
+    )
+    args = parser.parse_args()
+    if args.limit < 1:
+        raise SystemExit("--limit must be positive")
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    table = (
+        bigtable.Client(project=PROJECT, admin=False)
+        .instance(INSTANCE)
+        .table(TABLE)
+    )
+    clickhouse = ClickHouse(password=password)
+    surfaces = {
+        surface: compare_surface(
+            clickhouse,
+            table,
+            surface=surface,
+            limit=args.limit,
+        )
+        for surface in ("benchmark", "activity", "synthetic", "rollup")
+    }
+    result = {
+        "checked_at": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),
+        "ok": all(item["ok"] for item in surfaces.values()),
+        "surfaces": surfaces,
+    }
+    _write_history(Path(args.history_file), result)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import re
+import struct
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -63,7 +64,17 @@ def _parse(cls: type[T], payload: dict[str, Any] | None) -> T | None:
 
 def _iso(value: Any) -> str:
     text = str(value).replace(" ", "T")
-    return text if text.endswith("Z") else text + "Z"
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text if text.endswith("Z") else text + "Z"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return (
+        parsed.astimezone(dt.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
 
 
 def _canonical(payload: dict[str, Any], *, surface: str) -> str:
@@ -83,6 +94,11 @@ def _canonical(payload: dict[str, Any], *, surface: str) -> str:
                 payload[field] = bool(payload[field])
     if surface == "rollup" and payload.get("target_region") is None:
         payload["target_region"] = ""
+    if surface == "benchmark" and payload.get("speed_tokens_per_second") is not None:
+        payload["speed_tokens_per_second"] = struct.unpack(
+            "!f",
+            struct.pack("!f", float(payload["speed_tokens_per_second"])),
+        )[0]
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
     ).hexdigest()
@@ -123,7 +139,44 @@ def _clickhouse_rows(
     return rows
 
 
-def _source_rows(table: Any, *, surface: str, limit: int) -> dict[str, dict[str, Any]]:
+def _stable_source_row(
+    payload: dict[str, Any],
+    *,
+    surface: str,
+    cutoff: dt.datetime,
+) -> bool:
+    field = "period_start" if surface == "rollup" else "created_at"
+    value = payload.get(field)
+    if not value:
+        return False
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    parsed = parsed.astimezone(dt.UTC)
+    if surface != "rollup":
+        return parsed <= cutoff
+    period = str(payload.get("period") or "")
+    if period == "hour":
+        period_end = parsed + dt.timedelta(hours=1)
+    elif period == "day":
+        period_end = parsed + dt.timedelta(days=1)
+    elif period == "month":
+        period_end = (parsed.replace(day=28) + dt.timedelta(days=4)).replace(day=1)
+    else:
+        return False
+    return period_end <= cutoff
+
+
+def _source_rows(
+    table: Any,
+    *,
+    surface: str,
+    limit: int,
+    grace_seconds: int = 0,
+) -> dict[str, dict[str, Any]]:
     config = {
         "benchmark": (b"benchmark_recent#", ("benchmark", "m")),
         "activity": (b"ws_recent#", ("activity", "m")),
@@ -134,10 +187,11 @@ def _source_rows(table: Any, *, surface: str, limit: int) -> dict[str, dict[str,
     rows = table.read_rows(
         start_key=prefix,
         end_key=prefix + b"~",
-        limit=limit,
+        limit=max(limit * 2, limit + 1000),
         filter_=CellsColumnLimitFilter(1),
     )
     result: dict[str, dict[str, Any]] = {}
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     for row in rows:
         raw = _body(row, families)
         if surface == "benchmark":
@@ -145,7 +199,11 @@ def _source_rows(table: Any, *, surface: str, limit: int) -> dict[str, dict[str,
             if benchmark_sample is None:
                 continue
             normalized = normalise_benchmark(dataclasses.asdict(benchmark_sample))
-            if normalized is not None:
+            if normalized is not None and _stable_source_row(
+                normalized,
+                surface=surface,
+                cutoff=cutoff,
+            ):
                 result[benchmark_sample.id] = normalized
         elif surface == "activity":
             generation = _parse(Generation, raw)
@@ -161,15 +219,22 @@ def _source_rows(table: Any, *, surface: str, limit: int) -> dict[str, dict[str,
                 )
             )
             event.row.pop("ingest_version", None)
-            result[generation.id] = event.row
+            if _stable_source_row(event.row, surface=surface, cutoff=cutoff):
+                result[generation.id] = event.row
         elif surface == "synthetic":
             synthetic_sample = _parse(SyntheticProbeSample, raw)
             if synthetic_sample is not None:
-                result[synthetic_sample.id] = synthetic_payload(synthetic_sample)
+                payload = synthetic_payload(synthetic_sample)
+                if _stable_source_row(payload, surface=surface, cutoff=cutoff):
+                    result[synthetic_sample.id] = payload
         else:
             rollup = _parse(SyntheticRollup, raw)
             if rollup is not None:
-                result[rollup.id] = dataclasses.asdict(rollup)
+                payload = dataclasses.asdict(rollup)
+                if _stable_source_row(payload, surface=surface, cutoff=cutoff):
+                    result[rollup.id] = payload
+        if len(result) >= limit:
+            break
     return result
 
 
@@ -179,6 +244,7 @@ def compare_surface(
     *,
     surface: str,
     limit: int,
+    grace_seconds: int = 0,
 ) -> dict[str, Any]:
     destinations = {
         "benchmark": ("provider_benchmark_samples", "id"),
@@ -186,7 +252,12 @@ def compare_surface(
         "synthetic": ("synthetic_probe_samples", "id"),
         "rollup": ("synthetic_status_rollups", "id"),
     }
-    source = _source_rows(table, surface=surface, limit=limit)
+    source = _source_rows(
+        table,
+        surface=surface,
+        limit=limit,
+        grace_seconds=grace_seconds,
+    )
     ch_table, id_column = destinations[surface]
     destination = _clickhouse_rows(
         clickhouse,
@@ -238,6 +309,7 @@ def _write_history(path: Path, result: dict[str, Any]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--limit", type=int, default=5000)
+    parser.add_argument("--grace-seconds", type=int, default=120)
     parser.add_argument(
         "--history-file",
         default="/var/lib/tr-clickhouse-ingest/operational-parity.jsonl",
@@ -245,6 +317,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.limit < 1:
         raise SystemExit("--limit must be positive")
+    if args.grace_seconds < 0:
+        raise SystemExit("--grace-seconds cannot be negative")
     password = os.environ.get("CH_PASSWORD", "")
     if not password:
         raise SystemExit("CH_PASSWORD is required")
@@ -260,6 +334,7 @@ def main() -> int:
             table,
             surface=surface,
             limit=args.limit,
+            grace_seconds=args.grace_seconds,
         )
         for surface in ("benchmark", "activity", "synthetic", "rollup")
     }

--- a/docs/clickhouse-sharding.md
+++ b/docs/clickhouse-sharding.md
@@ -1,0 +1,25 @@
+# ClickHouse Sharding Gate
+
+TrustedRouter currently uses one logical ClickHouse shard with three replicas.
+The replicas provide read availability and durable copies. They do not multiply
+write throughput because one copy of each metadata row belongs to the shard.
+
+Run the bounded capacity probe before a major traffic increase:
+
+```bash
+TR_CLICKHOUSE_CAPACITY_ROWS=5000000 \
+  scripts/deploy/clickhouse_capacity_smoke.sh --apply
+```
+
+The probe touches only a temporary table and removes it on success or failure.
+Add another shard when either condition holds:
+
+1. Projected peak metadata rows per second exceed 25 percent of measured
+   replicated ingest throughput.
+2. Production p95 query latency exceeds 250 ms or replication lag exceeds 30
+   seconds under sustained load.
+
+New shards should use three replicas each. Distribute tenant activity by the
+opaque tenant hash and provider or synthetic data by stable event ID. Keep a
+Distributed table for cross-shard analytics. Never shard on a raw workspace ID,
+API key, prompt, or output.

--- a/scripts/deploy/clickhouse_analytics_cutover.sh
+++ b/scripts/deploy/clickhouse_analytics_cutover.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Promote operational analytics from Bigtable-primary dual reads to
+# ClickHouse-primary only after seven clean days.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+MIN_SOAK_SECONDS="${TR_ANALYTICS_MIN_SOAK_SECONDS:-604800}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+read_env() {
+  local region="$1"
+  local name="$2"
+  gc run services describe "$SERVICE" --region="$region" --format=json \
+    | jq -r --arg name "$name" '
+        [.spec.template.spec.containers[0].env[]?
+         | select(.name == $name) | .value][0] // empty
+      '
+}
+
+IFS=',' read -r -a regions <<<"$TR_CONTROL_PLANE_REGIONS"
+for region in "${regions[@]}"; do
+  mode="$(read_env "$region" TR_ANALYTICS_READ_MODE)"
+  if [ "$mode" != "dual" ]; then
+    echo "${region} is not in dual mode: ${mode:-unset}" >&2
+    exit 1
+  fi
+done
+
+started_at="$(read_env "$TR_PRIMARY_REGION" TR_ANALYTICS_DUAL_READ_STARTED_AT)"
+if [ -z "$started_at" ]; then
+  echo "dual-read start timestamp is missing" >&2
+  exit 1
+fi
+soak_seconds="$(python3 - "$started_at" <<'PY'
+import datetime as dt
+import sys
+start = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+print(int((dt.datetime.now(dt.UTC) - start).total_seconds()))
+PY
+)"
+if [ "$soak_seconds" -lt "$MIN_SOAK_SECONDS" ]; then
+  echo "dual-read soak is only ${soak_seconds}s; require ${MIN_SOAK_SECONDS}s" >&2
+  exit 1
+fi
+
+log_filter="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE}\" AND timestamp>=\"${started_at}\" AND (textPayload:\"analytics_dual_read_mismatch\" OR textPayload:\"analytics_read_error\" OR jsonPayload.message:\"analytics_dual_read_mismatch\" OR jsonPayload.message:\"analytics_read_error\")"
+error_count="$(gc logging read "$log_filter" --limit=1 --format='value(timestamp)' | wc -l | tr -d ' ')"
+if [ "$error_count" != "0" ]; then
+  echo "analytics parity or backend errors occurred during the soak" >&2
+  exit 1
+fi
+
+parity_history="$(gc compute ssh tr-clickhouse-1 \
+  --zone=us-central1-a \
+  --tunnel-through-iap \
+  --quiet \
+  --command='sudo cat /var/lib/tr-clickhouse-ingest/operational-parity.jsonl')"
+parity_file="$(mktemp "${TMPDIR:-/tmp}/tr-operational-parity.XXXXXX.jsonl")"
+trap 'rm -f "$parity_file"' EXIT
+printf '%s\n' "$parity_history" >"$parity_file"
+python3 - "$started_at" "$MIN_SOAK_SECONDS" "$parity_file" <<'PY'
+import datetime as dt
+import json
+import math
+from pathlib import Path
+import sys
+
+started = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+minimum = int(sys.argv[2])
+now = dt.datetime.now(dt.UTC)
+rows = []
+for line in Path(sys.argv[3]).read_text().splitlines():
+    try:
+        row = json.loads(line)
+        checked = dt.datetime.fromisoformat(row["checked_at"].replace("Z", "+00:00"))
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        continue
+    if checked >= started:
+        rows.append((checked, row))
+required = max(1, math.floor(minimum / 3600))
+if len(rows) < required:
+    raise SystemExit(f"only {len(rows)} parity samples; require at least {required}")
+if now - max(checked for checked, _ in rows) > dt.timedelta(hours=1):
+    raise SystemExit("latest operational parity sample is stale")
+for _, row in rows:
+    if not row.get("ok"):
+        raise SystemExit("operational parity history contains a failed check")
+for surface in ("benchmark", "activity", "synthetic", "rollup"):
+    if not any(row.get("surfaces", {}).get(surface, {}).get("sampled", 0) > 0 for _, row in rows):
+        raise SystemExit(f"no positive parity evidence for {surface}")
+PY
+unset parity_history
+rm -f "$parity_file"
+trap - EXIT
+
+outbox_count="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" \
+  --sql='SELECT COUNT(*) FROM tr_operational_analytics_outbox' \
+  --format='value(rows[0])')"
+if [ "${outbox_count:-0}" != "0" ]; then
+  echo "operational analytics outbox is not drained: ${outbox_count} rows" >&2
+  exit 1
+fi
+
+for index in 0 1 2; do
+  health="$(gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    --command="sudo sh -c 'set -a; . /etc/tr-clickhouse-ingest.env; set +a; /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr --query \"SELECT sum(queue_size), sum(absolute_delay), countIf(is_readonly) FROM system.replicas FORMAT TSVRaw\"'" \
+    | tail -1 | tr -d '\r')"
+  if [ "$health" != $'0\t0\t0' ]; then
+    echo "ClickHouse replica health gate failed on ${NAMES[$index]}: ${health}" >&2
+    exit 1
+  fi
+done
+
+if [ "$APPLY" -eq 0 ]; then
+  log "gate passed: would deploy ClickHouse-primary reads to every region"
+  exit 0
+fi
+
+TR_ANALYTICS_READ_MODE=clickhouse \
+TR_ANALYTICS_DUAL_READ_STARTED_AT="$started_at" \
+  "${SCRIPT_DIR}/rollout.sh"
+log "ClickHouse is primary; Bigtable remains a shadow and fallback for seven more days"

--- a/scripts/deploy/clickhouse_capacity_smoke.sh
+++ b/scripts/deploy/clickhouse_capacity_smoke.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Measure one-shard ClickHouse capacity using a disposable replicated table.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+ROWS="${TR_CLICKHOUSE_CAPACITY_ROWS:-5000000}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+if ! [[ "$ROWS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "TR_CLICKHOUSE_CAPACITY_ROWS must be a positive integer" >&2
+  exit 2
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would insert ${ROWS} generated metadata rows into a disposable replicated table"
+  log "dry-run: would measure replication parity, ingest throughput, query latency, and bytes per row"
+  exit 0
+fi
+
+run_id="$(date -u +%Y%m%d%H%M%S)"
+table="capacity_probe_${run_id}"
+keeper_path="/trustedrouter/capacity/${run_id}"
+
+node_ssh() {
+  local index="$1"
+  shift
+  gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+node_query() {
+  local index="$1"
+  local query="$2"
+  printf '%s\n' "$query" | node_ssh "$index" --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" \
+      --database tr --multiquery
+  '"
+}
+
+node_scalar() {
+  node_query "$1" "$2" | tail -1 | tr -d '\r'
+}
+
+cleanup() {
+  local index
+  for index in 0 1 2; do
+    node_query "$index" "DROP TABLE IF EXISTS ${table} SYNC" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+schema="CREATE TABLE IF NOT EXISTS ${table} (
+  generation_id String,
+  tenant_id FixedString(64),
+  model LowCardinality(String),
+  provider LowCardinality(String),
+  status LowCardinality(String),
+  tokens_prompt UInt64,
+  tokens_completion UInt64,
+  cost_microdollars Int64,
+  elapsed_milliseconds UInt64,
+  created_at DateTime64(3, 'UTC')
+) ENGINE = ReplicatedMergeTree('${keeper_path}', '{replica}')
+PARTITION BY toYYYYMMDD(created_at)
+ORDER BY (tenant_id, created_at, generation_id)"
+for index in 0 1 2; do
+  node_query "$index" "$schema"
+done
+
+started="$(python3 -c 'import time; print(time.time())')"
+node_query 0 "INSERT INTO ${table}
+SELECT
+  concat('gen-', toString(number)),
+  concat(hex(MD5(toString(number % 100000))), hex(MD5(toString(number % 100000)))),
+  concat('provider/model-', toString(number % 300)),
+  concat('provider-', toString(number % 60)),
+  if(number % 100 = 0, 'error', 'success'),
+  100 + number % 1000,
+  20 + number % 200,
+  1 + number % 1000,
+  20 + number % 20000,
+  now64(3) - toIntervalSecond(number % 86400)
+FROM numbers(${ROWS})"
+for index in 0 1 2; do
+  node_query "$index" "SYSTEM SYNC REPLICA ${table}"
+done
+finished="$(python3 -c 'import time; print(time.time())')"
+
+expected=""
+for index in 0 1 2; do
+  actual="$(node_scalar "$index" "SELECT count(), sum(cityHash64(generation_id)), groupBitXor(cityHash64(generation_id)) FROM ${table} FORMAT TSVRaw")"
+  if [ -z "$expected" ]; then
+    expected="$actual"
+  elif [ "$actual" != "$expected" ]; then
+    echo "capacity probe replica mismatch on ${NAMES[$index]}" >&2
+    exit 1
+  fi
+done
+
+ingest_seconds="$(python3 - "$started" "$finished" <<'PY'
+import sys
+print(max(float(sys.argv[2]) - float(sys.argv[1]), 0.001))
+PY
+)"
+rows_per_second="$(python3 - "$ROWS" "$ingest_seconds" <<'PY'
+import sys
+print(round(int(sys.argv[1]) / float(sys.argv[2]), 2))
+PY
+)"
+
+query_ms() {
+  local sql="$1"
+  local before after
+  before="$(python3 -c 'import time; print(time.perf_counter())')"
+  node_query 0 "$sql" >/dev/null
+  after="$(python3 -c 'import time; print(time.perf_counter())')"
+  python3 - "$before" "$after" <<'PY'
+import sys
+print(round((float(sys.argv[2]) - float(sys.argv[1])) * 1000, 2))
+PY
+}
+
+tenant_query_ms="$(query_ms "SELECT generation_id FROM ${table} WHERE tenant_id = concat(hex(MD5('42')), hex(MD5('42'))) ORDER BY created_at DESC LIMIT 100")"
+aggregate_query_ms="$(query_ms "SELECT provider, model, count(), quantileTDigest(0.95)(elapsed_milliseconds) FROM ${table} GROUP BY provider, model FORMAT Null")"
+bytes_on_disk="$(node_scalar 0 "SELECT sum(bytes_on_disk) FROM system.parts WHERE database='tr' AND table='${table}' AND active")"
+queue_size="$(node_scalar 0 "SELECT ifNull(max(queue_size), 0) FROM system.replicas WHERE database='tr' AND table='${table}'")"
+current_rows_day="$(node_scalar 0 "SELECT count() FROM activity_generations FINAL WHERE created_at >= now() - INTERVAL 1 DAY")"
+
+python3 - "$ROWS" "$ingest_seconds" "$rows_per_second" "$tenant_query_ms" "$aggregate_query_ms" "$bytes_on_disk" "$queue_size" "$current_rows_day" <<'PY'
+import json
+import sys
+
+rows = int(sys.argv[1])
+seconds = float(sys.argv[2])
+throughput = float(sys.argv[3])
+current_day = int(sys.argv[8])
+current_rps = current_day / 86400
+projected_rps = current_rps * 1000
+headroom_gate = throughput * 0.25
+print(json.dumps({
+    "rows": rows,
+    "replicated_ingest_seconds": round(seconds, 3),
+    "replicated_rows_per_second": throughput,
+    "tenant_recent_query_milliseconds": float(sys.argv[4]),
+    "provider_model_aggregate_milliseconds": float(sys.argv[5]),
+    "bytes_on_disk": int(sys.argv[6] or 0),
+    "bytes_per_row": round(int(sys.argv[6] or 0) / max(rows, 1), 2),
+    "replication_queue_after_sync": int(sys.argv[7] or 0),
+    "current_activity_rows_24h": current_day,
+    "projected_1000x_rows_per_second": round(projected_rps, 3),
+    "capacity_25_percent_rows_per_second": round(headroom_gate, 3),
+    "add_shard_now": projected_rps > headroom_gate,
+}, sort_keys=True))
+PY

--- a/scripts/deploy/clickhouse_control_reader.sh
+++ b/scripts/deploy/clickhouse_control_reader.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Install the control plane's least-privilege operational analytics reader.
+set -euo pipefail
+
+PROJECT="${PROJECT:-quill-cloud-proxy}"
+ZONE="${ZONE:-us-central1-a}"
+NAME="${NAME:-tr-clickhouse-1}"
+READER_SECRET="${READER_SECRET:-trustedrouter-clickhouse-control-read-password}"
+
+external_ip="$(gcloud compute instances describe "$NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --format='value(networkInterfaces[0].accessConfigs[0].natIP)')"
+if [ -n "$external_ip" ]; then
+  echo "refusing configuration: $NAME has external IP $external_ip" >&2
+  exit 1
+fi
+
+reader_password="$(gcloud secrets versions access latest \
+  --secret="$READER_SECRET" \
+  --project="$PROJECT")"
+reader_hash="$(printf '%s' "$reader_password" | shasum -a 256 | awk '{print $1}')"
+unset reader_password
+
+config="$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-control-reader.XXXXXX.xml")"
+trap 'rm -f "$config"' EXIT
+sed "s/__PASSWORD_SHA256__/${reader_hash}/g" >"$config" <<'XML'
+<clickhouse>
+  <profiles>
+    <tr_control_readonly>
+      <readonly>1</readonly>
+      <max_execution_time>30</max_execution_time>
+      <max_memory_usage>1073741824</max_memory_usage>
+      <max_result_bytes>1073741824</max_result_bytes>
+    </tr_control_readonly>
+  </profiles>
+  <users>
+    <tr_control_read>
+      <password_sha256_hex>__PASSWORD_SHA256__</password_sha256_hex>
+      <networks>
+        <ip>10.0.0.0/8</ip>
+        <ip>127.0.0.1</ip>
+        <ip>::1</ip>
+      </networks>
+      <profile>tr_control_readonly</profile>
+      <quota>default</quota>
+      <grants>
+        <query>GRANT SELECT ON tr.provider_benchmark_samples</query>
+        <query>GRANT SELECT ON tr.provider_analytics_hourly</query>
+        <query>GRANT SELECT ON tr.provider_analytics_daily</query>
+        <query>GRANT SELECT ON tr.provider_analytics_monthly</query>
+        <query>GRANT SELECT ON tr.activity_generations</query>
+        <query>GRANT SELECT ON tr.synthetic_probe_samples</query>
+        <query>GRANT SELECT ON tr.synthetic_status_rollups</query>
+      </grants>
+    </tr_control_read>
+  </users>
+</clickhouse>
+XML
+unset reader_hash
+
+gcloud compute ssh "$NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --tunnel-through-iap \
+  --quiet \
+  --command="sudo sh -c 'set -eu; umask 077; temporary=\$(mktemp); cat > \"\$temporary\"; if ! cmp -s \"\$temporary\" /etc/clickhouse-server/users.d/tr-control-reader.xml; then install -o clickhouse -g clickhouse -m 0640 \"\$temporary\" /etc/clickhouse-server/users.d/tr-control-reader.xml; systemctl restart clickhouse-server; fi; rm -f \"\$temporary\"'" \
+  <"$config"
+
+reader_password="$(gcloud secrets versions access latest \
+  --secret="$READER_SECRET" \
+  --project="$PROJECT")"
+printf 'CH_CONTROL_READ_PASSWORD=%s\n' "$reader_password" |
+  gcloud compute ssh "$NAME" \
+    --project="$PROJECT" \
+    --zone="$ZONE" \
+    --tunnel-through-iap \
+    --quiet \
+    --command="sudo sh -c 'umask 077; cat > /tmp/tr-control-reader.env; set -a; . /tmp/tr-control-reader.env; set +a; /usr/bin/clickhouse-client --user tr_control_read --password \"\$CH_CONTROL_READ_PASSWORD\" --query \"SELECT count() FROM tr.activity_generations FINAL LIMIT 1\" >/dev/null; rm -f /tmp/tr-control-reader.env'"
+unset reader_password
+
+echo "configured private read-only ClickHouse control-plane account"

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -173,7 +173,7 @@ for index in 0 1 2; do
     "${SCRIPT_DIR}/clickhouse_control_reader.sh"
 done
 
-node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer"
-node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-parity.service"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
 
-log "operational analytics expand phase is healthy; Bigtable is still authoritative"
+log "operational analytics infrastructure is ready; Bigtable is still authoritative"
+log "deploy the operational outbox producer, then run clickhouse_operational_analytics_finalize.sh --apply"

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Expand ClickHouse to tenant activity and synthetic status metadata.
+# Bigtable remains authoritative until a separate dual-read soak passes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+SCHEMA="${ROOT}/clickhouse/004_operational_analytics_replicated.sql"
+CONTROL_SECRET="trustedrouter-clickhouse-control-read-password"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would create the bounded Spanner operational analytics queue"
+  log "dry-run: would create three-replica activity and synthetic tables"
+  log "dry-run: would backfill bounded Bigtable history and verify replica parity"
+  log "dry-run: would install the ingester, rollup worker, and private reader"
+  exit 0
+fi
+
+node_ssh() {
+  local index="$1"
+  shift
+  gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+node_query() {
+  local index="$1"
+  local query="$2"
+  printf '%s\n' "$query" | node_ssh "$index" --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" \
+      --database tr --multiquery
+  '"
+}
+
+node_scalar() {
+  node_query "$1" "$2" | tail -1 | tr -d '\r'
+}
+
+for index in 0 1 2; do
+  external_ip="$(gc compute instances describe "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --format='value(networkInterfaces[0].accessConfigs[0].natIP)')"
+  if [ -n "$external_ip" ]; then
+    echo "refusing deployment: ${NAMES[$index]} has external IP ${external_ip}" >&2
+    exit 1
+  fi
+done
+
+log "creating the bounded Spanner outbox if needed"
+GCP_PROJECT_ID="$PROJECT_ID" \
+SPANNER_INSTANCE_ID="$SPANNER_INSTANCE_ID" \
+SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \
+  "${SCRIPT_DIR}/migrate_operational_analytics_outbox.sh"
+
+log "creating replicated operational tables"
+schema="$(cat "$SCHEMA")"
+for index in 0 1 2; do
+  node_query "$index" "CREATE DATABASE IF NOT EXISTS tr; ${schema}"
+done
+
+archive="$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-operational.XXXXXX.tar.gz")"
+trap 'rm -f "$archive"' EXIT
+tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router
+node_ssh 0 --command="sudo mkdir -p /opt/tr-clickhouse"
+node_ssh 0 --command="sudo tar -xzf - -C /opt/tr-clickhouse" <"$archive"
+
+log "installing operational analytics workers on node 1"
+node_ssh 0 --command="sudo sh -c '
+  set -eu
+  if ! id tr-clickhouse-ingest >/dev/null 2>&1; then
+    useradd --system --home /var/lib/tr-clickhouse-ingest --create-home \
+      --shell /usr/sbin/nologin tr-clickhouse-ingest
+  fi
+  if [ ! -x /opt/tr-clickhouse/venv/bin/python ]; then
+    apt-get update -y
+    apt-get install -y python3-venv
+    python3 -m venv /opt/tr-clickhouse/venv
+  fi
+  /opt/tr-clickhouse/venv/bin/pip install --disable-pip-version-check \
+    -r /opt/tr-clickhouse/clickhouse/requirements-live.txt
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-ingest.service \
+    /etc/systemd/system/tr-clickhouse-operational-ingest.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-rollup.service \
+    /etc/systemd/system/tr-clickhouse-synthetic-rollup.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-rollup.timer \
+    /etc/systemd/system/tr-clickhouse-synthetic-rollup.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-parity.service \
+    /etc/systemd/system/tr-clickhouse-operational-parity.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-parity.timer \
+    /etc/systemd/system/tr-clickhouse-operational-parity.timer
+  systemctl daemon-reload
+  systemctl stop tr-clickhouse-operational-ingest.service 2>/dev/null || true
+'"
+
+log "backfilling bounded Bigtable history"
+node_ssh 0 --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_operational_analytics --apply
+'"
+
+log "building initial synthetic status rollups"
+node_ssh 0 --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
+'"
+
+node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer"
+
+log "verifying exact replica identity after synchronization"
+for table in activity_generations synthetic_probe_samples synthetic_status_rollups; do
+  expected=""
+  id_column="id"
+  if [ "$table" = "activity_generations" ]; then
+    id_column="generation_id"
+  fi
+  for index in 0 1 2; do
+    node_query "$index" "SYSTEM SYNC REPLICA ${table}"
+    actual="$(node_scalar "$index" "SELECT count(), groupBitXor(cityHash64(${id_column})) FROM ${table} FINAL FORMAT TSVRaw")"
+    if [ -z "$expected" ]; then
+      expected="$actual"
+    elif [ "$actual" != "$expected" ]; then
+      echo "replica mismatch for ${table} on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+done
+
+log "replicating published provider rollups"
+"${SCRIPT_DIR}/clickhouse_replicate_rollups.sh" --apply
+
+if ! gc secrets describe "$CONTROL_SECRET" >/dev/null 2>&1; then
+  ensure_secret_value "$CONTROL_SECRET" "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+fi
+for index in 0 1 2; do
+  PROJECT="$PROJECT_ID" \
+  ZONE="${ZONES[$index]}" \
+  NAME="${NAMES[$index]}" \
+  READER_SECRET="$CONTROL_SECRET" \
+    "${SCRIPT_DIR}/clickhouse_control_reader.sh"
+done
+
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-parity.service"
+
+log "operational analytics expand phase is healthy; Bigtable is still authoritative"

--- a/scripts/deploy/clickhouse_operational_analytics_finalize.sh
+++ b/scripts/deploy/clickhouse_operational_analytics_finalize.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Close the Bigtable-to-ClickHouse snapshot gap after every control-plane
+# region is producing the durable operational analytics outbox.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAME="tr-clickhouse-1"
+ZONE="us-central1-a"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+node_ssh() {
+  gc compute ssh "$NAME" \
+    --zone="$ZONE" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+read_env() {
+  local region="$1"
+  local name="$2"
+  gc run services describe "$SERVICE" --region="$region" --format=json \
+    | jq -r --arg name "$name" '
+        [.spec.template.spec.containers[0].env[]?
+         | select(.name == $name) | .value][0] // empty
+      '
+}
+
+IFS=',' read -r -a regions <<<"$TR_CONTROL_PLANE_REGIONS"
+for region in "${regions[@]}"; do
+  if [ "$(read_env "$region" TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED)" != "true" ]; then
+    echo "${region} is not producing the operational analytics outbox" >&2
+    exit 1
+  fi
+done
+
+if [ "$APPLY" -eq 0 ]; then
+  log "gate passed: would replay activity, catch up synthetic rows, rebuild rollups, and start parity"
+  exit 0
+fi
+
+log "replaying activity after the outbox producer is live"
+node_ssh --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_operational_analytics \
+      --apply --skip-synthetic --skip-rollups
+'"
+
+log "catching up the globally ordered synthetic stream"
+node_ssh --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_operational_analytics \
+      --apply --recent-limit 20000 --skip-activity --skip-rollups
+'"
+
+log "waiting for the outbox to drain"
+outbox_count=""
+for _ in $(seq 1 60); do
+  outbox_count="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --sql='SELECT COUNT(*) FROM tr_operational_analytics_outbox' \
+    --format='value(rows[0])')"
+  if [ "${outbox_count:-0}" = "0" ]; then
+    break
+  fi
+  sleep 5
+done
+if [ "${outbox_count:-0}" != "0" ]; then
+  echo "operational analytics outbox did not drain: ${outbox_count} rows" >&2
+  exit 1
+fi
+
+log "rebuilding bounded synthetic rollups"
+node_ssh --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
+'"
+
+node_ssh --command="sudo systemctl start tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer"
+node_ssh --command="sudo systemctl start tr-clickhouse-operational-parity.service"
+log "operational parity is healthy; begin the seven-day dual-read soak"

--- a/scripts/deploy/clickhouse_replicate_rollups.sh
+++ b/scripts/deploy/clickhouse_replicate_rollups.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Migrate published provider rollups from node-local MergeTree tables to one
+# ClickHouse shard with three replicas. Source tables are retained as backups.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+TABLES=(
+  provider_analytics_hourly
+  provider_analytics_daily
+  provider_analytics_monthly
+)
+SCHEMA="${SCRIPT_DIR}/../../clickhouse/005_provider_rollups_replicated.sql"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would stop provider rollup timers on node 1"
+  log "dry-run: would backfill and fingerprint three replicated aggregate tables"
+  log "dry-run: would rename replicas 2/3 before node 1 and retain local backups"
+  exit 0
+fi
+
+node_ssh() {
+  local index="$1"
+  shift
+  gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    "$@"
+}
+
+node_query() {
+  local index="$1"
+  local query="$2"
+  printf '%s\n' "$query" | node_ssh "$index" --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" \
+      --database tr --multiquery
+  '"
+}
+
+node_scalar() {
+  node_query "$1" "$2" | tail -1 | tr -d '\r'
+}
+
+columns="period_start,provider,model,source,region,usage_type,status,error_type,error_status,streamed,attempts,completed,failed,input_tokens,output_tokens,total_cost_microdollars,p50_elapsed_milliseconds,p95_elapsed_milliseconds,p50_first_token_milliseconds,p95_first_token_milliseconds,p50_ttfb_milliseconds,p95_ttfb_milliseconds,p50_tokens_per_second,p95_tokens_per_second"
+
+fingerprint() {
+  local index="$1"
+  local table="$2"
+  node_scalar "$index" "SELECT count(), sum(cityHash64(toJSONString(tuple(${columns})))), groupBitXor(cityHash64(toJSONString(tuple(${columns})))) FROM ${table} FORMAT TSVRaw"
+}
+
+all_replicated=1
+for index in 0 1 2; do
+  for table in "${TABLES[@]}"; do
+    if [ "$(node_scalar "$index" "SELECT engine FROM system.tables WHERE database='tr' AND name='${table}'")" != "ReplicatedMergeTree" ]; then
+      all_replicated=0
+    fi
+  done
+done
+if [ "$all_replicated" -eq 1 ]; then
+  for table in "${TABLES[@]}"; do
+    expected=""
+    for index in 0 1 2; do
+      node_query "$index" "SYSTEM SYNC REPLICA ${table}"
+      actual="$(fingerprint "$index" "$table")"
+      if [ -z "$expected" ]; then
+        expected="$actual"
+      elif [ "$actual" != "$expected" ]; then
+        echo "canonical ${table} differs on ${NAMES[$index]}" >&2
+        exit 1
+      fi
+    done
+  done
+  log "provider rollups were already replicated and have full parity"
+  exit 0
+fi
+
+timers_stopped=0
+restart_timers() {
+  if [ "$timers_stopped" -eq 1 ]; then
+    node_ssh 0 --command="sudo systemctl start tr-clickhouse-rollup-hourly.timer tr-clickhouse-rollup-daily.timer" \
+      >/dev/null 2>&1 || true
+  fi
+}
+trap restart_timers EXIT
+
+log "stopping rollup writers during the migration"
+node_ssh 0 --command="sudo systemctl stop tr-clickhouse-rollup-hourly.timer tr-clickhouse-rollup-daily.timer"
+timers_stopped=1
+
+schema="$(cat "$SCHEMA")"
+for index in 0 1 2; do
+  node_query "$index" "$schema"
+done
+
+for table in "${TABLES[@]}"; do
+  engine="$(node_scalar 0 "SELECT engine FROM system.tables WHERE database='tr' AND name='${table}'")"
+  if [ "$engine" = "ReplicatedMergeTree" ]; then
+    log "${table} is already replicated"
+    continue
+  fi
+  if [ "$engine" != "MergeTree" ]; then
+    echo "refusing ${table} migration: unexpected engine ${engine}" >&2
+    exit 1
+  fi
+  replicated="${table}_replicated"
+  log "backfilling ${table}"
+  node_query 0 "INSERT INTO ${replicated} SELECT * FROM ${table}"
+  for index in 0 1 2; do
+    node_query "$index" "SYSTEM SYNC REPLICA ${replicated}"
+  done
+  expected="$(fingerprint 0 "$table")"
+  for index in 0 1 2; do
+    actual="$(fingerprint "$index" "$replicated")"
+    if [ "$actual" != "$expected" ]; then
+      echo "${table} fingerprint mismatch on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+done
+
+for index in 1 2; do
+  for table in "${TABLES[@]}"; do
+    engine="$(node_scalar "$index" "SELECT engine FROM system.tables WHERE database='tr' AND name='${table}'")"
+    replicated="${table}_replicated"
+    if [ "$engine" = "ReplicatedMergeTree" ]; then
+      continue
+    fi
+    if [ -n "$engine" ]; then
+      if [ "$(node_scalar "$index" "SELECT count() FROM system.tables WHERE database='tr' AND name='${table}_local_backup'")" != "0" ]; then
+        echo "backup already exists for ${table} on ${NAMES[$index]}" >&2
+        exit 1
+      fi
+      node_query "$index" "RENAME TABLE ${table} TO ${table}_local_backup, ${replicated} TO ${table}"
+    else
+      node_query "$index" "RENAME TABLE ${replicated} TO ${table}"
+    fi
+  done
+done
+
+rename_query=""
+for table in "${TABLES[@]}"; do
+  engine="$(node_scalar 0 "SELECT engine FROM system.tables WHERE database='tr' AND name='${table}'")"
+  if [ "$engine" = "ReplicatedMergeTree" ]; then
+    continue
+  fi
+  if [ "$(node_scalar 0 "SELECT count() FROM system.tables WHERE database='tr' AND name='${table}_local_backup'")" != "0" ]; then
+    echo "backup already exists for ${table} on node 1" >&2
+    exit 1
+  fi
+  if [ -n "$rename_query" ]; then
+    rename_query="${rename_query}, "
+  fi
+  rename_query="${rename_query}${table} TO ${table}_local_backup, ${table}_replicated TO ${table}"
+done
+if [ -n "$rename_query" ]; then
+  node_query 0 "RENAME TABLE ${rename_query}"
+fi
+
+for table in "${TABLES[@]}"; do
+  expected=""
+  for index in 0 1 2; do
+    engine="$(node_scalar "$index" "SELECT engine FROM system.tables WHERE database='tr' AND name='${table}'")"
+    if [ "$engine" != "ReplicatedMergeTree" ]; then
+      echo "${table} is not replicated on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+    actual="$(fingerprint "$index" "$table")"
+    if [ -z "$expected" ]; then
+      expected="$actual"
+    elif [ "$actual" != "$expected" ]; then
+      echo "canonical ${table} differs on ${NAMES[$index]}" >&2
+      exit 1
+    fi
+  done
+done
+
+restart_timers
+timers_stopped=0
+trap - EXIT
+log "provider rollups are replicated on all three ClickHouse nodes"

--- a/scripts/deploy/migrate_operational_analytics_outbox.sh
+++ b/scripts/deploy/migrate_operational_analytics_outbox.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Add the bounded durable queue for ClickHouse activity and status metadata.
+set -euo pipefail
+
+PROJECT="${GCP_PROJECT_ID:-quill-cloud-proxy}"
+INSTANCE="${SPANNER_INSTANCE_ID:-trusted-router-nam6}"
+DATABASE="${SPANNER_DATABASE_ID:-trusted-router}"
+
+count=$(gcloud spanner databases execute-sql "$DATABASE" \
+  --project="$PROJECT" \
+  --instance="$INSTANCE" \
+  --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+         WHERE table_name='tr_operational_analytics_outbox'" \
+  --format='value(rows[0])' 2>/dev/null || echo 0)
+
+if [ "${count:-0}" != "0" ]; then
+  echo "tr_operational_analytics_outbox exists"
+  exit 0
+fi
+
+gcloud spanner databases ddl update "$DATABASE" \
+  --project="$PROJECT" \
+  --instance="$INSTANCE" \
+  --ddl="CREATE TABLE tr_operational_analytics_outbox (
+    shard INT64 NOT NULL,
+    commit_ts TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    event_kind STRING(32) NOT NULL,
+    event_id STRING(128) NOT NULL,
+    payload STRING(MAX) NOT NULL,
+  ) PRIMARY KEY (shard, commit_ts, event_kind, event_id),
+    ROW DELETION POLICY (OLDER_THAN(commit_ts, INTERVAL 30 DAY))"
+
+echo "created tr_operational_analytics_outbox"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -80,6 +80,9 @@ add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-
 add_secret_env_if_exists \
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_PASSWORD" \
   "trustedrouter-clickhouse-provider-read-password"
+add_secret_env_if_exists \
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD" \
+  "trustedrouter-clickhouse-control-read-password"
 UPDATE_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
 
 REQUEST_RECORD_WRITE_MODE="${TR_REQUEST_RECORD_WRITE_MODE:-}"
@@ -104,6 +107,49 @@ case "$REQUEST_RECORD_WRITE_MODE" in
     exit 1
     ;;
 esac
+
+LIVE_ANALYTICS_READ_MODE="$(
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format=json 2>/dev/null \
+    | jq -r '
+        [
+          .spec.template.spec.containers[0].env[]?
+          | select(.name == "TR_ANALYTICS_READ_MODE")
+          | .value
+        ][0] // "bigtable"
+      ' || true
+)"
+ANALYTICS_READ_MODE="${TR_ANALYTICS_READ_MODE:-$LIVE_ANALYTICS_READ_MODE}"
+case "$ANALYTICS_READ_MODE" in
+  bigtable|dual|clickhouse) ;;
+  *)
+    log "refusing rollout: TR_ANALYTICS_READ_MODE must be bigtable, dual, or clickhouse"
+    exit 1
+    ;;
+esac
+
+ANALYTICS_DUAL_READ_STARTED_AT="${TR_ANALYTICS_DUAL_READ_STARTED_AT:-}"
+if [ -z "$ANALYTICS_DUAL_READ_STARTED_AT" ]; then
+  ANALYTICS_DUAL_READ_STARTED_AT="$(
+    gc run services describe "$SERVICE" \
+      --region="$TR_PRIMARY_REGION" \
+      --format=json 2>/dev/null \
+      | jq -r '
+          [
+            .spec.template.spec.containers[0].env[]?
+            | select(.name == "TR_ANALYTICS_DUAL_READ_STARTED_AT")
+            | .value
+          ][0] // empty
+        ' || true
+  )"
+fi
+if [ "$ANALYTICS_READ_MODE" = "dual" ] && {
+  [ "$LIVE_ANALYTICS_READ_MODE" != "dual" ] ||
+  [ -z "$ANALYTICS_DUAL_READ_STARTED_AT" ];
+}; then
+  ANALYTICS_DUAL_READ_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
 
 # Prefer the private three-replica ClickHouse load balancer once provisioned.
 # The direct node-1 address remains only as a migration fallback for projects
@@ -176,6 +222,7 @@ ENV_VARS=(
   # three-replica load balancer below; inference and billing never depend on
   # ClickHouse. Remove this line to stop enqueueing new analytics rows.
   "TR_ANALYTICS_OUTBOX_ENABLED=true"
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
   # Private provider operations portal. Direct VPC egress below reaches this
   # RFC1918 address; ClickHouse has no public IP and the credential is a
   # SELECT-only account scoped to the benchmark table.
@@ -183,6 +230,12 @@ ENV_VARS=(
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read"
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_DATABASE=tr"
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_TABLE=provider_benchmark_samples"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=tr_control_read"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=tr"
+  "TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}"
+  "TR_ANALYTICS_DUAL_READ_GRACE_SECONDS=30"
+  "TR_ANALYTICS_DUAL_READ_STARTED_AT=${ANALYTICS_DUAL_READ_STARTED_AT}"
   # The first expand deployment defaults to legacy. After an explicit typed
   # cutover, preserve the primary region's live mode on later deploys unless an
   # operator overrides it. This prevents routine rollouts from reopening the

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -161,6 +161,14 @@ ensure_secret_from_env_file "NEUROMETRIC_API_KEY" "trustedrouter-neurometric-api
 ensure_secret_from_env_file \
   "TR_PROVIDER_ANALYTICS_CLICKHOUSE_PASSWORD" \
   "trustedrouter-clickhouse-provider-read-password"
+if ! gc secrets describe trustedrouter-clickhouse-control-read-password >/dev/null 2>&1; then
+  ensure_secret_value trustedrouter-clickhouse-control-read-password "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+  log "generated secret trustedrouter-clickhouse-control-read-password"
+fi
 
 SYNTH_PROMPTS_FILE="${TR_SYNTH_PROMPTS_FILE:-${HOME}/.trustedrouter_synth_prompts_v1.md}"
 SYNTH_CODE_PROMPTS_FILE="${TR_SYNTH_CODE_PROMPTS_FILE:-/Users/jperla/claude/fusion-code-prompts-v1.md}"
@@ -227,6 +235,7 @@ grant_tr_deploy_secret_access "trustedrouter-morph-api-key"
 grant_tr_deploy_secret_access "trustedrouter-atlas-cloud-api-key"
 grant_tr_deploy_secret_access "trustedrouter-streamlake-api-key"
 grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"
+grant_tr_deploy_secret_access "trustedrouter-clickhouse-control-read-password"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -65,9 +65,21 @@ class Settings(BaseSettings):
     provider_analytics_clickhouse_password: str = ""
     provider_analytics_clickhouse_database: str = "tr"
     provider_analytics_clickhouse_table: str = "provider_benchmark_samples"
+    operational_analytics_clickhouse_url: str = ""
+    operational_analytics_clickhouse_user: str = "tr_control_read"
+    operational_analytics_clickhouse_password: str = ""
+    operational_analytics_clickhouse_database: str = "tr"
+    # dual returns Bigtable and compares ClickHouse; clickhouse reverses those
+    # roles for the second soak before Bigtable reads are disabled.
+    analytics_read_mode: str = "bigtable"
+    analytics_dual_read_grace_seconds: int = 30
+    analytics_dual_read_started_at: str = ""
     # Stage 1 live analytics outbox. This is intentionally off by default and
     # must remain off until the shadow ingester and reconciler are observed.
     analytics_outbox_enabled: bool = False
+    # Durable tenant-activity and synthetic-status stream. Kept independent
+    # from provider analytics so its privacy and cutover can be controlled.
+    operational_analytics_outbox_enabled: bool = False
 
     # Starter credit granted exactly once with a new email/OAuth account's
     # first workspace. Wallet-only and secondary workspaces receive no grant.
@@ -344,6 +356,12 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'"
             )
+        if self.analytics_read_mode not in {"bigtable", "dual", "clickhouse"}:
+            raise ValueError(
+                "TR_ANALYTICS_READ_MODE must be bigtable, dual, or clickhouse"
+            )
+        if self.analytics_dual_read_grace_seconds < 0:
+            raise ValueError("TR_ANALYTICS_DUAL_READ_GRACE_SECONDS cannot be negative")
         if not 5 <= self.regional_quota_lease_ttl_seconds <= 300:
             raise ValueError(
                 "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS must be between 5 and 300"
@@ -460,6 +478,11 @@ class Settings(BaseSettings):
                 missing.append("TR_SPANNER_DATABASE_ID")
             if not self.bigtable_instance_id:
                 missing.append("TR_BIGTABLE_INSTANCE_ID")
+        if self.analytics_read_mode != "bigtable":
+            if not self.operational_analytics_clickhouse_url:
+                missing.append("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL")
+            if not self.operational_analytics_clickhouse_password:
+                missing.append("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD")
         if self.request_record_write_mode == "typed" and not self.settle_outbox_enabled:
             missing.append(
                 "TR_SETTLE_OUTBOX_ENABLED=true when "

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -1,0 +1,365 @@
+"""Read-only ClickHouse adapter for operational metadata."""
+
+# ruff: noqa: S608
+# Identifiers are fixed constants and every request value is server-bound.
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import re
+import struct
+from typing import Any, TypeVar, cast
+
+import httpx
+
+from trusted_router.storage_models import (
+    Generation,
+    ProviderBenchmarkSample,
+    SyntheticProbeSample,
+    SyntheticRollup,
+)
+from trusted_router.types import UsageType
+
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+T = TypeVar("T")
+
+
+def _identifier(value: str, *, label: str) -> str:
+    if _IDENTIFIER.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a ClickHouse identifier")
+    return value
+
+
+def _iso(value: Any) -> str:
+    text = str(value)
+    if text.endswith("Z") or "+" in text[10:]:
+        return text
+    return text.replace(" ", "T") + "Z"
+
+
+class OperationalAnalyticsClient:
+    """Fixed, parameterized reads over replicated ClickHouse tables."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        user: str,
+        password: str,
+        database: str = "tr",
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("operational analytics ClickHouse URL is required")
+        self._base_url = base_url.rstrip("/")
+        self._user = user
+        self._password = password
+        self._database = _identifier(database, label="database")
+        self._transport = transport
+
+    def _query(
+        self,
+        sql: str,
+        *,
+        params: dict[str, str | int] | None = None,
+    ) -> list[dict[str, Any]]:
+        query_params: dict[str, str] = {"database": self._database}
+        for key, value in (params or {}).items():
+            query_params[f"param_{key}"] = str(value)
+        with httpx.Client(
+            auth=(self._user, self._password),
+            timeout=httpx.Timeout(20.0),
+            transport=self._transport,
+        ) as client:
+            response = client.post(
+                self._base_url,
+                params=query_params,
+                content=sql,
+                headers={"content-type": "text/plain; charset=utf-8"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            raise RuntimeError("ClickHouse response did not contain data rows")
+        return [dict(row) for row in rows if isinstance(row, dict)]
+
+    def benchmark_samples(
+        self,
+        *,
+        date: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        limit: int = 1000,
+    ) -> list[ProviderBenchmarkSample]:
+        clauses: list[str] = []
+        params: dict[str, str | int] = {"limit": max(1, limit)}
+        if date is not None:
+            clauses.append("toDate(created_at) = toDate({date:String})")
+            params["date"] = date
+        if provider is not None:
+            clauses.append("provider = {provider:String}")
+            params["provider"] = provider
+        if model is not None:
+            clauses.append("model = {model:String}")
+            params["model"] = model
+        where = " AND ".join(clauses) if clauses else "1"
+        rows = self._query(
+            """
+SELECT
+  id, model, provider, provider_name, status, usage_type, streamed,
+  input_tokens, output_tokens, total_cost_microdollars,
+  speed_tokens_per_second, elapsed_milliseconds,
+  first_token_milliseconds, ttfb_milliseconds, finish_reason,
+  error_type, error_status, error_message, region, source, app, created_at
+FROM provider_benchmark_samples FINAL
+WHERE """
+            + where
+            + """
+ORDER BY created_at DESC
+LIMIT {limit:UInt32}
+FORMAT JSON
+""",
+            params=params,
+        )
+        return [_benchmark_sample(row) for row in rows]
+
+    def activity_generations(
+        self,
+        *,
+        tenant_id: str,
+        key_id: str | None = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        date: str | None = None,
+        start_at: str | None = None,
+        end_at: str | None = None,
+        limit: int = 5001,
+    ) -> list[Generation]:
+        clauses = ["tenant_id = {tenant_id:String}"]
+        params: dict[str, str | int] = {
+            "tenant_id": tenant_id,
+            "limit": max(1, limit),
+        }
+        if date is not None:
+            clauses.append("toDate(created_at) = toDate({date:String})")
+            params["date"] = date
+        if key_id is not None:
+            clauses.append("key_id = {key_id:String}")
+            params["key_id"] = key_id
+        if tag_key is not None:
+            clauses.append("mapContains(tags, {tag_key:String})")
+            params["tag_key"] = tag_key
+            if tag_value is not None:
+                clauses.append("tags[{tag_key:String}] = {tag_value:String}")
+                params["tag_value"] = tag_value
+        if start_at is not None:
+            clauses.append("created_at >= parseDateTime64BestEffort({start_at:String}, 3)")
+            params["start_at"] = start_at
+        if end_at is not None:
+            clauses.append("created_at < parseDateTime64BestEffort({end_at:String}, 3)")
+            params["end_at"] = end_at
+        rows = self._query(
+            """
+SELECT
+  generation_id, request_id, key_id, model, provider, provider_name, app,
+  tokens_prompt, tokens_completion, cached_input_tokens, reasoning_tokens,
+  total_cost_microdollars, usage_type, speed_tokens_per_second,
+  finish_reason, status, streamed, usage_estimated, elapsed_milliseconds,
+  first_token_milliseconds, ttfb_milliseconds, region, user, session_id,
+  http_referer, app_categories, tags, created_at
+FROM activity_generations FINAL
+WHERE """
+            + " AND ".join(clauses)
+            + """
+ORDER BY created_at DESC
+LIMIT {limit:UInt32}
+FORMAT JSON
+""",
+            params=params,
+        )
+        return [_generation(row, tenant_id=tenant_id) for row in rows]
+
+    def synthetic_samples(
+        self,
+        *,
+        date: str | None = None,
+        target: str | None = None,
+        probe_type: str | None = None,
+        monitor_region: str | None = None,
+        limit: int = 1000,
+    ) -> list[SyntheticProbeSample]:
+        clauses: list[str] = []
+        params: dict[str, str | int] = {"limit": max(1, limit)}
+        for column, value in (
+            ("target", target),
+            ("probe_type", probe_type),
+            ("monitor_region", monitor_region),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = {{{column}:String}}")
+                params[column] = value
+        if date is not None:
+            clauses.append("toDate(created_at) = toDate({date:String})")
+            params["date"] = date
+        where = " AND ".join(clauses) if clauses else "1"
+        rows = self._query(
+            "SELECT * EXCEPT ingest_version FROM synthetic_probe_samples FINAL "
+            f"WHERE {where} ORDER BY created_at DESC LIMIT {{limit:UInt32}} FORMAT JSON",
+            params=params,
+        )
+        return [_dataclass_from_row(SyntheticProbeSample, row) for row in rows]
+
+    def synthetic_rollups(
+        self,
+        *,
+        period: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        include_histograms: bool = True,
+        limit: int = 1000,
+    ) -> list[SyntheticRollup]:
+        clauses: list[str] = []
+        params: dict[str, str | int] = {"limit": max(1, limit)}
+        if period is not None:
+            clauses.append("period = {period:String}")
+            params["period"] = period
+        if since is not None:
+            clauses.append("period_start >= parseDateTimeBestEffort({since:String})")
+            params["since"] = since
+        if until is not None:
+            clauses.append("period_start <= parseDateTimeBestEffort({until:String})")
+            params["until"] = until
+        where = " AND ".join(clauses) if clauses else "1"
+        rows = self._query(
+            "SELECT * EXCEPT ingest_version FROM synthetic_status_rollups FINAL "
+            f"WHERE {where} ORDER BY period_start DESC LIMIT {{limit:UInt32}} FORMAT JSON",
+            params=params,
+        )
+        rollups = [_dataclass_from_row(SyntheticRollup, row) for row in rows]
+        if not include_histograms:
+            rollups = [
+                dataclasses.replace(
+                    rollup,
+                    latency_histogram={},
+                    ttfb_histogram={},
+                    dns_histogram={},
+                    tcp_connect_histogram={},
+                    tls_handshake_histogram={},
+                    gateway_processing_histogram={},
+                )
+                for rollup in rollups
+            ]
+        return rollups
+
+
+def _dataclass_from_row(cls: type[T], row: dict[str, Any]) -> T:
+    allowed = {field.name for field in dataclasses.fields(cls)}  # type: ignore[arg-type]
+    payload = {key: value for key, value in row.items() if key in allowed}
+    if cls is SyntheticProbeSample:
+        for key in ("connection_reused", "output_match"):
+            if payload.get(key) is not None:
+                payload[key] = bool(payload[key])
+    if cls is SyntheticRollup and payload.get("target_region") == "":
+        payload["target_region"] = None
+    for key in ("created_at", "period_start", "updated_at", "last_checked_at"):
+        if payload.get(key) is not None:
+            payload[key] = _iso(payload[key])
+    return cls(**payload)
+
+
+def _benchmark_sample(row: dict[str, Any]) -> ProviderBenchmarkSample:
+    row = dict(row)
+    row["created_at"] = _iso(row["created_at"])
+    row["streamed"] = bool(row["streamed"])
+    return _dataclass_from_row(ProviderBenchmarkSample, row)
+
+
+def _generation(row: dict[str, Any], *, tenant_id: str) -> Generation:
+    return Generation(
+        id=str(row["generation_id"]),
+        request_id=str(row["request_id"]),
+        workspace_id=tenant_id,
+        key_hash=str(row["key_id"]),
+        model=str(row["model"]),
+        provider_name=str(row["provider_name"]),
+        app=str(row["app"]),
+        tokens_prompt=int(row["tokens_prompt"]),
+        tokens_completion=int(row["tokens_completion"]),
+        total_cost_microdollars=int(row["total_cost_microdollars"]),
+        usage_type=UsageType.coerce(row["usage_type"]),
+        speed_tokens_per_second=float(row["speed_tokens_per_second"]),
+        finish_reason=str(row["finish_reason"]),
+        status=str(row["status"]),
+        streamed=bool(row["streamed"]),
+        usage_estimated=bool(row["usage_estimated"]),
+        cached_input_tokens=int(row["cached_input_tokens"]),
+        reasoning_tokens=int(row["reasoning_tokens"]),
+        provider=str(row["provider"] or "") or None,
+        elapsed_milliseconds=_optional_int(row.get("elapsed_milliseconds")),
+        first_token_milliseconds=_optional_int(row.get("first_token_milliseconds")),
+        ttfb_milliseconds=_optional_int(row.get("ttfb_milliseconds")),
+        region=str(row["region"]) if row.get("region") is not None else None,
+        user=str(row["user"]) if row.get("user") is not None else None,
+        session_id=(
+            str(row["session_id"]) if row.get("session_id") is not None else None
+        ),
+        http_referer=(
+            str(row["http_referer"])
+            if row.get("http_referer") is not None
+            else None
+        ),
+        app_categories=[str(item) for item in row.get("app_categories") or []],
+        tags={str(key): str(value) for key, value in (row.get("tags") or {}).items()},
+        created_at=_iso(row["created_at"]),
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
+def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tuple[int, str]:
+    """Fingerprint only rows old enough to have drained from the outbox."""
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
+    stable: list[dict[str, Any]] = []
+    for row in rows:
+        payload = (
+            dataclasses.asdict(cast(Any, row))
+            if dataclasses.is_dataclass(row)
+            else dict(row)
+        )
+        # Rebuild timestamps are expected to differ across stores. Raw tenant
+        # and key identifiers are intentionally replaced by opaque surrogates
+        # in ClickHouse, so they are not parity fields either.
+        for volatile in ("updated_at", "workspace_id", "key_hash"):
+            payload.pop(volatile, None)
+        speed = payload.get("speed_tokens_per_second")
+        if speed is not None and "input_tokens" in payload:
+            # The long-lived provider benchmark table intentionally stores
+            # this one metric as Float32. Canonicalize the Bigtable value to
+            # the same representation before comparing the two stores.
+            payload["speed_tokens_per_second"] = struct.unpack(
+                "!f",
+                struct.pack("!f", float(speed)),
+            )[0]
+        created_at = payload.get("created_at") or payload.get("period_start")
+        if created_at:
+            try:
+                parsed = dt.datetime.fromisoformat(str(created_at).replace("Z", "+00:00"))
+            except ValueError:
+                parsed = cutoff
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.UTC)
+            if parsed > cutoff:
+                continue
+        stable.append(payload)
+    canonical_rows = sorted(
+        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
+        for row in stable
+    )
+    encoded = "\n".join(canonical_rows)
+    return len(stable), hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1465,6 +1465,29 @@ def create_store(settings: Any) -> Store:
             bigtable_app_profile_id=getattr(settings, "bigtable_app_profile_id", ""),
             request_record_write_mode=getattr(settings, "request_record_write_mode", "legacy"),
             analytics_outbox_enabled=getattr(settings, "analytics_outbox_enabled", False),
+            operational_analytics_outbox_enabled=getattr(
+                settings,
+                "operational_analytics_outbox_enabled",
+                False,
+            ),
+            operational_analytics_clickhouse_url=getattr(
+                settings, "operational_analytics_clickhouse_url", ""
+            ),
+            operational_analytics_clickhouse_user=getattr(
+                settings,
+                "operational_analytics_clickhouse_user",
+                "tr_control_read",
+            ),
+            operational_analytics_clickhouse_password=getattr(
+                settings, "operational_analytics_clickhouse_password", ""
+            ),
+            operational_analytics_clickhouse_database=getattr(
+                settings, "operational_analytics_clickhouse_database", "tr"
+            ),
+            analytics_read_mode=getattr(settings, "analytics_read_mode", "bigtable"),
+            analytics_dual_read_grace_seconds=getattr(
+                settings, "analytics_dual_read_grace_seconds", 30
+            ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -12,6 +12,10 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
+from trusted_router.operational_analytics import (
+    OperationalAnalyticsClient,
+    stable_rows_fingerprint,
+)
 from trusted_router.storage import (
     AcquisitionAttribution,
     ApiKey,
@@ -43,6 +47,14 @@ from trusted_router.storage import (
     iso_now,
     normalize_provider_access_role,
     normalize_provider_access_slug,
+)
+from trusted_router.storage_activity import (
+    ActivityResult,
+    filter_generations,
+    generation_events,
+    generation_metrics,
+    summarize_activity_result,
+    usage_bucket_key,
 )
 from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
@@ -82,6 +94,10 @@ from trusted_router.storage_gcp_generations import SpannerGenerations
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
 from trusted_router.storage_gcp_keys import SpannerApiKeys
 from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    SpannerOperationalAnalyticsOutbox,
+    analytics_surrogate,
+)
 from trusted_router.storage_gcp_rate_limits import SpannerRateLimits
 from trusted_router.storage_gcp_request_records import read_gateway_authorization
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
@@ -102,6 +118,23 @@ from trusted_router.types import UsageType
 
 T = TypeVar("T")
 log = logging.getLogger(__name__)
+
+
+def _empty_usage_bucket(bucket: str) -> dict[str, Any]:
+    return {
+        "bucket": bucket,
+        "requests": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_micro": 0,
+        "byok_micro": 0,
+    }
+
+
+def _add_usage_metrics(bucket: dict[str, Any], metrics: dict[str, int]) -> None:
+    for key, value in metrics.items():
+        bucket[key] += value
 
 
 class SpannerBigtableStore:
@@ -139,12 +172,39 @@ class SpannerBigtableStore:
         bigtable_app_profile_id: str = "",
         request_record_write_mode: str = "legacy",
         analytics_outbox_enabled: bool = False,
+        operational_analytics_outbox_enabled: bool = False,
+        operational_analytics_clickhouse_url: str = "",
+        operational_analytics_clickhouse_user: str = "tr_control_read",
+        operational_analytics_clickhouse_password: str = "",
+        operational_analytics_clickhouse_database: str = "tr",
+        analytics_read_mode: str = "bigtable",
+        analytics_dual_read_grace_seconds: int = 30,
     ) -> None:
         if not spanner_instance_id or not spanner_database_id or not bigtable_instance_id:
             raise ValueError("Spanner and Bigtable IDs are required")
         if request_record_write_mode not in {"legacy", "typed"}:
             raise ValueError("request_record_write_mode must be 'legacy' or 'typed'")
+        if analytics_read_mode not in {"bigtable", "dual", "clickhouse"}:
+            raise ValueError("analytics_read_mode must be bigtable, dual, or clickhouse")
         self.request_record_write_mode = request_record_write_mode
+        self._analytics_read_mode = analytics_read_mode
+        self._analytics_dual_read_grace_seconds = max(
+            0,
+            int(analytics_dual_read_grace_seconds),
+        )
+        self._operational_analytics = (
+            OperationalAnalyticsClient(
+                base_url=operational_analytics_clickhouse_url,
+                user=operational_analytics_clickhouse_user,
+                password=operational_analytics_clickhouse_password,
+                database=operational_analytics_clickhouse_database,
+            )
+            if operational_analytics_clickhouse_url
+            and operational_analytics_clickhouse_password
+            else None
+        )
+        self._analytics_parity_log_lock = threading.Lock()
+        self._analytics_last_parity_log: dict[str, float] = {}
         try:
             from google.cloud import bigtable, spanner
             from google.cloud.spanner_v1 import FixedSizePool, param_types
@@ -239,6 +299,11 @@ class SpannerBigtableStore:
         )
         self.api_keys = SpannerApiKeys(io)
         self.acquisition_store = SpannerAcquisitionAttribution(io)
+        self._operational_analytics_outbox = (
+            SpannerOperationalAnalyticsOutbox(self._database, self._param_types)
+            if operational_analytics_outbox_enabled
+            else None
+        )
         self.generation_store = SpannerGenerations(
             io,
             bt_table=self._bt_table,
@@ -251,6 +316,7 @@ class SpannerBigtableStore:
                 if analytics_outbox_enabled
                 else None
             ),
+            operational_analytics_outbox=self._operational_analytics_outbox,
         )
         self.byok_store = SpannerByok(io)
         self.custom_model_store = SpannerCustomModels(io)
@@ -1853,8 +1919,20 @@ class SpannerBigtableStore:
         model: str | None = None,
         limit: int = 1000,
     ) -> list[ProviderBenchmarkSample]:
-        return self.generation_store.benchmark_samples(
-            date=date, provider=provider, model=model, limit=limit
+        return self._analytics_read(
+            "provider_benchmark_samples",
+            bigtable=lambda: self.generation_store.benchmark_samples(
+                date=date,
+                provider=provider,
+                model=model,
+                limit=limit,
+            ),
+            clickhouse=lambda: self._require_operational_analytics().benchmark_samples(
+                date=date,
+                provider=provider,
+                model=model,
+                limit=limit,
+            ),
         )
 
     def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
@@ -1865,6 +1943,21 @@ class SpannerBigtableStore:
             rollup_family=self.synthetic_rollup_family,
             legacy_family=self.legacy_generation_family,
         )
+        if self._operational_analytics_outbox is not None:
+            try:
+                self._operational_analytics_outbox.enqueue_synthetic(sample)
+            except Exception as exc:
+                log.exception(
+                    "spanner.operational_analytics_synthetic_enqueue_failed",
+                    extra={
+                        "sample_id": sample.id,
+                        "probe_type": sample.probe_type,
+                        "target": sample.target,
+                        "error_class": type(exc).__name__,
+                        "error_message": str(exc)[:500],
+                        "loss_tolerated": True,
+                    },
+                )
 
     def synthetic_probe_samples(
         self,
@@ -1875,14 +1968,24 @@ class SpannerBigtableStore:
         monitor_region: str | None = None,
         limit: int = 1000,
     ) -> list[SyntheticProbeSample]:
-        return _bt_synthetic_probe_samples(
-            self._bt_table,
-            (self.synthetic_family, self.legacy_generation_family),
-            date=date,
-            target=target,
-            probe_type=probe_type,
-            monitor_region=monitor_region,
-            limit=limit,
+        return self._analytics_read(
+            "synthetic_probe_samples",
+            bigtable=lambda: _bt_synthetic_probe_samples(
+                self._bt_table,
+                (self.synthetic_family, self.legacy_generation_family),
+                date=date,
+                target=target,
+                probe_type=probe_type,
+                monitor_region=monitor_region,
+                limit=limit,
+            ),
+            clickhouse=lambda: self._require_operational_analytics().synthetic_samples(
+                date=date,
+                target=target,
+                probe_type=probe_type,
+                monitor_region=monitor_region,
+                limit=limit,
+            ),
         )
 
     def synthetic_rollups(
@@ -1894,14 +1997,24 @@ class SpannerBigtableStore:
         include_histograms: bool = True,
         limit: int = 1000,
     ) -> list[SyntheticRollup]:
-        return _bt_synthetic_rollups(
-            self._bt_table,
-            (self.synthetic_rollup_family, self.legacy_generation_family),
-            period=period,
-            since=since,
-            until=until,
-            include_histograms=include_histograms,
-            limit=limit,
+        return self._analytics_read(
+            "synthetic_rollups",
+            bigtable=lambda: _bt_synthetic_rollups(
+                self._bt_table,
+                (self.synthetic_rollup_family, self.legacy_generation_family),
+                period=period,
+                since=since,
+                until=until,
+                include_histograms=include_histograms,
+                limit=limit,
+            ),
+            clickhouse=lambda: self._require_operational_analytics().synthetic_rollups(
+                period=period,
+                since=since,
+                until=until,
+                include_histograms=include_histograms,
+                limit=limit,
+            ),
         )
 
     def activity(
@@ -1914,14 +2027,14 @@ class SpannerBigtableStore:
         tag_value: str | None = None,
         group_by_tag: str | None = None,
     ) -> list[dict[str, Any]]:
-        return self.generation_store.activity(
+        return self.activity_result(
             workspace_id,
             api_key_hash=api_key_hash,
             date=date,
             tag_key=tag_key,
             tag_value=tag_value,
             group_by_tag=group_by_tag,
-        )
+        ).data
 
     def activity_events(
         self,
@@ -1933,14 +2046,14 @@ class SpannerBigtableStore:
         tag_key: str | None = None,
         tag_value: str | None = None,
     ) -> list[dict[str, Any]]:
-        return self.generation_store.activity_events(
+        return self.activity_events_result(
             workspace_id,
             api_key_hash=api_key_hash,
             date=date,
             limit=limit,
             tag_key=tag_key,
             tag_value=tag_value,
-        )
+        ).data
 
     def activity_result(
         self,
@@ -1952,13 +2065,24 @@ class SpannerBigtableStore:
         tag_value: str | None = None,
         group_by_tag: str | None = None,
     ) -> Any:
-        return self.generation_store.activity_result(
-            workspace_id,
-            api_key_hash=api_key_hash,
-            date=date,
-            tag_key=tag_key,
-            tag_value=tag_value,
-            group_by_tag=group_by_tag,
+        return self._analytics_read(
+            "activity_result",
+            bigtable=lambda: self.generation_store.activity_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                tag_key=tag_key,
+                tag_value=tag_value,
+                group_by_tag=group_by_tag,
+            ),
+            clickhouse=lambda: self._clickhouse_activity_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                tag_key=tag_key,
+                tag_value=tag_value,
+                group_by_tag=group_by_tag,
+            ),
         )
 
     def activity_events_result(
@@ -1971,13 +2095,24 @@ class SpannerBigtableStore:
         tag_key: str | None = None,
         tag_value: str | None = None,
     ) -> Any:
-        return self.generation_store.activity_events_result(
-            workspace_id,
-            api_key_hash=api_key_hash,
-            date=date,
-            limit=limit,
-            tag_key=tag_key,
-            tag_value=tag_value,
+        return self._analytics_read(
+            "activity_events_result",
+            bigtable=lambda: self.generation_store.activity_events_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                limit=limit,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            ),
+            clickhouse=lambda: self._clickhouse_activity_events_result(
+                workspace_id,
+                api_key_hash=api_key_hash,
+                date=date,
+                limit=limit,
+                tag_key=tag_key,
+                tag_value=tag_value,
+            ),
         )
 
     def usage_series(
@@ -2001,15 +2136,269 @@ class SpannerBigtableStore:
             start_day = since.date().isoformat()
             end_day = now.date().isoformat()
             min_created_at = since.strftime("%Y-%m-%dT%H:%M:%S")
-        return self.generation_store.usage_series(
-            workspace_id,
-            start_day=start_day,
-            end_day=end_day,
-            granularity=granularity,
-            api_key_hash=api_key_hash,
-            by_model=by_model,
-            min_created_at=min_created_at,
+        return self._analytics_read(
+            "usage_series",
+            bigtable=lambda: self.generation_store.usage_series(
+                workspace_id,
+                start_day=start_day,
+                end_day=end_day,
+                granularity=granularity,
+                api_key_hash=api_key_hash,
+                by_model=by_model,
+                min_created_at=min_created_at,
+            ),
+            clickhouse=lambda: self._clickhouse_usage_series(
+                workspace_id,
+                start_day=start_day,
+                end_day=end_day,
+                granularity=granularity,
+                api_key_hash=api_key_hash,
+                by_model=by_model,
+                min_created_at=min_created_at,
+            ),
         )
+
+    def _require_operational_analytics(self) -> OperationalAnalyticsClient:
+        if self._operational_analytics is None:
+            raise RuntimeError("operational ClickHouse reader is not configured")
+        return self._operational_analytics
+
+    def _analytics_read(
+        self,
+        label: str,
+        *,
+        bigtable: Callable[[], T],
+        clickhouse: Callable[[], T],
+    ) -> T:
+        if self._analytics_read_mode == "bigtable":
+            return bigtable()
+        if self._analytics_read_mode == "dual":
+            primary = bigtable()
+            try:
+                shadow = clickhouse()
+            except Exception as exc:
+                self._log_analytics_read_error(label, "clickhouse", exc)
+                return primary
+            self._compare_analytics_reads(label, primary, shadow)
+            return primary
+        try:
+            primary = clickhouse()
+        except Exception as exc:
+            self._log_analytics_read_error(label, "clickhouse", exc)
+            return bigtable()
+        try:
+            shadow = bigtable()
+        except Exception as exc:
+            self._log_analytics_read_error(label, "bigtable", exc)
+            return primary
+        self._compare_analytics_reads(label, shadow, primary)
+        return primary
+
+    def _log_analytics_read_error(
+        self,
+        label: str,
+        backend: str,
+        exc: Exception,
+    ) -> None:
+        if not self._should_log_analytics_event(f"error:{label}:{backend}"):
+            return
+        log.error(
+            "analytics_read_error surface=%s backend=%s error_class=%s error=%s",
+            label,
+            backend,
+            type(exc).__name__,
+            str(exc)[:300],
+        )
+
+    def _compare_analytics_reads(self, label: str, expected: Any, actual: Any) -> None:
+        expected_signature = self._analytics_signature(expected)
+        actual_signature = self._analytics_signature(actual)
+        if expected_signature == actual_signature:
+            return
+        if not self._should_log_analytics_event(f"mismatch:{label}"):
+            return
+        log.warning(
+            "analytics_dual_read_mismatch surface=%s expected_count=%s "
+            "actual_count=%s expected_fingerprint=%s actual_fingerprint=%s",
+            label,
+            expected_signature[0],
+            actual_signature[0],
+            expected_signature[1],
+            actual_signature[1],
+        )
+
+    def _analytics_signature(self, value: Any) -> tuple[int, str]:
+        if isinstance(value, ActivityResult):
+            return stable_rows_fingerprint(value.data, grace_seconds=0)
+        if isinstance(value, list):
+            return stable_rows_fingerprint(
+                value,
+                grace_seconds=self._analytics_dual_read_grace_seconds,
+            )
+        if isinstance(value, dict):
+            return stable_rows_fingerprint([value], grace_seconds=0)
+        return stable_rows_fingerprint([{"value": str(value)}], grace_seconds=0)
+
+    def _should_log_analytics_event(self, key: str) -> bool:
+        now = time.monotonic()
+        with self._analytics_parity_log_lock:
+            previous = self._analytics_last_parity_log.get(key, 0.0)
+            if now - previous < 300.0:
+                return False
+            self._analytics_last_parity_log[key] = now
+        return True
+
+    def _clickhouse_activity_rows(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        limit: int,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+    ) -> list[Generation]:
+        tenant_id = analytics_surrogate("workspace", workspace_id)
+        key_id = (
+            analytics_surrogate("api-key", api_key_hash)
+            if api_key_hash is not None
+            else None
+        )
+        rows = self._require_operational_analytics().activity_generations(
+            tenant_id=tenant_id,
+            key_id=key_id,
+            tag_key=tag_key,
+            tag_value=tag_value,
+            date=date,
+            limit=limit,
+        )
+        return filter_generations(
+            rows,
+            workspace_id=tenant_id,
+            date=date,
+        )
+
+    def _clickhouse_activity_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        tag_key: str | None,
+        tag_value: str | None,
+        group_by_tag: str | None,
+    ) -> ActivityResult:
+        scan_limit = 5000
+        rows = self._clickhouse_activity_rows(
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            limit=scan_limit + 1,
+            tag_key=tag_key,
+            tag_value=tag_value,
+        )
+        truncated = len(rows) > scan_limit
+        rows = rows[:scan_limit]
+        scanned = len(rows)
+        rows = filter_generations(
+            rows,
+            workspace_id=analytics_surrogate("workspace", workspace_id),
+        )
+        result = summarize_activity_result(
+            rows,
+            group_by_tag=group_by_tag,
+            truncated=truncated,
+            scan_limit=scan_limit,
+        )
+        return dataclasses.replace(result, scanned=scanned)
+
+    def _clickhouse_activity_events_result(
+        self,
+        workspace_id: str,
+        *,
+        api_key_hash: str | None,
+        date: str | None,
+        limit: int,
+        tag_key: str | None,
+        tag_value: str | None,
+    ) -> ActivityResult:
+        normalized_limit = max(1, min(limit, 1000))
+        rows = self._clickhouse_activity_rows(
+            workspace_id,
+            api_key_hash=api_key_hash,
+            date=date,
+            limit=normalized_limit + 1,
+            tag_key=tag_key,
+            tag_value=tag_value,
+        )
+        truncated = len(rows) > normalized_limit
+        rows = rows[:normalized_limit]
+        scanned = len(rows)
+        rows = filter_generations(
+            rows,
+            workspace_id=analytics_surrogate("workspace", workspace_id),
+        )
+        return ActivityResult(
+            data=generation_events(rows, limit=normalized_limit),
+            truncated=truncated,
+            scanned=scanned,
+            scan_limit=normalized_limit,
+        )
+
+    def _clickhouse_usage_series(
+        self,
+        workspace_id: str,
+        *,
+        start_day: str,
+        end_day: str,
+        granularity: str,
+        api_key_hash: str | None,
+        by_model: bool,
+        min_created_at: str | None,
+    ) -> dict[str, Any]:
+        tenant_id = analytics_surrogate("workspace", workspace_id)
+        key_id = (
+            analytics_surrogate("api-key", api_key_hash)
+            if api_key_hash is not None
+            else None
+        )
+        end_exclusive = (
+            dt.date.fromisoformat(end_day) + dt.timedelta(days=1)
+        ).isoformat()
+        rows = self._require_operational_analytics().activity_generations(
+            tenant_id=tenant_id,
+            key_id=key_id,
+            start_at=min_created_at or start_day,
+            end_at=end_exclusive,
+            limit=200_001,
+        )
+        truncated = len(rows) > 200_000
+        rows = rows[:200_000]
+        buckets: dict[str, dict[str, Any]] = {}
+        by_model_buckets: dict[str, dict[str, dict[str, Any]]] = {}
+        for generation in rows:
+            bucket_id = usage_bucket_key(generation.created_at, granularity)
+            bucket = buckets.setdefault(bucket_id, _empty_usage_bucket(bucket_id))
+            _add_usage_metrics(bucket, generation_metrics(generation))
+            if by_model:
+                model_bucket = by_model_buckets.setdefault(
+                    generation.model,
+                    {},
+                ).setdefault(bucket_id, _empty_usage_bucket(bucket_id))
+                _add_usage_metrics(model_bucket, generation_metrics(generation))
+        result: dict[str, Any] = {
+            "granularity": granularity,
+            "start_day": start_day,
+            "end_day": end_day,
+            "truncated": truncated,
+            "buckets": [buckets[key] for key in sorted(buckets)],
+        }
+        if by_model:
+            result["by_model"] = {
+                model: [model_buckets[key] for key in sorted(model_buckets)]
+                for model, model_buckets in sorted(by_model_buckets.items())
+            }
+        return result
 
     def reconcile_generation_activity(
         self,

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -53,6 +53,9 @@ from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
 )
 from trusted_router.storage_gcp_io import SpannerIO
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    SpannerOperationalAnalyticsOutbox,
+)
 from trusted_router.storage_models import (
     Generation,
     ProviderBenchmarkSample,
@@ -81,6 +84,7 @@ class SpannerGenerations:
         legacy_family: str | None = None,
         add_usage_to_key: _AddUsageCallback,
         analytics_outbox: SpannerAnalyticsOutbox | None = None,
+        operational_analytics_outbox: SpannerOperationalAnalyticsOutbox | None = None,
     ) -> None:
         self._io = io
         self._bt_table = bt_table
@@ -101,6 +105,7 @@ class SpannerGenerations:
         )
         self._add_usage_to_key = add_usage_to_key
         self._analytics_outbox = analytics_outbox
+        self._operational_analytics_outbox = operational_analytics_outbox
 
     def add(self, generation: Generation) -> None:
         # Two separate transactions instead of one fused one. Per-key
@@ -152,9 +157,27 @@ class SpannerGenerations:
             activity_indexed = False
         else:
             activity_indexed = True
+        activity_queued = True
+        if self._operational_analytics_outbox is not None:
+            try:
+                self._operational_analytics_outbox.enqueue_activity(generation)
+            except Exception as exc:
+                log.exception(
+                    "spanner.operational_analytics_activity_enqueue_failed",
+                    extra={
+                        "request_id": generation.request_id,
+                        "generation_id": generation.id,
+                        "model": generation.model,
+                        "provider": generation.provider,
+                        "error_class": type(exc).__name__,
+                        "error_message": str(exc)[:500],
+                        "repairable_via": "settle_outbox",
+                    },
+                )
+                activity_queued = False
         if generation.app != "TrustedRouter Synthetic":
             self.record_benchmark(ProviderBenchmarkSample.from_generation(generation))
-        return activity_indexed
+        return activity_indexed and activity_queued
 
     def get(self, generation_id: str) -> Generation | None:
         generation = _bt_generation_by_id(

--- a/src/trusted_router/storage_gcp_operational_analytics_outbox.py
+++ b/src/trusted_router/storage_gcp_operational_analytics_outbox.py
@@ -1,0 +1,140 @@
+"""Durable outbox for tenant activity and synthetic status metadata.
+
+This outbox is separate from the public/provider benchmark stream because its
+tables have different privacy and retention boundaries.  Raw workspace and API
+key identifiers never leave Spanner: ClickHouse receives stable one-way
+surrogates and content-free request metadata only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_models import Generation, SyntheticProbeSample
+
+OPERATIONAL_ANALYTICS_OUTBOX_SHARDS = 32
+ACTIVITY_EVENT_KIND = "activity"
+SYNTHETIC_EVENT_KIND = "synthetic"
+
+
+def operational_analytics_shard(
+    event_id: str,
+    *,
+    shard_count: int = OPERATIONAL_ANALYTICS_OUTBOX_SHARDS,
+) -> int:
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    digest = hashlib.blake2b(event_id.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % shard_count
+
+
+def analytics_surrogate(namespace: str, value: str) -> str:
+    """Return a stable non-reversible identifier for private analytics."""
+    material = f"trustedrouter:{namespace}:{value}".encode()
+    return hashlib.sha256(material).hexdigest()
+
+
+def activity_payload(generation: Generation) -> dict[str, Any]:
+    """Project a generation onto the content-free tenant activity schema."""
+    return {
+        "generation_id": generation.id,
+        "request_id": generation.request_id,
+        "tenant_id": analytics_surrogate("workspace", generation.workspace_id),
+        "key_id": analytics_surrogate("api-key", generation.key_hash),
+        "model": generation.model,
+        "provider": generation.provider or "",
+        "provider_name": generation.provider_name,
+        "app": generation.app,
+        "tokens_prompt": generation.tokens_prompt,
+        "tokens_completion": generation.tokens_completion,
+        "cached_input_tokens": generation.cached_input_tokens,
+        "reasoning_tokens": generation.reasoning_tokens,
+        "total_cost_microdollars": generation.total_cost_microdollars,
+        "usage_type": str(generation.usage_type),
+        "speed_tokens_per_second": generation.speed_tokens_per_second,
+        "finish_reason": generation.finish_reason,
+        "status": generation.status,
+        "streamed": generation.streamed,
+        "usage_estimated": generation.usage_estimated,
+        "elapsed_milliseconds": generation.elapsed_milliseconds,
+        "first_token_milliseconds": generation.first_token_milliseconds,
+        "ttfb_milliseconds": generation.ttfb_milliseconds,
+        "region": generation.region,
+        "user": generation.user,
+        "session_id": generation.session_id,
+        "http_referer": generation.http_referer,
+        "app_categories": list(generation.app_categories),
+        "tags": dict(generation.tags),
+        "created_at": generation.created_at,
+    }
+
+
+def synthetic_payload(sample: SyntheticProbeSample) -> dict[str, Any]:
+    return sample.public_dict()
+
+
+class SpannerOperationalAnalyticsOutbox:
+    """Append immutable operational events using Spanner commit timestamps."""
+
+    def __init__(
+        self,
+        database: Any,
+        param_types: Any,
+        *,
+        shard_count: int = OPERATIONAL_ANALYTICS_OUTBOX_SHARDS,
+    ) -> None:
+        if shard_count < 1:
+            raise ValueError("shard_count must be positive")
+        self._database = database
+        self._pt = param_types
+        self._shard_count = shard_count
+
+    def enqueue_activity(self, generation: Generation) -> None:
+        self._enqueue(
+            event_kind=ACTIVITY_EVENT_KIND,
+            event_id=generation.id,
+            payload=activity_payload(generation),
+        )
+
+    def enqueue_synthetic(self, sample: SyntheticProbeSample) -> None:
+        self._enqueue(
+            event_kind=SYNTHETIC_EVENT_KIND,
+            event_id=sample.id,
+            payload=synthetic_payload(sample),
+        )
+
+    def _enqueue(
+        self,
+        *,
+        event_kind: str,
+        event_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        shard = operational_analytics_shard(
+            f"{event_kind}:{event_id}",
+            shard_count=self._shard_count,
+        )
+
+        def txn(transaction: Any) -> None:
+            transaction.execute_update(
+                "INSERT INTO tr_operational_analytics_outbox "
+                "(shard, commit_ts, event_kind, event_id, payload) "
+                "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_kind, "
+                "@event_id, @payload)",
+                params={
+                    "shard": shard,
+                    "event_kind": event_kind,
+                    "event_id": event_id,
+                    "payload": json_body(payload),
+                },
+                param_types={
+                    "shard": self._pt.INT64,
+                    "event_kind": self._pt.STRING,
+                    "event_id": self._pt.STRING,
+                    "payload": self._pt.STRING,
+                },
+            )
+
+        self._database.run_in_transaction(txn)

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -39,6 +39,20 @@ def test_operational_deploy_backfills_before_starting_live_ingest() -> None:
     assert backfill < start
     assert "SYSTEM SYNC REPLICA" in script
     assert "clickhouse_replicate_rollups.sh" in script
+    assert "clickhouse_operational_analytics_finalize.sh --apply" in script
+    assert "systemctl start tr-clickhouse-operational-parity.service" not in script
+
+
+def test_operational_finalize_requires_live_outbox_before_closing_gap() -> None:
+    script = (
+        ROOT / "scripts/deploy/clickhouse_operational_analytics_finalize.sh"
+    ).read_text()
+    assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in script
+    assert "--skip-synthetic --skip-rollups" in script
+    assert "--recent-limit 20000 --skip-activity --skip-rollups" in script
+    replay = script.index("replaying activity after the outbox producer is live")
+    parity = script.index("systemctl start tr-clickhouse-operational-parity.service")
+    assert replay < parity
 
 
 def test_control_reader_is_private_read_only_and_cannot_read_secrets() -> None:

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_operational_schema_is_replicated_bounded_and_content_free() -> None:
+    schema = (ROOT / "clickhouse/004_operational_analytics_replicated.sql").read_text()
+    assert schema.count("ENGINE = ReplicatedReplacingMergeTree") == 3
+    assert "INTERVAL 400 DAY" in schema
+    assert "INTERVAL 14 DAY" in schema
+    assert "INTERVAL 24 MONTH" in schema
+    for forbidden_column in (
+        "prompt_content",
+        "output_content",
+        "workspace_id ",
+        "key_hash ",
+        "api_key ",
+        "authorization_header",
+    ):
+        assert forbidden_column not in schema.lower()
+
+
+def test_provider_rollup_schema_replicates_all_published_granularities() -> None:
+    schema = (ROOT / "clickhouse/005_provider_rollups_replicated.sql").read_text()
+    assert schema.count("ENGINE = ReplicatedMergeTree") == 3
+    for granularity in ("hourly", "daily", "monthly"):
+        assert f"provider_analytics_{granularity}_replicated" in schema
+
+
+def test_operational_deploy_backfills_before_starting_live_ingest() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_operational_analytics.sh").read_text()
+    backfill = script.index("clickhouse.backfill_operational_analytics --apply")
+    start = script.index(
+        "systemctl start tr-clickhouse-operational-ingest.service",
+        backfill,
+    )
+    assert backfill < start
+    assert "SYSTEM SYNC REPLICA" in script
+    assert "clickhouse_replicate_rollups.sh" in script
+
+
+def test_control_reader_is_private_read_only_and_cannot_read_secrets() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_control_reader.sh").read_text()
+    assert "<readonly>1</readonly>" in script
+    assert "<ip>10.0.0.0/8</ip>" in script
+    assert "GRANT SELECT ON tr.activity_generations" in script
+    assert "GRANT SELECT ON tr.synthetic_probe_samples" in script
+    assert "GRANT SELECT ON tr.synthetic_status_rollups" in script
+    assert "GRANT SELECT ON tr.tr_entities" not in script
+    assert "GRANT ALL" not in script
+
+
+def test_rollout_preserves_dual_read_mode_and_uses_distinct_reader_secret() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
+    assert "TR_ANALYTICS_READ_MODE" in rollout
+    assert "LIVE_ANALYTICS_READ_MODE" in rollout
+    assert "TR_ANALYTICS_DUAL_READ_STARTED_AT" in rollout
+    assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true" in rollout
+    assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=tr_control_read" in rollout
+    assert "trustedrouter-clickhouse-control-read-password" in rollout
+    assert "trustedrouter-clickhouse-control-read-password" in secrets
+
+
+def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_analytics_cutover.sh").read_text()
+    assert "604800" in script
+    assert "analytics_dual_read_mismatch" in script
+    assert "tr_operational_analytics_outbox" in script
+    assert "system.replicas" in script
+    assert "operational-parity.jsonl" in script
+    assert "TR_ANALYTICS_READ_MODE=clickhouse" in script
+
+
+def test_capacity_probe_is_disposable_and_uses_a_conservative_gate() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_capacity_smoke.sh").read_text()
+    assert "trap cleanup EXIT" in script
+    assert "DROP TABLE IF EXISTS" in script
+    assert "SYSTEM SYNC REPLICA" in script
+    assert "throughput * 0.25" in script
+    assert "add_shard_now" in script

--- a/tests/test_clickhouse_operational_parity.py
+++ b/tests/test_clickhouse_operational_parity.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from clickhouse.verify_operational_parity import _canonical, _stable_source_row
+
+
+def test_activity_parity_uses_clickhouse_millisecond_precision() -> None:
+    source = {
+        "generation_id": "gen_one",
+        "created_at": "2026-07-31T17:00:00.123987Z",
+        "streamed": True,
+        "usage_estimated": False,
+    }
+    destination = {
+        "generation_id": "gen_one",
+        "created_at": "2026-07-31 17:00:00.123",
+        "streamed": 1,
+        "usage_estimated": 0,
+    }
+    assert _canonical(source, surface="activity") == _canonical(
+        destination,
+        surface="activity",
+    )
+
+
+def test_benchmark_parity_uses_clickhouse_float32_precision() -> None:
+    source = {
+        "id": "bench_one",
+        "created_at": "2026-07-31T17:00:00Z",
+        "speed_tokens_per_second": 1.234567890123,
+    }
+    destination = {
+        "id": "bench_one",
+        "created_at": "2026-07-31 17:00:00.000",
+        "speed_tokens_per_second": 1.2345678806304932,
+    }
+    assert _canonical(source, surface="benchmark") == _canonical(
+        destination,
+        surface="benchmark",
+    )
+
+
+def test_rollup_parity_ignores_rebuild_time_and_normalizes_null_region() -> None:
+    source = {
+        "id": "rollup_one",
+        "period_start": "2026-07-30T17:00:00Z",
+        "last_checked_at": "2026-07-30T17:59:59.999987Z",
+        "updated_at": "2026-07-30T18:00:01.123456Z",
+        "target_region": None,
+    }
+    destination = {
+        "id": "rollup_one",
+        "period_start": "2026-07-30 17:00:00",
+        "last_checked_at": "2026-07-30 17:59:59.999",
+        "updated_at": "2026-07-31 12:00:00.000",
+        "target_region": "",
+    }
+    assert _canonical(source, surface="rollup") == _canonical(
+        destination,
+        surface="rollup",
+    )
+
+
+def test_parity_grace_excludes_recent_raw_rows() -> None:
+    cutoff = dt.datetime(2026, 7, 31, 17, 0, tzinfo=dt.UTC)
+    assert _stable_source_row(
+        {"created_at": "2026-07-31T16:59:59Z"},
+        surface="synthetic",
+        cutoff=cutoff,
+    )
+    assert not _stable_source_row(
+        {"created_at": "2026-07-31T17:00:01Z"},
+        surface="synthetic",
+        cutoff=cutoff,
+    )
+
+
+def test_parity_excludes_incomplete_rollup_periods() -> None:
+    cutoff = dt.datetime(2026, 8, 1, 0, 2, tzinfo=dt.UTC)
+    assert _stable_source_row(
+        {"period": "hour", "period_start": "2026-07-31T23:00:00Z"},
+        surface="rollup",
+        cutoff=cutoff,
+    )
+    assert not _stable_source_row(
+        {"period": "day", "period_start": "2026-08-01T00:00:00Z"},
+        surface="rollup",
+        cutoff=cutoff,
+    )

--- a/tests/test_clickhouse_replay_functional.py
+++ b/tests/test_clickhouse_replay_functional.py
@@ -260,5 +260,224 @@ def test_replayed_batch_collapses_under_final() -> None:
                 "AND name='provider_benchmark_samples_replicated'",
             )
             assert engine.stdout.decode().strip() == "ReplicatedReplacingMergeTree"
+
+            operational_schema = (
+                Path(__file__).parents[1]
+                / "clickhouse"
+                / "004_operational_analytics_replicated.sql"
+            ).read_bytes()
+            _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--multiquery",
+                input_bytes=operational_schema,
+            )
+            activity = {
+                "generation_id": "gen-functional-replay",
+                "request_id": "req-functional-replay",
+                "tenant_id": "a" * 64,
+                "key_id": "b" * 64,
+                "model": "anthropic/claude-haiku-4.5",
+                "provider": "anthropic",
+                "provider_name": "Anthropic",
+                "app": "Functional test",
+                "tokens_prompt": 12,
+                "tokens_completion": 3,
+                "cached_input_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_cost_microdollars": 9,
+                "usage_type": "Credits",
+                "speed_tokens_per_second": 7.5,
+                "finish_reason": "stop",
+                "status": "success",
+                "streamed": 1,
+                "usage_estimated": 0,
+                "elapsed_milliseconds": 400,
+                "first_token_milliseconds": 100,
+                "ttfb_milliseconds": 20,
+                "region": "us-central1",
+                "user": None,
+                "session_id": None,
+                "http_referer": None,
+                "app_categories": [],
+                "tags": {},
+                "created_at": "2026-07-28T12:34:56.789Z",
+                "ingest_version": "2026-07-28T12:35:00.000001Z",
+            }
+            activity_payload = (json.dumps(activity) + "\n").encode()
+            for _ in range(2):
+                _docker(
+                    docker,
+                    "exec",
+                    "-i",
+                    name,
+                    "clickhouse-client",
+                    "--database",
+                    database,
+                    "--query",
+                    "INSERT INTO activity_generations FORMAT JSONEachRow",
+                    input_bytes=activity_payload,
+                )
+            activity_count = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT count() FROM activity_generations FINAL",
+            )
+            assert activity_count.stdout.decode().strip() == "1"
+            sampled_activity = _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--external",
+                "--file",
+                "-",
+                "--name",
+                "wanted",
+                "--structure",
+                "id String",
+                "--format",
+                "TabSeparated",
+                "--query",
+                "SELECT generation_id FROM activity_generations FINAL "
+                "WHERE generation_id IN (SELECT id FROM wanted) "
+                "FORMAT JSONEachRow",
+                input_bytes=b"gen-functional-replay\n",
+            )
+            assert json.loads(sampled_activity.stdout)["generation_id"] == (
+                "gen-functional-replay"
+            )
+
+            synthetic = {
+                "id": "synthetic-functional-replay",
+                "probe_type": "tls_health",
+                "target": "regional_api",
+                "target_url": "https://api-us-central1.quillrouter.com/health",
+                "monitor_region": "us-central1",
+                "status": "up",
+                "target_region": "us-central1",
+                "latency_milliseconds": 10,
+                "ttfb_milliseconds": 9,
+                "dns_milliseconds": 1,
+                "tcp_connect_milliseconds": 2,
+                "tls_handshake_milliseconds": 3,
+                "gateway_processing_milliseconds": 4,
+                "connection_reused": 0,
+                "protocol": "h2",
+                "http_status": 200,
+                "error_type": None,
+                "provider": None,
+                "model": None,
+                "selected_provider": None,
+                "selected_model": None,
+                "generation_id": None,
+                "attestation_digest": None,
+                "source_commit": None,
+                "cost_microdollars": 0,
+                "output_match": 1,
+                "created_at": "2026-07-28T12:34:56.789Z",
+                "ingest_version": "2026-07-28T12:35:00.000001Z",
+            }
+            synthetic_payload = (json.dumps(synthetic) + "\n").encode()
+            for _ in range(2):
+                _docker(
+                    docker,
+                    "exec",
+                    "-i",
+                    name,
+                    "clickhouse-client",
+                    "--database",
+                    database,
+                    "--query",
+                    "INSERT INTO synthetic_probe_samples FORMAT JSONEachRow",
+                    input_bytes=synthetic_payload,
+                )
+            synthetic_count = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT count() FROM synthetic_probe_samples FINAL",
+            )
+            assert synthetic_count.stdout.decode().strip() == "1"
+
+            replicated_rollup_schema = (
+                Path(__file__).parents[1]
+                / "clickhouse"
+                / "005_provider_rollups_replicated.sql"
+            ).read_bytes()
+            _docker(
+                docker,
+                "exec",
+                "-i",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--multiquery",
+                input_bytes=replicated_rollup_schema,
+            )
+            rollup_engines = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT groupUniqArray(engine) FROM system.tables "
+                "WHERE database=currentDatabase() "
+                "AND name LIKE 'provider_analytics_%_replicated'",
+            )
+            assert rollup_engines.stdout.decode().strip() == "['ReplicatedMergeTree']"
+            _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "RENAME TABLE provider_analytics_hourly TO "
+                "provider_analytics_hourly_local_backup, "
+                "provider_analytics_hourly_replicated TO provider_analytics_hourly",
+            )
+            replicated_rollup_rows = recompute_partition(
+                DockerExecutor(),
+                RollupPartition(
+                    "hourly",
+                    dt.datetime(2026, 7, 28, tzinfo=dt.UTC),
+                    dt.datetime(2026, 7, 29, tzinfo=dt.UTC),
+                    "20260728",
+                ),
+            )
+            assert replicated_rollup_rows == 1
+            replicated_rollup_count = _docker(
+                docker,
+                "exec",
+                name,
+                "clickhouse-client",
+                "--database",
+                database,
+                "--query",
+                "SELECT sum(attempts) FROM provider_analytics_hourly",
+            )
+            assert replicated_rollup_count.stdout.decode().strip() == "1"
         finally:
             _docker(docker, "rm", "-f", name, check=False)

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+import threading
+from typing import Any
+
+import httpx
+import pytest
+
+from clickhouse.ingest_operational_outbox import (
+    CanonicalOperationalEvent,
+    OperationalOutboxRow,
+    drain_once,
+    normalise_operational_event,
+)
+from clickhouse.rollup_synthetic import (
+    build_raw_rollups,
+    complete_window_rollups,
+    monthly_from_daily,
+)
+from trusted_router.operational_analytics import (
+    OperationalAnalyticsClient,
+    stable_rows_fingerprint,
+)
+from trusted_router.storage_gcp import SpannerBigtableStore
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    SpannerOperationalAnalyticsOutbox,
+    activity_payload,
+    analytics_surrogate,
+    operational_analytics_shard,
+)
+from trusted_router.storage_models import Generation, SyntheticProbeSample
+from trusted_router.types import UsageType
+
+
+def _generation() -> Generation:
+    return Generation(
+        id="gen-activity-1",
+        request_id="req-activity-1",
+        workspace_id="ws-private-123",
+        key_hash="salted-key-hash-private",
+        model="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        provider_name="Anthropic",
+        app="Test app",
+        tokens_prompt=12,
+        tokens_completion=3,
+        total_cost_microdollars=9,
+        usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=7.5,
+        finish_reason="stop",
+        status="success",
+        streamed=True,
+        usage_estimated=False,
+        cached_input_tokens=2,
+        reasoning_tokens=1,
+        tool_calls=[{"function": {"arguments": "private model output"}}],
+        operator_cost_microdollars=7,
+        tags={"team": "legal"},
+        created_at="2026-07-31T12:34:56.789Z",
+    )
+
+
+class _ParamTypes:
+    INT64 = "INT64"
+    STRING = "STRING"
+
+
+class _Transaction:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def execute_update(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any],
+        param_types: dict[str, Any],
+    ) -> None:
+        self.calls.append((sql, params, param_types))
+
+
+class _Database:
+    def __init__(self) -> None:
+        self.transaction = _Transaction()
+
+    def run_in_transaction(self, callback: Any) -> None:
+        callback(self.transaction)
+
+
+def test_activity_payload_uses_surrogates_and_omits_content_and_raw_ids() -> None:
+    generation = _generation()
+    payload = activity_payload(generation)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["tenant_id"] == analytics_surrogate(
+        "workspace", generation.workspace_id
+    )
+    assert payload["key_id"] == analytics_surrogate("api-key", generation.key_hash)
+    assert generation.workspace_id not in encoded
+    assert generation.key_hash not in encoded
+    assert "private model output" not in encoded
+    assert "tool_calls" not in payload
+    assert "operator_cost_microdollars" not in payload
+    assert "prompt_content" not in payload
+    assert "output_content" not in payload
+
+
+def test_operational_outbox_enqueue_is_sharded_and_commit_timestamped() -> None:
+    database = _Database()
+    generation = _generation()
+    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(
+        generation
+    )
+
+    [(sql, params, param_types)] = database.transaction.calls
+    assert "PENDING_COMMIT_TIMESTAMP()" in sql
+    assert params["event_kind"] == "activity"
+    assert params["event_id"] == generation.id
+    assert params["shard"] == operational_analytics_shard(
+        f"activity:{generation.id}"
+    )
+    assert json.loads(params["payload"])["tenant_id"] != generation.workspace_id
+    assert param_types == {
+        "shard": "INT64",
+        "event_kind": "STRING",
+        "event_id": "STRING",
+        "payload": "STRING",
+    }
+
+
+def _outbox_row() -> OperationalOutboxRow:
+    return OperationalOutboxRow(
+        shard=2,
+        commit_ts=dt.datetime(2026, 7, 31, 12, 35, tzinfo=dt.UTC),
+        event_kind="activity",
+        event_id=_generation().id,
+        payload=json.dumps(activity_payload(_generation())),
+    )
+
+
+def test_operational_normalizer_adds_commit_version_and_rejects_unknown_kind() -> None:
+    event = normalise_operational_event(_outbox_row())
+    assert event.event_kind == "activity"
+    assert event.row["generation_id"] == _generation().id
+    assert event.row["ingest_version"].startswith("2026-07-31T12:35:00")
+
+    with pytest.raises(ValueError, match="unsupported operational event kind"):
+        normalise_operational_event(
+            dataclasses.replace(_outbox_row(), event_kind="prompt")
+        )
+
+
+class _Source:
+    def __init__(self, rows: list[OperationalOutboxRow]) -> None:
+        self.rows = rows
+        self.deleted: list[OperationalOutboxRow] = []
+
+    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
+        return self.rows[:limit]
+
+    def delete(self, rows: list[OperationalOutboxRow]) -> None:
+        self.deleted.extend(rows)
+        self.rows = [row for row in self.rows if row not in rows]
+
+    def oldest_commit_ts(self) -> dt.datetime | None:
+        return self.rows[0].commit_ts if self.rows else None
+
+
+class _Writer:
+    def __init__(self, *, failures: int = 0) -> None:
+        self.failures = failures
+        self.batches: list[list[CanonicalOperationalEvent]] = []
+
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None:
+        self.batches.append(events)
+        if self.failures:
+            self.failures -= 1
+            raise RuntimeError("ClickHouse unavailable")
+
+
+def test_operational_cursor_advances_only_after_clickhouse_ack() -> None:
+    row = _outbox_row()
+    source = _Source([row])
+    writer = _Writer(failures=1)
+
+    with pytest.raises(RuntimeError, match="ClickHouse unavailable"):
+        drain_once(source, writer, batch_size=10)
+    assert source.rows == [row]
+    assert source.deleted == []
+
+    result = drain_once(source, writer, batch_size=10)
+    assert result.inserted == 1
+    assert source.rows == []
+    assert source.deleted == [row]
+    assert len(writer.batches) == 2
+
+
+def test_clickhouse_activity_reader_binds_private_filters_and_never_sends_raw_ids() -> None:
+    tenant_id = analytics_surrogate("workspace", "ws-private-123")
+    key_id = analytics_surrogate("api-key", "key-hash")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["param_tenant_id"] == tenant_id
+        assert request.url.params["param_key_id"] == key_id
+        assert request.url.params["param_tag_key"] == "team"
+        assert request.url.params["param_tag_value"] == "legal"
+        body = request.content.decode()
+        assert "ws-private-123" not in body
+        assert "key-hash" not in body
+        assert "{tenant_id:String}" in body
+        assert "mapContains(tags, {tag_key:String})" in body
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "generation_id": "gen-1",
+                        "request_id": "req-1",
+                        "key_id": analytics_surrogate("api-key", "key-hash"),
+                        "model": "anthropic/claude-haiku-4.5",
+                        "provider": "anthropic",
+                        "provider_name": "Anthropic",
+                        "app": "Test",
+                        "tokens_prompt": 2,
+                        "tokens_completion": 1,
+                        "cached_input_tokens": 0,
+                        "reasoning_tokens": 0,
+                        "total_cost_microdollars": 1,
+                        "usage_type": "Credits",
+                        "speed_tokens_per_second": 4.0,
+                        "finish_reason": "stop",
+                        "status": "success",
+                        "streamed": 1,
+                        "usage_estimated": 0,
+                        "elapsed_milliseconds": 250,
+                        "first_token_milliseconds": 100,
+                        "ttfb_milliseconds": 20,
+                        "region": "us-central1",
+                        "user": None,
+                        "session_id": None,
+                        "http_referer": None,
+                        "app_categories": [],
+                        "tags": {"team": "legal"},
+                        "created_at": "2026-07-31 12:34:56.789",
+                    }
+                ]
+            },
+        )
+
+    client = OperationalAnalyticsClient(
+        base_url="http://clickhouse.test:8123",
+        user="reader",
+        password="secret",  # noqa: S106 - inert test credential.
+        transport=httpx.MockTransport(handler),
+    )
+    [generation] = client.activity_generations(
+        tenant_id=tenant_id,
+        key_id=key_id,
+        tag_key="team",
+        tag_value="legal",
+        limit=10,
+    )
+    assert generation.workspace_id == tenant_id
+    assert generation.tags == {"team": "legal"}
+    assert generation.created_at == "2026-07-31T12:34:56.789Z"
+
+
+def _read_router(mode: str) -> SpannerBigtableStore:
+    store = object.__new__(SpannerBigtableStore)
+    store._analytics_read_mode = mode
+    store._analytics_dual_read_grace_seconds = 0
+    store._analytics_parity_log_lock = threading.Lock()
+    store._analytics_last_parity_log = {}
+    return store
+
+
+def test_dual_read_returns_bigtable_and_tolerates_clickhouse_failure() -> None:
+    store = _read_router("dual")
+    result = store._analytics_read(
+        "test",
+        bigtable=lambda: ["bigtable"],
+        clickhouse=lambda: (_ for _ in ()).throw(RuntimeError("down")),
+    )
+    assert result == ["bigtable"]
+
+
+def test_clickhouse_primary_falls_back_to_bigtable() -> None:
+    store = _read_router("clickhouse")
+    result = store._analytics_read(
+        "test",
+        bigtable=lambda: ["fallback"],
+        clickhouse=lambda: (_ for _ in ()).throw(RuntimeError("down")),
+    )
+    assert result == ["fallback"]
+
+
+def test_parity_fingerprint_ignores_rebuild_time_opaque_ids_and_order() -> None:
+    first = [
+        {
+            "id": "one",
+            "created_at": "2020-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "workspace_id": "raw-workspace",
+            "key_hash": "raw-key-hash",
+            "requests": 2,
+        },
+        {"id": "two", "created_at": "2020-01-02T00:00:00Z", "requests": 3},
+    ]
+    second = [
+        {"id": "two", "created_at": "2020-01-02T00:00:00Z", "requests": 3},
+        {
+            "id": "one",
+            "created_at": "2020-01-01T00:00:00Z",
+            "updated_at": "2026-07-31T00:00:00Z",
+            "workspace_id": analytics_surrogate("workspace", "raw-workspace"),
+            "key_hash": analytics_surrogate("api-key", "raw-key-hash"),
+            "requests": 2,
+        },
+    ]
+    assert stable_rows_fingerprint(first, grace_seconds=0) == stable_rows_fingerprint(
+        second,
+        grace_seconds=0,
+    )
+
+
+def test_parity_fingerprint_matches_clickhouse_float32_benchmark_storage() -> None:
+    high_precision = [
+        {
+            "id": "bench-one",
+            "created_at": "2020-01-01T00:00:00Z",
+            "input_tokens": 1,
+            "speed_tokens_per_second": 1.234567890123,
+        }
+    ]
+    stored_float32 = [
+        {
+            "id": "bench-one",
+            "created_at": "2020-01-01T00:00:00Z",
+            "input_tokens": 1,
+            "speed_tokens_per_second": 1.2345678806304932,
+        }
+    ]
+    assert stable_rows_fingerprint(
+        high_precision,
+        grace_seconds=0,
+    ) == stable_rows_fingerprint(stored_float32, grace_seconds=0)
+
+
+def _synthetic_sample(
+    sample_id: str,
+    *,
+    status: str,
+    created_at: str,
+    latency: int,
+    error_type: str | None = None,
+) -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=sample_id,
+        probe_type="tls_health",
+        target="regional_api",
+        target_url="https://api-us-central1.quillrouter.com/health",
+        monitor_region="us-central1",
+        target_region="us-central1",
+        status=status,
+        latency_milliseconds=latency,
+        ttfb_milliseconds=latency - 1,
+        error_type=error_type,
+        cost_microdollars=2,
+        created_at=created_at,
+    )
+
+
+def test_synthetic_rollups_preserve_exact_counts_histograms_and_costs() -> None:
+    samples = [
+        _synthetic_sample(
+            "sample-up",
+            status="up",
+            created_at="2026-07-31T12:01:00Z",
+            latency=10,
+        ),
+        _synthetic_sample(
+            "sample-down",
+            status="down",
+            created_at="2026-07-31T12:02:00Z",
+            latency=30,
+            error_type="timeout",
+        ),
+    ]
+
+    first = build_raw_rollups(samples, periods={"hour", "day"})
+    second = build_raw_rollups(samples, periods={"hour", "day"})
+    assert [dataclasses.asdict(item) for item in first] == [
+        dataclasses.asdict(item) for item in second
+    ]
+
+    hourly = [item for item in first if item.period == "hour"]
+    assert hourly
+    for rollup in hourly:
+        assert rollup.sample_count == 2
+        assert rollup.up_count == 1
+        assert rollup.down_count == 1
+        assert rollup.latency_histogram == {"10": 1, "30": 1}
+        assert rollup.error_counts == {"timeout": 1}
+        assert rollup.cost_microdollars == 4
+
+
+def test_synthetic_monthly_rollups_merge_daily_without_losing_dimensions() -> None:
+    day_one = build_raw_rollups(
+        [
+            _synthetic_sample(
+                "sample-one",
+                status="up",
+                created_at="2026-07-01T12:01:00Z",
+                latency=10,
+            )
+        ],
+        periods={"day"},
+    )
+    day_two = build_raw_rollups(
+        [
+            _synthetic_sample(
+                "sample-two",
+                status="degraded",
+                created_at="2026-07-02T12:01:00Z",
+                latency=20,
+                error_type="slow",
+            )
+        ],
+        periods={"day"},
+    )
+
+    monthly = monthly_from_daily(day_one + day_two)
+    assert monthly
+    for rollup in monthly:
+        assert rollup.period == "month"
+        assert rollup.period_start == "2026-07-01T00:00:00Z"
+        assert rollup.sample_count == 2
+        assert rollup.up_count == 1
+        assert rollup.degraded_count == 1
+        assert rollup.latency_histogram == {"10": 1, "20": 1}
+        assert rollup.error_counts == {"slow": 1}
+        assert rollup.cost_microdollars == 4
+
+
+def test_synthetic_rollup_rebuild_never_overwrites_partial_ttl_boundary() -> None:
+    samples = [
+        _synthetic_sample(
+            "boundary",
+            status="up",
+            created_at="2026-07-17T12:45:00Z",
+            latency=10,
+        ),
+        _synthetic_sample(
+            "complete",
+            status="up",
+            created_at="2026-07-18T00:01:00Z",
+            latency=20,
+        ),
+    ]
+    rollups = complete_window_rollups(
+        build_raw_rollups(samples, periods={"hour", "day"}),
+        raw_start=dt.datetime(2026, 7, 17, 12, 30, tzinfo=dt.UTC),
+    )
+    starts = {(rollup.period, rollup.period_start) for rollup in rollups}
+    assert ("hour", "2026-07-17T12:00:00Z") not in starts
+    assert ("day", "2026-07-17T00:00:00Z") not in starts
+    assert ("day", "2026-07-18T00:00:00Z") in starts


### PR DESCRIPTION
## Summary
- replicate tenant activity, synthetic monitoring, and provider rollup tables across the three-node ClickHouse cluster
- add bounded Spanner outbox ingestion, privacy-safe backfill, status rollups, and active Bigtable parity sampling
- add a measured capacity probe and fail-closed seven-day dual-read cutover gate

## Safety
- Bigtable remains authoritative in the first deployment
- raw workspace IDs, API keys, prompts, outputs, and BYOK secrets never enter ClickHouse
- generation point lookup remains on Bigtable
- provider and control-plane readers use separate least-privilege credentials

## Verification
- 2363 passed, 86 skipped
- Ruff clean
- mypy clean across 204 source files
- real ClickHouse Docker replay and replicated partition replacement proof passes