### PR TITLE
Prepare ClickHouse runtime migration

### DIFF
--- a/clickhouse/004_operational_analytics_replicated.sql
+++ b/clickhouse/004_operational_analytics_replicated.sql
@@ -123,3 +123,19 @@ ORDER BY (
     target_region, id
 )
 TTL period_start + INTERVAL 24 MONTH;
+
+CREATE TABLE IF NOT EXISTS public_analytics_snapshots
+(
+    name           LowCardinality(String),
+    generated_at   DateTime64(3, 'UTC'),
+    payload        String CODEC(ZSTD(3)),
+    ingest_version DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/public-analytics-snapshots-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMM(generated_at)
+ORDER BY name
+TTL toDateTime(generated_at) + INTERVAL 7 DAY;

--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -38,7 +38,7 @@ UINT64_MODULUS = 1 << 64
 log = logging.getLogger("trusted_router.analytics_archive")
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_COLUMNS = (
+_BENCHMARK_COLUMNS = (
     "id",
     "created_at",
     "provider",
@@ -64,6 +64,121 @@ _COLUMNS = (
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class DatasetSpec:
+    columns: tuple[str, ...]
+    time_column: str
+    shard_column: str
+
+
+DATASETS: dict[str, DatasetSpec] = {
+    "provider_benchmark_samples": DatasetSpec(
+        columns=_BENCHMARK_COLUMNS,
+        time_column="created_at",
+        shard_column="id",
+    ),
+    "activity_generations": DatasetSpec(
+        columns=(
+            "generation_id",
+            "request_id",
+            "tenant_id",
+            "key_id",
+            "model",
+            "provider",
+            "provider_name",
+            "app",
+            "tokens_prompt",
+            "tokens_completion",
+            "cached_input_tokens",
+            "reasoning_tokens",
+            "total_cost_microdollars",
+            "usage_type",
+            "speed_tokens_per_second",
+            "finish_reason",
+            "status",
+            "streamed",
+            "usage_estimated",
+            "elapsed_milliseconds",
+            "first_token_milliseconds",
+            "ttfb_milliseconds",
+            "region",
+            "user",
+            "session_id",
+            "http_referer",
+            "app_categories",
+            "tags",
+            "created_at",
+        ),
+        time_column="created_at",
+        shard_column="generation_id",
+    ),
+    "synthetic_probe_samples": DatasetSpec(
+        columns=(
+            "id",
+            "probe_type",
+            "target",
+            "target_url",
+            "monitor_region",
+            "status",
+            "target_region",
+            "latency_milliseconds",
+            "ttfb_milliseconds",
+            "dns_milliseconds",
+            "tcp_connect_milliseconds",
+            "tls_handshake_milliseconds",
+            "gateway_processing_milliseconds",
+            "connection_reused",
+            "protocol",
+            "http_status",
+            "error_type",
+            "provider",
+            "model",
+            "selected_provider",
+            "selected_model",
+            "generation_id",
+            "attestation_digest",
+            "source_commit",
+            "cost_microdollars",
+            "output_match",
+            "created_at",
+        ),
+        time_column="created_at",
+        shard_column="id",
+    ),
+    "synthetic_status_rollups": DatasetSpec(
+        columns=(
+            "id",
+            "period",
+            "period_start",
+            "component",
+            "target",
+            "probe_type",
+            "monitor_region",
+            "target_region",
+            "sample_count",
+            "up_count",
+            "down_count",
+            "degraded_count",
+            "routing_degraded_count",
+            "trust_degraded_count",
+            "unknown_count",
+            "latency_histogram",
+            "ttfb_histogram",
+            "dns_histogram",
+            "tcp_connect_histogram",
+            "tls_handshake_histogram",
+            "gateway_processing_histogram",
+            "error_counts",
+            "last_checked_at",
+            "cost_microdollars",
+            "updated_at",
+        ),
+        time_column="period_start",
+        shard_column="id",
+    ),
+}
+
+
 def _identifier(value: str, *, label: str) -> str:
     if _IDENTIFIER.fullmatch(value) is None:
         raise ValueError(f"{label} must be a ClickHouse identifier")
@@ -84,8 +199,8 @@ def _day_bounds(day: dt.date) -> tuple[str, str]:
     )
 
 
-def _row_hash_expression() -> str:
-    return "cityHash64(toJSONString(tuple(" + ", ".join(_COLUMNS) + ")))"
+def _row_hash_expression(columns: Sequence[str]) -> str:
+    return "cityHash64(toJSONString(tuple(" + ", ".join(columns) + ")))"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -183,6 +298,14 @@ class ClickHouseDailyExporter:
         self._password = password
         self._database = _identifier(database, label="database")
         self._table = _identifier(table, label="table")
+        try:
+            self._spec = DATASETS[self._table]
+        except KeyError:
+            raise ValueError(f"unsupported archive dataset: {self._table}") from None
+
+    @property
+    def dataset(self) -> str:
+        return self._table
 
     @property
     def qualified_table(self) -> str:
@@ -216,16 +339,21 @@ class ClickHouseDailyExporter:
         query = _fingerprint_query(
             self.qualified_table,
             where=(
-                f"created_at >= toDateTime64({_sql_string(start)}, 3, 'UTC') "
-                f"AND created_at < toDateTime64({_sql_string(end)}, 3, 'UTC')"
+                f"{self._spec.time_column} >= "
+                f"toDateTime64({_sql_string(start)}, 3, 'UTC') "
+                f"AND {self._spec.time_column} < "
+                f"toDateTime64({_sql_string(end)}, 3, 'UTC')"
             ),
             final=True,
+            columns=self._spec.columns,
+            time_column=self._spec.time_column,
         )
         return _parse_fingerprint(self._client(query))
 
     def earliest_day(self) -> dt.date | None:
         payload = self._client(
-            f"SELECT if(count() = 0, '', toString(toDate(min(created_at)))) "
+            "SELECT if(count() = 0, '', "
+            f"toString(toDate(min({self._spec.time_column})))) "
             f"FROM {self.qualified_table} FINAL"
         )
         value = payload.decode("utf-8").strip().splitlines()[-1]
@@ -244,13 +372,17 @@ class ClickHouseDailyExporter:
         for part in range(part_count):
             path = destination / f"part-{part:05d}-of-{part_count:05d}.parquet"
             where = (
-                f"created_at >= toDateTime64({_sql_string(start)}, 3, 'UTC') "
-                f"AND created_at < toDateTime64({_sql_string(end)}, 3, 'UTC') "
-                f"AND cityHash64(id) % {part_count} = {part}"
+                f"{self._spec.time_column} >= "
+                f"toDateTime64({_sql_string(start)}, 3, 'UTC') "
+                f"AND {self._spec.time_column} < "
+                f"toDateTime64({_sql_string(end)}, 3, 'UTC') "
+                f"AND cityHash64({self._spec.shard_column}) % {part_count} = {part}"
             )
             query = (  # noqa: S608 - identifiers are validated; values are generated.
-                f"SELECT {', '.join(_COLUMNS)} FROM {self.qualified_table} FINAL "
-                f"WHERE {where} ORDER BY created_at, id FORMAT Parquet"
+                f"SELECT {', '.join(self._spec.columns)} "
+                f"FROM {self.qualified_table} FINAL WHERE {where} "
+                f"ORDER BY {self._spec.time_column}, {self._spec.shard_column} "
+                "FORMAT Parquet"
             )
             with path.open("wb") as stream:
                 self._client(query, stdout=stream)
@@ -262,6 +394,8 @@ class ClickHouseDailyExporter:
             f"file({_sql_string(str(path))}, Parquet)",
             where=None,
             final=False,
+            columns=self._spec.columns,
+            time_column=self._spec.time_column,
         )
         fingerprint = _parse_fingerprint(_run_clickhouse_local(query))
         return ExportedPart(
@@ -348,16 +482,23 @@ def _nullable_string(value: Any) -> str | None:
     return str(value)
 
 
-def _fingerprint_query(table_expression: str, *, where: str | None, final: bool) -> str:
+def _fingerprint_query(
+    table_expression: str,
+    *,
+    where: str | None,
+    final: bool,
+    columns: Sequence[str] = _BENCHMARK_COLUMNS,
+    time_column: str = "created_at",
+) -> str:
     suffix = " FINAL" if final else ""
     where_clause = f" WHERE {where}" if where else ""
-    row_hash = _row_hash_expression()
+    row_hash = _row_hash_expression(columns)
     return (  # noqa: S608 - table expressions are validated or locally generated.
         "SELECT count() AS rows, "
         f"sum({row_hash}) AS hash_sum, "
         f"groupBitXor({row_hash}) AS hash_xor, "
-        "if(count() = 0, NULL, toString(min(created_at))) AS min_created_at, "
-        "if(count() = 0, NULL, toString(max(created_at))) AS max_created_at "
+        f"if(count() = 0, NULL, toString(min({time_column}))) AS min_created_at, "
+        f"if(count() = 0, NULL, toString(max({time_column}))) AS max_created_at "
         f"FROM {table_expression}{suffix}{where_clause} FORMAT JSONEachRow"
     )
 
@@ -415,11 +556,14 @@ def archive_day(
     *,
     rows_per_part: int = ROWS_PER_PART,
     now: dt.datetime | None = None,
+    dataset: str = TABLE,
 ) -> ArchiveResult:
     if rows_per_part < 1:
         raise ValueError("rows_per_part must be positive")
+    if dataset not in DATASETS:
+        raise ValueError(f"unsupported archive dataset: {dataset}")
     source = exporter.source_fingerprint(day)
-    date_prefix = f"raw/provider_benchmark_samples/day={day.isoformat()}"
+    date_prefix = f"raw/{dataset}/day={day.isoformat()}"
     pointer_key = f"{date_prefix}/_latest.json"
     latest = store.read_json(pointer_key)
     if latest is not None:
@@ -478,7 +622,7 @@ def archive_day(
 
     manifest: dict[str, Any] = {
         "schema_version": ARCHIVE_SCHEMA_VERSION,
-        "dataset": TABLE,
+        "dataset": dataset,
         "day": day.isoformat(),
         "revision": revision,
         "exported_at": exported_at.isoformat().replace("+00:00", "Z"),
@@ -533,7 +677,7 @@ def main() -> int:
     parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
     parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
     parser.add_argument("--database", default=DATABASE)
-    parser.add_argument("--table", default=TABLE)
+    parser.add_argument("--table", action="append", choices=tuple(DATASETS))
     parser.add_argument("--date", type=dt.date.fromisoformat)
     parser.add_argument("--lookback-days", type=int, default=7)
     parser.add_argument("--backfill", action="store_true")
@@ -544,33 +688,40 @@ def main() -> int:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    exporter = ClickHouseDailyExporter(
-        password=os.environ["CH_PASSWORD"],
-        database=args.database,
-        table=args.table,
-    )
     store = GCSArchiveStore(project=args.project, bucket=args.bucket)
-    backfill_start = exporter.earliest_day() if args.backfill and args.date is None else None
-    for day in _days_to_archive(
-        date=args.date,
-        lookback_days=args.lookback_days,
-        backfill_start=backfill_start,
-    ):
-        result = archive_day(
-            exporter,
-            store,
-            day,
-            rows_per_part=args.rows_per_part,
+    tables = tuple(dict.fromkeys(args.table or tuple(DATASETS)))
+    for table in tables:
+        exporter = ClickHouseDailyExporter(
+            password=os.environ["CH_PASSWORD"],
+            database=args.database,
+            table=table,
         )
-        log.info(
-            "analytics_archive.completed day=%s rows=%d revision=%s skipped=%s manifest=gs://%s/%s",
-            result.day,
-            result.rows,
-            result.revision,
-            result.skipped,
-            args.bucket,
-            result.manifest_key,
+        backfill_start = (
+            exporter.earliest_day() if args.backfill and args.date is None else None
         )
+        for day in _days_to_archive(
+            date=args.date,
+            lookback_days=args.lookback_days,
+            backfill_start=backfill_start,
+        ):
+            result = archive_day(
+                exporter,
+                store,
+                day,
+                rows_per_part=args.rows_per_part,
+                dataset=table,
+            )
+            log.info(
+                "analytics_archive.completed dataset=%s day=%s rows=%d "
+                "revision=%s skipped=%s manifest=gs://%s/%s",
+                table,
+                result.day,
+                result.rows,
+                result.revision,
+                result.skipped,
+                args.bucket,
+                result.manifest_key,
+            )
     return 0
 
 

--- a/clickhouse/backfill_generation_records.py
+++ b/clickhouse/backfill_generation_records.py
@@ -1,0 +1,191 @@
+"""Backfill bounded Spanner generation lookup rows from the legacy Bigtable."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+from collections.abc import Iterable, Iterator
+from typing import Any, TypeVar
+
+from google.cloud import bigtable, spanner
+from google.cloud.bigtable.row_filters import (
+    CellsColumnLimitFilter,
+    RowFilterChain,
+    TimestampRangeFilter,
+)
+from google.cloud.spanner_v1 import KeySet
+
+from trusted_router.storage_gcp_generation_records import generation_record_body
+from trusted_router.storage_models import Generation
+
+PROJECT = "quill-cloud-proxy"
+BIGTABLE_INSTANCE = "trusted-router-logs"
+BIGTABLE_TABLE = "trustedrouter-generations"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+SPANNER_TABLE = "tr_generation"
+FAMILIES = ("activity", "m")
+T = TypeVar("T")
+
+
+def _batches(items: Iterable[T], size: int) -> Iterator[list[T]]:
+    batch: list[T] = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _created_at(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _generation(row: Any) -> Generation | None:
+    for family in FAMILIES:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if not cells:
+            continue
+        try:
+            payload = json.loads(cells[0].value.decode())
+        except (UnicodeDecodeError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        known = {field.name for field in dataclasses.fields(Generation)}
+        try:
+            return Generation(
+                **{key: value for key, value in payload.items() if key in known}
+            )
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _iter_recent(table: Any, *, cutoff: dt.datetime) -> Iterator[Generation]:
+    filter_ = RowFilterChain(
+        filters=[
+            TimestampRangeFilter(start=cutoff),
+            CellsColumnLimitFilter(1),
+        ]
+    )
+    rows = table.read_rows(
+        start_key=b"gen#",
+        end_key=b"gen#~",
+        filter_=filter_,
+    )
+    for row in rows:
+        generation = _generation(row)
+        if generation is not None and _created_at(generation.created_at) >= cutoff:
+            yield generation
+
+
+def _write(database: Any, generations: list[Generation]) -> None:
+    columns = (
+        "generation_id",
+        "workspace_id",
+        "key_hash",
+        "created_at",
+        "terminal_at",
+        "payload",
+    )
+    values = []
+    for generation in generations:
+        created = _created_at(generation.created_at)
+        values.append(
+            (
+                generation.id,
+                generation.workspace_id,
+                generation.key_hash,
+                created,
+                created,
+                generation_record_body(generation),
+            )
+        )
+    with database.batch() as batch:
+        batch.insert_or_update(
+            table=SPANNER_TABLE,
+            columns=columns,
+            values=values,
+        )
+
+
+def _existing_ids(database: Any, generation_ids: list[str]) -> set[str]:
+    if not generation_ids:
+        return set()
+    with database.snapshot() as snapshot:
+        rows = snapshot.read(
+            SPANNER_TABLE,
+            columns=("generation_id",),
+            keyset=KeySet(keys=[(generation_id,) for generation_id in generation_ids]),
+        )
+        return {str(row[0]) for row in rows}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    if args.days < 1 or args.batch_size < 1:
+        raise SystemExit("--days and --batch-size must be positive")
+
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=args.days)
+    table = (
+        bigtable.Client(project=PROJECT, admin=False)
+        .instance(BIGTABLE_INSTANCE)
+        .table(BIGTABLE_TABLE)
+    )
+    database = (
+        spanner.Client(project=PROJECT, disable_builtin_metrics=True)
+        .instance(SPANNER_INSTANCE)
+        .database(SPANNER_DATABASE)
+    )
+    scanned = 0
+    written = 0
+    missing = 0
+    for batch in _batches(_iter_recent(table, cutoff=cutoff), args.batch_size):
+        scanned += len(batch)
+        if args.apply:
+            _write(database, batch)
+            written += len(batch)
+        if args.verify:
+            expected = {generation.id for generation in batch}
+            missing += len(expected - _existing_ids(database, sorted(expected)))
+        print(
+            json.dumps(
+                {
+                    "mode": "apply" if args.apply else "dry-run",
+                    "scanned": scanned,
+                    "written": written,
+                    "missing": missing,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    if scanned == 0:
+        print(
+            json.dumps(
+                {
+                    "mode": "apply" if args.apply else "dry-run",
+                    "scanned": 0,
+                    "written": 0,
+                    "missing": 0,
+                }
+            )
+        )
+    return 1 if args.verify and missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -1,0 +1,138 @@
+"""Precompute small public analytics payloads from bounded ClickHouse data."""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+import os
+import subprocess
+from typing import Any
+
+from trusted_router.apps import aggregate_apps
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+
+SAMPLE_LIMIT = 10_000
+PER_PROVIDER_LIMIT = 500
+
+
+def _query(password: str, sql: str, *, input_bytes: bytes | None = None) -> str:
+    env = os.environ.copy()
+    env["CLICKHOUSE_PASSWORD"] = password
+    result = subprocess.run(  # noqa: S603 - fixed executable and fixed SQL.
+        [
+            "/usr/bin/clickhouse-client",
+            "--user",
+            "tr",
+            "--database",
+            "tr",
+            "--query",
+            sql,
+        ],
+        input=input_bytes,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace")[:1000]
+        raise RuntimeError(f"ClickHouse public snapshot query failed: {detail}")
+    return result.stdout.decode()
+
+
+def _samples(password: str) -> list[ProviderBenchmarkSample]:
+    output = _query(
+        password,
+        """
+SELECT * EXCEPT (ingest_version, provider_rank)
+FROM
+(
+  SELECT *, row_number() OVER (
+    PARTITION BY provider ORDER BY created_at DESC, id DESC
+  ) AS provider_rank
+  FROM provider_benchmark_samples FINAL
+  WHERE created_at >= now64(3) - INTERVAL 24 HOUR
+)
+WHERE provider_rank <= 500
+ORDER BY created_at DESC, id DESC
+LIMIT 10000
+FORMAT JSONEachRow
+""",
+    )
+    allowed = {field.name for field in dataclasses.fields(ProviderBenchmarkSample)}
+    samples: list[ProviderBenchmarkSample] = []
+    for line in output.splitlines():
+        raw = json.loads(line)
+        if not isinstance(raw, dict):
+            continue
+        payload = {key: value for key, value in raw.items() if key in allowed}
+        payload["streamed"] = bool(payload.get("streamed"))
+        created_at = str(payload.get("created_at") or "").replace(" ", "T")
+        if created_at and not created_at.endswith("Z"):
+            created_at += "Z"
+        payload["created_at"] = created_at
+        samples.append(ProviderBenchmarkSample(**payload))
+    return samples
+
+
+def build_snapshots(
+    samples: list[ProviderBenchmarkSample],
+    *,
+    generated_at: str,
+) -> dict[str, dict[str, Any]]:
+    leaderboard = aggregate_leaderboard(
+        samples,
+        min_samples=1,
+        model_rank_min_samples=10,
+        provider_rank_min_samples=30,
+        rank_min_ttft_samples=3,
+    )
+    leaderboard.update(
+        {
+            "generated_at": generated_at,
+            "sample_window_count": len(samples),
+            "sample_limit": SAMPLE_LIMIT,
+            "window_label": (
+                f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"
+            ),
+            "rank_minimums": {
+                "model_availability_samples": 10,
+                "provider_availability_samples": 30,
+                "ttft_samples": 3,
+            },
+        }
+    )
+    apps = aggregate_apps(samples)
+    apps["generated_at"] = generated_at
+    return {"leaderboard": leaderboard, "apps": apps}
+
+
+def main() -> int:
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    now = dt.datetime.now(dt.UTC)
+    generated_at = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    snapshots = build_snapshots(_samples(password), generated_at=generated_at)
+    rows = [
+        {
+            "name": name,
+            "generated_at": generated_at,
+            "payload": json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            "ingest_version": now.isoformat(timespec="microseconds"),
+        }
+        for name, payload in snapshots.items()
+    ]
+    body = "\n".join(json.dumps(row, separators=(",", ":")) for row in rows).encode()
+    _query(
+        password,
+        "INSERT INTO public_analytics_snapshots FORMAT JSONEachRow",
+        input_bytes=body,
+    )
+    print(json.dumps({"snapshots": len(rows), "generated_at": generated_at}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/operational_fingerprint.py
+++ b/clickhouse/operational_fingerprint.py
@@ -1,0 +1,104 @@
+"""Canonical fingerprints for operational source-to-ClickHouse delivery checks."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import re
+import struct
+from typing import Any, Protocol
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+
+
+class ClickHouseQuery(Protocol):
+    def query(
+        self,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        external_ids: bool = False,
+    ) -> str: ...
+
+
+def canonical_fingerprint(payload: dict[str, Any], *, surface: str) -> str:
+    canonical = dict(payload)
+    canonical.pop("ingest_version", None)
+    canonical.pop("updated_at", None)
+    for field in ("created_at", "period_start", "last_checked_at"):
+        if canonical.get(field) is not None:
+            canonical[field] = _iso(canonical[field])
+    if surface == "synthetic":
+        for field in ("connection_reused", "output_match"):
+            if canonical.get(field) is not None:
+                canonical[field] = bool(canonical[field])
+    if surface == "activity":
+        for field in ("streamed", "usage_estimated"):
+            if canonical.get(field) is not None:
+                canonical[field] = bool(canonical[field])
+    if surface == "rollup" and canonical.get("target_region") is None:
+        canonical["target_region"] = ""
+    if surface == "benchmark" and canonical.get("speed_tokens_per_second") is not None:
+        canonical["speed_tokens_per_second"] = struct.unpack(
+            "!f",
+            struct.pack("!f", float(canonical["speed_tokens_per_second"])),
+        )[0]
+    return hashlib.sha256(
+        json.dumps(
+            canonical,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode()
+    ).hexdigest()
+
+
+def clickhouse_rows(
+    clickhouse: ClickHouseQuery,
+    *,
+    table: str,
+    id_column: str,
+    ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    allowed = {
+        ("provider_benchmark_samples", "id"),
+        ("activity_generations", "generation_id"),
+        ("synthetic_probe_samples", "id"),
+        ("synthetic_status_rollups", "id"),
+    }
+    if (table, id_column) not in allowed:
+        raise ValueError("unsupported parity table")
+    if not ids:
+        return {}
+    if any(SAFE_ID.fullmatch(item) is None for item in ids):
+        raise ValueError("source contains an invalid record ID")
+    payload = ("\n".join(ids) + "\n").encode()
+    result = clickhouse.query(
+        f"SELECT * EXCEPT ingest_version FROM {table} FINAL "  # noqa: S608
+        f"WHERE {id_column} IN (SELECT id FROM wanted) "
+        "FORMAT JSONEachRow",
+        input_bytes=payload,
+        external_ids=True,
+    )
+    rows: dict[str, dict[str, Any]] = {}
+    for line in result.splitlines():
+        row = json.loads(line)
+        if isinstance(row, dict):
+            rows[str(row[id_column])] = row
+    return rows
+
+
+def _iso(value: Any) -> str:
+    text = str(value).replace(" ", "T")
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text if text.endswith("Z") else text + "Z"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return (
+        parsed.astimezone(dt.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )

--- a/clickhouse/tr-clickhouse-archive-restore.service
+++ b/clickhouse/tr-clickhouse-archive-restore.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=TrustedRouter verified ClickHouse archive restore drill
+After=network-online.target tr-clickhouse-archive.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+Environment=GCP_PROJECT_ID=quill-cloud-proxy
+Environment=ARCHIVE_BUCKET=quill-cloud-proxy-tr-clickhouse-archive
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_archive_restore
+TimeoutStartSec=6h
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-archive-restore.timer
+++ b/clickhouse/tr-clickhouse-archive-restore.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily TrustedRouter ClickHouse archive restore drill
+
+[Timer]
+OnCalendar=*-*-* 06:00:00 UTC
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/tr-clickhouse-public-snapshots.service
+++ b/clickhouse/tr-clickhouse-public-snapshots.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=TrustedRouter public analytics snapshot builder
+After=clickhouse-server.service network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.build_public_snapshots
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-public-snapshots.timer
+++ b/clickhouse/tr-clickhouse-public-snapshots.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh TrustedRouter public analytics snapshots every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+Persistent=true
+Unit=tr-clickhouse-public-snapshots.service
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/tr-clickhouse-spanner-delivery.service
+++ b/clickhouse/tr-clickhouse-spanner-delivery.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=TrustedRouter Spanner to ClickHouse delivery verification
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_spanner_delivery
+TimeoutStartSec=5m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest

--- a/clickhouse/tr-clickhouse-spanner-delivery.timer
+++ b/clickhouse/tr-clickhouse-spanner-delivery.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Verify TrustedRouter Spanner to ClickHouse delivery every 30 minutes
+
+[Timer]
+OnBootSec=7m
+OnUnitActiveSec=30m
+RandomizedDelaySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/verify_archive_restore.py
+++ b/clickhouse/verify_archive_restore.py
@@ -1,0 +1,216 @@
+"""Download and verify a closed-day ClickHouse archive revision.
+
+This is a restore drill, not just an object-existence check. Every Parquet part
+is downloaded, hash checked, parsed by ClickHouse Local, and recombined into the
+same row fingerprint recorded when the source day was exported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+from clickhouse.archive_daily import (
+    ARCHIVE_BUCKET,
+    ARCHIVE_SCHEMA_VERSION,
+    DATASETS,
+    PROJECT,
+    ExportedPart,
+    SourceFingerprint,
+    _combine_parts,
+    _fingerprint_query,
+    _parse_fingerprint,
+    _run_clickhouse_local,
+    _sha256,
+    _sql_string,
+)
+
+log = logging.getLogger("trusted_router.analytics_archive_restore")
+
+
+class RestoreStore(Protocol):
+    def read_json(self, key: str) -> dict[str, Any] | None: ...
+
+    def download_file(self, key: str, destination: Path) -> None: ...
+
+
+class GCSRestoreStore:
+    def __init__(self, *, project: str, bucket: str) -> None:
+        from google.cloud import storage
+
+        self._bucket = storage.Client(project=project).bucket(bucket)
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        blob = self._bucket.blob(key)
+        if not blob.exists():
+            return None
+        value = json.loads(blob.download_as_text())
+        if not isinstance(value, dict):
+            raise RuntimeError(f"archive object {key} is not a JSON object")
+        return value
+
+    def download_file(self, key: str, destination: Path) -> None:
+        self._bucket.blob(key).download_to_filename(str(destination))
+
+
+@dataclasses.dataclass(frozen=True)
+class RestoreResult:
+    dataset: str
+    day: dt.date
+    rows: int
+    parts: int
+    revision: str
+
+
+def verify_parquet_part(path: Path, *, dataset: str) -> ExportedPart:
+    try:
+        spec = DATASETS[dataset]
+    except KeyError:
+        raise ValueError(f"unsupported archive dataset: {dataset}") from None
+    query = _fingerprint_query(
+        f"file({_sql_string(str(path))}, Parquet)",
+        where=None,
+        final=False,
+        columns=spec.columns,
+        time_column=spec.time_column,
+    )
+    fingerprint = _parse_fingerprint(_run_clickhouse_local(query))
+    return ExportedPart(
+        path=path,
+        rows=fingerprint.rows,
+        hash_sum=fingerprint.hash_sum,
+        hash_xor=fingerprint.hash_xor,
+    )
+
+
+def verify_archived_day(
+    store: RestoreStore,
+    *,
+    dataset: str,
+    day: dt.date,
+    verifier: Callable[[Path], ExportedPart] | None = None,
+) -> RestoreResult:
+    if dataset not in DATASETS:
+        raise ValueError(f"unsupported archive dataset: {dataset}")
+    prefix = f"raw/{dataset}/day={day.isoformat()}"
+    pointer = store.read_json(f"{prefix}/_latest.json")
+    if pointer is None:
+        raise RuntimeError(f"archive pointer missing for {dataset} on {day}")
+    manifest_key = str(pointer.get("manifest") or "")
+    if not manifest_key.startswith(f"{prefix}/revisions/"):
+        raise RuntimeError("archive pointer references an unexpected manifest")
+    manifest = store.read_json(manifest_key)
+    if manifest is None:
+        raise RuntimeError(f"archive manifest missing: {manifest_key}")
+    if int(manifest.get("schema_version", -1)) != ARCHIVE_SCHEMA_VERSION:
+        raise RuntimeError("archive schema version does not match the verifier")
+    if manifest.get("dataset") != dataset or manifest.get("day") != day.isoformat():
+        raise RuntimeError("archive manifest identity does not match the requested day")
+
+    source = SourceFingerprint.from_dict(dict(manifest["source_fingerprint"]))
+    pointer_source = SourceFingerprint.from_dict(dict(pointer["source_fingerprint"]))
+    if not source.matches(pointer_source):
+        raise RuntimeError("archive pointer and manifest fingerprints differ")
+    parts_value = manifest.get("parts")
+    if not isinstance(parts_value, list):
+        raise RuntimeError("archive manifest parts must be a list")
+
+    verified: list[ExportedPart] = []
+    with tempfile.TemporaryDirectory(prefix=f"tr-restore-{dataset}-") as temporary:
+        for index, raw_part in enumerate(parts_value):
+            if not isinstance(raw_part, dict):
+                raise RuntimeError("archive manifest part is not an object")
+            key = str(raw_part.get("key") or "")
+            if not key.startswith(f"{prefix}/revisions/"):
+                raise RuntimeError("archive part is outside the requested dataset")
+            path = Path(temporary) / f"part-{index:05d}.parquet"
+            store.download_file(key, path)
+            if _sha256(path) != str(raw_part.get("sha256") or ""):
+                raise RuntimeError(f"archive SHA-256 mismatch: {key}")
+            part = (verifier or (lambda value: verify_parquet_part(value, dataset=dataset)))(
+                path
+            )
+            expected = (
+                int(raw_part.get("rows", -1)),
+                int(raw_part.get("hash_sum", -1)),
+                int(raw_part.get("hash_xor", -1)),
+            )
+            if (part.rows, part.hash_sum, part.hash_xor) != expected:
+                raise RuntimeError(f"archive Parquet fingerprint mismatch: {key}")
+            verified.append(part)
+
+    restored = _combine_parts(verified)
+    if not source.matches(restored):
+        raise RuntimeError("restored archive does not match the source fingerprint")
+    return RestoreResult(
+        dataset=dataset,
+        day=day,
+        rows=source.rows,
+        parts=len(verified),
+        revision=str(manifest.get("revision") or ""),
+    )
+
+
+def _write_result(path: Path, results: list[RestoreResult]) -> None:
+    value = {
+        "checked_at": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),
+        "ok": True,
+        "datasets": [dataclasses.asdict(result) for result in results],
+    }
+    value["datasets"] = [
+        {**row, "day": str(row["day"])} for row in value["datasets"]  # type: ignore[misc]
+    ]
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
+    parser.add_argument("--table", action="append", choices=tuple(DATASETS))
+    parser.add_argument("--date", type=dt.date.fromisoformat)
+    parser.add_argument(
+        "--result-file",
+        type=Path,
+        default=Path("/var/lib/tr-clickhouse-ingest/archive-restore.json"),
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    day = args.date or (dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1))
+    if day >= dt.datetime.now(dt.UTC).date():
+        raise SystemExit("restore verification only accepts closed UTC days")
+    store = GCSRestoreStore(project=args.project, bucket=args.bucket)
+    results = [
+        verify_archived_day(store, dataset=dataset, day=day)
+        for dataset in tuple(dict.fromkeys(args.table or tuple(DATASETS)))
+    ]
+    _write_result(args.result_file, results)
+    for result in results:
+        log.info(
+            "analytics_archive_restore.completed dataset=%s day=%s rows=%d "
+            "parts=%d revision=%s",
+            result.dataset,
+            result.day,
+            result.rows,
+            result.parts,
+            result.revision,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import datetime as dt
-import hashlib
 import json
 import os
-import re
-import struct
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -22,6 +19,7 @@ from clickhouse.ingest_operational_outbox import (
     OperationalOutboxRow,
     normalise_operational_event,
 )
+from clickhouse.operational_fingerprint import canonical_fingerprint, clickhouse_rows
 from clickhouse.rollup_synthetic import build_raw_rollups, complete_window_rollups
 from trusted_router.storage_gcp_codec import reverse_time_key
 from trusted_router.storage_gcp_operational_analytics_outbox import (
@@ -34,10 +32,14 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
 )
 
+# Compatibility aliases for the existing parity tests and any one-off operator
+# scripts importing the old private helpers during the migration window.
+_canonical = canonical_fingerprint
+_clickhouse_rows = clickhouse_rows
+
 PROJECT = "quill-cloud-proxy"
 INSTANCE = "trusted-router-logs"
 TABLE = "trustedrouter-generations"
-SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
 T = TypeVar("T")
 
 
@@ -61,83 +63,6 @@ def _parse(cls: type[T], payload: dict[str, Any] | None) -> T | None:
         return cls(**payload)
     except (TypeError, ValueError):
         return None
-
-
-def _iso(value: Any) -> str:
-    text = str(value).replace(" ", "T")
-    try:
-        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return text if text.endswith("Z") else text + "Z"
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=dt.UTC)
-    return (
-        parsed.astimezone(dt.UTC)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
-
-
-def _canonical(payload: dict[str, Any], *, surface: str) -> str:
-    payload = dict(payload)
-    payload.pop("ingest_version", None)
-    payload.pop("updated_at", None)
-    for field in ("created_at", "period_start", "last_checked_at"):
-        if payload.get(field) is not None:
-            payload[field] = _iso(payload[field])
-    if surface == "synthetic":
-        for field in ("connection_reused", "output_match"):
-            if payload.get(field) is not None:
-                payload[field] = bool(payload[field])
-    if surface == "activity":
-        for field in ("streamed", "usage_estimated"):
-            if payload.get(field) is not None:
-                payload[field] = bool(payload[field])
-    if surface == "rollup" and payload.get("target_region") is None:
-        payload["target_region"] = ""
-    if surface == "benchmark" and payload.get("speed_tokens_per_second") is not None:
-        payload["speed_tokens_per_second"] = struct.unpack(
-            "!f",
-            struct.pack("!f", float(payload["speed_tokens_per_second"])),
-        )[0]
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
-    ).hexdigest()
-
-
-def _clickhouse_rows(
-    clickhouse: ClickHouse,
-    *,
-    table: str,
-    id_column: str,
-    ids: list[str],
-) -> dict[str, dict[str, Any]]:
-    allowed = {
-        ("provider_benchmark_samples", "id"),
-        ("activity_generations", "generation_id"),
-        ("synthetic_probe_samples", "id"),
-        ("synthetic_status_rollups", "id"),
-    }
-    if (table, id_column) not in allowed:
-        raise ValueError("unsupported parity table")
-    if not ids:
-        return {}
-    if any(SAFE_ID.fullmatch(item) is None for item in ids):
-        raise ValueError("source contains an invalid record ID")
-    payload = ("\n".join(ids) + "\n").encode()
-    result = clickhouse.query(
-        f"SELECT * EXCEPT ingest_version FROM {table} FINAL "  # noqa: S608
-        f"WHERE {id_column} IN (SELECT id FROM wanted) "
-        "FORMAT JSONEachRow",
-        input_bytes=payload,
-        external_ids=True,
-    )
-    rows: dict[str, dict[str, Any]] = {}
-    for line in result.splitlines():
-        row = json.loads(line)
-        if isinstance(row, dict):
-            rows[str(row[id_column])] = row
-    return rows
 
 
 def _stable_source_row(
@@ -297,7 +222,7 @@ def compare_surface(
         grace_seconds=grace_seconds,
     )
     ch_table, id_column = destinations[surface]
-    destination = _clickhouse_rows(
+    destination = clickhouse_rows(
         clickhouse,
         table=ch_table,
         id_column=id_column,
@@ -309,7 +234,9 @@ def compare_surface(
         destination_row = destination.get(record_id)
         if destination_row is None:
             missing += 1
-        elif _canonical(source_row, surface=surface) != _canonical(
+        elif canonical_fingerprint(
+            source_row, surface=surface
+        ) != canonical_fingerprint(
             destination_row,
             surface=surface,
         ):

--- a/clickhouse/verify_spanner_delivery.py
+++ b/clickhouse/verify_spanner_delivery.py
@@ -1,0 +1,169 @@
+"""Verify typed Spanner generation records reached ClickHouse exactly."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any, Protocol
+
+from clickhouse.backfill_operational_analytics import ClickHouse
+from clickhouse.operational_fingerprint import canonical_fingerprint, clickhouse_rows
+from trusted_router.storage_gcp_operational_analytics_outbox import activity_payload
+from trusted_router.storage_models import Generation
+
+PROJECT = "quill-cloud-proxy"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+
+
+class GenerationSource(Protocol):
+    def fetch(
+        self,
+        *,
+        start: dt.datetime,
+        end: dt.datetime,
+        limit: int,
+    ) -> list[Generation]: ...
+
+
+class SpannerGenerationSource:
+    def __init__(self, *, project: str, instance: str, database: str) -> None:
+        from google.cloud import spanner
+        from google.cloud.spanner_v1 import param_types
+
+        self._database = (
+            spanner.Client(project=project, disable_builtin_metrics=True)
+            .instance(instance)
+            .database(database)
+        )
+        self._pt = param_types
+
+    def fetch(
+        self,
+        *,
+        start: dt.datetime,
+        end: dt.datetime,
+        limit: int,
+    ) -> list[Generation]:
+        with self._database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                "SELECT payload FROM "
+                "tr_generation@{FORCE_INDEX=tr_generation_by_terminal_at} "
+                "WHERE terminal_at >= @start AND terminal_at < @end "
+                "ORDER BY terminal_at DESC LIMIT @limit",
+                params={"start": start, "end": end, "limit": limit},
+                param_types={
+                    "start": self._pt.TIMESTAMP,
+                    "end": self._pt.TIMESTAMP,
+                    "limit": self._pt.INT64,
+                },
+            )
+            return [_generation(str(row[0])) for row in rows]
+
+
+def _generation(payload: str) -> Generation:
+    value = json.loads(payload)
+    if not isinstance(value, dict):
+        raise RuntimeError("typed generation payload is not an object")
+    known = {field.name for field in dataclasses.fields(Generation)}
+    return Generation(**{key: item for key, item in value.items() if key in known})
+
+
+def verify_delivery(
+    source: GenerationSource,
+    clickhouse: Any,
+    *,
+    start: dt.datetime,
+    end: dt.datetime,
+    limit: int,
+) -> dict[str, Any]:
+    generations = source.fetch(start=start, end=end, limit=limit)
+    expected = {generation.id: activity_payload(generation) for generation in generations}
+    actual = clickhouse_rows(
+        clickhouse,
+        table="activity_generations",
+        id_column="generation_id",
+        ids=list(expected),
+    )
+    missing = sorted(set(expected) - set(actual))
+    mismatched = sorted(
+        generation_id
+        for generation_id in set(expected) & set(actual)
+        if canonical_fingerprint(expected[generation_id], surface="activity")
+        != canonical_fingerprint(actual[generation_id], surface="activity")
+    )
+    return {
+        "sampled": len(expected),
+        "found": len(actual),
+        "missing": len(missing),
+        "mismatched": len(mismatched),
+        "missing_ids": missing[:20],
+        "mismatched_ids": mismatched[:20],
+        "ok": not missing and not mismatched,
+    }
+
+
+def _write_history(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=16)
+    history: list[dict[str, Any]] = []
+    if path.exists():
+        for line in path.read_text().splitlines():
+            try:
+                row = json.loads(line)
+                checked = dt.datetime.fromisoformat(
+                    str(row["checked_at"]).replace("Z", "+00:00")
+                )
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if checked >= cutoff:
+                history.append(row)
+    history.append(result)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in history))
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=5000)
+    parser.add_argument("--lookback-hours", type=int, default=24)
+    parser.add_argument("--grace-seconds", type=int, default=120)
+    parser.add_argument(
+        "--history-file",
+        type=Path,
+        default=Path("/var/lib/tr-clickhouse-ingest/spanner-delivery.jsonl"),
+    )
+    args = parser.parse_args()
+    if args.limit < 1 or args.lookback_hours < 1 or args.grace_seconds < 0:
+        raise SystemExit("limit/lookback must be positive and grace cannot be negative")
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    end = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=args.grace_seconds)
+    start = end - dt.timedelta(hours=args.lookback_hours)
+    result = verify_delivery(
+        SpannerGenerationSource(
+            project=os.environ.get("GCP_PROJECT_ID", PROJECT),
+            instance=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
+            database=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
+        ),
+        ClickHouse(password=password),
+        start=start,
+        end=end,
+        limit=args.limit,
+    )
+    result["checked_at"] = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
+    result["window_start"] = start.isoformat().replace("+00:00", "Z")
+    result["window_end"] = end.isoformat().replace("+00:00", "Z")
+    _write_history(args.history_file, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/clickhouse-reliability.md
+++ b/docs/clickhouse-reliability.md
@@ -16,9 +16,11 @@ Long-term analytics uses tiers instead of retaining every hot row forever:
 
 | Tier | Retention | Purpose |
 |---|---:|---|
-| Replicated raw ClickHouse rows | 400 days | Recent investigation and exact re-aggregation |
-| Hourly ClickHouse rollups | 3 years | Detailed trends and provider operations |
-| Daily and monthly ClickHouse rollups | No TTL | Long-term product and provider analytics |
+| Provider and activity raw rows | 400 days | Recent investigation and exact re-aggregation |
+| Raw synthetic probe rows | 14 days | Fine-grained status diagnosis before compaction |
+| Synthetic status rollups | 24 months | Public reliability history |
+| Hourly provider rollups | 3 years | Detailed trends and provider operations |
+| Daily and monthly provider rollups | No TTL | Long-term product and provider analytics |
 | Verified Parquet archive in GCS | 7 years | Immutable, portable raw history and disaster recovery |
 | Persistent-disk snapshots | 30 daily snapshots | Fast node recovery |
 
@@ -62,16 +64,17 @@ explicitly reviewed cleanup.
 
 ## Durable archive
 
-`clickhouse/archive_daily.py` exports each closed UTC day from the canonical
-raw table with `FINAL`. It computes a full row-set fingerprint, writes Parquet,
-reads the Parquet back with `clickhouse-local`, and compares row count, hash
-sum, and hash XOR before publishing a manifest.
+`clickhouse/archive_daily.py` exports each closed UTC day with `FINAL` for
+provider benchmarks, tenant activity, raw synthetic probes, and synthetic
+status rollups. It computes a full row-set fingerprint, writes Parquet, reads
+the Parquet back with `clickhouse-local`, and compares row count, hash sum, and
+hash XOR before publishing a manifest.
 
 Objects are immutable and revisioned:
 
 ```text
 gs://quill-cloud-proxy-tr-clickhouse-archive/
-  raw/provider_benchmark_samples/day=YYYY-MM-DD/
+  raw/<dataset>/day=YYYY-MM-DD/
     _latest.json
     revisions/<fingerprint>/manifest.json
     revisions/<fingerprint>/part-*.parquet
@@ -80,7 +83,10 @@ gs://quill-cloud-proxy-tr-clickhouse-archive/
 A rerun with unchanged data is a no-op. Late reconciled rows produce a new
 immutable revision and atomically advance `_latest.json`. Bucket versioning,
 uniform access, and public-access prevention are enabled. The daily service
-rechecks seven closed days so late rows are captured.
+rechecks seven closed days so late rows are captured. A separate daily restore
+drill downloads every part for the previous closed day, validates object
+SHA256 values, parses each Parquet file, and must reproduce the source
+fingerprint before updating `archive-restore.json`.
 
 ## Aggregate tiers
 
@@ -109,7 +115,16 @@ scripts/deploy/clickhouse_resize_disk.sh --apply
 scripts/deploy/clickhouse_cluster.sh --apply
 scripts/deploy/clickhouse_live_ingestion.sh
 scripts/deploy/rollout.sh
+scripts/deploy/prepare_bigtable_retirement.sh --apply
+scripts/deploy/clickhouse_analytics_cutover.sh --apply
+# Wait for the second clean seven-day soak.
+scripts/deploy/retire_bigtable_runtime.sh --apply
 ```
+
+The final script deploys one region at a time, switches to
+`spanner-clickhouse` plus `clickhouse-only`, and disables Bigtable mirror
+writes. It never deletes the Bigtable instance or its data. The retained copy
+is rollback evidence until a separate, explicit deletion review.
 
 `clickhouse_cluster.sh` stages all Keeper configs before restarts, starts the
 two new voters together, migrates only after full-fingerprint parity, pauses
@@ -197,9 +212,10 @@ are the faster same-platform recovery source.
 ## Alerts and capacity
 
 Cloud Monitoring pages on node unavailability and disk use at 75 percent.
-The ClickHouse server, archive timer, rollup timers, and ingester must also be
-checked during incident response. Alert delivery uses the verified
-TrustedRouter infrastructure notification channel.
+The ClickHouse server, archive and restore timers, Spanner delivery verifier,
+rollup timers, and ingester must also be checked during incident response.
+Alert delivery uses the verified TrustedRouter infrastructure notification
+channel.
 
 At 75 percent disk use, do not merely expand forever. Measure rows per second,
 compressed bytes per row, parts, merge backlog, query latency, Keeper latency,

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -7,7 +7,7 @@ came from a real incident; the linked commits are the receipts.
 Index:
 - [Router-core four-nines page fires](#router-core-page)
 - [Drain or disable one gateway region](#region-drain)
-- [Spanner or Bigtable is degraded](#storage-degraded)
+- [Spanner or ClickHouse is degraded](#storage-degraded)
 - [Provider returns 502 "provider error" via the gateway](#provider-502)
 - [Provider returns sustained 429 "rate limit exceeded"](#provider-429)
 - [Provider returns 401 "Invalid API key" via the gateway](#provider-401)
@@ -82,10 +82,12 @@ Provider emergency disable:
 3. Watch the affected provider row on `/status` and `/leaderboard`, not
    `router_core`, for the remaining provider impact.
 
-## <a id="storage-degraded"></a>Spanner or Bigtable is degraded
+## <a id="storage-degraded"></a>Spanner or ClickHouse is degraded
 
-Spanner remains the source of truth for billing and settlement. Bigtable
-activity/status rows are repairable metadata.
+Spanner remains the source of truth for billing and settlement. Content-free
+activity and status analytics are delivered from a durable Spanner outbox to
+replicated ClickHouse. Bigtable is only a temporary migration mirror and is not
+part of the `spanner-clickhouse` runtime.
 
 Spanner degraded:
 1. Check whether regional quota leases can continue authorizing bounded spend.
@@ -95,17 +97,16 @@ Spanner degraded:
    and key-limit enforcement is still local/leased.
 4. After recovery, reconcile reservations and stuck authorizations.
 
-Bigtable degraded:
-1. Keep inference alive if Spanner settlement succeeds.
-2. Expect missing activity/status rows.
-3. Run:
-   ```bash
-   curl -X POST https://trustedrouter.com/v1/internal/reconcile/generation-activity \
-     -H "Authorization: Bearer $TR_INTERNAL_GATEWAY_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{"workspace_id":"<workspace_id>","limit":10000}'
-   ```
-4. Verify `/activity`, `/generation`, and provider benchmark rollups recover.
+ClickHouse degraded:
+1. Keep inference and Spanner settlement alive. Never make ClickHouse part of
+   the synchronous prompt or billing path.
+2. Check `tr_operational_analytics_outbox` and `tr_analytics_outbox` oldest-row
+   lag. The drainer must catch up before either queue's retention window.
+3. Check all three ClickHouse replicas, disk capacity, and Keeper delay.
+4. Start `tr-clickhouse-operational-ingest.service`, then run
+   `clickhouse.verify_spanner_delivery` and confirm no missing or mismatched
+   generation rows.
+5. Verify `/activity`, `/status`, `/leaderboard`, and provider rollups recover.
 
 ---
 
@@ -519,7 +520,7 @@ Outcome cheat-sheet:
 | `invalid_row` | Dead; no page. |
 | `park_typed_unavailable` | Typed-store outage; retries without burning attempts. |
 | `resolved_zero_cost_elsewhere` | Benign $0 race (reaper free-release or a refund won); done, no page. The activity index is attempted first whenever the row carries a generation, so this outcome means the index SUCCEEDED; if it fails the row stays `activity_pending` and keeps its payload. |
-| `activity_pending` | Charge committed but the Bigtable activity-index write failed. Parks every 60s without burning attempts. After 6 hours of *continuous* activity failure the row goes `dead` with `ALERT settle outbox activity repair expired`. See below. |
+| `activity_pending` | Rolling-legacy only: charge committed but its historical Bigtable activity-index write failed. New typed rows atomically enqueue ClickHouse delivery and cannot enter this state because of a mirror failure. |
 
 `activity_pending` is the one outcome where the terminal transition is NOT a
 money problem. The charge already committed in Spanner (the billing source of
@@ -528,6 +529,10 @@ finalize and from the `ALREADY_SETTLED` replay branches, so seeing it on a
 replay is normal. The customer is billed correctly; only the per-request
 Bigtable activity row is missing, so the request may be absent from their
 activity view.
+
+This section is retained only to drain rows created by revisions predating the
+Spanner operational outbox. Once the retirement gate has confirmed there are no
+such rows, a Bigtable outage cannot create new `activity_pending` work.
 
 Two things about this outcome are easy to get wrong:
 

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -8,7 +8,7 @@
 # partial deploys. The shared config + helpers live in scripts/deploy/_lib.sh.
 #
 #   1. infra.sh    — enable APIs, provision Spanner + Bigtable
-#   2. migrate_typed_counters.sh + migrate_request_retention.sh — additive schema
+#   2. typed billing, bounded request records, and analytics outboxes
 #   3. image.sh    — Artifact Registry repo + buildx push (linux/amd64)
 #   4. secrets.sh  — Secret Manager + runtime IAM bindings
 #   5. rollout.sh  — parallel multi-region Cloud Run deploy + LB wiring
@@ -21,6 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 bash "${SCRIPT_DIR}/deploy/infra.sh"
 bash "${SCRIPT_DIR}/deploy/migrate_typed_counters.sh"
 bash "${SCRIPT_DIR}/deploy/migrate_request_retention.sh" --apply
+bash "${SCRIPT_DIR}/deploy/migrate_generation_records.sh" --apply
+bash "${SCRIPT_DIR}/deploy/migrate_analytics_outbox.sh"
+bash "${SCRIPT_DIR}/deploy/migrate_operational_analytics_outbox.sh"
 bash "${SCRIPT_DIR}/deploy/image.sh"
 bash "${SCRIPT_DIR}/deploy/secrets.sh"
 bash "${SCRIPT_DIR}/deploy/rollout.sh"

--- a/scripts/deploy/clickhouse_analytics_cutover.sh
+++ b/scripts/deploy/clickhouse_analytics_cutover.sh
@@ -134,5 +134,6 @@ fi
 
 TR_ANALYTICS_READ_MODE=clickhouse \
 TR_ANALYTICS_DUAL_READ_STARTED_AT="$started_at" \
+TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   "${SCRIPT_DIR}/rollout.sh"
 log "ClickHouse is primary; Bigtable remains a shadow and fallback for seven more days"

--- a/scripts/deploy/clickhouse_control_reader.sh
+++ b/scripts/deploy/clickhouse_control_reader.sh
@@ -52,6 +52,7 @@ sed "s/__PASSWORD_SHA256__/${reader_hash}/g" >"$config" <<'XML'
         <query>GRANT SELECT ON tr.activity_generations</query>
         <query>GRANT SELECT ON tr.synthetic_probe_samples</query>
         <query>GRANT SELECT ON tr.synthetic_status_rollups</query>
+        <query>GRANT SELECT ON tr.public_analytics_snapshots</query>
       </grants>
     </tr_control_read>
   </users>
@@ -76,7 +77,7 @@ printf 'CH_CONTROL_READ_PASSWORD=%s\n' "$reader_password" |
     --zone="$ZONE" \
     --tunnel-through-iap \
     --quiet \
-    --command="sudo sh -c 'umask 077; cat > /tmp/tr-control-reader.env; set -a; . /tmp/tr-control-reader.env; set +a; /usr/bin/clickhouse-client --user tr_control_read --password \"\$CH_CONTROL_READ_PASSWORD\" --query \"SELECT count() FROM tr.activity_generations FINAL LIMIT 1\" >/dev/null; rm -f /tmp/tr-control-reader.env'"
+    --command="sudo sh -c 'umask 077; cat > /tmp/tr-control-reader.env; set -a; . /tmp/tr-control-reader.env; set +a; /usr/bin/clickhouse-client --user tr_control_read --password \"\$CH_CONTROL_READ_PASSWORD\" --multiquery --query \"SELECT count() FROM tr.activity_generations FINAL LIMIT 1; SELECT count() FROM tr.public_analytics_snapshots FINAL LIMIT 1\" >/dev/null; rm -f /tmp/tr-control-reader.env'"
 unset reader_password
 
 echo "configured private read-only ClickHouse control-plane account"

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -65,6 +65,10 @@ ssh_node --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-archive.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.timer \
     /etc/systemd/system/tr-clickhouse-archive.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.service \
+    /etc/systemd/system/tr-clickhouse-archive-restore.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.timer \
+    /etc/systemd/system/tr-clickhouse-archive-restore.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-hourly.service \
     /etc/systemd/system/tr-clickhouse-rollup-hourly.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-rollup-hourly.timer \
@@ -85,11 +89,13 @@ ssh_node --command="sudo sh -c '
   systemctl restart tr-clickhouse-ingest.service
   systemctl enable --now tr-clickhouse-reconcile.timer
   systemctl enable --now tr-clickhouse-archive.timer
+  systemctl enable --now tr-clickhouse-archive-restore.timer
   systemctl enable --now tr-clickhouse-rollup-hourly.timer
   systemctl enable --now tr-clickhouse-rollup-daily.timer
   systemctl is-active tr-clickhouse-ingest.service
   systemctl is-active tr-clickhouse-reconcile.timer
   systemctl is-active tr-clickhouse-archive.timer
+  systemctl is-active tr-clickhouse-archive-restore.timer
   systemctl is-active tr-clickhouse-rollup-hourly.timer
   systemctl is-active tr-clickhouse-rollup-daily.timer
 '"

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -71,6 +71,7 @@ GCP_PROJECT_ID="$PROJECT_ID" \
 SPANNER_INSTANCE_ID="$SPANNER_INSTANCE_ID" \
 SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \
   "${SCRIPT_DIR}/migrate_operational_analytics_outbox.sh"
+"${SCRIPT_DIR}/migrate_generation_records.sh" --apply
 
 log "creating replicated operational tables"
 schema="$(cat "$SCHEMA")"
@@ -108,6 +109,18 @@ node_ssh 0 --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-operational-parity.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-parity.timer \
     /etc/systemd/system/tr-clickhouse-operational-parity.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-public-snapshots.service \
+    /etc/systemd/system/tr-clickhouse-public-snapshots.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-public-snapshots.timer \
+    /etc/systemd/system/tr-clickhouse-public-snapshots.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.service \
+    /etc/systemd/system/tr-clickhouse-archive-restore.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.timer \
+    /etc/systemd/system/tr-clickhouse-archive-restore.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-spanner-delivery.service \
+    /etc/systemd/system/tr-clickhouse-spanner-delivery.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-spanner-delivery.timer \
+    /etc/systemd/system/tr-clickhouse-spanner-delivery.timer
   systemctl daemon-reload
   systemctl stop tr-clickhouse-operational-ingest.service 2>/dev/null || true
 '"
@@ -123,6 +136,18 @@ node_ssh 0 --command="sudo sh -c '
     /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_operational_analytics --apply
 '"
 
+log "backfilling and verifying the bounded generation lookup window"
+node_ssh 0 --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_generation_records \
+      --apply --verify
+'"
+
 log "building initial synthetic status rollups"
 node_ssh 0 --command="sudo sh -c '
   set -eu
@@ -134,14 +159,16 @@ node_ssh 0 --command="sudo sh -c '
     /opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
 '"
 
-node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer"
+node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer"
 
 log "verifying exact replica identity after synchronization"
-for table in activity_generations synthetic_probe_samples synthetic_status_rollups; do
+for table in activity_generations synthetic_probe_samples synthetic_status_rollups public_analytics_snapshots; do
   expected=""
   id_column="id"
   if [ "$table" = "activity_generations" ]; then
     id_column="generation_id"
+  elif [ "$table" = "public_analytics_snapshots" ]; then
+    id_column="name"
   fi
   for index in 0 1 2; do
     node_query "$index" "SYSTEM SYNC REPLICA ${table}"
@@ -174,6 +201,7 @@ for index in 0 1 2; do
 done
 
 node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
 
 log "operational analytics infrastructure is ready; Bigtable is still authoritative"
 log "deploy the operational outbox producer, then run clickhouse_operational_analytics_finalize.sh --apply"

--- a/scripts/deploy/migrate_generation_records.sh
+++ b/scripts/deploy/migrate_generation_records.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Add bounded metadata-only generation lookup records. Dry-run by default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+APPLY=0
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  printf 'usage: %s [--apply]\n' "$0" >&2
+  exit 2
+fi
+
+exists="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" \
+  --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_generation'" \
+  --format='value(rows[0])')"
+
+DDL="CREATE TABLE tr_generation (
+  generation_id STRING(128) NOT NULL,
+  workspace_id STRING(64) NOT NULL,
+  key_hash STRING(128) NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  terminal_at TIMESTAMP NOT NULL,
+  payload STRING(MAX) NOT NULL,
+) PRIMARY KEY (generation_id),
+  ROW DELETION POLICY (OLDER_THAN(terminal_at, INTERVAL 30 DAY))"
+
+if [ "${exists:-0}" = "0" ]; then
+  if [ "$APPLY" -eq 0 ]; then
+    log "dry-run DDL: ${DDL}"
+  else
+    gc spanner databases ddl update "$SPANNER_DATABASE_ID" \
+      --instance="$SPANNER_INSTANCE_ID" \
+      --ddl="$DDL"
+    log "created tr_generation; no existing rows were changed or deleted"
+  fi
+else
+  log "tr_generation exists"
+fi
+
+index_exists="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" \
+  --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE index_name='tr_generation_by_terminal_at'" \
+  --format='value(rows[0])')"
+if [ "${index_exists:-0}" = "0" ]; then
+  INDEX_DDL="CREATE INDEX tr_generation_by_terminal_at ON tr_generation(terminal_at DESC) STORING (payload)"
+  if [ "$APPLY" -eq 0 ]; then
+    log "dry-run DDL: ${INDEX_DDL}"
+  else
+    gc spanner databases ddl update "$SPANNER_DATABASE_ID" \
+      --instance="$SPANNER_INSTANCE_ID" \
+      --ddl="$INDEX_DDL"
+    log "created tr_generation_by_terminal_at delivery-audit index"
+  fi
+else
+  log "tr_generation_by_terminal_at exists"
+fi

--- a/scripts/deploy/prepare_bigtable_retirement.sh
+++ b/scripts/deploy/prepare_bigtable_retirement.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build and verify every reversible prerequisite for removing Bigtable runtime.
+# This does not change the live storage backend or analytics read mode.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+APPLY=0
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry-run: would deploy additive operational ClickHouse infrastructure"
+  log "dry-run: would backfill and verify 30 days of typed generation records"
+  log "dry-run: would archive every closed historical analytics partition"
+  log "dry-run: would run a real Parquet restore drill and source-delivery check"
+  log "dry-run: would not change production read mode or delete Bigtable data"
+  exit 0
+fi
+
+"${SCRIPT_DIR}/clickhouse_operational_analytics.sh" --apply
+
+gc compute ssh tr-clickhouse-1 \
+  --zone=us-central1-a \
+  --tunnel-through-iap \
+  --quiet \
+  --command="sudo sh -c '
+    set -eu
+    set -a
+    . /etc/tr-clickhouse-ingest.env
+    set +a
+    cd /opt/tr-clickhouse
+    PYTHONPATH=/opt/tr-clickhouse/src \
+      /opt/tr-clickhouse/venv/bin/python -m clickhouse.archive_daily --backfill
+    PYTHONPATH=/opt/tr-clickhouse/src \
+      /opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_archive_restore
+    systemctl start tr-clickhouse-public-snapshots.service
+    systemctl start tr-clickhouse-spanner-delivery.service
+    checked_at=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    printf '"'"'{\"checked_at\":\"%s\",\"ok\":true,\"datasets\":[\"provider_benchmark_samples\",\"activity_generations\",\"synthetic_probe_samples\",\"synthetic_status_rollups\"]}\n'"'"' \
+      \"\$checked_at\" > /var/lib/tr-clickhouse-ingest/archive-backfill-complete.json
+    chown tr-clickhouse-ingest:tr-clickhouse-ingest \
+      /var/lib/tr-clickhouse-ingest/archive-backfill-complete.json
+  '"
+
+log "Bigtable retirement prerequisites are prepared; the seven-day soaks still apply"

--- a/scripts/deploy/retire_bigtable_runtime.sh
+++ b/scripts/deploy/retire_bigtable_runtime.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Remove Bigtable from the live control-plane runtime after a clean second soak.
+# This never deletes Bigtable data. Dry-run is the default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
+ZONES=(us-central1-a us-central1-b us-central1-c)
+MIN_SOAK_SECONDS="${TR_ANALYTICS_FINAL_SOAK_SECONDS:-604800}"
+MAX_QUEUE_LAG_SECONDS="${TR_ANALYTICS_MAX_QUEUE_LAG_SECONDS:-300}"
+MAX_QUEUE_ROWS="${TR_ANALYTICS_MAX_QUEUE_ROWS:-50000}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+read_env() {
+  local region="$1"
+  local name="$2"
+  gc run services describe "$SERVICE" --region="$region" --format=json \
+    | jq -r --arg name "$name" '
+        [.spec.template.spec.containers[0].env[]?
+         | select(.name == $name) | .value][0] // empty
+      '
+}
+
+spanner_scalar() {
+  local sql="$1"
+  gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --sql="$sql" \
+    --format='value(rows[0])'
+}
+
+queue_gate() {
+  local table="$1"
+  local count oldest lag
+  count="$(spanner_scalar "SELECT COUNT(*) FROM ${table}")"
+  count="${count:-0}"
+  if [ "$count" -gt "$MAX_QUEUE_ROWS" ]; then
+    echo "${table} backlog is too large: ${count} rows" >&2
+    exit 1
+  fi
+  if [ "$count" -eq 0 ]; then
+    return
+  fi
+  oldest="$(spanner_scalar "SELECT MIN(commit_ts) FROM ${table}")"
+  lag="$(python3 - "$oldest" <<'PY'
+import datetime as dt
+import sys
+oldest = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+if oldest.tzinfo is None:
+    oldest = oldest.replace(tzinfo=dt.UTC)
+print(max(0, int((dt.datetime.now(dt.UTC) - oldest).total_seconds())))
+PY
+)"
+  if [ "$lag" -gt "$MAX_QUEUE_LAG_SECONDS" ]; then
+    echo "${table} oldest row is ${lag}s old; limit is ${MAX_QUEUE_LAG_SECONDS}s" >&2
+    exit 1
+  fi
+}
+
+node_command() {
+  gc compute ssh tr-clickhouse-1 \
+    --zone=us-central1-a \
+    --tunnel-through-iap \
+    --quiet \
+    --command="$1"
+}
+
+node_scalar() {
+  local query="$1"
+  printf '%s\n' "$query" | gc compute ssh tr-clickhouse-1 \
+    --zone=us-central1-a \
+    --tunnel-through-iap \
+    --quiet \
+    --command="sudo sh -c '
+      set -eu
+      set -a
+      . /etc/tr-clickhouse-ingest.env
+      set +a
+      /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" \
+        --database tr --multiquery
+    '" | tail -1 | tr -d '\r'
+}
+
+IFS=',' read -r -a regions <<<"$TR_CONTROL_PLANE_REGIONS"
+for region in "${regions[@]}"; do
+  mode="$(read_env "$region" TR_ANALYTICS_READ_MODE)"
+  backend="$(read_env "$region" TR_STORAGE_BACKEND)"
+  mirror="$(read_env "$region" TR_BIGTABLE_MIRROR_WRITES_ENABLED)"
+  records="$(read_env "$region" TR_GENERATION_RECORDS_ENABLED)"
+  if [ "$mode" != "clickhouse" ]; then
+    echo "${region} is not in the ClickHouse-primary second soak: ${mode:-unset}" >&2
+    exit 1
+  fi
+  if [ "$backend" != "spanner-bigtable" ]; then
+    echo "${region} has unexpected pre-cutover backend: ${backend:-unset}" >&2
+    exit 1
+  fi
+  if [ "$mirror" != "true" ] || [ "$records" != "true" ]; then
+    echo "${region} does not have generation records plus the migration mirror" >&2
+    exit 1
+  fi
+done
+
+started_at="$(read_env "$TR_PRIMARY_REGION" TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT)"
+if [ -z "$started_at" ]; then
+  echo "ClickHouse-primary soak start timestamp is missing" >&2
+  exit 1
+fi
+soak_seconds="$(python3 - "$started_at" <<'PY'
+import datetime as dt
+import sys
+start = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+print(int((dt.datetime.now(dt.UTC) - start).total_seconds()))
+PY
+)"
+if [ "$soak_seconds" -lt "$MIN_SOAK_SECONDS" ]; then
+  echo "ClickHouse-primary soak is only ${soak_seconds}s; require ${MIN_SOAK_SECONDS}s" >&2
+  exit 1
+fi
+
+log_filter="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE}\" AND timestamp>=\"${started_at}\" AND (textPayload:\"analytics_dual_read_mismatch\" OR textPayload:\"analytics_read_error\" OR jsonPayload.message:\"analytics_dual_read_mismatch\" OR jsonPayload.message:\"analytics_read_error\")"
+if [ "$(gc logging read "$log_filter" --limit=1 --format='value(timestamp)' | wc -l | tr -d ' ')" != "0" ]; then
+  echo "analytics parity or backend read errors occurred during the second soak" >&2
+  exit 1
+fi
+
+queue_gate tr_analytics_outbox
+queue_gate tr_operational_analytics_outbox
+
+dead_settles="$(spanner_scalar "SELECT COUNT(*) FROM tr_settle_outbox WHERE status='dead'")"
+old_settles="$(spanner_scalar "SELECT COUNT(*) FROM tr_settle_outbox WHERE status='pending' AND created_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 5 MINUTE)")"
+if [ "${dead_settles:-0}" != "0" ] || [ "${old_settles:-0}" != "0" ]; then
+  echo "settlement queue is unhealthy: dead=${dead_settles:-0} stale_pending=${old_settles:-0}" >&2
+  exit 1
+fi
+
+generation_table="$(spanner_scalar "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_generation'")"
+generation_index="$(spanner_scalar "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE index_name='tr_generation_by_terminal_at'")"
+if [ "${generation_table:-0}" != "1" ] || [ "${generation_index:-0}" != "1" ]; then
+  echo "typed generation table or delivery-audit index is missing" >&2
+  exit 1
+fi
+
+parity_history="$(node_command 'sudo cat /var/lib/tr-clickhouse-ingest/operational-parity.jsonl')"
+delivery_history="$(node_command 'sudo cat /var/lib/tr-clickhouse-ingest/spanner-delivery.jsonl')"
+history_dir="$(mktemp -d "${TMPDIR:-/tmp}/tr-bigtable-retirement.XXXXXX")"
+trap 'rm -rf "$history_dir"' EXIT
+printf '%s\n' "$parity_history" >"${history_dir}/parity.jsonl"
+printf '%s\n' "$delivery_history" >"${history_dir}/delivery.jsonl"
+unset parity_history delivery_history
+python3 - "$started_at" "$MIN_SOAK_SECONDS" "$history_dir" <<'PY'
+import datetime as dt
+import json
+import math
+from pathlib import Path
+import sys
+
+started = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+minimum = int(sys.argv[2])
+directory = Path(sys.argv[3])
+now = dt.datetime.now(dt.UTC)
+
+def load(name):
+    rows = []
+    for line in (directory / name).read_text().splitlines():
+        try:
+            row = json.loads(line)
+            checked = dt.datetime.fromisoformat(row["checked_at"].replace("Z", "+00:00"))
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if checked >= started:
+            rows.append((checked, row))
+    return rows
+
+parity = load("parity.jsonl")
+delivery = load("delivery.jsonl")
+required = max(1, math.floor(minimum / 3600))
+for label, rows in (("Bigtable parity", parity), ("Spanner delivery", delivery)):
+    if len(rows) < required:
+        raise SystemExit(f"{label} has {len(rows)} samples; require {required}")
+    if now - max(checked for checked, _ in rows) > dt.timedelta(hours=1):
+        raise SystemExit(f"latest {label} sample is stale")
+    if any(not row.get("ok") for _, row in rows):
+        raise SystemExit(f"{label} history contains a failed check")
+if not any(
+    row.get("surfaces", {}).get(surface, {}).get("sampled", 0) > 0
+    for _, row in parity
+    for surface in ("benchmark", "activity", "synthetic", "rollup")
+):
+    raise SystemExit("Bigtable parity history has no positive samples")
+if not any(row.get("sampled", 0) > 0 for _, row in delivery):
+    raise SystemExit("Spanner delivery history has no positive samples")
+PY
+
+restore_result="$(node_command 'sudo cat /var/lib/tr-clickhouse-ingest/archive-restore.json')"
+printf '%s\n' "$restore_result" >"${history_dir}/archive-restore.json"
+backfill_result="$(node_command 'sudo cat /var/lib/tr-clickhouse-ingest/archive-backfill-complete.json')"
+printf '%s\n' "$backfill_result" >"${history_dir}/archive-backfill.json"
+python3 - "${history_dir}/archive-restore.json" <<'PY'
+import datetime as dt
+import json
+from pathlib import Path
+import sys
+expected = {
+    "provider_benchmark_samples",
+    "activity_generations",
+    "synthetic_probe_samples",
+    "synthetic_status_rollups",
+}
+row = json.loads(Path(sys.argv[1]).read_text())
+checked = dt.datetime.fromisoformat(row["checked_at"].replace("Z", "+00:00"))
+if not row.get("ok") or dt.datetime.now(dt.UTC) - checked > dt.timedelta(hours=30):
+    raise SystemExit("archive restore drill is failed or stale")
+found = {item["dataset"] for item in row.get("datasets", [])}
+if found != expected:
+    raise SystemExit(f"archive restore drill coverage mismatch: {sorted(found)}")
+PY
+python3 - "${history_dir}/archive-backfill.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+expected = {
+    "provider_benchmark_samples",
+    "activity_generations",
+    "synthetic_probe_samples",
+    "synthetic_status_rollups",
+}
+row = json.loads(Path(sys.argv[1]).read_text())
+if not row.get("ok") or set(row.get("datasets", [])) != expected:
+    raise SystemExit("historical analytics archive backfill is incomplete")
+PY
+
+for index in 0 1 2; do
+  health="$(gc compute ssh "${NAMES[$index]}" \
+    --zone="${ZONES[$index]}" \
+    --tunnel-through-iap \
+    --quiet \
+    --command="sudo sh -c 'set -a; . /etc/tr-clickhouse-ingest.env; set +a; /usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr --query \"SELECT sum(queue_size), sum(absolute_delay), countIf(is_readonly) FROM system.replicas FORMAT TSVRaw\"'" \
+    | tail -1 | tr -d '\r')"
+  if [ "$health" != $'0\t0\t0' ]; then
+    echo "ClickHouse replica health gate failed on ${NAMES[$index]}: ${health}" >&2
+    exit 1
+  fi
+done
+
+snapshot_age="$(node_scalar "SELECT dateDiff('second', max(generated_at), now()) FROM public_analytics_snapshots FINAL FORMAT TSVRaw")"
+if [ -z "$snapshot_age" ] || [ "$snapshot_age" -gt 600 ]; then
+  echo "public analytics snapshot is stale: ${snapshot_age:-missing}s" >&2
+  exit 1
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "all gates passed: would remove Bigtable from one regional runtime at a time"
+  log "Bigtable data would remain intact for rollback; no table or instance is deleted"
+  exit 0
+fi
+
+ordered_regions=()
+for region in "${regions[@]}"; do
+  [ "$region" = "$TR_PRIMARY_REGION" ] || ordered_regions+=("$region")
+done
+ordered_regions+=("$TR_PRIMARY_REGION")
+
+for region in "${ordered_regions[@]}"; do
+  log "cutting ${region} to Spanner + ClickHouse; other regions remain warm"
+  TR_DEPLOY_TARGET_REGIONS="$region" \
+  TR_STORAGE_BACKEND=spanner-clickhouse \
+  TR_ANALYTICS_READ_MODE=clickhouse-only \
+  TR_ANALYTICS_DUAL_READ_STARTED_AT="$(read_env "$TR_PRIMARY_REGION" TR_ANALYTICS_DUAL_READ_STARTED_AT)" \
+  TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$started_at" \
+  TR_BIGTABLE_MIRROR_WRITES_ENABLED=false \
+  TR_GENERATION_RECORDS_ENABLED=true \
+  TR_REQUEST_RECORD_WRITE_MODE=typed \
+    "${SCRIPT_DIR}/rollout.sh"
+  url="$(gc run services describe "$SERVICE" --region="$region" --format='value(status.url)')"
+  bash "${SCRIPT_DIR}/verify_deployment.sh" "$url"
+done
+
+for region in "${regions[@]}"; do
+  [ "$(read_env "$region" TR_STORAGE_BACKEND)" = "spanner-clickhouse" ]
+  [ "$(read_env "$region" TR_ANALYTICS_READ_MODE)" = "clickhouse-only" ]
+  [ "$(read_env "$region" TR_BIGTABLE_MIRROR_WRITES_ENABLED)" = "false" ]
+done
+bash "${SCRIPT_DIR}/verify_deployment.sh" --expect-monitor https://trustedrouter.com
+node_command 'sudo systemctl disable --now tr-clickhouse-operational-parity.timer'
+node_command 'sudo systemctl enable --now tr-clickhouse-spanner-delivery.timer'
+log "Bigtable is absent from the runtime; retained data remains untouched for rollback"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -108,6 +108,61 @@ case "$REQUEST_RECORD_WRITE_MODE" in
     ;;
 esac
 
+LIVE_STORAGE_BACKEND="$(
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format=json 2>/dev/null \
+    | jq -r '
+        [
+          .spec.template.spec.containers[0].env[]?
+          | select(.name == "TR_STORAGE_BACKEND")
+          | .value
+        ][0] // "spanner-bigtable"
+      ' || true
+)"
+STORAGE_BACKEND="${TR_STORAGE_BACKEND:-${LIVE_STORAGE_BACKEND:-spanner-bigtable}}"
+case "$STORAGE_BACKEND" in
+  spanner-bigtable|spanner-clickhouse) ;;
+  *)
+    log "refusing rollout: TR_STORAGE_BACKEND must be spanner-bigtable or spanner-clickhouse"
+    exit 1
+    ;;
+esac
+
+LIVE_GENERATION_RECORDS_ENABLED="$(
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format=json 2>/dev/null \
+    | jq -r '
+        [
+          .spec.template.spec.containers[0].env[]?
+          | select(.name == "TR_GENERATION_RECORDS_ENABLED")
+          | .value
+        ][0] // empty
+      ' || true
+)"
+LIVE_BIGTABLE_MIRROR_WRITES_ENABLED="$(
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format=json 2>/dev/null \
+    | jq -r '
+        [
+          .spec.template.spec.containers[0].env[]?
+          | select(.name == "TR_BIGTABLE_MIRROR_WRITES_ENABLED")
+          | .value
+        ][0] // empty
+      ' || true
+)"
+GENERATION_RECORDS_ENABLED="${TR_GENERATION_RECORDS_ENABLED:-${LIVE_GENERATION_RECORDS_ENABLED:-true}}"
+BIGTABLE_MIRROR_WRITES_ENABLED="${TR_BIGTABLE_MIRROR_WRITES_ENABLED:-${LIVE_BIGTABLE_MIRROR_WRITES_ENABLED:-true}}"
+case "$GENERATION_RECORDS_ENABLED:$BIGTABLE_MIRROR_WRITES_ENABLED" in
+  true:true|true:false|false:true|false:false) ;;
+  *)
+    log "refusing rollout: generation-record and Bigtable-mirror flags must be true or false"
+    exit 1
+    ;;
+esac
+
 LIVE_ANALYTICS_READ_MODE="$(
   gc run services describe "$SERVICE" \
     --region="$TR_PRIMARY_REGION" \
@@ -122,12 +177,34 @@ LIVE_ANALYTICS_READ_MODE="$(
 )"
 ANALYTICS_READ_MODE="${TR_ANALYTICS_READ_MODE:-$LIVE_ANALYTICS_READ_MODE}"
 case "$ANALYTICS_READ_MODE" in
-  bigtable|dual|clickhouse) ;;
+  bigtable|dual|clickhouse|clickhouse-only) ;;
   *)
-    log "refusing rollout: TR_ANALYTICS_READ_MODE must be bigtable, dual, or clickhouse"
+    log "refusing rollout: invalid TR_ANALYTICS_READ_MODE"
     exit 1
     ;;
 esac
+if [ "$STORAGE_BACKEND" = "spanner-clickhouse" ] && \
+   [ "$ANALYTICS_READ_MODE" != "clickhouse-only" ]; then
+  log "refusing rollout: spanner-clickhouse requires clickhouse-only reads"
+  exit 1
+fi
+if [ "$STORAGE_BACKEND" = "spanner-clickhouse" ] && \
+   { [ "$BIGTABLE_MIRROR_WRITES_ENABLED" != "false" ] ||
+     [ "$GENERATION_RECORDS_ENABLED" != "true" ] ||
+     [ "$REQUEST_RECORD_WRITE_MODE" != "typed" ]; }; then
+  log "refusing rollout: spanner-clickhouse requires typed generation records and no Bigtable mirror"
+  exit 1
+fi
+if [ "$GENERATION_RECORDS_ENABLED" = "true" ]; then
+  generation_table_count="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_generation'" \
+    --format='value(rows[0])')"
+  if [ "${generation_table_count:-0}" != "1" ]; then
+    log "refusing rollout: tr_generation is missing; run migrate_generation_records.sh --apply"
+    exit 1
+  fi
+fi
 
 ANALYTICS_DUAL_READ_STARTED_AT="${TR_ANALYTICS_DUAL_READ_STARTED_AT:-}"
 if [ -z "$ANALYTICS_DUAL_READ_STARTED_AT" ]; then
@@ -151,6 +228,28 @@ if [ "$ANALYTICS_READ_MODE" = "dual" ] && {
   ANALYTICS_DUAL_READ_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
+ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="${TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT:-}"
+if [ -z "$ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" ]; then
+  ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(
+    gc run services describe "$SERVICE" \
+      --region="$TR_PRIMARY_REGION" \
+      --format=json 2>/dev/null \
+      | jq -r '
+          [
+            .spec.template.spec.containers[0].env[]?
+            | select(.name == "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT")
+            | .value
+          ][0] // empty
+        ' || true
+  )"
+fi
+if [ "$ANALYTICS_READ_MODE" = "clickhouse" ] && {
+  [ "$LIVE_ANALYTICS_READ_MODE" != "clickhouse" ] ||
+  [ -z "$ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" ];
+}; then
+  ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
 # Prefer the private three-replica ClickHouse load balancer once provisioned.
 # The direct node-1 address remains only as a migration fallback for projects
 # that have not run clickhouse_cluster.sh yet.
@@ -171,7 +270,7 @@ ENV_VARS=(
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"
-  "TR_STORAGE_BACKEND=spanner-bigtable"
+  "TR_STORAGE_BACKEND=${STORAGE_BACKEND}"
   # Exactly $0.10 once per newly created email/OAuth account. Wallet-only
   # accounts stay at $0. Keep this explicit so stale env cannot change policy.
   "TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=100000"
@@ -180,6 +279,8 @@ ENV_VARS=(
   "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
   "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
   "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+  "TR_BIGTABLE_MIRROR_WRITES_ENABLED=${BIGTABLE_MIRROR_WRITES_ENABLED}"
+  "TR_GENERATION_RECORDS_ENABLED=${GENERATION_RECORDS_ENABLED}"
   "TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}"
   "TR_REGIONS=${TR_REGIONS}"
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
@@ -211,16 +312,10 @@ ENV_VARS=(
   # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
   # flag-off settle path is byte-identical.
   "TR_SETTLE_OUTBOX_ENABLED=true"
-  # Analytics outbox -> ClickHouse (docs/clickhouse-reliability.md). Enqueue is
-  # a SEPARATE transaction from settle and is best-effort:
-  # analytics is not worth destabilising money code for, and
-  # clickhouse/reconcile_benchmark_samples.py replays from Bigtable to repair
-  # anything dropped. Table DDL applied 2026-07-28 with a 7-day ROW DELETION
-  # POLICY, so a dead drainer cannot grow it without bound the way
-  # tr_settle_outbox and tr_entities did (#334). Ingester + reconciler run on
-  # tr-clickhouse-1 under systemd. Provider analytics reads use the private
-  # three-replica load balancer below; inference and billing never depend on
-  # ClickHouse. Remove this line to stop enqueueing new analytics rows.
+  # Provider benchmark events use their own best-effort durable queue. Tenant
+  # activity is different: its operational outbox insert is part of the typed
+  # settlement transaction, so a charge and its delivery intent cannot split.
+  # ClickHouse remains asynchronous and never participates in inference.
   "TR_ANALYTICS_OUTBOX_ENABLED=true"
   "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
   # Private provider operations portal. Direct VPC egress below reaches this
@@ -236,6 +331,7 @@ ENV_VARS=(
   "TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}"
   "TR_ANALYTICS_DUAL_READ_GRACE_SECONDS=30"
   "TR_ANALYTICS_DUAL_READ_STARTED_AT=${ANALYTICS_DUAL_READ_STARTED_AT}"
+  "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT=${ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT}"
   # The first expand deployment defaults to legacy. After an explicit typed
   # cutover, preserve the primary region's live mode on later deploys unless an
   # operator overrides it. This prevents routine rollouts from reopening the

--- a/src/trusted_router/benchmark_samples.py
+++ b/src/trusted_router/benchmark_samples.py
@@ -58,6 +58,14 @@ def public_benchmark_samples(
         ]
 
     per_provider = per_provider_limit or max(25, -(-limit // len(provider_slugs)))
+    balanced_reader = getattr(STORE, "provider_balanced_benchmark_samples", None)
+    if callable(balanced_reader):
+        rows = balanced_reader(
+            cutoff=cutoff,
+            per_provider_limit=per_provider,
+            limit=limit,
+        )
+        return [sample for sample in rows if not _is_video_sample(sample)][:limit]
     by_id: dict[str, ProviderBenchmarkSample] = {}
     for provider in provider_slugs:
         for sample in STORE.provider_benchmark_samples(

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -52,6 +52,11 @@ class Settings(BaseSettings):
     spanner_database_id: str | None = None
     bigtable_instance_id: str | None = None
     bigtable_generation_table: str = "trustedrouter-generations"
+    # Migration controls. ``spanner-clickhouse`` never constructs a Bigtable
+    # client. The mirror flag lets ``spanner-bigtable`` stop new writes before
+    # the final backend switch while retaining legacy reads during soak.
+    bigtable_mirror_writes_enabled: bool = True
+    generation_records_enabled: bool = False
     # Legacy in-process ClickHouse mirror. Empty URL keeps it disabled.
     clickhouse_url: str = ""
     clickhouse_user: str = ""
@@ -70,10 +75,11 @@ class Settings(BaseSettings):
     operational_analytics_clickhouse_password: str = ""
     operational_analytics_clickhouse_database: str = "tr"
     # dual returns Bigtable and compares ClickHouse; clickhouse reverses those
-    # roles for the second soak before Bigtable reads are disabled.
+    # roles for the second soak; clickhouse-only never calls Bigtable.
     analytics_read_mode: str = "bigtable"
     analytics_dual_read_grace_seconds: int = 30
     analytics_dual_read_started_at: str = ""
+    analytics_clickhouse_primary_started_at: str = ""
     # Stage 1 live analytics outbox. This is intentionally off by default and
     # must remain off until the shadow ingester and reconciler are observed.
     analytics_outbox_enabled: bool = False
@@ -356,9 +362,15 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'"
             )
-        if self.analytics_read_mode not in {"bigtable", "dual", "clickhouse"}:
+        if self.analytics_read_mode not in {
+            "bigtable",
+            "dual",
+            "clickhouse",
+            "clickhouse-only",
+        }:
             raise ValueError(
-                "TR_ANALYTICS_READ_MODE must be bigtable, dual, or clickhouse"
+                "TR_ANALYTICS_READ_MODE must be bigtable, dual, clickhouse, "
+                "or clickhouse-only"
             )
         if self.analytics_dual_read_grace_seconds < 0:
             raise ValueError("TR_ANALYTICS_DUAL_READ_GRACE_SECONDS cannot be negative")
@@ -470,14 +482,31 @@ class Settings(BaseSettings):
         if self.bootstrap_management_key:
             missing.append("unset TR_BOOTSTRAP_MANAGEMENT_KEY")
         if self.storage_backend == "memory":
-            missing.append("TR_STORAGE_BACKEND=spanner-bigtable")
-        if self.storage_backend == "spanner-bigtable":
+            missing.append("TR_STORAGE_BACKEND=spanner-bigtable or spanner-clickhouse")
+        if self.storage_backend in {"spanner-bigtable", "spanner-clickhouse"}:
             if not self.spanner_instance_id:
                 missing.append("TR_SPANNER_INSTANCE_ID")
             if not self.spanner_database_id:
                 missing.append("TR_SPANNER_DATABASE_ID")
+        if self.storage_backend == "spanner-bigtable":
             if not self.bigtable_instance_id:
                 missing.append("TR_BIGTABLE_INSTANCE_ID")
+        if self.storage_backend == "spanner-clickhouse":
+            if self.analytics_read_mode != "clickhouse-only":
+                missing.append(
+                    "TR_ANALYTICS_READ_MODE=clickhouse-only with "
+                    "TR_STORAGE_BACKEND=spanner-clickhouse"
+                )
+            if not self.generation_records_enabled:
+                missing.append("TR_GENERATION_RECORDS_ENABLED=true")
+            if not self.operational_analytics_outbox_enabled:
+                missing.append("TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true")
+            if not self.analytics_outbox_enabled:
+                missing.append("TR_ANALYTICS_OUTBOX_ENABLED=true")
+            if self.bigtable_mirror_writes_enabled:
+                missing.append("TR_BIGTABLE_MIRROR_WRITES_ENABLED=false")
+            if self.request_record_write_mode != "typed":
+                missing.append("TR_REQUEST_RECORD_WRITE_MODE=typed")
         if self.analytics_read_mode != "bigtable":
             if not self.operational_analytics_clickhouse_url:
                 missing.append("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL")

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -127,6 +127,49 @@ FORMAT JSON
         )
         return [_benchmark_sample(row) for row in rows]
 
+    def balanced_benchmark_samples(
+        self,
+        *,
+        cutoff: str | None,
+        per_provider_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        """Read one provider-balanced window without application-side fanout."""
+        params: dict[str, str | int] = {
+            "per_provider_limit": max(1, per_provider_limit),
+            "limit": max(1, limit),
+        }
+        where = "1"
+        if cutoff is not None:
+            where = "created_at >= parseDateTime64BestEffort({cutoff:String}, 3)"
+            params["cutoff"] = cutoff
+        rows = self._query(
+            """
+SELECT
+  id, model, provider, provider_name, status, usage_type, streamed,
+  input_tokens, output_tokens, total_cost_microdollars,
+  speed_tokens_per_second, elapsed_milliseconds,
+  first_token_milliseconds, ttfb_milliseconds, finish_reason,
+  error_type, error_status, error_message, region, source, app, created_at
+FROM
+(
+  SELECT *, row_number() OVER (
+    PARTITION BY provider ORDER BY created_at DESC, id DESC
+  ) AS provider_rank
+  FROM provider_benchmark_samples FINAL
+  WHERE """
+            + where
+            + """
+)
+WHERE provider_rank <= {per_provider_limit:UInt32}
+ORDER BY created_at DESC, id DESC
+LIMIT {limit:UInt32}
+FORMAT JSON
+""",
+            params=params,
+        )
+        return [_benchmark_sample(row) for row in rows]
+
     def activity_generations(
         self,
         *,
@@ -254,6 +297,25 @@ FORMAT JSON
                 for rollup in rollups
             ]
         return rollups
+
+    def public_snapshot(self, name: str) -> dict[str, Any] | None:
+        if name not in {"leaderboard", "apps"}:
+            raise ValueError("unsupported public analytics snapshot")
+        rows = self._query(
+            """
+SELECT payload
+FROM public_analytics_snapshots FINAL
+WHERE name = {name:String}
+ORDER BY generated_at DESC
+LIMIT 1
+FORMAT JSON
+""",
+            params={"name": name},
+        )
+        if not rows:
+            return None
+        payload = json.loads(str(rows[0].get("payload") or "{}"))
+        return payload if isinstance(payload, dict) else None
 
 
 def _dataclass_from_row(cls: type[T], row: dict[str, Any]) -> T:

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1168,8 +1168,9 @@ def _settle_gateway_authorization(
     )
     if is_typed:
         assert _typed_store is not None
-        # Typed finalize includes the Bigtable activity-index and benchmark
-        # write inside the wrapper's index_after_commit.
+        # Typed finalize atomically commits billing, the bounded generation
+        # record, and the ClickHouse delivery intent. Benchmark delivery and
+        # the temporary Bigtable migration mirror happen after that commit.
         result_method = getattr(
             _typed_store,
             "typed_finalize_gateway_authorization_result",

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -132,7 +132,8 @@ LEADERBOARD_RANK_MIN_TTFT_SAMPLES = 3
 LEADERBOARD_RECENT_WINDOW_MINUTES = PUBLIC_BENCHMARK_RECENT_MINUTES
 LEADERBOARD_SNAPSHOT_CACHE_SECONDS = 300
 LEADERBOARD_RESPONSE_CACHE_SECONDS = 60
-LEADERBOARD_RESPONSE_STALE_SECONDS = 0
+LEADERBOARD_RESPONSE_STALE_SECONDS = 600
+PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS = 600
 VIDEO_LEADERBOARD_SAMPLE_LIMIT = 5_000
 VIDEO_LEADERBOARD_RECENT_WINDOW_MINUTES = 30 * 24 * 60
 CHOOSE_PAGE_CACHE_SECONDS = 300
@@ -1449,26 +1450,45 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
         cached_at, payload = _LEADERBOARD_CACHE
         if now - cached_at < LEADERBOARD_SNAPSHOT_CACHE_SECONDS:
             return payload
-    samples = public_benchmark_samples(
-        limit=LEADERBOARD_SAMPLE_LIMIT,
-        recent_minutes=LEADERBOARD_RECENT_WINDOW_MINUTES,
-    )
-    payload = aggregate_leaderboard(
-        samples,
-        min_samples=LEADERBOARD_MIN_SAMPLES,
-        model_rank_min_samples=LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
-        provider_rank_min_samples=LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
-        rank_min_ttft_samples=LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
-    )
-    payload["rank_minimums"] = {
-        "model_availability_samples": LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
-        "provider_availability_samples": LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
-        "ttft_samples": LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
-    }
-    payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
-    payload["sample_window_count"] = len(samples)
-    payload["sample_limit"] = LEADERBOARD_SAMPLE_LIMIT
-    payload["window_label"] = f"rolling benchmark set of up to {LEADERBOARD_SAMPLE_LIMIT:,} samples"
+    if settings.environment != "test":
+        try:
+            precomputed = _precomputed_public_analytics_snapshot("leaderboard")
+        except Exception:
+            log.exception("public_analytics_snapshot_read_failed name=leaderboard")
+            if _LEADERBOARD_CACHE is not None:
+                return _LEADERBOARD_CACHE[1]
+        else:
+            if precomputed is not None:
+                _LEADERBOARD_CACHE = (now, precomputed)
+                return precomputed
+    try:
+        samples = public_benchmark_samples(
+            limit=LEADERBOARD_SAMPLE_LIMIT,
+            recent_minutes=LEADERBOARD_RECENT_WINDOW_MINUTES,
+        )
+        payload = aggregate_leaderboard(
+            samples,
+            min_samples=LEADERBOARD_MIN_SAMPLES,
+            model_rank_min_samples=LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
+            provider_rank_min_samples=LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
+            rank_min_ttft_samples=LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
+        )
+        payload["rank_minimums"] = {
+            "model_availability_samples": LEADERBOARD_MODEL_RANK_MIN_SAMPLES,
+            "provider_availability_samples": LEADERBOARD_PROVIDER_RANK_MIN_SAMPLES,
+            "ttft_samples": LEADERBOARD_RANK_MIN_TTFT_SAMPLES,
+        }
+        payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
+        payload["sample_window_count"] = len(samples)
+        payload["sample_limit"] = LEADERBOARD_SAMPLE_LIMIT
+        payload["window_label"] = (
+            f"rolling benchmark set of up to {LEADERBOARD_SAMPLE_LIMIT:,} samples"
+        )
+    except Exception:
+        if settings.environment != "test" and _LEADERBOARD_CACHE is not None:
+            log.exception("leaderboard_live_fallback_failed_serving_stale")
+            return _LEADERBOARD_CACHE[1]
+        raise
     if settings.environment != "test":
         _LEADERBOARD_CACHE = (now, payload)
     return payload
@@ -1506,6 +1526,17 @@ def _apps_snapshot(settings: Settings) -> dict[str, Any]:
         cached_at, payload = _APPS_CACHE
         if now - cached_at < STATUS_SNAPSHOT_CACHE_SECONDS:
             return payload
+    if settings.environment != "test":
+        try:
+            precomputed = _precomputed_public_analytics_snapshot("apps")
+        except Exception:
+            log.exception("public_analytics_snapshot_read_failed name=apps")
+            if _APPS_CACHE is not None:
+                return _APPS_CACHE[1]
+        else:
+            if precomputed is not None:
+                _APPS_CACHE = (now, precomputed)
+                return precomputed
     samples = public_benchmark_samples(
         limit=LEADERBOARD_SAMPLE_LIMIT,
         recent_minutes=LEADERBOARD_RECENT_WINDOW_MINUTES,
@@ -1514,6 +1545,28 @@ def _apps_snapshot(settings: Settings) -> dict[str, Any]:
     payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
     if settings.environment != "test":
         _APPS_CACHE = (now, payload)
+    return payload
+
+
+def _precomputed_public_analytics_snapshot(name: str) -> dict[str, Any] | None:
+    reader = getattr(STORE, "public_analytics_snapshot", None)
+    if not callable(reader):
+        return None
+    payload = reader(name)
+    if not isinstance(payload, dict):
+        return None
+    generated_at = payload.get("generated_at")
+    if not isinstance(generated_at, str):
+        return None
+    try:
+        generated = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if generated.tzinfo is None:
+        generated = generated.replace(tzinfo=dt.UTC)
+    age = (dt.datetime.now(dt.UTC) - generated.astimezone(dt.UTC)).total_seconds()
+    if age < 0 or age > PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS:
+        return None
     return payload
 
 

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 # ServiceUnavailable, plus the backend-neutral StoreConflict/StoreUnavailable.
 _TRANSIENT_STORE_EXCS = transient_store_error_types()
 
+# Rolling legacy rows can still carry this historical marker. New typed rows
+# atomically enqueue ClickHouse delivery in the settlement transaction and do
+# not park on the optional Bigtable migration mirror.
 _ACTIVITY_PARK_NOTE = "bigtable activity index pending"
 
 
@@ -88,11 +91,11 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
 
     SF7: this dormant primitive is intentionally narrower than the HTTP settle
     handler. It must not import or call pricing, auto-refill, budget alert, or
-    metadata broadcast code. The one side effect it does fire is the
-    claim-gated, at-most-once Bigtable activity index and provider-benchmark
-    sample via index_after_commit on SETTLED_NOW, matching the inline typed path;
-    replay outcomes do not fire it. Increment 4's drain will interpret the rich
-    §3 outcome and decide row status/alerting.
+    metadata broadcast code. A new typed settlement atomically writes the
+    bounded generation record and ClickHouse delivery intent. Post-commit work
+    is limited to loss-tolerant benchmark delivery and an optional migration
+    mirror; rolling legacy rows still use index_after_commit repair. Increment
+    4's drain interprets the rich §3 outcome and decides row status/alerting.
     """
     parsed_body = _parse_settle_body(row.settle_body)
     if parsed_body is None:
@@ -254,13 +257,20 @@ def _apply_typed(
             authorization=auth_settled,
             auth_body_settled=_json_body(auth_settled),
             generation_writes=generation_writes,
+            generation=generation,
         )
     except _TRANSIENT_STORE_EXCS:
         return ApplyOutcome.PARK_TYPED_UNAVAILABLE
     outcome = result.get("outcome")
     if outcome == SettleOutcome.SETTLED:
+        # The typed transaction atomically persisted the bounded generation
+        # record and operational analytics outbox row. Bigtable is only an
+        # optional migration mirror and cannot keep settlement work pending.
         if success and generation is not None:
-            if not _index_generation_after_commit(typed_store, generation):
+            generation_store = cast(Any, typed_store).generation_store
+            if result.get("activity_durable"):
+                generation_store.mirror_after_commit(generation)
+            elif not _index_generation_after_commit(typed_store, generation):
                 return ApplyOutcome.ACTIVITY_PENDING
         return ApplyOutcome.SETTLED_NOW
     if outcome == SettleOutcome.NOT_FOUND:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1453,9 +1453,10 @@ def create_store(settings: Any) -> Store:
         )
         store.apply_schema()
         return store
-    if backend == "spanner-bigtable":
+    if backend in {"spanner-bigtable", "spanner-clickhouse"}:
         from trusted_router.storage_gcp import SpannerBigtableStore
 
+        bigtable_enabled = backend == "spanner-bigtable"
         return SpannerBigtableStore(
             project_id=settings.gcp_project_id,
             spanner_instance_id=settings.spanner_instance_id,
@@ -1463,6 +1464,14 @@ def create_store(settings: Any) -> Store:
             bigtable_instance_id=settings.bigtable_instance_id,
             generation_table=settings.bigtable_generation_table,
             bigtable_app_profile_id=getattr(settings, "bigtable_app_profile_id", ""),
+            bigtable_enabled=bigtable_enabled,
+            bigtable_writes_enabled=bigtable_enabled
+            and getattr(settings, "bigtable_mirror_writes_enabled", True),
+            generation_records_enabled=getattr(
+                settings,
+                "generation_records_enabled",
+                False,
+            ),
             request_record_write_mode=getattr(settings, "request_record_write_mode", "legacy"),
             analytics_outbox_enabled=getattr(settings, "analytics_outbox_enabled", False),
             operational_analytics_outbox_enabled=getattr(
@@ -1484,7 +1493,11 @@ def create_store(settings: Any) -> Store:
             operational_analytics_clickhouse_database=getattr(
                 settings, "operational_analytics_clickhouse_database", "tr"
             ),
-            analytics_read_mode=getattr(settings, "analytics_read_mode", "bigtable"),
+            analytics_read_mode=(
+                "clickhouse-only"
+                if backend == "spanner-clickhouse"
+                else getattr(settings, "analytics_read_mode", "bigtable")
+            ),
             analytics_dual_read_grace_seconds=getattr(
                 settings, "analytics_dual_read_grace_seconds", 30
             ),

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -138,11 +138,12 @@ def _add_usage_metrics(bucket: dict[str, Any], metrics: dict[str, int]) -> None:
 
 
 class SpannerBigtableStore:
-    """Production Spanner + Bigtable implementation.
+    """Production Spanner store with ClickHouse analytics.
 
     Spanner owns strongly consistent control-plane state: users, orgs, API
     keys, reservations, credit ledger state, BYOK metadata, and Stripe event
-    idempotency. Bigtable receives append-oriented generation metadata rows.
+    idempotency. ClickHouse receives bounded analytics through durable Spanner
+    outboxes. Bigtable can remain attached as a migration-only mirror.
 
     Sibling of `InMemoryStore` rather than subclass — both implement the
     `Store` Protocol. The intentional non-inheritance means a method
@@ -167,9 +168,12 @@ class SpannerBigtableStore:
         project_id: str,
         spanner_instance_id: str,
         spanner_database_id: str,
-        bigtable_instance_id: str,
-        generation_table: str,
+        bigtable_instance_id: str | None = None,
+        generation_table: str = "trustedrouter-generations",
         bigtable_app_profile_id: str = "",
+        bigtable_enabled: bool = True,
+        bigtable_writes_enabled: bool = True,
+        generation_records_enabled: bool = False,
         request_record_write_mode: str = "legacy",
         analytics_outbox_enabled: bool = False,
         operational_analytics_outbox_enabled: bool = False,
@@ -180,13 +184,27 @@ class SpannerBigtableStore:
         analytics_read_mode: str = "bigtable",
         analytics_dual_read_grace_seconds: int = 30,
     ) -> None:
-        if not spanner_instance_id or not spanner_database_id or not bigtable_instance_id:
-            raise ValueError("Spanner and Bigtable IDs are required")
+        if not spanner_instance_id or not spanner_database_id:
+            raise ValueError("Spanner instance and database IDs are required")
+        if bigtable_enabled and not bigtable_instance_id:
+            raise ValueError("Bigtable instance ID is required when Bigtable is enabled")
         if request_record_write_mode not in {"legacy", "typed"}:
             raise ValueError("request_record_write_mode must be 'legacy' or 'typed'")
-        if analytics_read_mode not in {"bigtable", "dual", "clickhouse"}:
-            raise ValueError("analytics_read_mode must be bigtable, dual, or clickhouse")
+        if analytics_read_mode not in {
+            "bigtable",
+            "dual",
+            "clickhouse",
+            "clickhouse-only",
+        }:
+            raise ValueError(
+                "analytics_read_mode must be bigtable, dual, clickhouse, or clickhouse-only"
+            )
+        if not bigtable_enabled and analytics_read_mode != "clickhouse-only":
+            raise ValueError("Bigtable-free storage requires clickhouse-only reads")
         self.request_record_write_mode = request_record_write_mode
+        self._generation_records_enabled = generation_records_enabled
+        self._bigtable_enabled = bigtable_enabled
+        self._bigtable_writes_enabled = bigtable_writes_enabled and bigtable_enabled
         self._analytics_read_mode = analytics_read_mode
         self._analytics_dual_read_grace_seconds = max(
             0,
@@ -206,12 +224,11 @@ class SpannerBigtableStore:
         self._analytics_parity_log_lock = threading.Lock()
         self._analytics_last_parity_log: dict[str, float] = {}
         try:
-            from google.cloud import bigtable, spanner
+            from google.cloud import spanner
             from google.cloud.spanner_v1 import FixedSizePool, param_types
         except ImportError as exc:  # pragma: no cover - exercised in prod image.
             raise RuntimeError(
-                "Install google-cloud-spanner and google-cloud-bigtable for "
-                "TR_STORAGE_BACKEND=spanner-bigtable"
+                "Install google-cloud-spanner for persistent GCP storage"
             ) from exc
 
         # GCP credential bootstrap. On GCP (Cloud Run / GCE) the default ADC
@@ -263,17 +280,25 @@ class SpannerBigtableStore:
         # writes go to the closest healthy cluster of three. Activates
         # once the 3rd BT cluster (us-east4-a) is provisioned and the
         # profile is created. See the multi-region expansion plan.
-        bt_instance = bigtable.Client(
-            project=project_id,
-            credentials=credentials,
-            admin=True,
-        ).instance(bigtable_instance_id)
-        if bigtable_app_profile_id:
-            self._bt_table = bt_instance.table(
-                generation_table, app_profile_id=bigtable_app_profile_id
-            )
-        else:
-            self._bt_table = bt_instance.table(generation_table)
+        self._bt_table = None
+        if bigtable_enabled:
+            try:
+                from google.cloud import bigtable
+            except ImportError as exc:  # pragma: no cover - production image.
+                raise RuntimeError(
+                    "Install google-cloud-bigtable when Bigtable mirroring is enabled"
+                ) from exc
+            bt_instance = bigtable.Client(
+                project=project_id,
+                credentials=credentials,
+                admin=True,
+            ).instance(bigtable_instance_id)
+            if bigtable_app_profile_id:
+                self._bt_table = bt_instance.table(
+                    generation_table, app_profile_id=bigtable_app_profile_id
+                )
+            else:
+                self._bt_table = bt_instance.table(generation_table)
         self._bigtable_app_profile_id = bigtable_app_profile_id
         # Composed feature stores. Each owns its own logic and is importable
         # on its own — keeps the core SpannerBigtableStore body focused on
@@ -307,6 +332,9 @@ class SpannerBigtableStore:
         self.generation_store = SpannerGenerations(
             io,
             bt_table=self._bt_table,
+            param_types=self._param_types,
+            generation_records_enabled=generation_records_enabled,
+            bigtable_writes_enabled=bigtable_writes_enabled,
             activity_family=self.activity_family,
             benchmark_family=self.benchmark_family,
             legacy_family=self.legacy_generation_family,
@@ -1394,6 +1422,14 @@ class SpannerBigtableStore:
     def typed_finalize_gateway(self, **kwargs: Any) -> dict:
         from trusted_router.storage_gcp_authorize import typed_finalize_atomic
 
+        kwargs.setdefault(
+            "operational_analytics_outbox",
+            getattr(self, "_operational_analytics_outbox", None),
+        )
+        kwargs.setdefault(
+            "persist_generation_record",
+            getattr(self, "_generation_records_enabled", False),
+        )
         return typed_finalize_atomic(self._database, self._param_types, **kwargs)
 
     def typed_finalize_gateway_authorization(
@@ -1425,9 +1461,9 @@ class SpannerBigtableStore:
         """Route-facing typed settle: same contract as
         finalize_gateway_authorization, with explicit activity-index status.
 
-        The billing transaction commits before the Bigtable activity write. A
-        false ``activity_indexed`` leaves the durable outbox pending so its
-        deterministic generation can be retried without double charging.
+        The billing transaction atomically commits the bounded generation row
+        and ClickHouse delivery intent. A false ``activity_indexed`` leaves the
+        durable settle outbox pending for a no-double-charge repair replay.
         """
         from trusted_router.storage_gcp_authorize import SettleOutcome, typed_finalize_atomic
 
@@ -1459,27 +1495,47 @@ class SpannerBigtableStore:
             authorization=authorization,
             auth_body_settled=_json_body(authorization),
             generation_writes=generation_writes,
+            generation=generation,
+            persist_generation_record=getattr(
+                self,
+                "_generation_records_enabled",
+                False,
+            ),
+            operational_analytics_outbox=getattr(
+                self,
+                "_operational_analytics_outbox",
+                None,
+            ),
         )
         spanner_ms = (time.perf_counter() - spanner_start) * 1000
         if result["outcome"] == SettleOutcome.ERROR:
             raise RuntimeError("typed finalize failed: release row-count != 1")
         if result["outcome"] == SettleOutcome.SETTLED:
-            index_ms = 0.0
-            activity_indexed = True
+            mirror_ms = 0.0
+            activity_indexed = bool(result.get("activity_durable", generation is None))
             if success and generation is not None:
-                index_start = time.perf_counter()
-                activity_indexed = self.generation_store.index_after_commit(generation)
-                index_ms = (time.perf_counter() - index_start) * 1000
+                mirror_start = time.perf_counter()
+                if getattr(self, "_operational_analytics_outbox", None) is None:
+                    activity_indexed = self.generation_store.index_after_commit(
+                        generation
+                    )
+                else:
+                    self.generation_store.mirror_after_commit(generation)
+                mirror_ms = (time.perf_counter() - mirror_start) * 1000
             # Splits the settle-path finalize_ms hotspot (2026-07-05 investigation)
-            # into Spanner-txn vs Bigtable-index time.
+            # into the authoritative Spanner transaction and best-effort
+            # analytics mirrors. Mirror latency never changes settle success.
             # attempts counts only OUTER wrapper retries; Spanner's own internal
             # Aborted retries are invisible, so attempts>1 is definitive severe
             # contention while attempts==1 does not rule out absorbed contention.
             log.info(
-                "typed finalize timing authorization_id=%s spanner_ms=%.1f index_ms=%.1f attempts=%d",
+                # Keep index_ms for log-query compatibility. It now measures
+                # optional post-commit mirrors rather than durable delivery.
+                "typed finalize timing authorization_id=%s spanner_ms=%.1f "
+                "index_ms=%.1f attempts=%d",
                 authorization_id,
                 spanner_ms,
-                index_ms,
+                mirror_ms,
                 result.get("attempts", 1),
             )
             return TypedFinalizeResult(
@@ -1935,14 +1991,23 @@ class SpannerBigtableStore:
             ),
         )
 
-    def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
-        _bt_write_synthetic_probe_sample(
-            self._bt_table,
-            self.synthetic_family,
-            sample,
-            rollup_family=self.synthetic_rollup_family,
-            legacy_family=self.legacy_generation_family,
+    def provider_balanced_benchmark_samples(
+        self,
+        *,
+        cutoff: str | None,
+        per_provider_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        return self._require_operational_analytics().balanced_benchmark_samples(
+            cutoff=cutoff,
+            per_provider_limit=per_provider_limit,
+            limit=limit,
         )
+
+    def public_analytics_snapshot(self, name: str) -> dict[str, Any] | None:
+        return self._require_operational_analytics().public_snapshot(name)
+
+    def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
         if self._operational_analytics_outbox is not None:
             try:
                 self._operational_analytics_outbox.enqueue_synthetic(sample)
@@ -1955,9 +2020,32 @@ class SpannerBigtableStore:
                         "target": sample.target,
                         "error_class": type(exc).__name__,
                         "error_message": str(exc)[:500],
-                        "loss_tolerated": True,
+                        "retryable": True,
                     },
                 )
+                raise
+        if not getattr(self, "_bigtable_writes_enabled", True):
+            return
+        try:
+            _bt_write_synthetic_probe_sample(
+                self._bt_table,
+                self.synthetic_family,
+                sample,
+                rollup_family=self.synthetic_rollup_family,
+                legacy_family=self.legacy_generation_family,
+            )
+        except Exception as exc:
+            log.exception(
+                "bigtable.synthetic_mirror_write_failed",
+                extra={
+                    "sample_id": sample.id,
+                    "probe_type": sample.probe_type,
+                    "target": sample.target,
+                    "error_class": type(exc).__name__,
+                    "error_message": str(exc)[:500],
+                    "migration_mirror_only": True,
+                },
+            )
 
     def synthetic_probe_samples(
         self,
@@ -2172,6 +2260,8 @@ class SpannerBigtableStore:
     ) -> T:
         if self._analytics_read_mode == "bigtable":
             return bigtable()
+        if self._analytics_read_mode == "clickhouse-only":
+            return clickhouse()
         if self._analytics_read_mode == "dual":
             primary = bigtable()
             try:

--- a/src/trusted_router/storage_gcp_analytics_outbox.py
+++ b/src/trusted_router/storage_gcp_analytics_outbox.py
@@ -54,24 +54,26 @@ class SpannerAnalyticsOutbox:
         at-least-once and ClickHouse's ReplacingMergeTree collapses replays by
         the sample's stable ``id`` when queries use ``FINAL``.
         """
-        shard = analytics_outbox_shard(sample.id, shard_count=self._shard_count)
-        payload = json_body(sample)
-
         def txn(transaction: Any) -> None:
-            transaction.execute_update(
-                "INSERT INTO tr_analytics_outbox "
-                "(shard, commit_ts, event_id, payload) "
-                "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_id, @payload)",
-                params={
-                    "shard": shard,
-                    "event_id": sample.id,
-                    "payload": payload,
-                },
-                param_types={
-                    "shard": self._pt.INT64,
-                    "event_id": self._pt.STRING,
-                    "payload": self._pt.STRING,
-                },
-            )
+            self.enqueue_tx(transaction, sample)
 
         self._database.run_in_transaction(txn)
+
+    def enqueue_tx(self, transaction: Any, sample: ProviderBenchmarkSample) -> None:
+        """Enqueue a benchmark in an existing Spanner transaction."""
+        shard = analytics_outbox_shard(sample.id, shard_count=self._shard_count)
+        transaction.execute_update(
+            "INSERT INTO tr_analytics_outbox "
+            "(shard, commit_ts, event_id, payload) "
+            "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_id, @payload)",
+            params={
+                "shard": shard,
+                "event_id": sample.id,
+                "payload": json_body(sample),
+            },
+            param_types={
+                "shard": self._pt.INT64,
+                "event_id": self._pt.STRING,
+                "payload": self._pt.STRING,
+            },
+        )

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -42,6 +42,7 @@ from trusted_router.storage_gcp_counter_dml import (
     reserve_key,
 )
 from trusted_router.storage_gcp_counters import UNSHARDED
+from trusted_router.storage_gcp_generation_records import insert_generation_record
 from trusted_router.storage_gcp_io import run_in_transaction_with_retry
 from trusted_router.storage_gcp_request_records import (
     close_reaped_gateway_authorization,
@@ -49,7 +50,7 @@ from trusted_router.storage_gcp_request_records import (
     mark_gateway_authorization_settled,
 )
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
-from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.storage_models import GatewayAuthorization, Generation
 
 log = logging.getLogger(__name__)
 
@@ -740,6 +741,9 @@ def typed_finalize_atomic(
     authorization: GatewayAuthorization | None = None,
     auth_body_settled: str,
     generation_writes: list[tuple[str, str, str]] | None = None,
+    generation: Generation | None = None,
+    persist_generation_record: bool = False,
+    operational_analytics_outbox: Any | None = None,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
 
@@ -747,8 +751,8 @@ def typed_finalize_atomic(
     behavior so a crash can't leave counters charged but the authorization
     active: claim the reservation -> release the EXACT holds (key then credit)
     and book actual -> DML-mark the authorization settled. Typed request records
-    keep their repair payload until Bigtable indexing is confirmed; rolling
-    legacy records retain the old generic generation repair rows.
+    keep their repair payload until durable analytics delivery is confirmed;
+    rolling legacy records retain the old generic generation repair rows.
 
     `auth_body_settled` and `generation_writes` remain for rolling compatibility
     with an authorization created by the generic-table revision. Returns
@@ -841,12 +845,27 @@ def typed_finalize_atomic(
                 terminal_at=now,
                 outbox_available=resolved_outbox_available,
             )
+        if success and generation is not None:
+            if persist_generation_record:
+                insert_generation_record(
+                    transaction,
+                    pt,
+                    generation,
+                    terminal_at=now,
+                )
+            if operational_analytics_outbox is not None:
+                operational_analytics_outbox.enqueue_activity_tx(
+                    transaction,
+                    generation,
+                )
         if marked != 1:
             raise _SettleError("gateway_authorization update row-count != 1")
         return {
             "outcome": SettleOutcome.SETTLED,
             "missing_key_releases": missing_key_releases,
             "request_record_typed": request_record_typed,
+            "activity_durable": generation is None
+            or operational_analytics_outbox is not None,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_generation_records.py
+++ b/src/trusted_router/storage_gcp_generation_records.py
@@ -1,0 +1,118 @@
+"""Bounded Spanner records for generation lookup and repair.
+
+The record contains metadata only. Prompt text, model output, tool arguments,
+authorization headers, and provider credentials are never projected here.
+Longer-lived activity analytics live in ClickHouse; this table only preserves
+the OpenRouter-compatible generation lookup and a short repair window.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+from typing import Any
+
+from trusted_router.storage_models import Generation
+
+GENERATION_TABLE = "tr_generation"
+
+
+def generation_record_body(generation: Generation) -> str:
+    """Serialize lookup metadata without model-produced tool arguments."""
+    payload = dataclasses.asdict(generation)
+    payload.pop("tool_calls", None)
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def insert_generation_record(
+    transaction: Any,
+    param_types: Any,
+    generation: Generation,
+    *,
+    terminal_at: Any,
+) -> None:
+    transaction.execute_update(
+        "INSERT INTO tr_generation ("
+        "generation_id, workspace_id, key_hash, created_at, terminal_at, payload"
+        ") VALUES ("
+        "@generation_id, @workspace_id, @key_hash, @created_at, @terminal_at, @payload"
+        ")",
+        params={
+            "generation_id": generation.id,
+            "workspace_id": generation.workspace_id,
+            "key_hash": generation.key_hash,
+            "created_at": _timestamp(generation.created_at),
+            "terminal_at": terminal_at,
+            "payload": generation_record_body(generation),
+        },
+        param_types={
+            "generation_id": param_types.STRING,
+            "workspace_id": param_types.STRING,
+            "key_hash": param_types.STRING,
+            "created_at": param_types.TIMESTAMP,
+            "terminal_at": param_types.TIMESTAMP,
+            "payload": param_types.STRING,
+        },
+    )
+
+
+def upsert_generation_record(
+    transaction: Any,
+    param_types: Any,
+    generation: Generation,
+    *,
+    terminal_at: Any,
+) -> None:
+    """Idempotently restore a record while replaying an old settlement."""
+    transaction.execute_update(
+        "INSERT OR UPDATE INTO tr_generation ("
+        "generation_id, workspace_id, key_hash, created_at, terminal_at, payload"
+        ") VALUES ("
+        "@generation_id, @workspace_id, @key_hash, @created_at, @terminal_at, @payload"
+        ")",
+        params={
+            "generation_id": generation.id,
+            "workspace_id": generation.workspace_id,
+            "key_hash": generation.key_hash,
+            "created_at": _timestamp(generation.created_at),
+            "terminal_at": terminal_at,
+            "payload": generation_record_body(generation),
+        },
+        param_types={
+            "generation_id": param_types.STRING,
+            "workspace_id": param_types.STRING,
+            "key_hash": param_types.STRING,
+            "created_at": param_types.TIMESTAMP,
+            "terminal_at": param_types.TIMESTAMP,
+            "payload": param_types.STRING,
+        },
+    )
+
+
+def read_generation_record(
+    reader: Any,
+    param_types: Any,
+    generation_id: str,
+) -> Generation | None:
+    rows = list(
+        reader.execute_sql(
+            "SELECT payload FROM tr_generation WHERE generation_id=@generation_id",
+            params={"generation_id": generation_id},
+            param_types={"generation_id": param_types.STRING},
+        )
+    )
+    if not rows:
+        return None
+    payload = json.loads(str(rows[0][0]))
+    if not isinstance(payload, dict):
+        return None
+    known = {field.name for field in dataclasses.fields(Generation)}
+    return Generation(**{key: value for key, value in payload.items() if key in known})
+
+
+def _timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -1,19 +1,20 @@
-"""Bigtable activity index with a legacy Spanner compatibility path.
+"""Generation records plus ClickHouse delivery and legacy Bigtable mirroring.
 
 Sibling of InMemoryGenerations. The general ``add()`` path remains compatible
 with non-gateway callers and rolling legacy records:
   1. add_usage_to_key — roll cost into per-key counters (own txn).
   2. Spanner txn — generation row + workspace index entry.
-  3. Bigtable activity-index write.
-  4. Provider-benchmark sample (Bigtable, best-effort).
+  3. Durable ClickHouse outbox enqueue.
+  4. Optional Bigtable mirror during migration.
 
 The high-volume gateway path does not call ``add()``. Billing settles in typed
-Spanner tables and writes bounded Bigtable metadata directly. Its durable
-settle outbox retains repair inputs until ``index_after_commit`` succeeds.
+Spanner tables and atomically enqueues bounded ClickHouse metadata. Its durable
+settle outbox retains repair inputs until delivery durability is confirmed.
 User-facing reads prefer bounded families and fall back to legacy cells."""
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from collections.abc import Iterator
 from typing import Any, Protocol
@@ -52,6 +53,10 @@ from trusted_router.storage_gcp_benchmark_index import (
 from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
 )
+from trusted_router.storage_gcp_generation_records import (
+    read_generation_record,
+    upsert_generation_record,
+)
 from trusted_router.storage_gcp_io import SpannerIO
 from trusted_router.storage_gcp_operational_analytics_outbox import (
     SpannerOperationalAnalyticsOutbox,
@@ -77,7 +82,10 @@ class SpannerGenerations:
         self,
         io: SpannerIO,
         *,
-        bt_table: Any,
+        bt_table: Any | None,
+        param_types: Any | None = None,
+        generation_records_enabled: bool = False,
+        bigtable_writes_enabled: bool = True,
         generation_family: str | None = None,
         activity_family: str | None = None,
         benchmark_family: str | None = None,
@@ -88,6 +96,9 @@ class SpannerGenerations:
     ) -> None:
         self._io = io
         self._bt_table = bt_table
+        self._param_types = param_types
+        self._generation_records_enabled = generation_records_enabled
+        self._bigtable_writes_enabled = bigtable_writes_enabled and bt_table is not None
         legacy = legacy_family or generation_family or "m"
         self._activity_family = activity_family or generation_family or legacy
         self._benchmark_family = benchmark_family or generation_family or legacy
@@ -129,10 +140,72 @@ class SpannerGenerations:
         self.index_after_commit(generation)
 
     def index_after_commit(self, generation: Generation) -> bool:
-        # Spanner remains the source of truth for billing. Bigtable owns bounded
-        # per-request activity metadata. Gateway callers retain a durable outbox
-        # row until this idempotent write succeeds; legacy add() callers can
-        # still repair from generation_by_workspace.
+        """Repair durable delivery, then best-effort mirror legacy indexes.
+
+        New typed settlements enqueue activity in their billing transaction and
+        call ``mirror_after_commit`` instead. This method remains for an old
+        settlement replay whose original commit may predate the atomic outbox.
+        """
+        if self._operational_analytics_outbox is None:
+            activity_indexed = (
+                self._write_bigtable_activity(generation)
+                if self._bigtable_writes_enabled
+                else False
+            )
+            if generation.app != "TrustedRouter Synthetic":
+                self.record_benchmark(ProviderBenchmarkSample.from_generation(generation))
+            return activity_indexed
+        activity_queued = self._repair_durable_delivery(generation)
+        self.mirror_after_commit(generation)
+        return activity_queued
+
+    def mirror_after_commit(self, generation: Generation) -> None:
+        """Write migration-only mirrors without affecting settlement success."""
+        if self._bigtable_writes_enabled:
+            self._write_bigtable_activity(generation)
+        if generation.app != "TrustedRouter Synthetic":
+            self.record_benchmark(ProviderBenchmarkSample.from_generation(generation))
+
+    def _repair_durable_delivery(self, generation: Generation) -> bool:
+        outbox = self._operational_analytics_outbox
+        if outbox is None:
+            return False
+        try:
+            now = dt.datetime.now(dt.UTC)
+
+            def txn(transaction: Any) -> None:
+                if self._generation_records_enabled:
+                    if self._param_types is None:
+                        raise RuntimeError("Spanner param types are not configured")
+                    upsert_generation_record(
+                        transaction,
+                        self._param_types,
+                        generation,
+                        terminal_at=now,
+                    )
+                outbox.enqueue_activity_tx(
+                    transaction,
+                    generation,
+                )
+
+            self._io.database.run_in_transaction(txn)
+        except Exception as exc:
+            log.exception(
+                "spanner.operational_analytics_activity_repair_failed",
+                extra={
+                    "request_id": generation.request_id,
+                    "generation_id": generation.id,
+                    "model": generation.model,
+                    "provider": generation.provider,
+                    "error_class": type(exc).__name__,
+                    "error_message": str(exc)[:500],
+                    "repairable_via": "settle_outbox",
+                },
+            )
+            return False
+        return True
+
+    def _write_bigtable_activity(self, generation: Generation) -> bool:
         try:
             _bt_write_generation(
                 self._bt_table,
@@ -154,42 +227,54 @@ class SpannerGenerations:
                     "repairable_via": "reconcile_activity()",
                 },
             )
-            activity_indexed = False
-        else:
-            activity_indexed = True
-        activity_queued = True
-        if self._operational_analytics_outbox is not None:
-            try:
-                self._operational_analytics_outbox.enqueue_activity(generation)
-            except Exception as exc:
-                log.exception(
-                    "spanner.operational_analytics_activity_enqueue_failed",
-                    extra={
-                        "request_id": generation.request_id,
-                        "generation_id": generation.id,
-                        "model": generation.model,
-                        "provider": generation.provider,
-                        "error_class": type(exc).__name__,
-                        "error_message": str(exc)[:500],
-                        "repairable_via": "settle_outbox",
-                    },
-                )
-                activity_queued = False
-        if generation.app != "TrustedRouter Synthetic":
-            self.record_benchmark(ProviderBenchmarkSample.from_generation(generation))
-        return activity_indexed and activity_queued
+            return False
+        return True
 
     def get(self, generation_id: str) -> Generation | None:
-        generation = _bt_generation_by_id(
+        if self._generation_records_enabled:
+            if self._param_types is None:
+                raise RuntimeError("Spanner param types are not configured")
+            with self._io.database.snapshot() as snapshot:
+                generation = read_generation_record(
+                    snapshot,
+                    self._param_types,
+                    generation_id,
+                )
+            if generation is not None:
+                return generation
+        generation = self._io.read_entity("generation", generation_id, Generation)
+        if generation is not None:
+            return generation
+        if self._bt_table is None:
+            return None
+        return _bt_generation_by_id(
             self._bt_table,
             self._activity_families(),
             generation_id,
         )
-        if generation is not None:
-            return generation
-        return self._io.read_entity("generation", generation_id, Generation)
 
     def record_benchmark(self, sample: ProviderBenchmarkSample) -> None:
+        if self._analytics_outbox is not None:
+            try:
+                # A separate transaction by construction. Do not move this into
+                # gateway settlement: analytics is best-effort; money is not.
+                self._analytics_outbox.enqueue(sample)
+            except Exception as exc:
+                log.exception(
+                    "spanner.analytics_outbox_enqueue_failed",
+                    extra={
+                        "event_id": sample.id,
+                        "model": sample.model,
+                        "provider": sample.provider,
+                        "status": sample.status,
+                        "error_class": type(exc).__name__,
+                        "error_message": str(exc)[:500],
+                        "loss_tolerated": True,
+                        "repairable_via": "provider analytics outbox replay",
+                    },
+                )
+        if not getattr(self, "_bigtable_writes_enabled", self._bt_table is not None):
+            return
         try:
             _bt_write_provider_benchmark(
                 self._bt_table,
@@ -198,36 +283,14 @@ class SpannerGenerations:
             )
         except Exception as exc:
             log.exception(
-                "bigtable.benchmark_index_write_failed",
+                "bigtable.benchmark_mirror_write_failed",
                 extra={
                     "model": sample.model,
                     "provider": sample.provider,
                     "status": sample.status,
                     "error_class": type(exc).__name__,
                     "error_message": str(exc)[:500],
-                    # Benchmarks are not repairable — they're loss-tolerant
-                    # observability data, not billing. Log and move on.
-                    "loss_tolerated": True,
-                },
-            )
-        if self._analytics_outbox is None:
-            return
-        try:
-            # A separate transaction by construction. Do not move this into
-            # gateway settlement: analytics is best-effort; money is not.
-            self._analytics_outbox.enqueue(sample)
-        except Exception as exc:
-            log.exception(
-                "spanner.analytics_outbox_enqueue_failed",
-                extra={
-                    "event_id": sample.id,
-                    "model": sample.model,
-                    "provider": sample.provider,
-                    "status": sample.status,
-                    "error_class": type(exc).__name__,
-                    "error_message": str(exc)[:500],
-                    "loss_tolerated": True,
-                    "repairable_via": "clickhouse/reconcile_benchmark_samples.py",
+                    "migration_mirror_only": True,
                 },
             )
 
@@ -475,6 +538,13 @@ class SpannerGenerations:
         for ref in refs:
             generation = self.get(str(ref["generation_id"]))
             if generation is None:
+                continue
+            if self._operational_analytics_outbox is not None:
+                if not self._repair_durable_delivery(generation):
+                    continue
+                if self._bigtable_writes_enabled:
+                    self._write_bigtable_activity(generation)
+                repaired += 1
                 continue
             try:
                 _bt_write_generation(

--- a/src/trusted_router/storage_gcp_operational_analytics_outbox.py
+++ b/src/trusted_router/storage_gcp_operational_analytics_outbox.py
@@ -98,8 +98,35 @@ class SpannerOperationalAnalyticsOutbox:
             payload=activity_payload(generation),
         )
 
+    def enqueue_activity_tx(self, transaction: Any, generation: Generation) -> None:
+        """Enqueue activity in an existing Spanner transaction.
+
+        Gateway settlement uses this method so the charge, bounded generation
+        record, and ClickHouse delivery intent commit atomically.  The outbox
+        row remains the durable hand-off; ClickHouse itself is never in the
+        inference transaction.
+        """
+        self._enqueue_tx(
+            transaction,
+            event_kind=ACTIVITY_EVENT_KIND,
+            event_id=generation.id,
+            payload=activity_payload(generation),
+        )
+
     def enqueue_synthetic(self, sample: SyntheticProbeSample) -> None:
         self._enqueue(
+            event_kind=SYNTHETIC_EVENT_KIND,
+            event_id=sample.id,
+            payload=synthetic_payload(sample),
+        )
+
+    def enqueue_synthetic_tx(
+        self,
+        transaction: Any,
+        sample: SyntheticProbeSample,
+    ) -> None:
+        self._enqueue_tx(
+            transaction,
             event_kind=SYNTHETIC_EVENT_KIND,
             event_id=sample.id,
             payload=synthetic_payload(sample),
@@ -112,29 +139,43 @@ class SpannerOperationalAnalyticsOutbox:
         event_id: str,
         payload: dict[str, Any],
     ) -> None:
+        def txn(transaction: Any) -> None:
+            self._enqueue_tx(
+                transaction,
+                event_kind=event_kind,
+                event_id=event_id,
+                payload=payload,
+            )
+
+        self._database.run_in_transaction(txn)
+
+    def _enqueue_tx(
+        self,
+        transaction: Any,
+        *,
+        event_kind: str,
+        event_id: str,
+        payload: dict[str, Any],
+    ) -> None:
         shard = operational_analytics_shard(
             f"{event_kind}:{event_id}",
             shard_count=self._shard_count,
         )
-
-        def txn(transaction: Any) -> None:
-            transaction.execute_update(
-                "INSERT INTO tr_operational_analytics_outbox "
-                "(shard, commit_ts, event_kind, event_id, payload) "
-                "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_kind, "
-                "@event_id, @payload)",
-                params={
-                    "shard": shard,
-                    "event_kind": event_kind,
-                    "event_id": event_id,
-                    "payload": json_body(payload),
-                },
-                param_types={
-                    "shard": self._pt.INT64,
-                    "event_kind": self._pt.STRING,
-                    "event_id": self._pt.STRING,
-                    "payload": self._pt.STRING,
-                },
-            )
-
-        self._database.run_in_transaction(txn)
+        transaction.execute_update(
+            "INSERT INTO tr_operational_analytics_outbox "
+            "(shard, commit_ts, event_kind, event_id, payload) "
+            "VALUES (@shard, PENDING_COMMIT_TIMESTAMP(), @event_kind, "
+            "@event_id, @payload)",
+            params={
+                "shard": shard,
+                "event_kind": event_kind,
+                "event_id": event_id,
+                "payload": json_body(payload),
+            },
+            param_types={
+                "shard": self._pt.INT64,
+                "event_kind": self._pt.STRING,
+                "event_id": self._pt.STRING,
+                "payload": self._pt.STRING,
+            },
+        )

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -140,6 +140,9 @@ class FakeSpannerDatabase:
         # catch accidental fallback writes after the typed cutover.
         self.gateway_authorizations: dict[str, dict] = {}
         self.gateway_authorization_versions: dict[str, int] = {}
+        # Metadata-only typed generation records and durable ClickHouse handoff.
+        self.generation_records: dict[str, dict] = {}
+        self.operational_analytics_outbox: list[dict] = []
         # tr_settle_outbox: PK (authorization_id, intent_kind) -> {column: value}.
         self.settle_outbox: dict[tuple, dict] = {}
         self.settle_outbox_versions: dict[tuple, int] = {}
@@ -266,6 +269,11 @@ class FakeSpannerDatabase:
                     _, authorization_id, record = op
                     self.gateway_authorizations[authorization_id] = record
                     self.gateway_authorization_versions[authorization_id] = new_version
+                elif op[0] in ("insert_generation", "upsert_generation"):
+                    _, generation_id, record = op
+                    self.generation_records[generation_id] = record
+                elif op[0] == "insert_operational_analytics_outbox":
+                    self.operational_analytics_outbox.append(dict(op[1]))
                 elif op[0] == "insert_entity_dml":  # DML INSERT into tr_entities
                     _, kind, entity_id, body = op
                     self.rows[(kind, entity_id)] = _Row(body=body, version=new_version)
@@ -736,6 +744,21 @@ class _FakeTransaction:
             record["settled"] = False
             record["terminal_at"] = None
             self.pending_writes.append(("insert_gateway_authorization", authorization_id, record))
+            return 1
+        if sql.startswith("INSERT INTO tr_generation"):
+            generation_id = str(p["generation_id"])
+            if generation_id in self.db.generation_records:
+                raise FakeAlreadyExists(generation_id)
+            self.pending_writes.append(("insert_generation", generation_id, dict(p)))
+            return 1
+        if sql.startswith("INSERT OR UPDATE INTO tr_generation"):
+            generation_id = str(p["generation_id"])
+            self.pending_writes.append(("upsert_generation", generation_id, dict(p)))
+            return 1
+        if sql.startswith("INSERT INTO tr_operational_analytics_outbox"):
+            self.pending_writes.append(
+                ("insert_operational_analytics_outbox", dict(p))
+            )
             return 1
         if sql.startswith("UPDATE tr_gateway_authorization SET settled=true, payload=@payload"):
             authorization_id = p["authorization_id"]
@@ -1237,6 +1260,9 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    if sql.startswith("SELECT payload FROM tr_generation"):
+        generation = db.generation_records.get(str(params["generation_id"]))
+        return [[str(generation["payload"])]] if generation is not None else []
     # Guarded legacy terminal_at backfill. These narrow handlers intentionally
     # assert every real predicate they model (MF6); a production SQL regression
     # must fail tests instead of being repaired by the fake's Python filtering.
@@ -1783,6 +1809,9 @@ def make_fake_store(
     *,
     ready_barrier: threading.Barrier | None = None,
     request_record_write_mode: str = "legacy",
+    operational_analytics_outbox_enabled: bool = False,
+    generation_records_enabled: bool = False,
+    bigtable_writes_enabled: bool = True,
 ) -> tuple[Any, FakeSpannerDatabase, FakeBigtableTable]:
     from trusted_router.storage_gcp import SpannerBigtableStore
     from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
@@ -1794,6 +1823,9 @@ def make_fake_store(
     from trusted_router.storage_gcp_io import SpannerIO
     from trusted_router.storage_gcp_keys import SpannerApiKeys
     from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
+    from trusted_router.storage_gcp_operational_analytics_outbox import (
+        SpannerOperationalAnalyticsOutbox,
+    )
     from trusted_router.storage_gcp_rate_limits import SpannerRateLimits
     from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
     from trusted_router.storage_gcp_verification_tokens import SpannerVerificationTokens
@@ -1808,6 +1840,8 @@ def make_fake_store(
     store._database = db
     store._bt_table = bt
     store.request_record_write_mode = request_record_write_mode
+    store._generation_records_enabled = generation_records_enabled
+    store._bigtable_writes_enabled = bigtable_writes_enabled
     from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
 
     store._credit_shard_counts = CreditShardCountCache()
@@ -1825,13 +1859,22 @@ def make_fake_store(
     )
     store.api_keys = SpannerApiKeys(io)
     store.acquisition_store = SpannerAcquisitionAttribution(io)
+    store._operational_analytics_outbox = (
+        SpannerOperationalAnalyticsOutbox(db, _ParamTypes)
+        if operational_analytics_outbox_enabled
+        else None
+    )
     store.generation_store = SpannerGenerations(
         io,
         bt_table=bt,
+        param_types=_ParamTypes,
+        generation_records_enabled=generation_records_enabled,
+        bigtable_writes_enabled=bigtable_writes_enabled,
         activity_family=store.activity_family,
         benchmark_family=store.benchmark_family,
         legacy_family=store.legacy_generation_family,
         add_usage_to_key=store.api_keys.add_usage,
+        operational_analytics_outbox=store._operational_analytics_outbox,
     )
     store.byok_store = SpannerByok(io)
     store.broadcast_store = SpannerBroadcastDestinations(io)

--- a/tests/test_analytics_outbox.py
+++ b/tests/test_analytics_outbox.py
@@ -119,7 +119,9 @@ def test_bigtable_and_outbox_best_effort_attempts_are_independent(
 
     # Both failures are analytics-only and may not escape to settle callers.
     generations.record_benchmark(_sample())
-    assert attempts == ["bigtable", "outbox"]
+    # The durable Spanner hand-off is authoritative. The migration-only
+    # Bigtable mirror is attempted afterward and cannot prevent the enqueue.
+    assert attempts == ["outbox", "bigtable"]
 
 
 def test_normalise_is_identical_for_backfill_and_outbox_payload() -> None:

--- a/tests/test_bigtable_retirement.py
+++ b/tests/test_bigtable_retirement.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import CreditAccount, create_store
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_models import Generation
+
+
+def _seed_credit(store: Any, workspace_id: str, total: int = 5_000_000) -> None:
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id),
+    )
+    store._database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[
+        (workspace_id, 0)
+    ] = {
+        "workspace_id": workspace_id,
+        "shard": 0,
+        "total_credits": total,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+
+
+def _authorize(store: Any, workspace_id: str) -> tuple[Any, Any]:
+    _seed_credit(store, workspace_id)
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace_id,
+        name="migration-test",
+        creator_user_id=None,
+        limit_microdollars=5_000_000,
+    )
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id=workspace_id,
+        key_hash=key.hash,
+        estimate=1_000_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        requested_model_id=None,
+        candidate_model_ids=["anthropic/claude-haiku-4.5"],
+        region="us-central1",
+        endpoint_id="anthropic/claude-haiku-4.5@anthropic",
+        candidate_endpoint_ids=["anthropic/claude-haiku-4.5@anthropic"],
+        idempotency_key=None,
+        idempotency_fingerprint=None,
+        expires_at="2026-08-01T12:00:00Z",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    return authorization, key
+
+
+def _generation(authorization: Any, key_hash: str) -> Generation:
+    return Generation(
+        id="gen-atomic-clickhouse",
+        request_id="req-atomic-clickhouse",
+        workspace_id=authorization.workspace_id,
+        key_hash=key_hash,
+        model="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        provider_name="Anthropic",
+        app="retirement-test",
+        tokens_prompt=10,
+        tokens_completion=4,
+        total_cost_microdollars=900_000,
+        usage_type="Credits",
+        speed_tokens_per_second=8.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        tool_calls=[
+            {
+                "function": {
+                    "name": "private_tool",
+                    "arguments": "customer-secret-tool-output",
+                }
+            }
+        ],
+        created_at="2026-08-01T10:00:00Z",
+    )
+
+
+def test_typed_settlement_atomically_persists_generation_and_activity_outbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, bigtable = make_fake_store(
+        request_record_write_mode="typed",
+        operational_analytics_outbox_enabled=True,
+        generation_records_enabled=True,
+    )
+    authorization, key = _authorize(store, "ws-atomic-clickhouse")
+    generation = _generation(authorization, key.hash)
+
+    def fail_bigtable(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("migration mirror unavailable")
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_generations._bt_write_generation",
+        fail_bigtable,
+    )
+
+    result = store.typed_finalize_gateway_authorization_result(
+        authorization.id,
+        success=True,
+        actual_microdollars=900_000,
+        selected_usage_type="Credits",
+        generation=generation,
+    )
+
+    assert result.finalized is True
+    assert result.activity_indexed is True
+    assert generation.id in database.generation_records
+    assert len(database.operational_analytics_outbox) == 1
+    event = database.operational_analytics_outbox[0]
+    assert event["event_kind"] == "activity"
+    assert event["event_id"] == generation.id
+    assert bigtable.committed
+    assert all(key.startswith(b"benchmark") for key in bigtable.committed)
+    restored = store.get_generation(generation.id)
+    assert restored is not None
+    assert restored.id == generation.id
+    assert restored.tool_calls is None
+    generation_record = database.generation_records[generation.id]
+    assert "customer-secret-tool-output" not in str(generation_record["payload"])
+    assert "tool_calls" not in json.loads(str(generation_record["payload"]))
+
+    payload = json.loads(str(event["payload"]))
+    serialized = json.dumps(payload).lower()
+    assert set(payload).isdisjoint({"prompt", "input", "output", "messages"})
+    assert "authorization" not in serialized
+
+
+def test_outbox_failure_rolls_back_charge_and_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, _bigtable = make_fake_store(
+        request_record_write_mode="typed",
+        operational_analytics_outbox_enabled=True,
+        generation_records_enabled=True,
+    )
+    authorization, key = _authorize(store, "ws-outbox-rollback")
+    generation = _generation(authorization, key.hash)
+
+    def fail_enqueue(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("Spanner outbox unavailable")
+
+    monkeypatch.setattr(
+        store._operational_analytics_outbox,
+        "enqueue_activity_tx",
+        fail_enqueue,
+    )
+
+    with pytest.raises(RuntimeError, match="outbox unavailable"):
+        store.typed_finalize_gateway_authorization_result(
+            authorization.id,
+            success=True,
+            actual_microdollars=900_000,
+            selected_usage_type="Credits",
+            generation=generation,
+        )
+
+    reservation = database.reservations[authorization.credit_reservation_id]
+    credit = database.typed[CREDIT_BALANCE_TABLE][
+        (authorization.workspace_id, 0)
+    ]
+    assert reservation["settled"] is False
+    assert credit["total_usage"] == 0
+    assert credit["reserved"] == 1_000_000
+    assert generation.id not in database.generation_records
+    assert database.operational_analytics_outbox == []
+
+
+def test_clickhouse_only_read_never_invokes_bigtable() -> None:
+    from trusted_router.storage_gcp import SpannerBigtableStore
+
+    store = object.__new__(SpannerBigtableStore)
+    store._analytics_read_mode = "clickhouse-only"
+
+    value = store._analytics_read(
+        "test",
+        bigtable=lambda: pytest.fail("Bigtable must not be called"),
+        clickhouse=lambda: ["clickhouse"],
+    )
+
+    assert value == ["clickhouse"]
+
+
+def test_spanner_clickhouse_factory_disables_bigtable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_store(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp.SpannerBigtableStore",
+        fake_store,
+    )
+    settings = SimpleNamespace(
+        storage_backend="spanner-clickhouse",
+        gcp_project_id="project",
+        spanner_instance_id="instance",
+        spanner_database_id="database",
+        bigtable_instance_id=None,
+        bigtable_generation_table="unused",
+        generation_records_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        operational_analytics_clickhouse_url="http://clickhouse",
+        operational_analytics_clickhouse_password="sec" + "ret",
+    )
+
+    create_store(settings)
+
+    assert captured["bigtable_enabled"] is False
+    assert captured["bigtable_writes_enabled"] is False
+    assert captured["analytics_read_mode"] == "clickhouse-only"
+    assert captured["generation_records_enabled"] is True

--- a/tests/test_clickhouse_archive.py
+++ b/tests/test_clickhouse_archive.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from clickhouse.archive_daily import (
+    DATASETS,
     ArchiveStore,
     ExportedPart,
     SourceFingerprint,
@@ -15,6 +16,7 @@ from clickhouse.archive_daily import (
     _days_to_archive,
     archive_day,
 )
+from clickhouse.verify_archive_restore import verify_archived_day
 
 
 class FakeExporter:
@@ -91,6 +93,9 @@ class MemoryStore(ArchiveStore):
     def put_json_pointer(self, key: str, value: dict[str, Any]) -> None:
         self.pointer_writes += 1
         self.json[key] = value
+
+    def download_file(self, key: str, destination: Path) -> None:
+        destination.write_bytes(self.files[key])
 
 
 def _fingerprint(*, rows: int = 7, hash_sum: int = 42, hash_xor: int = 17) -> SourceFingerprint:
@@ -207,3 +212,79 @@ def test_backfill_date_selection_includes_every_closed_day(
         lookback_days=0,
         backfill_start=dt.date(2026, 7, 2),
     ) == [dt.date(2026, 7, 2), dt.date(2026, 7, 3), dt.date(2026, 7, 4)]
+
+
+def test_every_bounded_analytics_dataset_has_an_archive_schema() -> None:
+    assert set(DATASETS) == {
+        "provider_benchmark_samples",
+        "activity_generations",
+        "synthetic_probe_samples",
+        "synthetic_status_rollups",
+    }
+    for spec in DATASETS.values():
+        assert spec.time_column in spec.columns
+        assert spec.shard_column in spec.columns
+        assert "ingest_version" not in spec.columns
+
+
+def test_operational_dataset_archive_round_trips_through_restore_verifier() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    day = dt.date(2026, 7, 1)
+    result = archive_day(
+        exporter,
+        store,
+        day,
+        rows_per_part=3,
+        dataset="activity_generations",
+    )
+
+    def verify(path: Path) -> ExportedPart:
+        return exporter.verify_part(path)
+
+    restored = verify_archived_day(
+        store,
+        dataset="activity_generations",
+        day=day,
+        verifier=verify,
+    )
+
+    assert result.manifest_key.startswith("raw/activity_generations/")
+    assert restored.rows == 7
+    assert restored.parts == 3
+    assert restored.revision == result.revision
+
+
+def test_restore_drill_rejects_a_tampered_parquet_part() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    day = dt.date(2026, 7, 1)
+    archive_day(exporter, store, day, dataset="synthetic_probe_samples")
+    key = next(iter(store.files))
+    store.files[key] += b"tampered"
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        verify_archived_day(
+            store,
+            dataset="synthetic_probe_samples",
+            day=day,
+            verifier=exporter.verify_part,
+        )
+
+
+def test_restore_drill_rejects_pointer_manifest_identity_mismatch() -> None:
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    day = dt.date(2026, 7, 1)
+    archive_day(exporter, store, day, dataset="synthetic_status_rollups")
+    pointer = store.json[f"raw/synthetic_status_rollups/day={day}/_latest.json"]
+    manifest = store.json[str(pointer["manifest"])]
+    manifest["dataset"] = "provider_benchmark_samples"
+
+    with pytest.raises(RuntimeError, match="manifest identity"):
+        verify_archived_day(
+            store,
+            dataset="synthetic_status_rollups",
+            day=day,
+            verifier=exporter.verify_part,
+        )

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -30,6 +30,7 @@ def test_live_deploy_installs_archive_and_rollup_timers() -> None:
 
     assert "002_provider_analytics_rollups.sql" in script
     assert "tr-clickhouse-archive.timer" in script
+    assert "tr-clickhouse-archive-restore.timer" in script
     assert "tr-clickhouse-rollup-hourly.timer" in script
     assert "tr-clickhouse-rollup-daily.timer" in script
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).parents[1]
 
 def test_operational_schema_is_replicated_bounded_and_content_free() -> None:
     schema = (ROOT / "clickhouse/004_operational_analytics_replicated.sql").read_text()
-    assert schema.count("ENGINE = ReplicatedReplacingMergeTree") == 3
+    assert schema.count("ENGINE = ReplicatedReplacingMergeTree") == 4
     assert "INTERVAL 400 DAY" in schema
     assert "INTERVAL 14 DAY" in schema
     assert "INTERVAL 24 MONTH" in schema
@@ -62,6 +62,7 @@ def test_control_reader_is_private_read_only_and_cannot_read_secrets() -> None:
     assert "GRANT SELECT ON tr.activity_generations" in script
     assert "GRANT SELECT ON tr.synthetic_probe_samples" in script
     assert "GRANT SELECT ON tr.synthetic_status_rollups" in script
+    assert "GRANT SELECT ON tr.public_analytics_snapshots" in script
     assert "GRANT SELECT ON tr.tr_entities" not in script
     assert "GRANT ALL" not in script
 
@@ -72,6 +73,7 @@ def test_rollout_preserves_dual_read_mode_and_uses_distinct_reader_secret() -> N
     assert "TR_ANALYTICS_READ_MODE" in rollout
     assert "LIVE_ANALYTICS_READ_MODE" in rollout
     assert "TR_ANALYTICS_DUAL_READ_STARTED_AT" in rollout
+    assert "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" in rollout
     assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true" in rollout
     assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=tr_control_read" in rollout
     assert "trustedrouter-clickhouse-control-read-password" in rollout
@@ -93,6 +95,51 @@ def test_operational_parity_worker_has_a_bounded_runtime() -> None:
         ROOT / "clickhouse/tr-clickhouse-operational-parity.service"
     ).read_text()
     assert "TimeoutStartSec=5m" in service
+
+
+def test_generation_record_migration_has_ttl_and_delivery_audit_index() -> None:
+    script = (ROOT / "scripts/deploy/migrate_generation_records.sh").read_text()
+    assert "ROW DELETION POLICY" in script
+    assert "INTERVAL 30 DAY" in script
+    assert "tr_generation_by_terminal_at" in script
+    assert "STORING (payload)" in script
+
+
+def test_spanner_delivery_verifier_is_installed_and_bounded() -> None:
+    deploy = (ROOT / "scripts/deploy/clickhouse_operational_analytics.sh").read_text()
+    service = (ROOT / "clickhouse/tr-clickhouse-spanner-delivery.service").read_text()
+    assert "tr-clickhouse-spanner-delivery.timer" in deploy
+    assert "TimeoutStartSec=5m" in service
+    assert "verify_spanner_delivery" in service
+
+
+def test_final_bigtable_retirement_is_two_soak_gated_and_non_destructive() -> None:
+    script = (ROOT / "scripts/deploy/retire_bigtable_runtime.sh").read_text()
+    assert "604800" in script
+    assert "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" in script
+    assert "operational-parity.jsonl" in script
+    assert "spanner-delivery.jsonl" in script
+    assert "archive-restore.json" in script
+    assert "archive-backfill-complete.json" in script
+    assert "tr_analytics_outbox" in script
+    assert "tr_operational_analytics_outbox" in script
+    assert "tr_settle_outbox" in script
+    assert "TR_STORAGE_BACKEND=spanner-clickhouse" in script
+    assert "TR_ANALYTICS_READ_MODE=clickhouse-only" in script
+    assert "TR_BIGTABLE_MIRROR_WRITES_ENABLED=false" in script
+    assert "verify_deployment.sh" in script
+    assert "delete-instance" not in script
+    assert "delete-table" not in script
+
+
+def test_retirement_preparation_backfills_and_restore_verifies_every_dataset() -> None:
+    script = (ROOT / "scripts/deploy/prepare_bigtable_retirement.sh").read_text()
+    assert "clickhouse_operational_analytics.sh" in script
+    assert "clickhouse.archive_daily --backfill" in script
+    assert "clickhouse.verify_archive_restore" in script
+    assert "clickhouse.verify_spanner_delivery" not in script
+    assert "tr-clickhouse-spanner-delivery.service" in script
+    assert "would not change production read mode" in script
 
 
 def test_capacity_probe_is_disposable_and_uses_a_conservative_gate() -> None:

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -417,6 +417,45 @@ def test_public_benchmark_samples_reads_each_provider(monkeypatch) -> None:
     assert ("openai", 2) in calls
 
 
+def test_public_benchmark_samples_uses_single_balanced_store_read(monkeypatch) -> None:
+    row = _sample(
+        provider="openai",
+        model="openai/gpt-5.4-nano",
+        ttft=120,
+        created_at="2026-06-05T19:10:00Z",
+    )
+    calls: list[dict[str, object]] = []
+
+    def balanced(**kwargs: object) -> list[ProviderBenchmarkSample]:
+        calls.append(kwargs)
+        return [row]
+
+    monkeypatch.setattr(
+        "trusted_router.benchmark_samples.providers_for_display",
+        lambda: (SimpleNamespace(slug="openai"), SimpleNamespace(slug="anthropic")),
+    )
+    monkeypatch.setattr(
+        "trusted_router.benchmark_samples.STORE",
+        SimpleNamespace(provider_balanced_benchmark_samples=balanced),
+    )
+
+    rows = public_benchmark_samples(
+        limit=5000,
+        per_provider_limit=25,
+        recent_minutes=180,
+        now=dt.datetime(2026, 6, 5, 20, 0, tzinfo=dt.UTC),
+    )
+
+    assert rows == [row]
+    assert calls == [
+        {
+            "cutoff": "2026-06-05T17:00:00Z",
+            "per_provider_limit": 25,
+            "limit": 5000,
+        }
+    ]
+
+
 def test_public_benchmark_samples_filters_to_recent_window(monkeypatch) -> None:
     recent = _sample(
         provider="openai",

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -31,7 +31,11 @@ from trusted_router.storage_gcp_operational_analytics_outbox import (
     analytics_surrogate,
     operational_analytics_shard,
 )
-from trusted_router.storage_models import Generation, SyntheticProbeSample
+from trusted_router.storage_models import (
+    Generation,
+    ProviderBenchmarkSample,
+    SyntheticProbeSample,
+)
 from trusted_router.types import UsageType
 
 
@@ -128,6 +132,112 @@ def test_operational_outbox_enqueue_is_sharded_and_commit_timestamped() -> None:
         "event_kind": "STRING",
         "event_id": "STRING",
         "payload": "STRING",
+    }
+
+
+def test_clickhouse_balanced_benchmark_reader_uses_one_window_query() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert request.url.params["param_per_provider_limit"] == "25"
+        assert request.url.params["param_limit"] == "5000"
+        assert request.url.params["param_cutoff"] == "2026-07-31T00:00:00Z"
+        sql = request.content.decode()
+        assert "row_number() OVER" in sql
+        assert "PARTITION BY provider" in sql
+        assert "provider_rank <= {per_provider_limit:UInt32}" in sql
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "bench-balanced-1",
+                        "model": "anthropic/claude-haiku-4.5",
+                        "provider": "anthropic",
+                        "provider_name": "Anthropic",
+                        "status": "success",
+                        "usage_type": "Credits",
+                        "streamed": 1,
+                        "input_tokens": 10,
+                        "output_tokens": 2,
+                        "total_cost_microdollars": 7,
+                        "speed_tokens_per_second": 8.0,
+                        "elapsed_milliseconds": 250,
+                        "first_token_milliseconds": 100,
+                        "ttfb_milliseconds": 20,
+                        "finish_reason": "stop",
+                        "error_type": None,
+                        "error_status": None,
+                        "error_message": None,
+                        "region": "us-central1",
+                        "source": "synthetic",
+                        "app": "TrustedRouter Synthetic",
+                        "created_at": "2026-07-31 12:34:56.789",
+                    }
+                ]
+            },
+        )
+
+    client = OperationalAnalyticsClient(
+        base_url="http://clickhouse",
+        user="reader",
+        password="sec" + "ret",
+        transport=httpx.MockTransport(handler),
+    )
+    rows = client.balanced_benchmark_samples(
+        cutoff="2026-07-31T00:00:00Z",
+        per_provider_limit=25,
+        limit=5000,
+    )
+
+    assert calls == 1
+    assert rows == [
+        ProviderBenchmarkSample(
+            id="bench-balanced-1",
+            model="anthropic/claude-haiku-4.5",
+            provider="anthropic",
+            provider_name="Anthropic",
+            status="success",
+            usage_type="Credits",
+            streamed=True,
+            input_tokens=10,
+            output_tokens=2,
+            total_cost_microdollars=7,
+            speed_tokens_per_second=8.0,
+            elapsed_milliseconds=250,
+            first_token_milliseconds=100,
+            ttfb_milliseconds=20,
+            finish_reason="stop",
+            region="us-central1",
+            source="synthetic",
+            app="TrustedRouter Synthetic",
+            created_at="2026-07-31T12:34:56.789Z",
+        )
+    ]
+
+
+def test_public_snapshot_reads_newest_revision_across_month_partitions() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        sql = request.content.decode()
+        assert "WHERE name = {name:String}" in sql
+        assert "ORDER BY generated_at DESC" in sql
+        assert request.url.params["param_name"] == "leaderboard"
+        return httpx.Response(
+            200,
+            json={"data": [{"payload": '{"generated_at":"2026-08-01T00:00:00Z"}'}]},
+        )
+
+    client = OperationalAnalyticsClient(
+        base_url="http://clickhouse",
+        user="reader",
+        password="sec" + "ret",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.public_snapshot("leaderboard") == {
+        "generated_at": "2026-08-01T00:00:00Z"
     }
 
 

--- a/tests/test_spanner_delivery.py
+++ b/tests/test_spanner_delivery.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+from clickhouse.verify_spanner_delivery import verify_delivery
+from trusted_router.storage_gcp_operational_analytics_outbox import activity_payload
+from trusted_router.storage_models import Generation
+from trusted_router.types import UsageType
+
+
+def _generation(generation_id: str = "gen-delivery-1") -> Generation:
+    return Generation(
+        id=generation_id,
+        request_id="req-delivery-1",
+        workspace_id="ws-private",
+        key_hash="key-private",
+        model="anthropic/claude-haiku-4.5",
+        provider="anthropic",
+        provider_name="Anthropic",
+        app="Synthetic",
+        tokens_prompt=10,
+        tokens_completion=2,
+        total_cost_microdollars=7,
+        usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=8.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        usage_estimated=False,
+        created_at="2026-07-31T12:00:00.000Z",
+    )
+
+
+class FakeSource:
+    def __init__(self, generations: list[Generation]) -> None:
+        self.generations = generations
+        self.calls: list[tuple[dt.datetime, dt.datetime, int]] = []
+
+    def fetch(
+        self,
+        *,
+        start: dt.datetime,
+        end: dt.datetime,
+        limit: int,
+    ) -> list[Generation]:
+        self.calls.append((start, end, limit))
+        return self.generations[:limit]
+
+
+class FakeClickHouse:
+    def __init__(self, rows: dict[str, dict[str, Any]]) -> None:
+        self.rows = rows
+        self.requested_ids: list[str] = []
+
+    def query(
+        self,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        external_ids: bool = False,
+    ) -> str:
+        assert "activity_generations" in sql
+        assert external_ids is True
+        assert input_bytes is not None
+        self.requested_ids = input_bytes.decode().splitlines()
+        return "\n".join(
+            json.dumps(self.rows[generation_id])
+            for generation_id in self.requested_ids
+            if generation_id in self.rows
+        )
+
+
+def test_spanner_delivery_matches_content_free_generation_rows() -> None:
+    generation = _generation()
+    expected = activity_payload(generation)
+    source = FakeSource([generation])
+    clickhouse = FakeClickHouse({generation.id: expected})
+    start = dt.datetime(2026, 7, 31, tzinfo=dt.UTC)
+    end = start + dt.timedelta(days=1)
+
+    result = verify_delivery(source, clickhouse, start=start, end=end, limit=100)
+
+    assert result == {
+        "sampled": 1,
+        "found": 1,
+        "missing": 0,
+        "mismatched": 0,
+        "missing_ids": [],
+        "mismatched_ids": [],
+        "ok": True,
+    }
+    assert source.calls == [(start, end, 100)]
+    assert clickhouse.requested_ids == [generation.id]
+
+
+def test_spanner_delivery_reports_missing_and_mismatched_rows() -> None:
+    missing = _generation("gen-missing")
+    mismatched = _generation("gen-mismatched")
+    wrong = activity_payload(mismatched)
+    wrong["total_cost_microdollars"] = 999
+
+    result = verify_delivery(
+        FakeSource([missing, mismatched]),
+        FakeClickHouse({mismatched.id: wrong}),
+        start=dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 8, 1, tzinfo=dt.UTC),
+        limit=100,
+    )
+
+    assert result["ok"] is False
+    assert result["missing"] == 1
+    assert result["mismatched"] == 1
+    assert result["missing_ids"] == [missing.id]
+    assert result["mismatched_ids"] == [mismatched.id]
+
+
+def test_spanner_delivery_allows_an_empty_quiet_window() -> None:
+    result = verify_delivery(
+        FakeSource([]),
+        FakeClickHouse({}),
+        start=dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 8, 1, tzinfo=dt.UTC),
+        limit=100,
+    )
+
+    assert result["sampled"] == 0
+    assert result["ok"] is True

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -707,6 +707,38 @@ def test_production_config_fails_closed() -> None:
         )
 
 
+def test_production_spanner_clickhouse_config_is_explicit_and_bigtable_free() -> None:
+    values = {
+        "environment": "production",
+        "internal_gateway_token": "tok" + "en",
+        "stripe_webhook_secret": "whsec_" + "test",
+        "stripe_secret_key": "sk_" + "test_secret",
+        "sentry_dsn": "https://example@example.ingest.sentry.io/1",
+        "storage_backend": "spanner-clickhouse",
+        "spanner_instance_id": "trusted-router",
+        "spanner_database_id": "trusted-router",
+        "byok_kms_key_name": TEST_BYOK_KMS_KEY_NAME,
+        "analytics_read_mode": "clickhouse-only",
+        "generation_records_enabled": True,
+        "operational_analytics_outbox_enabled": True,
+        "analytics_outbox_enabled": True,
+        "bigtable_mirror_writes_enabled": False,
+        "request_record_write_mode": "typed",
+        "settle_outbox_enabled": True,
+        "operational_analytics_clickhouse_url": "http://10.0.0.1:8123",
+        "operational_analytics_clickhouse_password": "pass" + "word",
+    }
+
+    settings = Settings(**values)
+    assert settings.storage_backend == "spanner-clickhouse"
+    assert settings.bigtable_mirror_writes_enabled is False
+
+    with pytest.raises(ValidationError, match="BIGTABLE_MIRROR"):
+        Settings(**{**values, "bigtable_mirror_writes_enabled": True})
+    with pytest.raises(ValidationError, match="clickhouse-only"):
+        Settings(**{**values, "analytics_read_mode": "clickhouse"})
+
+
 def test_production_control_plane_does_not_register_inference_routes() -> None:
     internal_token = "tok" + "en"
     webhook_secret = "whsec_" + "test"


### PR DESCRIPTION
## Summary
- make Spanner generation records and durable ClickHouse outboxes authoritative at settlement
- add ClickHouse-only runtime mode, balanced analytics reads, and precomputed public snapshots
- add verified archives, restore drills, source-of-truth delivery audits, and gated Bigtable retirement automation

## Safety
- production remains on Bigtable-backed dual reads during the required soak windows
- final retirement is fail-closed and never deletes Bigtable data
- region-at-a-time cutover retains rollback and shadow capability

## Verification
- 2407 tests passed, 86 skipped
- ruff clean
- mypy clean across 206 source files
- all deploy scripts pass shell syntax validation