### PR TITLE
conformance: reach Aurora DSQL, keep rollup window inside retention

### DIFF
--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -97,7 +97,18 @@ def _spanner_emulator_store() -> Store:
 
 
 def _postgres_store() -> Store:
-    """A PostgresStore pointed at the conformance database."""
+    """A PostgresStore pointed at the conformance database.
+
+    Honours the SAME IAM-auth switches production uses
+    (TR_POSTGRES_IAM_AUTH / TR_POSTGRES_IAM_REGION). Without them this
+    harness could only ever reach a password-authenticated Postgres, so
+    Aurora DSQL — the backend the EU deployment actually runs on — was
+    unreachable and every DSQL run died in the fixture with
+    `fe_sendauth: no password supplied`, before exercising a single
+    behaviour. A conformance suite that cannot connect to the real
+    backend proves nothing about it, which is exactly how "Postgres-wire
+    compatible" hid three DSQL incompatibilities previously.
+    """
     dsn = os.environ.get("TR_CONFORMANCE_POSTGRES_DSN")
     if not dsn:
         pytest.skip(
@@ -106,7 +117,11 @@ def _postgres_store() -> Store:
         )
     from trusted_router.storage_postgres import PostgresStore
 
-    store = PostgresStore(dsn)
+    store = PostgresStore(
+        dsn,
+        postgres_iam_auth=os.environ.get("TR_POSTGRES_IAM_AUTH", ""),
+        postgres_iam_region=os.environ.get("TR_POSTGRES_IAM_REGION", ""),
+    )
     store.apply_schema()
     return store
 

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -514,9 +514,16 @@ def test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option(
     # would fail those guards anyway. Uniqueness against persistent
     # conformance databases comes from filtering assertions to this
     # test's own target below, not from an exclusive time range.
+    # Stay well inside ROLLUP_RETENTION_MONTHS (24). An earlier version of
+    # this fix used a ~17,000 hour spread (~23 months), which could place
+    # the window a month or two outside retention depending on `unique`
+    # and the day of the month — rollup_is_within_retention then filtered
+    # every row and the assertions saw an empty list. 4,000 hours (~166
+    # days) keeps every generated window recent, and uniqueness comes from
+    # filtering to this test's own target below, not from the time range.
     now = dt.datetime.now(dt.UTC).replace(
         minute=10, second=0, microsecond=0
-    ) - dt.timedelta(hours=3 + int(unique, 16) % 17_000)
+    ) - dt.timedelta(hours=3 + int(unique, 16) % 4_000)
     target = f"status-{unique}"
     probe_type = f"probe-{unique}"
     monitor_region = f"monitor-{unique}"


### PR DESCRIPTION
Two harness fixes, both surfaced by pointing the conformance suite at a **real Aurora DSQL cluster** for the first time (throwaway cluster, not prod).

**1. The suite could never reach DSQL.** `_postgres_store()` built `PostgresStore` without the IAM-auth switches production uses, so it only ever worked against password-authenticated Postgres. Against DSQL all 24 postgres-backend tests died in the fixture with `fe_sendauth: no password supplied` — not one behaviour exercised. A conformance suite that can't connect to the backend it certifies proves nothing about it; that's exactly how "Postgres-wire compatible" hid three DSQL incompatibilities previously. Now honours `TR_POSTGRES_IAM_AUTH` / `TR_POSTGRES_IAM_REGION`.

**2. Fixes a bug already on main (from #407, mine).** I'd replaced a far-future unique window with a past one spanning ~17,000 hours (~23 months) — which can land outside `ROLLUP_RETENTION_MONTHS=24` depending on `unique` and the day of month, so every row is filtered and the assertion sees `[]`. CI's `conformance-postgres` job caught it on #412.

Verified against the real predicate:
```
    3h ago  (2026-08-02): within_retention=True
 4000h ago  (2026-02-16): within_retention=True
17000h ago  (2024-08-24): within_retention=False   <- the bug
```
4,000h (~166 days) is comfortably inside. Uniqueness comes from filtering to the test's own target, not the time range.

This unblocks #412, whose CI failure is this bug inherited from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)