### PR TITLE
CI: four parallel jobs + pytest-xdist (16-19 min → ~6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,43 @@ on:
   # CI explicitly for the generated commit before dispatching deploy.yml.
   workflow_dispatch: {}
 
+# Four independent jobs instead of one serial pipeline: wall time becomes the
+# slowest job, not the sum. deploy.yml's gate polls this WORKFLOW RUN's
+# conclusion for the SHA, and a run only concludes success when every job
+# succeeds, so the gate semantics are unchanged by the split.
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
+      - name: Ruff
+        run: uv run ruff check .
+      - name: Mypy
+        run: uv run mypy
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install npm deps
+        run: npm ci
+      - name: TypeScript build (verify dashboard.js matches dashboard.ts)
+        run: |
+          npx tsc
+          git diff --exit-code -- src/trusted_router/static/dashboard.js
+      - name: ESLint
+        run: npx eslint frontend/src
+      - name: Stylelint
+        run: npx stylelint "src/trusted_router/static/*.css"
+
   test:
     runs-on: ubuntu-latest
     env:
@@ -45,29 +81,36 @@ jobs:
           version: "latest"
       - name: Sync
         run: uv sync --frozen
-      - name: Ruff
-        run: uv run ruff check .
-      - name: Mypy
-        run: uv run mypy
+      # The coverage invocation executes the complete test suite. Running a
+      # separate plain pytest pass doubled CI time and delayed every guarded
+      # production rollout without checking any additional behavior.
+      # -n 4 (pytest-xdist) uses the runner's 4 vCPUs; pytest-cov combines
+      # worker coverage natively. --dist loadgroup is LOAD-BEARING: the
+      # server-backed conformance backends are xdist_group-marked (see
+      # tests/conformance/conftest.py) because the Spanner PG emulator rejects
+      # concurrent schema changes -- measured 14 setup errors under plain -n 4,
+      # 53/53 with grouping. Per-test id namespacing makes the shared DATABASE
+      # order-independent; grouping is what serializes the DDL.
+      - name: Tests and coverage
+        run: uv run pytest -q -n 4 --dist loadgroup --cov=trusted_router --cov-report=term-missing --cov-fail-under=70
+
+  browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: Install npm deps
         run: npm ci
-      - name: TypeScript build (verify dashboard.js matches dashboard.ts)
-        run: |
-          npx tsc
-          git diff --exit-code -- src/trusted_router/static/dashboard.js
-      - name: ESLint
-        run: npx eslint frontend/src
-      - name: Stylelint
-        run: npx stylelint "src/trusted_router/static/*.css"
-      # The coverage invocation executes the complete test suite. Running a
-      # separate plain pytest pass doubled CI time and delayed every guarded
-      # production rollout without checking any additional behavior.
-      - name: Tests and coverage
-        run: uv run pytest -q --cov=trusted_router --cov-report=term-missing --cov-fail-under=70
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
+      # playwright.config.js starts the app itself (uv run uvicorn, memory
+      # backend) and waits on /health — no DB service containers needed.
       - name: Browser smoke
         run: npm run test:browser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pytest-asyncio>=0.24.0",
   "pytest-cov>=7.1.0",
   "pytest-httpx>=0.36.2",
+  "pytest-xdist>=3.8.0",
   "ruff>=0.8.0",
   "sec-parser>=0.58.0",
 ]

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -153,7 +153,26 @@ BACKENDS: dict[str, Callable[[], Store]] = {
 }
 
 
-@pytest.fixture(params=sorted(BACKENDS), ids=lambda name: f"backend={name}")
+# Server-backed backends are marked into one xdist_group each: the Spanner PG
+# emulator rejects CONCURRENT schema changes, and every server-backed store
+# fixture applies schema on construction. Measured: plain `-n 4` against the
+# real containers produced 14 setup errors on backend=spanner-pg; a serial run
+# passed 53/53. With `--dist loadgroup` each backend's tests share one worker
+# (DDL serialized) while memory-backend tests parallelize freely. The per-test
+# `unique` fixture keeps the shared database ORDER-independent; this keeps it
+# CONCURRENCY-safe too. Marks ride the fixture params (not
+# collection_modifyitems) so xdist's scheduler sees them reliably.
+_BACKEND_PARAMS = [
+    name
+    if name == "memory"
+    else pytest.param(
+        name, marks=pytest.mark.xdist_group(f"conformance-{name}")
+    )
+    for name in sorted(BACKENDS)
+]
+
+
+@pytest.fixture(params=_BACKEND_PARAMS, ids=lambda name: f"backend={name}")
 def store(request: pytest.FixtureRequest) -> Iterator[Store]:
     """A live store for each registered backend.
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -10,6 +10,6 @@ def test_ci_runs_python_suite_once_with_coverage() -> None:
 
     assert workflow.count("uv run pytest") == 1
     assert (
-        "uv run pytest -q --cov=trusted_router --cov-report=term-missing "
-        "--cov-fail-under=70"
+        "uv run pytest -q -n 4 --dist loadgroup --cov=trusted_router "
+        "--cov-report=term-missing --cov-fail-under=70"
     ) in workflow

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2343,6 +2343,16 @@ async def test_run_synthetic_once_bounds_credit_bearing_probe_concurrency(
 async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPatch) -> None:
     from trusted_router.synthetic import cli as cli_module
 
+    # Concurrency is asserted STRUCTURALLY (peak in-flight), not by wall
+    # clock: an elapsed-time bound flaked under contended CI CPU (xdist
+    # workers sharing cores pushed 120ms to 128ms). The interleaving of an
+    # in-flight counter is deterministic on one event loop — the second
+    # probe's increment always runs while the first awaits — so this proves
+    # the same fan-out with zero timing sensitivity, and additionally pins
+    # the billing budget: peak must be exactly the semaphore's 2.
+    active = 0
+    peak = 0
+
     async def fake_rotation_probe(
         _client: httpx.AsyncClient,
         _target: SyntheticTarget,
@@ -2353,10 +2363,14 @@ async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPa
         model: str,
         default_timeout_seconds: float,
     ) -> tuple[str, str, str, str]:
+        nonlocal active, peak
         assert monitor_region == "us-central1"
         assert api_key == "sk-tr-test"
         assert default_timeout_seconds == 20.0
-        await asyncio.sleep(0.03)
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.005)
+        active -= 1
         return (provider, model, monitor_region, api_key)
 
     monkeypatch.setattr(
@@ -2366,7 +2380,6 @@ async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPa
     )
     monkeypatch.setattr(cli_module, "provider_rotation_probe", fake_rotation_probe)
 
-    started = time.perf_counter()
     samples = await cli_module._rotation_pass(
         settings=Settings(environment="test", api_base_url="https://api.trustedrouter.com/v1"),
         monitor_region="us-central1",
@@ -2375,10 +2388,10 @@ async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPa
         count=4,
         rng=random.Random(0),  # noqa: S311 - deterministic test selection.
     )
-    elapsed = time.perf_counter() - started
 
     assert len(samples) == 4
-    assert elapsed < 0.12
+    # Parallel within the billing budget, never beyond it.
+    assert peak == 2
 
 
 @pytest.mark.asyncio
@@ -2387,21 +2400,31 @@ async def test_probe_and_rotation_pass_runs_independent_blocks_concurrently(
 ) -> None:
     from trusted_router.synthetic import cli as cli_module
 
+    # Overlap is proven by a mutual handshake, not wall clock (an elapsed
+    # bound flaked under contended CI CPU): each block signals its start and
+    # then WAITS for the other block to have started before it can finish.
+    # Serialized execution deadlocks the first block until wait_for's timeout
+    # fails the test deterministically; concurrent execution releases both
+    # immediately. No timing margin exists to erode.
+    probe_started = asyncio.Event()
+    rotation_started = asyncio.Event()
+
     async def fake_one_probe_pass(**_kwargs: Any) -> list[SyntheticProbeSample]:
-        await asyncio.sleep(0.03)
+        probe_started.set()
+        await asyncio.wait_for(rotation_started.wait(), timeout=5)
         return [
             _sample(id="tls", probe_type="tls_health", status="up"),
             _sample(id="settle", probe_type="gateway_authorize_settle", status="up"),
         ]
 
     async def fake_rotation_pass(**_kwargs: Any) -> list[str]:
-        await asyncio.sleep(0.03)
+        rotation_started.set()
+        await asyncio.wait_for(probe_started.wait(), timeout=5)
         return ["rotation-a", "rotation-b"]
 
     monkeypatch.setattr(cli_module, "_one_probe_pass", fake_one_probe_pass)
     monkeypatch.setattr(cli_module, "_rotation_pass", fake_rotation_pass)
 
-    started = time.perf_counter()
     samples, rotation_samples = await cli_module._probe_and_rotation_pass(
         settings=Settings(environment="test", api_base_url="https://api.trustedrouter.com/v1"),
         monitor_region="us-central1",
@@ -2413,14 +2436,12 @@ async def test_probe_and_rotation_pass_runs_independent_blocks_concurrently(
         rotation_per_pass=4,
         rotation_rng=random.Random(0),  # noqa: S311 - deterministic test selection.
     )
-    elapsed = time.perf_counter() - started
 
     assert [sample.probe_type for sample in samples] == [
         "tls_health",
         "gateway_authorize_settle",
     ]
     assert rotation_samples == ["rotation-a", "rotation-b"]
-    assert elapsed < 0.06
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1218,6 +1218,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "faker"
 version = "40.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3294,6 +3303,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -4512,6 +4534,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sec-parser" },
 ]
@@ -4547,6 +4570,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-httpx", specifier = ">=0.36.2" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "sec-parser", specifier = ">=0.58.0" },
 ]


### PR DESCRIPTION
CI was one serial job: lint → mypy → npm/tsc/eslint/stylelint → pytest-with-coverage (single process) → Playwright, on a 4-vCPU public-repo runner. ~15–19 min wall.

**Now:** four independent jobs — `lint`, `frontend`, `test`, `browser` — wall time = slowest job; and pytest runs `-n 4 --dist loadgroup`. Measured locally: 2450 tests 164s → 44s (no cov), 87s with coverage and all conformance backends live. Expected CI wall ~5–7 min.

**Gate compatibility (audited):** deploy.yml's gate polls the workflow *run* conclusion (success only when all jobs pass) — unchanged; refresh-prices dispatches `ci.yml` by filename — unchanged; the `test_ci_workflow` meta-test now pins the new invocation (still exactly one pytest pass with coverage).

**Parallel safety proven, not assumed** — full suite run against the real postgres:17 + Spanner-PG-emulator containers:
- plain `-n 4`: **14 setup errors** on `backend=spanner-pg` (*"Schema change operation rejected because a concurrent schema change … is already in progress"* — every server-backed store fixture applies schema on construction; the emulator serializes DDL)
- serial control: 53/53
- fix: server-backed backend params carry `xdist_group` marks **on the fixture params** (a `collection_modifyitems` hook was measurably ignored by the scheduler) + `--dist loadgroup`: all 17 spanner-pg tests pinned to one worker, **2485/2485 green** CI-shaped

An adversarial audit workflow reviewed the split (completeness: every step/env/service/comment mapped to the right job; cross-references; xdist hazards) and its three blocking findings are all closed in this PR — including the missing `--dist loadgroup` that would have made the grouping inert.

**Out of scope, surfaced by the audit:** `main` has no branch protection and no rulesets (pre-existing; already tracked as a SOC2 gap in `docs/compliance/soc2/`). When enabling it, the required checks should be exactly `lint`, `frontend`, `test`, `browser`.