### PR TITLE
docs: keep video pricing at twenty percent

### DIFF
--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -82,7 +82,7 @@ base64 data URLs. Local, private-network, and cloud-metadata URLs are rejected.
 
 - The gateway asks the direct provider for a content-free quote before sending
   the prompt or references upstream.
-- The exact quote plus TrustedRouter's 5% fee is reserved and settled as integer
+- The exact quote plus TrustedRouter's 20% video fee is reserved and settled as integer
   microdollars. Floating point values never touch the credit ledger.
 - Retries with the same `Idempotency-Key` reuse the original authorization and
   job instead of generating and billing twice.
@@ -92,4 +92,3 @@ base64 data URLs. Local, private-network, and cloud-metadata URLs are rejected.
 - The launch provider temporarily stores generated media while the asynchronous
   job is pending and until download or the 24-hour cleanup deadline. These
   routes are not advertised as provider E2EE or provider ZDR.
-

--- a/tests/test_video_docs.py
+++ b/tests/test_video_docs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 
@@ -23,3 +25,9 @@ def test_video_docs_are_public_discoverable_and_truthful(client: TestClient) -> 
     assert "/docs/video" in client.get("/docs/llms.txt").text
     assert "/docs/video" in client.get("/docs/llms-full.txt").text
     assert "<loc>https://trustedrouter.com/docs/video</loc>" in client.get("/sitemap-core.xml").text
+
+
+def test_standalone_video_guide_uses_video_pricing() -> None:
+    guide = Path("docs/video-generation.md").read_text()
+    assert "TrustedRouter's 20% video fee" in guide
+    assert "TrustedRouter's 5% fee" not in guide


### PR DESCRIPTION
Keeps the standalone video guide aligned with the enforced 20% video fee and adds a regression assertion. Focused test: `uv run pytest -q tests/test_video_docs.py` (2 passed).