### PR TITLE
Add durable DeepSeek V4 dated-model discovery

### DIFF
--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -750,6 +750,36 @@ def validate(
     return errors
 
 
+def apply_required_model_price_aliases(
+    prices: dict[str, ModelPrice],
+    required_models: frozenset[str],
+    aliases: dict[str, str],
+) -> tuple[dict[str, ModelPrice], list[str]]:
+    """Copy an approved family price onto required provider aliases.
+
+    Some providers publish one unversioned pricing row while their model API
+    exposes dated, separately addressable snapshots. Provider modules own the
+    alias map so parser output cannot invent pricing relationships. Only model
+    IDs required by this provider refresh are expanded; unrelated aliases do not
+    silently become routable merely because a broad family prefix matched.
+    """
+
+    expanded = dict(prices)
+    applied: list[str] = []
+    for target_model in sorted(required_models):
+        if target_model in expanded:
+            continue
+        source_model = aliases.get(target_model)
+        if source_model is None or source_model == target_model:
+            continue
+        source_price = expanded.get(source_model)
+        if source_price is None:
+            continue
+        expanded[target_model] = ModelPrice(tiers=list(source_price.tiers))
+        applied.append(f"{target_model} <- {source_model}")
+    return expanded, applied
+
+
 # ----------------------------------------------------------------------
 # AST whitelist gate — runs BEFORE any execution of LLM-generated code.
 # ----------------------------------------------------------------------
@@ -1166,6 +1196,7 @@ def fetch_provider(
     url: str,
     expected_models: list[str],
     required_models: list[str] | tuple[str, ...] | frozenset[str] = (),
+    required_model_price_aliases: dict[str, str] | None = None,
     extra_headers: dict[str, str] | None = None,
     accepted_status_codes: frozenset[int] = frozenset(),
 ) -> ProviderPricingResult:
@@ -1225,7 +1256,13 @@ def fetch_provider(
         log.warning("pricing.parse schema_errors slug=%s errors=%s", slug, schema_errors)
         prices = None
     errors = schema_errors[:] if schema_errors else []
+    applied_price_aliases: list[str] = []
     if prices is not None:
+        prices, applied_price_aliases = apply_required_model_price_aliases(
+            prices,
+            strict_models,
+            required_model_price_aliases or {},
+        )
         errors = validate(
             prices,
             expected_models,
@@ -1237,6 +1274,11 @@ def fetch_provider(
             prices=prices or {},
             source="deterministic",
             fetched_url=url,
+            notes=(
+                ["applied approved price aliases: " + ", ".join(applied_price_aliases)]
+                if applied_price_aliases
+                else []
+            ),
         )
 
     log.warning("pricing.deterministic_failed slug=%s errors=%s", slug, errors)
@@ -1268,6 +1310,11 @@ def fetch_provider(
     if sandbox_errors:
         raise RuntimeError(f"{slug}: self-heal sandbox failed: {sandbox_errors}")
     assert sandbox_prices is not None  # for type checker
+    sandbox_prices, sandbox_price_aliases = apply_required_model_price_aliases(
+        sandbox_prices,
+        strict_models,
+        required_model_price_aliases or {},
+    )
     final_errors = validate(
         sandbox_prices,
         expected_models,
@@ -1292,5 +1339,12 @@ def fetch_provider(
         source="self_healed",
         heal_diff=diff,
         fetched_url=url,
-        notes=[f"self-healed parser (validation errors: {len(errors)} → 0)"],
+        notes=[
+            f"self-healed parser (validation errors: {len(errors)} → 0)",
+            *(
+                ["applied approved price aliases: " + ", ".join(sandbox_price_aliases)]
+                if sandbox_price_aliases
+                else []
+            ),
+        ],
     )

--- a/scripts/pricing/model_ids.py
+++ b/scripts/pricing/model_ids.py
@@ -119,3 +119,23 @@ def remember_upstream_id(
     """
 
     upstream_map.setdefault(canonical_id, native_id)
+
+
+def price_aliases_for_versioned_families(
+    model_ids: set[str] | frozenset[str],
+    family_prices: dict[str, str],
+) -> dict[str, str]:
+    """Map provider-confirmed version IDs to an approved family price row.
+
+    ``family_prices`` maps a canonical model-id prefix to the provider's
+    unversioned pricing ID. The caller supplies model IDs observed from an
+    authenticated provider catalog (or the provider's own required IDs), so
+    this helper never creates speculative routes.
+    """
+
+    return {
+        model_id: source_model
+        for model_id in model_ids
+        for prefix, source_model in family_prices.items()
+        if model_id != source_model and model_id.startswith(prefix)
+    }

--- a/scripts/pricing/providers/deepseek.py
+++ b/scripts/pricing/providers/deepseek.py
@@ -1,14 +1,40 @@
 """DeepSeek — human-only provider config."""
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    fetch_provider,
+    runtime_required_models,
+)
+from scripts.pricing.model_ids import (
+    price_aliases_for_versioned_families,
+    remember_upstream_id,
+)
 
 SLUG = "deepseek"
 URL = "https://api-docs.deepseek.com/quick_start/pricing"
 EXPECTED_MODELS = [
     "deepseek/deepseek-v4-flash",
 ]
+UPSTREAM_ID_MAP: dict[str, str] = {}
+_VERSIONED_PRICE_FAMILIES = {
+    "deepseek/deepseek-v4-flash-": "deepseek/deepseek-v4-flash",
+}
+_PERSISTED_VERSIONED_MODELS = frozenset({"deepseek/deepseek-v4-flash-0731"})
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(slug=SLUG, url=URL, expected_models=EXPECTED_MODELS)
+    required_models = _PERSISTED_VERSIONED_MODELS | runtime_required_models(SLUG)
+    price_aliases = price_aliases_for_versioned_families(
+        required_models,
+        _VERSIONED_PRICE_FAMILIES,
+    )
+    for model_id in price_aliases:
+        remember_upstream_id(UPSTREAM_ID_MAP, model_id, "deepseek-v4-flash")
+    return fetch_provider(
+        slug=SLUG,
+        url=URL,
+        expected_models=EXPECTED_MODELS,
+        required_models=required_models,
+        required_model_price_aliases=price_aliases,
+    )

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -22,6 +22,7 @@ from scripts.pricing.base import (
 )
 from scripts.pricing.model_ids import (
     canonicalize_unqualified_model_id,
+    price_aliases_for_versioned_families,
     remember_upstream_id,
 )
 
@@ -68,6 +69,9 @@ UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] = "accounts/fireworks/routers/glm-5p2-fast"
 # and only while the first-party pricing page still contains the model.
 VERIFIED_PRICED_LAUNCH_MODELS = frozenset({"moonshotai/kimi-k3"})
 _DISCOVERED_LIVE_MODEL_IDS: set[str] = set()
+_VERSIONED_PRICE_FAMILIES = {
+    "deepseek/deepseek-v4-flash-": "deepseek/deepseek-v4-flash",
+}
 
 
 def _live_model_ids() -> set[str]:
@@ -101,10 +105,16 @@ def fetch() -> ProviderPricingResult:
     global _DISCOVERED_LIVE_MODEL_IDS
 
     live_model_ids = _live_model_ids()
+    price_aliases = price_aliases_for_versioned_families(
+        live_model_ids,
+        _VERSIONED_PRICE_FAMILIES,
+    )
     result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
+        required_models=frozenset(price_aliases),
+        required_model_price_aliases=price_aliases,
     )
     verified_launch_ids = VERIFIED_PRICED_LAUNCH_MODELS.intersection(result.prices)
     routable_model_ids = live_model_ids | verified_launch_ids

--- a/scripts/pricing/providers/siliconflow.py
+++ b/scripts/pricing/providers/siliconflow.py
@@ -7,17 +7,73 @@ OpenAI-compatible chat completions at api.siliconflow.com/v1.
 """
 from __future__ import annotations
 
-from scripts.pricing.base import ProviderPricingResult, fetch_provider
+import os
+
+from scripts.pricing.base import ProviderPricingResult, fetch_json, fetch_provider
+from scripts.pricing.model_ids import (
+    canonicalize_native_model_id,
+    price_aliases_for_versioned_families,
+    remember_upstream_id,
+)
 
 SLUG = "siliconflow"
 URL = "https://www.siliconflow.com/pricing"
+MODELS_URL = "https://api.siliconflow.com/v1/models"
 
 EXPECTED_MODELS: list[str] = []  # parser tolerant of upstream renames
+UPSTREAM_ID_MAP: dict[str, str] = {}
+
+# SiliconFlow's public pricing card remains unversioned while its authenticated
+# model catalog exposes dated DeepSeek Flash snapshots. The family relationship
+# is human-approved here; only IDs actually present in /v1/models can inherit it.
+_VERSIONED_PRICE_FAMILIES = {
+    "deepseek/deepseek-v4-flash-": "deepseek/deepseek-v4-flash",
+}
+
+
+def _live_model_ids() -> set[str]:
+    api_key = os.environ.get("SILICON_FLOW_API_KEY") or os.environ.get(
+        "SILICONFLOW_API_KEY"
+    )
+    if not api_key:
+        return set()
+    payload = fetch_json(
+        MODELS_URL,
+        extra_headers={"Authorization": f"Bearer {api_key}"},
+    )
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError("siliconflow: /v1/models response has no data list")
+    discovered: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        native_id = row.get("id")
+        if not isinstance(native_id, str):
+            continue
+        canonical_id = canonicalize_native_model_id(native_id)
+        if canonical_id is None:
+            continue
+        discovered.add(canonical_id)
+        remember_upstream_id(UPSTREAM_ID_MAP, canonical_id, native_id)
+    return discovered
 
 
 def fetch() -> ProviderPricingResult:
-    return fetch_provider(
+    live_model_ids = _live_model_ids()
+    price_aliases = price_aliases_for_versioned_families(
+        live_model_ids,
+        _VERSIONED_PRICE_FAMILIES,
+    )
+    result = fetch_provider(
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
+        required_models=frozenset(price_aliases),
+        required_model_price_aliases=price_aliases,
     )
+    if live_model_ids:
+        result.notes.append(
+            f"matched pricing against {len(live_model_ids)} authenticated live models"
+        )
+    return result

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -31,7 +31,7 @@
     "wafer",
     "zai"
   ],
-  "model_count": 162,
+  "model_count": 164,
   "models": [
     {
       "id": "anthropic/claude-fable-5",
@@ -99,9 +99,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 81.48148148148148,
-          "uptime_last_5m": 90.58823529411765,
-          "uptime_last_1d": 79.4821568487784,
+          "uptime_last_30m": 84.21052631578947,
+          "uptime_last_5m": 74.72527472527473,
+          "uptime_last_1d": 84.22093981863149,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -123,6 +123,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "deepinfra | anthropic/claude-fable-5",
+          "model_id": "anthropic/claude-fable-5",
+          "model_name": "Anthropic: Claude Fable 5",
+          "provider_name": "deepinfra",
+          "tag": "deepinfra",
+          "tr_provider_slug": "deepinfra",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.00001",
+            "completion": "0.00005"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "gmi | anthropic/claude-fable-5",
           "model_id": "anthropic/claude-fable-5",
           "model_name": "Anthropic: Claude Fable 5",
@@ -134,22 +150,6 @@
             "prompt": "0.00001",
             "completion": "0.00005",
             "input_cache_read": "0.000001"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | anthropic/claude-fable-5",
-          "model_id": "anthropic/claude-fable-5",
-          "model_name": "Anthropic: Claude Fable 5",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.00001",
-            "completion": "0.00005"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -225,9 +225,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.82003599280144,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.90045476454932,
+          "uptime_last_1d": 99.94794626319236,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -317,9 +317,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.6984318455971,
+          "uptime_last_1d": 99.94459833795014,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -410,9 +410,9 @@
             "verbosity"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.53554119547657,
+          "uptime_last_1d": 99.4,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -451,7 +451,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.86028460543338,
+          "uptime_last_1d": 90.78014184397163,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -544,9 +544,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86717073669153,
+          "uptime_last_30m": 99.98610596517229,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86952595034354,
+          "uptime_last_1d": 99.85678581857533,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -587,7 +587,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 87.15953307392996,
+          "uptime_last_1d": 63.366336633663366,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -695,9 +695,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.57849760378775,
-          "uptime_last_5m": 99.958071278826,
-          "uptime_last_1d": 99.86596018387743,
+          "uptime_last_30m": 99.98249146458899,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.93374863796421,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -736,7 +736,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 90.68413391557496,
+          "uptime_last_1d": 96.55172413793103,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -846,7 +846,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 85.95052524567943,
+          "uptime_last_1d": 89.6380525304292,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -883,9 +883,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88927642141394,
-          "uptime_last_5m": 99.95891536565324,
-          "uptime_last_1d": 99.52606104483014,
+          "uptime_last_30m": 99.9865933771283,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.69113963555554,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -993,9 +993,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94541484716157,
+          "uptime_last_30m": 99.86187845303867,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.57216800045839,
+          "uptime_last_1d": 99.47009989598257,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1017,6 +1017,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "deepinfra | anthropic/claude-opus-5",
+          "model_id": "anthropic/claude-opus-5",
+          "model_name": "Claude Opus 5",
+          "provider_name": "deepinfra",
+          "tag": "deepinfra",
+          "tr_provider_slug": "deepinfra",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000005",
+            "completion": "0.000025"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "gmi | anthropic/claude-opus-5",
           "model_id": "anthropic/claude-opus-5",
           "model_name": "Claude Opus 5",
@@ -1028,22 +1044,6 @@
             "prompt": "0.000005",
             "completion": "0.000025",
             "input_cache_read": "0.0000005"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | anthropic/claude-opus-5",
-          "model_id": "anthropic/claude-opus-5",
-          "model_name": "Claude Opus 5",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000005",
-            "completion": "0.000025"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -1120,7 +1120,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99944246208742,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1215,9 +1215,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.26062846580407,
-          "uptime_last_5m": 99.2,
-          "uptime_last_1d": 99.57097791798107,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.54091960670908,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1267,7 +1267,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 64.65517241379311,
+          "uptime_last_1d": 57.7922077922078,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1360,9 +1360,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.83043440258719,
-          "uptime_last_5m": 99.98520053278082,
-          "uptime_last_1d": 99.79839850942909,
+          "uptime_last_30m": 99.99728179618907,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9432545511302,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1400,10 +1400,10 @@
             "verbosity",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 47.82608695652174,
+          "status": 0,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.57945041816009,
+          "uptime_last_1d": 95.64967420467612,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1511,9 +1511,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97704315886135,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.15162035622166,
+          "uptime_last_1d": 98.91349254468095,
           "supports_implicit_caching": false,
           "tr_provider_slug": "anthropic",
           "pricing_source": "provider_direct"
@@ -1535,6 +1535,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "deepinfra | anthropic/claude-sonnet-5",
+          "model_id": "anthropic/claude-sonnet-5",
+          "model_name": "Anthropic: Claude Sonnet 5",
+          "provider_name": "deepinfra",
+          "tag": "deepinfra",
+          "tr_provider_slug": "deepinfra",
+          "context_length": 1000000,
+          "pricing": {
+            "prompt": "0.000002",
+            "completion": "0.00001"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "gmi | anthropic/claude-sonnet-5",
           "model_id": "anthropic/claude-sonnet-5",
           "model_name": "Anthropic: Claude Sonnet 5",
@@ -1546,22 +1562,6 @@
             "prompt": "0.000002",
             "completion": "0.00001",
             "input_cache_read": "0.0000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | anthropic/claude-sonnet-5",
-          "model_id": "anthropic/claude-sonnet-5",
-          "model_name": "Anthropic: Claude Sonnet 5",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1000000,
-          "pricing": {
-            "prompt": "0.000002",
-            "completion": "0.00001"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -1636,9 +1636,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 100,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.94732961129253,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -1704,7 +1704,7 @@
             "repetition_penalty"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -1777,8 +1777,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99078043608537,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.90844354018311,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -1851,7 +1851,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.91102793416067,
+          "uptime_last_1d": 99.92707465174425,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -1892,7 +1892,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 78.239608801956,
+          "uptime_last_1d": 94.9579831932773,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -1974,7 +1974,7 @@
             "repetition_penalty"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -2067,7 +2067,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.81456680745853,
+          "uptime_last_1d": 99.7988225826945,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2108,14 +2108,14 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99992478884468,
+          "uptime_last_1d": 99.99984673566117,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | deepseek/deepseek-v3.1-terminus",
-          "model_id": "deepseek/deepseek-v3.1-terminus",
+          "model_id": "deepseek-ai/DeepSeek-V3.1-Terminus",
           "model_name": "DeepSeek: DeepSeek V3.1 Terminus",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -2141,10 +2141,10 @@
             "tool_choice",
             "max_tokens"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.83925549915398,
-          "uptime_last_5m": 96.5986394557823,
-          "uptime_last_1d": 97.04646976465098,
+          "status": 0,
+          "uptime_last_30m": 95.55555555555556,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.40790329760641,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2234,9 +2234,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.63947724200091,
-          "uptime_last_5m": 99.26470588235294,
-          "uptime_last_1d": 98.17406551366861,
+          "uptime_last_30m": 97.53954305799648,
+          "uptime_last_5m": 99.02912621359224,
+          "uptime_last_1d": 97.98828519491012,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2278,9 +2278,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95371798827523,
-          "uptime_last_5m": 99.95361781076066,
-          "uptime_last_1d": 99.89280428123209,
+          "uptime_last_30m": 99.98179169701383,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.91234035830637,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -2312,9 +2312,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 98.55072463768117,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.07895999232467,
+          "uptime_last_1d": 99.3372528059861,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2351,16 +2351,16 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98116406102844,
+          "uptime_last_30m": 99.99566555415889,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.91757386297722,
+          "uptime_last_1d": 99.94524294214594,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | deepseek/deepseek-v3.2-20251201",
-          "model_id": "deepseek/deepseek-v3.2",
+          "model_id": "deepseek-ai/DeepSeek-V3.2",
           "model_name": "DeepSeek: DeepSeek V3.2",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -2388,9 +2388,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 97.29839528742636,
-          "uptime_last_5m": 98.59154929577466,
-          "uptime_last_1d": 94.3620636934616,
+          "uptime_last_30m": 99.29718875502009,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 95.52731118799635,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2511,16 +2511,16 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9551234106208,
+          "uptime_last_30m": 99.68177639488015,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.96477314516073,
+          "uptime_last_1d": 99.6181494971484,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | deepseek/deepseek-v3.2-exp",
-          "model_id": "deepseek/deepseek-v3.2-exp",
+          "model_id": "deepseek-ai/DeepSeek-V3.2-Exp",
           "model_name": "DeepSeek: DeepSeek V3.2 Exp",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -2547,9 +2547,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 97.84735812133071,
-          "uptime_last_5m": 99.10979228486647,
-          "uptime_last_1d": 93.5017429100142,
+          "uptime_last_30m": 99.36026936026936,
+          "uptime_last_5m": 99.98370539351474,
+          "uptime_last_1d": 95.50076258261312,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2640,9 +2640,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.69772158901016,
-          "uptime_last_5m": 99.22426566721869,
-          "uptime_last_1d": 99.09485725475203,
+          "uptime_last_30m": 99.5982694684796,
+          "uptime_last_5m": 99.52787361539859,
+          "uptime_last_1d": 99.16872288629226,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -2680,9 +2680,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99939907096372,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.63524772064999,
+          "uptime_last_30m": 99.9963919943509,
+          "uptime_last_5m": 99.99655421935839,
+          "uptime_last_1d": 99.57259162875866,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -2723,10 +2723,10 @@
             "tools",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 91.10918544194108,
-          "uptime_last_5m": 91.76319176319177,
-          "uptime_last_1d": 96.80097792743962,
+          "status": 0,
+          "uptime_last_30m": 98.78802281368822,
+          "uptime_last_5m": 99.8185117967332,
+          "uptime_last_1d": 96.09924219268753,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -2760,9 +2760,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.88742127687766,
-          "uptime_last_5m": 98.87045309508615,
-          "uptime_last_1d": 98.08682303251524,
+          "uptime_last_30m": 99.6452821476172,
+          "uptime_last_5m": 99.69394497965429,
+          "uptime_last_1d": 98.83213860187485,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -2801,9 +2801,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85404076615795,
-          "uptime_last_5m": 99.87737142032749,
-          "uptime_last_1d": 99.64567417963708,
+          "uptime_last_30m": 99.97027656618303,
+          "uptime_last_5m": 99.97475385003787,
+          "uptime_last_1d": 99.63225042626038,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -2846,16 +2846,16 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.06504873682117,
-          "uptime_last_5m": 99.7415099384972,
-          "uptime_last_1d": 99.01077553250597,
+          "uptime_last_30m": 98.9060368577313,
+          "uptime_last_5m": 99.5748031496063,
+          "uptime_last_1d": 99.07406589718907,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | deepseek/deepseek-v4-flash-20260423",
-          "model_id": "deepseek/deepseek-v4-flash",
+          "model_id": "deepseek-ai/DeepSeek-V4-Flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -2883,9 +2883,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.14121893157908,
-          "uptime_last_5m": 98.94836570345808,
-          "uptime_last_1d": 97.31425638757275,
+          "uptime_last_30m": 99.81553899505644,
+          "uptime_last_5m": 99.94216310005784,
+          "uptime_last_1d": 97.9924172975294,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -2908,23 +2908,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | deepseek/deepseek-v4-flash",
-          "model_id": "deepseek/deepseek-v4-flash",
-          "model_name": "DeepSeek: DeepSeek V4 Flash",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000009",
-            "completion": "0.000000195",
-            "input_cache_read": "0.0000000196"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | deepseek/deepseek-v4-flash",
           "model_id": "deepseek-v4-flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
@@ -2936,6 +2919,23 @@
             "prompt": "0.0000002",
             "completion": "0.0000004",
             "input_cache_read": "0.00000002"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "makora | deepseek/deepseek-v4-flash",
+          "model_id": "deepseek/deepseek-v4-flash",
+          "model_name": "DeepSeek: DeepSeek V4 Flash",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000009",
+            "completion": "0.000000195",
+            "input_cache_read": "0.0000000196"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -2978,6 +2978,276 @@
           "name": "atlas-cloud | deepseek/deepseek-v4-flash",
           "model_id": "deepseek/deepseek-v4-flash",
           "model_name": "DeepSeek: DeepSeek V4 Flash",
+          "provider_name": "atlas-cloud",
+          "tag": "atlas-cloud",
+          "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek: DeepSeek V4 Flash 0731",
+      "created": 1785478908,
+      "description": "DeepSeek V4 Flash 0731 is a sparse mixture-of-experts model from DeepSeek, with 13B active parameters out of 284B total. This re-post-trained revision is suited for coding, reasoning, and agent workflows.",
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000009",
+        "completion": "0.00000018",
+        "input_cache_read": "0.0000000028"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 384000,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "DeepInfra | deepseek/deepseek-v4-flash-20260731",
+          "model_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "DeepInfra",
+          "tag": "deepinfra/fp4",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000009",
+            "completion": "0.00000018",
+            "input_cache_read": "0.000000018",
+            "discount": 0
+          },
+          "quantization": "fp4",
+          "max_completion_tokens": 65536,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "top_k",
+            "seed",
+            "min_p",
+            "response_format",
+            "logit_bias",
+            "tools",
+            "tool_choice",
+            "structured_outputs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.4760982999495,
+          "uptime_last_5m": 99.60911174012669,
+          "uptime_last_1d": 98.45455242917697,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "DeepSeek | deepseek/deepseek-v4-flash-20260731",
+          "model_id": "deepseek-v4-flash",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "DeepSeek",
+          "tag": "deepseek/fp8",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.0000000028",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 384000,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "logprobs",
+            "top_logprobs",
+            "tools",
+            "tool_choice",
+            "response_format",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.98523379819524,
+          "supports_implicit_caching": true,
+          "tr_provider_slug": "deepseek",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "Fireworks | deepseek/deepseek-v4-flash-20260731",
+          "model_id": "accounts/fireworks/models/deepseek-v4-flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "Fireworks",
+          "tag": "fireworks",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028",
+            "discount": 0
+          },
+          "quantization": "unknown",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "top_k",
+            "repetition_penalty",
+            "logit_bias",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": -2,
+          "uptime_last_30m": 93.17286652078775,
+          "uptime_last_5m": 99.50372208436724,
+          "uptime_last_1d": 96.04307269053862,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "fireworks",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "GMICloud | deepseek/deepseek-v4-flash-20260731",
+          "model_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "GMICloud",
+          "tag": "gmicloud/fp8",
+          "context_length": 1048575,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "seed",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "logprobs",
+            "top_logprobs",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.95537042546862,
+          "uptime_last_5m": 99.81308411214953,
+          "uptime_last_1d": 99.49795856646,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "gmi",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "SiliconFlow | deepseek/deepseek-v4-flash-20260731",
+          "model_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "SiliconFlow",
+          "tag": "siliconflow/fp8",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000013",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 393216,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "max_tokens",
+            "response_format",
+            "structured_outputs",
+            "tools",
+            "tool_choice",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.86472105481504,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "siliconflow",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "novita | deepseek/deepseek-v4-flash-0731",
+          "model_id": "deepseek/deepseek-v4-flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000014",
+            "completion": "0.00000028",
+            "input_cache_read": "0.000000028"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "atlas-cloud | deepseek/deepseek-v4-flash-0731",
+          "model_id": "deepseek/deepseek-v4-flash-0731",
+          "model_name": "DeepSeek: DeepSeek V4 Flash 0731",
           "provider_name": "atlas-cloud",
           "tag": "atlas-cloud",
           "tr_provider_slug": "atlas-cloud",
@@ -3060,9 +3330,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.64940983989716,
-          "uptime_last_5m": 98.54809437386571,
-          "uptime_last_1d": 99.39332802909753,
+          "uptime_last_30m": 99.85033140902287,
+          "uptime_last_5m": 99.7080291970803,
+          "uptime_last_1d": 99.4076961290076,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -3100,9 +3370,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99893638519873,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.79448898777463,
+          "uptime_last_30m": 99.99236155315086,
+          "uptime_last_5m": 99.98405612244898,
+          "uptime_last_1d": 99.71208893178928,
           "supports_implicit_caching": true,
           "tr_provider_slug": "deepseek",
           "pricing_source": "provider_direct"
@@ -3143,10 +3413,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -5,
+          "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": null,
+          "uptime_last_1d": 67.42556917688266,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -3180,9 +3450,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.62429018426238,
-          "uptime_last_5m": 99.17127071823204,
-          "uptime_last_1d": 75.27540114144011,
+          "uptime_last_30m": 99.51865222623346,
+          "uptime_last_5m": 99.835255354201,
+          "uptime_last_1d": 97.89032682687629,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -3223,9 +3493,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86780557250356,
-          "uptime_last_5m": 99.92079656030776,
-          "uptime_last_1d": 99.58547829321975,
+          "uptime_last_30m": 99.97808259209877,
+          "uptime_last_5m": 99.97508098679292,
+          "uptime_last_1d": 99.51179960520768,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -3268,16 +3538,16 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.57867360208063,
-          "uptime_last_5m": 99.58333333333333,
-          "uptime_last_1d": 95.58834670325508,
+          "uptime_last_30m": 99.52830188679245,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.14981446089548,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | deepseek/deepseek-v4-pro-20260423",
-          "model_id": "deepseek/deepseek-v4-pro",
+          "model_id": "deepseek-ai/DeepSeek-V4-Pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -3305,9 +3575,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.87020648967551,
-          "uptime_last_5m": 97.71428571428571,
-          "uptime_last_1d": 96.8534764576726,
+          "uptime_last_30m": 99.59159859976663,
+          "uptime_last_5m": 98.62068965517241,
+          "uptime_last_1d": 98.64607197749615,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -3348,9 +3618,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.02444208289054,
-          "uptime_last_5m": 97.31800766283524,
-          "uptime_last_1d": 88.13994326624342,
+          "uptime_last_30m": 98.60335195530726,
+          "uptime_last_5m": 99.30795847750865,
+          "uptime_last_1d": 95.25535046993545,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -3390,23 +3660,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | deepseek/deepseek-v4-pro",
-          "model_id": "deepseek/deepseek-v4-pro",
-          "model_name": "DeepSeek: DeepSeek V4 Pro",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000139",
-            "completion": "0.00000279",
-            "input_cache_read": "0.000000301"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | deepseek/deepseek-v4-pro",
           "model_id": "deepseek-v4-pro",
           "model_name": "DeepSeek: DeepSeek V4 Pro",
@@ -3418,6 +3671,23 @@
             "prompt": "0.0000024",
             "completion": "0.0000048",
             "input_cache_read": "0.00000024"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "makora | deepseek/deepseek-v4-pro",
+          "model_id": "deepseek/deepseek-v4-pro",
+          "model_name": "DeepSeek: DeepSeek V4 Pro",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000139",
+            "completion": "0.00000279",
+            "input_cache_read": "0.000000301"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -3535,9 +3805,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69771696762389,
-          "uptime_last_5m": 98.81889763779527,
-          "uptime_last_1d": 99.79693556257307,
+          "uptime_last_30m": 99.65135849963933,
+          "uptime_last_5m": 99.83695652173913,
+          "uptime_last_1d": 99.72903676165626,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3578,9 +3848,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 97.35844787601108,
-          "uptime_last_5m": 98.79100825349425,
-          "uptime_last_1d": 97.5698089206112,
+          "uptime_last_30m": 99.93549530069637,
+          "uptime_last_5m": 99.93505026544675,
+          "uptime_last_1d": 98.10655965630943,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3712,9 +3982,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.52699655000062,
-          "uptime_last_5m": 99.58621727354799,
-          "uptime_last_1d": 99.42934657425559,
+          "uptime_last_30m": 99.26885314393148,
+          "uptime_last_5m": 99.04707451877263,
+          "uptime_last_1d": 99.04318221980893,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3755,9 +4025,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 97.79787210927711,
-          "uptime_last_5m": 97.86127167630057,
-          "uptime_last_1d": 98.24589895176638,
+          "uptime_last_30m": 99.92253669007677,
+          "uptime_last_5m": 99.84220428476057,
+          "uptime_last_1d": 98.75695163567258,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -3897,10 +4167,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -2,
-          "uptime_last_30m": 89.49880668257757,
-          "uptime_last_5m": 95.77464788732394,
-          "uptime_last_1d": 94.35843342747286,
+          "status": 0,
+          "uptime_last_30m": 96.61835748792271,
+          "uptime_last_5m": 99.00990099009901,
+          "uptime_last_1d": 93.27991729128973,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -3973,9 +4243,9 @@
             "stop"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69863957292922,
-          "uptime_last_5m": 99.47368421052632,
-          "uptime_last_1d": 98.41166193364418,
+          "uptime_last_30m": 98.61992545582754,
+          "uptime_last_5m": 98.5665529010239,
+          "uptime_last_1d": 99.54671784012706,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4107,9 +4377,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.63856035024011,
-          "uptime_last_5m": 99.48035487959443,
-          "uptime_last_1d": 99.78405868879334,
+          "uptime_last_30m": 99.7908013218931,
+          "uptime_last_5m": 99.88584474885845,
+          "uptime_last_1d": 99.77381125615425,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4151,9 +4421,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.96939693969397,
-          "uptime_last_5m": 98.31291822615403,
-          "uptime_last_1d": 97.806135770428,
+          "uptime_last_30m": 99.14807780288642,
+          "uptime_last_5m": 99.13725164876188,
+          "uptime_last_1d": 98.36358136031214,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4285,9 +4555,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.72418724621396,
-          "uptime_last_5m": 99.72255548890222,
-          "uptime_last_1d": 99.38985850890936,
+          "uptime_last_30m": 99.48850460478369,
+          "uptime_last_5m": 99.62157880841328,
+          "uptime_last_1d": 99.4787035144488,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4329,9 +4599,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.0009382063201,
-          "uptime_last_5m": 97.31882467308476,
-          "uptime_last_1d": 98.58854698920184,
+          "uptime_last_30m": 98.87938766967649,
+          "uptime_last_5m": 98.71326449563146,
+          "uptime_last_1d": 97.85916112698719,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4564,9 +4834,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.74176888315041,
+          "uptime_last_30m": 98.2367758186398,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.55083368715422,
+          "uptime_last_1d": 99.42749683903804,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4640,9 +4910,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 95.6753307997448,
-          "uptime_last_5m": 96.49005141962888,
-          "uptime_last_1d": 95.1205672019608,
+          "uptime_last_30m": 98.74833897723863,
+          "uptime_last_5m": 97.44756128380085,
+          "uptime_last_1d": 96.37346450128207,
           "supports_implicit_caching": false,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4774,9 +5044,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.92211231404315,
+          "uptime_last_30m": 99.97143401256903,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95875479872053,
+          "uptime_last_1d": 99.96000855905378,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -4818,9 +5088,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.29076524881575,
-          "uptime_last_5m": 97.85901838012524,
-          "uptime_last_1d": 99.27450684010718,
+          "uptime_last_30m": 99.90133836650652,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.4427408274689,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -4842,6 +5112,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "deepinfra | google/gemini-3.5-flash",
+          "model_id": "google/gemini-3.5-flash",
+          "model_name": "Google: Gemini 3.5 Flash",
+          "provider_name": "deepinfra",
+          "tag": "deepinfra",
+          "tr_provider_slug": "deepinfra",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000015",
+            "completion": "0.000009"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "gmi | google/gemini-3.5-flash",
           "model_id": "google/gemini-3.5-flash",
           "model_name": "Google: Gemini 3.5 Flash",
@@ -4853,22 +5139,6 @@
             "prompt": "0.0000015",
             "completion": "0.000009",
             "input_cache_read": "0.00000015"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "deepinfra | google/gemini-3.5-flash",
-          "model_id": "google/gemini-3.5-flash",
-          "model_name": "Google: Gemini 3.5 Flash",
-          "provider_name": "deepinfra",
-          "tag": "deepinfra",
-          "tr_provider_slug": "deepinfra",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.0000015",
-            "completion": "0.000009"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -4969,9 +5239,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89745736109657,
-          "uptime_last_5m": 99.7788969414077,
-          "uptime_last_1d": 99.83479501850903,
+          "uptime_last_30m": 99.74327679811455,
+          "uptime_last_5m": 99.9749184850765,
+          "uptime_last_1d": 99.81350773239689,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -5011,9 +5281,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87128243343946,
-          "uptime_last_5m": 99.79989994997499,
-          "uptime_last_1d": 99.45918005504825,
+          "uptime_last_30m": 99.9381625441696,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.86404874331254,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -5113,9 +5383,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.77849454008472,
-          "uptime_last_5m": 99.67455621301775,
-          "uptime_last_1d": 99.3577656856954,
+          "uptime_last_30m": 99.60291908134793,
+          "uptime_last_5m": 99.86216402481047,
+          "uptime_last_1d": 99.29733380547313,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-ai-studio",
           "pricing_source": "provider_direct"
@@ -5155,9 +5425,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85156340363189,
-          "uptime_last_5m": 99.59471826382533,
-          "uptime_last_1d": 99.59829231950772,
+          "uptime_last_30m": 99.94595258567743,
+          "uptime_last_5m": 99.93895925530292,
+          "uptime_last_1d": 99.72265195918601,
           "supports_implicit_caching": true,
           "tr_provider_slug": "google-vertex",
           "pricing_source": "provider_direct"
@@ -5246,7 +5516,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9906807176593,
+          "uptime_last_1d": 99.98571724725595,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5333,9 +5603,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.91494187694924,
+          "uptime_last_30m": 99.87041036717062,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.29418311490676,
+          "uptime_last_1d": 99.01901011199543,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5350,8 +5620,7 @@
           "pricing": {
             "prompt": "0.0000001",
             "completion": "0.0000003",
-            "discount": 0,
-            "input_cache_read": "0"
+            "discount": 0
           },
           "quantization": "fp8",
           "max_completion_tokens": null,
@@ -5371,9 +5640,9 @@
             "repetition_penalty"
           ],
           "status": -5,
-          "uptime_last_30m": 68.50145339847857,
-          "uptime_last_5m": 82.123575284943,
-          "uptime_last_1d": 78.34224410833627,
+          "uptime_last_30m": 77.45335069121568,
+          "uptime_last_5m": 55.963915803541596,
+          "uptime_last_1d": 71.27269759660506,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -5404,10 +5673,10 @@
             "top_k",
             "repetition_penalty"
           ],
-          "status": -2,
-          "uptime_last_30m": 88.5026357030916,
-          "uptime_last_5m": 91.98423127463863,
-          "uptime_last_1d": 81.65429606459107,
+          "status": -5,
+          "uptime_last_30m": 69.12981581991279,
+          "uptime_last_5m": 81.03806228373702,
+          "uptime_last_1d": 79.98881353876288,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -5445,9 +5714,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.91252298296628,
-          "uptime_last_5m": 99.86151502561972,
-          "uptime_last_1d": 99.40949297978119,
+          "uptime_last_30m": 99.73469084423306,
+          "uptime_last_5m": 99.80539338337503,
+          "uptime_last_1d": 99.59017014936109,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -5515,9 +5784,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99289015286172,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9675580006896,
+          "uptime_last_1d": 99.94113906322156,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5585,7 +5854,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99756434196638,
+          "uptime_last_1d": 99.9988446073976,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -5658,9 +5927,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86028173327209,
-          "uptime_last_5m": 99.75316260413453,
-          "uptime_last_1d": 99.72633384390707,
+          "uptime_last_30m": 99.81346852879281,
+          "uptime_last_5m": 99.87182474947565,
+          "uptime_last_1d": 99.75427106453644,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5700,16 +5969,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.9278329461619,
-          "uptime_last_5m": 98.78934624697337,
-          "uptime_last_1d": 98.00037138824928,
+          "uptime_last_30m": 99.70448871452591,
+          "uptime_last_5m": 99.55801104972376,
+          "uptime_last_1d": 98.63790006341912,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | google/gemma-4-26b-a4b-it-20260403",
-          "model_id": "google/gemma-4-26b-a4b-it",
+          "model_id": "google/gemma-4-26B-A4B-it",
           "model_name": "Google: Gemma 4 26B A4B ",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -5733,10 +6002,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.18344150988544,
-          "uptime_last_5m": 99.79691995261466,
-          "uptime_last_1d": 98.6778445198199,
+          "status": -5,
+          "uptime_last_30m": 76.94986938673965,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.35447261963284,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -5857,9 +6126,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.96662216288385,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98618299472075,
+          "uptime_last_1d": 99.96563599008562,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -5900,9 +6169,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85911524373063,
-          "uptime_last_5m": 99.9290780141844,
-          "uptime_last_1d": 96.2232536468227,
+          "uptime_last_30m": 99.95253915519696,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 97.76723888543519,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -5917,6 +6186,7 @@
           "pricing": {
             "prompt": "0.00000013",
             "completion": "0.00000038",
+            "input_cache_read": "0.00000005",
             "discount": 0
           },
           "quantization": "fp4",
@@ -5940,9 +6210,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.78895532887795,
-          "uptime_last_5m": 99.79144942648593,
-          "uptime_last_1d": 98.63498963967426,
+          "uptime_last_30m": 99.95276334435522,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.63284669897992,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -5981,10 +6251,10 @@
             "structured_outputs",
             "logit_bias"
           ],
-          "status": -2,
-          "uptime_last_30m": 80.60810810810811,
-          "uptime_last_5m": 77.31958762886599,
-          "uptime_last_1d": 93.7505116550573,
+          "status": 0,
+          "uptime_last_30m": 98.50815418828762,
+          "uptime_last_5m": 98.84963023829087,
+          "uptime_last_1d": 92.60930977613295,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6021,9 +6291,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98047256395235,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.78056309740766,
+          "uptime_last_1d": 99.26080882593465,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -6065,16 +6335,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.01708059291254,
-          "uptime_last_5m": 98.31552999178307,
-          "uptime_last_1d": 98.87141833486018,
+          "uptime_last_30m": 99.58256306279443,
+          "uptime_last_5m": 99.34740882917467,
+          "uptime_last_1d": 99.03609037795901,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | google/gemma-4-31b-it-20260402",
-          "model_id": "google/gemma-4-31b-it",
+          "model_id": "google/gemma-4-31B-it",
           "model_name": "Google: Gemma 4 31B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -6100,10 +6370,10 @@
             "tool_choice",
             "tools"
           ],
-          "status": -5,
-          "uptime_last_30m": 66.41597510373444,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 64.76027311815437,
+          "status": 0,
+          "uptime_last_30m": 97.5199291408326,
+          "uptime_last_5m": 97.4947807933194,
+          "uptime_last_1d": 51.12088948758428,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -6138,10 +6408,10 @@
             "min_p",
             "response_format"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.03453689167975,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 93.13688057381296,
+          "status": 0,
+          "uptime_last_30m": 96.06481481481481,
+          "uptime_last_5m": 80,
+          "uptime_last_1d": 92.85226823749146,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -6179,10 +6449,10 @@
             "tool_choice",
             "tools"
           ],
-          "status": 0,
-          "uptime_last_30m": 95.8102766798419,
-          "uptime_last_5m": 97.79411764705883,
-          "uptime_last_1d": 91.6330718165359,
+          "status": -5,
+          "uptime_last_30m": 64.65517241379311,
+          "uptime_last_5m": 54.54545454545454,
+          "uptime_last_1d": 91.53387178927453,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -6314,9 +6584,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.86577181208054,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.85128531973656,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6476,9 +6746,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.28388881802066,
-          "uptime_last_5m": 99.7119095504702,
-          "uptime_last_1d": 99.09734261816475,
+          "uptime_last_30m": 98.98132427843804,
+          "uptime_last_5m": 99.83366600133067,
+          "uptime_last_1d": 99.1418792246626,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6550,7 +6820,7 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
@@ -6620,9 +6890,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.88593118406783,
-          "uptime_last_5m": 97.18849840255591,
-          "uptime_last_1d": 98.57558289759888,
+          "uptime_last_30m": 98.0518435034616,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 97.98519175212034,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -6705,10 +6975,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.90020261240679,
-          "uptime_last_5m": 91.08260325406758,
-          "uptime_last_1d": 98.39015448683752,
+          "status": 0,
+          "uptime_last_30m": 99.44005658375575,
+          "uptime_last_5m": 99.04177845917977,
+          "uptime_last_1d": 97.44187529468144,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6856,9 +7126,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88584474885845,
+          "uptime_last_30m": 99.93373094764745,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84097511571504,
+          "uptime_last_1d": 99.8548903107861,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -6895,9 +7165,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.85078292907585,
-          "uptime_last_5m": 98.56115107913669,
-          "uptime_last_1d": 96.33042555515675,
+          "uptime_last_30m": 98.14340588988476,
+          "uptime_last_5m": 98.53249475890985,
+          "uptime_last_1d": 97.28957401437424,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -6935,9 +7205,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.89752375019467,
-          "uptime_last_5m": 95.73105656350054,
-          "uptime_last_1d": 94.82996010005995,
+          "uptime_last_30m": 98.19200407435702,
+          "uptime_last_5m": 98.06338028169014,
+          "uptime_last_1d": 94.88974434076741,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -6974,9 +7244,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 96.16519174041298,
-          "uptime_last_5m": 95.45454545454545,
-          "uptime_last_1d": 97.92146406496182,
+          "uptime_last_30m": 99.47089947089947,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.17581510524144,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -6998,6 +7268,22 @@
           "quantization": "unknown"
         },
         {
+          "name": "digitalocean | meta-llama/llama-3.3-70b-instruct",
+          "model_id": "llama3.3-70b-instruct",
+          "model_name": "Meta: Llama 3.3 70B Instruct",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
+          "context_length": 131072,
+          "pricing": {
+            "prompt": "0.00000065",
+            "completion": "0.00000065"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "telnyx | meta-llama/llama-3.3-70b-instruct",
           "model_id": "meta-llama/Llama-3.3-70B-Instruct",
           "model_name": "Meta: Llama 3.3 70B Instruct",
@@ -7009,22 +7295,6 @@
             "prompt": "0.0000006",
             "completion": "0.0000006",
             "input_cache_read": "0.0000006"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "digitalocean | meta-llama/llama-3.3-70b-instruct",
-          "model_id": "llama3.3-70b-instruct",
-          "model_name": "Meta: Llama 3.3 70B Instruct",
-          "provider_name": "digitalocean",
-          "tag": "digitalocean",
-          "tr_provider_slug": "digitalocean",
-          "context_length": 131072,
-          "pricing": {
-            "prompt": "0.00000065",
-            "completion": "0.00000065"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7097,9 +7367,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95540691192865,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.68627001671429,
+          "uptime_last_30m": 99.95779318661441,
+          "uptime_last_5m": 99.96478873239437,
+          "uptime_last_1d": 99.85564602816889,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -7182,9 +7452,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.18738049713193,
+          "uptime_last_30m": 98.82267441860465,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.19646294663372,
+          "uptime_last_1d": 99.31198578103948,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7328,7 +7598,7 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
@@ -7395,7 +7665,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9935098650052,
+          "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7465,9 +7735,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.31892212022505,
+          "uptime_last_1d": 99.1825613079019,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7539,7 +7809,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.22202274087373,
+          "uptime_last_1d": 74.37295528898582,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7612,8 +7882,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.97357433539453,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.96060277750418,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -7651,9 +7921,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.82544729131601,
+          "uptime_last_1d": 99.92429977289932,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -7695,16 +7965,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.82300884955752,
+          "uptime_last_30m": 99.61389961389962,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.89858553509474,
+          "uptime_last_1d": 99.88885639075752,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | minimax/minimax-m2.5-20260211",
-          "model_id": "minimax/minimax-m2.5",
+          "model_id": "MiniMaxAI/MiniMax-M2.5",
           "model_name": "MiniMax: MiniMax M2.5",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -7732,9 +8002,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.96851385390428,
+          "uptime_last_1d": 99.98104265402844,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -7751,23 +8021,6 @@
             "prompt": "0.0000003",
             "completion": "0.0000012",
             "input_cache_read": "0.00000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "chutes | minimax/minimax-m2.5",
-          "model_id": "MiniMaxAI/MiniMax-M2.5-TEE",
-          "model_name": "MiniMax: MiniMax M2.5",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000015",
-            "completion": "0.0000012",
-            "input_cache_read": "0.000000075"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -7891,9 +8144,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.82387210405093,
-          "uptime_last_5m": 99.92138364779875,
-          "uptime_last_1d": 99.09088198080373,
+          "uptime_last_30m": 99.76303317535546,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.79120236075002,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7933,9 +8186,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.951703481842,
-          "uptime_last_5m": 95.52715654952077,
-          "uptime_last_1d": 96.21604007983382,
+          "uptime_last_30m": 98.77300613496932,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 97.1254805209708,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -7968,9 +8221,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.93617021276596,
+          "uptime_last_30m": 96.01873536299766,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.50009177342976,
+          "uptime_last_1d": 97.7545870578675,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -8002,9 +8255,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 98.83091956028616,
-          "uptime_last_5m": 98.54014598540147,
-          "uptime_last_1d": 98.41647863095105,
+          "uptime_last_30m": 97.45179063360881,
+          "uptime_last_5m": 98.10126582278481,
+          "uptime_last_1d": 98.04645129547005,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -8036,9 +8289,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 98.50746268656717,
-          "uptime_last_5m": 98.46153846153847,
-          "uptime_last_1d": 96.77050040547631,
+          "uptime_last_30m": 97.6878612716763,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 97.69471176161154,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -8076,9 +8329,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.4722474977252,
-          "uptime_last_5m": 99.55947136563876,
-          "uptime_last_1d": 99.14915045277351,
+          "uptime_last_30m": 98.9,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.30371532096696,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8201,9 +8454,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94863893168979,
+          "uptime_last_30m": 99.54692556634305,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.08113302568424,
+          "uptime_last_1d": 99.07230350645236,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -8234,9 +8487,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.0933512424446,
-          "uptime_last_5m": 98.78048780487805,
-          "uptime_last_1d": 99.33527413876759,
+          "uptime_last_30m": 99.60042621204049,
+          "uptime_last_5m": 99.54682779456193,
+          "uptime_last_1d": 99.3460468445173,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -8290,9 +8543,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59758551307847,
-          "uptime_last_5m": 99.77859778597787,
-          "uptime_last_1d": 98.48819326703551,
+          "uptime_last_30m": 98.98826386078511,
+          "uptime_last_5m": 99.55089820359282,
+          "uptime_last_1d": 98.5934307716486,
           "supports_implicit_caching": false,
           "tr_provider_slug": "minimax",
           "pricing_source": "provider_direct"
@@ -8329,9 +8582,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.61622807017544,
-          "uptime_last_5m": 99.66029723991508,
-          "uptime_last_1d": 99.56369865564369,
+          "uptime_last_30m": 99.61227428824637,
+          "uptime_last_5m": 99.83093829247676,
+          "uptime_last_1d": 99.57474317612925,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -8373,9 +8626,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.6591390261115,
-          "uptime_last_5m": 97.07602339181285,
-          "uptime_last_1d": 97.08092440019534,
+          "uptime_last_30m": 99.19011082693947,
+          "uptime_last_5m": 99.75728155339806,
+          "uptime_last_1d": 97.69023282226009,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -8415,9 +8668,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.81678020795984,
-          "uptime_last_5m": 99.58890030832477,
-          "uptime_last_1d": 98.53911038694731,
+          "uptime_last_30m": 99.95957145744896,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.97112707020372,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -8441,7 +8694,7 @@
         },
         {
           "name": "siliconflow | minimax/minimax-m3",
-          "model_id": "minimax/minimax-m3",
+          "model_id": "MiniMaxAI/MiniMax-M3",
           "model_name": "MiniMax: MiniMax M3",
           "provider_name": "siliconflow",
           "tag": "siliconflow",
@@ -8587,9 +8840,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.85729386892177,
+          "uptime_last_30m": 99.5,
+          "uptime_last_5m": 98.79518072289156,
+          "uptime_last_1d": 99.83709564812659,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8659,7 +8912,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98255769587162,
+          "uptime_last_1d": 99.97932158247794,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8727,9 +8980,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.73509933774835,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.85223891280562,
+          "uptime_last_1d": 99.75158317458683,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8797,9 +9050,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90159417437512,
-          "uptime_last_5m": 99.85785358919688,
-          "uptime_last_1d": 99.91442682095641,
+          "uptime_last_30m": 99.94522048753765,
+          "uptime_last_5m": 99.9322033898305,
+          "uptime_last_1d": 99.89707416468599,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8869,7 +9122,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98449323905223,
+          "uptime_last_1d": 99.99745572969672,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -8941,7 +9194,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94704324801413,
+          "uptime_last_1d": 99.99847474947761,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -9009,9 +9262,9 @@
             "top_logprobs"
           ],
           "status": -5,
-          "uptime_last_30m": 77.69896193771626,
-          "uptime_last_5m": 73.82198952879581,
-          "uptime_last_1d": 51.14539839554624,
+          "uptime_last_30m": 50.7631160572337,
+          "uptime_last_5m": 84.09728718428437,
+          "uptime_last_1d": 61.93124197959272,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9113,7 +9366,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99492327596089,
+          "uptime_last_1d": 99.99619036561606,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9184,9 +9437,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86925825852,
-          "uptime_last_5m": 99.92970123022847,
-          "uptime_last_1d": 99.98026461993639,
+          "uptime_last_30m": 99.88018212317277,
+          "uptime_last_5m": 99.90403071017275,
+          "uptime_last_1d": 99.96872639620182,
           "supports_implicit_caching": false,
           "tr_provider_slug": "mistral",
           "pricing_source": "provider_direct"
@@ -9257,9 +9510,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.57004657828735,
-          "uptime_last_5m": 99.38837920489296,
-          "uptime_last_1d": 99.55941907236027,
+          "uptime_last_30m": 99.8269040553907,
+          "uptime_last_5m": 99.76771196283391,
+          "uptime_last_1d": 99.56948443541988,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -9396,9 +9649,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.71426154626967,
-          "uptime_last_5m": 98.68852459016394,
-          "uptime_last_1d": 98.9706466108911,
+          "uptime_last_30m": 99.7876256548209,
+          "uptime_last_5m": 99.34086629001884,
+          "uptime_last_1d": 99.04048464319447,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9468,10 +9721,10 @@
             "response_format",
             "structured_outputs"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.11504424778761,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.70281111453953,
+          "status": -2,
+          "uptime_last_30m": 94.6969696969697,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.07882983474765,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -9560,9 +9813,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.96651038178165,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.84613130128956,
+          "uptime_last_1d": 99.82544168543231,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9596,9 +9849,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.94506500640908,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95310556684495,
+          "uptime_last_1d": 99.96915103652518,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -9639,16 +9892,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.90558879322924,
-          "uptime_last_5m": 99.60500329163924,
-          "uptime_last_1d": 99.81536463587994,
+          "uptime_last_30m": 95.26411657559198,
+          "uptime_last_5m": 98.18181818181819,
+          "uptime_last_1d": 99.69119505329435,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | moonshotai/kimi-k2.5-0127",
-          "model_id": "moonshotai/kimi-k2.5",
+          "model_id": "moonshotai/Kimi-K2.5",
           "model_name": "MoonshotAI: Kimi K2.5",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/int4",
@@ -9675,10 +9928,10 @@
             "structured_outputs",
             "max_tokens"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.88408037094281,
+          "status": -2,
+          "uptime_last_30m": 81.11111111111111,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.96161928261299,
+          "uptime_last_1d": 97.0087969538906,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -9717,17 +9970,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "chutes | moonshotai/kimi-k2.5",
-          "model_id": "moonshotai/Kimi-K2.5-TEE",
+          "name": "digitalocean | moonshotai/kimi-k2.5",
+          "model_id": "kimi-k2.5",
           "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
+          "provider_name": "digitalocean",
+          "tag": "digitalocean",
+          "tr_provider_slug": "digitalocean",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000044",
-            "completion": "0.000002",
-            "input_cache_read": "0.00000022"
+            "prompt": "0.000000375",
+            "completion": "0.000002025",
+            "input_cache_read": "0.000000203"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9745,23 +9998,6 @@
             "prompt": "0.0000006",
             "completion": "0.000003",
             "input_cache_read": "0.0000004"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "digitalocean | moonshotai/kimi-k2.5",
-          "model_id": "kimi-k2.5",
-          "model_name": "MoonshotAI: Kimi K2.5",
-          "provider_name": "digitalocean",
-          "tag": "digitalocean",
-          "tr_provider_slug": "digitalocean",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000375",
-            "completion": "0.000002025",
-            "input_cache_read": "0.000000203"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -9853,9 +10089,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.38398357289527,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 92.81882955728125,
+          "uptime_last_1d": 95.25162615542622,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -9896,9 +10132,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.80378619962937,
+          "uptime_last_30m": 98.46153846153847,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.77683654415448,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -9941,7 +10177,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 0,
+          "uptime_last_1d": 5.346985210466439,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -9975,9 +10211,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.85229052735717,
+          "uptime_last_30m": 99.46737683089214,
+          "uptime_last_5m": 93.65079365079364,
+          "uptime_last_1d": 99.76520374035903,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -10016,9 +10252,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49874686716792,
+          "uptime_last_30m": 99.40387481371089,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.91298326459828,
+          "uptime_last_1d": 99.80327662454164,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -10060,16 +10296,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.86130374479889,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.71343173204326,
+          "uptime_last_30m": 99.8389694041868,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.72246511804738,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | moonshotai/kimi-k2.6-20260420",
-          "model_id": "moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/Kimi-K2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -10097,9 +10333,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 98.88888888888889,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.30195983229557,
+          "uptime_last_1d": 93.6207343412527,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -10141,7 +10377,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 94.98940910086918,
+          "uptime_last_1d": 97.17706177948567,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -10231,23 +10467,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "telnyx | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/Kimi-K2.6",
-          "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "telnyx",
-          "tag": "telnyx",
-          "tr_provider_slug": "telnyx",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.000000665",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000008"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "digitalocean | moonshotai/kimi-k2.6",
           "model_id": "kimi-k2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
@@ -10265,17 +10484,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.6",
-          "model_id": "moonshotai/kimi-k2.6",
+          "name": "telnyx | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/Kimi-K2.6",
           "model_name": "MoonshotAI: Kimi K2.6",
-          "provider_name": "cloudflare-workers-ai",
-          "tag": "cloudflare-workers-ai",
-          "tr_provider_slug": "cloudflare-workers-ai",
+          "provider_name": "telnyx",
+          "tag": "telnyx",
+          "tr_provider_slug": "telnyx",
           "context_length": 262144,
           "pricing": {
-            "prompt": "0.00000095",
+            "prompt": "0.000000665",
             "completion": "0.000004",
-            "input_cache_read": "0.00000016"
+            "input_cache_read": "0.00000008"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10288,6 +10507,23 @@
           "provider_name": "atlas-cloud",
           "tag": "atlas-cloud",
           "tr_provider_slug": "atlas-cloud",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.6",
+          "model_id": "moonshotai/kimi-k2.6",
+          "model_name": "MoonshotAI: Kimi K2.6",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000095",
@@ -10383,9 +10619,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.30555555555556,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.87502297371806,
+          "uptime_last_30m": 99.5766299745978,
+          "uptime_last_5m": 99.56331877729258,
+          "uptime_last_1d": 99.8926208015982,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -10428,7 +10664,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.59036144578313,
+          "uptime_last_1d": 98.5962014863749,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -10464,7 +10700,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.96593309259384,
+          "uptime_last_1d": 99.82818887374845,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -10498,9 +10734,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9860594795539,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.99428832533698,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -10541,9 +10777,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59100204498978,
-          "uptime_last_5m": 99.29078014184397,
-          "uptime_last_1d": 99.89916495982354,
+          "uptime_last_30m": 99.6124031007752,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.83319076133448,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -10585,16 +10821,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.38271604938271,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.56620532947737,
+          "uptime_last_1d": 99.84711605281446,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | moonshotai/kimi-k2.7-code-20260612",
-          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/Kimi-K2.7-Code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -10622,7 +10858,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95322974588163,
+          "uptime_last_1d": 99.92010282419147,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -10662,9 +10898,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 96.06114050558496,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.52421835873221,
+          "uptime_last_1d": 99.52338923212709,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -10721,23 +10957,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.7-code",
-          "model_id": "moonshotai/kimi-k2.7-code",
-          "model_name": "MoonshotAI: Kimi K2.7 Code",
-          "provider_name": "cloudflare-workers-ai",
-          "tag": "cloudflare-workers-ai",
-          "tr_provider_slug": "cloudflare-workers-ai",
-          "context_length": 262144,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000019"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "atlas-cloud | moonshotai/kimi-k2.7-code",
           "model_id": "moonshotai/kimi-k2.7-code",
           "model_name": "MoonshotAI: Kimi K2.7 Code",
@@ -10749,6 +10968,23 @@
             "prompt": "0.00000095",
             "completion": "0.000004",
             "input_cache_read": "0.00000016"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k2.7-code",
+          "model_id": "moonshotai/kimi-k2.7-code",
+          "model_name": "MoonshotAI: Kimi K2.7 Code",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
+          "context_length": 262144,
+          "pricing": {
+            "prompt": "0.00000095",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000019"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -10840,10 +11076,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 80.62481225593271,
-          "uptime_last_5m": 53.43511450381679,
-          "uptime_last_1d": 89.7588649702623,
+          "status": -5,
+          "uptime_last_30m": 75.61192701379618,
+          "uptime_last_5m": 91.61676646706587,
+          "uptime_last_1d": 87.61406800453976,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -10882,10 +11118,10 @@
             "structured_outputs",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 84.76144109055501,
-          "uptime_last_5m": 72.42647058823529,
-          "uptime_last_1d": 92.8341324941259,
+          "status": 0,
+          "uptime_last_30m": 99.6560619088564,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 88.10070410793756,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -10920,9 +11156,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90917544276971,
-          "uptime_last_5m": 99.87623762376238,
-          "uptime_last_1d": 98.9546190145921,
+          "uptime_last_30m": 99.97761432683083,
+          "uptime_last_5m": 99.97447677386421,
+          "uptime_last_1d": 99.565474239739,
           "supports_implicit_caching": false,
           "tr_provider_slug": "kimi",
           "pricing_source": "provider_direct"
@@ -10963,9 +11199,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 86.68745896257387,
-          "uptime_last_5m": 82.30088495575221,
-          "uptime_last_1d": 92.59082976360463,
+          "uptime_last_30m": 94.78114478114477,
+          "uptime_last_5m": 94.41489361702128,
+          "uptime_last_1d": 89.08920187793427,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -10989,28 +11225,11 @@
         },
         {
           "name": "siliconflow | moonshotai/kimi-k3",
-          "model_id": "moonshotai/kimi-k3",
+          "model_id": "moonshotai/Kimi-K3",
           "model_name": "MoonshotAI: Kimi K3",
           "provider_name": "siliconflow",
           "tag": "siliconflow",
           "tr_provider_slug": "siliconflow",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015",
-            "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
-          "name": "gmi | moonshotai/kimi-k3",
-          "model_id": "moonshotai/kimi-k3",
-          "model_name": "MoonshotAI: Kimi K3",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000003",
@@ -11039,6 +11258,23 @@
           "quantization": "unknown"
         },
         {
+          "name": "gmi | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
           "name": "baseten | moonshotai/kimi-k3",
           "model_id": "moonshotai/Kimi-K3",
           "model_name": "MoonshotAI: Kimi K3",
@@ -11050,6 +11286,22 @@
             "prompt": "0.000003",
             "completion": "0.000015",
             "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "nebius | moonshotai/kimi-k3",
+          "model_id": "moonshotai/Kimi-K3",
+          "model_name": "MoonshotAI: Kimi K3",
+          "provider_name": "nebius",
+          "tag": "nebius",
+          "tr_provider_slug": "nebius",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.000003",
+            "completion": "0.000015"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11090,23 +11342,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "cloudflare-workers-ai | moonshotai/kimi-k3",
-          "model_id": "moonshotai/kimi-k3",
-          "model_name": "MoonshotAI: Kimi K3",
-          "provider_name": "cloudflare-workers-ai",
-          "tag": "cloudflare-workers-ai",
-          "tr_provider_slug": "cloudflare-workers-ai",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000003",
-            "completion": "0.000015",
-            "input_cache_read": "0.0000003"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "atlas-cloud | moonshotai/kimi-k3",
           "model_id": "moonshotai/kimi-k3",
           "model_name": "MoonshotAI: Kimi K3",
@@ -11124,17 +11359,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "nebius | moonshotai/kimi-k3",
-          "model_id": "moonshotai/Kimi-K3",
+          "name": "cloudflare-workers-ai | moonshotai/kimi-k3",
+          "model_id": "moonshotai/kimi-k3",
           "model_name": "MoonshotAI: Kimi K3",
-          "provider_name": "nebius",
-          "tag": "nebius",
-          "tr_provider_slug": "nebius",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.000003",
             "completion": "0.000015",
-            "input_cache_read": "0"
+            "input_cache_read": "0.0000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11347,7 +11582,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98560368545652,
+          "uptime_last_1d": 99.99711962900821,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -11387,9 +11622,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 98.5207100591716,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.87990238800766,
+          "uptime_last_30m": 99.68701095461658,
+          "uptime_last_5m": 99.31972789115646,
+          "uptime_last_1d": 96.24162986180367,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -11428,9 +11663,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.92357886073717,
+          "uptime_last_1d": 99.93976508382693,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -11457,8 +11692,7 @@
       },
       "pricing": {
         "prompt": "0.0000003",
-        "completion": "0.0000009",
-        "input_cache_read": "0"
+        "completion": "0.0000009"
       },
       "top_provider": {
         "context_length": 262144,
@@ -11477,8 +11711,7 @@
           "pricing": {
             "prompt": "0.0000003",
             "completion": "0.0000009",
-            "discount": 0,
-            "input_cache_read": "0"
+            "discount": 0
           },
           "quantization": "fp4",
           "max_completion_tokens": null,
@@ -11502,7 +11735,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.82446516730664,
+          "uptime_last_1d": 99.36569773249425,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -11592,9 +11825,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.88143176733782,
+          "uptime_last_30m": 98.13084112149532,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.00916656202556,
+          "uptime_last_1d": 96.86321763128231,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -11643,8 +11876,7 @@
           "context_length": 512288,
           "pricing": {
             "prompt": "0.000001",
-            "completion": "0.000003",
-            "input_cache_read": "0"
+            "completion": "0.000003"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -11724,7 +11956,7 @@
       "top_provider": {
         "context_length": 8191,
         "max_completion_tokens": 4096,
-        "is_moderated": false
+        "is_moderated": true
       },
       "per_request_limits": null,
       "endpoints": [
@@ -11901,10 +12133,10 @@
             "temperature",
             "top_p"
           ],
-          "status": 0,
-          "uptime_last_30m": 99.65914088843279,
-          "uptime_last_5m": 99.84744469870328,
-          "uptime_last_1d": 92.17749090171843,
+          "status": -2,
+          "uptime_last_30m": 89.6207405275089,
+          "uptime_last_5m": 94.3549271073112,
+          "uptime_last_1d": 87.75951269822973,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12005,9 +12237,9 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 95.75601402199781,
-          "uptime_last_5m": 94.8937746381988,
-          "uptime_last_1d": 97.66776354194143,
+          "uptime_last_30m": 98.21770108661384,
+          "uptime_last_5m": 97.95918367346938,
+          "uptime_last_1d": 97.02528433557065,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12092,9 +12324,9 @@
             "top_p"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8631712374189,
-          "uptime_last_5m": 99.8027397260274,
-          "uptime_last_1d": 99.55944186263204,
+          "uptime_last_30m": 99.83154742407936,
+          "uptime_last_5m": 99.8478856099787,
+          "uptime_last_1d": 99.42632589499375,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12185,9 +12417,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99276568038776,
+          "uptime_last_30m": 99.93179880647911,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.94552020059741,
+          "uptime_last_1d": 99.94358373475676,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12311,9 +12543,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.98310473528193,
-          "uptime_last_5m": 99.98685637301612,
-          "uptime_last_1d": 99.98371100241197,
+          "uptime_last_30m": 99.98413474047608,
+          "uptime_last_5m": 99.99526851194702,
+          "uptime_last_1d": 99.97118338032624,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12898,7 +13130,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.74787308318895,
+          "uptime_last_1d": 99.84870765228212,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -12934,7 +13166,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.74787308318895,
+          "uptime_last_1d": 99.84870765228212,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13075,9 +13307,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70618335479186,
-          "uptime_last_5m": 99.75550122249389,
-          "uptime_last_1d": 98.67522227287745,
+          "uptime_last_30m": 99.59154034673686,
+          "uptime_last_5m": 99.78914074855034,
+          "uptime_last_1d": 89.27990882307981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13141,9 +13373,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70618335479186,
-          "uptime_last_5m": 99.75550122249389,
-          "uptime_last_1d": 98.67522227287745,
+          "uptime_last_30m": 99.59154034673686,
+          "uptime_last_5m": 99.78914074855034,
+          "uptime_last_1d": 89.27990882307981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13199,9 +13431,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.70618335479186,
-          "uptime_last_5m": 99.75550122249389,
-          "uptime_last_1d": 98.67522227287745,
+          "uptime_last_30m": 99.59154034673686,
+          "uptime_last_5m": 99.78914074855034,
+          "uptime_last_1d": 89.27990882307981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13304,9 +13536,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.12566383888544,
-          "uptime_last_5m": 98.38975082275505,
-          "uptime_last_1d": 95.19093014011382,
+          "uptime_last_30m": 99.15809167446211,
+          "uptime_last_5m": 99.46788990825688,
+          "uptime_last_1d": 96.46654926430226,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13340,9 +13572,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.12566383888544,
-          "uptime_last_5m": 98.38975082275505,
-          "uptime_last_1d": 95.19093014011382,
+          "uptime_last_30m": 99.15809167446211,
+          "uptime_last_5m": 99.46788990825688,
+          "uptime_last_1d": 96.46654926430226,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13376,9 +13608,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 97.12566383888544,
-          "uptime_last_5m": 98.38975082275505,
-          "uptime_last_1d": 95.19093014011382,
+          "uptime_last_30m": 99.15809167446211,
+          "uptime_last_5m": 99.46788990825688,
+          "uptime_last_1d": 96.46654926430226,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13480,10 +13712,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 97.7802954981618,
-          "uptime_last_5m": 97.7957260642773,
-          "uptime_last_1d": 97.27443603147685,
+          "status": -2,
+          "uptime_last_30m": 87.8229921374226,
+          "uptime_last_5m": 84.50954809631124,
+          "uptime_last_1d": 94.60824718454161,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13516,10 +13748,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": 97.7802954981618,
-          "uptime_last_5m": 97.7957260642773,
-          "uptime_last_1d": 97.27443603147685,
+          "status": -2,
+          "uptime_last_30m": 87.8229921374226,
+          "uptime_last_5m": 84.50954809631124,
+          "uptime_last_1d": 94.60824718454161,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13656,7 +13888,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.33408374606033,
+          "uptime_last_1d": 99.82342554443791,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13718,7 +13950,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.33408374606033,
+          "uptime_last_1d": 99.82342554443791,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13841,9 +14073,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58381887797569,
-          "uptime_last_5m": 99.9245283018868,
-          "uptime_last_1d": 99.31793278070464,
+          "uptime_last_30m": 98.73124448367166,
+          "uptime_last_5m": 97.75280898876404,
+          "uptime_last_1d": 99.28099758554819,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13907,9 +14139,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58381887797569,
-          "uptime_last_5m": 99.9245283018868,
-          "uptime_last_1d": 99.31793278070464,
+          "uptime_last_30m": 98.73124448367166,
+          "uptime_last_5m": 97.75280898876404,
+          "uptime_last_1d": 99.28099758554819,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -13965,9 +14197,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.58381887797569,
-          "uptime_last_5m": 99.9245283018868,
-          "uptime_last_1d": 99.31793278070464,
+          "uptime_last_30m": 98.73124448367166,
+          "uptime_last_5m": 97.75280898876404,
+          "uptime_last_1d": 99.28099758554819,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14319,9 +14551,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69180425711448,
-          "uptime_last_5m": 99.6846899451127,
-          "uptime_last_1d": 99.89428967829609,
+          "uptime_last_30m": 99.6248778517663,
+          "uptime_last_5m": 99.71146136641768,
+          "uptime_last_1d": 99.50172729813019,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14387,9 +14619,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69180425711448,
-          "uptime_last_5m": 99.6846899451127,
-          "uptime_last_1d": 99.89428967829609,
+          "uptime_last_30m": 99.6248778517663,
+          "uptime_last_5m": 99.71146136641768,
+          "uptime_last_1d": 99.50172729813019,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14446,9 +14678,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69180425711448,
-          "uptime_last_5m": 99.6846899451127,
-          "uptime_last_1d": 99.89428967829609,
+          "uptime_last_30m": 99.6248778517663,
+          "uptime_last_5m": 99.71146136641768,
+          "uptime_last_1d": 99.50172729813019,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14609,9 +14841,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.89750740805299,
-          "uptime_last_5m": 99.88502443230813,
-          "uptime_last_1d": 97.39028269729563,
+          "uptime_last_30m": 95.1423487544484,
+          "uptime_last_5m": 95.38745387453874,
+          "uptime_last_1d": 87.84343421072538,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14677,9 +14909,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.89750740805299,
-          "uptime_last_5m": 99.88502443230813,
-          "uptime_last_1d": 97.39028269729563,
+          "uptime_last_30m": 95.1423487544484,
+          "uptime_last_5m": 95.38745387453874,
+          "uptime_last_1d": 87.84343421072538,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14736,9 +14968,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.89750740805299,
-          "uptime_last_5m": 99.88502443230813,
-          "uptime_last_1d": 97.39028269729563,
+          "uptime_last_30m": 95.1423487544484,
+          "uptime_last_5m": 95.38745387453874,
+          "uptime_last_1d": 87.84343421072538,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14921,9 +15153,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88699899947031,
-          "uptime_last_5m": 99.9874419188748,
-          "uptime_last_1d": 97.15805776201935,
+          "uptime_last_30m": 97.25063560574706,
+          "uptime_last_5m": 96.89229459344402,
+          "uptime_last_1d": 98.93321115721758,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -14989,9 +15221,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88699899947031,
-          "uptime_last_5m": 99.9874419188748,
-          "uptime_last_1d": 97.15805776201935,
+          "uptime_last_30m": 97.25063560574706,
+          "uptime_last_5m": 96.89229459344402,
+          "uptime_last_1d": 98.93321115721758,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -15048,9 +15280,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.88699899947031,
-          "uptime_last_5m": 99.9874419188748,
-          "uptime_last_1d": 97.15805776201935,
+          "uptime_last_30m": 97.25063560574706,
+          "uptime_last_5m": 96.89229459344402,
+          "uptime_last_1d": 98.93321115721758,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
           "pricing_source": "provider_direct"
@@ -15174,7 +15406,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.98056349135493,
+          "uptime_last_1d": 99.97567526943655,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -15215,9 +15447,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.9774307927137,
-          "uptime_last_5m": 99.99272330362015,
-          "uptime_last_1d": 99.80392859008806,
+          "uptime_last_30m": 99.97754791115388,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.65995368133774,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15258,9 +15490,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94256174612292,
-          "uptime_last_5m": 99.95619798510732,
-          "uptime_last_1d": 99.76947970937312,
+          "uptime_last_30m": 99.95726495726495,
+          "uptime_last_5m": 99.72144846796658,
+          "uptime_last_1d": 99.82954886123223,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15275,8 +15507,7 @@
           "pricing": {
             "prompt": "0.00000015",
             "completion": "0.0000006",
-            "discount": 0,
-            "input_cache_read": "0"
+            "discount": 0
           },
           "quantization": "fp4",
           "max_completion_tokens": null,
@@ -15301,9 +15532,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97984480499849,
-          "uptime_last_5m": 99.89241527703066,
-          "uptime_last_1d": 98.5185029272121,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.02274002984544,
           "supports_implicit_caching": false,
           "tr_provider_slug": "nebius",
           "pricing_source": "provider_direct"
@@ -15343,10 +15574,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 1.7142857142857144,
-          "uptime_last_5m": 1.8181818181818181,
-          "uptime_last_1d": 89.11172443847258,
+          "status": 0,
+          "uptime_last_30m": 98.93509127789046,
+          "uptime_last_5m": 99.94353472614343,
+          "uptime_last_1d": 77.51609369070039,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15388,10 +15619,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.9940786691104,
-          "uptime_last_5m": 95.11986301369863,
-          "uptime_last_1d": 93.9597587728831,
+          "status": 0,
+          "uptime_last_30m": 97.13028505835088,
+          "uptime_last_5m": 98.28080229226362,
+          "uptime_last_1d": 89.66214716623287,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -15424,9 +15655,9 @@
             "reasoning_effort"
           ],
           "status": -5,
-          "uptime_last_30m": 70.82119205298014,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 73.91457573688972,
+          "uptime_last_30m": 74.52352590827874,
+          "uptime_last_5m": 77.40784780023782,
+          "uptime_last_1d": 70.65996511045476,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -15466,9 +15697,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.53929979132855,
-          "uptime_last_5m": 99.25233644859813,
-          "uptime_last_1d": 96.36360991716303,
+          "uptime_last_30m": 97.94442329653597,
+          "uptime_last_5m": 97.5609756097561,
+          "uptime_last_1d": 88.5369837718831,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -15623,9 +15854,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.93418346359523,
-          "uptime_last_5m": 99.94058229352348,
-          "uptime_last_1d": 99.88402695847802,
+          "uptime_last_30m": 99.96938463108481,
+          "uptime_last_5m": 99.9221183800623,
+          "uptime_last_1d": 99.7676158608345,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -15667,7 +15898,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": null,
+          "uptime_last_1d": 39.39393939393939,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -15705,10 +15936,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 90.10043041606886,
-          "uptime_last_5m": 88.61386138613861,
-          "uptime_last_1d": 88.31079824677911,
+          "status": 0,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 86.36964413142627,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -15750,10 +15981,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 77.29864575908766,
-          "uptime_last_5m": 74.5819397993311,
-          "uptime_last_1d": 80.84066292415626,
+          "status": -2,
+          "uptime_last_30m": 93.80413057961358,
+          "uptime_last_5m": 83.73590982286635,
+          "uptime_last_1d": 80.63619547820086,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -15786,9 +16017,9 @@
             "reasoning_effort"
           ],
           "status": -2,
-          "uptime_last_30m": 90.78812691914023,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 92.75101600255124,
+          "uptime_last_30m": 93.48411416262789,
+          "uptime_last_5m": 82.35294117647058,
+          "uptime_last_1d": 92.92090287102755,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -15828,7 +16059,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 91.43835616438356,
+          "uptime_last_1d": 95.68345323741008,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -16101,8 +16332,8 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "openai",
@@ -16343,7 +16574,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 78.52723522989203,
+          "uptime_last_1d": 82.19450848878643,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16411,7 +16642,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.63032103215839,
+          "uptime_last_1d": 99.88690771227556,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -16482,9 +16713,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60191082802548,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.6239837398374,
+          "uptime_last_1d": 99.73419601388613,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16555,9 +16786,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89241527703066,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.206524286837,
+          "uptime_last_1d": 99.02605524130752,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16627,9 +16858,9 @@
             "tools"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89195029713667,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.16585439004274,
+          "uptime_last_30m": 98.78869448183042,
+          "uptime_last_5m": 98.85057471264368,
+          "uptime_last_1d": 99.31682137590006,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -16666,10 +16897,10 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -5,
-          "uptime_last_30m": 63.93034825870647,
+          "status": 0,
+          "uptime_last_30m": 99.74489795918367,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 94.39729471569262,
+          "uptime_last_1d": 93.32652242127924,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -16709,9 +16940,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.81232405380044,
-          "uptime_last_5m": 99.09638554216868,
-          "uptime_last_1d": 99.7186032488534,
+          "uptime_last_30m": 99.86033519553072,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.82126414992146,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -16799,8 +17030,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.91316213869247,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.8872155509852,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -16838,9 +17069,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 99.00990099009901,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.99749373433583,
+          "uptime_last_1d": 99.16810097532989,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -16876,7 +17107,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.81617647058823,
+          "uptime_last_1d": 99.8019801980198,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -16980,9 +17211,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 96.25413147264047,
-          "uptime_last_5m": 95.84295612009238,
-          "uptime_last_1d": 99.72102770671167,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.79792063259629,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17119,9 +17350,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.96961673683754,
+          "uptime_last_30m": 99.97237187456831,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86018556816848,
+          "uptime_last_1d": 99.80157188101113,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17201,8 +17432,8 @@
         "completion": "0.00000027"
       },
       "top_provider": {
-        "context_length": 160000,
-        "max_completion_tokens": 32768,
+        "context_length": 262144,
+        "max_completion_tokens": 262144,
         "is_moderated": false
       },
       "per_request_limits": null,
@@ -17238,9 +17469,9 @@
             "structured_outputs"
           ],
           "status": -2,
-          "uptime_last_30m": 89.95633187772926,
-          "uptime_last_5m": 95,
-          "uptime_last_1d": 88.21841684032496,
+          "uptime_last_30m": 88.76811594202898,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 86.33210934312525,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17324,9 +17555,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.85496183206108,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.57983193277312,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.72031324916094,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17368,7 +17599,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.88686701297046,
+          "uptime_last_1d": 99.96665819890765,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -17455,9 +17686,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.95569339831634,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.80048678883195,
+          "uptime_last_30m": 96.23312011371713,
+          "uptime_last_5m": 97.27891156462584,
+          "uptime_last_1d": 99.36245517262932,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17494,9 +17725,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.80881202746154,
+          "uptime_last_1d": 99.78246960972488,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17538,7 +17769,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.88780497081028,
+          "uptime_last_1d": 99.9035814419649,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -17707,10 +17938,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": -5,
-          "uptime_last_30m": 58.60597439544808,
-          "uptime_last_5m": 82.5,
-          "uptime_last_1d": 90.0524422077464,
+          "status": -2,
+          "uptime_last_30m": 90.3436018957346,
+          "uptime_last_5m": 88.73239436619718,
+          "uptime_last_1d": 78.50723914128807,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -17748,9 +17979,9 @@
             "top_logprobs"
           ],
           "status": -2,
-          "uptime_last_30m": 91.87705817782657,
-          "uptime_last_5m": 92.22222222222223,
-          "uptime_last_1d": 92.69140523159815,
+          "uptime_last_30m": 90.45996592844975,
+          "uptime_last_5m": 92.92929292929293,
+          "uptime_last_1d": 93.8476046774802,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17790,9 +18021,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 98.70276367738296,
-          "uptime_last_5m": 99.44341372912801,
-          "uptime_last_1d": 98.64290296973716,
+          "uptime_last_30m": 99.43246311010215,
+          "uptime_last_5m": 99.66159052453469,
+          "uptime_last_1d": 99.0010133164106,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -17882,7 +18113,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.94402776222994,
+          "uptime_last_1d": 99.90954319312529,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -17986,9 +18217,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.46876717347499,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.59804464786285,
+          "uptime_last_30m": 99.82527664531159,
+          "uptime_last_5m": 99.59100204498978,
+          "uptime_last_1d": 99.7163176809421,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18026,9 +18257,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.56217162872154,
-          "uptime_last_5m": 99.18032786885246,
-          "uptime_last_1d": 97.48674875642176,
+          "uptime_last_30m": 97.84615384615385,
+          "uptime_last_5m": 98.4126984126984,
+          "uptime_last_1d": 97.59067219267507,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -18168,9 +18399,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.23118279569893,
-          "uptime_last_5m": 99.22027290448344,
-          "uptime_last_1d": 96.58350098533066,
+          "uptime_last_30m": 98.85700389105058,
+          "uptime_last_5m": 96.17940199335548,
+          "uptime_last_1d": 97.6364113625729,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -18274,9 +18505,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": null,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 85.37859007832898,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 88.69725900831537,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18314,17 +18545,17 @@
             "logprobs",
             "top_logprobs"
           ],
-          "status": -2,
-          "uptime_last_30m": 93.75,
-          "uptime_last_5m": 93.54838709677419,
-          "uptime_last_1d": 98.5712680698075,
+          "status": 0,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 97.78609933747583,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | qwen/qwen3.5-122b-a10b-20260224",
-          "model_id": "qwen/qwen3.5-122b-a10b",
+          "model_id": "Qwen/Qwen3.5-122B-A10B",
           "model_name": "Qwen: Qwen3.5-122B-A10B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -18351,9 +18582,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.52153110047847,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 97.81411864351566,
+          "uptime_last_1d": 90.25893958076449,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -18476,9 +18707,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.85096870342772,
-          "uptime_last_5m": 97.84946236559139,
-          "uptime_last_1d": 99.2366576355739,
+          "uptime_last_30m": 98.74125874125875,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.97856630089221,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18517,16 +18748,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.59560947429232,
-          "uptime_last_5m": 99.28057553956835,
-          "uptime_last_1d": 99.58056118021406,
+          "uptime_last_30m": 99.07834101382488,
+          "uptime_last_5m": 99.06542056074767,
+          "uptime_last_1d": 99.53830281145216,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | qwen/qwen3.5-27b-20260224",
-          "model_id": "qwen/qwen3.5-27b",
+          "model_id": "Qwen/Qwen3.5-27B",
           "model_name": "Qwen: Qwen3.5-27B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -18554,10 +18785,10 @@
             "tools",
             "tool_choice"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.79218967921896,
-          "uptime_last_5m": 97.70114942528735,
-          "uptime_last_1d": 96.9741290430863,
+          "status": -2,
+          "uptime_last_30m": 93.47258485639686,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.49877149877149,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -18679,9 +18910,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 98.28178694158075,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.48380624820867,
+          "uptime_last_1d": 99.32706173178603,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18723,20 +18954,20 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.87050825509873,
+          "uptime_last_30m": 99.87271955876113,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.18247662288525,
+          "uptime_last_1d": 93.01286633309506,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "gmi | qwen/qwen3.5-35b-a3b",
-          "model_id": "Qwen/Qwen3.5-35B-A3B",
+          "name": "novita | qwen/qwen3.5-35b-a3b",
+          "model_id": "qwen/qwen3.5-35b-a3b",
           "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000025",
@@ -18747,12 +18978,12 @@
           "quantization": "unknown"
         },
         {
-          "name": "novita | qwen/qwen3.5-35b-a3b",
-          "model_id": "qwen/qwen3.5-35b-a3b",
+          "name": "gmi | qwen/qwen3.5-35b-a3b",
+          "model_id": "Qwen/Qwen3.5-35B-A3B",
           "model_name": "Qwen: Qwen3.5-35B-A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.00000025",
@@ -18866,9 +19097,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 97.2027972027972,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.28275259148245,
+          "uptime_last_30m": 99.41520467836257,
+          "uptime_last_5m": 98.07692307692307,
+          "uptime_last_1d": 98.187952331719,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -18943,7 +19174,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.47999095636446,
+          "uptime_last_1d": 98.65098039215687,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -18985,9 +19216,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.8876404494382,
+          "uptime_last_30m": 97.7657935285054,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.1512001979708,
+          "uptime_last_1d": 98.55706437234375,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -19027,7 +19258,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.00322710770472,
+          "uptime_last_1d": 97.15508559919435,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -19185,16 +19416,16 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.62854868665428,
-          "uptime_last_5m": 99.51338199513383,
-          "uptime_last_1d": 98.62336042593553,
+          "uptime_last_30m": 99.59334095819037,
+          "uptime_last_5m": 99.85000000000001,
+          "uptime_last_1d": 98.58785986108978,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | qwen/qwen3.5-9b-20260310",
-          "model_id": "qwen/qwen3.5-9b",
+          "model_id": "Qwen/Qwen3.5-9B",
           "model_name": "Qwen: Qwen3.5-9B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -19223,9 +19454,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94194484760523,
-          "uptime_last_5m": 99.47089947089947,
-          "uptime_last_1d": 96.28232399800993,
+          "uptime_last_30m": 95.36651583710407,
+          "uptime_last_5m": 83.88003748828491,
+          "uptime_last_1d": 98.38955459086584,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -19264,9 +19495,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 98.37303893085415,
-          "uptime_last_5m": 91.51515151515152,
-          "uptime_last_1d": 96.13968316733806,
+          "uptime_last_30m": 99.82365907421014,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 97.39600162387426,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -19304,9 +19535,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 96.23618301385196,
-          "uptime_last_5m": 98.7452948557089,
-          "uptime_last_1d": 99.6016386592041,
+          "uptime_last_30m": 99.94831150930393,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.66533905298405,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -19380,16 +19611,16 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.68847352024922,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 97.24759490153858,
+          "uptime_last_1d": 98.55315831296761,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | qwen/qwen3.6-27b-20260422",
-          "model_id": "qwen/qwen3.6-27b",
+          "model_id": "Qwen/Qwen3.6-27B",
           "model_name": "Qwen: Qwen3.6 27B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -19418,9 +19649,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.08172635445362,
+          "uptime_last_30m": 96.23287671232876,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 95.1356407857811,
+          "uptime_last_1d": 95.98354706024679,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -19456,9 +19687,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.46200403496974,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 96.19707898962608,
+          "uptime_last_30m": 99.90875912408758,
+          "uptime_last_5m": 99.6951219512195,
+          "uptime_last_1d": 96.80862603866098,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -19580,9 +19811,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60732984293193,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.48865681807125,
+          "uptime_last_1d": 99.48516162247637,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -19624,16 +19855,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97946190182789,
+          "uptime_last_30m": 99.9752658916646,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 98.45444199415545,
+          "uptime_last_1d": 99.20472593088301,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | qwen/qwen3.6-35b-a3b-20260415",
-          "model_id": "qwen/qwen3.6-35b-a3b",
+          "model_id": "Qwen/Qwen3.6-35B-A3B",
           "model_name": "Qwen: Qwen3.6 35B A3B",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -19660,20 +19891,20 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69418960244649,
+          "uptime_last_30m": 98.77551020408163,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 94.78581627796288,
+          "uptime_last_1d": 94.49751518498067,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
         },
         {
-          "name": "gmi | qwen/qwen3.6-35b-a3b",
-          "model_id": "Qwen/Qwen3.6-35B-A3B",
+          "name": "novita | qwen/qwen3.6-35b-a3b",
+          "model_id": "qwen/qwen3.6-35b-a3b",
           "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "gmi",
-          "tag": "gmi",
-          "tr_provider_slug": "gmi",
+          "provider_name": "novita",
+          "tag": "novita",
+          "tr_provider_slug": "novita",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.000000248",
@@ -19684,12 +19915,12 @@
           "quantization": "unknown"
         },
         {
-          "name": "novita | qwen/qwen3.6-35b-a3b",
-          "model_id": "qwen/qwen3.6-35b-a3b",
+          "name": "gmi | qwen/qwen3.6-35b-a3b",
+          "model_id": "Qwen/Qwen3.6-35B-A3B",
           "model_name": "Qwen: Qwen3.6 35B A3B",
-          "provider_name": "novita",
-          "tag": "novita",
-          "tr_provider_slug": "novita",
+          "provider_name": "gmi",
+          "tag": "gmi",
+          "tr_provider_slug": "gmi",
           "context_length": 262144,
           "pricing": {
             "prompt": "0.000000248",
@@ -19802,10 +20033,10 @@
             "top_logprobs",
             "reasoning_effort"
           ],
-          "status": 0,
-          "uptime_last_30m": null,
+          "status": -5,
+          "uptime_last_30m": 72.72727272727273,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.09339390779772,
+          "uptime_last_1d": 98.07348560079444,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -19843,7 +20074,7 @@
       "endpoints": [
         {
           "name": "SiliconFlow | tencent/hunyuan-a13b-instruct",
-          "model_id": "tencent/hunyuan-a13b-instruct",
+          "model_id": "tencent/Hunyuan-A13B-Instruct",
           "model_name": "Tencent: Hunyuan A13B Instruct",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -19943,9 +20174,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.10544768069039,
+          "uptime_last_30m": 97.6905311778291,
+          "uptime_last_5m": 94.52054794520548,
+          "uptime_last_1d": 98.60556914231776,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -19977,9 +20208,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.79006298110566,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 81.6350177019633,
+          "uptime_last_1d": 98.87078438802577,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -20018,16 +20249,16 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.60369881109644,
+          "uptime_last_30m": 99.8914223669924,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.58475721211157,
+          "uptime_last_1d": 99.4934047027337,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
         },
         {
           "name": "siliconflow | tencent/hy3",
-          "model_id": "tencent/hy3",
+          "model_id": "tencent/Hy3",
           "model_name": "Tencent: Hy3",
           "provider_name": "siliconflow",
           "tag": "siliconflow",
@@ -20119,9 +20350,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.82085987261146,
-          "uptime_last_5m": 99.73544973544973,
-          "uptime_last_1d": 99.89458889669713,
+          "uptime_last_30m": 99.93640025439899,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.81891334390806,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -20191,9 +20422,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.88738738738738,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9854160083615,
+          "uptime_last_1d": 99.97126373262009,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -20263,9 +20494,9 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 100,
+          "uptime_last_1d": 99.95194617972129,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
@@ -20338,9 +20569,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 92.57572548188942,
+          "uptime_last_30m": 98.84009942004971,
+          "uptime_last_5m": 98.54014598540147,
+          "uptime_last_1d": 97.15757220157768,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -20378,10 +20609,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -2,
-          "uptime_last_30m": 89.3071000855432,
-          "uptime_last_5m": 70.68273092369478,
-          "uptime_last_1d": 98.79432847082495,
+          "status": -5,
+          "uptime_last_30m": 75.53846153846155,
+          "uptime_last_5m": 79.59183673469387,
+          "uptime_last_1d": 97.28386119707645,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -20398,6 +20629,114 @@
             "prompt": "0.000001",
             "completion": "0.00000405",
             "input_cache_read": "0.00000017"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        }
+      ],
+      "pricing_source": "provider_direct"
+    },
+    {
+      "id": "thinkingmachines/inkling-small",
+      "name": "Thinking Machines: Inkling Small",
+      "created": 1785443117,
+      "description": "Inkling Small is an open-weight multimodal mixture-of-experts model from Thinking Machines Lab, with 12B active parameters out of 276B total. It is positioned as the smaller, more efficient member of...",
+      "context_length": 524288,
+      "architecture": {
+        "modality": "text+image+audio->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "audio"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000003",
+        "completion": "0.0000012",
+        "input_cache_read": "0.00000006"
+      },
+      "top_provider": {
+        "context_length": 524288,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "endpoints": [
+        {
+          "name": "DeepInfra | thinkingmachines/inkling-small-20260730",
+          "model_id": "thinkingmachines/Inkling-Small",
+          "model_name": "Thinking Machines: Inkling Small",
+          "provider_name": "DeepInfra",
+          "tag": "deepinfra/fp8",
+          "context_length": 524288,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.0000012",
+            "input_cache_read": "0.0000001",
+            "discount": 0
+          },
+          "quantization": "fp8",
+          "max_completion_tokens": 262144,
+          "max_prompt_tokens": null,
+          "supported_parameters": [
+            "reasoning",
+            "include_reasoning",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "stop",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "top_k",
+            "seed",
+            "min_p",
+            "logit_bias",
+            "reasoning_effort"
+          ],
+          "status": 0,
+          "uptime_last_30m": 99.33774834437085,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.88511961075821,
+          "supports_implicit_caching": false,
+          "tr_provider_slug": "deepinfra",
+          "pricing_source": "provider_direct"
+        },
+        {
+          "name": "thinkingmachines | thinkingmachines/inkling-small",
+          "model_id": "thinkingmachines/inkling-small",
+          "model_name": "Thinking Machines: Inkling Small",
+          "provider_name": "thinkingmachines",
+          "tag": "thinkingmachines",
+          "tr_provider_slug": "thinkingmachines",
+          "context_length": 524288,
+          "pricing": {
+            "prompt": "0.0000003",
+            "completion": "0.0000012",
+            "input_cache_read": "0.00000006"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "baseten | thinkingmachines/inkling-small",
+          "model_id": "thinkingmachines/inkling-small",
+          "model_name": "Thinking Machines: Inkling Small",
+          "provider_name": "baseten",
+          "tag": "baseten",
+          "tr_provider_slug": "baseten",
+          "context_length": 524288,
+          "pricing": {
+            "prompt": "0.0000005",
+            "completion": "0.0000012",
+            "input_cache_read": "0.0000001"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -20530,9 +20869,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9337810806456,
+          "uptime_last_30m": 99.95661605206074,
+          "uptime_last_5m": 99.92372234935164,
+          "uptime_last_1d": 99.9718394395843,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -20599,9 +20938,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.9337810806456,
+          "uptime_last_30m": 99.95661605206074,
+          "uptime_last_5m": 99.92372234935164,
+          "uptime_last_1d": 99.9718394395843,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -20670,7 +21009,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93216576221016,
+          "uptime_last_1d": 99.96096171952144,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -20739,7 +21078,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93216576221016,
+          "uptime_last_1d": 99.96096171952144,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -20870,9 +21209,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 99.05660377358491,
           "uptime_last_5m": null,
-          "uptime_last_1d": 96.06779661016948,
+          "uptime_last_1d": 95.57084497957429,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -20938,9 +21277,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 99.05660377358491,
           "uptime_last_5m": null,
-          "uptime_last_1d": 96.06779661016948,
+          "uptime_last_1d": 95.57084497957429,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21008,7 +21347,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.76059850374065,
+          "uptime_last_1d": 88.85135135135135,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21076,7 +21415,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.76059850374065,
+          "uptime_last_1d": 88.85135135135135,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21190,9 +21529,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99101312084356,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95843225285918,
+          "uptime_last_30m": 99.85933182617433,
+          "uptime_last_5m": 99.9463087248322,
+          "uptime_last_1d": 99.97054670451142,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21263,9 +21602,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.99101312084356,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95843225285918,
+          "uptime_last_30m": 99.85933182617433,
+          "uptime_last_5m": 99.9463087248322,
+          "uptime_last_1d": 99.97054670451142,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21336,9 +21675,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.94332672145083,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93926433930989,
+          "uptime_last_1d": 99.9875437913585,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21409,9 +21748,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.94332672145083,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93926433930989,
+          "uptime_last_1d": 99.9875437913585,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21542,9 +21881,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94149480766417,
-          "uptime_last_5m": 99.84693877551021,
-          "uptime_last_1d": 99.89666596789924,
+          "uptime_last_30m": 99.902761571373,
+          "uptime_last_5m": 99.75405804230202,
+          "uptime_last_1d": 99.88070336650263,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21615,9 +21954,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94149480766417,
-          "uptime_last_5m": 99.84693877551021,
-          "uptime_last_1d": 99.89666596789924,
+          "uptime_last_30m": 99.902761571373,
+          "uptime_last_5m": 99.75405804230202,
+          "uptime_last_1d": 99.88070336650263,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21688,9 +22027,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97088791848617,
+          "uptime_last_30m": 99.86565158978952,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96406699162604,
+          "uptime_last_1d": 99.91899823389592,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21761,9 +22100,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.97088791848617,
+          "uptime_last_30m": 99.86565158978952,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96406699162604,
+          "uptime_last_1d": 99.91899823389592,
           "supports_implicit_caching": false,
           "tr_provider_slug": "grok",
           "pricing_source": "provider_direct"
@@ -21910,7 +22249,7 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -21982,7 +22321,7 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
@@ -22346,7 +22685,7 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
+          "uptime_last_5m": 100,
           "uptime_last_1d": 100,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
@@ -22386,7 +22725,7 @@
       "endpoints": [
         {
           "name": "SiliconFlow | z-ai/glm-4.5-air",
-          "model_id": "z-ai/glm-4.5-air",
+          "model_id": "zai-org/GLM-4.5-Air",
           "model_name": "Z.ai: GLM 4.5 Air",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -22411,9 +22750,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 99.47916666666666,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.68811556139198,
+          "uptime_last_1d": 99.67942673958137,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -22445,9 +22784,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 99.69135802469135,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.67494971009349,
+          "uptime_last_30m": 98.84169884169884,
+          "uptime_last_5m": 97.91666666666666,
+          "uptime_last_1d": 97.98971482000935,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22513,9 +22852,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 96.3035019455253,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.11608961303462,
+          "uptime_last_1d": 97.70161290322581,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22589,7 +22928,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.93535471493514,
+          "uptime_last_1d": 99.94659546061415,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -22626,9 +22965,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.84202211690362,
+          "uptime_last_30m": 99.57081545064378,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.14624505928855,
+          "uptime_last_1d": 99.4162950952574,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -22660,9 +22999,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 96.31901840490798,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 96.36011616650532,
+          "uptime_last_30m": 97.77777777777777,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 96.65102389078498,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22745,9 +23084,9 @@
             "top_k"
           ],
           "status": 0,
-          "uptime_last_30m": 99.89473684210526,
+          "uptime_last_30m": 99.62121212121212,
           "uptime_last_5m": null,
-          "uptime_last_1d": 98.21329749387303,
+          "uptime_last_1d": 98.53192373389965,
           "supports_implicit_caching": true,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -22820,8 +23159,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.95547764142806,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.93299725607811,
           "supports_implicit_caching": false,
           "tr_provider_slug": "cerebras",
           "pricing_source": "provider_direct"
@@ -22862,9 +23201,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.90686122322259,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.86423070494607,
+          "uptime_last_1d": 99.85745976532368,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -22901,9 +23240,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": 99.89561586638831,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.68210115995232,
+          "uptime_last_1d": 99.67661789643886,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -22936,9 +23275,9 @@
             "response_format"
           ],
           "status": -2,
-          "uptime_last_30m": 87.90968681718864,
-          "uptime_last_5m": 90,
-          "uptime_last_1d": 85.39965076325127,
+          "uptime_last_30m": 92.44332493702771,
+          "uptime_last_5m": 91.80327868852459,
+          "uptime_last_1d": 86.59926342853173,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -23045,9 +23384,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.47368421052632,
-          "uptime_last_5m": 99.7005988023952,
-          "uptime_last_1d": 95.22517437771828,
+          "uptime_last_30m": 99.98561771897023,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.22620917085428,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -23060,8 +23399,9 @@
           "tag": "venice/fp8",
           "context_length": 128000,
           "pricing": {
-            "prompt": "0.00000013",
-            "completion": "0.0000005",
+            "prompt": "0.00000006",
+            "completion": "0.0000004",
+            "input_cache_read": "0.00000001",
             "discount": 0
           },
           "quantization": "fp8",
@@ -23083,9 +23423,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 98.79518072289156,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 91.30890784505664,
+          "uptime_last_30m": 100,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.18251091218465,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -23174,9 +23514,9 @@
             "logit_bias"
           ],
           "status": 0,
-          "uptime_last_30m": 99.94391475042063,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.80976090938982,
+          "uptime_last_1d": 99.95402045170309,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -23210,9 +23550,9 @@
             "response_format"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49622166246851,
-          "uptime_last_5m": 99.00990099009901,
-          "uptime_last_1d": 97.8517224436316,
+          "uptime_last_30m": 98.30148619957538,
+          "uptime_last_5m": 98.93617021276596,
+          "uptime_last_1d": 98.54678935988333,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -23254,16 +23594,16 @@
             "top_logprobs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.20318725099602,
-          "uptime_last_5m": 99.06542056074767,
-          "uptime_last_1d": 98.04865686771414,
+          "uptime_last_30m": 99.81684981684981,
+          "uptime_last_5m": 97.5,
+          "uptime_last_1d": 98.41784072930008,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | z-ai/glm-5-20260211",
-          "model_id": "z-ai/glm-5",
+          "model_id": "zai-org/GLM-5",
           "model_name": "Z.ai: GLM 5",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -23288,10 +23628,10 @@
             "tool_choice",
             "max_tokens"
           ],
-          "status": -2,
-          "uptime_last_30m": 94.51219512195121,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.73882995821279,
+          "status": 0,
+          "uptime_last_30m": 99.68,
+          "uptime_last_5m": 99.45652173913044,
+          "uptime_last_1d": 99.8619988057589,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -23330,7 +23670,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.50218735857595,
+          "uptime_last_1d": 99.74723361231254,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -23361,30 +23701,13 @@
             "tool_choice",
             "top_k"
           ],
-          "status": 0,
-          "uptime_last_30m": 96.89034369885434,
-          "uptime_last_5m": 96.82539682539682,
-          "uptime_last_1d": 98.21893764434179,
+          "status": -5,
+          "uptime_last_30m": 77.26396917148362,
+          "uptime_last_5m": 72.91666666666666,
+          "uptime_last_1d": 98.07895780981352,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "chutes | z-ai/glm-5",
-          "model_id": "zai-org/GLM-5-TEE",
-          "model_name": "Z.ai: GLM 5",
-          "provider_name": "chutes",
-          "tag": "chutes",
-          "tr_provider_slug": "chutes",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000095",
-            "completion": "0.00000255",
-            "input_cache_read": "0.000000475"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "digitalocean | z-ai/glm-5",
@@ -23481,8 +23804,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.99492874892236,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.9944988447574,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -23590,7 +23913,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.55411430887719,
+          "uptime_last_1d": 99.27884615384616,
           "supports_implicit_caching": false,
           "tr_provider_slug": "crusoe",
           "pricing_source": "provider_direct"
@@ -23631,9 +23954,9 @@
             "structured_outputs"
           ],
           "status": 0,
-          "uptime_last_30m": 99.35979513444302,
+          "uptime_last_30m": 99.88399071925754,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.79808458218328,
+          "uptime_last_1d": 99.71949509116409,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -23675,7 +23998,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.96603443036165,
+          "uptime_last_1d": 99.98770265007892,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -23709,7 +24032,7 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.31323922167111,
+          "uptime_last_1d": 99.44414751469802,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -23753,14 +24076,14 @@
           "status": 0,
           "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 95.64414913252122,
+          "uptime_last_1d": 96.71803652968036,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | z-ai/glm-5.1-20260406",
-          "model_id": "z-ai/glm-5.1",
+          "model_id": "zai-org/GLM-5.1",
           "model_name": "Z.ai: GLM 5.1",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -23786,9 +24109,9 @@
             "max_tokens"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.98911564625851,
+          "uptime_last_1d": 99.92214263469324,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -23825,9 +24148,9 @@
             "tool_choice"
           ],
           "status": 0,
-          "uptime_last_30m": 99.10714285714286,
+          "uptime_last_30m": null,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.70129439097245,
+          "uptime_last_1d": 99.3006993006993,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -23871,8 +24194,8 @@
           ],
           "status": 0,
           "uptime_last_30m": 100,
-          "uptime_last_5m": null,
-          "uptime_last_1d": 99.94535519125684,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.72717059861981,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -23904,10 +24227,10 @@
             "top_k",
             "response_format"
           ],
-          "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.73558575100992,
+          "status": -2,
+          "uptime_last_30m": 94.82758620689656,
+          "uptime_last_5m": 86.0655737704918,
+          "uptime_last_1d": 97.46098156237822,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
@@ -23947,23 +24270,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "telnyx | z-ai/glm-5.1",
-          "model_id": "zai-org/GLM-5.1-FP8",
-          "model_name": "Z.ai: GLM 5.1",
-          "provider_name": "telnyx",
-          "tag": "telnyx",
-          "tr_provider_slug": "telnyx",
-          "context_length": 204800,
-          "pricing": {
-            "prompt": "0.00000098",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000013"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "digitalocean | z-ai/glm-5.1",
           "model_id": "glm-5.1",
           "model_name": "Z.ai: GLM 5.1",
@@ -23975,6 +24281,23 @@
             "prompt": "0.000000975",
             "completion": "0.0000043",
             "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "telnyx | z-ai/glm-5.1",
+          "model_id": "zai-org/GLM-5.1-FP8",
+          "model_name": "Z.ai: GLM 5.1",
+          "provider_name": "telnyx",
+          "tag": "telnyx",
+          "tr_provider_slug": "telnyx",
+          "context_length": 204800,
+          "pricing": {
+            "prompt": "0.00000098",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000013"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -24020,7 +24343,7 @@
       "pricing": {
         "prompt": "0.00000075",
         "completion": "0.0000024",
-        "input_cache_read": "0.000000208"
+        "input_cache_read": "0.00000012987"
       },
       "top_provider": {
         "context_length": 1024000,
@@ -24066,9 +24389,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 96.14153627311522,
-          "uptime_last_5m": 98.3451536643026,
-          "uptime_last_1d": 96.84093854219428,
+          "uptime_last_30m": 99.44913267698078,
+          "uptime_last_5m": 99.84615384615385,
+          "uptime_last_1d": 97.17561678627618,
           "supports_implicit_caching": false,
           "tr_provider_slug": "deepinfra",
           "pricing_source": "provider_direct"
@@ -24110,9 +24433,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.88835186080232,
-          "uptime_last_5m": 99.23371647509579,
-          "uptime_last_1d": 99.1391000825893,
+          "uptime_last_30m": 99.41194676570721,
+          "uptime_last_5m": 99.72337482710927,
+          "uptime_last_1d": 98.99292721699993,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -24154,9 +24477,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.36305732484077,
-          "uptime_last_5m": 99.80314960629921,
-          "uptime_last_1d": 98.0396308935276,
+          "uptime_last_30m": 99.20358387257342,
+          "uptime_last_5m": 98.76084262701363,
+          "uptime_last_1d": 99.25475460283235,
           "supports_implicit_caching": false,
           "tr_provider_slug": "fireworks",
           "pricing_source": "provider_direct"
@@ -24197,9 +24520,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.49874686716792,
-          "uptime_last_5m": 98.31697054698458,
-          "uptime_last_1d": 98.77581667006909,
+          "uptime_last_30m": 99.32844932844932,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 99.20197543785056,
           "supports_implicit_caching": false,
           "tr_provider_slug": "friendli",
           "pricing_source": "provider_direct"
@@ -24236,9 +24559,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.27073837739289,
-          "uptime_last_5m": 99.3975903614458,
-          "uptime_last_1d": 98.80930776210762,
+          "uptime_last_30m": 99.35553168635876,
+          "uptime_last_5m": 100,
+          "uptime_last_1d": 98.66003697328999,
           "supports_implicit_caching": false,
           "tr_provider_slug": "gmi",
           "pricing_source": "provider_direct"
@@ -24254,7 +24577,7 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026",
-            "discount": 0.35
+            "discount": 0.5
           },
           "quantization": "fp8",
           "max_completion_tokens": 131072,
@@ -24277,9 +24600,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.55272557850597,
-          "uptime_last_5m": 99.70014992503748,
-          "uptime_last_1d": 99.63167529550901,
+          "uptime_last_30m": 99.93298710001676,
+          "uptime_last_5m": 99.87562189054727,
+          "uptime_last_1d": 99.55659915496291,
           "supports_implicit_caching": false,
           "tr_provider_slug": "novita",
           "pricing_source": "provider_direct"
@@ -24322,16 +24645,16 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 99.18772563176896,
+          "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.18799708871526,
+          "uptime_last_1d": 99.25433388743767,
           "supports_implicit_caching": false,
           "tr_provider_slug": "parasail",
           "pricing_source": "provider_direct"
         },
         {
           "name": "SiliconFlow | z-ai/glm-5.2-20260616",
-          "model_id": "z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2",
           "model_name": "Z.ai: GLM 5.2",
           "provider_name": "SiliconFlow",
           "tag": "siliconflow/fp8",
@@ -24358,9 +24681,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 100,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 99.62631771626354,
+          "uptime_last_30m": null,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 99.82267618630482,
           "supports_implicit_caching": false,
           "tr_provider_slug": "siliconflow",
           "pricing_source": "provider_direct"
@@ -24400,10 +24723,10 @@
             "tool_choice",
             "reasoning_effort"
           ],
-          "status": -5,
-          "uptime_last_30m": 79.3055313208864,
+          "status": -2,
+          "uptime_last_30m": 91.36594911937378,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 89.35093509350935,
+          "uptime_last_1d": 88.89575751124794,
           "supports_implicit_caching": false,
           "tr_provider_slug": "together",
           "pricing_source": "provider_direct"
@@ -24441,9 +24764,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": 98.16743023740109,
-          "uptime_last_5m": 100,
-          "uptime_last_1d": 98.75017037743787,
+          "uptime_last_30m": 97.4910394265233,
+          "uptime_last_5m": null,
+          "uptime_last_1d": 98.21909332619856,
           "supports_implicit_caching": false,
           "tr_provider_slug": "venice",
           "pricing_source": "provider_direct"
@@ -24453,7 +24776,7 @@
           "model_id": "GLM-5.2",
           "model_name": "Z.ai: GLM 5.2",
           "provider_name": "Wafer",
-          "tag": "wafer/fp4",
+          "tag": "wafer",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.00000126",
@@ -24487,9 +24810,9 @@
             "reasoning_effort"
           ],
           "status": 0,
-          "uptime_last_30m": null,
+          "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.6760343481655,
+          "uptime_last_1d": 99.6229062527405,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -24535,7 +24858,7 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": null,
-          "uptime_last_1d": 99.79326513213981,
+          "uptime_last_1d": 99.7945100444717,
           "supports_implicit_caching": false,
           "tr_provider_slug": "wafer",
           "pricing_source": "provider_direct"
@@ -24592,23 +24915,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "makora | z-ai/glm-5.2",
-          "model_id": "z-ai/glm-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "makora",
-          "tag": "makora",
-          "tr_provider_slug": "makora",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.00000094",
-            "completion": "0.0000028",
-            "input_cache_read": "0.00000018"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "alibaba | z-ai/glm-5.2",
           "model_id": "glm-5.2",
           "model_name": "Z.ai: GLM 5.2",
@@ -24620,6 +24926,23 @@
             "prompt": "0.0000014",
             "completion": "0.0000044",
             "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "makora | z-ai/glm-5.2",
+          "model_id": "z-ai/glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "makora",
+          "tag": "makora",
+          "tr_provider_slug": "makora",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.00000094",
+            "completion": "0.0000028",
+            "input_cache_read": "0.00000018"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -24643,23 +24966,6 @@
           "quantization": "unknown"
         },
         {
-          "name": "telnyx | z-ai/glm-5.2",
-          "model_id": "zai-org/GLM-5.2",
-          "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "telnyx",
-          "tag": "telnyx",
-          "tr_provider_slug": "telnyx",
-          "context_length": 1048576,
-          "pricing": {
-            "prompt": "0.000001",
-            "completion": "0.000004",
-            "input_cache_read": "0.0000002"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
-        },
-        {
           "name": "digitalocean | z-ai/glm-5.2",
           "model_id": "glm-5.2",
           "model_name": "Z.ai: GLM 5.2",
@@ -24677,17 +24983,17 @@
           "quantization": "unknown"
         },
         {
-          "name": "cloudflare-workers-ai | z-ai/glm-5.2",
-          "model_id": "z-ai/glm-5.2",
+          "name": "telnyx | z-ai/glm-5.2",
+          "model_id": "zai-org/GLM-5.2",
           "model_name": "Z.ai: GLM 5.2",
-          "provider_name": "cloudflare-workers-ai",
-          "tag": "cloudflare-workers-ai",
-          "tr_provider_slug": "cloudflare-workers-ai",
+          "provider_name": "telnyx",
+          "tag": "telnyx",
+          "tr_provider_slug": "telnyx",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000014",
-            "completion": "0.0000044",
-            "input_cache_read": "0.00000026"
+            "prompt": "0.000001",
+            "completion": "0.000004",
+            "input_cache_read": "0.0000002"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],
@@ -24716,6 +25022,23 @@
           "provider_name": "atlas-cloud",
           "tag": "atlas-cloud",
           "tr_provider_slug": "atlas-cloud",
+          "context_length": 1048576,
+          "pricing": {
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000026"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "cloudflare-workers-ai | z-ai/glm-5.2",
+          "model_id": "z-ai/glm-5.2",
+          "model_name": "Z.ai: GLM 5.2",
+          "provider_name": "cloudflare-workers-ai",
+          "tag": "cloudflare-workers-ai",
+          "tr_provider_slug": "cloudflare-workers-ai",
           "context_length": 1048576,
           "pricing": {
             "prompt": "0.0000014",
@@ -24807,27 +25130,10 @@
           "status": 0,
           "uptime_last_30m": 100,
           "uptime_last_5m": 100,
-          "uptime_last_1d": 99.99628100710328,
+          "uptime_last_1d": 99.99095636445851,
           "supports_implicit_caching": false,
           "tr_provider_slug": "zai",
           "pricing_source": "provider_direct"
-        },
-        {
-          "name": "siliconflow | z-ai/glm-5v-turbo",
-          "model_id": "z-ai/glm-5v-turbo",
-          "model_name": "Z.ai: GLM 5V Turbo",
-          "provider_name": "siliconflow",
-          "tag": "siliconflow",
-          "tr_provider_slug": "siliconflow",
-          "context_length": 202752,
-          "pricing": {
-            "prompt": "0.0000012",
-            "completion": "0.000004",
-            "input_cache_read": "0.00000024"
-          },
-          "pricing_source": "provider_direct",
-          "supported_parameters": [],
-          "quantization": "unknown"
         },
         {
           "name": "venice | z-ai/glm-5v-turbo",
@@ -24841,6 +25147,23 @@
             "prompt": "0.0000015",
             "completion": "0.000005",
             "input_cache_read": "0.0000003"
+          },
+          "pricing_source": "provider_direct",
+          "supported_parameters": [],
+          "quantization": "unknown"
+        },
+        {
+          "name": "siliconflow | z-ai/glm-5v-turbo",
+          "model_id": "zai-org/GLM-5V-Turbo",
+          "model_name": "Z.ai: GLM 5V Turbo",
+          "provider_name": "siliconflow",
+          "tag": "siliconflow",
+          "tr_provider_slug": "siliconflow",
+          "context_length": 202752,
+          "pricing": {
+            "prompt": "0.0000012",
+            "completion": "0.000004",
+            "input_cache_read": "0.00000024"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],

--- a/src/trusted_router/data/provider_models/alibaba.json
+++ b/src/trusted_router/data/provider_models/alibaba.json
@@ -3,7 +3,7 @@
   "provider": "alibaba",
   "source": "https://ws-el6e4bpnggpx7g88.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/models",
   "price_source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 75,
   "models": [

--- a/src/trusted_router/data/provider_models/anthropic.json
+++ b/src/trusted_router/data/provider_models/anthropic.json
@@ -294,7 +294,7 @@
   ],
   "provider": "anthropic",
   "source": "https://www.anthropic.com/pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 10
 }

--- a/src/trusted_router/data/provider_models/atlas-cloud.json
+++ b/src/trusted_router/data/provider_models/atlas-cloud.json
@@ -3373,8 +3373,48 @@
       "input_token_price_per_m": 200000,
       "output_token_price_per_m": 800000,
       "cached_input_token_price_per_m": 40000
+    },
+    {
+      "display_name": "DeepSeek V4 Flash 0731",
+      "title": "deepseek-ai/deepseek-v4-flash-0731",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "upstream_id": "deepseek-ai/deepseek-v4-flash-0731",
+      "context_length": 262144,
+      "max_output_tokens": 131072,
+      "supported_features": [
+        "json_mode",
+        "tools",
+        "structured_outputs"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "seed",
+        "max_tokens",
+        "logit_bias"
+      ],
+      "input_token_price_per_m": 140000,
+      "output_token_price_per_m": 280000,
+      "cached_input_token_price_per_m": 28000
     }
   ],
-  "generated_at": "2026-07-31T12:58:56Z",
-  "model_count": 123
+  "generated_at": "2026-08-01T03:28:38Z",
+  "model_count": 124
 }

--- a/src/trusted_router/data/provider_models/baseten.json
+++ b/src/trusted_router/data/provider_models/baseten.json
@@ -2,9 +2,9 @@
   "_about": "Provider-native Baseten Model API routes, capabilities, context windows, and account-billable prices refreshed hourly from Baseten's authenticated /v1/models feed.",
   "provider": "baseten",
   "source": "https://inference.baseten.co/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
-  "model_count": 17,
+  "model_count": 18,
   "models": [
     {
       "id": "openai/gpt-oss-120b",
@@ -519,8 +519,40 @@
         "temperature",
         "stop"
       ],
+      "input_token_price_per_m": 500000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 100000
+    },
+    {
+      "display_name": "Deepseek V4 Flash 0731",
+      "title": "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "upstream_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+      "context_length": 1048576,
+      "supported_features": [
+        "tools",
+        "json_mode",
+        "structured_outputs",
+        "reasoning"
+      ],
+      "supported_sampling_parameters": [
+        "temperature",
+        "stop"
+      ],
       "routable": false,
-      "routable_reason": "price-unavailable"
+      "routable_reason": "awaiting-price",
+      "unresolved_since": "2026-08-01"
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/cerebras.json
+++ b/src/trusted_router/data/provider_models/cerebras.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for the Cerebras models enabled on the TrustedRouter Cerebras account. Verified from Cerebras /v1/models and direct chat completions on 2026-06-05. The canonical OpenRouter-style model IDs remain openai/gpt-oss-120b and z-ai/glm-4.7; cerebras/* aliases are included so users can request the Cerebras-specific route directly.",
   "provider": "cerebras",
   "source": "https://api.cerebras.ai/public/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/chutes.json
+++ b/src/trusted_router/data/provider_models/chutes.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native Chutes TEE model catalog. Refreshed hourly from the authenticated Chutes OpenAI-compatible models API.",
   "provider": "chutes",
   "source": "https://llm.chutes.ai/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 13,
   "models": [
@@ -92,7 +92,8 @@
       ],
       "input_token_price_per_m": 150000,
       "output_token_price_per_m": 1200000,
-      "cached_input_token_price_per_m": 75000
+      "cached_input_token_price_per_m": 75000,
+      "missing_since": "2026-08-01"
     },
     {
       "display_name": "unsloth/Mistral-Nemo-Instruct-2407",
@@ -145,7 +146,8 @@
       ],
       "input_token_price_per_m": 440000,
       "output_token_price_per_m": 2000000,
-      "cached_input_token_price_per_m": 220000
+      "cached_input_token_price_per_m": 220000,
+      "missing_since": "2026-08-01"
     },
     {
       "display_name": "moonshotai/Kimi-K2.6",
@@ -323,7 +325,8 @@
       ],
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 2550000,
-      "cached_input_token_price_per_m": 475000
+      "cached_input_token_price_per_m": 475000,
+      "missing_since": "2026-08-01"
     },
     {
       "display_name": "zai-org/GLM-5.1",

--- a/src/trusted_router/data/provider_models/cohere.json
+++ b/src/trusted_router/data/provider_models/cohere.json
@@ -3,7 +3,7 @@
   "provider": "cohere",
   "source": "https://docs.cohere.com/docs/cohere-embed",
   "pricing_source": "https://cohere.com/pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 3,
   "models": [

--- a/src/trusted_router/data/provider_models/crusoe.json
+++ b/src/trusted_router/data/provider_models/crusoe.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Crusoe Managed Inference routes. Generated from https://api.inference.crusoecloud.com/v1/models; prices are provider cost in integer microdollars per million tokens and catalog applies markup.",
   "provider": "crusoe",
   "source": "https://api.inference.crusoecloud.com/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 15,
   "models": [

--- a/src/trusted_router/data/provider_models/digitalocean.json
+++ b/src/trusted_router/data/provider_models/digitalocean.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native DigitalOcean Gradient AI serverless catalog. Availability comes from /v1/models and rates from DigitalOcean's official pricing documentation.",
   "provider": "digitalocean",
   "source": "https://inference.do-ai.run/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 23,
   "models": [

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -3,7 +3,7 @@
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
   "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 6,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/friendli.json
+++ b/src/trusted_router/data/provider_models/friendli.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for FriendliAI serverless Model API routes. Verified against https://api.friendli.ai/serverless/v1/models on 2026-06-22.",
   "provider": "friendli",
   "source": "https://api.friendli.ai/serverless/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 9,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/google-ai-studio.json
+++ b/src/trusted_router/data/provider_models/google-ai-studio.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Google AI Studio chat and image models that are available from the Gemini API before the OpenRouter snapshot catches up. Verified against Google Gemini /v1beta/models and direct countTokens/generateContent smoke.",
   "provider": "google-ai-studio",
   "source": "https://generativelanguage.googleapis.com/v1beta/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 33,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/google-vertex.json
+++ b/src/trusted_router/data/provider_models/google-vertex.json
@@ -3,7 +3,7 @@
   "provider": "google-vertex",
   "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-6-flash",
   "pricing_source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 1,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/inceptron.json
+++ b/src/trusted_router/data/provider_models/inceptron.json
@@ -185,6 +185,6 @@
       "cached_input_token_price_per_m": 170000
     }
   ],
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 4
 }

--- a/src/trusted_router/data/provider_models/kimi.json
+++ b/src/trusted_router/data/provider_models/kimi.json
@@ -186,6 +186,6 @@
   "_about": "Provider-native Moonshot/Kimi routes. Refreshed hourly only for models present in both the official pricing docs and authenticated /v1/models feed.",
   "source": "https://api.moonshot.ai/v1/models",
   "pricing_source": "https://platform.kimi.ai/docs/llms.txt",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 11
 }

--- a/src/trusted_router/data/provider_models/makora.json
+++ b/src/trusted_router/data/provider_models/makora.json
@@ -3,7 +3,7 @@
   "provider": "makora",
   "source": "https://inference.makora.com/v1/models",
   "pricing_source": "https://inference.makora.com/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 12,
   "models": [
@@ -410,9 +410,7 @@
         "json_mode",
         "logprobs"
       ],
-      "missing_since": "2026-07-31",
-      "routable": false,
-      "routable_reason": "delisted-upstream"
+      "routable": true
     },
     {
       "id": "openai/gpt-oss-120b",

--- a/src/trusted_router/data/provider_models/meta.json
+++ b/src/trusted_router/data/provider_models/meta.json
@@ -2,7 +2,7 @@
   "_about": "Meta Muse Spark served through OpenRouter. This is not a direct Meta, ZDR, confidential-compute, or downstream-attested route.",
   "provider": "meta",
   "source": "https://openrouter.ai/api/v1/models/meta/muse-spark-1.1/endpoints",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/minimax.json
+++ b/src/trusted_router/data/provider_models/minimax.json
@@ -1,7 +1,7 @@
 {
   "provider": "minimax",
   "source": "https://api.minimax.io/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 8,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/morph.json
+++ b/src/trusted_router/data/provider_models/morph.json
@@ -165,6 +165,6 @@
       "output_token_price_per_m": 4100000
     }
   ],
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 8
 }

--- a/src/trusted_router/data/provider_models/nebius.json
+++ b/src/trusted_router/data/provider_models/nebius.json
@@ -1,7 +1,7 @@
 {
   "provider": "nebius",
   "source": "https://api.tokenfactory.nebius.com/v1/models?verbose=true",
-  "generated_at": "2026-07-28T08:37:44Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 39,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/neurometric.json
+++ b/src/trusted_router/data/provider_models/neurometric.json
@@ -102,8 +102,74 @@
       "routable": true,
       "input_token_price_per_m": 162000,
       "output_token_price_per_m": 1890000
+    },
+    {
+      "display_name": "gemma-4-12B-it",
+      "title": "google/gemma-4-12b-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-4-12b-it",
+      "upstream_id": "google/gemma-4-12b-it",
+      "context_length": 32768,
+      "max_output_tokens": 16384,
+      "supported_features": [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "lifecycle_status": "active",
+      "deprecation_at": null,
+      "retirement_at": null,
+      "replacement_model_id": null,
+      "routable": true,
+      "input_token_price_per_m": 10000,
+      "output_token_price_per_m": 120000
+    },
+    {
+      "display_name": "gemma-4-E2B-it",
+      "title": "google/gemma-4-e2b-it",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "google/gemma-4-e2b-it",
+      "upstream_id": "google/gemma-4-e2b-it",
+      "context_length": 4096,
+      "max_output_tokens": 2048,
+      "supported_features": [
+        "chat",
+        "completion",
+        "tools",
+        "json_mode",
+        "structured_outputs"
+      ],
+      "lifecycle_status": "active",
+      "deprecation_at": null,
+      "retirement_at": null,
+      "replacement_model_id": null,
+      "routable": true,
+      "input_token_price_per_m": 20000,
+      "output_token_price_per_m": 120000
     }
   ],
-  "generated_at": "2026-07-31T12:58:56Z",
-  "model_count": 3
+  "generated_at": "2026-08-01T03:28:38Z",
+  "model_count": 5
 }

--- a/src/trusted_router/data/provider_models/novita.json
+++ b/src/trusted_router/data/provider_models/novita.json
@@ -3,8 +3,8 @@
   "source": "https://api.novita.ai/openai/v1/models",
   "price_source": "https://novita.ai/pricing",
   "price_scale_to_microdollars_per_million_tokens": 100,
-  "generated_at": "2026-07-31T12:58:56Z",
-  "model_count": 138,
+  "generated_at": "2026-08-01T03:28:38Z",
+  "model_count": 139,
   "models": [
     {
       "id": "Sao10K/L3-8B-Stheno-v3.2",
@@ -3895,6 +3895,37 @@
       "max_output_tokens": 32768,
       "input_token_price_per_m": 0,
       "output_token_price_per_m": 0
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "upstream_id": "deepseek/deepseek-v4-flash-0731",
+      "display_name": "Deepseek V4 Flash 0731",
+      "title": "deepseek/deepseek-v4-flash-0731",
+      "model_type": "chat",
+      "features": [
+        "serverless",
+        "function-calling",
+        "structured-outputs",
+        "reasoning"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions",
+        "anthropic",
+        "responses"
+      ],
+      "status": 1,
+      "created": 1785546565,
+      "context_length": 1048576,
+      "max_output_tokens": 393216,
+      "input_token_price_per_m": 1400,
+      "output_token_price_per_m": 2800,
+      "cached_input_token_price_per_m": 280
     }
   ]
 }

--- a/src/trusted_router/data/provider_models/parasail.json
+++ b/src/trusted_router/data/provider_models/parasail.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Parasail models live ahead of the shared snapshot. Prices refreshed hourly from the public pricing page (www.parasail.io/pricing); model liveness gated on api.parasail.io/v1/models.",
   "provider": "parasail",
   "source": "https://www.parasail.io/pricing",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 4,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/streamlake.json
+++ b/src/trusted_router/data/provider_models/streamlake.json
@@ -67,6 +67,6 @@
       "cached_input_token_price_per_m": 150000
     }
   ],
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 3
 }

--- a/src/trusted_router/data/provider_models/telnyx.json
+++ b/src/trusted_router/data/provider_models/telnyx.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native Telnyx inference routes, context windows, capabilities, and reconciled account-billable prices refreshed hourly from Telnyx-owned sources.",
   "provider": "telnyx",
   "source": "https://api.telnyx.com/v2/ai/openai/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 12,
   "models": [

--- a/src/trusted_router/data/provider_models/thinkingmachines.json
+++ b/src/trusted_router/data/provider_models/thinkingmachines.json
@@ -1,6 +1,6 @@
 {
   "source": "https://tinker-docs.thinkingmachines.ai/tinker/models/",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "provider": "thinkingmachines",
   "currency": "USD",
   "price_unit": "microdollars_per_million_tokens",

--- a/src/trusted_router/data/provider_models/together.json
+++ b/src/trusted_router/data/provider_models/together.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Together AI routes that are live ahead of the shared OpenRouter snapshot. Verified against https://api.together.xyz/v1/models on 2026-06-22.",
   "provider": "together",
   "source": "https://api.together.xyz/v1/endpoints?type=serverless",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "model_count": 19,
   "models": [
     {

--- a/src/trusted_router/data/provider_models/voyage.json
+++ b/src/trusted_router/data/provider_models/voyage.json
@@ -3,7 +3,7 @@
   "provider": "voyage",
   "source": "https://docs.voyageai.com/docs/embeddings",
   "pricing_source": "https://docs.voyageai.com/docs/pricing.md",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "model_count": 1,
   "models": [

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Wafer serverless API. Refreshed hourly from Wafer's OpenAI-compatible /v1/models feed.",
   "provider": "wafer",
   "source": "https://pass.wafer.ai/v1/models",
-  "generated_at": "2026-07-31T12:58:56Z",
+  "generated_at": "2026-08-01T03:28:38Z",
   "price_scale": "microdollars_per_million",
   "zdr_header": "Wafer-ZDR: required",
   "model_count": 6,

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -150,7 +150,7 @@ def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:
     assert MODEL_ENDPOINTS["moonshotai/kimi-k3@novita/prepaid"].upstream_id == "moonshotai/kimi-k3"
     assert (
         MODEL_ENDPOINTS["moonshotai/kimi-k3@siliconflow/prepaid"].upstream_id
-        == "moonshotai/kimi-k3"
+        == "moonshotai/Kimi-K3"
     )
     assert MODEL_ENDPOINTS["moonshotai/kimi-k3@baseten/prepaid"].upstream_id == "moonshotai/Kimi-K3"
     assert MODEL_ENDPOINTS["moonshotai/kimi-k3@nebius/prepaid"].upstream_id == "moonshotai/Kimi-K3"
@@ -1095,7 +1095,10 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
 
     inkling_small = MODELS["thinkingmachines/inkling-small"]
     inkling_small_shape = model_to_openrouter_shape(inkling_small)
-    assert inkling_small.context_length == 262_144
+    # The first-party route is 256K, while independent hosts can expose a
+    # larger verified window for the same weights. The canonical model follows
+    # the largest live routed endpoint and must stay within the audited range.
+    assert 262_144 <= inkling_small.context_length <= 1_048_576
     assert inkling_small.input_modalities == ("text", "image")
     assert inkling_small.output_modalities == ("text",)
     assert inkling_small_shape["architecture"]["modality"] == "text+image->text"
@@ -1106,15 +1109,15 @@ def test_liberty_models_publish_verified_components_and_honest_context_limits() 
     assert inkling_small_shape["trustedrouter"]["open_weights"] is True
     assert inkling_small.prompt_price_microdollars_per_million_tokens == 315_000
     assert inkling_small.completion_price_microdollars_per_million_tokens == 1_260_000
-    assert {
+    inkling_small_routes = {
         (endpoint.provider, endpoint.upstream_id)
         for endpoint in endpoints_for_model(inkling_small.id)
-    } == {
-        (
-            "thinkingmachines",
-            "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4",
-        )
     }
+    assert (
+        "thinkingmachines",
+        "thinkingmachines/Inkling-Small:peft:262144:sampling-nvfp4",
+    ) in inkling_small_routes
+    assert all(provider and upstream_id for provider, upstream_id in inkling_small_routes)
 
 
 def test_catalog_modalities_publish_only_gateway_supported_capabilities() -> None:

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -47,6 +47,49 @@ def test_fireworks_fetch_intersects_prices_with_operator_catalog(
     assert any("kimi-k2.7-code" in note for note in result.notes)
 
 
+def test_fireworks_dated_flash_uses_live_native_id_and_family_price(
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    dated_model = "deepseek/deepseek-v4-flash-0731"
+    native_id = "accounts/fireworks/models/deepseek-v4-flash-0731"
+    captured: dict[str, object] = {}
+    priced_ids = {*fireworks.EXPECTED_MODELS, dated_model}
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(fireworks, "UPSTREAM_ID_MAP", dict(fireworks.UPSTREAM_ID_MAP))
+
+    def fake_fetch_provider(**kwargs: object) -> ProviderPricingResult:
+        captured.update(kwargs)
+        return ProviderPricingResult(
+            slug="fireworks",
+            prices={model_id: _price() for model_id in priced_ids},
+            source="deterministic",
+        )
+
+    monkeypatch.setattr(fireworks, "fetch_provider", fake_fetch_provider)
+    live_rows = [
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]}
+        for model_id in fireworks.EXPECTED_MODELS
+        if model_id not in fireworks.VERIFIED_PRICED_LAUNCH_MODELS
+    ]
+    live_rows.append({"id": native_id})
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_json",
+        lambda *_args, **_kwargs: {"data": live_rows},
+    )
+
+    result = fireworks.fetch()
+
+    aliases = captured["required_model_price_aliases"]
+    assert isinstance(aliases, dict)
+    assert aliases[dated_model] == "deepseek/deepseek-v4-flash"
+    required_models = captured["required_models"]
+    assert isinstance(required_models, frozenset)
+    assert dated_model in required_models
+    assert fireworks.UPSTREAM_ID_MAP[dated_model] == native_id
+    assert dated_model in result.prices
+
+
 def test_fireworks_parser_reads_kimi_k3_standard_pricing() -> None:
     parsed = fireworks_parser.parse(
         "| [Kimi K3](https://app.fireworks.ai/models/fireworks/kimi-k3) "

--- a/tests/test_neurometric_provider.py
+++ b/tests/test_neurometric_provider.py
@@ -193,9 +193,18 @@ def test_neurometric_manifest_tombstones_only_after_repeated_fresh_miss(
     manifest_path = tmp_path / "neurometric.json"
     raw = json.loads(neurometric.MANIFEST_PATH.read_text(encoding="utf-8"))
     manifest_path.write_text(json.dumps(raw) + "\n", encoding="utf-8")
+    target_id = "qwen/qwen3-vl-8b-thinking"
+    existing_ids = {
+        row["id"]
+        for row in raw["models"]
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    assert target_id in existing_ids
+    # Keep every other live row present. This test exercises one repeated
+    # delisting and must not become a mass-prune test when Neurometric adds
+    # unrelated models to its live catalog.
     payload = _payload(
-        _model_row(),
-        _model_row("qwen/qwen3-vl-8b-instruct"),
+        *(_model_row(model_id) for model_id in sorted(existing_ids - {target_id}))
     )
 
     class FakeResponse:
@@ -227,18 +236,15 @@ def test_neurometric_manifest_tombstones_only_after_repeated_fresh_miss(
     neurometric.write_provider_manifest(result)
     first = json.loads(manifest_path.read_text(encoding="utf-8"))
     first_rows = {row["id"]: row for row in first["models"]}
-    assert first_rows["qwen/qwen3-vl-8b-thinking"]["missing_since"]
-    assert first_rows["qwen/qwen3-vl-8b-thinking"].get("routable") is not False
+    assert first_rows[target_id]["missing_since"]
+    assert first_rows[target_id].get("routable") is not False
 
     result = neurometric.fetch()
     neurometric.write_provider_manifest(result)
     second = json.loads(manifest_path.read_text(encoding="utf-8"))
     second_rows = {row["id"]: row for row in second["models"]}
-    assert second_rows["qwen/qwen3-vl-8b-thinking"]["routable"] is False
-    assert (
-        second_rows["qwen/qwen3-vl-8b-thinking"]["routable_reason"]
-        == "delisted-upstream"
-    )
+    assert second_rows[target_id]["routable"] is False
+    assert second_rows[target_id]["routable_reason"] == "delisted-upstream"
 
 
 def test_neurometric_catalog_routes_are_prepaid_only_and_no_store() -> None:
@@ -257,12 +263,12 @@ def test_neurometric_catalog_routes_are_prepaid_only_and_no_store() -> None:
         for endpoint in MODEL_ENDPOINTS.values()
         if endpoint.provider == "neurometric"
     ]
-    assert len(endpoints) == 3
+    assert endpoints
     assert {endpoint.usage_type for endpoint in endpoints} == {"Credits"}
     assert {
         endpoint.upstream_id
         for endpoint in endpoints
-    } == {
+    } >= {
         "ibm-granite/granite-4.1-8b",
         "qwen/qwen3-vl-8b-instruct",
         "qwen/qwen3-vl-8b-thinking",

--- a/tests/test_pricing_base.py
+++ b/tests/test_pricing_base.py
@@ -10,6 +10,7 @@ from scripts.pricing.base import (
     MAX_PRICE_MICRO_PER_M,
     ModelPrice,
     _coerce_to_model_prices,
+    apply_required_model_price_aliases,
     ast_whitelist_check,
     guard_manifest_prune,
     normalize_parser_input,
@@ -75,6 +76,30 @@ def test_validate_fails_when_newly_discovered_required_model_is_missing() -> Non
     )
 
     assert errors == ["newly discovered models missing from parser output: ['provider/new-model']"]
+
+
+def test_required_price_aliases_expand_only_required_approved_ids() -> None:
+    source = ModelPrice(
+        130_000,
+        280_000,
+        prompt_cached_micro_per_m=28_000,
+    )
+    prices, applied = apply_required_model_price_aliases(
+        {"deepseek/deepseek-v4-flash": source},
+        frozenset({"deepseek/deepseek-v4-flash-0731"}),
+        {
+            "deepseek/deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash-0801": "deepseek/deepseek-v4-flash",
+        },
+    )
+
+    dated = prices["deepseek/deepseek-v4-flash-0731"]
+    assert dated == source
+    assert dated is not source
+    assert "deepseek/deepseek-v4-flash-0801" not in prices
+    assert applied == [
+        "deepseek/deepseek-v4-flash-0731 <- deepseek/deepseek-v4-flash"
+    ]
 
 
 def test_validate_fails_on_out_of_range_prompt_price() -> None:

--- a/tests/test_versioned_deepseek_pricing.py
+++ b/tests/test_versioned_deepseek_pricing.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing import base, refresh
+from scripts.pricing.base import configure_runtime_required_models
+from scripts.pricing.providers import deepseek, siliconflow
+
+_DATED_MODEL = "deepseek/deepseek-v4-flash-0731"
+_GENERIC_MODEL = "deepseek/deepseek-v4-flash"
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pricing"
+
+
+def _unexpected_self_heal(**_kwargs: object) -> str:
+    pytest.fail("approved version aliases must not invoke parser self-healing")
+
+
+def test_siliconflow_discovers_dated_model_and_reuses_family_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    native_id = "deepseek-ai/DeepSeek-V4-Flash-0731"
+    fixture = (_FIXTURE_DIR / "siliconflow.html").read_text(encoding="utf-8")
+    monkeypatch.setenv("SILICON_FLOW_API_KEY", "test-key")
+    monkeypatch.setattr(siliconflow, "UPSTREAM_ID_MAP", {})
+    monkeypatch.setattr(base, "fetch_html", lambda *_args, **_kwargs: fixture)
+    monkeypatch.setattr(base, "self_heal_parser", _unexpected_self_heal)
+    monkeypatch.setattr(
+        siliconflow,
+        "fetch_json",
+        lambda *_args, **_kwargs: {"data": [{"id": native_id}]},
+    )
+    configure_runtime_required_models({})
+    try:
+        result = siliconflow.fetch()
+    finally:
+        configure_runtime_required_models({})
+
+    assert result.source == "deterministic"
+    assert result.prices[_DATED_MODEL] == result.prices[_GENERIC_MODEL]
+    assert siliconflow.UPSTREAM_ID_MAP[_DATED_MODEL] == native_id
+    assert any("approved price aliases" in note for note in result.notes)
+
+    merged = refresh._merge_snapshot(
+        {
+            "models": [
+                {
+                    "id": _DATED_MODEL,
+                    "name": "DeepSeek V4 Flash 0731",
+                    "created": 1,
+                    "context_length": 1_048_576,
+                    "architecture": {"output_modalities": ["text"]},
+                    "pricing": {"prompt": "0.00000014", "completion": "0.00000028"},
+                    "endpoints": [
+                        {
+                            "provider_name": "SiliconFlow",
+                            "tr_provider_slug": "siliconflow",
+                            "model_id": _DATED_MODEL,
+                            "context_length": 1_048_576,
+                            "pricing": {
+                                "prompt": "0.00000014",
+                                "completion": "0.00000028",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "tr_keyed_providers": ["siliconflow"],
+        },
+        {_DATED_MODEL: {"siliconflow": result.prices[_DATED_MODEL]}},
+        set(),
+    )
+    model = merged["models"][0]
+    assert model["id"] == _DATED_MODEL
+    assert model["endpoints"][0]["model_id"] == native_id
+    assert model["endpoints"][0]["pricing"]["prompt"] == (
+        refresh._micro_per_m_to_dollars_per_token(
+            result.prices[_DATED_MODEL].prompt_micro_per_m
+        )
+    )
+
+
+def test_deepseek_dated_model_uses_official_family_price_and_native_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = (_FIXTURE_DIR / "deepseek.html").read_text(encoding="utf-8")
+    monkeypatch.setattr(deepseek, "UPSTREAM_ID_MAP", {})
+    monkeypatch.setattr(base, "fetch_html", lambda *_args, **_kwargs: fixture)
+    monkeypatch.setattr(base, "self_heal_parser", _unexpected_self_heal)
+    configure_runtime_required_models({})
+    try:
+        result = deepseek.fetch()
+    finally:
+        configure_runtime_required_models({})
+
+    assert result.source == "deterministic"
+    assert result.prices[_DATED_MODEL] == result.prices[_GENERIC_MODEL]
+    assert deepseek.UPSTREAM_ID_MAP[_DATED_MODEL] == "deepseek-v4-flash"
+    assert any("approved price aliases" in note for note in result.notes)


### PR DESCRIPTION
## Summary
- discover SiliconFlow native model IDs from its authenticated catalog
- price provider-confirmed dated DeepSeek Flash variants from explicitly approved family rows
- preserve dated routes across subsequent hourly refreshes
- refresh the current provider catalog and fix brittle live-feed assertions

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (2388 passed, 86 skipped)
- direct SiliconFlow `deepseek-ai/DeepSeek-V4-Flash-0731` PONG smoke