### PR TITLE
TTL for rate_limit entities via generated-column row deletion policy

### DIFF
--- a/scripts/deploy/migrate_entity_ttl.sh
+++ b/scripts/deploy/migrate_entity_ttl.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Give ephemeral tr_entities kinds a real expiry (issue #334, Problem 2).
+#
+# Mechanism: a STORED generated column extracts the numeric unix-seconds
+# `expires_at` that rate_limit bodies already carry (their window reset epoch),
+# and a ROW DELETION POLICY deletes rows one day after that expiry. This is the
+# documented Spanner pattern for TTL on a derived timestamp.
+#
+# Why this is safe for every other kind: the policy column is NULL unless the
+# body carries a NUMERIC expires_at. Only rate_limit writes one (an INT64
+# reset epoch); api_key / auth_session / wallet_challenge carry ISO-8601
+# STRINGS, which SAFE_CAST nulls out, and Spanner's TTL never deletes a row
+# whose policy timestamp is NULL (the same NULL-exemption semantics the
+# tr_reservation retention backfill relied on). Audited in prod 2026-08-01:
+# 386,574/386,574 rate_limit rows numeric; zero numeric rows in any other kind.
+#
+# TRAP for future kinds: writing a NUMERIC `expires_at` into an entity body
+# OPTS THAT ROW INTO DELETION one day after the epoch it names. That is the
+# intended contract — do it on purpose or use a different field name.
+#
+# Idempotent: INFORMATION_SCHEMA-guarded, safe to re-run.
+#
+# Operational sequencing: apply only when no Cloud Run deploy is rolling and
+# prefer a low-traffic window (receipt: 2026-07-04 Aborted burst). The STORED
+# column backfills ~9.4M rows as a background schema operation; expect the DDL
+# to run for several minutes. Deletion of expired rows starts on the next TTL
+# background sweep (daily; deletions typically complete within 72h).
+#
+# Usage:
+#   SPANNER_INSTANCE_ID=... SPANNER_DATABASE_ID=... [GCP_PROJECT_ID=...] \
+#     scripts/deploy/migrate_entity_ttl.sh
+set -euo pipefail
+
+INSTANCE="${SPANNER_INSTANCE_ID:?set SPANNER_INSTANCE_ID}"
+DATABASE="${SPANNER_DATABASE_ID:?set SPANNER_DATABASE_ID}"
+PROJECT_ARG=()
+[ -n "${GCP_PROJECT_ID:-}" ] && PROJECT_ARG=(--project "${GCP_PROJECT_ID}")
+
+log() { printf '%s %s\n' "[migrate_entity_ttl]" "$*"; }
+
+column_exists() {
+  local n
+  n=$(gcloud spanner databases execute-sql "$DATABASE" \
+        --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+        --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='tr_entities' AND column_name='ephemeral_expires_at'" \
+        --format='value(rows[0])' 2>/dev/null || echo 0)
+  [ "${n:-0}" != "0" ]
+}
+
+policy_exists() {
+  local ddl
+  ddl=$(gcloud spanner databases ddl describe "$DATABASE" \
+          --instance="$INSTANCE" "${PROJECT_ARG[@]}" 2>/dev/null || true)
+  printf '%s' "$ddl" | grep -q "OLDER_THAN(ephemeral_expires_at"
+}
+
+apply_ddl() {
+  local ddl="$1"
+  log "applying: ${ddl%%(*}..."
+  gcloud spanner databases ddl update "$DATABASE" \
+    --instance="$INSTANCE" "${PROJECT_ARG[@]}" --ddl="$ddl"
+}
+
+if column_exists; then
+  log "ephemeral_expires_at exists, skip"
+else
+  apply_ddl "ALTER TABLE tr_entities ADD COLUMN ephemeral_expires_at TIMESTAMP AS (TIMESTAMP_SECONDS(SAFE_CAST(JSON_VALUE(body, '\$.expires_at') AS INT64))) STORED"
+fi
+
+if policy_exists; then
+  log "row deletion policy exists, skip"
+else
+  apply_ddl "ALTER TABLE tr_entities ADD ROW DELETION POLICY (OLDER_THAN(ephemeral_expires_at, INTERVAL 1 DAY))"
+fi
+
+log "verify: expired-but-undeleted rate_limit rows (drops to ~0 within 72h)"
+gcloud spanner databases execute-sql "$DATABASE" \
+  --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+  --sql="SELECT COUNT(*) FROM tr_entities WHERE kind='rate_limit' AND ephemeral_expires_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)"

--- a/scripts/deploy/migrate_entity_ttl.sh
+++ b/scripts/deploy/migrate_entity_ttl.sh
@@ -53,6 +53,10 @@ column_exists() {
   [ "${n:-0}" != "0" ] && [ -n "${n}" ]
 }
 
+column_expression() {
+  sql_value "SELECT COALESCE(GENERATION_EXPRESSION, '') FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='tr_entities' AND column_name='ephemeral_expires_at'"
+}
+
 policy_expression() {
   sql_value "SELECT COALESCE(ROW_DELETION_POLICY_EXPRESSION, '') FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_entities'"
 }
@@ -65,14 +69,31 @@ apply_ddl() {
 }
 
 if column_exists; then
-  log "ephemeral_expires_at exists, skip"
+  # "Column exists" is NOT enough: a stored generated-column expression cannot
+  # be altered in place, and attaching the policy to a column with a DIFFERENT
+  # expression (e.g. an earlier unscoped draft) would re-open the string-cast
+  # hole. Require BOTH safety discriminators to be present in the actual
+  # deployed expression; abort loudly otherwise so a human drops/rebuilds.
+  expr="$(column_expression)"
+  if printf '%s' "$expr" | grep -q "kind = 'rate_limit'" \
+     && printf '%s' "$expr" | grep -q "JSON_QUERY"; then
+    log "ephemeral_expires_at exists with the kind-scoped JSON_QUERY expression, skip"
+  else
+    log "ERROR: ephemeral_expires_at exists with an UNEXPECTED expression:"
+    log "  ${expr:-<empty / not a generated column>}"
+    log "Stored generated expressions cannot be altered in place. Drop the"
+    log "policy and column manually, then re-run:"
+    log "  ALTER TABLE tr_entities DROP ROW DELETION POLICY;"
+    log "  ALTER TABLE tr_entities DROP COLUMN ephemeral_expires_at;"
+    exit 1
+  fi
 else
   apply_ddl "ALTER TABLE tr_entities ADD COLUMN ephemeral_expires_at TIMESTAMP AS (CASE WHEN kind = 'rate_limit' THEN SAFE.TIMESTAMP_SECONDS(SAFE_CAST(JSON_QUERY(body, '\$.expires_at') AS INT64)) END) STORED"
 fi
 
 policy="$(policy_expression)"
-if printf '%s' "$policy" | grep -q "ephemeral_expires_at"; then
-  log "row deletion policy exists, skip"
+if printf '%s' "$policy" | grep -q "OLDER_THAN(ephemeral_expires_at, INTERVAL 1 DAY)"; then
+  log "row deletion policy exists with the expected interval, skip"
 elif [ -n "$policy" ]; then
   log "ERROR: tr_entities already has a DIFFERENT row deletion policy: $policy"
   log "Spanner allows one policy per table; refusing to replace it implicitly."

--- a/scripts/deploy/migrate_entity_ttl.sh
+++ b/scripts/deploy/migrate_entity_ttl.sh
@@ -36,6 +36,9 @@ set -euo pipefail
 
 INSTANCE="${SPANNER_INSTANCE_ID:?set SPANNER_INSTANCE_ID}"
 DATABASE="${SPANNER_DATABASE_ID:?set SPANNER_DATABASE_ID}"
+# Bash-3.2-safe under set -u: expanding an EMPTY array with "${arr[@]}" aborts
+# as "unbound variable" on macOS bash. The ${arr[@]+...} idiom expands to
+# nothing when the array is empty and to the quoted elements otherwise.
 PROJECT_ARG=()
 [ -n "${GCP_PROJECT_ID:-}" ] && PROJECT_ARG=(--project "${GCP_PROJECT_ID}")
 
@@ -43,7 +46,7 @@ log() { printf '%s %s\n' "[migrate_entity_ttl]" "$*"; }
 
 sql_value() {
   gcloud spanner databases execute-sql "$DATABASE" \
-    --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+    --instance="$INSTANCE" ${PROJECT_ARG[@]+"${PROJECT_ARG[@]}"} \
     --sql="$1" --format='value(rows[0])' 2>/dev/null || echo ""
 }
 
@@ -65,7 +68,7 @@ apply_ddl() {
   local ddl="$1"
   log "applying: ${ddl:0:60}..."
   gcloud spanner databases ddl update "$DATABASE" \
-    --instance="$INSTANCE" "${PROJECT_ARG[@]}" --ddl="$ddl"
+    --instance="$INSTANCE" ${PROJECT_ARG[@]+"${PROJECT_ARG[@]}"} --ddl="$ddl"
 }
 
 if column_exists; then
@@ -75,8 +78,12 @@ if column_exists; then
   # hole. Require BOTH safety discriminators to be present in the actual
   # deployed expression; abort loudly otherwise so a human drops/rebuilds.
   expr="$(column_expression)"
-  if printf '%s' "$expr" | grep -q "kind = 'rate_limit'" \
-     && printf '%s' "$expr" | grep -q "JSON_QUERY"; then
+  # Match the discriminators robustly: Spanner may normalize whitespace/case
+  # when storing the expression, but the quoted literal 'rate_limit' and the
+  # JSON_QUERY function name survive any reformatting. A false ABORT here is
+  # safe-noisy; the by-kind verify query below backstops a false pass.
+  if printf '%s' "$expr" | grep -q "'rate_limit'" \
+     && printf '%s' "$expr" | grep -qi "json_query"; then
     log "ephemeral_expires_at exists with the kind-scoped JSON_QUERY expression, skip"
   else
     log "ERROR: ephemeral_expires_at exists with an UNEXPECTED expression:"
@@ -104,10 +111,10 @@ fi
 
 log "verify: non-NULL policy timestamps by kind (must be rate_limit ONLY)"
 gcloud spanner databases execute-sql "$DATABASE" \
-  --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+  --instance="$INSTANCE" ${PROJECT_ARG[@]+"${PROJECT_ARG[@]}"} \
   --sql="SELECT kind, COUNT(*) AS opted_in FROM tr_entities WHERE ephemeral_expires_at IS NOT NULL GROUP BY kind"
 
 log "verify: expired-but-undeleted rate_limit rows (drops to ~0 within 72h)"
 gcloud spanner databases execute-sql "$DATABASE" \
-  --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+  --instance="$INSTANCE" ${PROJECT_ARG[@]+"${PROJECT_ARG[@]}"} \
   --sql="SELECT COUNT(*) FROM tr_entities WHERE kind='rate_limit' AND ephemeral_expires_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)"

--- a/scripts/deploy/migrate_entity_ttl.sh
+++ b/scripts/deploy/migrate_entity_ttl.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# Give ephemeral tr_entities kinds a real expiry (issue #334, Problem 2).
+# Give rate_limit tr_entities rows a real expiry (issue #334, Problem 2).
 #
-# Mechanism: a STORED generated column extracts the numeric unix-seconds
-# `expires_at` that rate_limit bodies already carry (their window reset epoch),
-# and a ROW DELETION POLICY deletes rows one day after that expiry. This is the
-# documented Spanner pattern for TTL on a derived timestamp.
+# Mechanism: a STORED generated column extracts the unix-seconds window reset
+# epoch that rate_limit bodies carry in `expires_at`, and a ROW DELETION POLICY
+# deletes rows one day after that expiry. Generated-column TTL is the
+# documented Spanner pattern for a derived expiration.
 #
-# Why this is safe for every other kind: the policy column is NULL unless the
-# body carries a NUMERIC expires_at. Only rate_limit writes one (an INT64
-# reset epoch); api_key / auth_session / wallet_challenge carry ISO-8601
-# STRINGS, which SAFE_CAST nulls out, and Spanner's TTL never deletes a row
-# whose policy timestamp is NULL (the same NULL-exemption semantics the
-# tr_reservation retention backfill relied on). Audited in prod 2026-08-01:
-# 386,574/386,574 rate_limit rows numeric; zero numeric rows in any other kind.
+# The column is DOUBLY scoped, and both guards are load-bearing:
+#   1. `kind = 'rate_limit'` — no other kind can EVER opt in, castable value or
+#      not. Opting in a future kind requires changing this DDL on purpose.
+#   2. JSON_QUERY, not JSON_VALUE — JSON_VALUE strips quotes, so a customer
+#      string like "20270101" (a valid ISO-basic date some writers accept)
+#      would cast to unix-seconds 1970 and make the row TTL-eligible.
+#      JSON_QUERY preserves quotes, so only a bare JSON NUMBER casts; any
+#      quoted string yields NULL, and Spanner TTL never deletes a
+#      NULL-timestamp row. Verified against prod's SQL engine 2026-08-01.
+#   SAFE.TIMESTAMP_SECONDS additionally turns a pathological out-of-range
+#   epoch into NULL (row simply never expires) instead of failing writes.
 #
-# TRAP for future kinds: writing a NUMERIC `expires_at` into an entity body
-# OPTS THAT ROW INTO DELETION one day after the epoch it names. That is the
-# intended contract — do it on purpose or use a different field name.
-#
-# Idempotent: INFORMATION_SCHEMA-guarded, safe to re-run.
+# Idempotent: INFORMATION_SCHEMA-guarded (scoped ROW_DELETION_POLICY_EXPRESSION
+# check, same pattern as migrate_request_retention.sh), safe to re-run. A
+# conflicting pre-existing policy on tr_entities aborts loudly rather than
+# stacking (Spanner allows one policy per table).
 #
 # Operational sequencing: apply only when no Cloud Run deploy is rolling and
 # prefer a low-traffic window (receipt: 2026-07-04 Aborted burst). The STORED
@@ -38,25 +41,25 @@ PROJECT_ARG=()
 
 log() { printf '%s %s\n' "[migrate_entity_ttl]" "$*"; }
 
-column_exists() {
-  local n
-  n=$(gcloud spanner databases execute-sql "$DATABASE" \
-        --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
-        --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='tr_entities' AND column_name='ephemeral_expires_at'" \
-        --format='value(rows[0])' 2>/dev/null || echo 0)
-  [ "${n:-0}" != "0" ]
+sql_value() {
+  gcloud spanner databases execute-sql "$DATABASE" \
+    --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+    --sql="$1" --format='value(rows[0])' 2>/dev/null || echo ""
 }
 
-policy_exists() {
-  local ddl
-  ddl=$(gcloud spanner databases ddl describe "$DATABASE" \
-          --instance="$INSTANCE" "${PROJECT_ARG[@]}" 2>/dev/null || true)
-  printf '%s' "$ddl" | grep -q "OLDER_THAN(ephemeral_expires_at"
+column_exists() {
+  local n
+  n=$(sql_value "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='tr_entities' AND column_name='ephemeral_expires_at'")
+  [ "${n:-0}" != "0" ] && [ -n "${n}" ]
+}
+
+policy_expression() {
+  sql_value "SELECT COALESCE(ROW_DELETION_POLICY_EXPRESSION, '') FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_entities'"
 }
 
 apply_ddl() {
   local ddl="$1"
-  log "applying: ${ddl%%(*}..."
+  log "applying: ${ddl:0:60}..."
   gcloud spanner databases ddl update "$DATABASE" \
     --instance="$INSTANCE" "${PROJECT_ARG[@]}" --ddl="$ddl"
 }
@@ -64,14 +67,24 @@ apply_ddl() {
 if column_exists; then
   log "ephemeral_expires_at exists, skip"
 else
-  apply_ddl "ALTER TABLE tr_entities ADD COLUMN ephemeral_expires_at TIMESTAMP AS (TIMESTAMP_SECONDS(SAFE_CAST(JSON_VALUE(body, '\$.expires_at') AS INT64))) STORED"
+  apply_ddl "ALTER TABLE tr_entities ADD COLUMN ephemeral_expires_at TIMESTAMP AS (CASE WHEN kind = 'rate_limit' THEN SAFE.TIMESTAMP_SECONDS(SAFE_CAST(JSON_QUERY(body, '\$.expires_at') AS INT64)) END) STORED"
 fi
 
-if policy_exists; then
+policy="$(policy_expression)"
+if printf '%s' "$policy" | grep -q "ephemeral_expires_at"; then
   log "row deletion policy exists, skip"
+elif [ -n "$policy" ]; then
+  log "ERROR: tr_entities already has a DIFFERENT row deletion policy: $policy"
+  log "Spanner allows one policy per table; refusing to replace it implicitly."
+  exit 1
 else
   apply_ddl "ALTER TABLE tr_entities ADD ROW DELETION POLICY (OLDER_THAN(ephemeral_expires_at, INTERVAL 1 DAY))"
 fi
+
+log "verify: non-NULL policy timestamps by kind (must be rate_limit ONLY)"
+gcloud spanner databases execute-sql "$DATABASE" \
+  --instance="$INSTANCE" "${PROJECT_ARG[@]}" \
+  --sql="SELECT kind, COUNT(*) AS opted_in FROM tr_entities WHERE ephemeral_expires_at IS NOT NULL GROUP BY kind"
 
 log "verify: expired-but-undeleted rate_limit rows (drops to ~0 within 72h)"
 gcloud spanner databases execute-sql "$DATABASE" \

--- a/src/trusted_router/storage_gcp_rate_limits.py
+++ b/src/trusted_router/storage_gcp_rate_limits.py
@@ -31,10 +31,12 @@ class SpannerRateLimits:
             row = self._io.read_entity_tx(transaction, "rate_limit", entity_id, dict)
             count = int(row.get("count", 0)) + 1 if row else 1
             # The NUMERIC expires_at is load-bearing for retention: tr_entities'
-            # ephemeral_expires_at generated column casts it and the table's ROW
-            # DELETION POLICY deletes the row one day later (issue #334;
-            # scripts/deploy/migrate_entity_ttl.sh). Only a numeric value opts a
-            # row in — ISO-string expires_at on other kinds stays exempt.
+            # ephemeral_expires_at generated column extracts it and the table's
+            # ROW DELETION POLICY deletes the row one day later (issue #334;
+            # scripts/deploy/migrate_entity_ttl.sh). The column is scoped
+            # kind='rate_limit' AND bare-JSON-number (JSON_QUERY keeps quotes,
+            # so strings never cast) — other kinds cannot opt in, by value or
+            # by accident; extending TTL to a new kind means changing that DDL.
             self._io.write_entity_tx(
                 transaction,
                 "rate_limit",

--- a/src/trusted_router/storage_gcp_rate_limits.py
+++ b/src/trusted_router/storage_gcp_rate_limits.py
@@ -30,6 +30,11 @@ class SpannerRateLimits:
         def txn(transaction: Any) -> int:
             row = self._io.read_entity_tx(transaction, "rate_limit", entity_id, dict)
             count = int(row.get("count", 0)) + 1 if row else 1
+            # The NUMERIC expires_at is load-bearing for retention: tr_entities'
+            # ephemeral_expires_at generated column casts it and the table's ROW
+            # DELETION POLICY deletes the row one day later (issue #334;
+            # scripts/deploy/migrate_entity_ttl.sh). Only a numeric value opts a
+            # row in — ISO-string expires_at on other kinds stays exempt.
             self._io.write_entity_tx(
                 transaction,
                 "rate_limit",


### PR DESCRIPTION
Codifies the schema fix for the actively-growing half of #334 Problem 2.

`rate_limit` entities are `namespace#subject#bucket` window counters — each new window mints a new row, only the current bucket is ever read, and 386,574 had accumulated with no expiry. Their bodies already carry the window reset epoch as a **numeric** `expires_at`, so this is pure schema, applied by the new guarded, idempotent `scripts/deploy/migrate_entity_ttl.sh`:

```sql
ALTER TABLE tr_entities ADD COLUMN ephemeral_expires_at TIMESTAMP
  AS (TIMESTAMP_SECONDS(SAFE_CAST(JSON_VALUE(body, '$.expires_at') AS INT64))) STORED;
ALTER TABLE tr_entities ADD ROW DELETION POLICY (OLDER_THAN(ephemeral_expires_at, INTERVAL 1 DAY));
```

The generated-column TTL is the [documented Spanner pattern](https://docs.cloud.google.com/spanner/docs/ttl/working-with-ttl) for derived expirations. No writer changes; existing rows backfill via the STORED column; deletions start on the next daily TTL sweep.

**Safety, audited in prod 2026-08-01:** only a *numeric* `expires_at` opts a row in. All 386,574 `rate_limit` rows are numeric; every other kind carrying the field (`api_key` 25, `auth_session` 208, `wallet_challenge` 191, `verification_token` 1) stores ISO-8601 strings → `SAFE_CAST` → NULL → exempt (Spanner TTL never deletes NULL-timestamp rows — the semantics #357 relied on). Epoch range is sane (2026-05-02 → 2026-08-01). The opt-in contract is commented at the single write site.

Runbook sequencing note is in the script header: apply only with no deploy rolling (the 2026-07-04 Aborted-burst receipt); the STORED backfill over 9.4M rows runs as background DDL.