### PR TITLE
Avoid deploy rollbacks on monitor cadence jitter

### DIFF
--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -25,6 +25,11 @@ from trusted_router.synthetic.components import (
 from trusted_router.synthetic.rollups import merge_rollups, new_rollup_for_sample
 
 CURRENT_SAMPLE_TTL_SECONDS = 5 * 60
+# Regional monitor jobs run on a five-minute cadence. Treating a sample as
+# failed at exactly one cadence boundary makes normal scheduler jitter look
+# like an outage. One missed/late cycle is degraded; only two missed cycles
+# plus a small scheduling allowance are a silent-probe failure.
+SILENT_PROBE_TTL_SECONDS = (2 * CURRENT_SAMPLE_TTL_SECONDS) + 60
 IMAGE_GENERATION_SAMPLE_TTL_SECONDS = 7 * 60 * 60
 STATUS_HISTORY_HOURS = 48
 # Uptime thresholds for per-bucket coloring. Single-sample blips
@@ -295,13 +300,16 @@ def _sample_effective_status(
 
     Too OLD depends on whether the monitor is otherwise alive:
 
-      * monitor_reporting=True  -> "down". This probe stopped emitting
-        while its siblings kept going. That is the silent-disappearance
-        outage: previously it dropped to "unknown", and _worse_status
-        treats unknown as no-opinion, so a probe that vanished entirely
-        left the SLO green. A reachability break emits `down` samples and
-        was caught; a probe that simply stops emitting produced NOTHING
-        to aggregate, and nothing is not evidence of health.
+      * monitor_reporting=True and one cadence late -> "degraded". Regional
+        jobs run every five minutes and routinely cross that boundary by a
+        few seconds. The status stays visible without turning scheduler
+        jitter into a deploy rollback.
+
+      * monitor_reporting=True and two cadences late -> "down". This probe
+        stopped emitting while its siblings kept going. That is the
+        silent-disappearance outage: previously it dropped to "unknown",
+        and _worse_status treats unknown as no-opinion, so a probe that
+        vanished entirely left the SLO green.
 
       * monitor_reporting=False -> "unknown". Every probe is stale, so
         the monitor itself is down or cold-starting. monitor_freshness
@@ -311,8 +319,10 @@ def _sample_effective_status(
     age = (now - _parse_time(sample.created_at)).total_seconds()
     if age < -FUTURE_SAMPLE_SKEW_SECONDS:
         return "unknown", age
-    if age > CURRENT_SAMPLE_TTL_SECONDS:
+    if age > SILENT_PROBE_TTL_SECONDS:
         return ("down" if monitor_reporting else "unknown"), age
+    if age > CURRENT_SAMPLE_TTL_SECONDS:
+        return ("degraded" if monitor_reporting else "unknown"), age
     return sample.status, age
 
 

--- a/tests/test_monitor_freshness_poison.py
+++ b/tests/test_monitor_freshness_poison.py
@@ -20,8 +20,10 @@ from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, SyntheticP
 from trusted_router.synthetic.rollups import raw_sample_is_within_retention
 from trusted_router.synthetic.status import (
     CURRENT_SAMPLE_TTL_SECONDS,
+    SILENT_PROBE_TTL_SECONDS,
     _current_status,
     _monitor_freshness,
+    _slo_current,
 )
 
 NOW = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
@@ -185,6 +187,54 @@ class TestSilentProbeDisappearance:
         assert by_probe["attestation_nonce"] == "down"
         assert by_probe["tls_health"] == "up"
         assert current["overall_status"] == "down"
+
+    def test_one_late_monitor_cycle_is_degraded_not_down(self) -> None:
+        """Five-minute workers can finish a few seconds late.
+
+        A normal 5m07 cadence must not trigger the deploy watchdog. It remains
+        visible as degraded until a second cycle is missed.
+        """
+        samples = self._pair(
+            fresh_age=30,
+            stale_age=CURRENT_SAMPLE_TTL_SECONDS + 7,
+        )
+        current = _current_status(samples, now=NOW)
+        by_probe = {c["probe_type"]: c["effective_status"] for c in current["checks"]}
+        assert by_probe["attestation_nonce"] == "degraded"
+        assert by_probe["tls_health"] == "up"
+        assert current["overall_status"] == "degraded"
+
+    def test_control_plane_region_waits_for_two_missed_cycles(self) -> None:
+        fresh = SyntheticProbeSample(
+            id="eu-fresh",
+            probe_type="control_plane_health",
+            target="us-central1",
+            target_url="https://trusted-router.example/health",
+            monitor_region="europe-west4",
+            target_region="us-central1",
+            status="up",
+            created_at=(NOW - dt.timedelta(seconds=30)).isoformat().replace("+00:00", "Z"),
+        )
+        jittered = SyntheticProbeSample(
+            id="us-jittered",
+            probe_type="control_plane_health",
+            target="us-central1",
+            target_url="https://trusted-router.example/health",
+            monitor_region="us-central1",
+            target_region="us-central1",
+            status="up",
+            created_at=(NOW - dt.timedelta(seconds=CURRENT_SAMPLE_TTL_SECONDS + 7))
+            .isoformat()
+            .replace("+00:00", "Z"),
+        )
+
+        current = _slo_current([fresh, jittered], now=NOW)
+
+        assert current["by_region"]["us-central1"]["status"] == "degraded"
+        assert current["by_region"]["us-central1"]["status"] != "down"
+
+    def test_silent_probe_threshold_covers_two_monitor_cycles(self) -> None:
+        assert SILENT_PROBE_TTL_SECONDS > 2 * CURRENT_SAMPLE_TTL_SECONDS
 
     def test_whole_monitor_stale_stays_unknown_not_false_outage(self) -> None:
         """Cold start / monitor down: every probe stale. monitor_freshness


### PR DESCRIPTION
## Summary
- separate five-minute monitor freshness from silent-probe failure detection
- mark one late cycle degraded instead of down
- require two missed cycles plus scheduler allowance before a silent probe becomes down
- cover the exact 5m07 regional cadence regression in current and SLO status tests

## Production evidence
The unchanged healthy revision reproduced `up`, `up`, `down` in the deploy watchdog. At the down snapshot, every raw control-plane probe was successful; one worker was 5m10s old while the other was fresh. The five-minute failure threshold was equal to the job cadence.

## Verification
- 28 focused status/watchdog tests passed
- ruff passed
- mypy passed across 209 files
- full suite: 2586 passed, 107 skipped