### PR TITLE
Add independent OAuth and UptimeRouter alias

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -570,6 +570,11 @@ jobs:
           check_url ally_status https://status.allyrouter.com/status.json
           check_url ally_trust https://trust.allyrouter.com/
           check_url ally_trust_release https://trust.allyrouter.com/trust/gcp-release.json
+          check_url uptime_homepage https://uptimerouter.com/
+          check_url uptime_health https://uptimerouter.com/health
+          check_url uptime_status https://status.uptimerouter.com/status.json
+          check_url uptime_trust https://trust.uptimerouter.com/
+          check_url uptime_trust_release https://trust.uptimerouter.com/trust/gcp-release.json
           check_url canonical_trust_release \
             "https://trust.trustedrouter.com/trust/gcp-release.json?nocache=${GITHUB_RUN_ID}"
 
@@ -594,6 +599,9 @@ jobs:
           ally_homepage = Path("/tmp/ally_homepage.body").read_text()
           ally_trust = Path("/tmp/ally_trust.body").read_text()
           ally_release = json.loads(Path("/tmp/ally_trust_release.body").read_text())
+          uptime_homepage = Path("/tmp/uptime_homepage.body").read_text()
+          uptime_trust = Path("/tmp/uptime_trust.body").read_text()
+          uptime_release = json.loads(Path("/tmp/uptime_trust_release.body").read_text())
           canonical_release = json.loads(Path("/tmp/canonical_trust_release.body").read_text())
 
           assert any(item["id"] == "us-central1" for item in regions), regions
@@ -603,10 +611,18 @@ jobs:
           assert "https://api.allyrouter.com/v1" in ally_homepage
           assert "https://api.allyrouter.com/attestation" in ally_trust
           assert ally_release["release_metadata_status"] == "live", ally_release
+          assert "https://api.uptimerouter.com/v1" in uptime_homepage
+          assert "https://api.uptimerouter.com/attestation" in uptime_trust
+          assert uptime_release["release_metadata_status"] == "live", uptime_release
           for field in ("source_commit", "image_reference", "image_digest"):
               assert ally_release[field] == canonical_release[field], (
                   field,
                   ally_release[field],
+                  canonical_release[field],
+              )
+              assert uptime_release[field] == canonical_release[field], (
+                  field,
+                  uptime_release[field],
                   canonical_release[field],
               )
           PY

--- a/docs/operations/allyrouter-alias.md
+++ b/docs/operations/allyrouter-alias.md
@@ -13,7 +13,7 @@ registrar or DNS incident. Search-engine canonical tags still identify
 | `www.allyrouter.com` | Control-plane load balancer, then 308 to apex | Google external HTTPS load balancer |
 | `status.allyrouter.com` | Status surface on the control plane | Google external HTTPS load balancer |
 | `trust.allyrouter.com` | Trust surface on the control plane; release metadata is read from the canonical published record | Google external HTTPS load balancer |
-| `api.allyrouter.com` | DNS-only CNAME to `api.quillrouter.com` and the attested regional instance pool | Inside GCP Confidential Space |
+| `api.allyrouter.com` | Direct Route53 A records to the attested regional instance pool | Inside GCP Confidential Space |
 
 The API alias must never be proxied through a CDN or terminated on the control
 plane. Its ACME private key is generated and retained inside each attested
@@ -23,8 +23,9 @@ The alias trust surface validates and caches the canonical gateway release for
 at most 60 seconds. A failed refresh uses the last validated record only for a
 bounded five-minute window, returns HTTP 503, and labels it stale. With no valid
 record it returns HTTP 503 and does not publish an embedded historical digest.
-The production deployment smoke compares the alias release commit, image, and
-digest with the canonical trust publication.
+It can also validate the independently hosted release artifact committed on
+GitHub if canonical DNS is unavailable. The production deployment smoke compares
+the alias release commit, image, and digest with the canonical trust publication.
 
 ## Route 53 delegation
 
@@ -41,12 +42,16 @@ Run `scripts/deploy/ensure_allyrouter_alias.sh` after DNS changes to create and
 attach the control-plane certificate idempotently. Gateway deployment adds
 `api.allyrouter.com` to the enclave ACME allowlist in every region.
 
+The API record deliberately does not CNAME to a TrustedRouter or QuillRouter
+domain. The gateway health reconciler copies its attestation-gated IP set into
+Route53 after each change and leaves the last-good record untouched on failure.
+
 ## Auth behavior
 
 Email and wallet sessions are host-only and work independently on either apex.
 SIWE challenges bind to the apex that initiated the request. Google and GitHub
-callbacks are also same-origin; each OAuth provider must list the AllyRouter
-callback URI before enabling its button there.
+callbacks are also same-origin. AllyRouter has separate OAuth clients for both
+providers, so login does not depend on a canonical-domain OAuth application.
 
 ## Registrar transfer
 

--- a/docs/operations/uptimerouter-alias.md
+++ b/docs/operations/uptimerouter-alias.md
@@ -1,0 +1,46 @@
+# UptimeRouter operational alias
+
+`uptimerouter.com` is an independent first-party alias for TrustedRouter. It
+serves the complete website, status surface, trust surface, console, and API
+without redirecting through a TrustedRouter or QuillRouter domain.
+
+## Public hostnames
+
+| Hostname | Target | TLS termination |
+|---|---|---|
+| `uptimerouter.com` | Multi-region control-plane load balancer | Google external HTTPS load balancer |
+| `www.uptimerouter.com` | Control plane, then 308 to apex | Google external HTTPS load balancer |
+| `status.uptimerouter.com` | Public status surface | Google external HTTPS load balancer |
+| `trust.uptimerouter.com` | Public trust and attestation surface | Google external HTTPS load balancer |
+| `api.uptimerouter.com` | Direct Route53 A records to attested gateways | Inside GCP Confidential Space |
+
+The API record is not a CNAME. The gateway health reconciler copies the
+attestation-gated healthy IP set into Route53 and freezes the last-good set on
+any validation failure. Each gateway includes `api.uptimerouter.com` in its
+in-enclave ACME allowlist.
+
+The trust surface first reads the canonical published release and then falls
+back to the independently hosted, committed release artifact on GitHub. Both
+sources pass the same issuer, audience, repository, commit, image, and digest
+validation. If neither validates, the trust endpoints return 503 rather than
+silently serving an old embedded digest.
+
+## DNS
+
+Route53 hosted zone: `Z00893363GIOMU7Z8647K`
+
+```text
+ns-855.awsdns-42.net
+ns-509.awsdns-63.com
+ns-1544.awsdns-01.co.uk
+ns-1243.awsdns-27.org
+```
+
+## Authentication
+
+UptimeRouter has independent Google and GitHub OAuth clients. Both callbacks
+remain on `uptimerouter.com`; signed state binds the initiating hostname and
+host-only cookies keep sessions isolated from other product domains.
+
+Run `scripts/deploy/ensure_uptimerouter_alias.sh` after DNS changes to
+idempotently create and attach the Google-managed control-plane certificate.

--- a/scripts/deploy/ensure_uptimerouter_alias.sh
+++ b/scripts/deploy/ensure_uptimerouter_alias.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Provision and attach UptimeRouter's control-plane certificate. The shared
+# helper is parameterized even though its historical filename mentions Ally.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CERT_NAME="${CERT_NAME:-uptimerouter-control-cert-v1}" \
+DOMAINS="${DOMAINS:-uptimerouter.com,www.uptimerouter.com,status.uptimerouter.com,trust.uptimerouter.com}" \
+  exec "${SCRIPT_DIR}/ensure_allyrouter_alias.sh"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -67,8 +67,14 @@ add_secret_env_if_exists "ALIBABA_API_KEY" "trustedrouter-alibaba-api-key"
 add_secret_env_if_exists "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key"
 add_secret_env_if_exists "TR_GOOGLE_CLIENT_ID" "trustedrouter-google-client-id"
 add_secret_env_if_exists "TR_GOOGLE_CLIENT_SECRET" "trustedrouter-google-client-secret"
+add_secret_env_if_exists \
+  "TR_GOOGLE_ALIAS_CREDENTIALS_JSON" \
+  "trustedrouter-google-alias-credentials-json"
 add_secret_env_if_exists "TR_GITHUB_CLIENT_ID" "trustedrouter-github-client-id"
 add_secret_env_if_exists "TR_GITHUB_CLIENT_SECRET" "trustedrouter-github-client-secret"
+add_secret_env_if_exists \
+  "TR_GITHUB_ALIAS_CREDENTIALS_JSON" \
+  "trustedrouter-github-alias-credentials-json"
 # SES email credentials only; not used for AWS hosting or failover.
 add_secret_env_if_exists "TR_AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
 add_secret_env_if_exists "TR_AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
@@ -270,7 +276,7 @@ ENV_VARS=(
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"
-  "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com"
+  "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com,uptimerouter.com"
   "TR_STORAGE_BACKEND=${STORAGE_BACKEND}"
   # Exactly $0.10 once per newly created email/OAuth account. Wallet-only
   # accounts stay at $0. Keep this explicit so stale env cannot change policy.
@@ -291,6 +297,7 @@ ENV_VARS=(
   "TR_TRUST_GCP_IMAGE_REFERENCE=${TRUST_IMAGE_REFERENCE}"
   "TR_TRUST_GCP_IMAGE_DIGEST=${TRUST_IMAGE_DIGEST}"
   "TR_TRUST_GCP_RELEASE_URL=${TRUST_FILE_URL}"
+  "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=https://raw.githubusercontent.com/Lore-Hex/quill-cloud-proxy/main/trust-page/gcp-release.json"
   "TR_GOOGLE_OAUTH_REDIRECT_URL=https://trustedrouter.com/google_oauth_callback"
   "TR_GITHUB_OAUTH_REDIRECT_URL=https://trustedrouter.com/github_oauth_callback"
   "TR_SIWE_DOMAIN=trustedrouter.com"

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -265,8 +265,14 @@ fi
 # rule treats half-configured providers as a hard error.
 ensure_secret_from_env_file "GOOGLE_CLIENT_ID" "trustedrouter-google-client-id"
 ensure_secret_from_env_file "GOOGLE_CLIENT_SECRET" "trustedrouter-google-client-secret"
+ensure_secret_from_env_file \
+  "GOOGLE_ALIAS_CREDENTIALS_JSON" \
+  "trustedrouter-google-alias-credentials-json"
 ensure_secret_from_env_file "GITHUB_CLIENT_ID" "trustedrouter-github-client-id"
 ensure_secret_from_env_file "GITHUB_CLIENT_SECRET" "trustedrouter-github-client-secret"
+ensure_secret_from_env_file \
+  "GITHUB_ALIAS_CREDENTIALS_JSON" \
+  "trustedrouter-github-alias-credentials-json"
 # SES email credentials only; not used for AWS hosting or failover.
 ensure_secret_from_env_file "AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
 ensure_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -26,7 +27,7 @@ class Settings(BaseSettings):
     # usable as independent operational aliases. SEO canonicals still point at
     # ``trusted_domain``. The corresponding inference hostname is derived as
     # ``api.<alias>/v1`` and still terminates inside the attested gateway.
-    trusted_domain_aliases: str = "allyrouter.com"
+    trusted_domain_aliases: str = "allyrouter.com,uptimerouter.com"
     legal_entity_name: str = "Lore Hex Corp"
     legal_entity_type: str = "Delaware C Corporation"
     legal_entity_address: str = "1111 Brickell Ave, Floor 10, Miami, FL 33131"
@@ -152,6 +153,10 @@ class Settings(BaseSettings):
     # release from this canonical, independently published record. The
     # deploy-time values above remain the offline/local fallback.
     trust_gcp_release_url: str = ""
+    # Independently hosted copies keep the backup-domain trust pages live when
+    # the canonical DNS zone is unavailable. Every fetched record is subjected
+    # to the same strict release validation before it enters the cache.
+    trust_gcp_release_fallback_urls: str = ""
 
     rate_limit_enabled: bool = True
     rate_limit_window_seconds: int = 60
@@ -193,9 +198,19 @@ class Settings(BaseSettings):
     google_client_id: str | None = None
     google_client_secret: str | None = None
     google_oauth_redirect_url: str | None = None
+    # Backup domains use independent provider credentials so login remains
+    # available even if the canonical domain or its OAuth app is unavailable.
+    # Each provider has its own Secret Manager value so credentials can rotate
+    # independently without exposing one provider while updating the other.
+    google_alias_credentials_json: str = "{}"
     github_client_id: str | None = None
     github_client_secret: str | None = None
     github_oauth_redirect_url: str | None = None
+    # GitHub OAuth Apps permit exactly one callback URL. Each independent
+    # first-party domain therefore has its own app credentials, supplied as a
+    # single Secret Manager JSON value:
+    # {"allyrouter.com":{"client_id":"...","client_secret":"..."}}
+    github_alias_credentials_json: str = "{}"
     # MetaMask uses public-key crypto (no shared secret). The SIWE message
     # carries this domain so wallet UIs show the right hostname.
     siwe_domain: str | None = None
@@ -535,6 +550,12 @@ class Settings(BaseSettings):
             )
         elif not self.trust_gcp_release_url.startswith("https://"):
             missing.append("TR_TRUST_GCP_RELEASE_URL=https://...")
+        invalid_release_fallbacks = [
+            url for url in self.trust_gcp_release_fallback_url_list
+            if not url.startswith("https://")
+        ]
+        if invalid_release_fallbacks:
+            missing.append("TR_TRUST_GCP_RELEASE_FALLBACK_URLS must contain HTTPS URLs")
         # OAuth providers are independently optional in production. We DO
         # enforce that no provider is half-configured: a client_id without
         # the matching client_secret would cause silent runtime failures.
@@ -542,6 +563,39 @@ class Settings(BaseSettings):
             missing.append("TR_GOOGLE_CLIENT_ID and TR_GOOGLE_CLIENT_SECRET must both be set or both unset")
         if bool(self.github_client_id) != bool(self.github_client_secret):
             missing.append("TR_GITHUB_CLIENT_ID and TR_GITHUB_CLIENT_SECRET must both be set or both unset")
+        configured_aliases = {
+            value.strip().lower().rstrip(".")
+            for value in self.trusted_domain_aliases.split(",")
+            if value.strip()
+        }
+        for provider, canonical_enabled, raw_credentials in (
+            ("GOOGLE", self.google_oauth_enabled, self.google_alias_credentials_json),
+            ("GITHUB", self.github_oauth_enabled, self.github_alias_credentials_json),
+        ):
+            setting_name = f"TR_{provider}_ALIAS_CREDENTIALS_JSON"
+            try:
+                alias_credentials = _parse_oauth_alias_credentials(
+                    raw_credentials,
+                    setting_name,
+                )
+            except ValueError as exc:
+                missing.append(str(exc))
+                alias_credentials = {}
+            unknown_oauth_aliases = sorted(set(alias_credentials) - configured_aliases)
+            if unknown_oauth_aliases:
+                missing.append(
+                    f"{setting_name} contains unconfigured domain(s): "
+                    + ", ".join(unknown_oauth_aliases)
+                )
+            if canonical_enabled:
+                missing_oauth_aliases = sorted(
+                    configured_aliases - set(alias_credentials)
+                )
+                if missing_oauth_aliases:
+                    missing.append(
+                        f"{setting_name} is missing configured domain(s): "
+                        + ", ".join(missing_oauth_aliases)
+                    )
         paypal_fields = [
             self.paypal_client_id,
             self.paypal_client_secret,
@@ -566,6 +620,30 @@ class Settings(BaseSettings):
         return bool(self.github_client_id and self.github_client_secret)
 
     @property
+    def trust_gcp_release_fallback_url_list(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                value.strip()
+                for value in self.trust_gcp_release_fallback_urls.split(",")
+                if value.strip()
+            )
+        )
+
+    @property
+    def google_alias_credentials(self) -> dict[str, tuple[str, str]]:
+        return _parse_oauth_alias_credentials(
+            self.google_alias_credentials_json,
+            "TR_GOOGLE_ALIAS_CREDENTIALS_JSON",
+        )
+
+    @property
+    def github_alias_credentials(self) -> dict[str, tuple[str, str]]:
+        return _parse_oauth_alias_credentials(
+            self.github_alias_credentials_json,
+            "TR_GITHUB_ALIAS_CREDENTIALS_JSON",
+        )
+
+    @property
     def paypal_enabled(self) -> bool:
         return bool(self.paypal_client_id and self.paypal_client_secret)
 
@@ -582,6 +660,32 @@ class Settings(BaseSettings):
         return bool(self.aws_access_key_id and self.aws_secret_access_key and self.ses_from_email)
 
 
+def _parse_oauth_alias_credentials(
+    raw_json: str,
+    setting_name: str,
+) -> dict[str, tuple[str, str]]:
+    try:
+        payload = json.loads(raw_json or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{setting_name} must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{setting_name} must be a JSON object")
+
+    credentials: dict[str, tuple[str, str]] = {}
+    for raw_domain, raw_config in payload.items():
+        domain = str(raw_domain).strip().lower().rstrip(".")
+        if not domain or not isinstance(raw_config, dict):
+            raise ValueError(f"{setting_name} has an invalid entry")
+        client_id = raw_config.get("client_id")
+        client_secret = raw_config.get("client_secret")
+        if not isinstance(client_id, str) or not client_id.strip():
+            raise ValueError(f"{setting_name} entry is missing client_id")
+        if not isinstance(client_secret, str) or not client_secret.strip():
+            raise ValueError(f"{setting_name} entry is missing client_secret")
+        credentials[domain] = (client_id.strip(), client_secret.strip())
+    return credentials
+
+
 # Names that flow from `~/.quill_cloud_keys.private` into Settings as a
 # fallback when the matching `TR_<UPPER>` env var isn't set. Provider API
 # keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) stay in the LocalKeyFile
@@ -590,9 +694,11 @@ _LOCAL_KEY_FALLBACKS: tuple[str, ...] = (
     "google_client_id",
     "google_client_secret",
     "google_oauth_redirect_url",
+    "google_alias_credentials_json",
     "github_client_id",
     "github_client_secret",
     "github_oauth_redirect_url",
+    "github_alias_credentials_json",
     "siwe_domain",
     "aws_access_key_id",
     "aws_secret_access_key",

--- a/src/trusted_router/routes/oauth.py
+++ b/src/trusted_router/routes/oauth.py
@@ -10,13 +10,16 @@ For each `OAuthProvider` in `OAUTH_PROVIDERS` we register two routes:
   page (new user) or the requested `next` / `/console/api-keys`.
 
 The callback path is `/{slug}_oauth_callback` (not `/auth/{slug}/callback`)
-because Google + GitHub require the redirect URL registered with them to
-match exactly, and ours are `https://trustedrouter.com/google_oauth_callback`
-and `https://TrustedRouter.com/github_oauth_callback`.
+because providers require an exact registered redirect URI. Every first-party
+domain uses its own provider client and same-origin callback, so a backup
+domain never depends on the canonical domain to complete login.
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import secrets
 
 from fastapi import APIRouter, FastAPI, Request, Response
@@ -25,7 +28,7 @@ from fastapi.responses import RedirectResponse
 from trusted_router.acquisition import record_signup_attribution
 from trusted_router.auth import SettingsDep, set_session_cookie
 from trusted_router.config import Settings
-from trusted_router.domains import request_control_domain
+from trusted_router.domains import configured_control_domains, request_hostname
 from trusted_router.errors import api_error
 from trusted_router.oauth_provider import (
     OAUTH_PROVIDERS,
@@ -39,6 +42,7 @@ from trusted_router.types import ErrorType
 OAUTH_STATE_COOKIE = "tr_oauth_state"
 OAUTH_NEXT_COOKIE = "tr_oauth_next"
 OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
+OAUTH_STATE_VERSION = "v1"
 
 # Short-lived one-shot cookie that carries the raw API key from the OAuth
 # signup callback to the /console/welcome reveal page. Without this the
@@ -91,14 +95,26 @@ async def _handle_login(
     settings: Settings,
     next_path: str | None,
 ) -> Response:
-    if not _enabled(provider, settings):
+    request_domain = _request_oauth_domain(request, settings)
+    if request_domain is None:
+        raise api_error(400, "Invalid OAuth host", ErrorType.BAD_REQUEST)
+    if not _enabled(provider, settings, request_domain):
         raise api_error(
             404, f"{provider.slug.title()} sign-in is not configured", ErrorType.NOT_FOUND,
         )
-    redirect_uri = _redirect_uri(provider, request, settings)
-    state = secrets.token_urlsafe(24)
+    redirect_uri = _provider_redirect_uri(
+        provider,
+        request,
+        settings,
+        request_domain,
+    )
+    state = _new_state(
+        provider,
+        request_domain,
+        settings,
+    )
     url = provider.authorize_redirect(
-        client_id=_client_id(provider, settings) or "",
+        client_id=_client_id(provider, settings, request_domain) or "",
         redirect_uri=redirect_uri,
         state=state,
     )
@@ -115,12 +131,20 @@ async def _handle_callback(
     code: str | None,
     state: str | None,
 ) -> Response:
-    if not _enabled(provider, settings):
+    if not code or not state:
+        raise api_error(400, "Missing OAuth code or state", ErrorType.BAD_REQUEST)
+    state_domain = _state_domain(provider, state, settings)
+    if state_domain is None:
+        raise api_error(400, "Invalid OAuth state", ErrorType.BAD_REQUEST)
+    if not _enabled(provider, settings, state_domain):
         raise api_error(
             404, f"{provider.slug.title()} sign-in is not configured", ErrorType.NOT_FOUND,
         )
-    if not code or not state:
-        raise api_error(400, "Missing OAuth code or state", ErrorType.BAD_REQUEST)
+
+    request_domain = _request_oauth_domain(request, settings)
+    if request_domain is None or request_domain != state_domain:
+        raise api_error(400, "Invalid OAuth callback host", ErrorType.BAD_REQUEST)
+
     cookie_state = request.cookies.get(OAUTH_STATE_COOKIE)
     if not cookie_state or cookie_state != state:
         raise api_error(400, "Invalid OAuth state", ErrorType.BAD_REQUEST)
@@ -128,9 +152,14 @@ async def _handle_callback(
     access_token = await exchange_code(
         provider=provider,
         code=code,
-        client_id=_client_id(provider, settings) or "",
-        client_secret=_client_secret(provider, settings) or "",
-        redirect_uri=_redirect_uri(provider, request, settings),
+        client_id=_client_id(provider, settings, state_domain) or "",
+        client_secret=_client_secret(provider, settings, state_domain) or "",
+        redirect_uri=_provider_redirect_uri(
+            provider,
+            request,
+            settings,
+            state_domain,
+        ),
     )
     info = await fetch_user(provider=provider, access_token=access_token)
     if not info.email_verified:
@@ -206,35 +235,152 @@ async def _handle_callback(
     return response
 
 
-def _enabled(provider: OAuthProvider, settings: Settings) -> bool:
-    if provider.slug == "google":
-        return settings.google_oauth_enabled
-    if provider.slug == "github":
-        return settings.github_oauth_enabled
-    return False
+def _enabled(provider: OAuthProvider, settings: Settings, domain: str) -> bool:
+    return bool(
+        _client_id(provider, settings, domain)
+        and _client_secret(provider, settings, domain)
+    )
 
 
-def _client_id(provider: OAuthProvider, settings: Settings) -> str | None:
+def _request_oauth_domain(request: Request, settings: Settings) -> str | None:
+    """Return an exact configured apex, never the generic Host fallback.
+
+    Public rendering intentionally falls back to the canonical domain when an
+    unknown Host arrives so untrusted values are never reflected. OAuth must be
+    stricter: treating an unknown or prefixed host as canonical would weaken
+    the same-origin binding carried in signed state.
+    """
+    hostname = request_hostname(request)
+    domains = configured_control_domains(settings)
+    if hostname in domains:
+        return hostname
+    local_hostname = request.headers.get("host", "").split(":", 1)[0].lower()
+    if settings.environment.lower() in {"local", "test"} and local_hostname in {
+        "127.0.0.1",
+        "localhost",
+        "testserver",
+    }:
+        return domains[0]
+    return None
+
+
+def _client_id(
+    provider: OAuthProvider,
+    settings: Settings,
+    domain: str,
+) -> str | None:
+    if domain != configured_control_domains(settings)[0]:
+        credentials = _alias_credentials(provider, settings).get(domain)
+        return credentials[0] if credentials else None
     return getattr(settings, f"{provider.slug}_client_id", None)
 
 
-def _client_secret(provider: OAuthProvider, settings: Settings) -> str | None:
+def _client_secret(
+    provider: OAuthProvider,
+    settings: Settings,
+    domain: str,
+) -> str | None:
+    if domain != configured_control_domains(settings)[0]:
+        credentials = _alias_credentials(provider, settings).get(domain)
+        return credentials[1] if credentials else None
     return getattr(settings, f"{provider.slug}_client_secret", None)
 
 
-def _redirect_uri(provider: OAuthProvider, request: Request, settings: Settings) -> str:
-    request_domain = request_control_domain(request, settings)
-    if request_domain != settings.trusted_domain:
-        # Alias OAuth remains same-origin so the host-only CSRF/session cookies
-        # survive the callback. Each provider must explicitly allow this URI;
-        # an unlisted Host header cannot reach this branch.
-        return f"https://{request_domain}/{provider.slug}_oauth_callback"
+def _alias_credentials(
+    provider: OAuthProvider,
+    settings: Settings,
+) -> dict[str, tuple[str, str]]:
+    credentials = getattr(settings, f"{provider.slug}_alias_credentials", None)
+    if isinstance(credentials, dict):
+        return credentials
+    return {}
+
+
+def _provider_redirect_uri(
+    provider: OAuthProvider,
+    request: Request,
+    settings: Settings,
+    domain: str,
+) -> str:
+    """Return the provider-registered callback URI for this domain.
+
+    Every production domain completes OAuth on its own origin and uses an
+    independent OAuth client. GitHub requires this because an OAuth App permits
+    one callback URL; using the same isolation for Google preserves login when
+    a canonical-domain OAuth client is disabled or misconfigured.
+    """
+    if domain != configured_control_domains(settings)[0]:
+        return f"https://{domain}/{provider.slug}_oauth_callback"
     configured = getattr(settings, f"{provider.slug}_oauth_redirect_url", None)
     if configured:
         return configured
     scheme = "https" if settings.environment.lower() == "production" else request.url.scheme
     host = request.headers.get("host", request.url.netloc)
     return f"{scheme}://{host}/{provider.slug}_oauth_callback"
+
+
+def _new_state(
+    provider: OAuthProvider,
+    domain: str,
+    settings: Settings,
+) -> str:
+    nonce = secrets.token_urlsafe(24)
+    encoded_domain = _b64encode(domain.encode("ascii"))
+    unsigned = f"{OAUTH_STATE_VERSION}.{encoded_domain}.{nonce}"
+    signature = _state_signature(provider, unsigned, settings, domain)
+    return f"{unsigned}.{signature}"
+
+
+def _state_domain(
+    provider: OAuthProvider,
+    state: str,
+    settings: Settings,
+) -> str | None:
+    parts = state.split(".")
+    if len(parts) != 4 or parts[0] != OAUTH_STATE_VERSION:
+        return None
+    try:
+        domain = _b64decode(parts[1]).decode("ascii")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if domain not in configured_control_domains(settings):
+        return None
+    unsigned = ".".join(parts[:3])
+    try:
+        expected = _state_signature(provider, unsigned, settings, domain)
+    except RuntimeError:
+        return None
+    if not hmac.compare_digest(parts[3], expected):
+        return None
+    return domain
+
+
+def _state_signature(
+    provider: OAuthProvider,
+    unsigned_state: str,
+    settings: Settings,
+    domain: str,
+) -> str:
+    secret = _client_secret(provider, settings, domain)
+    if not secret:
+        # Callers already reject disabled providers. Keeping this fail-closed
+        # guard makes the helper safe if it is reused independently.
+        raise RuntimeError(f"{provider.slug} OAuth client secret is unavailable")
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        f"{provider.slug}:{unsigned_state}".encode(),
+        hashlib.sha256,
+    ).digest()
+    return _b64encode(digest)
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.b64decode(value + padding, altchars=b"-_", validate=True)
 
 
 def _safe_next_path(value: str | None) -> str | None:

--- a/src/trusted_router/services/trust_release.py
+++ b/src/trusted_router/services/trust_release.py
@@ -60,8 +60,16 @@ class TrustReleaseResolver:
         self._refresh_lock = asyncio.Lock()
 
     async def resolve(self) -> ResolvedTrustRelease:
-        release_url = self._settings.trust_gcp_release_url.strip()
-        if not release_url:
+        release_urls = tuple(
+            dict.fromkeys(
+                [
+                    self._settings.trust_gcp_release_url.strip(),
+                    *self._settings.trust_gcp_release_fallback_url_list,
+                ]
+            )
+        )
+        release_urls = tuple(url for url in release_urls if url)
+        if not release_urls:
             return ResolvedTrustRelease(
                 metadata=_embedded_metadata(self._settings),
                 status="embedded",
@@ -79,14 +87,20 @@ class TrustReleaseResolver:
                 return ResolvedTrustRelease(metadata=self._entry.metadata, status="live")
             if now < self._retry_after:
                 return self._stale_or_raise(now)
-            try:
-                metadata = await self._fetch(release_url)
-            except (httpx.HTTPError, TypeError, ValueError) as exc:
+            last_error: Exception | None = None
+            metadata: Mapping[str, str] | None = None
+            for release_url in release_urls:
+                try:
+                    metadata = await self._fetch(release_url)
+                    break
+                except (httpx.HTTPError, TypeError, ValueError) as exc:
+                    last_error = exc
+            if metadata is None:
                 self._retry_after = now + _RETRY_SECONDS
                 try:
                     return self._stale_or_raise(now)
                 except TrustReleaseUnavailable as unavailable:
-                    raise unavailable from exc
+                    raise unavailable from last_error
 
             self._retry_after = 0.0
             self._entry = _CacheEntry(

--- a/tests/test_domain_aliases.py
+++ b/tests/test_domain_aliases.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlsplit
 
+import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from trusted_router.config import Settings
 from trusted_router.domains import (
@@ -45,23 +50,31 @@ def test_configured_domains_are_normalized_and_deduplicated() -> None:
     )
 
 
-def test_allyrouter_homepage_uses_attested_api_alias(client: TestClient) -> None:
-    response = client.get("/", headers={"host": "allyrouter.com"})
+@pytest.mark.parametrize("domain", ["allyrouter.com", "uptimerouter.com"])
+def test_alias_homepage_uses_attested_api_alias(
+    client: TestClient,
+    domain: str,
+) -> None:
+    response = client.get("/", headers={"host": domain})
     assert response.status_code == 200
-    assert "https://api.allyrouter.com/v1" in response.text
+    assert f"https://api.{domain}/v1" in response.text
     assert '<link rel="canonical" href="https://trustedrouter.com/">' in response.text
 
 
-def test_allyrouter_status_and_trust_hosts_render(client: TestClient) -> None:
-    status = client.get("/", headers={"host": "status.allyrouter.com"})
-    trust = client.get("/", headers={"host": "trust.allyrouter.com"})
+@pytest.mark.parametrize("domain", ["allyrouter.com", "uptimerouter.com"])
+def test_alias_status_and_trust_hosts_render(
+    client: TestClient,
+    domain: str,
+) -> None:
+    status = client.get("/", headers={"host": f"status.{domain}"})
+    trust = client.get("/", headers={"host": f"trust.{domain}"})
 
     assert status.status_code == 200
     assert "TrustedRouter Status" in status.text
-    assert "https://api.allyrouter.com/v1" in status.text
+    assert f"https://api.{domain}/v1" in status.text
     assert trust.status_code == 200
-    assert "https://api.allyrouter.com/v1" in trust.text
-    assert "https://api.allyrouter.com/attestation" in trust.text
+    assert f"https://api.{domain}/v1" in trust.text
+    assert f"https://api.{domain}/attestation" in trust.text
     assert '<link rel="canonical" href="https://trust.trustedrouter.com/">' in trust.text
 
 
@@ -129,24 +142,310 @@ def test_wallet_challenge_uses_alias_siwe_domain(client: TestClient) -> None:
     assert "URI: https://allyrouter.com" in message
 
 
-def test_google_oauth_callback_stays_same_origin_on_alias() -> None:
+@pytest.mark.parametrize(
+    ("domain", "client_id"),
+    [
+        ("allyrouter.com", "ally-google-client"),
+        ("uptimerouter.com", "uptime-google-client"),
+    ],
+)
+def test_google_oauth_callback_stays_same_origin_on_alias(
+    domain: str,
+    client_id: str,
+) -> None:
     settings = Settings(
         environment="test",
-        google_client_id="client-id",
-        google_client_secret="client-secret",  # noqa: S106 - test credential.
+        trusted_domain_aliases="allyrouter.com,uptimerouter.com",
+        google_client_id="canonical-client-id",
+        google_client_secret="canonical-client-secret",  # noqa: S106
         google_oauth_redirect_url="https://trustedrouter.com/google_oauth_callback",
+        google_alias_credentials_json=json.dumps(
+            {
+                domain: {
+                    "client_id": client_id,
+                    "client_secret": f"{domain}-secret",
+                }
+            }
+        ),
     )
     client = TestClient(create_app(settings, init_observability=False))
 
     response = client.get(
         "/auth/google/login",
-        headers={"host": "allyrouter.com"},
+        headers={"host": domain},
         follow_redirects=False,
     )
 
     assert response.status_code == 302
     query = parse_qs(urlsplit(response.headers["location"]).query)
-    assert query["redirect_uri"] == ["https://allyrouter.com/google_oauth_callback"]
+    assert query["client_id"] == [client_id]
+    assert query["redirect_uri"] == [f"https://{domain}/google_oauth_callback"]
+
+
+def test_normalized_canonical_domain_uses_canonical_oauth_client() -> None:
+    settings = Settings(
+        environment="test",
+        trusted_domain="TrustedRouter.COM.",
+        google_client_id="canonical-client",
+        google_client_secret="canonical-secret",  # noqa: S106
+        google_oauth_redirect_url=(
+            "https://trustedrouter.com/google_oauth_callback"
+        ),
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+
+    response = client.get(
+        "/auth/google/login",
+        headers={"host": "trustedrouter.com"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    query = parse_qs(urlsplit(response.headers["location"]).query)
+    assert query["client_id"] == ["canonical-client"]
+    assert query["redirect_uri"] == [
+        "https://trustedrouter.com/google_oauth_callback"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("domain", "client_id"),
+    [
+        ("allyrouter.com", "ally-github-client"),
+        ("uptimerouter.com", "uptime-github-client"),
+    ],
+)
+def test_github_oauth_uses_domain_specific_client(
+    domain: str,
+    client_id: str,
+) -> None:
+    settings = Settings(
+        environment="test",
+        trusted_domain_aliases="allyrouter.com,uptimerouter.com",
+        github_client_id="canonical-client-id",
+        github_client_secret="canonical-client-secret",  # noqa: S106
+        github_oauth_redirect_url="https://trustedrouter.com/github_oauth_callback",
+        github_alias_credentials_json=json.dumps(
+            {
+                domain: {
+                    "client_id": client_id,
+                    "client_secret": f"{domain}-secret",
+                }
+            }
+        ),
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+
+    response = client.get(
+        "/auth/github/login",
+        headers={"host": domain},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    query = parse_qs(urlsplit(response.headers["location"]).query)
+    assert query["client_id"] == [client_id]
+    assert query["redirect_uri"] == [f"https://{domain}/github_oauth_callback"]
+
+
+def test_oauth_state_cannot_cross_backup_domains() -> None:
+    alias_credentials = {
+        domain: {
+            "client_id": f"{domain}-client",
+            "client_secret": f"{domain}-secret",
+        }
+        for domain in ("allyrouter.com", "uptimerouter.com")
+    }
+    settings = Settings(
+        environment="test",
+        trusted_domain_aliases="allyrouter.com,uptimerouter.com",
+        google_client_id="canonical-client-id",
+        google_client_secret="canonical-client-secret",  # noqa: S106
+        google_alias_credentials_json=json.dumps(alias_credentials),
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+    login = client.get(
+        "/auth/google/login",
+        headers={"host": "allyrouter.com"},
+        follow_redirects=False,
+    )
+    state = parse_qs(urlsplit(login.headers["location"]).query)["state"][0]
+
+    callback = client.get(
+        f"/google_oauth_callback?code=test&state={state}",
+        headers={
+            "host": "uptimerouter.com",
+            "cookie": f"tr_oauth_state={state}",
+        },
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 400
+    assert callback.json()["error"]["message"] == "Invalid OAuth callback host"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "attacker.example",
+        "trust.uptimerouter.com",
+    ],
+)
+def test_oauth_rejects_non_apex_host_instead_of_using_canonical_fallback(
+    host: str,
+) -> None:
+    settings = Settings(
+        environment="test",
+        google_client_id="canonical-client-id",
+        google_client_secret="canonical-client-secret",  # noqa: S106
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+
+    response = client.get(
+        "/auth/google/login",
+        headers={"host": host},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Invalid OAuth host"
+
+
+@pytest.mark.parametrize("host", ["www.uptimerouter.com", "status.uptimerouter.com"])
+def test_oauth_on_redirecting_alias_host_moves_to_exact_apex(host: str) -> None:
+    settings = Settings(environment="test")
+    client = TestClient(create_app(settings, init_observability=False))
+
+    response = client.get(
+        "/auth/google/login?next=/console",
+        headers={"host": host},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 308
+    assert response.headers["location"] == (
+        "https://uptimerouter.com/auth/google/login?next=/console"
+    )
+
+
+def test_alias_oauth_callback_exchanges_with_same_domain_credentials() -> None:
+    settings = Settings(
+        environment="test",
+        trusted_domain_aliases="allyrouter.com,uptimerouter.com",
+        google_client_id="canonical-client-id",
+        google_client_secret="canonical-client-secret",  # noqa: S106
+        google_alias_credentials_json=json.dumps(
+            {
+                "uptimerouter.com": {
+                    "client_id": "uptime-client-id",
+                    "client_secret": "uptime-client-secret",
+                }
+            }
+        ),
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+    login = client.get(
+        "/auth/google/login",
+        headers={"host": "uptimerouter.com"},
+        follow_redirects=False,
+    )
+    state = parse_qs(urlsplit(login.headers["location"]).query)["state"][0]
+    exchanged: dict[str, Any] = {}
+
+    async def fake_exchange(**kwargs: Any) -> str:
+        exchanged.update(kwargs)
+        return "test-access-token"  # noqa: S105
+
+    async def fake_fetch_user(**_: Any) -> Any:
+        from trusted_router.oauth_provider import OAuthUserInfo
+
+        return OAuthUserInfo(
+            sub="uptime-user",
+            email="uptime-oauth@example.com",
+            email_verified=True,
+            display_name="Uptime User",
+        )
+
+    with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), patch(
+        "trusted_router.routes.oauth.fetch_user",
+        fake_fetch_user,
+    ):
+        callback = client.get(
+            f"/google_oauth_callback?code=test-code&state={state}",
+            headers={"host": "uptimerouter.com"},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 302
+    assert exchanged["client_id"] == "uptime-client-id"
+    assert exchanged["client_secret"] == "uptime-client-secret"  # noqa: S105
+    assert exchanged["redirect_uri"] == (
+        "https://uptimerouter.com/google_oauth_callback"
+    )
+
+
+def test_alias_oauth_credentials_are_normalized_and_fail_closed() -> None:
+    settings = Settings(
+        environment="test",
+        google_alias_credentials_json=json.dumps(
+            {
+                " UPTIMEROUTER.COM. ": {
+                    "client_id": " client-id ",
+                    "client_secret": " client-secret ",
+                }
+            }
+        ),
+    )
+    assert settings.google_alias_credentials == {
+        "uptimerouter.com": ("client-id", "client-secret")
+    }
+
+    malformed = Settings(
+        environment="test",
+        github_alias_credentials_json="not-json",
+    )
+    with pytest.raises(ValueError, match="must be valid JSON"):
+        _ = malformed.github_alias_credentials
+
+
+def test_production_oauth_requires_credentials_for_every_backup_domain() -> None:
+    values = {
+        "environment": "production",
+        "internal_gateway_token": "internal-token",
+        "stripe_webhook_secret": "whsec-test",
+        "stripe_secret_key": "sk-test",
+        "sentry_dsn": "https://example@example.ingest.sentry.io/1",
+        "storage_backend": "spanner-bigtable",
+        "spanner_instance_id": "trusted-router",
+        "spanner_database_id": "trusted-router",
+        "bigtable_instance_id": "trusted-router-logs",
+        "byok_kms_key_name": "projects/test/locations/global/keyRings/test/cryptoKeys/test",
+        "trusted_domain_aliases": "allyrouter.com,uptimerouter.com",
+        "google_client_id": "canonical-google",
+        "google_client_secret": "canonical-google-secret",
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="TR_GOOGLE_ALIAS_CREDENTIALS_JSON is missing configured domain",
+    ):
+        Settings(**values)
+
+    alias_credentials = {
+        domain: {
+            "client_id": f"{domain}-client",
+            "client_secret": f"{domain}-secret",
+        }
+        for domain in ("allyrouter.com", "uptimerouter.com")
+    }
+    settings = Settings(
+        **values,
+        google_alias_credentials_json=json.dumps(alias_credentials),
+    )
+    assert set(settings.google_alias_credentials) == {
+        "allyrouter.com",
+        "uptimerouter.com",
+    }
 
 
 def test_console_uses_attested_api_alias(client: TestClient) -> None:

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from eth_account import Account
@@ -59,6 +60,14 @@ def github_client(github_settings: Settings) -> Iterator[TestClient]:
     app = create_app(github_settings, init_observability=False)
     with TestClient(app) as client:
         yield client
+
+
+def _begin_oauth(client: TestClient, provider: str) -> str:
+    response = client.get(f"/auth/{provider}/login", follow_redirects=False)
+    assert response.status_code == 302
+    state = parse_qs(urlsplit(response.headers["location"]).query)["state"][0]
+    assert client.cookies.get("tr_oauth_state") == state
+    return state
 
 
 # ── Provider availability ───────────────────────────────────────────────────
@@ -143,7 +152,7 @@ async def test_google_oauth_helpers_use_expected_http_contract(httpx_mock) -> No
 
 
 def test_google_callback_rejects_state_mismatch(google_client: TestClient) -> None:
-    google_client.cookies.set("tr_oauth_state", "good-state")
+    _begin_oauth(google_client, "google")
     resp = google_client.get(
         "/google_oauth_callback?code=abc&state=evil-state",
         follow_redirects=False,
@@ -153,7 +162,7 @@ def test_google_callback_rejects_state_mismatch(google_client: TestClient) -> No
 
 @pytest.mark.asyncio
 async def test_google_callback_creates_session_for_new_user(google_client: TestClient) -> None:
-    google_client.cookies.set("tr_oauth_state", "matching-state")
+    state = _begin_oauth(google_client, "google")
 
     async def fake_exchange(**_: Any) -> str:
         return "access-token"  # noqa: S105
@@ -171,7 +180,7 @@ async def test_google_callback_creates_session_for_new_user(google_client: TestC
     with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), \
          patch("trusted_router.routes.oauth.fetch_user", fake_fetch_user):
         resp = google_client.get(
-            "/google_oauth_callback?code=auth-code&state=matching-state",
+            f"/google_oauth_callback?code=auth-code&state={state}",
             follow_redirects=False,
         )
     assert resp.status_code == 302
@@ -205,7 +214,7 @@ async def test_google_callback_for_returning_user_sets_no_pending_reveal(
     pointing at a stale value. A returning user already has API keys; the
     welcome page's one-shot reveal is meaningless for them and the cookie
     would only widen the log-exposure surface."""
-    google_client.cookies.set("tr_oauth_state", "matching-state")
+    state = _begin_oauth(google_client, "google")
 
     # Seed an existing user so first_time=False
     seeded = STORE.signup(email="bob@example.com")
@@ -227,7 +236,7 @@ async def test_google_callback_for_returning_user_sets_no_pending_reveal(
     with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), \
          patch("trusted_router.routes.oauth.fetch_user", fake_fetch_user):
         resp = google_client.get(
-            "/google_oauth_callback?code=c&state=matching-state",
+            f"/google_oauth_callback?code=c&state={state}",
             follow_redirects=False,
         )
     assert resp.status_code == 302
@@ -237,7 +246,7 @@ async def test_google_callback_for_returning_user_sets_no_pending_reveal(
 
 @pytest.mark.asyncio
 async def test_google_callback_rejects_unverified_email(google_client: TestClient) -> None:
-    google_client.cookies.set("tr_oauth_state", "matching-state")
+    state = _begin_oauth(google_client, "google")
 
     async def fake_exchange(**_: Any) -> str:
         return "tok"  # noqa: S105
@@ -255,7 +264,7 @@ async def test_google_callback_rejects_unverified_email(google_client: TestClien
     with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), \
          patch("trusted_router.routes.oauth.fetch_user", fake_fetch_user):
         resp = google_client.get(
-            "/google_oauth_callback?code=x&state=matching-state",
+            f"/google_oauth_callback?code=x&state={state}",
             follow_redirects=False,
         )
     assert resp.status_code == 400
@@ -342,7 +351,7 @@ async def test_github_oauth_helper_marks_fallback_email_unverified(httpx_mock) -
 
 @pytest.mark.asyncio
 async def test_github_callback_creates_session(github_client: TestClient) -> None:
-    github_client.cookies.set("tr_oauth_state", "gh-state")
+    state = _begin_oauth(github_client, "github")
 
     async def fake_exchange(**_: Any) -> str:
         return "gh-tok"  # noqa: S105
@@ -360,7 +369,7 @@ async def test_github_callback_creates_session(github_client: TestClient) -> Non
     with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), \
          patch("trusted_router.routes.oauth.fetch_user", fake_fetch_user):
         resp = github_client.get(
-            "/github_oauth_callback?code=c&state=gh-state",
+            f"/github_oauth_callback?code=c&state={state}",
             follow_redirects=False,
         )
     assert resp.status_code == 302

--- a/tests/test_session_cookie_attributes.py
+++ b/tests/test_session_cookie_attributes.py
@@ -74,6 +74,7 @@ def production_settings() -> Settings:
         google_client_id="g-prod",
         google_client_secret="g-prod-secret",  # noqa: S106 - test fixture.
         google_oauth_redirect_url="https://trustedrouter.com/google_oauth_callback",
+        trusted_domain_aliases="",
         byok_kms_key_name=TEST_BYOK_KMS_KEY_NAME,
     )
 
@@ -91,7 +92,11 @@ def test_oauth_state_cookie_is_httponly_secure_lax_in_production(
     """The OAuth state cookie protects against CSRF — if it loses HttpOnly,
     JS can read it; if it loses Secure, downgrade attacks read it; if
     SameSite weakens, third-party iframes can replay it."""
-    resp = production_client.get("/auth/google/login", follow_redirects=False)
+    resp = production_client.get(
+        "/auth/google/login",
+        headers={"host": "trustedrouter.com"},
+        follow_redirects=False,
+    )
     assert resp.status_code == 302
     cookies = _parse_cookies(resp.headers.get("set-cookie", ""))
     state = cookies.get("tr_oauth_state")

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -58,6 +58,39 @@ async def test_live_release_is_validated_and_cached(httpx_mock: HTTPXMock) -> No
 
 
 @pytest.mark.asyncio
+async def test_release_uses_independent_validated_fallback(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://trust.trustedrouter.com/release.json?tr_cache_bucket=10",
+        status_code=503,
+    )
+    httpx_mock.add_response(
+        url="https://trust.backup.example/release.json?tr_cache_bucket=10",
+        json=release_payload(),
+    )
+    resolver = TrustReleaseResolver(
+        Settings(
+            trust_gcp_release_url="https://trust.trustedrouter.com/release.json",
+            trust_gcp_release_fallback_urls=(
+                "https://trust.backup.example/release.json"
+            ),
+        ),
+        monotonic=lambda: 100.0,
+        wall_clock=lambda: 600.0,
+    )
+
+    release = await resolver.resolve()
+
+    assert release.status == "live"
+    assert release.metadata["image_digest"] == IMAGE_DIGEST
+    assert [str(request.url) for request in httpx_mock.get_requests()] == [
+        "https://trust.trustedrouter.com/release.json?tr_cache_bucket=10",
+        "https://trust.backup.example/release.json?tr_cache_bucket=10",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_live_release_uses_bounded_stale_cache_on_refresh_error(
     httpx_mock: HTTPXMock,
 ) -> None:
@@ -201,6 +234,7 @@ def test_alias_trust_routes_render_live_release(httpx_mock: HTTPXMock) -> None:
     assert release.json()["api_base_urls"] == [
         "https://api.trustedrouter.com/v1",
         "https://api.allyrouter.com/v1",
+        "https://api.uptimerouter.com/v1",
     ]
     assert len(httpx_mock.get_requests()) == 1
 


### PR DESCRIPTION
## Summary\n- add independent Google and GitHub OAuth credentials and same-origin callbacks for AllyRouter and UptimeRouter\n- bind OAuth state to the exact domain and provider\n- add UptimeRouter control-plane, status, trust, deployment, and resilience coverage\n\n## Verification\n- 2,471 pytest tests passed, 86 skipped\n- ruff passed\n- mypy passed