### PR TITLE
Fix 0G activation canary output budget

### DIFF
--- a/scripts/pricing/openai_catalog.py
+++ b/scripts/pricing/openai_catalog.py
@@ -127,6 +127,7 @@ def probe_openai_chat(
     model: str,
     extra_headers: dict[str, str] | None = None,
     expected_content: str | None = None,
+    max_tokens: int = 4,
 ) -> bool:
     """Run a minimal paid-path canary without logging response content."""
 
@@ -145,7 +146,7 @@ def probe_openai_chat(
             json={
                 "model": model,
                 "messages": [{"role": "user", "content": "Reply PONG"}],
-                "max_tokens": 4,
+                "max_tokens": max_tokens,
                 "stream": False,
             },
             timeout=PROVIDER_FETCH_TIMEOUT,

--- a/scripts/pricing/providers/zero_g.py
+++ b/scripts/pricing/providers/zero_g.py
@@ -306,6 +306,7 @@ def fetch() -> ProviderPricingResult:
         model="0gm-1.0-35b-a3b",
         extra_headers=PRIVATE_TRUST_HEADERS,
         expected_content="PONG",
+        max_tokens=256,
     )
     for row in discovered.values():
         row["routable"] = _LIVE_CANARY_OK

--- a/tests/test_zero_g_provider.py
+++ b/tests/test_zero_g_provider.py
@@ -218,6 +218,7 @@ def test_zero_g_fetch_forces_private_canary_and_enables_only_after_pong(
         "model": "0gm-1.0-35b-a3b",
         "extra_headers": {"X-0G-Provider-Trust-Mode": "private"},
         "expected_content": "PONG",
+        "max_tokens": 256,
     }
     assert zero_g._LIVE_CANARY_OK is True
     assert all(
@@ -263,11 +264,13 @@ def test_zero_g_canary_requires_exact_openai_pong(
             model="0gm-1.0-35b-a3b",
             extra_headers=zero_g.PRIVATE_TRUST_HEADERS,
             expected_content="PONG",
+            max_tokens=256,
         )
         is expected
     )
     assert captured["url"] == "https://router-api.0g.ai/v1/chat/completions"
     assert captured["headers"]["X-0G-Provider-Trust-Mode"] == "private"
+    assert captured["json"]["max_tokens"] == 256
 
 
 def test_zero_g_missing_key_keeps_every_route_dark(


### PR DESCRIPTION
## Summary
- make the shared OpenAI-compatible PONG probe accept a provider-specific output budget
- give 0G 256 tokens because 0GM emits hidden reasoning before visible content
- retain the four-token default for every existing provider

## Evidence
- the production-key private TeeML probe returned HTTP 200 but `finish_reason=length` and no visible content at 8 and 128 tokens
- the same bounded probe returned exact `PONG` with `finish_reason=stop` at 256 tokens
- `uv run pytest -q tests/test_zero_g_provider.py` (12 passed)
- `uv run ruff check ...`
- `uv run mypy` (209 files)