### PR TITLE
Correct 0G end-to-end trust classification

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -819,13 +819,15 @@ PROVIDERS: dict[str, Provider] = {
         stores_content=False,
         provider_zero_data_retention=None,
         provider_confidential_compute=True,
-        provider_e2ee=True,
+        provider_e2ee=False,
         provider_policy=(
-            "TrustedRouter publishes only 0G routes marked private, TeeML, "
-            "TEE-attested, and healthy, and forces X-0G-Provider-Trust-Mode: "
-            "private on every request. Standard and TeeTLS routes are excluded: "
-            "TeeTLS attests the routing proxy but does not place model execution "
-            "inside confidential compute."
+            "0G labels these routes private, TeeML, TEE-attested, and healthy. "
+            "TrustedRouter requests that mode with X-0G-Provider-Trust-Mode: "
+            "private and excludes standard and TeeTLS routes. The current live "
+            "0G router path does not expose the route quote, audited code "
+            "measurement, or response authentication needed for TrustedRouter "
+            "to verify and encrypt each request end to end, so 0G is not in the "
+            "trustedrouter/e2e pool."
         ),
         provider_policy_url="https://pc.0g.ai/models",
     ),

--- a/tests/test_zero_g_provider.py
+++ b/tests/test_zero_g_provider.py
@@ -20,7 +20,11 @@ from trusted_router.catalog_data import (
     PRIVACY_TIER_CONFIDENTIAL,
     Model,
 )
-from trusted_router.catalog_privacy import provider_privacy_tier
+from trusted_router.catalog_privacy import (
+    endpoint_e2ee,
+    endpoint_privacy_tier,
+    provider_privacy_tier,
+)
 from trusted_router.providers import OPENAI_COMPATIBLE_PROVIDERS, ProviderClient
 from trusted_router.services.inference_errors import default_provider_secret_ref
 
@@ -325,15 +329,16 @@ def test_zero_g_manifest_writer_preserves_dark_launch(
     )
 
 
-def test_zero_g_catalog_and_local_adapter_are_confidential_credits_only() -> None:
+def test_zero_g_catalog_and_local_adapter_request_private_tee_without_e2ee() -> None:
     provider = PROVIDERS["zero-g"]
     assert provider.supports_prepaid is True
     assert provider.supports_byok is False
     assert provider.provider_zero_data_retention is None
     assert provider.provider_confidential_compute is True
-    assert provider.provider_e2ee is True
-    assert provider_privacy_tier(provider) == PRIVACY_TIER_CONFIDENTIAL
+    assert provider.provider_e2ee is False
+    assert provider_privacy_tier(provider) != PRIVACY_TIER_CONFIDENTIAL
     assert "TeeTLS" in provider.provider_policy
+    assert "not in the trustedrouter/e2e pool" in provider.provider_policy
     assert "zero-g" in GATEWAY_PREPAID_PROVIDER_SLUGS
     assert OPENAI_COMPATIBLE_PROVIDERS["zero-g"] == (
         ("ZERO_G_API_KEY",),
@@ -379,6 +384,11 @@ def test_zero_g_catalog_and_local_adapter_are_confidential_credits_only() -> Non
         endpoint.usage_type == "Credits"
         and endpoint.upstream_id == routable_rows[model_id]["upstream_id"]
         for model_id, endpoint in zero_g_endpoints.items()
+    )
+    assert all(
+        endpoint_e2ee(endpoint) is False
+        and endpoint_privacy_tier(endpoint) != PRIVACY_TIER_CONFIDENTIAL
+        for endpoint in zero_g_endpoints.values()
     )
 
 
@@ -466,7 +476,7 @@ def test_zero_g_public_provider_page_is_published(
     assert provider["supports_prepaid"] is True
     assert provider["supports_byok"] is False
     assert provider["provider_confidential_compute"] is True
-    assert provider["provider_e2ee"] is True
+    assert provider["provider_e2ee"] is False
 
     sitemap = client.get("/sitemap-providers.xml")
     assert sitemap.status_code == 200


### PR DESCRIPTION
## Summary
- keep direct 0G private TeeML routes available
- stop classifying the current 0G router path as provider E2EE
- exclude 0G endpoints from trustedrouter/e2e and confidential minimum-privacy routing
- disclose the missing route quote, audited code measurement, and response authentication

## Verification
- uv run pytest -q tests/test_zero_g_provider.py tests/test_routing_unit.py (70 passed)
- uv run ruff check src/trusted_router/catalog_data.py tests/test_zero_g_provider.py
- uv run mypy