### PR TITLE
Harden ClickHouse retirement verification

### DIFF
--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -34,6 +34,18 @@ ARCHIVE_BUCKET = "quill-cloud-proxy-tr-clickhouse-archive"
 ARCHIVE_SCHEMA_VERSION = 1
 ROWS_PER_PART = 5_000_000
 UINT64_MODULUS = 1 << 64
+_UNORDERED_MAP_COLUMNS = frozenset(
+    {
+        "latency_histogram",
+        "ttfb_histogram",
+        "dns_histogram",
+        "tcp_connect_histogram",
+        "tls_handshake_histogram",
+        "gateway_processing_histogram",
+        "error_counts",
+    }
+)
+_DATETIME_MILLI_COLUMNS = frozenset({"period_start"})
 
 log = logging.getLogger("trusted_router.analytics_archive")
 
@@ -171,7 +183,6 @@ DATASETS: dict[str, DatasetSpec] = {
             "error_counts",
             "last_checked_at",
             "cost_microdollars",
-            "updated_at",
         ),
         time_column="period_start",
         shard_column="id",
@@ -200,7 +211,18 @@ def _day_bounds(day: dt.date) -> tuple[str, str]:
 
 
 def _row_hash_expression(columns: Sequence[str]) -> str:
-    return "cityHash64(toJSONString(tuple(" + ", ".join(columns) + ")))"
+    def canonical_column(column: str) -> str:
+        if column in _UNORDERED_MAP_COLUMNS:
+            return f"mapSort({column})"
+        if column in _DATETIME_MILLI_COLUMNS:
+            return (
+                "toUnixTimestamp64Milli("
+                f"toDateTime64({column}, 3, 'UTC'))"
+            )
+        return column
+
+    canonical = (canonical_column(column) for column in columns)
+    return "cityHash64(toJSONString(tuple(" + ", ".join(canonical) + ")))"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -408,9 +430,9 @@ class ClickHouseDailyExporter:
 
 class GCSArchiveStore:
     def __init__(self, *, project: str, bucket: str) -> None:
-        from google.cloud import storage
+        import google.cloud.storage as gcs_storage
 
-        self._bucket = storage.Client(project=project).bucket(bucket)
+        self._bucket = gcs_storage.Client(project=project).bucket(bucket)
 
     def read_json(self, key: str) -> dict[str, Any] | None:
         blob = self._bucket.blob(key)

--- a/clickhouse/backfill_generation_records.py
+++ b/clickhouse/backfill_generation_records.py
@@ -13,6 +13,7 @@ from google.cloud import bigtable, spanner
 from google.cloud.bigtable.row_filters import (
     CellsColumnLimitFilter,
     RowFilterChain,
+    TimestampRange,
     TimestampRangeFilter,
 )
 from google.cloud.spanner_v1 import KeySet
@@ -72,7 +73,7 @@ def _generation(row: Any) -> Generation | None:
 def _iter_recent(table: Any, *, cutoff: dt.datetime) -> Iterator[Generation]:
     filter_ = RowFilterChain(
         filters=[
-            TimestampRangeFilter(start=cutoff),
+            TimestampRangeFilter(TimestampRange(start=cutoff)),
             CellsColumnLimitFilter(1),
         ]
     )

--- a/clickhouse/operational_fingerprint.py
+++ b/clickhouse/operational_fingerprint.py
@@ -37,6 +37,10 @@ def canonical_fingerprint(payload: dict[str, Any], *, surface: str) -> str:
         for field in ("streamed", "usage_estimated"):
             if canonical.get(field) is not None:
                 canonical[field] = bool(canonical[field])
+        if canonical.get("speed_tokens_per_second") is not None:
+            canonical["speed_tokens_per_second"] = float(
+                canonical["speed_tokens_per_second"]
+            )
     if surface == "rollup" and canonical.get("target_region") is None:
         canonical["target_region"] = ""
     if surface == "benchmark" and canonical.get("speed_tokens_per_second") is not None:

--- a/clickhouse/verify_archive_backfill.py
+++ b/clickhouse/verify_archive_backfill.py
@@ -1,0 +1,159 @@
+"""Prove every closed ClickHouse partition has a current archive pointer."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any, Protocol
+
+from clickhouse.archive_daily import (
+    ARCHIVE_BUCKET,
+    DATABASE,
+    DATASETS,
+    PROJECT,
+    ArchiveStore,
+    ClickHouseDailyExporter,
+    GCSArchiveStore,
+    SourceFingerprint,
+)
+
+
+class BackfillExporter(Protocol):
+    def earliest_day(self) -> dt.date | None: ...
+
+    def source_fingerprint(self, day: dt.date) -> SourceFingerprint: ...
+
+
+def _closed_days(first: dt.date, today: dt.date) -> list[dt.date]:
+    if first >= today:
+        return []
+    return [first + dt.timedelta(days=offset) for offset in range((today - first).days)]
+
+
+def _verified_restore(path: Path, *, now: dt.datetime) -> None:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict) or not value.get("ok"):
+        raise RuntimeError("archive restore drill has not passed")
+    checked_at = dt.datetime.fromisoformat(
+        str(value["checked_at"]).replace("Z", "+00:00")
+    )
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=dt.UTC)
+    if now - checked_at.astimezone(dt.UTC) > dt.timedelta(hours=30):
+        raise RuntimeError("archive restore drill is stale")
+    found = {
+        str(item["dataset"])
+        for item in value.get("datasets", [])
+        if isinstance(item, dict) and item.get("dataset")
+    }
+    if found != set(DATASETS):
+        raise RuntimeError("archive restore drill does not cover every dataset")
+
+
+def verify_archive_backfill(
+    exporters: dict[str, BackfillExporter],
+    store: ArchiveStore,
+    *,
+    now: dt.datetime,
+    restore_result: Path,
+) -> dict[str, Any]:
+    _verified_restore(restore_result, now=now)
+    today = now.astimezone(dt.UTC).date()
+    coverage: dict[str, dict[str, Any]] = {}
+    for dataset in DATASETS:
+        exporter = exporters[dataset]
+        first = exporter.earliest_day()
+        days = [] if first is None else _closed_days(first, today)
+        for day in days:
+            source = exporter.source_fingerprint(day)
+            prefix = f"raw/{dataset}/day={day.isoformat()}"
+            pointer = store.read_json(f"{prefix}/_latest.json")
+            if pointer is None:
+                raise RuntimeError(f"archive pointer missing for {dataset} on {day}")
+            archived = SourceFingerprint.from_dict(
+                dict(pointer.get("source_fingerprint") or {})
+            )
+            if not source.matches(archived):
+                raise RuntimeError(f"archive pointer is stale for {dataset} on {day}")
+            manifest_key = str(pointer.get("manifest") or "")
+            if not manifest_key.startswith(f"{prefix}/revisions/"):
+                raise RuntimeError(f"archive manifest path is invalid for {dataset} on {day}")
+            manifest = store.read_json(manifest_key)
+            if (
+                manifest is None
+                or manifest.get("dataset") != dataset
+                or manifest.get("day") != day.isoformat()
+                or str(manifest.get("revision") or "")
+                != str(pointer.get("revision") or "")
+            ):
+                raise RuntimeError(f"archive manifest is invalid for {dataset} on {day}")
+            manifest_source = SourceFingerprint.from_dict(
+                dict(manifest.get("source_fingerprint") or {})
+            )
+            if not source.matches(manifest_source):
+                raise RuntimeError(f"archive manifest is stale for {dataset} on {day}")
+        coverage[dataset] = {
+            "first_day": first.isoformat() if first is not None else None,
+            "last_day": days[-1].isoformat() if days else None,
+            "days": len(days),
+        }
+    return {
+        "checked_at": now.astimezone(dt.UTC).isoformat().replace("+00:00", "Z"),
+        "ok": True,
+        "datasets": list(DATASETS),
+        "coverage": coverage,
+    }
+
+
+def _write_result(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(result, sort_keys=True) + "\n")
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
+    parser.add_argument("--database", default=DATABASE)
+    parser.add_argument(
+        "--restore-result",
+        type=Path,
+        default=Path("/var/lib/tr-clickhouse-ingest/archive-restore.json"),
+    )
+    parser.add_argument(
+        "--result-file",
+        type=Path,
+        default=Path(
+            "/var/lib/tr-clickhouse-ingest/archive-backfill-complete.json"
+        ),
+    )
+    args = parser.parse_args()
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    exporters: dict[str, BackfillExporter] = {
+        dataset: ClickHouseDailyExporter(
+            password=password,
+            database=args.database,
+            table=dataset,
+        )
+        for dataset in DATASETS
+    }
+    result = verify_archive_backfill(
+        exporters,
+        GCSArchiveStore(project=args.project, bucket=args.bucket),
+        now=dt.datetime.now(dt.UTC),
+        restore_result=args.restore_result,
+    )
+    _write_result(args.result_file, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/verify_spanner_delivery.py
+++ b/clickhouse/verify_spanner_delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import collections
 import dataclasses
 import datetime as dt
 import json
@@ -90,12 +91,26 @@ def verify_delivery(
         ids=list(expected),
     )
     missing = sorted(set(expected) - set(actual))
-    mismatched = sorted(
-        generation_id
-        for generation_id in set(expected) & set(actual)
-        if canonical_fingerprint(expected[generation_id], surface="activity")
-        != canonical_fingerprint(actual[generation_id], surface="activity")
-    )
+    mismatched: list[str] = []
+    mismatch_fields: collections.Counter[str] = collections.Counter()
+    for generation_id in sorted(set(expected) & set(actual)):
+        expected_row = expected[generation_id]
+        actual_row = actual[generation_id]
+        if canonical_fingerprint(
+            expected_row,
+            surface="activity",
+        ) == canonical_fingerprint(actual_row, surface="activity"):
+            continue
+        mismatched.append(generation_id)
+        for field in set(expected_row) | set(actual_row):
+            if canonical_fingerprint(
+                {field: expected_row.get(field)},
+                surface="activity",
+            ) != canonical_fingerprint(
+                {field: actual_row.get(field)},
+                surface="activity",
+            ):
+                mismatch_fields[field] += 1
     return {
         "sampled": len(expected),
         "found": len(actual),
@@ -103,6 +118,7 @@ def verify_delivery(
         "mismatched": len(mismatched),
         "missing_ids": missing[:20],
         "mismatched_ids": mismatched[:20],
+        "mismatch_fields": dict(sorted(mismatch_fields.items())),
         "ok": not missing and not mismatched,
     }
 

--- a/scripts/deploy/prepare_bigtable_retirement.sh
+++ b/scripts/deploy/prepare_bigtable_retirement.sh
@@ -42,9 +42,8 @@ gc compute ssh tr-clickhouse-1 \
       /opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_archive_restore
     systemctl start tr-clickhouse-public-snapshots.service
     systemctl start tr-clickhouse-spanner-delivery.service
-    checked_at=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    printf '"'"'{\"checked_at\":\"%s\",\"ok\":true,\"datasets\":[\"provider_benchmark_samples\",\"activity_generations\",\"synthetic_probe_samples\",\"synthetic_status_rollups\"]}\n'"'"' \
-      \"\$checked_at\" > /var/lib/tr-clickhouse-ingest/archive-backfill-complete.json
+    PYTHONPATH=/opt/tr-clickhouse/src \
+      /opt/tr-clickhouse/venv/bin/python -m clickhouse.verify_archive_backfill
     chown tr-clickhouse-ingest:tr-clickhouse-ingest \
       /var/lib/tr-clickhouse-ingest/archive-backfill-complete.json
   '"

--- a/tests/test_bigtable_retirement.py
+++ b/tests/test_bigtable_retirement.py
@@ -1,16 +1,35 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from clickhouse.backfill_generation_records import _iter_recent
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage import CreditAccount, create_store
 from trusted_router.storage_gcp_authorize import AuthorizeOutcome
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.storage_models import Generation
+
+
+class _CapturingBigtableTable:
+    def __init__(self) -> None:
+        self.filter: Any = None
+
+    def read_rows(self, **kwargs: Any) -> list[Any]:
+        self.filter = kwargs["filter_"]
+        return []
+
+
+def test_generation_backfill_uses_sdk_timestamp_range_object() -> None:
+    table = _CapturingBigtableTable()
+    cutoff = dt.datetime(2026, 7, 1, tzinfo=dt.UTC)
+
+    assert list(_iter_recent(table, cutoff=cutoff)) == []
+    assert table.filter.filters[0].range_.start == cutoff
 
 
 def _seed_credit(store: Any, workspace_id: str, total: int = 5_000_000) -> None:

--- a/tests/test_clickhouse_archive.py
+++ b/tests/test_clickhouse_archive.py
@@ -14,8 +14,10 @@ from clickhouse.archive_daily import (
     SourceFingerprint,
     _combine_parts,
     _days_to_archive,
+    _row_hash_expression,
     archive_day,
 )
+from clickhouse.verify_archive_backfill import verify_archive_backfill
 from clickhouse.verify_archive_restore import verify_archived_day
 
 
@@ -225,6 +227,19 @@ def test_every_bounded_analytics_dataset_has_an_archive_schema() -> None:
         assert spec.time_column in spec.columns
         assert spec.shard_column in spec.columns
         assert "ingest_version" not in spec.columns
+    assert "updated_at" not in DATASETS["synthetic_status_rollups"].columns
+
+
+def test_rollup_archive_fingerprint_sorts_unordered_map_columns() -> None:
+    expression = _row_hash_expression(DATASETS["synthetic_status_rollups"].columns)
+
+    assert "mapSort(latency_histogram)" in expression
+    assert "mapSort(error_counts)" in expression
+    assert "mapSort(id)" not in expression
+    assert (
+        "toUnixTimestamp64Milli(toDateTime64(period_start, 3, 'UTC'))"
+        in expression
+    )
 
 
 def test_operational_dataset_archive_round_trips_through_restore_verifier() -> None:
@@ -287,4 +302,78 @@ def test_restore_drill_rejects_pointer_manifest_identity_mismatch() -> None:
             dataset="synthetic_status_rollups",
             day=day,
             verifier=exporter.verify_part,
+        )
+
+
+class _BackfillExporter:
+    def __init__(self, first: dt.date, fingerprints: dict[dt.date, SourceFingerprint]) -> None:
+        self.first = first
+        self.fingerprints = fingerprints
+
+    def earliest_day(self) -> dt.date:
+        return self.first
+
+    def source_fingerprint(self, day: dt.date) -> SourceFingerprint:
+        return self.fingerprints[day]
+
+
+def _restore_result(path: Path, *, now: dt.datetime) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "checked_at": now.isoformat().replace("+00:00", "Z"),
+                "ok": True,
+                "datasets": [{"dataset": dataset} for dataset in DATASETS],
+            }
+        )
+    )
+
+
+def test_archive_backfill_marker_requires_current_pointer_and_manifest(
+    tmp_path: Path,
+) -> None:
+    now = dt.datetime(2026, 7, 3, tzinfo=dt.UTC)
+    day = dt.date(2026, 7, 2)
+    fingerprint = _fingerprint()
+    store = MemoryStore()
+    exporters: dict[str, _BackfillExporter] = {}
+    for dataset in DATASETS:
+        exporter = FakeExporter(fingerprint)
+        archive_day(exporter, store, day, dataset=dataset)
+        exporters[dataset] = _BackfillExporter(day, {day: fingerprint})
+    restore = tmp_path / "restore.json"
+    _restore_result(restore, now=now)
+
+    result = verify_archive_backfill(
+        exporters,
+        store,
+        now=now,
+        restore_result=restore,
+    )
+
+    assert result["ok"] is True
+    assert set(result["coverage"]) == set(DATASETS)
+    assert all(item["days"] == 1 for item in result["coverage"].values())
+
+
+def test_archive_backfill_marker_rejects_stale_pointer(tmp_path: Path) -> None:
+    now = dt.datetime(2026, 7, 3, tzinfo=dt.UTC)
+    day = dt.date(2026, 7, 2)
+    original = _fingerprint()
+    changed = _fingerprint(rows=8, hash_sum=99, hash_xor=31)
+    store = MemoryStore()
+    exporters: dict[str, _BackfillExporter] = {}
+    for dataset in DATASETS:
+        archive_day(FakeExporter(original), store, day, dataset=dataset)
+        fingerprints = {day: changed if dataset == "activity_generations" else original}
+        exporters[dataset] = _BackfillExporter(day, fingerprints)
+    restore = tmp_path / "restore.json"
+    _restore_result(restore, now=now)
+
+    with pytest.raises(RuntimeError, match="pointer is stale"):
+        verify_archive_backfill(
+            exporters,
+            store,
+            now=now,
+            restore_result=restore,
         )

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -137,6 +137,8 @@ def test_retirement_preparation_backfills_and_restore_verifies_every_dataset() -
     assert "clickhouse_operational_analytics.sh" in script
     assert "clickhouse.archive_daily --backfill" in script
     assert "clickhouse.verify_archive_restore" in script
+    assert "clickhouse.verify_archive_backfill" in script
+    assert "printf" not in script
     assert "clickhouse.verify_spanner_delivery" not in script
     assert "tr-clickhouse-spanner-delivery.service" in script
     assert "would not change production read mode" in script

--- a/tests/test_spanner_delivery.py
+++ b/tests/test_spanner_delivery.py
@@ -89,10 +89,29 @@ def test_spanner_delivery_matches_content_free_generation_rows() -> None:
         "mismatched": 0,
         "missing_ids": [],
         "mismatched_ids": [],
+        "mismatch_fields": {},
         "ok": True,
     }
     assert source.calls == [(start, end, 100)]
     assert clickhouse.requested_ids == [generation.id]
+
+
+def test_spanner_delivery_normalizes_integral_float_json_values() -> None:
+    generation = _generation()
+    generation.speed_tokens_per_second = 1000.0
+    actual = activity_payload(generation)
+    actual["speed_tokens_per_second"] = 1000
+
+    result = verify_delivery(
+        FakeSource([generation]),
+        FakeClickHouse({generation.id: actual}),
+        start=dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 8, 1, tzinfo=dt.UTC),
+        limit=100,
+    )
+
+    assert result["ok"] is True
+    assert result["mismatch_fields"] == {}
 
 
 def test_spanner_delivery_reports_missing_and_mismatched_rows() -> None:
@@ -114,6 +133,7 @@ def test_spanner_delivery_reports_missing_and_mismatched_rows() -> None:
     assert result["mismatched"] == 1
     assert result["missing_ids"] == [missing.id]
     assert result["mismatched_ids"] == [mismatched.id]
+    assert result["mismatch_fields"] == {"total_cost_microdollars": 1}
 
 
 def test_spanner_delivery_allows_an_empty_quiet_window() -> None:


### PR DESCRIPTION
Fixes the Bigtable SDK timestamp filter used by generation backfill. Normalizes numeric delivery fingerprints and adds redacted mismatch diagnostics. Makes rollup Parquet fingerprints type-stable and excludes volatile rebuild timestamps. Replaces the unconditional archive completion marker with full closed-partition pointer and manifest verification.\n\nVerified locally: 2,414 passed, 86 skipped; ruff and mypy clean; deploy scripts pass bash syntax checks. Production evidence: 626,398 generation rows backfilled with zero missing; 20,000 sampled Bigtable/ClickHouse rows exact; three ClickHouse replicas exact and healthy; all archived partitions plus four-dataset restore drill verified.