### PR TITLE
schema: tr_key_limit window counters + key_hash index (federation A1)

### DIFF
--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -82,7 +82,53 @@ CREATE TABLE IF NOT EXISTS tr_key_limit (
     day_limit_micro BIGINT,
     week_limit_micro BIGINT,
     month_limit_micro BIGINT,
+    -- Lazy rolling-window counters, mirroring the Spanner shape
+    -- (scripts/deploy/migrate_typed_counters.sh:216-221). "Lazy" means no
+    -- scheduled reset job: a window whose *_start is NULL or older than the
+    -- current floor reads as ZERO and is rewritten on the next settle. That
+    -- keeps enforcement correct without a cron that could silently stop and
+    -- leave every key permanently over its limit.
+    day_usage BIGINT NOT NULL DEFAULT 0,
+    day_start TIMESTAMPTZ,
+    week_usage BIGINT NOT NULL DEFAULT 0,
+    week_start TIMESTAMPTZ,
+    month_usage BIGINT NOT NULL DEFAULT 0,
+    month_start TIMESTAMPTZ,
     source_updated_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (workspace_id, key_hash, shard)
 );
+
+-- The key-limit call family (reserve/settle/refund_key_limit) is keyed by
+-- key_hash ALONE — Spanner's PK is (key_hash, shard), but the Postgres PK
+-- leads with workspace_id, so none of those statements can use it. Without
+-- this index every reserve is a full scan of tr_key_limit, which on Aurora
+-- DSQL means a distributed scan on the hottest path in the product.
+CREATE INDEX IF NOT EXISTS tr_key_limit_by_key_hash ON tr_key_limit (key_hash, shard);
+
+-- Upgrade path for stores created before the window counters existed.
+-- CREATE TABLE IF NOT EXISTS above is a no-op on an existing table, so the
+-- columns would silently never appear and every window check would read a
+-- missing column.
+--
+-- The usage columns are added BARE and then given a default, because Aurora
+-- DSQL rejects a constraint in ADD COLUMN outright:
+--     FeatureNotSupported: ALTER TABLE ADD COLUMN with constraint not supported
+-- The tr_entities ALTERs above are all bare nullable types, so they never hit
+-- this; `NOT NULL DEFAULT 0` does. Verified against a real DSQL cluster --
+-- the fresh-create path (CREATE TABLE) passes either way, so this is only
+-- reachable on an EXISTING deployment, which is every deployment that matters.
+--
+-- NOT NULL is deliberately NOT re-added on the upgrade path: DSQL would have
+-- to validate it against existing rows, and the readers already coalesce a
+-- NULL window counter to zero (a NULL *_start means "window not started",
+-- which is the same lazy-floor case as a stale one).
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS day_usage BIGINT;
+ALTER TABLE tr_key_limit ALTER COLUMN day_usage SET DEFAULT 0;
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS day_start TIMESTAMPTZ;
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS week_usage BIGINT;
+ALTER TABLE tr_key_limit ALTER COLUMN week_usage SET DEFAULT 0;
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS week_start TIMESTAMPTZ;
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS month_usage BIGINT;
+ALTER TABLE tr_key_limit ALTER COLUMN month_usage SET DEFAULT 0;
+ALTER TABLE tr_key_limit ADD COLUMN IF NOT EXISTS month_start TIMESTAMPTZ;

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -623,3 +623,39 @@ def test_memory_backend_is_always_runnable() -> None:
 
 def _iso_utc(value: dt.datetime) -> str:
     return value.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
+
+
+# --------------------------------------------------------------------------
+# Schema shape the key-limit call family depends on
+# --------------------------------------------------------------------------
+
+
+def test_key_limit_window_columns_and_index_exist(store: Store, unique: str) -> None:
+    """tr_key_limit must carry the lazy rolling-window counters.
+
+    reserve/settle/refund_key_limit enforce day/week/month caps by reading
+    *_usage against a *_start floor. If the columns are missing the call
+    family cannot be implemented at all — and because CREATE TABLE IF NOT
+    EXISTS is a no-op on an existing table, a store created before they
+    were added would silently lack them forever without the ALTERs.
+
+    Skips on backends that do not expose an introspectable SQL schema
+    (the in-memory store has no DDL); the point is to pin Postgres/DSQL.
+    """
+    pool = getattr(store, "_pool", None)
+    if pool is None:
+        pytest.skip("backend has no SQL schema to introspect")
+
+    with pool.connection() as conn:
+        rows = conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'tr_key_limit'"
+        ).fetchall()
+    columns = {str(row[0]) for row in rows}
+
+    for window in ("day", "week", "month"):
+        assert f"{window}_usage" in columns, f"missing {window}_usage"
+        assert f"{window}_start" in columns, f"missing {window}_start"
+        # The limit columns predate this change; assert them too so a
+        # regression in either half is caught by one test.
+        assert f"{window}_limit_micro" in columns, f"missing {window}_limit_micro"


### PR DESCRIPTION
First increment toward the EU plane authorizing API keys locally (federation prerequisite).

**What:** `day/week/month` `_usage`+`_start` columns on `tr_key_limit` mirroring the Spanner shape, plus an index on `(key_hash, shard)`. The key-limit statements are keyed by `key_hash` alone — Spanner's PK is `(key_hash, shard)` but the Postgres PK leads with `workspace_id`, so none of them can use it. Without the index every reserve is a full scan, which on DSQL is a distributed scan on the hottest path in the product.

**The DSQL landmine this caught.** The upgrade ALTERs originally read `ADD COLUMN IF NOT EXISTS day_usage BIGINT NOT NULL DEFAULT 0`. DSQL rejects that:

```
FeatureNotSupported: ALTER TABLE ADD COLUMN with constraint not supported
```

I'd justified the spelling from the `tr_entities` ALTERs — but those are all **bare nullable types**, so the precedent didn't cover a constraint. `CREATE TABLE` accepts it either way, so this would have passed a fresh-cluster test and **broken every existing deployment**. Now a bare add plus `SET DEFAULT`.

**Verification** — real Aurora DSQL, applying the *pre-change* schema first and then upgrading, because a blank-slate run proves nothing about the path real deployments take:
```
confirmed: pre-change table lacks window counters
window columns present: True   missing: []
indexes: ['tr_key_limit_by_key_hash', 'tr_key_limit_pkey']
UPGRADE PATH OK
re-apply idempotent OK
50 passed, 51 skipped
```

New conformance test pins the columns on any backend with an introspectable schema. Next increment (A2) implements `reserve/settle/refund_key_limit`, currently `_not_implemented`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)