### PR TITLE
Close the status swallows: silent probes, deploy gate, watchdog rollback

### DIFF
--- a/scripts/deploy/verify_deployment.sh
+++ b/scripts/deploy/verify_deployment.sh
@@ -66,11 +66,36 @@ status_code="$(code "$BASE/status.json")"
 if [ "$status_code" = "200" ]; then
   ok "/status.json responds 200 (database read path works)"
   status_payload="$(body "$BASE/status.json")"
-  if printf '%s' "$status_payload" | grep -q '"overall_status"'; then
-    ok "status payload is well-formed"
-  else
-    bad "status payload missing overall_status — served, but wrong shape"
-  fi
+  # Parse the VALUE, don't grep for the key. `grep -q '"overall_status"'`
+  # matches just as happily when the value is "down" — a deploy gate that
+  # passes on a red status page is not a gate. Attestation failures
+  # (trust_degraded) count as failures here: an attested gateway that
+  # cannot prove itself is the product being broken.
+  overall_status="$(
+    printf '%s' "$status_payload" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except ValueError:
+    print("UNPARSEABLE")
+    sys.exit(0)
+data = payload.get("data") or {}
+print(str(data.get("overall_status") or "MISSING"))
+'
+  )"
+  case "$overall_status" in
+    up|degraded|routing_degraded)
+      ok "status payload overall_status=$overall_status"
+      ;;
+    MISSING|UNPARSEABLE)
+      bad "status payload missing/unparseable overall_status — served, but wrong shape"
+      ;;
+    *)
+      bad "status page reports overall_status=$overall_status"
+      ;;
+  esac
   if [ "$EXPECT_MONITOR" -eq 1 ]; then
     monitor_result="$(
       printf '%s' "$status_payload" | python3 -c '
@@ -78,7 +103,11 @@ import datetime as dt
 import json
 import sys
 
-MAX_AGE_SECONDS = 30 * 60
+# Must match CURRENT_SAMPLE_TTL_SECONDS in the app (5 min). At 30 min
+# this gate printed "synthetic monitor is fresh" for a deployment whose
+# own status page already rendered "Monitor Data Stale" - a gate looser
+# than the thing it gates cannot fail before the product does.
+MAX_AGE_SECONDS = 5 * 60
 
 
 def parse_time(value):

--- a/scripts/deploy/watchdog.py
+++ b/scripts/deploy/watchdog.py
@@ -23,9 +23,11 @@ Logic:
     other regions.
   - Exit 1 if at least one region is in the rollback set, else 0.
 
-Why "down" only (not "degraded"): synthetics naturally flap during a
-rolling update — only sustained-down means the deploy actually broke
-something for that region. degraded alone is normal churn.
+Why "down" and "trust_degraded" (not "degraded"): synthetics naturally
+flap during a rolling update, so plain degraded is normal churn. But
+trust_degraded means the attestation no longer verifies — for an
+attested gateway that is the product being broken, not churn, so it
+counts toward rollback exactly like down.
 
 Why per-region: a deploy can break us-central1 but leave
 europe-west4 healthy (e.g., bad regional secret rotation). Rolling
@@ -45,8 +47,15 @@ from collections.abc import Iterable
 # Worst-of: the per-region effective_status is the worst over its checks.
 # `unknown` is treated as severity 0 for ranking but reported separately
 # so the operator can tell "no signal" apart from "all healthy."
-SEVERITY = {"up": 0, "degraded": 1, "down": 2}
-INVERSE_SEVERITY = {0: "up", 1: "degraded", 2: "down"}
+# trust_degraded ranks with down, not with degraded. For an ATTESTED
+# gateway, "cannot prove what code is running" is the product failing —
+# a deploy that ships an enclave whose attestation no longer verifies
+# must roll back. Previously it folded into "degraded", and rollback
+# fires only on "down", so an attestation regression could never
+# trigger one.
+SEVERITY = {"up": 0, "degraded": 1, "trust_degraded": 2, "down": 2}
+# Statuses that count toward the consecutive-failure rollback counter.
+ROLLBACK_STATUSES = frozenset({"down", "trust_degraded"})
 
 
 def normalize_watchdog_status(status: object) -> str:
@@ -55,7 +64,9 @@ def normalize_watchdog_status(status: object) -> str:
         return "up"
     if text == "down":
         return "down"
-    if text in {"degraded", "routing_degraded", "trust_degraded"}:
+    if text == "trust_degraded":
+        return "trust_degraded"
+    if text in {"degraded", "routing_degraded"}:
         return "degraded"
     return "unknown"
 
@@ -95,7 +106,12 @@ def fetch_per_region(
             out[region] = normalize_watchdog_status(status)
         return out
 
-    worst: dict[str, int] = {}
+    # Keep the worst STATUS, not the worst severity int. down and
+    # trust_degraded share severity 2, so ranking by int and mapping back
+    # collapses trust_degraded into down — and the caller needs the
+    # distinction to report WHY it rolled back (an attestation regression
+    # reads very differently from an unreachable region).
+    worst: dict[str, str] = {}
     for check in checks:
         target = (check or {}).get("target_region")
         status = normalize_watchdog_status(
@@ -105,18 +121,12 @@ def fetch_per_region(
             continue
         if target not in regions:
             continue
-        sev = SEVERITY.get(str(status).lower())
+        sev = SEVERITY.get(status)
         if sev is None:
             continue
-        if sev > worst.get(target, -1):
-            worst[target] = sev
-    fallback_out: dict[str, str] = {}
-    for region in regions:
-        if region in worst:
-            fallback_out[region] = INVERSE_SEVERITY[worst[region]]
-        else:
-            fallback_out[region] = "unknown"
-    return fallback_out
+        if sev > SEVERITY.get(worst.get(target, ""), -1):
+            worst[target] = status
+    return {region: worst.get(region, "unknown") for region in regions}
 
 
 def write_output(key: str, value: str) -> None:
@@ -227,7 +237,7 @@ def main() -> int:
             # healthy in the baseline. If it was already down, the
             # deploy isn't the suspect; leave the counter at 0 so
             # we don't roll back over a pre-existing condition.
-            if status == "down" and region not in baseline_down:
+            if status in ROLLBACK_STATUSES and region not in baseline_down:
                 consecutive_down[region] += 1
             else:
                 consecutive_down[region] = 0

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -264,13 +264,55 @@ def history_payload(
     return {"window": window, "scope": ROUTER_CORE_SLO_ID, "data": {}}
 
 
-def _sample_effective_status(sample: SyntheticProbeSample, *, now: dt.datetime) -> tuple[str, float]:
-    """(effective status, signed age). Too old OR too far in the future
-    both degrade to "unknown": a future-dated `up` sample must never pin
-    a component green — it is poison or clock breakage, not evidence."""
+def _monitor_is_reporting(samples: list[SyntheticProbeSample], *, now: dt.datetime) -> bool:
+    """Is the monitor alive at all — i.e. did ANY probe report recently?
+
+    Distinguishes "the whole monitor stopped" (reported once, by
+    monitor_freshness) from "one probe stopped while the rest kept
+    reporting" (a real, probe-specific outage that must turn something
+    red). Without the distinction you must choose between missing the
+    second case and painting the page red on every cold start.
+    """
+    return any(
+        -FUTURE_SAMPLE_SKEW_SECONDS
+        <= (now - _parse_time(sample.created_at)).total_seconds()
+        <= CURRENT_SAMPLE_TTL_SECONDS
+        for sample in samples
+    )
+
+
+def _sample_effective_status(
+    sample: SyntheticProbeSample,
+    *,
+    now: dt.datetime,
+    monitor_reporting: bool = False,
+) -> tuple[str, float]:
+    """(effective status, signed age).
+
+    Too far in the FUTURE is always "unknown": a future-dated `up` sample
+    must never pin a component green — that is poison or clock breakage,
+    not evidence.
+
+    Too OLD depends on whether the monitor is otherwise alive:
+
+      * monitor_reporting=True  -> "down". This probe stopped emitting
+        while its siblings kept going. That is the silent-disappearance
+        outage: previously it dropped to "unknown", and _worse_status
+        treats unknown as no-opinion, so a probe that vanished entirely
+        left the SLO green. A reachability break emits `down` samples and
+        was caught; a probe that simply stops emitting produced NOTHING
+        to aggregate, and nothing is not evidence of health.
+
+      * monitor_reporting=False -> "unknown". Every probe is stale, so
+        the monitor itself is down or cold-starting. monitor_freshness
+        reports that as is_stale; marking each probe `down` too would
+        paint a false outage on every deploy.
+    """
     age = (now - _parse_time(sample.created_at)).total_seconds()
-    if age > CURRENT_SAMPLE_TTL_SECONDS or age < -FUTURE_SAMPLE_SKEW_SECONDS:
+    if age < -FUTURE_SAMPLE_SKEW_SECONDS:
         return "unknown", age
+    if age > CURRENT_SAMPLE_TTL_SECONDS:
+        return ("down" if monitor_reporting else "unknown"), age
     return sample.status, age
 
 
@@ -286,8 +328,11 @@ def _current_status(
             latest[key] = sample
     rows = []
     overall = "unknown"
+    monitor_reporting = _monitor_is_reporting(samples, now=now)
     for sample in latest.values():
-        status, signed_age = _sample_effective_status(sample, now=now)
+        status, signed_age = _sample_effective_status(
+            sample, now=now, monitor_reporting=monitor_reporting
+        )
         age = max(signed_age, 0)
         overall = _worse_status(overall, status)
         row = sample.public_dict()
@@ -542,8 +587,11 @@ def _slo_current(
     overall = "unknown"
     by_region: dict[str, dict[str, Any]] = {}
     sample_count = 0
+    monitor_reporting = _monitor_is_reporting(samples, now=now)
     for sample in latest.values():
-        status, _signed_age = _sample_effective_status(sample, now=now)
+        status, _signed_age = _sample_effective_status(
+            sample, now=now, monitor_reporting=monitor_reporting
+        )
         overall = _worse_status(overall, status)
         sample_count += 1
         for region in _sample_region_keys(sample):

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -80,3 +80,58 @@ def test_watchdog_falls_back_to_current_checks_and_normalizes_degraded(monkeypat
         "https://trustedrouter.com/status.json",
         ["us-central1", "europe-west4"],
     ) == {"us-central1": "degraded", "europe-west4": "up"}
+
+
+def test_trust_degraded_is_preserved_not_folded_into_degraded(monkeypatch) -> None:
+    """An attested gateway that cannot prove what it runs is BROKEN.
+
+    trust_degraded used to normalize to "degraded", and rollback fires
+    only on "down" — so an attestation regression could ship and never
+    trigger a rollback. That is the one failure this product cannot
+    afford to treat as churn.
+    """
+    watchdog = _load_watchdog()
+    payload = {
+        "data": {
+            "current": {
+                "checks": [
+                    {"target_region": "eu-west-3", "effective_status": "trust_degraded"},
+                    {"target_region": "us-central1", "effective_status": "up"},
+                ]
+            }
+        }
+    }
+
+    def fake_urlopen(_url: str, timeout: int) -> _FakeResponse:
+        return _FakeResponse(json.dumps(payload).encode())
+
+    monkeypatch.setattr(watchdog.urllib.request, "urlopen", fake_urlopen)
+
+    assert watchdog.fetch_per_region(
+        "https://aws.trustedrouter.com/status.json",
+        ["eu-west-3", "us-central1"],
+    ) == {"eu-west-3": "trust_degraded", "us-central1": "up"}
+
+
+def test_rollback_statuses_cover_down_and_trust_degraded() -> None:
+    watchdog = _load_watchdog()
+    assert "down" in watchdog.ROLLBACK_STATUSES
+    assert "trust_degraded" in watchdog.ROLLBACK_STATUSES
+    # Plain degraded stays out: synthetics flap during a rolling update.
+    assert "degraded" not in watchdog.ROLLBACK_STATUSES
+    assert "up" not in watchdog.ROLLBACK_STATUSES
+    assert "unknown" not in watchdog.ROLLBACK_STATUSES
+
+
+def test_normalize_maps_routing_degraded_but_not_trust_degraded() -> None:
+    watchdog = _load_watchdog()
+    assert watchdog.normalize_watchdog_status("routing_degraded") == "degraded"
+    assert watchdog.normalize_watchdog_status("trust_degraded") == "trust_degraded"
+    assert watchdog.normalize_watchdog_status("down") == "down"
+    assert watchdog.normalize_watchdog_status("anything else") == "unknown"
+
+
+def test_trust_degraded_ranks_with_down_in_severity() -> None:
+    watchdog = _load_watchdog()
+    assert watchdog.SEVERITY["trust_degraded"] == watchdog.SEVERITY["down"]
+    assert watchdog.SEVERITY["trust_degraded"] > watchdog.SEVERITY["degraded"]

--- a/tests/test_monitor_freshness_poison.py
+++ b/tests/test_monitor_freshness_poison.py
@@ -149,3 +149,87 @@ class TestIngestBoundary:
 
     def test_garbage_created_at_rejected_as_400(self, client: TestClient) -> None:
         assert self._post(client, "not-a-timestamp").status_code == 400
+
+
+class TestSilentProbeDisappearance:
+    """A probe that STOPS EMITTING must turn something red.
+
+    The negative control that validated this deployment broke
+    reachability, which emits `down` samples. A probe that simply stops
+    producing samples emits NOTHING — and nothing was being treated as
+    no-opinion ("unknown"), which _worse_status ignores. So the outage
+    shape most likely to go unnoticed was the one the page could not
+    show. Nothing is not evidence of health.
+    """
+
+    def _pair(self, fresh_age: int, stale_age: int) -> list[SyntheticProbeSample]:
+        return [
+            _sample(NOW - dt.timedelta(seconds=fresh_age), sample_id="fresh"),
+            SyntheticProbeSample(
+                id="stopped",
+                probe_type="attestation_nonce",
+                target="canonical",
+                target_url="https://api-aws.trustedrouter.com/attestation",
+                monitor_region="eu-west-3",
+                status="up",
+                created_at=(NOW - dt.timedelta(seconds=stale_age))
+                .isoformat()
+                .replace("+00:00", "Z"),
+            ),
+        ]
+
+    def test_stopped_probe_is_down_while_siblings_report(self) -> None:
+        samples = self._pair(fresh_age=30, stale_age=CURRENT_SAMPLE_TTL_SECONDS + 600)
+        current = _current_status(samples, now=NOW)
+        by_probe = {c["probe_type"]: c["effective_status"] for c in current["checks"]}
+        assert by_probe["attestation_nonce"] == "down"
+        assert by_probe["tls_health"] == "up"
+        assert current["overall_status"] == "down"
+
+    def test_whole_monitor_stale_stays_unknown_not_false_outage(self) -> None:
+        """Cold start / monitor down: every probe stale. monitor_freshness
+        already reports that; marking each probe `down` too would paint a
+        false outage on every deploy."""
+        samples = self._pair(
+            fresh_age=CURRENT_SAMPLE_TTL_SECONDS + 900,
+            stale_age=CURRENT_SAMPLE_TTL_SECONDS + 600,
+        )
+        current = _current_status(samples, now=NOW)
+        assert {c["effective_status"] for c in current["checks"]} == {"unknown"}
+        assert current["overall_status"] == "unknown"
+        assert _monitor_freshness(samples, now=NOW)["is_stale"] is True
+
+    def test_all_fresh_is_untouched(self) -> None:
+        samples = self._pair(fresh_age=20, stale_age=40)
+        current = _current_status(samples, now=NOW)
+        assert {c["effective_status"] for c in current["checks"]} == {"up"}
+        assert current["overall_status"] == "up"
+
+    def test_future_dated_still_unknown_never_down(self) -> None:
+        """Poison must not be reclassified as an outage — it is absence of
+        evidence, and it would page someone for a clock bug."""
+        poison = SyntheticProbeSample(
+            id="poison",
+            probe_type="attestation_nonce",  # distinct key so dedup keeps both
+            target="canonical",
+            target_url="https://api-aws.trustedrouter.com/attestation",
+            monitor_region="eu-west-3",
+            status="up",
+            created_at="7748-06-05T20:10:00Z",
+        )
+        samples = [_sample(NOW - dt.timedelta(seconds=30), sample_id="fresh"), poison]
+        current = _current_status(samples, now=NOW)
+        statuses = {c["probe_type"]: c["effective_status"] for c in current["checks"]}
+        assert statuses["attestation_nonce"] == "unknown"
+        assert statuses["tls_health"] == "up"
+
+    def test_monitor_reporting_helper(self) -> None:
+        from trusted_router.synthetic.status import _monitor_is_reporting
+
+        fresh = [_sample(NOW - dt.timedelta(seconds=10))]
+        stale = [_sample(NOW - dt.timedelta(seconds=CURRENT_SAMPLE_TTL_SECONDS + 60))]
+        poison = [_sample(dt.datetime(7748, 6, 5, tzinfo=dt.UTC))]
+        assert _monitor_is_reporting(fresh, now=NOW) is True
+        assert _monitor_is_reporting(stale, now=NOW) is False
+        # Poison must not count as "the monitor is alive".
+        assert _monitor_is_reporting(poison, now=NOW) is False

--- a/tests/test_verify_deployment.py
+++ b/tests/test_verify_deployment.py
@@ -20,8 +20,9 @@ def _status_payload(
     *,
     monitor_age_minutes: int | None = None,
     check_age_minutes: int | None = None,
+    overall_status: str = "up",
 ) -> str:
-    data: dict[str, Any] = {"overall_status": "up"}
+    data: dict[str, Any] = {"overall_status": overall_status}
     if monitor_age_minutes is not None:
         data["monitor_freshness"] = {
             "latest_sample_at": _iso_at_age(monitor_age_minutes),
@@ -83,7 +84,7 @@ def test_verify_deployment_expect_monitor_accepts_fresh_monitor_freshness(
 ) -> None:
     result = _run_verifier(
         tmp_path,
-        _status_payload(monitor_age_minutes=5),
+        _status_payload(monitor_age_minutes=1),
         "--expect-monitor",
     )
 
@@ -96,7 +97,7 @@ def test_verify_deployment_expect_monitor_falls_back_to_current_checks(
 ) -> None:
     result = _run_verifier(
         tmp_path,
-        _status_payload(check_age_minutes=10),
+        _status_payload(check_age_minutes=2),
         "--expect-monitor",
     )
 
@@ -109,9 +110,66 @@ def test_verify_deployment_expect_monitor_rejects_stale_data(
 ) -> None:
     result = _run_verifier(
         tmp_path,
-        _status_payload(monitor_age_minutes=31),
+        _status_payload(monitor_age_minutes=6),
         "--expect-monitor",
     )
 
     assert result.returncode == 1
     assert "FAIL  synthetic monitor is stale or missing" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# overall_status must be READ, not merely present.
+#
+# The gate used `grep -q '"overall_status"'`, which matches just as happily
+# when the value is "down" — so a deploy could pass its own smoke test against
+# a red status page. For an attested gateway, trust_degraded is likewise a
+# failure: an enclave that cannot prove what it is running is the product
+# being broken.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_deployment_fails_when_status_is_down(tmp_path: Path) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=1, overall_status="down"),
+        "--expect-monitor",
+    )
+    assert result.returncode != 0, result.stdout
+    assert "overall_status=down" in result.stdout
+
+
+def test_verify_deployment_fails_when_trust_degraded(tmp_path: Path) -> None:
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=1, overall_status="trust_degraded"),
+        "--expect-monitor",
+    )
+    assert result.returncode != 0, result.stdout
+    assert "overall_status=trust_degraded" in result.stdout
+
+
+def test_verify_deployment_fails_when_status_unknown(tmp_path: Path) -> None:
+    """No signal is not a pass — that is the whole lesson of this deployment."""
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=1, overall_status="unknown"),
+        "--expect-monitor",
+    )
+    assert result.returncode != 0, result.stdout
+
+
+def test_verify_deployment_accepts_degraded(tmp_path: Path) -> None:
+    """Plain degraded is normal churn during a rolling update; blocking on it
+    would make the gate unusable."""
+    result = _run_verifier(
+        tmp_path,
+        _status_payload(monitor_age_minutes=1, overall_status="degraded"),
+        "--expect-monitor",
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_verify_deployment_fails_on_malformed_payload(tmp_path: Path) -> None:
+    result = _run_verifier(tmp_path, "not json at all", "--expect-monitor")
+    assert result.returncode != 0, result.stdout


### PR DESCRIPTION
Three places where a real failure could not turn anything red.

**1. A probe that stops emitting left the SLO green.** The negative control that validated this deployment broke *reachability*, which emits `down` samples. A probe that simply stops producing samples emits **nothing** — and nothing was treated as no-opinion (`unknown`), which `_worse_status` ignores. The outage shape most likely to go unnoticed was the one the page couldn't show.

A stale probe is now `down` **when the monitor is otherwise reporting**, and stays `unknown` when every probe is stale (monitor down/cold start — already covered by `monitor_freshness`; marking each probe down would paint a false outage on every deploy). Future-dated poison stays `unknown`, never `down`.

**2. The deploy gate passed against a red page.** `grep -q '"overall_status"'` matches when the value is `"down"`. Now parses the value; fails on `down`/`trust_degraded`/`unknown`/malformed. Its staleness window was **30 min against the app's own 5 min TTL** — it could print "monitor is fresh" for a deployment whose own page said "Monitor Data Stale". Now aligned at 5 min.

**3. An attestation regression could never trigger rollback.** `watchdog.py` folded `trust_degraded` into `degraded`, and rollback fires only on `down`. For an attested gateway that's the product being broken. Now ranks with `down` and is in `ROLLBACK_STATUSES`. The per-region fallback also stopped round-tripping through a severity int (`down` and `trust_degraded` share severity 2, collapsing them on the way back).

## Verification
Live against the EU deployment: `PASS status payload overall_status=up`, `PASS synthetic monitor is fresh (newest sample is 24s old)` — 6 passed, 0 failed under the tightened window.

Full suite 2575 passed / 86 skipped; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)