### PR TITLE
Pass Spanner config through top-level deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,20 @@ jobs:
           TR_BIGTABLE_INSTANCE_ID: trusted-router-logs
           TR_BIGTABLE_GENERATION_TABLE: trustedrouter-generations
         run: scripts/deploy/migrate_request_retention.sh --apply
+      - name: Apply bounded generation-record schema
+        run: scripts/deploy/migrate_generation_records.sh --apply
+      - name: Apply provider analytics outbox schema
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/migrate_analytics_outbox.sh
+      - name: Apply operational analytics outbox schema
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/migrate_operational_analytics_outbox.sh
 
   deploy:
     needs: [gate-on-ci, build-image, migrate-schema]

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -17,9 +17,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/deploy/_lib.sh"
 
 bash "${SCRIPT_DIR}/deploy/infra.sh"
-bash "${SCRIPT_DIR}/deploy/migrate_typed_counters.sh"
+GCP_PROJECT_ID="$PROJECT_ID" \
+SPANNER_INSTANCE_ID="$SPANNER_INSTANCE_ID" \
+SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \
+  bash "${SCRIPT_DIR}/deploy/migrate_typed_counters.sh"
 bash "${SCRIPT_DIR}/deploy/migrate_request_retention.sh" --apply
 bash "${SCRIPT_DIR}/deploy/migrate_generation_records.sh" --apply
 bash "${SCRIPT_DIR}/deploy/migrate_analytics_outbox.sh"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -9,6 +9,31 @@ from scripts.check_price_coverage import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_top_level_deploy_passes_spanner_config_to_unshared_migration() -> None:
+    deploy = (ROOT / "scripts/deploy-gcp.sh").read_text()
+
+    assert 'source "${SCRIPT_DIR}/deploy/_lib.sh"' in deploy
+    assert 'GCP_PROJECT_ID="$PROJECT_ID" \\\n' in deploy
+    assert 'SPANNER_INSTANCE_ID="$SPANNER_INSTANCE_ID" \\\n' in deploy
+    assert 'SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \\\n' in deploy
+    assert 'bash "${SCRIPT_DIR}/deploy/migrate_typed_counters.sh"' in deploy
+
+
+def test_guarded_deploy_applies_clickhouse_delivery_schemas_before_rollout() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+
+    generation = "scripts/deploy/migrate_generation_records.sh --apply"
+    provider_outbox = "scripts/deploy/migrate_analytics_outbox.sh"
+    operational_outbox = "scripts/deploy/migrate_operational_analytics_outbox.sh"
+    rollout = "run: bash scripts/deploy/rollout.sh"
+    assert generation in workflow
+    assert provider_outbox in workflow
+    assert operational_outbox in workflow
+    assert workflow.index(generation) < workflow.index(rollout)
+    assert workflow.index(provider_outbox) < workflow.index(rollout)
+    assert workflow.index(operational_outbox) < workflow.index(rollout)
+
+
 def test_deploy_pins_ten_cent_signup_credit_policy() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 


### PR DESCRIPTION
## Summary
- load the shared production deploy configuration in the top-level orchestrator
- pass project, Spanner instance, and database explicitly to the one migration that does not source the shared library
- add a regression test for the orchestration contract

## Verification
- focused deployment tests pass
- shell syntax validation passes

## Production impact
The failed rollout stopped before image build or Cloud Run changes. Infrastructure checks were idempotent; no traffic configuration changed.