### PR TITLE
Synthetic detach mode + EventBridge connection re-auth

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -155,6 +155,33 @@ echo "https://${URL}"
 # ---------------------------------------------------------------------------
 if [ "${SKIP_EVENTBRIDGE:-0}" != "1" ]; then
   log "aligning EventBridge rule tr-eu-synthetic-1min"
+
+  # Re-authorize the connection with the CURRENT internal gateway token.
+  #
+  # The connection stores its own copy of the credential. When the token
+  # this service reads changes (e.g. moving it from a plaintext env var
+  # to Secrets Manager, as this script did), that stored copy goes stale,
+  # every invocation 401s, and EventBridge flips the connection to
+  # DEAUTHORIZED and stops trying. Nothing on the service side reports
+  # this — the app is healthy, the rule is ENABLED, and the status page
+  # simply goes quietly stale. Observed exactly that: 15/15
+  # FailedInvocations with the app returning 200 to manual calls.
+  #
+  # Re-authorizing here binds the credential to the same token the
+  # service was just deployed with, so the two cannot drift.
+  CONN_TOKEN=$(aws secretsmanager get-secret-value --region "$REGION" \
+    --secret-id quill/trustedrouter-internal-gateway-token --query SecretString --output text)
+  aws events update-connection --region "$REGION" --name tr-eu-synthetic \
+    --authorization-type API_KEY \
+    --auth-parameters "ApiKeyAuthParameters={ApiKeyName=Authorization,ApiKeyValue=Bearer ${CONN_TOKEN}}" >/dev/null
+  for _ in $(seq 1 15); do
+    CONN_STATE=$(aws events describe-connection --region "$REGION" --name tr-eu-synthetic --query ConnectionState --output text)
+    [ "$CONN_STATE" = "AUTHORIZED" ] && break
+    sleep 10
+  done
+  [ "$CONN_STATE" = "AUTHORIZED" ] || { echo "FAILED: connection state $CONN_STATE" >&2; exit 1; }
+  log "connection AUTHORIZED with current token"
+
   DEST_ARN=$(aws events list-api-destinations --region "$REGION" --name-prefix tr-eu-synthetic-run --query 'ApiDestinations[0].ApiDestinationArn' --output text)
   ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/tr-eu-eventbridge-invoke-par"
   TARGETS=$(python3 - "$DEST_ARN" "$ROLE_ARN" "$REGION" <<'PY'
@@ -166,6 +193,12 @@ rule_input = {
     "monitor_region": region,
     "rotation_count": 2,
     "rotation_models": ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+    # REQUIRED here: EventBridge API destinations abandon the request
+    # after ~5s and a probe pass takes 10-17s, so without detach every
+    # tick is a FailedInvocation (observed 15/15) even though the app
+    # completes the run and returns 200. detach acknowledges in
+    # milliseconds and probes in the background.
+    "detach": True,
 }
 print(json.dumps([
     {

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import random
 from dataclasses import asdict
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Response
 from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
+from trusted_router.config import Settings
 from trusted_router.errors import api_error
 from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
@@ -79,9 +81,30 @@ def register(router: APIRouter) -> None:
         return {"data": {"flagged": [asdict(flag) for flag in flags]}}
 
     @router.post("/internal/synthetic/run")
-    async def synthetic_run(request: Request, settings: SettingsDep) -> dict[str, Any]:
+    async def synthetic_run(
+        request: Request, settings: SettingsDep, response: Response
+    ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
         body = await json_body(request)
+        # Fire-and-forget mode for schedulers with a short response
+        # deadline. EventBridge API destinations give up waiting after
+        # ~5s; a full probe pass takes 10-17s (longer with rotation), so
+        # EVERY tick was recorded as a FailedInvocation even though the
+        # app completed the run and returned 200. The scheduler retries,
+        # then EventBridge gives up on the connection entirely — and
+        # nothing on the service side reports any of it, because from the
+        # app's point of view every request succeeded.
+        #
+        # With detach=true we acknowledge immediately and run the pass on
+        # the event loop. `recorded` is then unknowable at response time,
+        # so we do not pretend: the body says scheduled, not recorded.
+        if _is_true(body.get("detach")):
+            asyncio.create_task(_run_and_record(settings, body))  # noqa: RUF006 - fire-and-forget by design
+            response.status_code = 202
+            return {"data": {"scheduled": True}}
+        return await _run_and_record(settings, body)
+
+    async def _run_and_record(settings: Settings, body: dict[str, Any]) -> dict[str, Any]:
         monitor_region = _optional_str(body.get("monitor_region"))
         # Which control plane the billing probes (authorize+settle) hit.
         # Precedence: request body > settings > canonical GCP plane. The
@@ -308,3 +331,9 @@ def _rotation_models(body: dict[str, Any]) -> frozenset[str] | None:
         return None
     models = frozenset(str(item) for item in raw if isinstance(item, str) and item)
     return models or None
+
+
+def _is_true(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}

--- a/tests/test_synthetic_run_rotation.py
+++ b/tests/test_synthetic_run_rotation.py
@@ -148,3 +148,45 @@ class TestControlPlaneResolution:
         settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
         assert _post_run(settings, {}).status_code == 200
         assert no_network_probes["billing_urls"] == ["https://trustedrouter.com"]
+
+
+class TestDetachMode:
+    """EventBridge API destinations abandon a request after ~5s; a probe
+    pass takes 10-17s. Every tick was a FailedInvocation even though the
+    app completed and returned 200 — invisible from the service side.
+    detach=true acknowledges immediately and probes in the background.
+    """
+
+    def test_detach_returns_202_scheduled(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {"detach": True, "rotation_count": 1})
+        assert resp.status_code == 202
+        assert resp.json()["data"] == {"scheduled": True}
+        # Deliberately does NOT claim a recorded count it cannot know yet.
+        assert "recorded" not in resp.json()["data"]
+
+    def test_detach_still_runs_the_pass(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        _post_run(settings, {"detach": True, "rotation_count": 2})
+        # TestClient drives the event loop to completion on exit, so the
+        # background task has run by the time the response is returned.
+        assert no_network_probes["rotation_calls"], "detached pass never executed"
+        assert no_network_probes["rotation_calls"][0]["count"] == 2
+
+    def test_default_is_synchronous(self, no_network_probes: dict[str, Any]) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        resp = _post_run(settings, {})
+        assert resp.status_code == 200
+        assert "recorded" in resp.json()["data"]
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "on", True])
+    def test_truthy_spellings_detach(self, no_network_probes: dict[str, Any], value: Any) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        assert _post_run(settings, {"detach": value}).status_code == 202
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", False, None, ""])
+    def test_falsy_spellings_stay_synchronous(
+        self, no_network_probes: dict[str, Any], value: Any
+    ) -> None:
+        settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
+        assert _post_run(settings, {"detach": value}).status_code == 200


### PR DESCRIPTION
Two independent reasons the EU 1-minute scheduler was failing 100% of ticks while the application reported success.

**1. Response-deadline mismatch.** EventBridge API destinations abandon a request after ~5s; a probe pass takes 10–17s. Every tick was a `FailedInvocation` even though the app completed and returned 200 — invisible from the service side, symptom was a status page going quietly stale. `detach=true` returns `202 {"scheduled": true}` immediately and probes in the background. The response deliberately omits a `recorded` count rather than inventing one.

**2. Credential drift.** The EventBridge connection stores its own copy of the internal gateway token. Moving that token to Secrets Manager left the stored copy stale → every call 401'd → EventBridge marked the connection `DEAUTHORIZED` and gave up. The deploy now re-authorizes with the same token the service was deployed with and fails if it doesn't reach `AUTHORIZED`.

Default behaviour is unchanged (synchronous), so the GCP monitor CLI and manual runs are unaffected.

## Testing
- 14 new route tests: 202/scheduled shape, background pass actually executes, truthy/falsy `detach` spellings, sync default
- Full suite 2549 passed / 86 skipped; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)