### PR TITLE
Add AllyRouter operational domain aliases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -565,6 +565,10 @@ jobs:
           check_url regions https://trustedrouter.com/v1/regions
           check_url status_json https://trustedrouter.com/status.json
           check_url status_host https://status.trustedrouter.com/status.json
+          check_url ally_homepage https://allyrouter.com/
+          check_url ally_health https://allyrouter.com/health
+          check_url ally_status https://status.allyrouter.com/status.json
+          check_url ally_trust https://trust.allyrouter.com/
 
           # A global request can repeatedly land on a healthy warm region and
           # miss a stale cold revision. Exercise the shared-storage reader in
@@ -584,11 +588,15 @@ jobs:
           regions = json.loads(Path("/tmp/regions.body").read_text())["data"]
           status = json.loads(Path("/tmp/status_json.body").read_text())["data"]
           status_host = json.loads(Path("/tmp/status_host.body").read_text())["data"]
+          ally_homepage = Path("/tmp/ally_homepage.body").read_text()
+          ally_trust = Path("/tmp/ally_trust.body").read_text()
 
           assert any(item["id"] == "us-central1" for item in regions), regions
           assert any(item["id"] == "europe-west4" for item in regions), regions
           assert "components" in status, status.keys()
           assert status_host.get("current", {}).get("overall_status") or status_host.get("overall_status"), status_host.keys()
+          assert "https://api.allyrouter.com/v1" in ally_homepage
+          assert "https://api.allyrouter.com/attestation" in ally_trust
           PY
 
           count=$(curl -fsS --max-time 15 https://trustedrouter.com/v1/models \

--- a/docs/operations/allyrouter-alias.md
+++ b/docs/operations/allyrouter-alias.md
@@ -1,0 +1,49 @@
+# AllyRouter operational alias
+
+`allyrouter.com` is an independent first-party alias for TrustedRouter. It is
+served without redirecting so it remains usable if the canonical domain has a
+registrar or DNS incident. Search-engine canonical tags still identify
+`trustedrouter.com` as the canonical content source.
+
+## Public hostnames
+
+| Hostname | Target | TLS termination |
+|---|---|---|
+| `allyrouter.com` | TrustedRouter control-plane load balancer | Google external HTTPS load balancer |
+| `www.allyrouter.com` | Control-plane load balancer, then 308 to apex | Google external HTTPS load balancer |
+| `status.allyrouter.com` | Status surface on the control plane | Google external HTTPS load balancer |
+| `trust.allyrouter.com` | Trust surface on the control plane | Google external HTTPS load balancer |
+| `api.allyrouter.com` | Attested API regional TCP load balancers | Inside GCP Confidential Space |
+
+The API alias must never be proxied through a CDN or terminated on the control
+plane. Its ACME private key is generated and retained inside each attested
+gateway workload.
+
+## Route 53 delegation
+
+The hosted zone is `Z09662142UE0IQL51B13V`. Its authoritative nameservers are:
+
+```text
+ns-1324.awsdns-37.org
+ns-1917.awsdns-47.co.uk
+ns-556.awsdns-05.net
+ns-82.awsdns-10.com
+```
+
+Run `scripts/deploy/ensure_allyrouter_alias.sh` after DNS changes to create and
+attach the control-plane certificate idempotently. Gateway deployment adds
+`api.allyrouter.com` to the enclave ACME allowlist in every region.
+
+## Auth behavior
+
+Email and wallet sessions are host-only and work independently on either apex.
+SIWE challenges bind to the apex that initiated the request. Google and GitHub
+callbacks are also same-origin; each OAuth provider must list the AllyRouter
+callback URI before enabling its button there.
+
+## Registrar transfer
+
+Route 53 can host DNS before it becomes the registrar. The current registrar's
+60-day transfer lock must expire before starting the Route 53 Domains transfer.
+Keep Route 53 nameservers unchanged during the transfer so there is no DNS
+cutover. Never store the registrar authorization code in this repository.

--- a/scripts/deploy/ensure_allyrouter_alias.sh
+++ b/scripts/deploy/ensure_allyrouter_alias.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Idempotently provision and attach the public control-plane certificate for
+# AllyRouter. DNS must already point every listed hostname at the control-plane
+# load balancer before Google can mark the managed certificate ACTIVE.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-quill-cloud-proxy}"
+CERT_NAME="${CERT_NAME:-allyrouter-control-cert-v1}"
+HTTPS_PROXY="${HTTPS_PROXY:-trusted-router-control-https-proxy}"
+DOMAINS="${DOMAINS:-allyrouter.com,www.allyrouter.com,status.allyrouter.com,trust.allyrouter.com}"
+
+if ! gcloud compute ssl-certificates describe "${CERT_NAME}" \
+  --global --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud compute ssl-certificates create "${CERT_NAME}" \
+    --global \
+    --project="${PROJECT_ID}" \
+    --domains="${DOMAINS}"
+fi
+
+current="$(gcloud compute target-https-proxies describe "${HTTPS_PROXY}" \
+  --global \
+  --project="${PROJECT_ID}" \
+  --format='value(sslCertificates.basename())')"
+current_csv="${current//;/,}"
+case ",${current_csv}," in
+  *",${CERT_NAME},"*) ;;
+  *)
+    gcloud compute target-https-proxies update "${HTTPS_PROXY}" \
+      --global \
+      --project="${PROJECT_ID}" \
+      --ssl-certificates="${current_csv},${CERT_NAME}"
+    ;;
+esac
+
+gcloud compute ssl-certificates describe "${CERT_NAME}" \
+  --global \
+  --project="${PROJECT_ID}" \
+  --format='yaml(managed.status,managed.domainStatus,expireTime)'

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -270,6 +270,7 @@ ENV_VARS=(
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"
+  "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com"
   "TR_STORAGE_BACKEND=${STORAGE_BACKEND}"
   # Exactly $0.10 once per newly created email/OAuth account. Wallet-only
   # accounts stay at $0. Keep this explicit so stale env cannot change policy.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -21,6 +21,12 @@ class Settings(BaseSettings):
     service_name: str = "trusted-router"
     api_base_url: str = "https://api.trustedrouter.com/v1"
     trusted_domain: str = "trustedrouter.com"
+    # Additional first-party control-plane domains. They serve the same
+    # application without redirecting to the canonical domain, so they remain
+    # usable as independent operational aliases. SEO canonicals still point at
+    # ``trusted_domain``. The corresponding inference hostname is derived as
+    # ``api.<alias>/v1`` and still terminates inside the attested gateway.
+    trusted_domain_aliases: str = "allyrouter.com"
     legal_entity_name: str = "Lore Hex Corp"
     legal_entity_type: str = "Delaware C Corporation"
     legal_entity_address: str = "1111 Brickell Ave, Floor 10, Miami, FL 33131"

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1317,13 +1317,18 @@ def _static_version(settings: Settings) -> str:
         return "local"
 
 
-def dashboard_html(settings: Settings) -> str:
+def dashboard_html(
+    settings: Settings,
+    *,
+    api_base_url: str | None = None,
+) -> str:
     domain = settings.trusted_domain
+    resolved_api_base_url = api_base_url or settings.api_base_url
     environment = settings.environment.lower()
     tr_config = {
         "environment": environment,
         "defaultDevUser": "" if environment == "production" else DEV_USER_FALLBACK,
-        "apiBaseUrl": settings.api_base_url,
+        "apiBaseUrl": resolved_api_base_url,
         "stablecoinCheckoutEnabled": settings.stablecoin_checkout_enabled,
         "paypalEnabled": settings.paypal_enabled,
         "googleEnabled": settings.google_oauth_enabled,
@@ -1335,7 +1340,7 @@ def dashboard_html(settings: Settings) -> str:
         _env()
         .get_template("dashboard.html")
         .render(
-            api_base_url=settings.api_base_url,
+            api_base_url=resolved_api_base_url,
             site_url=f"https://{domain}/",
             og_image=f"https://{domain}/og.png",
             og_title=OG_TITLE,

--- a/src/trusted_router/domains.py
+++ b/src/trusted_router/domains.py
@@ -1,0 +1,113 @@
+"""First-party hostname policy.
+
+All request-derived absolute URLs must pass through this module. Reflecting an
+arbitrary Host header into OAuth, billing, or wallet flows would create an open
+redirect and SIWE-domain confusion. Only the canonical domain and explicitly
+configured aliases are accepted; everything else falls back to the canonical
+domain.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import Request
+
+from trusted_router.config import Settings
+
+_DOMAIN_RE = re.compile(
+    r"(?=.{1,253}\Z)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z"
+)
+
+
+def configured_control_domains(settings: Settings) -> tuple[str, ...]:
+    """Return the canonical control domain followed by unique aliases."""
+    values = [settings.trusted_domain, *settings.trusted_domain_aliases.split(",")]
+    domains: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        domain = _normalized_domain(value)
+        if domain is None or domain in seen:
+            continue
+        seen.add(domain)
+        domains.append(domain)
+    canonical = _normalized_domain(settings.trusted_domain)
+    if canonical is None:
+        raise ValueError("TR_TRUSTED_DOMAIN must be a valid DNS domain")
+    if not domains or domains[0] != canonical:
+        domains.insert(0, canonical)
+    return tuple(domains)
+
+
+def request_hostname(request: Request) -> str:
+    """Return a normalized DNS hostname, or an empty string if invalid."""
+    host = request.headers.get("host", "").strip()
+    # Product domains are DNS names, never IPv6 literals. Splitting on the
+    # first colon safely removes the optional HTTP port for this allowlist.
+    hostname = host.split(":", 1)[0]
+    return _normalized_domain(hostname) or ""
+
+
+def control_domain_for_hostname(settings: Settings, hostname: str) -> str:
+    """Map an apex/www/status/trust hostname to its allowed base domain."""
+    normalized = _normalized_domain(hostname)
+    domains = configured_control_domains(settings)
+    if normalized:
+        for domain in domains:
+            if normalized == domain or normalized in {
+                f"www.{domain}",
+                f"status.{domain}",
+                f"trust.{domain}",
+            }:
+                return domain
+    return domains[0]
+
+
+def request_control_domain(request: Request, settings: Settings) -> str:
+    return control_domain_for_hostname(settings, request_hostname(request))
+
+
+def request_control_origin(request: Request, settings: Settings) -> str:
+    return f"https://{request_control_domain(request, settings)}"
+
+
+def api_base_url_for_domain(settings: Settings, domain: str) -> str:
+    canonical = configured_control_domains(settings)[0]
+    normalized = _normalized_domain(domain)
+    if normalized == canonical:
+        return settings.api_base_url.rstrip("/")
+    if normalized in configured_control_domains(settings):
+        return f"https://api.{normalized}/v1"
+    return settings.api_base_url.rstrip("/")
+
+
+def request_api_base_url(request: Request, settings: Settings) -> str:
+    return api_base_url_for_domain(settings, request_control_domain(request, settings))
+
+
+def is_www_hostname(settings: Settings, hostname: str) -> bool:
+    return any(hostname == f"www.{domain}" for domain in configured_control_domains(settings))
+
+
+def is_status_hostname(settings: Settings, hostname: str) -> bool:
+    return any(hostname == f"status.{domain}" for domain in configured_control_domains(settings))
+
+
+def is_trust_hostname(settings: Settings, hostname: str) -> bool:
+    return any(hostname == f"trust.{domain}" for domain in configured_control_domains(settings))
+
+
+def status_hostname_for_domain(domain: str) -> str:
+    return f"status.{domain}"
+
+
+def trust_hostname_for_domain(domain: str) -> str:
+    return f"trust.{domain}"
+
+
+def _normalized_domain(value: str) -> str | None:
+    domain = value.strip().lower().rstrip(".")
+    if not domain or not _DOMAIN_RE.fullmatch(domain):
+        return None
+    return domain

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -43,6 +43,12 @@ from trusted_router.acquisition import (
 )
 from trusted_router.auth import get_authorization_bearer
 from trusted_router.config import Settings
+from trusted_router.domains import (
+    control_domain_for_hostname,
+    is_status_hostname,
+    is_www_hostname,
+    request_hostname,
+)
 from trusted_router.errors import error_response
 from trusted_router.storage import STORE
 from trusted_router.storage_models import RateLimitHit
@@ -127,16 +133,16 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         Redirecting those escaped paths prevents duplicate pages and
         status-host 404s without changing the status API or static assets.
         """
-        hostname = request.headers.get("host", "").split(":", 1)[0].lower()
+        hostname = request_hostname(request)
         path = request.url.path
-        if hostname == f"www.{settings.trusted_domain}":
+        if is_www_hostname(settings, hostname):
             return RedirectResponse(
-                url=_canonical_public_url(settings, request),
+                url=_apex_public_url(settings, request, hostname),
                 status_code=308,
             )
-        if hostname == f"status.{settings.trusted_domain}" and not _status_host_path(path):
+        if is_status_hostname(settings, hostname) and not _status_host_path(path):
             return RedirectResponse(
-                url=_canonical_public_url(settings, request),
+                url=_apex_public_url(settings, request, hostname),
                 status_code=308,
             )
         return await call_next(request)
@@ -279,10 +285,11 @@ def _status_host_path(path: str) -> bool:
     return path in STATUS_HOST_EXACT_PATHS or path.startswith(STATUS_HOST_PATH_PREFIXES)
 
 
-def _canonical_public_url(settings: Settings, request: Request) -> str:
+def _apex_public_url(settings: Settings, request: Request, hostname: str) -> str:
     query = request.url.query
     suffix = f"?{query}" if query else ""
-    return f"https://{settings.trusted_domain}{request.url.path}{suffix}"
+    domain = control_domain_for_hostname(settings, hostname)
+    return f"https://{domain}{request.url.path}{suffix}"
 
 
 def _rate_limit_request(

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -8,6 +8,8 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
+from trusted_router.config import Settings
+from trusted_router.domains import request_control_origin
 from trusted_router.errors import api_error, deprecated
 from trusted_router.money import money_pair
 from trusted_router.routes.helpers import json_body
@@ -52,6 +54,7 @@ def register_billing_routes(router: APIRouter) -> None:
 
     @router.post("/billing/checkout")
     async def billing_checkout(
+        request: Request,
         body: CheckoutRequest,
         principal: ManagementPrincipal,
         settings: SettingsDep,
@@ -59,6 +62,7 @@ def register_billing_routes(router: APIRouter) -> None:
         workspace_id = body.workspace_id or principal.workspace.id
         if workspace_id != principal.workspace.id:
             raise api_error(403, "Forbidden", ErrorType.FORBIDDEN)
+        body = _checkout_body_with_first_party_returns(body, request, settings)
         account = STORE.get_credit_account(workspace_id)
         return JSONResponse(
             {
@@ -176,13 +180,14 @@ def register_billing_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> dict[str, dict[str, str]]:
         body = await json_body(request)
-        return_url = str(body.get("return_url") or f"https://{settings.trusted_domain}/billing")
+        return_url = str(body.get("return_url") or f"{request_control_origin(request, settings)}/billing")
         account = STORE.get_credit_account(principal.workspace.id)
         customer_id = account.stripe_customer_id if account else None
         return {"data": create_billing_portal_session(customer_id=customer_id, return_url=return_url, settings=settings)}
 
     @router.post("/billing/payment-methods/setup")
     async def billing_payment_method_setup(
+        request: Request,
         principal: ManagementPrincipal,
         settings: SettingsDep,
     ) -> JSONResponse:
@@ -193,8 +198,14 @@ def register_billing_routes(router: APIRouter) -> None:
                     workspace_id=principal.workspace.id,
                     customer_email=_checkout_customer_email(principal),
                     customer_id=account.stripe_customer_id if account else None,
-                    success_url=f"https://{settings.trusted_domain}/billing/payment-methods/success",
-                    cancel_url=f"https://{settings.trusted_domain}/billing/payment-methods",
+                    success_url=(
+                        f"{request_control_origin(request, settings)}"
+                        "/billing/payment-methods/success"
+                    ),
+                    cancel_url=(
+                        f"{request_control_origin(request, settings)}"
+                        "/billing/payment-methods"
+                    ),
                     settings=settings,
                 )
             },
@@ -214,6 +225,26 @@ def _checkout_customer_email(principal: Any) -> str | None:
         if user is not None and user.email and "@" in user.email:
             return user.email
     return None
+
+
+def _checkout_body_with_first_party_returns(
+    body: CheckoutRequest,
+    request: Request,
+    settings: Settings,
+) -> CheckoutRequest:
+    origin = request_control_origin(request, settings)
+    if body.payment_method == "paypal":
+        default_success = f"{origin}/billing/paypal/success"
+        default_cancel = f"{origin}/billing/paypal/cancel"
+    else:
+        default_success = f"{origin}/billing/success"
+        default_cancel = f"{origin}/billing"
+    return body.model_copy(
+        update={
+            "success_url": body.success_url or default_success,
+            "cancel_url": body.cancel_url or default_cancel,
+        }
+    )
 
 
 def _validated_x402_body(model: Any, body: dict[str, Any]) -> Any:

--- a/src/trusted_router/routes/console/_shared.py
+++ b/src/trusted_router/routes/console/_shared.py
@@ -17,8 +17,9 @@ from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
 
-from trusted_router.auth import SESSION_COOKIE_NAME
+from trusted_router.auth import SESSION_COOKIE_NAME, SettingsDep
 from trusted_router.config import Settings
+from trusted_router.domains import request_api_base_url
 from trusted_router.money import format_money_display
 from trusted_router.storage import (
     STORE,
@@ -38,9 +39,10 @@ class ConsoleContext:
     session: AuthSession
     workspace: Workspace
     workspaces: list[Workspace]
+    api_base_url: str
 
 
-def require_console_context(request: Request) -> ConsoleContext:
+def require_console_context(request: Request, settings: SettingsDep) -> ConsoleContext:
     """FastAPI dependency. Resolves the active console session or raises a
     302 redirect to the marketing page so it can pop the sign-in modal."""
     cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
@@ -54,7 +56,13 @@ def require_console_context(request: Request) -> ConsoleContext:
     if not workspaces:
         raise HTTPException(status_code=302, headers={"Location": "/?reason=signin"})
     workspace = _selected_console_workspace(session, workspaces)
-    return ConsoleContext(user=user, session=session, workspace=workspace, workspaces=workspaces)
+    return ConsoleContext(
+        user=user,
+        session=session,
+        workspace=workspace,
+        workspaces=workspaces,
+        api_base_url=request_api_base_url(request, settings),
+    )
 
 
 ConsoleDep = Annotated[ConsoleContext, Depends(require_console_context)]

--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -91,7 +91,7 @@ def register(app: FastAPI) -> None:
             page_title="Observability",
             page_subtitle="Per-request metadata, no prompt content.",
             activity=events,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
 
     @app.get("/console/activity/usage.json")

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -62,7 +62,7 @@ def register(app: FastAPI) -> None:
             created_key=created_key,
             flash=flash,
             suggested=suggested,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
 
     @app.get("/console/api-keys")

--- a/src/trusted_router/routes/console/broadcast.py
+++ b/src/trusted_router/routes/console/broadcast.py
@@ -40,7 +40,7 @@ def register(app: FastAPI) -> None:
             page_subtitle="Export generation metadata to PostHog or an OTLP webhook.",
             destinations=destinations,
             default_posthog_endpoint=POSTHOG_DEFAULT_ENDPOINT,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
 
     @app.post("/console/broadcast")

--- a/src/trusted_router/routes/console/byok.py
+++ b/src/trusted_router/routes/console/byok.py
@@ -37,7 +37,7 @@ def register(app: FastAPI) -> None:
             page_title="BYOK",
             page_subtitle="Bring your own provider keys.",
             providers=providers,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
 
     @app.post("/console/byok")

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from fastapi import FastAPI, Form, HTTPException
+from fastapi import FastAPI, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from pydantic import ValidationError
 
 from trusted_router.auth import SettingsDep
+from trusted_router.domains import request_control_origin
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.schemas import CheckoutRequest
 from trusted_router.services.paypal_billing import (
@@ -82,7 +83,7 @@ def register(app: FastAPI) -> None:
             paypal_enabled=settings.paypal_enabled or settings.environment.lower() in {"local", "test"},
             payments=payments,
             saved_payment_method=saved_payment_method,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
 
     @app.get("/console/credits/checkout")
@@ -91,15 +92,17 @@ def register(app: FastAPI) -> None:
 
     @app.post("/console/credits/checkout")
     async def console_credit_checkout(
+        request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
         amount: str = Form(...),
         payment_method: str = Form("auto"),
     ) -> Response:
+        origin = request_control_origin(request, settings)
         success_url = (
-            f"https://{settings.trusted_domain}/console/credits/paypal/capture"
+            f"{origin}/console/credits/paypal/capture"
             if payment_method == "paypal"
-            else f"https://{settings.trusted_domain}/console/credits?checkout=success"
+            else f"{origin}/console/credits?checkout=success"
         )
         try:
             # CheckoutRequest validates payment_method against the Literal
@@ -110,7 +113,7 @@ def register(app: FastAPI) -> None:
                 workspace_id=ctx.workspace.id,
                 payment_method=cast(Any, payment_method),
                 success_url=success_url,
-                cancel_url=f"https://{settings.trusted_domain}/console/credits?checkout=cancel",
+                cancel_url=f"{origin}/console/credits?checkout=cancel",
             )
         except ValidationError:
             return RedirectResponse(url="/console/credits?error=invalid_checkout", status_code=303)
@@ -159,17 +162,19 @@ def register(app: FastAPI) -> None:
 
     @app.post("/console/credits/payment-methods/add")
     async def console_add_payment_method(
+        request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:
         credit = STORE.get_credit_account(ctx.workspace.id)
+        origin = request_control_origin(request, settings)
         try:
             data = create_payment_method_session(
                 workspace_id=ctx.workspace.id,
                 customer_email=ctx.user.email if ctx.user.email and "@" in ctx.user.email else None,
                 customer_id=credit.stripe_customer_id if credit else None,
-                success_url=f"https://{settings.trusted_domain}/console/credits?payment_method=success",
-                cancel_url=f"https://{settings.trusted_domain}/console/credits?payment_method=cancel",
+                success_url=f"{origin}/console/credits?payment_method=success",
+                cancel_url=f"{origin}/console/credits?payment_method=cancel",
                 settings=settings,
             )
         except HTTPException:
@@ -180,6 +185,7 @@ def register(app: FastAPI) -> None:
 
     @app.post("/console/credits/payment-methods/manage")
     async def console_manage_payment_methods(
+        request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:
@@ -188,7 +194,7 @@ def register(app: FastAPI) -> None:
             return RedirectResponse(url="/console/credits?error=no_payment_method", status_code=303)
         data = create_billing_portal_session(
             customer_id=credit.stripe_customer_id,
-            return_url=f"https://{settings.trusted_domain}/console/credits",
+            return_url=f"{request_control_origin(request, settings)}/console/credits",
             settings=settings,
         )
         if data["mode"] == "mock":

--- a/src/trusted_router/routes/console/preferences.py
+++ b/src/trusted_router/routes/console/preferences.py
@@ -21,5 +21,5 @@ def register(app: FastAPI) -> None:
             page_subtitle="Account and sign-in.",
             provider=ctx.session.provider,
             environment=settings.environment,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))

--- a/src/trusted_router/routes/console/routing_page.py
+++ b/src/trusted_router/routes/console/routing_page.py
@@ -40,5 +40,5 @@ def register(app: FastAPI) -> None:
             auto_order=auto_order,
             regions=regions,
             configured_regions=configured_regions(settings),
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))

--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -28,7 +28,7 @@ def register(app: FastAPI) -> None:
             page_title="Workspace settings",
             page_subtitle="Names, content storage, integrations.",
             workspace=ctx.workspace,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
             can_manage=STORE.user_can_manage(ctx.user.id, ctx.workspace.id),
             saved=bool(saved),
             error=error,

--- a/src/trusted_router/routes/console/welcome.py
+++ b/src/trusted_router/routes/console/welcome.py
@@ -50,7 +50,7 @@ def register(app: FastAPI) -> None:
             # from accounts configured with the grant disabled.
             trial_credit=money(trial_microdollars),
             trial_credit_microdollars=trial_microdollars,
-            api_base_url=settings.api_base_url,
+            api_base_url=ctx.api_base_url,
         ))
         if clear_pending_reveal:
             # Delete cookie with the same path it was set with — otherwise

--- a/src/trusted_router/routes/oauth.py
+++ b/src/trusted_router/routes/oauth.py
@@ -25,6 +25,7 @@ from fastapi.responses import RedirectResponse
 from trusted_router.acquisition import record_signup_attribution
 from trusted_router.auth import SettingsDep, set_session_cookie
 from trusted_router.config import Settings
+from trusted_router.domains import request_control_domain
 from trusted_router.errors import api_error
 from trusted_router.oauth_provider import (
     OAUTH_PROVIDERS,
@@ -222,6 +223,12 @@ def _client_secret(provider: OAuthProvider, settings: Settings) -> str | None:
 
 
 def _redirect_uri(provider: OAuthProvider, request: Request, settings: Settings) -> str:
+    request_domain = request_control_domain(request, settings)
+    if request_domain != settings.trusted_domain:
+        # Alias OAuth remains same-origin so the host-only CSRF/session cookies
+        # survive the callback. Each provider must explicitly allow this URI;
+        # an unlisted Host header cannot reach this branch.
+        return f"https://{request_domain}/{provider.slug}_oauth_callback"
     configured = getattr(settings, f"{provider.slug}_oauth_redirect_url", None)
     if configured:
         return configured

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -88,6 +88,15 @@ from trusted_router.dashboard import (
     soc2_readiness_json,
     subprocessors_json,
 )
+from trusted_router.domains import (
+    control_domain_for_hostname,
+    is_status_hostname,
+    is_trust_hostname,
+    request_api_base_url,
+    request_control_domain,
+    request_hostname,
+    status_hostname_for_domain,
+)
 from trusted_router.og import OG_PNG_PATH
 from trusted_router.provider_contract import (
     PROVIDER_CATALOG_SCHEMA,
@@ -408,11 +417,16 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @public_html_route("/", include_slash=False)
     async def dashboard(request: Request, background_tasks: BackgroundTasks) -> Any:
-        host = request.headers.get("host", "")
-        hostname = host.split(":", 1)[0].lower()
-        if hostname == "trust.trustedrouter.com":
-            return trust_html(settings)
-        if hostname == "status.trustedrouter.com":
+        hostname = request_hostname(request)
+        domain = request_control_domain(request, settings)
+        api_base_url = request_api_base_url(request, settings)
+        if is_trust_hostname(settings, hostname):
+            return trust_html(
+                settings,
+                public_domain=domain,
+                api_base_url=api_base_url,
+            )
+        if is_status_hostname(settings, hostname):
             return _cached_status_page_response(
                 settings,
                 host=hostname,
@@ -420,11 +434,15 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             )
         if hostname == "eu.trustedrouter.com":
             return public_page_html(settings, "eu", site_url="https://eu.trustedrouter.com/")
-        return dashboard_html(settings)
+        return dashboard_html(settings, api_base_url=api_base_url)
 
     @public_html_route("/trust")
-    async def trust_page() -> str:
-        return trust_html(settings)
+    async def trust_page(request: Request) -> str:
+        return trust_html(
+            settings,
+            public_domain=request_control_domain(request, settings),
+            api_base_url=request_api_base_url(request, settings),
+        )
 
     @public_html_route("/compare/openrouter")
     async def compare_openrouter() -> str:
@@ -1240,9 +1258,9 @@ def _cached_status_page_response(
 
 
 def _status_render_host(settings: Settings, host: str) -> str:
-    """Collapse arbitrary Host headers to the two rendered page variants."""
+    """Collapse arbitrary Host headers to configured status/apex variants."""
     hostname = host.partition(":")[0].strip().lower()
-    if hostname == "status.trustedrouter.com":
+    if is_status_hostname(settings, hostname):
         return hostname
     return settings.trusted_domain
 
@@ -1407,9 +1425,11 @@ def _status_history_page_html(
     history: dict[str, Any],
 ) -> str:
     hostname = host.split(":", 1)[0].lower()
+    domain = control_domain_for_hostname(settings, hostname)
+    status_hostname = status_hostname_for_domain(domain)
     site_url = (
-        f"https://status.trustedrouter.com/status/history?window={window}"
-        if hostname == "status.trustedrouter.com"
+        f"https://{status_hostname}/status/history?window={window}"
+        if is_status_hostname(settings, hostname)
         else f"https://{settings.trusted_domain}/status/history?window={window}"
     )
     title = {
@@ -1669,9 +1689,10 @@ def _dates_covering_recent_hours(*, hours: int) -> list[str]:
 
 def _status_page_html(settings: Settings, *, host: str) -> str:
     hostname = host.split(":", 1)[0].lower()
+    domain = control_domain_for_hostname(settings, hostname)
     site_url = (
-        "https://status.trustedrouter.com/"
-        if hostname == "status.trustedrouter.com"
+        f"https://{status_hostname_for_domain(domain)}/"
+        if is_status_hostname(settings, hostname)
         else f"https://{settings.trusted_domain}/status"
     )
     snapshot = _status_snapshot(settings)
@@ -1695,7 +1716,11 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
     )
     return render_template(
         "public/status.html",
-        api_base_url=settings.api_base_url,
+        api_base_url=(
+            f"https://api.{domain}/v1"
+            if domain != settings.trusted_domain
+            else settings.api_base_url
+        ),
         site_url=site_url,
         title="Status | TrustedRouter",
         heading="TrustedRouter Status",

--- a/src/trusted_router/routes/wallet_oauth.py
+++ b/src/trusted_router/routes/wallet_oauth.py
@@ -26,6 +26,7 @@ from trusted_router.auth import (
     SettingsDep,
     set_session_cookie,
 )
+from trusted_router.domains import request_control_domain
 from trusted_router.errors import api_error
 from trusted_router.services.email import build_verification_email, get_email_service
 from trusted_router.storage import STORE
@@ -56,12 +57,18 @@ class WalletVerifyRequest(BaseModel):
 def register_wallet_oauth_routes(router: APIRouter) -> None:
     @router.post("/auth/wallet/challenge")
     async def wallet_challenge(
+        request: Request,
         body: WalletChallengeRequest,
         settings: SettingsDep,
     ) -> JSONResponse:
         if not ADDRESS_RE.match(body.address):
             raise api_error(400, "Invalid Ethereum address", ErrorType.BAD_REQUEST)
-        domain = settings.siwe_domain or settings.trusted_domain
+        request_domain = request_control_domain(request, settings)
+        domain = (
+            settings.siwe_domain
+            if request_domain == settings.trusted_domain and settings.siwe_domain
+            else request_domain
+        )
         nonce = secrets.token_urlsafe(32)
         message, _ = build_siwe_message(
             domain=domain,

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -5,6 +5,10 @@ import json
 from typing import Any
 
 from trusted_router.config import Settings
+from trusted_router.domains import (
+    api_base_url_for_domain,
+    configured_control_domains,
+)
 
 ATTESTED_GATEWAY_REPO = "https://github.com/Lore-Hex/quill-cloud-proxy"
 CLOUD_INFRA_REPO = "https://github.com/Lore-Hex/quill-cloud-infra"
@@ -15,6 +19,7 @@ JAVASCRIPT_SDK_REPO = "https://github.com/Lore-Hex/trusted-router-js"
 
 
 def gcp_release(settings: Settings) -> dict[str, Any]:
+    api_hostnames = [f"api.{domain}" for domain in configured_control_domains(settings)]
     return {
         "platform": "gcp-confidential-space",
         "source_repo": ATTESTED_GATEWAY_REPO,
@@ -32,9 +37,14 @@ def gcp_release(settings: Settings) -> dict[str, Any]:
         "attestation_issuer": "https://confidentialcomputing.googleapis.com",
         "attestation_audience": "quill-cloud",
         "api_base_url": settings.api_base_url,
+        "api_base_urls": [
+            api_base_url_for_domain(settings, domain)
+            for domain in configured_control_domains(settings)
+        ],
         "tls": {
             "mode": "acme-inside-confidential-space",
             "hostname": "api.trustedrouter.com",
+            "hostnames": api_hostnames,
         },
         "data_policy": {
             "prompt_output_storage": False,
@@ -47,12 +57,21 @@ def gcp_release_json(settings: Settings) -> str:
     return json.dumps(gcp_release(settings), indent=2, sort_keys=True) + "\n"
 
 
-def trust_html(settings: Settings) -> str:
+def trust_html(
+    settings: Settings,
+    *,
+    public_domain: str | None = None,
+    api_base_url: str | None = None,
+) -> str:
     release = gcp_release(settings)
     digest = html.escape(str(release["image_digest"]))
     image = html.escape(str(release["image_reference"]))
     source = html.escape(str(release["source_commit"]))
-    api = html.escape(settings.api_base_url)
+    domain = public_domain or settings.trusted_domain
+    resolved_api_base_url = api_base_url or api_base_url_for_domain(settings, domain)
+    api = html.escape(resolved_api_base_url)
+    api_hostname = html.escape(resolved_api_base_url.removeprefix("https://").split("/", 1)[0])
+    control_origin = html.escape(f"https://{domain}")
     control_repo = html.escape(CONTROL_PLANE_REPO)
     gateway_repo = html.escape(ATTESTED_GATEWAY_REPO)
     infra_repo = html.escape(CLOUD_INFRA_REPO)
@@ -112,8 +131,8 @@ def trust_html(settings: Settings) -> str:
 <body>
   <header>
     <nav>
-      <a class="brand" href="https://trustedrouter.com"><span class="mark">TR</span><span>TrustedRouter</span></a>
-      <div class="links"><a href="{control_repo}">Control repo</a><a href="{gateway_repo}">Gateway repo</a><a href="{infra_repo}">Infra repo</a><a href="{quill_repo}">Quill repo</a><a href="/trust/gcp-release.json">gcp-release.json</a><a href="{api}">API</a><a href="https://trustedrouter.com">Console</a></div>
+      <a class="brand" href="{control_origin}"><span class="mark">TR</span><span>TrustedRouter</span></a>
+      <div class="links"><a href="{control_repo}">Control repo</a><a href="{gateway_repo}">Gateway repo</a><a href="{infra_repo}">Infra repo</a><a href="{quill_repo}">Quill repo</a><a href="/trust/gcp-release.json">gcp-release.json</a><a href="{api}">API</a><a href="{control_origin}">Console</a></div>
     </nav>
   </header>
   <main class="wrap">
@@ -121,7 +140,7 @@ def trust_html(settings: Settings) -> str:
       <div class="panel">
         <p class="status"><span class="dot"></span>Trust boundary</p>
         <h1>Verify that the hosted API runs the published open-source workload.</h1>
-        <p><code>api.trustedrouter.com</code> is the prompt path. Public TLS terminates inside the measured GCP Confidential Space workload. The TrustedRouter control plane does not serve production inference routes and does not receive prompt or output bodies.</p>
+        <p><code>{api_hostname}</code> is the prompt path. Public TLS terminates inside the measured GCP Confidential Space workload. The TrustedRouter control plane does not serve production inference routes and does not receive prompt or output bodies.</p>
         <p>Clients can fetch the live attestation, verify issuer/audience/digest, and compare the measured image digest with the release data published here.</p>
       </div>
       <aside class="panel">
@@ -139,7 +158,7 @@ def trust_html(settings: Settings) -> str:
       <div class="panel">
         <h2>Client Verification</h2>
         <ul class="checks">
-          <li><span class="check">OK</span><span>Fetch <code>https://api.trustedrouter.com/attestation</code> over normal public TLS.</span></li>
+          <li><span class="check">OK</span><span>Fetch <code>https://{api_hostname}/attestation</code> over normal public TLS.</span></li>
           <li><span class="check">OK</span><span>Verify the JWT issuer is <code>https://confidentialcomputing.googleapis.com</code>.</span></li>
           <li><span class="check">OK</span><span>Verify the audience is <code>quill-cloud</code>.</span></li>
           <li><span class="check">OK</span><span>Compare the attested image digest with this page.</span></li>
@@ -154,7 +173,7 @@ def trust_html(settings: Settings) -> str:
       </div>
       <div class="panel warn">
         <h2>DNS Requirement</h2>
-        <p><code>api.trustedrouter.com</code> must remain DNS-only or TCP-passthrough. TLS termination by a CDN would break the hosted-code trust claim because the prompt path certificate key must remain inside the measured workload.</p>
+        <p><code>{api_hostname}</code> must remain DNS-only or TCP-passthrough. TLS termination by a CDN would break the hosted-code trust claim because the prompt path certificate key must remain inside the measured workload.</p>
       </div>
     </section>
     <section class="grid">

--- a/tests/test_domain_aliases.py
+++ b/tests/test_domain_aliases.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.domains import (
+    configured_control_domains,
+    request_control_origin,
+)
+from trusted_router.main import create_app
+from trusted_router.routes.billing import _checkout_body_with_first_party_returns
+from trusted_router.schemas import CheckoutRequest
+from trusted_router.storage import STORE
+
+
+def _request(host: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [(b"host", host.encode())],
+            "client": ("127.0.0.1", 1234),
+            "server": (host, 443),
+        }
+    )
+
+
+def test_configured_domains_are_normalized_and_deduplicated() -> None:
+    settings = Settings(
+        environment="test",
+        trusted_domain="TrustedRouter.COM.",
+        trusted_domain_aliases=" allyrouter.com,ALLYROUTER.COM.,bad host ",
+    )
+    assert configured_control_domains(settings) == (
+        "trustedrouter.com",
+        "allyrouter.com",
+    )
+
+
+def test_allyrouter_homepage_uses_attested_api_alias(client: TestClient) -> None:
+    response = client.get("/", headers={"host": "allyrouter.com"})
+    assert response.status_code == 200
+    assert "https://api.allyrouter.com/v1" in response.text
+    assert '<link rel="canonical" href="https://trustedrouter.com/">' in response.text
+
+
+def test_allyrouter_status_and_trust_hosts_render(client: TestClient) -> None:
+    status = client.get("/", headers={"host": "status.allyrouter.com"})
+    trust = client.get("/", headers={"host": "trust.allyrouter.com"})
+
+    assert status.status_code == 200
+    assert "TrustedRouter Status" in status.text
+    assert "https://api.allyrouter.com/v1" in status.text
+    assert trust.status_code == 200
+    assert "https://api.allyrouter.com/v1" in trust.text
+    assert "https://api.allyrouter.com/attestation" in trust.text
+    assert '<link rel="canonical" href="https://trust.trustedrouter.com/">' in trust.text
+
+
+def test_alias_www_and_status_redirects_stay_on_alias(client: TestClient) -> None:
+    www = client.get(
+        "/models?view=all",
+        headers={"host": "www.allyrouter.com"},
+        follow_redirects=False,
+    )
+    escaped_status = client.get(
+        "/models?view=all",
+        headers={"host": "status.allyrouter.com"},
+        follow_redirects=False,
+    )
+
+    assert www.status_code == 308
+    assert www.headers["location"] == "https://allyrouter.com/models?view=all"
+    assert escaped_status.status_code == 308
+    assert escaped_status.headers["location"] == "https://allyrouter.com/models?view=all"
+
+
+def test_unknown_host_is_never_reflected_into_absolute_urls() -> None:
+    settings = Settings(environment="test")
+    assert request_control_origin(_request("attacker.example"), settings) == (
+        "https://trustedrouter.com"
+    )
+
+    body = _checkout_body_with_first_party_returns(
+        CheckoutRequest(amount="10"),
+        _request("attacker.example"),
+        settings,
+    )
+    assert body.success_url == "https://trustedrouter.com/billing/success"
+    assert body.cancel_url == "https://trustedrouter.com/billing"
+
+
+def test_checkout_defaults_follow_allowed_alias() -> None:
+    settings = Settings(environment="test")
+    stripe_body = _checkout_body_with_first_party_returns(
+        CheckoutRequest(amount="10"),
+        _request("allyrouter.com"),
+        settings,
+    )
+    paypal_body = _checkout_body_with_first_party_returns(
+        CheckoutRequest(amount="10", payment_method="paypal"),
+        _request("allyrouter.com"),
+        settings,
+    )
+
+    assert stripe_body.success_url == "https://allyrouter.com/billing/success"
+    assert stripe_body.cancel_url == "https://allyrouter.com/billing"
+    assert paypal_body.success_url == "https://allyrouter.com/billing/paypal/success"
+    assert paypal_body.cancel_url == "https://allyrouter.com/billing/paypal/cancel"
+
+
+def test_wallet_challenge_uses_alias_siwe_domain(client: TestClient) -> None:
+    response = client.post(
+        "/v1/auth/wallet/challenge",
+        headers={"host": "allyrouter.com"},
+        json={"address": "0x0000000000000000000000000000000000000001"},
+    )
+    assert response.status_code == 200
+    message = response.json()["data"]["message"]
+    assert message.startswith("allyrouter.com wants you to sign in")
+    assert "URI: https://allyrouter.com" in message
+
+
+def test_google_oauth_callback_stays_same_origin_on_alias() -> None:
+    settings = Settings(
+        environment="test",
+        google_client_id="client-id",
+        google_client_secret="client-secret",  # noqa: S106 - test credential.
+        google_oauth_redirect_url="https://trustedrouter.com/google_oauth_callback",
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+
+    response = client.get(
+        "/auth/google/login",
+        headers={"host": "allyrouter.com"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    query = parse_qs(urlsplit(response.headers["location"]).query)
+    assert query["redirect_uri"] == ["https://allyrouter.com/google_oauth_callback"]
+
+
+def test_console_uses_attested_api_alias(client: TestClient) -> None:
+    signup = STORE.signup(email="alias-console@example.com")
+    assert signup is not None
+    raw_token, _ = STORE.create_auth_session(
+        user_id=signup.user.id,
+        provider="email",
+        label=signup.user.email or "",
+        ttl_seconds=600,
+        workspace_id=signup.workspace.id,
+        state="active",
+    )
+
+    response = client.get(
+        "/console/welcome?first=1",
+        headers={
+            "host": "allyrouter.com",
+            "cookie": (
+                f"tr_session={raw_token}; tr_pending_reveal={signup.raw_key}"
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "https://api.allyrouter.com/v1" in response.text


### PR DESCRIPTION
Adds first-party allyrouter.com aliases for the website, status, trust, console, auth, wallet, and billing flows. Keeps SEO canonical on trustedrouter.com, rejects unknown Host reflection, provisions config-as-code TLS support, and adds production smoke coverage.\n\nValidation: ruff, mypy, 2,425 pytest tests plus 9 focused alias tests.