### PR TITLE
Harden public status reporting and caching

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -634,6 +634,19 @@ if gc compute backend-services describe "$LB_BACKEND_SERVICE" --global >/dev/nul
         --quiet >/dev/null || log "WARN: stale NEG detach failed for ${attached_region}"
     fi
   done
+  log "enabling origin-controlled Cloud CDN on ${LB_BACKEND_SERVICE}"
+  gc compute backend-services update "$LB_BACKEND_SERVICE" \
+    --global \
+    --enable-cdn \
+    --cache-mode=USE_ORIGIN_HEADERS \
+    --cache-key-include-host \
+    --cache-key-include-protocol \
+    --cache-key-include-query-string \
+    --cache-key-query-string-blacklist= \
+    --compression-mode=AUTOMATIC \
+    --serve-while-stale=600 \
+    --no-negative-caching \
+    --quiet >/dev/null
 else
   log "WARN: ${LB_BACKEND_SERVICE} not found; skipping NEG wiring"
 fi

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -152,7 +152,13 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        attribution, attribution_changed = prepare_request_attribution(request, settings)
+        if is_status_hostname(settings, request_hostname(request)):
+            # Status is operational infrastructure, not an acquisition page.
+            # Keeping it cookie-free also lets Cloud CDN cache it safely.
+            request.state.acquisition_attribution = None
+            attribution, attribution_changed = None, False
+        else:
+            attribution, attribution_changed = prepare_request_attribution(request, settings)
         start = time.perf_counter()
         response = await call_next(request)
         if attribution is not None and attribution_changed:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1062,7 +1062,9 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             ttl_seconds=STATUS_RESPONSE_CACHE_SECONDS,
             stale_seconds=STATUS_RESPONSE_STALE_SECONDS,
             background_tasks=background_tasks,
-            build=lambda: _json_body({"data": _status_snapshot(settings)}),
+            build=lambda: _json_body(
+                {"data": _compact_status_json(_status_snapshot(settings))}
+            ),
         )
 
     @app.get("/status/history")
@@ -1655,6 +1657,25 @@ def _status_snapshot(settings: Settings) -> dict[str, Any]:
     payload = status_snapshot(_status_samples(hours=1), rollups=_status_rollups("snapshot"))
     if settings.environment != "test":
         _STATUS_CACHE = (now, payload)
+    return payload
+
+
+def _compact_status_json(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Remove tooltip-only duplication from the machine-readable status feed."""
+    payload = dict(snapshot)
+    compact_components: list[dict[str, Any]] = []
+    for component in snapshot.get("components", []):
+        compact_component = dict(component)
+        compact_component["history"] = [
+            {
+                key: value
+                for key, value in bucket.items()
+                if key != "latency_breakdown"
+            }
+            for bucket in component.get("history", [])
+        ]
+        compact_components.append(compact_component)
+    payload["components"] = compact_components
     return payload
 
 

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -119,7 +119,11 @@ def status_snapshot(
         "slo_history": slo_history,
         "burn_rate_alerts": _burn_rate_alerts(slo_classes),
         "components": components,
-        "recent_events": _recent_events(ordered, now=now),
+        "recent_events": _recent_events(
+            ordered,
+            rollups=precomputed_rollups,
+            now=now,
+        ),
         "history_scope": ROUTER_CORE_SLO_ID,
         "windows": {
             "5m": five_minute,
@@ -841,10 +845,16 @@ def _sample_group_breakdown(
         statuses = [sample.status for sample in probe_samples]
         row = {
             "target": target,
+            "target_label": _target_label(target),
             "probe_type": probe_type,
             "monitor_region": monitor_region,
             "target_region": target_region or None,
             "region_pair": _region_pair(monitor_region, target_region or None),
+            "route_label": _route_label(
+                target,
+                monitor_region,
+                target_region or None,
+            ),
             "status": _aggregate_status(statuses),
             "uptime_percent": _uptime_percent(statuses),
             "sample_count": len(probe_samples),
@@ -897,10 +907,16 @@ def _rollup_group_breakdown(
         status_counts = _int_dict(merged["status_counts"])
         row = {
             "target": target,
+            "target_label": _target_label(target),
             "probe_type": probe_type,
             "monitor_region": monitor_region,
             "target_region": target_region or None,
             "region_pair": _region_pair(monitor_region, target_region or None),
+            "route_label": _route_label(
+                target,
+                monitor_region,
+                target_region or None,
+            ),
             "status": _aggregate_status_counts(status_counts),
             "uptime_percent": _uptime_percent_counts(status_counts),
             "sample_count": int(merged["sample_count"]),
@@ -938,6 +954,20 @@ def _region_pair(monitor_region: str, target_region: str | None) -> str:
     if target_region:
         return f"{monitor_region} -> {target_region}"
     return monitor_region
+
+
+def _target_label(target: str) -> str:
+    return {
+        "canonical": "Global endpoint",
+        "us-central1": "US Central direct",
+        "us-east4": "US East direct",
+        "europe-west4": "EU direct",
+        "control-plane": "Control plane",
+    }.get(target, target.replace("-", " ").title())
+
+
+def _route_label(target: str, monitor_region: str, target_region: str | None) -> str:
+    return f"{_target_label(target)} · {_region_pair(monitor_region, target_region)}"
 
 
 def _latest_recent_component_samples(
@@ -1166,20 +1196,33 @@ def _history_status(uptime: float, *, has_trust_degraded: bool) -> str:
 
 
 def _recent_events(
-    samples: list[SyntheticProbeSample], *, now: dt.datetime
+    samples: list[SyntheticProbeSample],
+    *,
+    rollups: list[SyntheticRollup],
+    now: dt.datetime,
 ) -> list[dict[str, Any]]:
     cutoff = now - dt.timedelta(seconds=WINDOW_SECONDS["24h"])
-    events = []
+    events: list[dict[str, Any]] = []
+    raw_event_buckets: set[tuple[str, str, str, str]] = set()
     for sample in samples:
         if _parse_time(sample.created_at) < cutoff or sample.status == "up":
             continue
-        if not sample_component_ids(sample) and not sample_slo_class_ids(sample):
+        component_ids = sample_component_ids(sample)
+        if not component_ids and not sample_slo_class_ids(sample):
             continue
         component_names = [
             str(definition["name"])
             for definition in COMPONENT_DEFINITIONS
-            if str(definition["id"]) in sample_component_ids(sample)
+            if str(definition["id"]) in component_ids
         ]
+        raw_event_buckets.add(
+            (
+                sample.target,
+                sample.probe_type,
+                sample.monitor_region,
+                sample.created_at[:13],
+            )
+        )
         events.append(
             {
                 "id": sample.id,
@@ -1193,9 +1236,74 @@ def _recent_events(
                 "created_at": sample.created_at,
                 "latency_milliseconds": sample.latency_milliseconds,
                 "error_type": sample.error_type,
+                "aggregate": False,
             }
         )
+
+    component_order = {
+        str(definition["id"]): index
+        for index, definition in enumerate(COMPONENT_DEFINITIONS)
+    }
+    rollup_groups_seen: set[tuple[str, str, str, str]] = set()
+    recent_rollups = sorted(
+        (
+            rollup
+            for rollup in rollups
+            if rollup.period == "hour"
+            and rollup.last_checked_at is not None
+            and _parse_time(rollup.last_checked_at) >= cutoff
+        ),
+        key=lambda rollup: (
+            rollup.period_start,
+            -component_order.get(rollup.component, len(component_order)),
+        ),
+        reverse=True,
+    )
+    for rollup in recent_rollups:
+        counts = _rollup_status_counts(rollup)
+        failure_count = sum(
+            count for status, count in counts.items() if status != "up"
+        )
+        if failure_count <= 0:
+            continue
+        bucket_key = (
+            rollup.target,
+            rollup.probe_type,
+            rollup.monitor_region,
+            rollup.period_start[:13],
+        )
+        if bucket_key in raw_event_buckets or bucket_key in rollup_groups_seen:
+            continue
+        rollup_groups_seen.add(bucket_key)
+        status = _rollup_failure_status(counts)
+        merged = merge_rollups([rollup])
+        events.append(
+            {
+                "id": f"rollup:{rollup.id}",
+                "component": component_name(rollup.component),
+                "status": status,
+                "status_label": _status_label(status),
+                "status_class": _status_class(status),
+                "probe_type": rollup.probe_type,
+                "target": rollup.target,
+                "monitor_region": rollup.monitor_region,
+                "created_at": rollup.period_start,
+                "latency_milliseconds": merged["p50_latency_milliseconds"],
+                "error_type": merged["top_error"],
+                "aggregate": True,
+                "failure_count": failure_count,
+                "sample_count": rollup.sample_count,
+            }
+        )
+    events.sort(key=lambda event: str(event["created_at"]), reverse=True)
     return events[:8]
+
+
+def _rollup_failure_status(counts: dict[str, int]) -> str:
+    for status in ("trust_degraded", "down", "routing_degraded", "degraded", "unknown"):
+        if counts.get(status, 0) > 0:
+            return status
+    return "unknown"
 
 
 def _aggregate_component_statuses(statuses: list[str]) -> str:

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -71,17 +71,18 @@
     </div>
     <div class="leaderboard-table-wrap">
       <table class="activity-table status-table">
-        <thead><tr><th>Path</th><th>Region path</th><th>Total p50</th><th>DNS</th><th>TCP</th><th>TLS</th><th>Gateway</th><th>Samples</th></tr></thead>
+        <thead><tr><th>Connection</th><th>Endpoint</th><th>Region path</th><th>Total p50</th><th>DNS</th><th>TCP</th><th>TLS</th><th>Gateway</th><th>Samples</th></tr></thead>
         <tbody>
           {% for row in snapshot.headline_metrics.latency_anatomy %}
           <tr>
             <td>{% if row.probe_type == "gateway_reused_path" %}Reused connection{% else %}Fresh connection{% endif %}</td>
+            <td>{{ row.target_label }}</td>
             <td>{{ row.region_pair }}</td>
             <td>{% if row.p50_latency_milliseconds is not none %}{{ row.p50_latency_milliseconds }} ms{% else %}n/a{% endif %}</td>
             <td>{% if row.p50_dns_milliseconds is not none %}{{ row.p50_dns_milliseconds }} ms{% else %}paid once{% endif %}</td>
             <td>{% if row.p50_tcp_connect_milliseconds is not none %}{{ row.p50_tcp_connect_milliseconds }} ms{% else %}paid once{% endif %}</td>
             <td>{% if row.p50_tls_handshake_milliseconds is not none %}{{ row.p50_tls_handshake_milliseconds }} ms{% else %}paid once{% endif %}</td>
-            <td>{% if row.p50_gateway_processing_milliseconds is not none %}{{ row.p50_gateway_processing_milliseconds }} ms{% else %}n/a{% endif %}</td>
+            <td>{% if row.p50_gateway_processing_milliseconds == 0 %}&lt;1 ms{% elif row.p50_gateway_processing_milliseconds is not none %}{{ row.p50_gateway_processing_milliseconds }} ms{% else %}n/a{% endif %}</td>
             <td>{{ row.sample_count }}</td>
           </tr>
           {% endfor %}
@@ -173,8 +174,8 @@
         <div class="component-breakdown" aria-label="{{ component.name }} latency breakdown">
           {% for breakdown in component.latency_breakdown_5m %}
           <span>
-            {{ breakdown.probe_type }} · {{ breakdown.region_pair }}
-            <strong>{% if breakdown.p50_latency_milliseconds %}p50 {{ breakdown.p50_latency_milliseconds }} ms{% else %}p50 n/a{% endif %}</strong>
+            {{ breakdown.probe_type }} · {{ breakdown.route_label }}
+            <strong>{% if breakdown.p50_latency_milliseconds is not none %}p50 {{ breakdown.p50_latency_milliseconds }} ms{% else %}p50 n/a{% endif %}</strong>
           </span>
           {% endfor %}
         </div>
@@ -189,7 +190,7 @@
                 <span>Uptime <strong>{{ bucket.uptime_percent | uptime_pct(2) }}</strong></span>
                 <span>Samples <strong>{{ bucket.sample_count }}</strong></span>
                 {% for breakdown in bucket.latency_breakdown %}
-                  <span>{{ breakdown.probe_type }} · {{ breakdown.region_pair }} <strong>{% if breakdown.p50_latency_milliseconds %}p50 {{ breakdown.p50_latency_milliseconds }} ms{% else %}p50 n/a{% endif %}</strong></span>
+                  <span>{{ breakdown.probe_type }} · {{ breakdown.route_label }} <strong>{% if breakdown.p50_latency_milliseconds is not none %}p50 {{ breakdown.p50_latency_milliseconds }} ms{% else %}p50 n/a{% endif %}</strong></span>
                 {% endfor %}
                 {% if bucket.top_error %}<span class="err">Top error <strong>{{ bucket.top_error }}</strong></span>{% endif %}
               {% else %}
@@ -257,7 +258,7 @@
           <span class="component-status status-{{ event.status_class }}">{{ event.status_label }}</span>
           <div>
             <strong>{{ event.component }}</strong>
-            <p>{{ event.created_at }} · {{ event.probe_type }} · {{ event.monitor_region }}{% if event.error_type %} · {{ event.error_type }}{% endif %}</p>
+            <p>{{ event.created_at }} · {{ event.probe_type }} · {{ event.monitor_region }}{% if event.aggregate %} · hourly rollup · {{ event.failure_count }} failed / {{ event.sample_count }}{% endif %}{% if event.error_type %} · {{ event.error_type }}{% endif %}</p>
           </div>
         </div>
         {% endfor %}

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -153,6 +153,16 @@ def test_crawlers_do_not_receive_attribution_cookie(client: TestClient) -> None:
     assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
 
 
+def test_status_host_does_not_receive_attribution_cookie(client: TestClient) -> None:
+    response = client.get(
+        "/",
+        headers={"host": "status.trustedrouter.com"},
+    )
+
+    assert response.status_code == 200
+    assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+
 @pytest.mark.parametrize(
     ("header", "value"),
     [

--- a/tests/test_public_cdn_deploy.py
+++ b/tests/test_public_cdn_deploy.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_rollout_enables_origin_controlled_public_cdn() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+
+    assert "--enable-cdn" in rollout
+    assert "--cache-mode=USE_ORIGIN_HEADERS" in rollout
+    assert "--cache-key-include-host" in rollout
+    assert "--cache-key-include-protocol" in rollout
+    assert "--cache-key-include-query-string" in rollout
+    assert "--serve-while-stale=600" in rollout
+    assert "--no-negative-caching" in rollout

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -201,6 +201,21 @@ def test_status_json_is_public_metadata_only(client: TestClient) -> None:
             model=MONITOR_MODEL_ID,
             output_match=True,
         ),
+        _sample(
+            id="syn_gateway_canonical",
+            probe_type="gateway_cold_path",
+            status="up",
+            gateway_processing_milliseconds=0,
+            latency_milliseconds=20,
+        ),
+        _sample(
+            id="syn_gateway_direct",
+            target="us-central1",
+            probe_type="gateway_cold_path",
+            status="up",
+            gateway_processing_milliseconds=0,
+            latency_milliseconds=10,
+        ),
     ]
     resp = client.post(
         "/v1/internal/synthetic/samples",
@@ -220,6 +235,9 @@ def test_status_json_is_public_metadata_only(client: TestClient) -> None:
     assert "All Systems Operational" in page.text
     assert "Components" in page.text
     assert "In region gateway overhead p50" in page.text
+    assert "Global endpoint" in page.text
+    assert "US Central direct" in page.text
+    assert "&lt;1 ms" in page.text
     assert "Error-Budget Burn" not in page.text
     assert "last 48 hour uptime history" in page.text
     text = status.text
@@ -234,6 +252,11 @@ def test_status_json_is_public_metadata_only(client: TestClient) -> None:
     assert provider_sample["output_match"] is True
     assert payload["components"][0]["name"] == "Canonical API"
     assert len(payload["components"][0]["history"]) == 48
+    assert all(
+        "latency_breakdown" not in bucket
+        for component in payload["components"]
+        for bucket in component["history"]
+    )
     assert payload["monitor_freshness"]["is_stale"] is False
 
 
@@ -298,6 +321,41 @@ def test_status_snapshot_reports_cold_and_reused_latency_anatomy_without_affecti
     assert anatomy["gateway_cold_path"]["p50_tls_handshake_milliseconds"] == 26
     assert anatomy["gateway_reused_path"]["p50_latency_milliseconds"] == 15
     assert snapshot["windows"]["5m"]["sample_count"] == 1
+
+
+def test_gateway_latency_anatomy_distinguishes_global_and_direct_targets() -> None:
+    now = utcnow()
+    created_at = (now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z")
+    samples = [
+        _sample(
+            id="global",
+            target="canonical",
+            target_region="us-central1",
+            monitor_region="us-central1",
+            probe_type="gateway_reused_path",
+            status="up",
+            latency_milliseconds=20,
+            created_at=created_at,
+        ),
+        _sample(
+            id="direct",
+            target="us-central1",
+            target_region="us-central1",
+            monitor_region="us-central1",
+            probe_type="gateway_reused_path",
+            status="up",
+            latency_milliseconds=10,
+            created_at=created_at,
+        ),
+    ]
+
+    rows = status_snapshot(samples, now=now)["headline_metrics"]["latency_anatomy"]
+    labels = {row["target"]: row["route_label"] for row in rows}
+
+    assert labels == {
+        "canonical": "Global endpoint · us-central1 -> us-central1",
+        "us-central1": "US Central direct · us-central1 -> us-central1",
+    }
 
 
 def test_public_status_response_cache_reuses_rendered_body() -> None:
@@ -1239,6 +1297,49 @@ def test_image_generation_component_uses_fresh_rollup_when_raw_window_is_empty()
         row for row in stale_snapshot["components"] if row["id"] == "image_generation"
     )
     assert stale_component["status"] == "unknown"
+
+
+def test_recent_events_use_rollups_for_failures_outside_live_sample_window() -> None:
+    now = utcnow()
+    failed = _sample(
+        id="syn_image_historical_failure",
+        target="canonical",
+        probe_type="image_generation",
+        status="down",
+        created_at=(now - dt.timedelta(hours=6)).isoformat().replace("+00:00", "Z"),
+        error_type="invalid_image_payload",
+    )
+
+    snapshot = status_snapshot([], rollups=_rollups_for_samples([failed]), now=now)
+
+    assert len(snapshot["recent_events"]) == 1
+    event = snapshot["recent_events"][0]
+    assert event["component"] == "Image Generation"
+    assert event["error_type"] == "invalid_image_payload"
+    assert event["aggregate"] is True
+    assert event["failure_count"] == 1
+    assert event["sample_count"] == 1
+
+
+def test_recent_events_do_not_duplicate_live_failure_and_its_rollup() -> None:
+    now = utcnow()
+    failed = _sample(
+        id="syn_live_failure",
+        target="canonical",
+        probe_type="image_generation",
+        status="down",
+        created_at=(now - dt.timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+        error_type="invalid_image_payload",
+    )
+
+    snapshot = status_snapshot(
+        [failed],
+        rollups=_rollups_for_samples([failed]),
+        now=now,
+    )
+
+    assert [event["id"] for event in snapshot["recent_events"]] == [failed.id]
+    assert snapshot["recent_events"][0]["aggregate"] is False
 
 
 def test_status_component_current_uses_latest_sample_per_probe() -> None:


### PR DESCRIPTION
Fixes the public status contradiction where 24-hour component failures were visible in rollups but absent from Recent Events. Distinguishes global and direct regional latency rows, renders sub-millisecond gateway time honestly, compacts status.json, keeps the status host cookie-free, and enables origin-controlled Cloud CDN caching.\n\nVerified locally: 2,444 passed, 86 skipped; ruff and mypy clean; rollout shell syntax valid.