### PR TITLE
Make public analytics pages edge cacheable

### DIFF
--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -81,6 +81,16 @@ STATUS_HOST_EXACT_PATHS = frozenset(
     }
 )
 STATUS_HOST_PATH_PREFIXES = ("/static/", "/status/")
+COOKIE_FREE_PUBLIC_ANALYTICS_PATHS = frozenset(
+    {
+        "/leaderboard",
+        "/leaderboard/video",
+        "/leaderboard/video.json",
+        "/status",
+        "/status.json",
+        "/status/history",
+    }
+)
 
 
 def register_http_middleware(app: FastAPI, settings: Settings) -> None:
@@ -152,9 +162,12 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        if is_status_hostname(settings, request_hostname(request)):
-            # Status is operational infrastructure, not an acquisition page.
-            # Keeping it cookie-free also lets Cloud CDN cache it safely.
+        if is_status_hostname(
+            settings, request_hostname(request)
+        ) or _cookie_free_public_analytics_path(request.url.path):
+            # Public operational analytics are not acquisition pages. Keeping
+            # them cookie-free also lets Cloud CDN cache one shared response
+            # instead of forcing an origin request for every anonymous viewer.
             request.state.acquisition_attribution = None
             attribution, attribution_changed = None, False
         else:
@@ -289,6 +302,10 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
 
 def _status_host_path(path: str) -> bool:
     return path in STATUS_HOST_EXACT_PATHS or path.startswith(STATUS_HOST_PATH_PREFIXES)
+
+
+def _cookie_free_public_analytics_path(path: str) -> bool:
+    return path in COOKIE_FREE_PUBLIC_ANALYTICS_PATHS
 
 
 def _apex_public_url(settings: Settings, request: Request, hostname: str) -> str:

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -164,6 +164,28 @@ def test_status_host_does_not_receive_attribution_cookie(client: TestClient) -> 
 
 
 @pytest.mark.parametrize(
+    "path",
+    [
+        "/leaderboard",
+        "/leaderboard/video",
+        "/leaderboard/video.json",
+        "/status",
+        "/status.json",
+        "/status/history?window=24h&format=json",
+    ],
+)
+def test_public_analytics_pages_are_cookie_free_for_shared_edge_cache(
+    client: TestClient,
+    path: str,
+) -> None:
+    response = client.get(path, headers={"host": "trustedrouter.com"})
+
+    assert response.status_code == 200
+    assert ATTRIBUTION_COOKIE_NAME not in response.headers.get("set-cookie", "")
+    assert "public" in response.headers.get("cache-control", "")
+
+
+@pytest.mark.parametrize(
     ("header", "value"),
     [
         ("purpose", "prefetch"),


### PR DESCRIPTION
## Summary
- stop setting acquisition cookies on public status and leaderboard surfaces
- let Cloud CDN share the existing public cacheable response across anonymous viewers
- retain attribution behavior everywhere else

## Production finding
Cloud CDN was enabled and caching status correctly, but /leaderboard carried Set-Cookie and therefore reached Cloud Run on every request. Two identical requests received different request IDs and attribution cookies with no Age header.

## Verification
- 2,450 tests passed, 86 skipped
- ruff clean
- mypy clean across 209 source files
- focused status/acquisition/readiness tests passed