### PR TITLE
AWS EU synthetics: COSE attestation parsing + rotation via /internal/synthetic/run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "BUSL-1.1"
 dependencies = [
   "axiom-py>=0.9.0",
   "boto3>=1.35.0",
+  "cbor2>=5.6",
   "cryptography>=43.0.0",
   "email-validator>=2.0.0",
   "eth-account>=0.13.7",

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -311,6 +311,13 @@ class Settings(BaseSettings):
     synthetic_monitor_region: str | None = None
     synthetic_monitor_api_key: str | None = None
     synthetic_monitor_model: str = "trustedrouter/monitor"
+    # Which control plane the /internal/synthetic/run billing probes
+    # (authorize+settle) exercise. None falls back to the canonical GCP
+    # plane, which is correct for GCP monitors but a WRONG-CLOUD trap for
+    # standalone deployments: the EU service must set this to its own
+    # plane or its probes measure another cloud's health. A per-request
+    # body override still wins over this setting.
+    synthetic_control_plane_base_url: str | None = None
     # Per-probe HTTP timeout for real provider-effective synthetic checks.
     # Keep this aligned with the gateway's first-byte budget. A successful
     # /responses probe in europe-west4 can legitimately take >10s on slow

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from dataclasses import asdict
 from typing import Any
 
@@ -13,6 +14,7 @@ from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
 from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.storage_models import scrub_provider_error_message
+from trusted_router.synthetic.cli import rotation_pass
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
     gateway_fallback_probe,
@@ -80,6 +82,17 @@ def register(router: APIRouter) -> None:
         require_internal_gateway(request, settings)
         body = await json_body(request)
         monitor_region = _optional_str(body.get("monitor_region"))
+        # Which control plane the billing probes (authorize+settle) hit.
+        # Precedence: request body > settings > canonical GCP plane. The
+        # settings tier exists because the hardcoded fallback is a
+        # wrong-cloud trap for standalone deployments: the EU service
+        # probing https://trustedrouter.com would record the US plane's
+        # health under an EU monitor region.
+        control_plane_base_url = str(
+            body.get("control_plane_base_url")
+            or settings.synthetic_control_plane_base_url
+            or "https://trustedrouter.com"
+        )
         samples = await run_synthetic_once(settings, monitor_region=monitor_region)
         if settings.synthetic_monitor_api_key and settings.internal_gateway_token:
             timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
@@ -87,9 +100,7 @@ def register(router: APIRouter) -> None:
                 samples.extend(
                     await gateway_billing_probe(
                         client,
-                        control_plane_base_url=str(
-                            body.get("control_plane_base_url") or "https://trustedrouter.com"
-                        ),
+                        control_plane_base_url=control_plane_base_url,
                         monitor_region=monitor_region
                         or settings.synthetic_monitor_region
                         or settings.primary_region,
@@ -101,9 +112,7 @@ def register(router: APIRouter) -> None:
                 samples.extend(
                     await gateway_fallback_probe(
                         client,
-                        control_plane_base_url=str(
-                            body.get("control_plane_base_url") or "https://trustedrouter.com"
-                        ),
+                        control_plane_base_url=control_plane_base_url,
                         monitor_region=monitor_region
                         or settings.synthetic_monitor_region
                         or settings.primary_region,
@@ -112,8 +121,36 @@ def register(router: APIRouter) -> None:
                         model=settings.synthetic_monitor_model,
                     )
                 )
+        benchmark_recorded = 0
+        rotation_count = _rotation_count(body)
+        if rotation_count and settings.synthetic_monitor_api_key:
+            # Provider/model rotation through the gateway — REAL inference,
+            # same pool mechanics as the GCP monitor CLI. Exposed via this
+            # route because standalone deployments (EU) have no monitor
+            # pool: their once-a-minute cadence is an EventBridge rule
+            # whose Input JSON sets rotation_count (and optionally
+            # rotation_models to pin a family, e.g. the DSv4 ids).
+            benchmark_samples = await rotation_pass(
+                settings=settings,
+                monitor_region=monitor_region
+                or settings.synthetic_monitor_region
+                or settings.primary_region,
+                api_key=settings.synthetic_monitor_api_key,
+                timeout=httpx.Timeout(settings.synthetic_monitor_timeout_seconds),
+                count=rotation_count,
+                rng=random.Random(),  # noqa: S311 - picks which model to probe, not cryptographic
+                models=_rotation_models(body),
+            )
+            await run_in_threadpool(_record_benchmark_samples, benchmark_samples)
+            benchmark_recorded = len(benchmark_samples)
         await run_in_threadpool(_record_probe_samples, samples)
-        return {"data": {"recorded": len(samples), "samples": [s.public_dict() for s in samples]}}
+        return {
+            "data": {
+                "recorded": len(samples),
+                "benchmark_recorded": benchmark_recorded,
+                "samples": [s.public_dict() for s in samples],
+            }
+        }
 
 
 def _record_probe_samples(samples: list[SyntheticProbeSample]) -> None:
@@ -228,3 +265,26 @@ def _optional_float(value: Any) -> float | None:
     if value is None or value == "":
         return None
     return float(value)
+
+
+# Ceiling on rotation probes per /run invocation. Each one is a real,
+# billed completion; with a 1-minute EventBridge cadence the worst case is
+# ROTATION_MAX_PER_RUN real requests per minute. A typo'd or hostile Input
+# JSON must not be able to turn the monitor into a spend firehose.
+ROTATION_MAX_PER_RUN = 8
+
+
+def _rotation_count(body: dict[str, Any]) -> int:
+    try:
+        count = int(body.get("rotation_count") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(count, ROTATION_MAX_PER_RUN))
+
+
+def _rotation_models(body: dict[str, Any]) -> frozenset[str] | None:
+    raw = body.get("rotation_models")
+    if not isinstance(raw, list):
+        return None
+    models = frozenset(str(item) for item in raw if isinstance(item, str) and item)
+    return models or None

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -145,7 +145,7 @@ async def _probe_and_rotation_pass(
     if rotation_enabled and api_key:
         benchmark_tasks.append(
             asyncio.create_task(
-                _rotation_pass(
+                rotation_pass(
                     settings=settings,
                     monitor_region=monitor_region,
                     api_key=api_key,
@@ -181,7 +181,7 @@ async def _probe_and_rotation_pass(
     return probe_samples, benchmark_samples
 
 
-async def _rotation_pass(
+async def rotation_pass(
     *,
     settings: Settings,
     monitor_region: str,
@@ -190,8 +190,24 @@ async def _rotation_pass(
     count: int,
     rng: random.Random,
     billing_semaphore: asyncio.Semaphore | None = None,
+    models: frozenset[str] | None = None,
 ) -> list[ProviderBenchmarkSample]:
+    """One rotation pass: `count` random provider+model picks, probed live.
+
+    Public because /internal/synthetic/run also drives it — deployments
+    without a monitor-pool CLI (the standalone EU cloud, where cadence
+    comes from an EventBridge rule) get provider rotation through the
+    route. `models` narrows the candidate pool to specific model ids so a
+    caller can pin rotation to a family (e.g. the DSv4 models) without
+    losing the equal-airtime-per-provider pick.
+    """
     pool = rotation_candidates()
+    if models is not None:
+        pool = {
+            provider: [model for model in candidates if model in models]
+            for provider, candidates in pool.items()
+        }
+        pool = {provider: candidates for provider, candidates in pool.items() if candidates}
     target = SyntheticTarget("rotation", settings.api_base_url, monitor_region)
     limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     probes = []

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -16,6 +16,7 @@ from dataclasses import field as dataclass_field
 from typing import Any
 from urllib.parse import urljoin, urlsplit
 
+import cbor2
 import httpx
 
 from trusted_router.config import Settings
@@ -2293,7 +2294,33 @@ def _responses_text(response: httpx.Response) -> str:
 
 
 def _attestation_evidence(body: bytes, nonce_hex: str) -> dict[str, str | bool | None]:
-    text = body.decode("utf-8", errors="ignore").strip()
+    """Extract nonce binding + identity evidence from an attestation body.
+
+    Two live formats:
+      * GCP Confidential Space — a JWT (ASCII, two dots). Nonce binding is
+        in eat_nonce; identity is the container image_digest claim.
+      * AWS Nitro — a binary COSE_Sign1/CBOR document. Nonce binding is the
+        payload's `nonce` field; identity is PCR0 (the EIF measurement),
+        reported as the attestation_digest so the status page shows the
+        running enclave's measurement, comparable against the trust page.
+
+    JWT is tried first but only for bodies that survive a STRICT ascii
+    decode — a binary CBOR document can contain 0x2E ('.') bytes by chance,
+    so "two dots after a lossy decode" (the previous check) would misroute
+    it. A JWT can never fail ascii decoding, so the ordering is safe.
+
+    This is the once-a-minute LIVENESS + BINDING check. Full chain
+    verification to the AWS Nitro root / Google's JWKS (signatures, cert
+    chains, cert-fingerprint-in-user_data) is the deploy gate's job
+    (tools/verify-attestation.py in quill-cloud-proxy) — pulling X.509
+    chain-walking into the control plane's probe loop would add heavy
+    dependencies for a check whose job is "is the enclave up, answering
+    MY nonce, and running the measurement we expect to see".
+    """
+    try:
+        text = body.decode("ascii").strip()
+    except UnicodeDecodeError:
+        text = ""
     if text.count(".") >= 2:
         payload = _decode_jwt_payload(text)
         nonces = payload.get("eat_nonce") or payload.get("nonces") or payload.get("nonce") or []
@@ -2309,12 +2336,54 @@ def _attestation_evidence(body: bytes, nonce_hex: str) -> dict[str, str | bool |
             "attestation_digest": _claim(payload, "image_digest", "submods.container.image_digest"),
             "source_commit": _claim(payload, "source_commit", "submods.container.source_commit"),
         }
+    aws = _decode_aws_attestation_payload(body)
+    if aws is not None:
+        nonce = aws.get("nonce")
+        nonce_ok = isinstance(nonce, bytes) and nonce.hex() == nonce_hex.lower()
+        pcrs = aws.get("pcrs")
+        pcr0 = pcrs.get(0) if isinstance(pcrs, dict) else None
+        return {
+            "nonce_ok": nonce_ok,
+            "error_type": None if nonce_ok else "nonce_missing",
+            "attestation_digest": pcr0.hex() if isinstance(pcr0, bytes) else None,
+            "source_commit": None,
+        }
     return {
         "nonce_ok": False,
         "error_type": "unsupported_attestation_format",
         "attestation_digest": None,
         "source_commit": None,
     }
+
+
+def _decode_aws_attestation_payload(body: bytes) -> dict[Any, Any] | None:
+    """Decode an AWS Nitro attestation document to its payload map.
+
+    The NSM emits COSE_Sign1: a CBOR array [protected: bstr,
+    unprotected: map, payload: bstr, signature: bstr], sometimes wrapped
+    in CBOR tag 18. The payload bstr is itself a CBOR map (module_id,
+    digest, timestamp, pcrs, nonce, user_data, ...). Returns None for
+    anything that doesn't match that exact shape — the caller then
+    reports unsupported_attestation_format rather than guessing.
+    """
+    try:
+        decoded = cbor2.loads(body)
+    except Exception:
+        return None
+    if isinstance(decoded, cbor2.CBORTag):
+        decoded = decoded.value
+    # cbor2 decodes arrays nested inside tags as immutable tuples (tagged
+    # containers must be hashable), so accept both sequence shapes.
+    if not (isinstance(decoded, (list, tuple)) and len(decoded) == 4):
+        return None
+    payload_bytes = decoded[2]
+    if not isinstance(payload_bytes, bytes):
+        return None
+    try:
+        payload = cbor2.loads(payload_bytes)
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any]:

--- a/tests/test_attestation_evidence.py
+++ b/tests/test_attestation_evidence.py
@@ -1,0 +1,124 @@
+"""_attestation_evidence must understand BOTH live attestation formats.
+
+GCP Confidential Space returns a JWT; AWS Nitro returns a binary
+COSE_Sign1/CBOR document. The parser originally only knew the JWT shape,
+so every probe against the AWS enclave (api-aws.trustedrouter.com)
+reported unsupported_attestation_format and the EU status page sat at 50%
+"trust degraded" while the enclave itself was verifiably healthy.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import cbor2
+
+from trusted_router.synthetic.probes import _attestation_evidence
+
+NONCE = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+PCR0 = bytes.fromhex("2c12e22215d4269d1a788063d59fc5a8cf565b92bf1bee1761d7651b0b9ca513" + "9274504adf001ca6626c7108fafc6883")
+
+
+def _cose_sign1(payload: dict[object, object], *, tag: bool = False) -> bytes:
+    """Build the COSE_Sign1 array shape the Nitro Security Module emits.
+
+    Signature bytes are fake — _attestation_evidence checks nonce binding
+    and extracts PCR0; chain verification is the deploy gate's job.
+    """
+    document = [b"\xa1\x01\x38\x22", {}, cbor2.dumps(payload), b"sig" * 32]
+    if tag:
+        return cbor2.dumps(cbor2.CBORTag(18, document))
+    return cbor2.dumps(document)
+
+
+def _aws_payload(nonce_hex: str = NONCE) -> dict[object, object]:
+    return {
+        "module_id": "i-00abc-enc0123",
+        "digest": "SHA384",
+        "timestamp": 1754000000000,
+        "pcrs": {0: PCR0, 1: b"\x01" * 48, 2: b"\x02" * 48},
+        "certificate": b"fake-der",
+        "cabundle": [b"fake-root"],
+        "nonce": bytes.fromhex(nonce_hex),
+        "user_data": b"\x00" * 32,
+    }
+
+
+def _jwt(claims: dict[str, object]) -> bytes:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=")
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
+    return header + b"." + body + b".c2lnbmF0dXJl"
+
+
+class TestAwsCose:
+    def test_nonce_binding_passes(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload()), NONCE)
+        assert evidence["nonce_ok"] is True
+        assert evidence["error_type"] is None
+
+    def test_pcr0_reported_as_attestation_digest(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload()), NONCE)
+        assert evidence["attestation_digest"] == PCR0.hex()
+
+    def test_tagged_cose_sign1_accepted(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload(), tag=True), NONCE)
+        assert evidence["nonce_ok"] is True
+
+    def test_wrong_nonce_is_nonce_missing_not_unsupported(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload("ff" * 16)), NONCE)
+        assert evidence["nonce_ok"] is False
+        assert evidence["error_type"] == "nonce_missing"
+        # A replayed document still reveals its measurement.
+        assert evidence["attestation_digest"] == PCR0.hex()
+
+    def test_absent_nonce_field(self) -> None:
+        payload = _aws_payload()
+        del payload["nonce"]
+        evidence = _attestation_evidence(_cose_sign1(payload), NONCE)
+        assert evidence["nonce_ok"] is False
+        assert evidence["error_type"] == "nonce_missing"
+
+    def test_nonce_uppercase_hex_input_still_binds(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload()), NONCE.upper())
+        assert evidence["nonce_ok"] is True
+
+    def test_binary_body_with_dot_bytes_not_misrouted_to_jwt(self) -> None:
+        """A CBOR document containing '.' (0x2E) bytes must still parse as
+        CBOR. The pre-fix code did a lossy decode and counted dots, so a
+        payload like this one was routed down the JWT path and reported
+        unsupported_attestation_format."""
+        payload = _aws_payload()
+        payload["module_id"] = "i-...dots.every.where..."
+        evidence = _attestation_evidence(_cose_sign1(payload), NONCE)
+        assert evidence["nonce_ok"] is True
+
+
+class TestGcpJwtUnchanged:
+    def test_eat_nonce_binds(self) -> None:
+        evidence = _attestation_evidence(_jwt({"eat_nonce": [NONCE], "image_digest": "sha256:abc"}), NONCE)
+        assert evidence["nonce_ok"] is True
+        assert evidence["attestation_digest"] == "sha256:abc"
+
+    def test_missing_nonce(self) -> None:
+        evidence = _attestation_evidence(_jwt({"eat_nonce": ["deadbeef"]}), NONCE)
+        assert evidence["error_type"] == "nonce_missing"
+
+
+class TestUnsupported:
+    def test_garbage_is_unsupported(self) -> None:
+        evidence = _attestation_evidence(b"not an attestation at all", NONCE)
+        assert evidence["error_type"] == "unsupported_attestation_format"
+
+    def test_error_json_body_is_unsupported(self) -> None:
+        # What a 404 "route not found" body looks like to the parser.
+        evidence = _attestation_evidence(b'{"error":{"message":"route not found"}}', NONCE)
+        assert evidence["error_type"] == "unsupported_attestation_format"
+
+    def test_cose_with_non_map_payload_is_unsupported(self) -> None:
+        evidence = _attestation_evidence(cbor2.dumps([b"p", {}, cbor2.dumps([1, 2]), b"s"]), NONCE)
+        assert evidence["error_type"] == "unsupported_attestation_format"
+
+    def test_truncated_cbor_is_unsupported(self) -> None:
+        evidence = _attestation_evidence(_cose_sign1(_aws_payload())[:20], NONCE)
+        assert evidence["error_type"] == "unsupported_attestation_format"

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2380,7 +2380,7 @@ async def test_rotation_pass_fans_out_model_samples(monkeypatch: pytest.MonkeyPa
     )
     monkeypatch.setattr(cli_module, "provider_rotation_probe", fake_rotation_probe)
 
-    samples = await cli_module._rotation_pass(
+    samples = await cli_module.rotation_pass(
         settings=Settings(environment="test", api_base_url="https://api.trustedrouter.com/v1"),
         monitor_region="us-central1",
         api_key="sk-tr-test",
@@ -2423,7 +2423,7 @@ async def test_probe_and_rotation_pass_runs_independent_blocks_concurrently(
         return ["rotation-a", "rotation-b"]
 
     monkeypatch.setattr(cli_module, "_one_probe_pass", fake_one_probe_pass)
-    monkeypatch.setattr(cli_module, "_rotation_pass", fake_rotation_pass)
+    monkeypatch.setattr(cli_module, "rotation_pass", fake_rotation_pass)
 
     samples, rotation_samples = await cli_module._probe_and_rotation_pass(
         settings=Settings(environment="test", api_base_url="https://api.trustedrouter.com/v1"),
@@ -2472,7 +2472,7 @@ async def test_probe_and_rotation_share_one_billing_concurrency_budget(
         return []
 
     monkeypatch.setattr(cli_module, "_one_probe_pass", fake_one_probe_pass)
-    monkeypatch.setattr(cli_module, "_rotation_pass", fake_rotation_pass)
+    monkeypatch.setattr(cli_module, "rotation_pass", fake_rotation_pass)
 
     await cli_module._probe_and_rotation_pass(
         settings=Settings(environment="test"),

--- a/tests/test_synthetic_run_rotation.py
+++ b/tests/test_synthetic_run_rotation.py
@@ -1,0 +1,150 @@
+"""/internal/synthetic/run — rotation pass + control-plane target resolution.
+
+Standalone deployments (the EU cloud) have no monitor-pool CLI; their
+once-a-minute cadence is an EventBridge rule POSTing this route. These
+tests pin the two behaviors that deployment relies on:
+
+  * rotation_count / rotation_models in the request body drive real
+    provider-rotation probes (bounded by ROTATION_MAX_PER_RUN so a typo'd
+    Input JSON can't become a spend firehose), and
+  * the billing probes' control plane resolves body > settings > canonical,
+    because the hardcoded canonical fallback is a wrong-cloud trap: an EU
+    monitor probing https://trustedrouter.com records the US plane's
+    health under an EU monitor region.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import trusted_router.routes.internal.synthetic as synthetic_route
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+
+INTERNAL_TOKEN = "test-internal-secret"  # noqa: S105 - test fixture.
+
+
+def _settings(**overrides: Any) -> Settings:
+    base: dict[str, Any] = dict(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token=INTERNAL_TOKEN,
+        stripe_secret_key=None,
+        stripe_webhook_secret=None,
+        google_client_id=None,
+        google_client_secret=None,
+        google_oauth_redirect_url=None,
+        github_client_id=None,
+        github_client_secret=None,
+        github_oauth_redirect_url=None,
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+@pytest.fixture
+def no_network_probes(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub every outbound probe the route can trigger; capture arguments."""
+    captured: dict[str, Any] = {"billing_urls": [], "rotation_calls": []}
+
+    async def fake_run_synthetic_once(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return []
+
+    async def fake_billing_probe(*_args: Any, **kwargs: Any) -> list[Any]:
+        captured["billing_urls"].append(kwargs["control_plane_base_url"])
+        return []
+
+    async def fake_fallback_probe(*_args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+    async def fake_rotation_pass(**kwargs: Any) -> list[Any]:
+        captured["rotation_calls"].append(kwargs)
+        return ["sample"] * kwargs["count"]
+
+    monkeypatch.setattr(synthetic_route, "run_synthetic_once", fake_run_synthetic_once)
+    monkeypatch.setattr(synthetic_route, "gateway_billing_probe", fake_billing_probe)
+    monkeypatch.setattr(synthetic_route, "gateway_fallback_probe", fake_fallback_probe)
+    monkeypatch.setattr(synthetic_route, "rotation_pass", fake_rotation_pass)
+    monkeypatch.setattr(synthetic_route, "_record_benchmark_samples", lambda _s: None)
+    return captured
+
+
+def _post_run(settings: Settings, body: dict[str, Any]) -> Any:
+    client = TestClient(create_app(settings, init_observability=False))
+    return client.post(
+        "/v1/internal/synthetic/run",
+        json=body,
+        headers={"x-trustedrouter-internal-token": INTERNAL_TOKEN},
+    )
+
+
+class TestRotation:
+    def test_rotation_count_triggers_pass_and_reports(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {"rotation_count": 3})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["benchmark_recorded"] == 3
+        (call,) = no_network_probes["rotation_calls"]
+        assert call["count"] == 3
+        assert call["models"] is None
+
+    def test_rotation_models_narrow_the_pool(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        dsv4 = ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"]
+        resp = _post_run(settings, {"rotation_count": 2, "rotation_models": dsv4})
+        assert resp.status_code == 200
+        (call,) = no_network_probes["rotation_calls"]
+        assert call["models"] == frozenset(dsv4)
+
+    def test_count_is_clamped_to_ceiling(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {"rotation_count": 5000})
+        assert resp.status_code == 200
+        (call,) = no_network_probes["rotation_calls"]
+        assert call["count"] == synthetic_route.ROTATION_MAX_PER_RUN
+
+    def test_no_monitor_key_means_no_rotation(self, no_network_probes: dict[str, Any]) -> None:
+        resp = _post_run(_settings(), {"rotation_count": 3})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["benchmark_recorded"] == 0
+        assert no_network_probes["rotation_calls"] == []
+
+    def test_default_is_zero_rotation(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["benchmark_recorded"] == 0
+        assert no_network_probes["rotation_calls"] == []
+
+    def test_garbage_count_is_zero_not_500(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {"rotation_count": "lots please"})
+        assert resp.status_code == 200
+        assert no_network_probes["rotation_calls"] == []
+
+
+class TestControlPlaneResolution:
+    def test_settings_beat_canonical_default(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(
+            synthetic_monitor_api_key="sk-test-monitor",
+            synthetic_control_plane_base_url="https://aws.trustedrouter.com",
+        )
+        assert _post_run(settings, {}).status_code == 200
+        assert no_network_probes["billing_urls"] == ["https://aws.trustedrouter.com"]
+
+    def test_body_beats_settings(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(
+            synthetic_monitor_api_key="sk-test-monitor",
+            synthetic_control_plane_base_url="https://aws.trustedrouter.com",
+        )
+        resp = _post_run(settings, {"control_plane_base_url": "https://override.example.com"})
+        assert resp.status_code == 200
+        assert no_network_probes["billing_urls"] == ["https://override.example.com"]
+
+    def test_canonical_fallback_unchanged_for_gcp(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        assert _post_run(settings, {}).status_code == 200
+        assert no_network_probes["billing_urls"] == ["https://trustedrouter.com"]

--- a/tests/test_synthetic_throughput.py
+++ b/tests/test_synthetic_throughput.py
@@ -367,7 +367,7 @@ async def test_throughput_only_cli_skips_every_health_path(
     )
     monkeypatch.setattr(cli_module, "get_settings", lambda: settings)
     monkeypatch.setattr(cli_module, "_one_probe_pass", forbidden_probe)
-    monkeypatch.setattr(cli_module, "_rotation_pass", forbidden_probe)
+    monkeypatch.setattr(cli_module, "rotation_pass", forbidden_probe)
     monkeypatch.setattr(cli_module, "_throughput_pass", fake_throughput_pass)
     monkeypatch.setattr(cli_module.httpx, "AsyncClient", _Client)
     monkeypatch.setenv("TR_SYNTHETIC_MONITOR_REGION", "us-central1")

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,54 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/14/b02446bacfe44351b1689c04937ade007588f44570431880a6937e525e6c/cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9", size = 90840, upload-time = "2026-08-01T20:41:39.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/84/1e363301c06f509963d134f5479e82b3ade87fb1495ddacf9bf7ff24ac42/cbor2-6.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8156fdeb73c3ff6c8cf67ad414fb5c887cd708ff0af6d61f62629f41cb4c17b2", size = 414947, upload-time = "2026-08-01T20:40:37.405Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/d8e1ed3e79ea20a3423a96b5c89ce794fa02cb428e4429e601f8ebcbac7c/cbor2-6.1.4-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e1fe2d62c50df290576280b18247ec63486f78be73e285bae269c2456c6ddff0", size = 457343, upload-time = "2026-08-01T20:40:38.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/5796c2ed2dcd0696fc4abedf0ea0dfd5361b3f022a311481f977fa51b2b8/cbor2-6.1.4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c204a75f91f8cd9ed0881f6b88ec395c59aeac9fcf4d08155e7f899db2a1c46e", size = 464314, upload-time = "2026-08-01T20:40:40.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/88/de524c6c2c91b740e5df6e6955a113fb616e979b26fd2e6a0693082d36e0/cbor2-6.1.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:28fa5db05a7eae8fd80709959988d8a7f12838c6d4e5c58ec951414058641195", size = 523053, upload-time = "2026-08-01T20:40:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/84/07/cb5fd92834633508d680a5b5695aeaf99d33ca0bdc5b844550d538f335b0/cbor2-6.1.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316e217a496640418d3137483279d0e70053b000cdd4b52a4dbf20ea478bc40a", size = 532177, upload-time = "2026-08-01T20:40:44.058Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/be98721365edfe6fc23e6bcd1385afa0e960b247c5f0b50bb67f5d05e2d9/cbor2-6.1.4-cp311-cp311-win32.whl", hash = "sha256:4903f24e0f9087275a0b6606c8b0aa586277001d51e4844fcdbc5b7211330aa8", size = 281660, upload-time = "2026-08-01T20:40:45.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/23/d54f679d4b155918f5a0879dab78203ce4fd514d311b7cfeba27dafe480b/cbor2-6.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:5b99305d4013867e059f147752b95f728680682ab03d75a3f4dcfbb270d8dfe9", size = 303207, upload-time = "2026-08-01T20:40:47.293Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3c/b3839d6213c88b249ba860525df05ff18b27bdc28ebc09cb1547790f001a/cbor2-6.1.4-cp311-cp311-win_arm64.whl", hash = "sha256:bd20ecc5c8ece24db952e48a91c8c47319eaa6358af707c85ac2bb388a79abc8", size = 296123, upload-time = "2026-08-01T20:40:48.808Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/fb64293c19cafb860060310c57b768fd9cfb7cf592449660b756538cc116/cbor2-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc15061553e4494dc10883237501e3402c645fe509248dd698e1faf2460d68b", size = 404608, upload-time = "2026-08-01T20:40:50.219Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ac/f58b3bafce7c86ada2ad8eaf189453136d2cf5bae526ea0540e1b9bc9d06/cbor2-6.1.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d9ada5a6ccfbb8ea7a3aa2aeb028421b52d8e0cd9323f0a2aeaa9c09d25fbce2", size = 449851, upload-time = "2026-08-01T20:40:51.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a5/10c6c126d59b07f2bd005094dd12a20afa46146f7e2673ed6f61a57641a7/cbor2-6.1.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:310f3dfb296ba48fe9b63c5cf26e691e3548a1eae6901d2f0c18e941d151f220", size = 461193, upload-time = "2026-08-01T20:40:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e4/4445e6237088d1cca3b8536daeb90d6b4e23776de5609c9fa46773874757/cbor2-6.1.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e6c76004d674ad1c620660cb0bc5a8a0b72a5d8c7b70926d8e09e6d7e87332f", size = 516937, upload-time = "2026-08-01T20:40:54.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/9c0959510f7a402e5995c81ccfd82cb9f314140dc0cce88c12836e5b93f1/cbor2-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32a4663425fbca4a4a7aa918eb5789d844c406439e58424cf34511f79f559242", size = 529229, upload-time = "2026-08-01T20:40:56.365Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8e/6811e4ee84203ac657f6f461a37c7c9ba0287bde80eb83c7971e9b3fe156/cbor2-6.1.4-cp312-cp312-win32.whl", hash = "sha256:2310f07db3f9ba26f2a623774ff9f3dc7185af54f732ea119785a6b1bf7e1e7e", size = 278810, upload-time = "2026-08-01T20:40:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/da/27/87440788fc0d9513534c3c699238e2a9ca6010f8cb72e9c203b7af20a9f6/cbor2-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:cc8cd300e236e9797b2e1ce306109dc481fcccf78bfa2682bf36d99e6eab1ec6", size = 299971, upload-time = "2026-08-01T20:40:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f9/77981e6e63092de19d7306a09a12b0eb3fd2907dc22c10dd5d389eb27faf/cbor2-6.1.4-cp312-cp312-win_arm64.whl", hash = "sha256:553a46bda7d09552631a714e22b91e6ff2c867ecd91511596ce290d8879b8d5b", size = 290662, upload-time = "2026-08-01T20:41:00.89Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/0b20c88e76942ede86c98cdce138681690f95908c540c264fff847729cd4/cbor2-6.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c48a7c938fc5fa5300ff82b5df09068dcb4838685ae8556b5ee8279d74f97ab4", size = 403677, upload-time = "2026-08-01T20:41:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/93eed770864540c5c9ea0841008208e9db686b7335f42520705b7d6dc6b2/cbor2-6.1.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4bd29f21529e279d50fc14f1a811f7b05b4d8e66a7969163cce98983b6817245", size = 449762, upload-time = "2026-08-01T20:41:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/21/69e4d37f00319b3d37322355aedc83154b4d8b75dc9e9789c06e1fbd8a92/cbor2-6.1.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ae16d64b1f7b620c1af748e7b6947e20069ef80eee56871c5fbb84cc635905", size = 460420, upload-time = "2026-08-01T20:41:05.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/26/2cfdd5ee826205a88a826bb38b7a572c676ec3efa29574be5cdbd04b4859/cbor2-6.1.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:69978901302ecbc8cda57b520487c5c5240ed217de783eb7728fceb258311d76", size = 516490, upload-time = "2026-08-01T20:41:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d687cd1c2c9f9a986e8552ad1fdbd22411cc86389b5705dba6ec6f7e3226/cbor2-6.1.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad4efa23fee6447e56a269191044e06eb39e809458bcd674e164fe9445feafd0", size = 528810, upload-time = "2026-08-01T20:41:09.144Z" },
+    { url = "https://files.pythonhosted.org/packages/40/08/88cecf20b8825bdd991c47b317415c08ef9e7d5f05a1def9acd346edabde/cbor2-6.1.4-cp313-cp313-win32.whl", hash = "sha256:d2560c2ba6a95904ba2a0ca257af878c4344409d9b46d8e646d8ebb617b1e0dd", size = 278058, upload-time = "2026-08-01T20:41:10.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/67/ba140234a6415c16dcfbe0585ce12f905157b70e9cb1bb63a2b6d5721e70/cbor2-6.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:c08b9c7d2ea013e24a0cb819b872b0119dde404f64a1182c0b24095b7bba781f", size = 299315, upload-time = "2026-08-01T20:41:12.067Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/35d53ff4252a5a85656480d3a81d5a5af823979ccd0c5cac95196a7548a6/cbor2-6.1.4-cp313-cp313-win_arm64.whl", hash = "sha256:598710183daae69cbdeb177a870ec64aa601de8138a61491fd256826d15a860f", size = 289976, upload-time = "2026-08-01T20:41:13.63Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5d/c5374c76471ab41dff4420a276569a56352e83166374fba6f40fd0bde7ad/cbor2-6.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24da0a481294ac416e1e369e2d204b2b1d993cbd082d0d99fa3d6f5f27ae5e69", size = 407497, upload-time = "2026-08-01T20:41:15.189Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f9/b9f12a5e24d5ae355e4c0f6d37330a2bbedad3331247a223a51c4cd39d5e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0859a0837e6e2d4fe5f5b849f6475797e4db545da98c19db4b1d3487bd47aa22", size = 452191, upload-time = "2026-08-01T20:41:16.705Z" },
+    { url = "https://files.pythonhosted.org/packages/67/22/8224b01f95a6fe07b1a64082aea34d9f49068392b3de93f5f3a10c73c62e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c0f5f2d6d3b58e44146860c049f3c082207a4005588b8926d51bf937ab66773c", size = 462383, upload-time = "2026-08-01T20:41:18.17Z" },
+    { url = "https://files.pythonhosted.org/packages/92/52/437e4aa4f5df1fb41020d64b3d99a8239f0f99a3a75eb6ffa5cb66004b7f/cbor2-6.1.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:239db0f92d537fd29eaec4e40195fc3b2b48bc34a5887059658162489a9eb6ae", size = 518700, upload-time = "2026-08-01T20:41:19.592Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/2f5ea5bfe0fd800b3739c7df8679bdffa9f7def6b2f2fee064ada1c63e85/cbor2-6.1.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3f4a434c36bb0d33aeb48ddae8e8b673ca7e1f14545ee7cf4a4c7c39380ea9a2", size = 531243, upload-time = "2026-08-01T20:41:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c6/0beac64cb74cd3217f295f9bb0d64675e1809c683a31ea2a49ac9d4d1504/cbor2-6.1.4-cp314-cp314-win32.whl", hash = "sha256:6abcf072b8c0fdc8ad7902ee26a906cafbf3427d026b662ff21166a253f85e18", size = 285248, upload-time = "2026-08-01T20:41:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7d/4afa096ddc94049f5a514690891b02a18319e146ceb14465ce30c8340a8b/cbor2-6.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:855764e02dc60ab9413acd044e997c3170000fdea6155d6c43a923a1d966dbe6", size = 313044, upload-time = "2026-08-01T20:41:24.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b5/e614cee861772f6b5c4d926b066d2e7dbc11e220b50ba716ba91e430fb0f/cbor2-6.1.4-cp314-cp314-win_arm64.whl", hash = "sha256:c6b28b928c5f2dbf47dffa12dce9c8e36fe6ac1c1358bc326499c0736263b66f", size = 304088, upload-time = "2026-08-01T20:41:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/3b28184154f6cbf7e47c1b7fb4a7a291c54f27a6f3a0a2f64b078c6a13e1/cbor2-6.1.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7336ff4cb7d161ec43b65eef43bf3e9bcab44bd152efb54dd637b7afe711254f", size = 401042, upload-time = "2026-08-01T20:41:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/a8624023b84b41c43a150a89517c104aed0e467bd258866f13be4c3ac0c6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8f1019494b0ec81a3df3ebb01b6acb446d5b946fe35845b1726379abd66a71da", size = 445301, upload-time = "2026-08-01T20:41:28.35Z" },
+    { url = "https://files.pythonhosted.org/packages/60/39/07dd0ea957c1f48673d3947f97ee36826efd4a824053dd0ec4df2f0c89d6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:179a794bf4be1d46ff190695929f65f0b42019c156919846ae539d2a7ec42e54", size = 459816, upload-time = "2026-08-01T20:41:29.839Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8e/2015175132a27c1daed434f671ac6d9c1311461995df47f201307700e0da/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b904b8d0f4ddac9259197d21d121fae4cb8b555700d65bc12c5d46a2e6c2025", size = 511565, upload-time = "2026-08-01T20:41:31.939Z" },
+    { url = "https://files.pythonhosted.org/packages/82/66/420991095d9473614b205d4c4e40b5d3b9f1ee4410eb3c48c1e902947837/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:71fcf4f237d68bf4445bf45070f36f82b333f2e6a62612aa2c256683b51378a9", size = 527709, upload-time = "2026-08-01T20:41:33.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/7c/73057e7a38488a816a0d40ff9e7cd9f418800894582e2e48fb2f47ce66a2/cbor2-6.1.4-cp314-cp314t-win32.whl", hash = "sha256:7deccc50fd0b55c4c7dd265b144c5358a645121e457c0ae3722b5ad59832b257", size = 281462, upload-time = "2026-08-01T20:41:35.127Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/d5db22837cb566de733b9d1c418cdf1912ccb1efc7b179e295430b1d81a2/cbor2-6.1.4-cp314-cp314t-win_amd64.whl", hash = "sha256:f3fc7d15cba4174373df2496070faa4a927fe3ed772130d281808120aec7b61c", size = 309165, upload-time = "2026-08-01T20:41:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5f/ff2c6da83553a692219a0a62a21b57a27ded4405200e50db758a17fbaf15/cbor2-6.1.4-cp314-cp314t-win_arm64.whl", hash = "sha256:164ca22b509408435b2d8236c80c964e4fc77c085ab034569cd04c40d5cc8883", size = 298386, upload-time = "2026-08-01T20:41:38.392Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -4507,6 +4555,7 @@ source = { editable = "." }
 dependencies = [
     { name = "axiom-py" },
     { name = "boto3" },
+    { name = "cbor2" },
     { name = "cryptography" },
     { name = "email-validator" },
     { name = "eth-account" },
@@ -4543,6 +4592,7 @@ dev = [
 requires-dist = [
     { name = "axiom-py", specifier = ">=0.9.0" },
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "cbor2", specifier = ">=5.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "eth-account", specifier = ">=0.13.7" },


### PR DESCRIPTION
## What

Two increments that make the standalone EU cloud's synthetic monitor actually measure the EU cloud:

1. **`_attestation_evidence` parses AWS Nitro COSE/CBOR documents.** It only knew the GCP Confidential Space JWT, so every probe against `api-aws.trustedrouter.com` reported `unsupported_attestation_format` — the EU status page sat at 50% "trust degraded" (critical burn-rate alerts) while the enclave was verifiably healthy. Now: strict-ascii JWT routing (a binary document with incidental `0x2E` bytes can't be misrouted), payload nonce binding (mismatch → `nonce_missing`, kept distinct from unsupported), PCR0 reported as `attestation_digest` so the status page shows the running EIF measurement. Chain verification stays in the deploy gate (`quill-cloud-proxy tools/verify-attestation.py`) by design.

2. **Provider rotation via `/internal/synthetic/run` + per-cloud control plane.** Standalone deployments have no monitor-pool CLI; cadence comes from an EventBridge rule POSTing this route. `rotation_count` (clamped to 8/run so a bad Input JSON can't become a spend firehose) drives real inference probes; `rotation_models` optionally pins the pool to a family (e.g. DSv4). The billing probes' control plane now resolves body > `synthetic_control_plane_base_url` setting > canonical — the hardcoded canonical fallback was a wrong-cloud trap for EU monitors.

GCP behavior unchanged: no body fields → no rotation, canonical plane, identical probe set.

## Testing

- 13 new parser tests incl. tagged COSE, dot-bytes misrouting, replay (wrong nonce), truncation
- 9 new route tests: rotation gating/clamping/model-pinning, control-plane precedence
- Parser verified against the **live** eu-west-1 enclave: fresh nonce bound, PCR0 `2c12e222…` matches the pinned measurement
- Full suite: 2493 passed / 86 skipped; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)