### PR TITLE
Confirm image canary failures before alerting

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -251,6 +251,7 @@ image_env_vars=(
   "TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"
   "TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"
   "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS=120"
+  "TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS=2"
 )
 image_set_env_vars="$(IFS='|'; echo "^|^${image_env_vars[*]}")"
 
@@ -264,7 +265,7 @@ gc run jobs deploy "$image_job_name" \
   --set-env-vars "$image_set_env_vars" \
   --update-secrets "$UPDATE_SECRETS" \
   --max-retries 0 \
-  --task-timeout 180s \
+  --task-timeout 300s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null

--- a/src/trusted_router/synthetic/image_generation.py
+++ b/src/trusted_router/synthetic/image_generation.py
@@ -31,6 +31,15 @@ async def run() -> int:
     model = os.environ.get("TR_SYNTHETIC_IMAGE_MODEL", IMAGE_GENERATION_MODEL)
     provider = os.environ.get("TR_SYNTHETIC_IMAGE_PROVIDER", IMAGE_GENERATION_PROVIDER)
     timeout_seconds = float(os.environ.get("TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS", "120"))
+    confirmation_delay_seconds = max(
+        0.0,
+        float(
+            os.environ.get(
+                "TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS",
+                "2",
+            )
+        ),
+    )
     control_plane = os.environ.get(
         "TR_SYNTHETIC_CONTROL_PLANE_URL",
         "https://trustedrouter.com",
@@ -43,18 +52,35 @@ async def run() -> int:
     timeout = httpx.Timeout(timeout_seconds)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
-        sample = await image_generation_probe(
-            client,
-            target,
-            monitor_region=monitor_region,
-            api_key=api_key,
-            model=model,
-            provider=provider,
-        )
+        samples = [
+            await image_generation_probe(
+                client,
+                target,
+                monitor_region=monitor_region,
+                api_key=api_key,
+                model=model,
+                provider=provider,
+            )
+        ]
+        if samples[-1].status != "up":
+            if confirmation_delay_seconds:
+                await asyncio.sleep(confirmation_delay_seconds)
+            samples.append(
+                await image_generation_probe(
+                    client,
+                    target,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                    model=model,
+                    provider=provider,
+                )
+            )
+
+        sample = samples[-1]
         response = await client.post(
             ingest_url,
             headers={"x-trustedrouter-internal-token": internal_token},
-            json={"samples": [sample.public_dict()]},
+            json={"samples": [item.public_dict() for item in samples]},
         )
 
     print(
@@ -68,6 +94,10 @@ async def run() -> int:
                 "provider": sample.selected_provider or sample.provider,
                 "generation_id": sample.generation_id,
                 "cost_microdollars": sample.cost_microdollars,
+                "attempts": len(samples),
+                "total_cost_microdollars": sum(
+                    item.cost_microdollars or 0 for item in samples
+                ),
                 "ingest_status": response.status_code,
             },
             separators=(",", ":"),

--- a/src/trusted_router/synthetic/route_health.py
+++ b/src/trusted_router/synthetic/route_health.py
@@ -145,20 +145,28 @@ def report_route_health(flags: list[RouteHealthFlag]) -> None:
 
 
 def report_image_generation_failures(samples: list[SyntheticProbeSample]) -> None:
-    """Report image-route failures without carrying generated content."""
-    failures = [
-        sample
-        for sample in samples
-        if sample.probe_type == "image_generation" and sample.status != "up"
+    """Report only image routes whose full confirmation batch failed."""
+    grouped: dict[tuple[str, str], list[SyntheticProbeSample]] = {}
+    for sample in samples:
+        if sample.probe_type != "image_generation":
+            continue
+        provider = sample.selected_provider or sample.provider or "unknown"
+        model = sample.selected_model or sample.model or "unknown"
+        grouped.setdefault((provider, model), []).append(sample)
+
+    confirmed_failures = [
+        route_samples[-1]
+        for route_samples in grouped.values()
+        if route_samples and all(sample.status != "up" for sample in route_samples)
     ]
-    if not failures:
+    if not confirmed_failures:
         return
     try:
         import sentry_sdk
     except ImportError:
         return
 
-    for sample in failures:
+    for sample in confirmed_failures:
         provider = sample.selected_provider or sample.provider or "unknown"
         model = sample.selected_model or sample.model or "unknown"
         error_type = sample.error_type or "unknown"

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2543,7 +2543,10 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     )
     assert '"TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"' in body
     assert '"TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"' in body
+    assert '"TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS=2"' in body
     assert '--args="-m,trusted_router.synthetic.image_generation"' in body
+    image_job = body.split("deploying isolated image-generation", maxsplit=1)[1]
+    assert "--task-timeout 300s" in image_job
     assert '"17 */6 * * *"' in body
 
 
@@ -2610,6 +2613,77 @@ async def test_image_generation_job_runs_one_probe_and_ingests_metadata(
     output = json.loads(capsys.readouterr().out)
     assert output["status"] == "up"
     assert output["generation_id"] == "gen-image-job"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_job_confirms_a_text_only_response(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from trusted_router.synthetic import image_generation as image_job
+
+    image = b"\xff\xd8\xff" + (b"\x00" * 2048) + b"\xff\xd9"
+    data_url = f"data:image/jpeg;base64,{base64.b64encode(image).decode()}"
+    chat_calls = 0
+    ingested: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal chat_calls
+        if request.url.path == "/v1/chat/completions":
+            chat_calls += 1
+            if chat_calls == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "chatcmpl-text-only",
+                        "choices": [{"message": {"content": "I cannot create an image."}}],
+                        "usage": {"cost_microdollars": 82},
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-image-confirmed",
+                    "choices": [{"message": {"content": data_url}}],
+                    "usage": {"cost_microdollars": 90_000},
+                },
+            )
+        if request.url.path == "/v1/internal/synthetic/samples":
+            ingested.append(json.loads(request.content))
+            return httpx.Response(200, json={"data": {"recorded": 2}})
+        return httpx.Response(404)
+
+    settings = Settings(
+        environment="test",
+        api_base_url="https://api.trustedrouter.com/v1",
+        internal_gateway_token="internal-test",  # noqa: S106 - test placeholder.
+        synthetic_monitor_api_key="sk-tr-test",
+    )
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs: Any) -> httpx.AsyncClient:
+        return real_async_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(image_job, "get_settings", lambda: settings)
+    monkeypatch.setattr(image_job.httpx, "AsyncClient", client_factory)
+    monkeypatch.setenv(
+        "TR_SYNTHETIC_INGEST_URL",
+        "https://trustedrouter.com/v1/internal/synthetic/samples",
+    )
+    monkeypatch.setenv("TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS", "0")
+
+    result = await image_job.run()
+
+    assert result == 0
+    assert chat_calls == 2
+    assert len(ingested) == 1
+    assert [sample["status"] for sample in ingested[0]["samples"]] == ["down", "up"]
+    assert data_url not in json.dumps(ingested)
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "up"
+    assert output["attempts"] == 2
+    assert output["generation_id"] == "chatcmpl-image-confirmed"
 
 
 class _FakeCell:
@@ -3707,15 +3781,7 @@ def test_image_generation_failure_alert_is_fingerprinted_and_metadata_only(
         error_type="invalid_image_payload",
         http_status=200,
     )
-    healthy = _sample(
-        id="syn_image_healthy",
-        probe_type="image_generation",
-        status="up",
-        provider=IMAGE_GENERATION_PROVIDER,
-        model=IMAGE_GENERATION_MODEL,
-    )
-
-    report_image_generation_failures([healthy, failed])
+    report_image_generation_failures([failed])
 
     assert captured == [
         (
@@ -3734,6 +3800,69 @@ def test_image_generation_failure_alert_is_fingerprinted_and_metadata_only(
     ]
     assert "prompt" not in json.dumps(scopes[0].tags).lower()
     assert "output" not in json.dumps(scopes[0].tags).lower()
+
+
+def test_image_generation_confirmation_success_does_not_alert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sentry_sdk
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, *, level: captured.append(f"{level}:{message}"),
+    )
+    failed = _sample(
+        id="syn_image_first_failed",
+        probe_type="image_generation",
+        status="down",
+        provider=IMAGE_GENERATION_PROVIDER,
+        model=IMAGE_GENERATION_MODEL,
+        error_type="invalid_image_payload",
+        http_status=200,
+    )
+    confirmed = _sample(
+        id="syn_image_confirmation_up",
+        probe_type="image_generation",
+        status="up",
+        provider=IMAGE_GENERATION_PROVIDER,
+        model=IMAGE_GENERATION_MODEL,
+        http_status=200,
+    )
+
+    report_image_generation_failures([failed, confirmed])
+
+    assert captured == []
+
+
+def test_image_generation_double_failure_alerts_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sentry_sdk
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, *, level: captured.append(f"{level}:{message}"),
+    )
+    failures = [
+        _sample(
+            id=f"syn_image_failed_{attempt}",
+            probe_type="image_generation",
+            status="down",
+            provider=IMAGE_GENERATION_PROVIDER,
+            model=IMAGE_GENERATION_MODEL,
+            error_type="invalid_image_payload",
+            http_status=200,
+        )
+        for attempt in range(2)
+    ]
+
+    report_image_generation_failures(failures)
+
+    assert len(captured) == 1
 
 
 def test_internal_route_health_reports_flags_and_requires_token(


### PR DESCRIPTION
## Summary
- immediately confirm failed image-generation canaries once
- preserve both attempt samples while suppressing Sentry when confirmation recovers
- emit one grouped alert only when the full confirmation batch fails
- extend the isolated image job timeout for the confirmation attempt

## Root cause
Gemini intermittently returned HTTP 200 with a tiny text-only response instead of generated image bytes. The failed production generation cost 82 microdollars versus roughly 79,000-94,000 microdollars for successful neighboring samples.

## Verification
- regression tests failed against the previous implementation
- 106 synthetic monitoring tests pass
- full suite: 2,384 passed, 86 skipped
- ruff, mypy, shell syntax checks pass