### PR TITLE
Verify status rollups from raw probes

### DIFF
--- a/clickhouse/tr-clickhouse-operational-parity.service
+++ b/clickhouse/tr-clickhouse-operational-parity.service
@@ -10,6 +10,7 @@ WorkingDirectory=/opt/tr-clickhouse
 Environment=PYTHONPATH=/opt/tr-clickhouse/src
 EnvironmentFile=/etc/tr-clickhouse-ingest.env
 ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_operational_parity
+TimeoutStartSec=5m
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true

--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -22,6 +22,8 @@ from clickhouse.ingest_operational_outbox import (
     OperationalOutboxRow,
     normalise_operational_event,
 )
+from clickhouse.rollup_synthetic import build_raw_rollups, complete_window_rollups
+from trusted_router.storage_gcp_codec import reverse_time_key
 from trusted_router.storage_gcp_operational_analytics_outbox import (
     activity_payload,
     synthetic_payload,
@@ -30,7 +32,6 @@ from trusted_router.storage_models import (
     Generation,
     ProviderBenchmarkSample,
     SyntheticProbeSample,
-    SyntheticRollup,
 )
 
 PROJECT = "quill-cloud-proxy"
@@ -177,11 +178,16 @@ def _source_rows(
     limit: int,
     grace_seconds: int = 0,
 ) -> dict[str, dict[str, Any]]:
+    if surface == "rollup":
+        return _source_rollups_from_raw(
+            table,
+            limit=limit,
+            grace_seconds=max(grace_seconds, 600),
+        )
     config = {
         "benchmark": (b"benchmark_recent#", ("benchmark", "m")),
         "activity": (b"ws_recent#", ("activity", "m")),
         "synthetic": (b"synthetic_recent#", ("synthetic", "m")),
-        "rollup": (b"synthetic_rollup#", ("rollup", "m")),
     }
     prefix, families = config[surface]
     rows = table.read_rows(
@@ -227,15 +233,47 @@ def _source_rows(
                 payload = synthetic_payload(synthetic_sample)
                 if _stable_source_row(payload, surface=surface, cutoff=cutoff):
                     result[synthetic_sample.id] = payload
-        else:
-            rollup = _parse(SyntheticRollup, raw)
-            if rollup is not None:
-                payload = dataclasses.asdict(rollup)
-                if _stable_source_row(payload, surface=surface, cutoff=cutoff):
-                    result[rollup.id] = payload
         if len(result) >= limit:
             break
     return result
+
+
+def _source_rollups_from_raw(
+    table: Any,
+    *,
+    limit: int,
+    grace_seconds: int,
+) -> dict[str, dict[str, Any]]:
+    now = dt.datetime.now(dt.UTC)
+    raw_start = now - dt.timedelta(days=14)
+    cutoff = now - dt.timedelta(seconds=max(0, grace_seconds))
+    start_key = f"synthetic_recent#{reverse_time_key(cutoff.isoformat())}#".encode()
+    end_key = f"synthetic_recent#{reverse_time_key(raw_start.isoformat())}#~".encode()
+    rows = table.read_rows(
+        start_key=start_key,
+        end_key=end_key,
+        filter_=CellsColumnLimitFilter(1),
+    )
+    samples: list[SyntheticProbeSample] = []
+    for row in rows:
+        sample = _parse(SyntheticProbeSample, _body(row, ("synthetic", "m")))
+        if sample is not None:
+            samples.append(sample)
+    rollups = complete_window_rollups(
+        build_raw_rollups(samples, periods={"hour", "day"}),
+        raw_start=raw_start,
+    )
+    stable = [
+        rollup
+        for rollup in rollups
+        if _stable_source_row(
+            dataclasses.asdict(rollup),
+            surface="rollup",
+            cutoff=cutoff,
+        )
+    ]
+    stable.sort(key=lambda item: (item.period_start, item.id), reverse=True)
+    return {rollup.id: dataclasses.asdict(rollup) for rollup in stable[:limit]}
 
 
 def compare_surface(

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -88,6 +88,13 @@ def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
     assert "TR_ANALYTICS_READ_MODE=clickhouse" in script
 
 
+def test_operational_parity_worker_has_a_bounded_runtime() -> None:
+    service = (
+        ROOT / "clickhouse/tr-clickhouse-operational-parity.service"
+    ).read_text()
+    assert "TimeoutStartSec=5m" in service
+
+
 def test_capacity_probe_is_disposable_and_uses_a_conservative_gate() -> None:
     script = (ROOT / "scripts/deploy/clickhouse_capacity_smoke.sh").read_text()
     assert "trap cleanup EXIT" in script

--- a/tests/test_clickhouse_operational_parity.py
+++ b/tests/test_clickhouse_operational_parity.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
+import json
+from types import SimpleNamespace
 
-from clickhouse.verify_operational_parity import _canonical, _stable_source_row
+from clickhouse.verify_operational_parity import (
+    _canonical,
+    _source_rollups_from_raw,
+    _stable_source_row,
+)
+from trusted_router.storage_models import SyntheticProbeSample
 
 
 def test_activity_parity_uses_clickhouse_millisecond_precision() -> None:
@@ -88,3 +96,44 @@ def test_parity_excludes_incomplete_rollup_periods() -> None:
         surface="rollup",
         cutoff=cutoff,
     )
+
+
+def test_rollup_parity_rebuilds_from_bounded_raw_bigtable_samples() -> None:
+    created_at = (dt.datetime.now(dt.UTC) - dt.timedelta(days=1)).replace(
+        minute=15,
+        second=0,
+        microsecond=0,
+    )
+    sample = SyntheticProbeSample(
+        id="syn_raw_one",
+        probe_type="tls_health",
+        target="canonical",
+        target_url="https://api.trustedrouter.com/health",
+        monitor_region="us-central1",
+        status="up",
+        target_region="us-central1",
+        latency_milliseconds=20,
+        ttfb_milliseconds=19,
+        created_at=created_at.isoformat().replace("+00:00", "Z"),
+    )
+    cell = SimpleNamespace(
+        value=json.dumps(dataclasses.asdict(sample)).encode("utf-8")
+    )
+    row = SimpleNamespace(cells={"synthetic": {b"body": [cell]}})
+
+    class Table:
+        start_key: bytes = b""
+        end_key: bytes = b""
+
+        def read_rows(self, *, start_key: bytes, end_key: bytes, filter_: object) -> list[object]:
+            self.start_key = start_key
+            self.end_key = end_key
+            return [row]
+
+    table = Table()
+    rollups = _source_rollups_from_raw(table, limit=10, grace_seconds=600)
+    assert rollups
+    assert table.start_key.startswith(b"synthetic_recent#")
+    assert table.end_key.startswith(b"synthetic_recent#")
+    assert table.start_key < table.end_key
+    assert all(payload["sample_count"] == 1 for payload in rollups.values())


### PR DESCRIPTION
## Summary
- rebuild recent hour/day rollup expectations from bounded Bigtable raw probe rows
- compare ClickHouse rollups exactly against that independent source instead of the legacy racy summary rows
- bound each parity run to five minutes

## Verification
- 2381 passed, 86 skipped
- ruff clean
- mypy clean
- production aggregate parity: 5000/5000 exact on benchmark, activity, synthetic raw, and rebuilt rollups