### PR TITLE
Attested-cert probe transport + future-dated sample poison defense

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -1,27 +1,47 @@
 #!/usr/bin/env bash
-# Deploy the AWS-EU control plane: App Runner (Dublin) on Aurora DSQL.
+# Deploy the AWS-EU control plane: App Runner (Paris) on Aurora DSQL.
 #
 # Mirrors azure_canary*.sh in shape — build locally, push, deploy, verify with
-# the same cloud-agnostic scripts/deploy/verify_deployment.sh. App Runner over
-# ECS+ALB for the same reason Container Apps won on Azure: an HTTPS URL with no
-# cert/LB ceremony, so the e2e loop closes fast. The four-nines active/active
-# topology (Dublin + Stockholm behind health-checked DNS) comes after
-# reserve/settle land; this is deliberately the single-region first rung.
+# the same cloud-agnostic scripts/deploy/verify_deployment.sh.
+#
+# THIS FILE IS THE SOURCE OF TRUTH FOR THE SERVICE ENV. The live service
+# once carried TR_API_BASE_URL out-of-band (unversioned), pointed at its
+# own App Runner URL — so the synthetic monitor probed the control plane
+# for /attestation (404) and reported the EU cloud 50% trust_degraded
+# while the actual enclave was healthy. Every runtime variable now lives
+# here; change it here or not at all.
 #
 # Auth to the database is IAM: the instance role tr-eu-app holds
-# dsql:DbConnectAdmin on the Dublin cluster, and TR_POSTGRES_IAM_AUTH=aws-dsql
+# dsql:DbConnectAdmin on the Paris cluster, and TR_POSTGRES_IAM_AUTH=aws-dsql
 # makes PostgresStore mint a fresh token per physical connection (DSQL tokens
 # expire in minutes — a static password dies within the hour). The DSN
 # deliberately carries NO password.
+#
+# Secrets (internal gateway token, synthetic monitor API key) are wired via
+# RuntimeEnvironmentSecrets from eu-west-3 Secrets Manager — NOT plaintext
+# env vars. describe-service returns RuntimeEnvironmentVariables in
+# cleartext to any caller with apprunner:DescribeService; it masks
+# RuntimeEnvironmentSecrets.
 set -euo pipefail
 
-REGION="${REGION:-eu-west-1}"
+REGION="${REGION:-eu-west-3}"                       # Paris. Dublin is GONE.
 ACCOUNT="${ACCOUNT:-330422590279}"
-CLUSTER_ID="${CLUSTER_ID:-7rt62n5uiz6xjdsoi2ahypz3cq}"
+CLUSTER_ID="${CLUSTER_ID:-tnt642i3ofzpn5z62msacutpuu}"
 ECR="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/trusted-router"
 TAG="${TAG:-eu}"
 SVC="${SVC:-tr-eu}"
 DSQL_HOST="${CLUSTER_ID}.dsql.${REGION}.on.aws"
+
+# The attested Nitro gateway this control plane fronts. The PCR0 pin must
+# match the EIF measurement the enclave deploy published — pass it in from
+# the same value quill-cloud-proxy's deploy-aws-nitro.sh pinned:
+#   ATTESTATION_PCR0=<hex> bash scripts/deploy/aws_eu_control_plane.sh
+API_BASE_URL="${API_BASE_URL:-https://api-aws.trustedrouter.com/v1}"
+ATTESTATION_PCR0="${ATTESTATION_PCR0:?set ATTESTATION_PCR0 to the published enclave PCR0 - measurement pinning is the point of the probe}"
+
+# Secrets Manager ARNs (eu-west-3 — App Runner requires same-region secrets).
+INTERNAL_TOKEN_SECRET_ARN="${INTERNAL_TOKEN_SECRET_ARN:-$(aws secretsmanager describe-secret --region "$REGION" --secret-id quill/trustedrouter-internal-gateway-token --query ARN --output text)}"
+MONITOR_KEY_SECRET_ARN="${MONITOR_KEY_SECRET_ARN:-$(aws secretsmanager describe-secret --region "$REGION" --secret-id quill/trustedrouter-synthetic-monitor-api-key --query ARN --output text)}"
 
 log(){ printf '\n=== %s\n' "$*" >&2; }
 
@@ -43,7 +63,21 @@ CONFIG=$(cat <<JSON
         "TR_POSTGRES_DSN": "host=${DSQL_HOST} port=5432 user=admin dbname=postgres sslmode=require",
         "TR_POSTGRES_IAM_AUTH": "aws-dsql",
         "TR_ENABLE_LIVE_PROVIDERS": "false",
-        "TR_SYNTHETIC_MONITOR_REGION": "${REGION}"
+
+        "TR_API_BASE_URL": "${API_BASE_URL}",
+        "TR_PRIMARY_REGION": "${REGION}",
+        "TR_REGIONS": "${REGION}",
+
+        "TR_SYNTHETIC_MONITOR_REGION": "${REGION}",
+        "TR_SYNTHETIC_CANONICAL_ATTESTED": "true",
+        "TR_ATTESTATION_EXPECTED_PCR0": "${ATTESTATION_PCR0}",
+        "TR_SYNTHETIC_REGIONAL_PROBES_ENABLED": "false",
+        "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL": "https://aws.trustedrouter.com",
+        "TR_SYNTHETIC_CONTROL_PLANE_BASE_URL": "https://trustedrouter.com"
+      },
+      "RuntimeEnvironmentSecrets": {
+        "TR_INTERNAL_GATEWAY_TOKEN": "${INTERNAL_TOKEN_SECRET_ARN}",
+        "TR_SYNTHETIC_MONITOR_API_KEY": "${MONITOR_KEY_SECRET_ARN}"
       }
     }
   },
@@ -54,6 +88,13 @@ CONFIG=$(cat <<JSON
 }
 JSON
 )
+# TR_SYNTHETIC_CONTROL_PLANE_BASE_URL is DELIBERATELY the GCP plane for
+# now: the enclave's authorize/settle dependency IS https://trustedrouter.com
+# today (see quill-cloud-proxy deploy-aws-nitro.sh
+# QUILL_TR_CONTROL_PLANE_BASE_URL). The billing probe must measure the
+# dependency the gateway actually has, not the one we wish it had. Flip
+# BOTH together when key federation makes the EU plane the authorize
+# target.
 
 if aws apprunner list-services --region "$REGION" --query "ServiceSummaryList[?ServiceName=='${SVC}'].ServiceArn" --output text | grep -q arn; then
   ARN=$(aws apprunner list-services --region "$REGION" --query "ServiceSummaryList[?ServiceName=='${SVC}'].ServiceArn" --output text)
@@ -78,3 +119,39 @@ done
 URL=$(aws apprunner describe-service --region "$REGION" --service-arn "$ARN" --query 'Service.ServiceUrl' --output text)
 log "service: https://${URL}"
 echo "https://${URL}"
+
+# ---------------------------------------------------------------------------
+# EventBridge synthetic cadence — versioned here for the same reason the env
+# is: an unversioned rule Input is how a probe silently measures the wrong
+# cloud. rotation_count=2 keeps steady-state spend bounded (2 real rotation
+# completions/min + the pong/billing probes); the route clamps at 8
+# regardless of what this Input says.
+# ---------------------------------------------------------------------------
+if [ "${SKIP_EVENTBRIDGE:-0}" != "1" ]; then
+  log "aligning EventBridge rule tr-eu-synthetic-1min"
+  DEST_ARN=$(aws events list-api-destinations --region "$REGION" --name-prefix tr-eu-synthetic-run --query 'ApiDestinations[0].ApiDestinationArn' --output text)
+  ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/tr-eu-eventbridge-invoke-par"
+  TARGETS=$(python3 - "$DEST_ARN" "$ROLE_ARN" "$REGION" <<'PY'
+import json
+import sys
+
+dest_arn, role_arn, region = sys.argv[1:4]
+rule_input = {
+    "monitor_region": region,
+    "rotation_count": 2,
+    "rotation_models": ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+}
+print(json.dumps([
+    {
+        "Id": "synthetic",
+        "Arn": dest_arn,
+        "RoleArn": role_arn,
+        "Input": json.dumps(rule_input),
+    }
+]))
+PY
+)
+  aws events put-rule --region "$REGION" --name tr-eu-synthetic-1min --schedule-expression 'rate(1 minute)' --state ENABLED >/dev/null
+  aws events put-targets --region "$REGION" --rule tr-eu-synthetic-1min --targets "$TARGETS" >/dev/null
+  log "rule aligned: rotation_count=2, DSv4-pinned"
+fi

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -329,6 +329,18 @@ class Settings(BaseSettings):
     # trust_degraded (pcr0_mismatch) if the serving enclave ever differs
     # from the deployed measurement. None = binding-only.
     attestation_expected_pcr0: str | None = None
+    # Per-region alias/Cloud-Run probing is a GCP-topology concept: it
+    # derives api-{region}.quillrouter.com aliases and *.run.app direct
+    # URLs from templates. On a standalone single-gateway deployment
+    # those templates produce hostnames that DO NOT EXIST, painting
+    # permanent failures onto the status page. False = probe only the
+    # canonical target.
+    synthetic_regional_probes_enabled: bool = True
+    # Explicit control-plane /health URL attached to the canonical
+    # target. Standalone deployments set this to their own control plane
+    # (e.g. the App Runner URL) so control_plane_health measures the
+    # RIGHT cloud; on GCP the per-region Cloud Run URLs already cover it.
+    synthetic_control_plane_health_url: str | None = None
     # Per-probe HTTP timeout for real provider-effective synthetic checks.
     # Keep this aligned with the gateway's first-byte budget. A successful
     # /responses probe in europe-west4 can legitimately take >10s on slow

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -318,6 +318,17 @@ class Settings(BaseSettings):
     # plane or its probes measure another cloud's health. A per-request
     # body override still wins over this setting.
     synthetic_control_plane_base_url: str | None = None
+    # The canonical target serves a self-signed cert minted inside the
+    # TEE (AWS Nitro standalone deployments): probes skip CA verification
+    # and the attestation probe instead verifies the document binds the
+    # cert served on its own connection. Leave False wherever the
+    # canonical gateway has a CA-issued cert (GCP).
+    synthetic_canonical_attested: bool = False
+    # Pin the enclave's PCR0 (EIF measurement). Set at deploy time from
+    # the same value tools/deploy-aws-nitro.sh pins, so the probe turns
+    # trust_degraded (pcr0_mismatch) if the serving enclave ever differs
+    # from the deployed measurement. None = binding-only.
+    attestation_expected_pcr0: str | None = None
     # Per-probe HTTP timeout for real provider-effective synthetic checks.
     # Keep this aligned with the gateway's first-byte budget. A successful
     # /responses probe in europe-west4 can legitimately take >10s on slow

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import random
 from dataclasses import asdict
 from typing import Any
@@ -13,7 +14,7 @@ from trusted_router.errors import api_error
 from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
 from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProbeSample
-from trusted_router.storage_models import scrub_provider_error_message
+from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, scrub_provider_error_message
 from trusted_router.synthetic.cli import rotation_pass
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
@@ -201,7 +202,26 @@ def _sample_from_body(body: Any) -> SyntheticProbeSample:
         else None,
     }
     if body.get("created_at"):
-        kwargs["created_at"] = str(body["created_at"])
+        created_at = str(body["created_at"])
+        # Ingest is the boundary: a future-dated sample is poison, not
+        # data. One accepted year-7748 row permanently disabled the
+        # staleness detector (it defined "latest" forever); storage and
+        # status now also guard, but rejecting here keeps the poison out
+        # of the store entirely instead of merely filtered on read.
+        try:
+            created = dt.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except ValueError:
+            raise api_error(400, "created_at is not a valid timestamp", ErrorType.BAD_REQUEST) from None
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=dt.UTC)
+        skew = (created - dt.datetime.now(dt.UTC)).total_seconds()
+        if skew > FUTURE_SAMPLE_SKEW_SECONDS:
+            raise api_error(
+                400,
+                f"created_at is {int(skew)}s in the future (max {FUTURE_SAMPLE_SKEW_SECONDS}s)",
+                ErrorType.BAD_REQUEST,
+            )
+        kwargs["created_at"] = created_at
     for field in ("id", "probe_type", "target", "target_url", "monitor_region", "status"):
         if not kwargs[field]:
             raise api_error(400, f"{field} is required", ErrorType.BAD_REQUEST)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -883,6 +883,16 @@ def _provider_from_model_id(model_id: str) -> str:
     return model_id.split("/", 1)[0] if "/" in model_id else model_id
 
 
+# How far into the future a synthetic sample's created_at may sit before
+# ingest, storage reads, and the status layer treat it as poison rather
+# than evidence. 60s absorbs ordinary monitor/host clock skew. Shared here
+# (next to the model) because all three layers must agree: a bound
+# enforced in only one of them leaves the others trusting year-7748
+# fixture rows — which happened, and permanently disabled the staleness
+# detector on a live deployment.
+FUTURE_SAMPLE_SKEW_SECONDS = 60
+
+
 @dataclass
 class SyntheticProbeSample:
     """Privacy-safe synthetic monitor sample.

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -37,6 +37,7 @@ from trusted_router.storage_gcp_codec import (
     workspace_key_id,
 )
 from trusted_router.storage_models import (
+    FUTURE_SAMPLE_SKEW_SECONDS,
     AcquisitionAttribution,
     ApiKey,
     AuthSession,
@@ -1745,13 +1746,21 @@ class PostgresStore:
         limit: int = 1000,
     ) -> list[SyntheticProbeSample]:
         def list_samples(conn: Any) -> list[SyntheticProbeSample]:
+            # Bounded on BOTH sides. The lower bound is retention; the
+            # upper bound keeps future-dated poison out of every read:
+            # indexed_at = sample.created_at, ORDER BY indexed_at DESC —
+            # so without the upper bound a single year-7748 fixture row
+            # sorts first in every response forever, and retention (a
+            # lower bound) never expires it.
             predicates = [
                 "kind = %s",
                 "indexed_at >= %s",
+                "indexed_at <= %s",
             ]
             params: list[Any] = [
                 "synthetic_probe",
                 utcnow() - dt.timedelta(days=RAW_SYNTHETIC_RETENTION_DAYS),
+                utcnow() + dt.timedelta(seconds=FUTURE_SAMPLE_SKEW_SECONDS),
             ]
             if date is not None:
                 predicates.append("index_date = %s")

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -104,10 +104,19 @@ def configured_targets(settings: Settings) -> list[SyntheticTarget]:
             "canonical",
             settings.api_base_url,
             choose_region(settings),
+            control_plane_url=settings.synthetic_control_plane_health_url,
             attested=settings.synthetic_canonical_attested,
             expected_pcr0=settings.attestation_expected_pcr0,
         )
     ]
+    if not settings.synthetic_regional_probes_enabled:
+        # Standalone single-gateway deployment: the per-region alias and
+        # Cloud Run URL templates below are GCP topology and would
+        # fabricate targets that do not exist (verified live: with
+        # TR_REGIONS=eu-west-3 the loop appends
+        # api-eu-west-3.quillrouter.com + a nonexistent *.run.app URL,
+        # both permanently down). One gateway, one target.
+        return targets
     for region in region_payload(settings):
         name = str(region["id"])
         api_base_url = str(region["api_base_url"])

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import contextlib
+import hashlib
 import json
 import random
 import secrets
@@ -18,6 +20,8 @@ from urllib.parse import urljoin, urlsplit
 
 import cbor2
 import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from trusted_router.config import Settings
 from trusted_router.provider_reliability import model_deadlines
@@ -65,10 +69,45 @@ class SyntheticTarget:
     # None for the canonical target since that probe already hits the
     # global enclave LB by definition.
     control_plane_url: str | None = None
+    # ATTESTED-CERT-ONLY target: the gateway serves a self-signed cert it
+    # minted inside the TEE (AWS Nitro standalone deployments), so CA
+    # verification can never pass and is not the trust model. Probes use
+    # a no-CA-verify TLS context instead, and the attestation probe
+    # closes the loop by verifying the attestation document binds the
+    # exact cert served on its own connection (SPKI + fingerprint).
+    # Skipping CA verification WITHOUT that binding check would be a
+    # plain `verify=False` hack; the pairing is what makes it sound.
+    attested: bool = False
+    # When set, the attestation probe additionally pins PCR0 (the EIF
+    # measurement) to this hex value; a running enclave with any other
+    # measurement reports pcr0_mismatch. None = binding-only, so a fresh
+    # deployment isn't permanently red before the pin is configured.
+    expected_pcr0: str | None = None
+
+
+def _attested_ssl_context() -> ssl.SSLContext:
+    """TLS context for attested-cert-only targets: no CA verification.
+
+    Sound ONLY in combination with the attestation probe's binding check
+    (SPKI + fingerprint of the cert served on this same probe pass). See
+    SyntheticTarget.attested.
+    """
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
 
 
 def configured_targets(settings: Settings) -> list[SyntheticTarget]:
-    targets = [SyntheticTarget("canonical", settings.api_base_url, choose_region(settings))]
+    targets = [
+        SyntheticTarget(
+            "canonical",
+            settings.api_base_url,
+            choose_region(settings),
+            attested=settings.synthetic_canonical_attested,
+            expected_pcr0=settings.attestation_expected_pcr0,
+        )
+    ]
     for region in region_payload(settings):
         name = str(region["id"])
         api_base_url = str(region["api_base_url"])
@@ -118,20 +157,30 @@ async def run_synthetic_once(
     timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
     limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     samples: list[SyntheticProbeSample] = []
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        target_results = await asyncio.gather(
-            *[
+    # Attested targets serve a self-signed TEE-minted cert, so they need
+    # a no-CA-verify client; everything else keeps full verification on
+    # the shared client. Never mix the two: handing the attested client
+    # to a CA-certified target would silently drop its TLS verification.
+    async with contextlib.AsyncExitStack() as stack:
+        default_client = await stack.enter_async_context(httpx.AsyncClient(timeout=timeout))
+        clients: dict[bool, httpx.AsyncClient] = {False: default_client}
+        probe_tasks = []
+        for target in configured_targets(settings):
+            if target.attested and True not in clients:
+                clients[True] = await stack.enter_async_context(
+                    httpx.AsyncClient(timeout=timeout, verify=_attested_ssl_context())
+                )
+            probe_tasks.append(
                 _run_target_synthetic_probes(
-                    client,
+                    clients[target.attested],
                     target,
                     monitor_region=region,
                     api_key=key,
                     model=settings.synthetic_monitor_model,
                     billing_semaphore=limiter,
                 )
-                for target in configured_targets(settings)
-            ]
-        )
+            )
+        target_results = await asyncio.gather(*probe_tasks)
     for target_samples in target_results:
         samples.extend(target_samples)
     return samples
@@ -305,7 +354,7 @@ async def gateway_latency_phase_probes(
         if raw_socket is None or tcp_ms is None:
             raise last_connect_error or OSError("no resolved address accepted TCP")
 
-        tls_context = ssl.create_default_context()
+        tls_context = _attested_ssl_context() if target.attested else ssl.create_default_context()
         tls_context.set_alpn_protocols(["http/1.1"])
         tls_started = time.perf_counter()
         reader, stream_writer = await asyncio.wait_for(
@@ -586,10 +635,28 @@ async def attestation_nonce_probe(
     url = _root_url(target.api_base_url, f"/attestation?nonce={nonce}")
     started = time.perf_counter()
     try:
-        response = await client.get(url)
+        if target.attested:
+            # Stream so the TLS connection is still open when we read the
+            # peer certificate: for an attested target the document must
+            # bind THE cert served on THIS connection, otherwise a relay
+            # could front a healthy enclave with its own TLS.
+            async with client.stream("GET", url) as response:
+                body = await response.aread()
+                status_code = response.status_code
+                peer_cert_der = _response_peer_cert_der(response)
+        else:
+            response = await client.get(url)
+            body = response.content
+            status_code = response.status_code
+            peer_cert_der = None
         latency_ms = _elapsed_ms(started)
-        evidence = _attestation_evidence(response.content, nonce)
-        ok = response.status_code == 200 and evidence["nonce_ok"]
+        evidence = _attestation_evidence(
+            body,
+            nonce,
+            peer_cert_der=peer_cert_der,
+            expected_pcr0=target.expected_pcr0,
+        )
+        ok = status_code == 200 and evidence["nonce_ok"] and evidence["error_type"] is None
         return _sample(
             "attestation_nonce",
             target,
@@ -598,7 +665,7 @@ async def attestation_nonce_probe(
             status="up" if ok else "trust_degraded",
             latency_milliseconds=latency_ms,
             ttfb_milliseconds=latency_ms,
-            http_status=response.status_code,
+            http_status=status_code,
             error_type=None if ok else str(evidence["error_type"]),
             attestation_digest=_evidence_str(evidence, "attestation_digest"),
             source_commit=_evidence_str(evidence, "source_commit"),
@@ -613,6 +680,28 @@ async def attestation_nonce_probe(
             latency_milliseconds=_elapsed_ms(started),
             error_type=exc.__class__.__name__,
         )
+
+
+def _response_peer_cert_der(response: httpx.Response) -> bytes | None:
+    """Peer certificate (DER) of the TLS connection a response arrived on.
+
+    Only available while the response is still streaming — httpx returns
+    the connection to the pool once the body is closed. Returns None when
+    the transport doesn't expose an ssl_object (HTTP, mocks, HTTP/2
+    transports without the extension); callers treat None as "binding
+    unverifiable", which for an attested target is a failure, not a pass.
+    """
+    try:
+        network_stream = response.extensions.get("network_stream")
+        if network_stream is None:
+            return None
+        ssl_object = network_stream.get_extra_info("ssl_object")
+        if ssl_object is None:
+            return None
+        der = ssl_object.getpeercert(binary_form=True)
+        return der if isinstance(der, bytes) else None
+    except Exception:  # noqa: BLE001 - diagnostics must never crash the probe
+        return None
 
 
 async def openai_chat_pong_probe(
@@ -2293,7 +2382,13 @@ def _responses_text(response: httpx.Response) -> str:
         return ""
 
 
-def _attestation_evidence(body: bytes, nonce_hex: str) -> dict[str, str | bool | None]:
+def _attestation_evidence(
+    body: bytes,
+    nonce_hex: str,
+    *,
+    peer_cert_der: bytes | None = None,
+    expected_pcr0: str | None = None,
+) -> dict[str, str | bool | None]:
     """Extract nonce binding + identity evidence from an attestation body.
 
     Two live formats:
@@ -2342,10 +2437,22 @@ def _attestation_evidence(body: bytes, nonce_hex: str) -> dict[str, str | bool |
         nonce_ok = isinstance(nonce, bytes) and nonce.hex() == nonce_hex.lower()
         pcrs = aws.get("pcrs")
         pcr0 = pcrs.get(0) if isinstance(pcrs, dict) else None
+        pcr0_hex = pcr0.hex() if isinstance(pcr0, bytes) else None
+        # Failure precedence: an unbound nonce is a replay and trumps
+        # everything; then the served-cert binding; then the measurement
+        # pin. The four error_types are deliberately distinct — they mean
+        # completely different things and top_error is how you triage.
+        error: str | None = None
+        if not nonce_ok:
+            error = "nonce_missing"
+        elif peer_cert_der is not None and not _aws_cert_binding_ok(aws, peer_cert_der):
+            error = "cert_binding_mismatch"
+        elif expected_pcr0 and (pcr0_hex or "").lower() != expected_pcr0.lower():
+            error = "pcr0_mismatch"
         return {
             "nonce_ok": nonce_ok,
-            "error_type": None if nonce_ok else "nonce_missing",
-            "attestation_digest": pcr0.hex() if isinstance(pcr0, bytes) else None,
+            "error_type": error,
+            "attestation_digest": pcr0_hex,
             "source_commit": None,
         }
     return {
@@ -2354,6 +2461,40 @@ def _attestation_evidence(body: bytes, nonce_hex: str) -> dict[str, str | bool |
         "attestation_digest": None,
         "source_commit": None,
     }
+
+
+def _aws_cert_binding_ok(payload: dict[Any, Any], peer_cert_der: bytes) -> bool:
+    """Does the attestation document bind the cert served on this probe's
+    own TLS connection?
+
+    The enclave publishes two independent bindings (mirrors
+    quill-cloud-proxy tools/verify-attestation.py):
+      * payload["public_key"]     — the served cert's SPKI, DER bytes
+      * payload["user_data"][:32] — sha256 of the full cert DER
+    Both present must both match. NEITHER present fails: an attested
+    target whose document binds nothing is indistinguishable from a
+    relay, and "unverifiable" must not read as "verified".
+    """
+    checked = 0
+    doc_spki = payload.get("public_key")
+    if isinstance(doc_spki, bytes) and doc_spki:
+        try:
+            cert = x509.load_der_x509_certificate(peer_cert_der)
+            live_spki = cert.public_key().public_bytes(
+                encoding=Encoding.DER,
+                format=PublicFormat.SubjectPublicKeyInfo,
+            )
+        except (ValueError, TypeError):
+            return False
+        if doc_spki != live_spki:
+            return False
+        checked += 1
+    user_data = payload.get("user_data")
+    if isinstance(user_data, bytes) and len(user_data) >= 32:
+        if user_data[:32] != hashlib.sha256(peer_cert_der).digest():
+            return False
+        checked += 1
+    return checked > 0
 
 
 def _decode_aws_attestation_payload(body: bytes) -> dict[Any, Any] | None:

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -6,7 +6,12 @@ import math
 from collections import Counter
 from typing import Any
 
-from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
+from trusted_router.storage_models import (
+    FUTURE_SAMPLE_SKEW_SECONDS,
+    SyntheticProbeSample,
+    SyntheticRollup,
+    iso_now,
+)
 from trusted_router.synthetic.components import sample_component_ids
 
 ROLLUP_PERIODS = {"hour", "day", "month"}
@@ -229,7 +234,15 @@ def raw_sample_is_within_retention(
     now: dt.datetime,
     days: int = RAW_SYNTHETIC_RETENTION_DAYS,
 ) -> bool:
-    return _parse_time(sample.created_at) >= now - dt.timedelta(days=days)
+    """Bounded on BOTH sides. The lower bound is retention. The upper
+    bound excludes future-dated poison: a sample dated past the skew
+    budget (e.g. a year-7748 conformance fixture written to a live
+    store) would otherwise sort first in every newest-first read forever
+    — retention alone never expires a row dated in the future."""
+    created = _parse_time(sample.created_at)
+    if created > now + dt.timedelta(seconds=FUTURE_SAMPLE_SKEW_SECONDS):
+        return False
+    return created >= now - dt.timedelta(days=days)
 
 
 def _increment_histogram(histogram: dict[str, int], value: int) -> None:

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -6,7 +6,13 @@ from collections import defaultdict
 from dataclasses import replace
 from typing import Any
 
-from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now, utcnow
+from trusted_router.storage_models import (
+    FUTURE_SAMPLE_SKEW_SECONDS,
+    SyntheticProbeSample,
+    SyntheticRollup,
+    iso_now,
+    utcnow,
+)
 from trusted_router.synthetic.components import (
     COMPONENT_DEFINITIONS,
     SLO_DEFINITIONS,
@@ -141,20 +147,37 @@ def _monitor_freshness(
     *,
     now: dt.datetime,
 ) -> dict[str, Any]:
-    if not samples:
+    # Future-dated samples are NOT evidence of freshness. This is not a
+    # theoretical case: conformance fixtures dated in the year 7748 were
+    # once written to a live store, and the previous implementation —
+    # `max(age, 0)` over `max(samples, key=created_at)` — locked
+    # latest_sample_age_seconds to 0 and is_stale to False permanently.
+    # A staleness detector a single poison row can disable forever is
+    # worse than none: it reports "fresh" through a total monitor outage.
+    # Small negative ages are ordinary clock skew between the monitor and
+    # this host, so only samples beyond the skew budget are excluded.
+    dateable = [
+        sample
+        for sample in samples
+        if (now - _parse_time(sample.created_at)).total_seconds() >= -FUTURE_SAMPLE_SKEW_SECONDS
+    ]
+    future_dated = len(samples) - len(dateable)
+    if not dateable:
         return {
             "latest_sample_at": None,
             "latest_sample_age_seconds": None,
             "stale_after_seconds": CURRENT_SAMPLE_TTL_SECONDS,
             "is_stale": True,
+            "future_dated_samples": future_dated,
         }
-    latest = max(samples, key=lambda sample: _parse_time(sample.created_at))
-    age = max((now - _parse_time(latest.created_at)).total_seconds(), 0)
+    latest = max(dateable, key=lambda sample: _parse_time(sample.created_at))
+    age = (now - _parse_time(latest.created_at)).total_seconds()
     return {
         "latest_sample_at": latest.created_at,
-        "latest_sample_age_seconds": int(age),
+        "latest_sample_age_seconds": int(max(age, 0)),
         "stale_after_seconds": CURRENT_SAMPLE_TTL_SECONDS,
         "is_stale": age > CURRENT_SAMPLE_TTL_SECONDS,
+        "future_dated_samples": future_dated,
     }
 
 
@@ -241,6 +264,16 @@ def history_payload(
     return {"window": window, "scope": ROUTER_CORE_SLO_ID, "data": {}}
 
 
+def _sample_effective_status(sample: SyntheticProbeSample, *, now: dt.datetime) -> tuple[str, float]:
+    """(effective status, signed age). Too old OR too far in the future
+    both degrade to "unknown": a future-dated `up` sample must never pin
+    a component green — it is poison or clock breakage, not evidence."""
+    age = (now - _parse_time(sample.created_at)).total_seconds()
+    if age > CURRENT_SAMPLE_TTL_SECONDS or age < -FUTURE_SAMPLE_SKEW_SECONDS:
+        return "unknown", age
+    return sample.status, age
+
+
 def _current_status(
     samples: list[SyntheticProbeSample],
     *,
@@ -254,8 +287,8 @@ def _current_status(
     rows = []
     overall = "unknown"
     for sample in latest.values():
-        age = max((now - _parse_time(sample.created_at)).total_seconds(), 0)
-        status = "unknown" if age > CURRENT_SAMPLE_TTL_SECONDS else sample.status
+        status, signed_age = _sample_effective_status(sample, now=now)
+        age = max(signed_age, 0)
         overall = _worse_status(overall, status)
         row = sample.public_dict()
         row["age_seconds"] = int(age)
@@ -510,8 +543,7 @@ def _slo_current(
     by_region: dict[str, dict[str, Any]] = {}
     sample_count = 0
     for sample in latest.values():
-        age = max((now - _parse_time(sample.created_at)).total_seconds(), 0)
-        status = "unknown" if age > CURRENT_SAMPLE_TTL_SECONDS else sample.status
+        status, _signed_age = _sample_effective_status(sample, now=now)
         overall = _worse_status(overall, status)
         sample_count += 1
         for region in _sample_region_keys(sample):

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -352,13 +352,19 @@ def test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option(
     store: Store, unique: str
 ) -> None:
     """Status history uses inclusive period ranges and newest-N ordering."""
-    # Rollup reads have no target/probe filters, and server-backed conformance
-    # databases persist between runs. Give this test a practically unique
-    # three-hour range so old test rows cannot consume its limit.
-    now = (
-        dt.datetime(2100, 1, 1, 0, 10, tzinfo=dt.UTC)
-        + dt.timedelta(hours=int(unique, 16) % 50_000_000)
-    )
+    # The window must be in the PAST and inside ROLLUP_RETENTION_MONTHS.
+    # An earlier version made it "practically unique" by basing it at
+    # 2100-01-01 (+ up to ~5,700 years of offset) — and a run pointed at
+    # a live store wrote year-7748 rows into production, where they
+    # sorted first in every newest-first read and permanently pinned the
+    # staleness detector's "latest sample". Future-dated samples are now
+    # rejected at ingest and filtered at read, so a future-based range
+    # would fail those guards anyway. Uniqueness against persistent
+    # conformance databases comes from filtering assertions to this
+    # test's own target below, not from an exclusive time range.
+    now = dt.datetime.now(dt.UTC).replace(
+        minute=10, second=0, microsecond=0
+    ) - dt.timedelta(hours=3 + int(unique, 16) % 17_000)
     target = f"status-{unique}"
     probe_type = f"probe-{unique}"
     monitor_region = f"monitor-{unique}"
@@ -383,17 +389,29 @@ def test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option(
         (now - dt.timedelta(hours=2)).replace(minute=0)
     )
     newest_start = _iso_utc(now.replace(minute=0))
-    newest = store.synthetic_rollups(
+    middle_start = _iso_utc(
+        (now - dt.timedelta(hours=1)).replace(minute=0)
+    )
+    # A persistent conformance database may hold foreign rows in the same
+    # hours, so exact-membership assertions go through this test's own
+    # target; the limit clause is asserted as a pure cap + newest-first
+    # prefix property, which holds regardless of what else is present.
+    full = store.synthetic_rollups(
+        period="hour",
+        since=oldest_start,
+        until=newest_start,
+        limit=1000,
+    )
+    own_full = [row for row in full if row.target == target]
+    assert [row.period_start for row in own_full] == [newest_start, middle_start, oldest_start]
+    capped = store.synthetic_rollups(
         period="hour",
         since=oldest_start,
         until=newest_start,
         limit=2,
     )
-    assert len(newest) == 2
-    middle_start = _iso_utc(
-        (now - dt.timedelta(hours=1)).replace(minute=0)
-    )
-    assert [row.period_start for row in newest] == [newest_start, middle_start]
+    assert len(capped) == 2
+    assert [row.id for row in capped] == [row.id for row in full[:2]]
 
     ranged = store.synthetic_rollups(
         period="hour",

--- a/tests/test_attested_transport.py
+++ b/tests/test_attested_transport.py
@@ -163,6 +163,30 @@ class TestTargetPlumbing:
         assert all(t.attested is False for t in configured_targets(settings))
         assert all(t.expected_pcr0 is None for t in configured_targets(settings))
 
+    def test_standalone_topology_is_one_canonical_target(self) -> None:
+        """Regional alias/Cloud-Run probing is GCP topology. On a
+        standalone deployment the templates fabricate hostnames that do
+        not exist (api-eu-west-3.quillrouter.com, a nonexistent *.run.app
+        URL) which would sit permanently down on the status page."""
+        settings = Settings(
+            environment="test",
+            sentry_dsn=None,
+            api_base_url="https://api-aws.trustedrouter.com/v1",
+            primary_region="eu-west-3",
+            regions="eu-west-3",
+            synthetic_regional_probes_enabled=False,
+            synthetic_control_plane_health_url="https://paris.example.com",
+        )
+        targets = configured_targets(settings)
+        assert [t.name for t in targets] == ["canonical"]
+        assert targets[0].control_plane_url == "https://paris.example.com"
+
+    def test_gcp_topology_unchanged_by_standalone_settings(self) -> None:
+        settings = Settings(environment="test", sentry_dsn=None)
+        names = [t.name for t in configured_targets(settings)]
+        assert names[0] == "canonical"
+        assert len(names) > 1  # regional targets still present by default
+
     def test_target_defaults_are_backward_compatible(self) -> None:
         target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1")
         assert target.attested is False

--- a/tests/test_attested_transport.py
+++ b/tests/test_attested_transport.py
@@ -1,0 +1,192 @@
+"""Attested-cert-only probe transport (SyntheticTarget.attested).
+
+An attested target serves a self-signed cert minted inside the TEE, so CA
+verification is replaced by a stronger check: the attestation document
+must bind the exact cert served on the probe's own TLS connection (SPKI +
+sha256 fingerprint), and optionally pin PCR0. These tests build real cert
+material so the binding math is exercised for real, not mocked.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+
+import cbor2
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.x509.oid import NameOID
+
+from trusted_router.config import Settings
+from trusted_router.synthetic.probes import (
+    SyntheticTarget,
+    _attestation_evidence,
+    _attested_ssl_context,
+    _aws_cert_binding_ok,
+    configured_targets,
+)
+
+NONCE = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
+PCR0 = bytes(range(48))
+
+
+def _self_signed_cert_der(cn: str = "api-aws.trustedrouter.com") -> bytes:
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    now = dt.datetime.now(dt.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(Encoding.DER)
+
+
+def _spki(cert_der: bytes) -> bytes:
+    return (
+        x509.load_der_x509_certificate(cert_der)
+        .public_key()
+        .public_bytes(encoding=Encoding.DER, format=PublicFormat.SubjectPublicKeyInfo)
+    )
+
+
+def _cose(payload: dict[object, object]) -> bytes:
+    return cbor2.dumps([b"\xa1\x01\x38\x22", {}, cbor2.dumps(payload), b"sig" * 32])
+
+
+def _payload(cert_der: bytes | None, *, nonce_hex: str = NONCE, pcr0: bytes = PCR0) -> dict[object, object]:
+    payload: dict[object, object] = {
+        "module_id": "i-test-enc0",
+        "digest": "SHA384",
+        "pcrs": {0: pcr0},
+        "nonce": bytes.fromhex(nonce_hex),
+    }
+    if cert_der is not None:
+        payload["public_key"] = _spki(cert_der)
+        payload["user_data"] = hashlib.sha256(cert_der).digest()
+    return payload
+
+
+class TestCertBinding:
+    def test_bound_cert_passes(self) -> None:
+        cert = _self_signed_cert_der()
+        evidence = _attestation_evidence(_cose(_payload(cert)), NONCE, peer_cert_der=cert)
+        assert evidence["error_type"] is None
+
+    def test_substituted_cert_fails_as_cert_binding_mismatch(self) -> None:
+        served = _self_signed_cert_der()
+        relay = _self_signed_cert_der("relay.example.com")
+        evidence = _attestation_evidence(_cose(_payload(served)), NONCE, peer_cert_der=relay)
+        assert evidence["error_type"] == "cert_binding_mismatch"
+
+    def test_document_binding_nothing_fails(self) -> None:
+        """An attested target whose document binds no cert at all must not
+        read as verified — unverifiable is a failure state."""
+        cert = _self_signed_cert_der()
+        evidence = _attestation_evidence(_cose(_payload(None)), NONCE, peer_cert_der=cert)
+        assert evidence["error_type"] == "cert_binding_mismatch"
+
+    def test_spki_match_with_wrong_fingerprint_fails(self) -> None:
+        cert = _self_signed_cert_der()
+        payload = _payload(cert)
+        payload["user_data"] = b"\xff" * 32
+        evidence = _attestation_evidence(_cose(payload), NONCE, peer_cert_der=cert)
+        assert evidence["error_type"] == "cert_binding_mismatch"
+
+    def test_no_peer_cert_skips_binding_gcp_path_unchanged(self) -> None:
+        cert = _self_signed_cert_der()
+        evidence = _attestation_evidence(_cose(_payload(cert)), NONCE, peer_cert_der=None)
+        assert evidence["error_type"] is None
+
+    def test_binding_helper_rejects_garbage_der(self) -> None:
+        cert = _self_signed_cert_der()
+        assert _aws_cert_binding_ok({"public_key": _spki(cert)}, b"not a certificate") is False
+
+
+class TestPcr0Pin:
+    def test_matching_pin_passes(self) -> None:
+        cert = _self_signed_cert_der()
+        evidence = _attestation_evidence(
+            _cose(_payload(cert)), NONCE, peer_cert_der=cert, expected_pcr0=PCR0.hex()
+        )
+        assert evidence["error_type"] is None
+
+    def test_pin_is_case_insensitive(self) -> None:
+        evidence = _attestation_evidence(_cose(_payload(None)), NONCE, expected_pcr0=PCR0.hex().upper())
+        assert evidence["error_type"] is None
+
+    def test_wrong_measurement_is_pcr0_mismatch(self) -> None:
+        cert = _self_signed_cert_der()
+        evidence = _attestation_evidence(
+            _cose(_payload(cert)), NONCE, peer_cert_der=cert, expected_pcr0="ab" * 48
+        )
+        assert evidence["error_type"] == "pcr0_mismatch"
+        # The digest is still reported so the operator sees WHAT is running.
+        assert evidence["attestation_digest"] == PCR0.hex()
+
+    def test_nonce_failure_outranks_pcr0(self) -> None:
+        evidence = _attestation_evidence(
+            _cose(_payload(None, nonce_hex="ff" * 16)), NONCE, expected_pcr0="ab" * 48
+        )
+        assert evidence["error_type"] == "nonce_missing"
+
+
+class TestTargetPlumbing:
+    def test_attested_context_disables_verification(self) -> None:
+        import ssl
+
+        context = _attested_ssl_context()
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+
+    def test_configured_targets_carry_attested_flag(self) -> None:
+        settings = Settings(
+            environment="test",
+            sentry_dsn=None,
+            synthetic_canonical_attested=True,
+            attestation_expected_pcr0="2c" * 48,
+        )
+        canonical = configured_targets(settings)[0]
+        assert canonical.attested is True
+        assert canonical.expected_pcr0 == "2c" * 48
+
+    def test_default_targets_are_not_attested(self) -> None:
+        settings = Settings(environment="test", sentry_dsn=None)
+        assert all(t.attested is False for t in configured_targets(settings))
+        assert all(t.expected_pcr0 is None for t in configured_targets(settings))
+
+    def test_target_defaults_are_backward_compatible(self) -> None:
+        target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1")
+        assert target.attested is False
+        assert target.expected_pcr0 is None
+
+
+@pytest.mark.parametrize("field", ["public_key", "user_data"])
+def test_single_binding_field_alone_is_sufficient(field: str) -> None:
+    """The enclave publishes two bindings; either one alone must still
+    bind (older enclave builds populated only user_data)."""
+    cert = _self_signed_cert_der()
+    full = _payload(cert)
+    partial: dict[object, object] = {k: v for k, v in full.items() if k != field}
+    evidence = _attestation_evidence(_cose(partial), NONCE, peer_cert_der=cert)
+    assert evidence["error_type"] is None
+
+
+def test_evidence_kwargs_default_to_prior_behavior() -> None:
+    """No peer cert, no pin — byte-identical semantics to the pre-change
+    parser for both formats (regression fence for GCP)."""
+    evidence = _attestation_evidence(_cose(_payload(None)), NONCE)
+    assert evidence == {
+        "nonce_ok": True,
+        "error_type": None,
+        "attestation_digest": PCR0.hex(),
+        "source_commit": None,
+    }

--- a/tests/test_monitor_freshness_poison.py
+++ b/tests/test_monitor_freshness_poison.py
@@ -1,0 +1,151 @@
+"""Future-dated samples must never disable the staleness detector.
+
+Regression for a live incident: conformance fixtures dated in the year
+7748 were written to a production store. The freshness computation took
+`max(samples, key=created_at)` and clamped the (negative) age to 0, so
+`latest_sample_age_seconds` read 0 and `is_stale` read False permanently —
+through what would otherwise be a total monitor outage. A staleness
+detector that one poison row disables forever is worse than none.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, SyntheticProbeSample
+from trusted_router.synthetic.rollups import raw_sample_is_within_retention
+from trusted_router.synthetic.status import (
+    CURRENT_SAMPLE_TTL_SECONDS,
+    _current_status,
+    _monitor_freshness,
+)
+
+NOW = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _sample(created_at: dt.datetime, *, status: str = "up", sample_id: str = "s1") -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=sample_id,
+        probe_type="tls_health",
+        target="canonical",
+        target_url="https://api-aws.trustedrouter.com/health",
+        monitor_region="eu-west-3",
+        status=status,
+        created_at=created_at.isoformat().replace("+00:00", "Z"),
+    )
+
+
+class TestMonitorFreshness:
+    def test_poison_row_does_not_define_latest(self) -> None:
+        poison = _sample(dt.datetime(7748, 6, 5, tzinfo=dt.UTC), sample_id="poison")
+        real = _sample(NOW - dt.timedelta(seconds=42), sample_id="real")
+        freshness = _monitor_freshness([poison, real], now=NOW)
+        assert freshness["latest_sample_age_seconds"] == 42
+        assert freshness["is_stale"] is False
+        assert freshness["future_dated_samples"] == 1
+
+    def test_only_poison_rows_is_stale_not_fresh(self) -> None:
+        poison = _sample(dt.datetime(7748, 6, 5, tzinfo=dt.UTC))
+        freshness = _monitor_freshness([poison], now=NOW)
+        assert freshness["is_stale"] is True
+        assert freshness["latest_sample_at"] is None
+        assert freshness["future_dated_samples"] == 1
+
+    def test_stale_real_samples_behind_poison_read_stale(self) -> None:
+        """The exact live failure shape: monitor died, poison remained."""
+        poison = _sample(dt.datetime(7748, 6, 5, tzinfo=dt.UTC), sample_id="poison")
+        old = _sample(NOW - dt.timedelta(hours=3), sample_id="old")
+        freshness = _monitor_freshness([poison, old], now=NOW)
+        assert freshness["is_stale"] is True
+
+    def test_ordinary_clock_skew_tolerated(self) -> None:
+        skewed = _sample(NOW + dt.timedelta(seconds=FUTURE_SAMPLE_SKEW_SECONDS - 5))
+        freshness = _monitor_freshness([skewed], now=NOW)
+        assert freshness["is_stale"] is False
+        assert freshness["future_dated_samples"] == 0
+        # Display clamps to zero; the decision logic does not.
+        assert freshness["latest_sample_age_seconds"] == 0
+
+    def test_empty_is_stale(self) -> None:
+        assert _monitor_freshness([], now=NOW)["is_stale"] is True
+
+
+class TestCurrentStatusPoison:
+    def test_future_dated_up_sample_cannot_pin_green(self) -> None:
+        poison = _sample(dt.datetime(7748, 6, 5, tzinfo=dt.UTC), status="up")
+        current = _current_status([poison], now=NOW)
+        (row,) = current["checks"]
+        assert row["effective_status"] == "unknown"
+        assert current["overall_status"] == "unknown"
+
+    def test_fresh_sample_still_reports_normally(self) -> None:
+        fresh = _sample(NOW - dt.timedelta(seconds=30), status="up")
+        current = _current_status([fresh], now=NOW)
+        assert current["overall_status"] == "up"
+
+    def test_old_sample_still_degrades_to_unknown(self) -> None:
+        old = _sample(NOW - dt.timedelta(seconds=CURRENT_SAMPLE_TTL_SECONDS + 60))
+        current = _current_status([old], now=NOW)
+        assert current["overall_status"] == "unknown"
+
+
+class TestRetentionUpperBound:
+    def test_future_sample_outside_skew_excluded(self) -> None:
+        poison = _sample(NOW + dt.timedelta(hours=1))
+        assert raw_sample_is_within_retention(poison, now=NOW) is False
+
+    def test_future_sample_inside_skew_included(self) -> None:
+        skewed = _sample(NOW + dt.timedelta(seconds=FUTURE_SAMPLE_SKEW_SECONDS - 5))
+        assert raw_sample_is_within_retention(skewed, now=NOW) is True
+
+    def test_recent_past_sample_included(self) -> None:
+        assert raw_sample_is_within_retention(_sample(NOW - dt.timedelta(days=1)), now=NOW) is True
+
+
+class TestIngestBoundary:
+    @pytest.fixture
+    def client(self) -> TestClient:
+        from trusted_router.config import Settings
+        from trusted_router.main import create_app
+
+        settings = Settings(
+            environment="test",
+            sentry_dsn=None,
+            internal_gateway_token="test-internal-secret",  # noqa: S106 - test fixture.
+        )
+        return TestClient(create_app(settings, init_observability=False))
+
+    def _post(self, client: TestClient, created_at: str) -> Any:
+        return client.post(
+            "/v1/internal/synthetic/samples",
+            json={
+                "samples": [
+                    {
+                        "id": "ingest-guard-1",
+                        "probe_type": "tls_health",
+                        "target": "canonical",
+                        "target_url": "https://example.com",
+                        "monitor_region": "eu-west-3",
+                        "status": "up",
+                        "created_at": created_at,
+                    }
+                ]
+            },
+            headers={"x-trustedrouter-internal-token": "test-internal-secret"},
+        )
+
+    def test_far_future_created_at_rejected(self, client: TestClient) -> None:
+        response = self._post(client, "7748-06-05T20:10:00Z")
+        assert response.status_code == 400
+        assert "future" in response.json()["error"]["message"]
+
+    def test_recent_created_at_accepted(self, client: TestClient) -> None:
+        recent = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
+        assert self._post(client, recent).status_code == 200
+
+    def test_garbage_created_at_rejected_as_400(self, client: TestClient) -> None:
+        assert self._post(client, "not-a-timestamp").status_code == 400


### PR DESCRIPTION
## What

Two increments finishing the EU synthetic monitor's correctness story:

**1. Attested-cert-only transport (`SyntheticTarget.attested`).** The AWS Nitro gateway serves a self-signed TEE-minted cert, so CA verification can never pass. Attested targets get a separate no-CA-verify httpx client (never shared with CA-certified targets), and the attestation probe streams its request so it can read the peer cert and require the document to bind it — `public_key` == served SPKI, `user_data[:32]` == sha256(cert DER), mirroring `verify-attestation.py`. A document binding nothing **fails**: unverifiable must not read as verified. `TR_ATTESTATION_EXPECTED_PCR0` additionally pins the EIF measurement. Distinct error taxonomy: `nonce_missing` / `cert_binding_mismatch` / `pcr0_mismatch` / `unsupported_attestation_format`.

Verified live against the eu-west-1 enclave including both negative controls: correct pin → `up` (digest `2c12e222…`), flipped PCR0 byte → `pcr0_mismatch`, strict-TLS client → `ConnectError`.

**2. Future-dated samples are poison, not evidence.** Year-7748 conformance fixtures written to a live store had (a) permanently disabled the staleness detector (`max(age,0)` clamp → `is_stale` false forever), (b) made a future-dated `up` sample able to pin components green, (c) sorted first in every newest-first read with no upper bound to ever expire them. Defense at all three layers sharing `FUTURE_SAMPLE_SKEW_SECONDS=60`: status (signed ages + exclusion + `future_dated_samples` count), storage (upper bound in the shared retention predicate + the Postgres query), ingest (400 on `created_at` >60s future). The conformance fixture that produced the poison now uses a past-dated in-retention window with uniqueness from target-filtered assertions.

## Testing
- 17 attested-transport tests with real cert material (EC keys, DER, SPKI); 14 poison-regression tests incl. the exact live failure shape
- Full suite 2524 passed / 86 skipped; ruff + mypy clean; conformance suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)