### PR TITLE
Deploy by digest + gateway 401 /health reachability

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -49,10 +49,26 @@ log "building linux/amd64 image and pushing to ${ECR}:${TAG}"
 aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com" >/dev/null
 docker buildx build --platform linux/amd64 -t "${ECR}:${TAG}" --push .
 
+# Resolve the tag to its DIGEST and deploy by digest.
+#
+# App Runner keys "did the source change?" off the ImageIdentifier STRING.
+# With a mutable tag that string is constant, so update-service applies new
+# environment variables but does NOT re-pull the image: the service comes
+# back RUNNING, the operation reports SUCCEEDED, describe-service shows the
+# new env — and the OLD CODE is still serving. That happened on this very
+# service and cost a full verification cycle chasing a "deployed" fix that
+# was never running. A digest changes whenever the image does, so the
+# update is honest by construction.
+IMAGE_DIGEST=$(aws ecr describe-images --region "$REGION" --repository-name trusted-router \
+  --image-ids "imageTag=${TAG}" --query 'imageDetails[0].imageDigest' --output text)
+[ -n "$IMAGE_DIGEST" ] && [ "$IMAGE_DIGEST" != "None" ] || { echo "could not resolve ${TAG} to a digest" >&2; exit 1; }
+IMAGE_REF="${ECR}@${IMAGE_DIGEST}"
+log "deploying by digest: ${IMAGE_DIGEST}"
+
 CONFIG=$(cat <<JSON
 {
   "ImageRepository": {
-    "ImageIdentifier": "${ECR}:${TAG}",
+    "ImageIdentifier": "${IMAGE_REF}",
     "ImageRepositoryType": "ECR",
     "ImageConfiguration": {
       "Port": "8080",
@@ -117,6 +133,16 @@ for _ in $(seq 1 60); do
   sleep 20
 done
 URL=$(aws apprunner describe-service --region "$REGION" --service-arn "$ARN" --query 'Service.ServiceUrl' --output text)
+
+# Assert the service is SERVING the digest we just built. RUNNING +
+# operation SUCCEEDED is not that assertion — see the digest note above.
+RUNNING_REF=$(aws apprunner describe-service --region "$REGION" --service-arn "$ARN" \
+  --query 'Service.SourceConfiguration.ImageRepository.ImageIdentifier' --output text)
+if [ "$RUNNING_REF" != "$IMAGE_REF" ]; then
+  echo "FAILED: service is serving ${RUNNING_REF}, expected ${IMAGE_REF}" >&2
+  exit 1
+fi
+log "verified serving digest ${IMAGE_DIGEST}"
 log "service: https://${URL}"
 echo "https://${URL}"
 

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -391,7 +391,7 @@ async def gateway_latency_phase_probes(
             timeout_seconds=_remaining_probe_seconds(started, timeout_seconds),
         )
         first_total_ms = _elapsed_ms(started)
-        first_ok = first_status == 200 and first_body == b'{"status":"ok"}'
+        first_ok = _health_status_reachable(first_status, first_body)
         cold = _sample(
             "gateway_cold_path",
             target,
@@ -438,7 +438,7 @@ async def gateway_latency_phase_probes(
             )
         )
         second_total_ms = _elapsed_ms(reused_started)
-        second_ok = second_status == 200 and second_body == b'{"status":"ok"}'
+        second_ok = _health_status_reachable(second_status, second_body)
         return [
             cold,
             _sample(
@@ -2281,6 +2281,31 @@ def _health_ok(response: httpx.Response) -> bool:
         return response.json().get("status") == "ok"
     except ValueError:
         return False
+
+
+def _health_status_reachable(status: int, body: bytes) -> bool:
+    """Did /health prove the request path is alive?
+
+    These latency-phase probes measure DNS/TCP/TLS/first-byte — they are
+    diagnostic timing, not an authorization signal. A 401 "Invalid API
+    key" still proves every one of those phases completed, so it counts
+    as reachable, matching what tls_health_probe already does.
+
+    Not cosmetic: the AWS Nitro gateway protects every route except
+    /attestation and answers /health with 401, while the GCP gateway
+    answers 200. Without this, tls_health reported `up` and the two
+    latency probes reported `down` for the SAME 401 on the SAME URL —
+    a permanent false red on the EU status page.
+    """
+    if status == 200 and body == b'{"status":"ok"}':
+        return True
+    if status != 401:
+        return False
+    try:
+        error = json.loads(body).get("error", {})
+    except (ValueError, AttributeError):
+        return False
+    return "invalid api key" in str(error.get("message", "")).lower()
 
 
 def _invalid_api_key(response: httpx.Response) -> bool:

--- a/tests/test_attested_transport.py
+++ b/tests/test_attested_transport.py
@@ -214,3 +214,29 @@ def test_evidence_kwargs_default_to_prior_behavior() -> None:
         "attestation_digest": PCR0.hex(),
         "source_commit": None,
     }
+
+
+class TestHealthReachability:
+    """The latency-phase probes measure DNS/TCP/TLS/first-byte, not
+    authorization. The AWS Nitro gateway answers /health with 401 (it
+    protects every route but /attestation) where GCP answers 200 —
+    without treating that 401 as reachable, tls_health reported `up`
+    and the two latency probes reported `down` for the SAME response.
+    """
+
+    @pytest.mark.parametrize(
+        ("status", "body", "expected"),
+        [
+            (200, b'{"status":"ok"}', True),
+            (401, b'{"error":{"message":"Invalid API key","status":401}}', True),
+            (401, b'{"error":{"message":"rate limited"}}', False),
+            (401, b"not json", False),
+            (500, b"boom", False),
+            (200, b"garbage", False),
+            (503, b'{"error":{"message":"Invalid API key"}}', False),
+        ],
+    )
+    def test_reachability(self, status: int, body: bytes, expected: bool) -> None:
+        from trusted_router.synthetic.probes import _health_status_reachable
+
+        assert _health_status_reachable(status, body) is expected


### PR DESCRIPTION
Both found by deploying and then looking at production rather than trusting the deploy's own report.

**1. The deploy didn't deploy.** App Runner keys "did the source change?" off the `ImageIdentifier` string. With the mutable tag `:eu` that string never changes, so `update-service` applied new env vars but **never re-pulled the image** — RUNNING, operation SUCCEEDED, new env visible in `describe-service`, old code serving. Caught only by a behavioural probe (post a future-dated sample: new code 400s, old code 200s). The script now deploys by **digest** and asserts the service is serving that exact digest before returning.

**2. Permanent false red on /health.** `tls_health_probe` already accepted a 401 "Invalid API key" as proof of reachability; the two latency-phase probes demanded 200. The AWS gateway protects every route but `/attestation` and answers 401 where GCP answers 200 — so the same response on the same URL produced `up` from one probe and `down` from two others. These probes measure DNS/TCP/TLS/first-byte; a 401 proves all of it. Shared `_health_status_reachable` predicate.

## Live verification after the real deploy
```
attestation_nonce    up    pcr0=2c12e22215d4269d... (matches pin)
openai_sdk_pong      up    -> api-aws.trustedrouter.com/v1/chat/completions
responses_pong       up    -> api-aws.trustedrouter.com/v1/responses
control_plane_health up    gateway_authorize up    gateway_settle up
benchmark_recorded: 1 (DSv4 rotation)
```
Also confirmed in prod: the ingest guard from #407 now rejects a year-7748 sample with `created_at is 180550407891s in the future (max 60s)`, and `future_dated=0 / stale=true` shows the read-side filter working.

Full suite 2535 passed / 86 skipped; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)