### PR TITLE
storage: reserve/settle/refund_key_limit on PostgresStore (federation A2)

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -29,6 +29,7 @@ from trusted_router.security import (
     new_key_id,
     verify_api_key,
 )
+from trusted_router.spend_windows import KeyWindowLimitExceeded, window_floors
 from trusted_router.storage_errors import StoreConflict, StoreUnavailable
 from trusted_router.storage_gcp_codec import (
     json_body,
@@ -65,6 +66,7 @@ from trusted_router.storage_models import (
     VideoJob,
     WalletChallenge,
     Workspace,
+    _is_byok,
     _is_expired,
     iso_now,
     normalize_provider_access_role,
@@ -1255,7 +1257,96 @@ class PostgresStore:
         *,
         usage_type: UsageType | str,
     ) -> None:
-        self._not_implemented("reserve_key_limit")
+        """Hold `amount` against this key's caps, or raise.
+
+        Mirrors InMemoryApiKeys.reserve_limit (storage_keys.py), which is the
+        semantic reference the conformance suite pins:
+
+          * BYOK spend on a key that excludes BYOK is a NO-OP — lifetime cap
+            and windows both.
+          * Window limits are checked FIRST and independently of the lifetime
+            cap, raising KeyWindowLimitExceeded(window) so the gateway can
+            answer 429 with a Retry-After derived from that window's reset.
+            In-flight `reserved` is deliberately not counted toward windows,
+            matching the typed authorize check.
+          * A key with no lifetime limit is uncapped: no-op after windows.
+          * Otherwise reserve conditionally; 0 rows updated means the
+            predicate failed, i.e. insufficient headroom.
+
+        The conditional UPDATE is a single statement so two concurrent
+        reserves cannot both pass the predicate. On DSQL a contended key is a
+        hot row and loses the race with a 40001 abort, which _run_transaction
+        retries.
+        """
+        window_floor_map = window_floors(utcnow())
+
+        def reserve(conn: Any) -> None:
+            row = conn.execute(
+                "SELECT limit_micro, usage, byok_usage, reserved, include_byok,"
+                " day_limit_micro, week_limit_micro, month_limit_micro,"
+                " day_usage, day_start, week_usage, week_start, month_usage, month_start"
+                " FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+                (key_hash,),
+                prepare=False,
+            ).fetchone()
+            if row is None:
+                # No typed row: nothing to enforce here. The gateway's own
+                # KEY_MISSING handling covers the typed-authorize path.
+                return
+            (
+                limit_micro,
+                _usage,
+                _byok_usage,
+                _reserved,
+                include_byok,
+                day_limit,
+                week_limit,
+                month_limit,
+                day_usage,
+                day_start,
+                week_usage,
+                week_start,
+                month_usage,
+                month_start,
+            ) = row
+
+            if _is_byok(usage_type) and not include_byok:
+                return
+
+            # Lazy windows: a NULL or stale *_start means the window has not
+            # started in this period, so its usage reads as ZERO. No reset job
+            # exists (or could silently stop and leave keys stuck over limit).
+            windows = (
+                ("daily", day_limit, day_usage, day_start),
+                ("weekly", week_limit, week_usage, week_start),
+                ("monthly", month_limit, month_usage, month_start),
+            )
+            for name, limit, used, started in windows:
+                if limit is None:
+                    continue
+                floor = window_floor_map[name]
+                current = 0 if started is None or _as_utc(started) < floor else int(used or 0)
+                if current + amount_microdollars > int(limit):
+                    raise KeyWindowLimitExceeded(name)
+
+            if limit_micro is None:
+                return
+
+            updated = conn.execute(
+                "UPDATE tr_key_limit"
+                " SET reserved = reserved + %s, updated_at = CURRENT_TIMESTAMP"
+                " WHERE key_hash = %s AND shard = 0"
+                " AND limit_micro IS NOT NULL"
+                " AND limit_micro - usage"
+                "     - CASE WHEN include_byok THEN byok_usage ELSE 0 END"
+                "     - reserved >= %s",
+                (amount_microdollars, key_hash, amount_microdollars),
+                prepare=False,
+            ).rowcount
+            if updated == 0:
+                raise ValueError("key limit exceeded")
+
+        self._run_transaction(reserve)
 
     def settle_key_limit(
         self,
@@ -1265,7 +1356,21 @@ class PostgresStore:
         *,
         usage_type: UsageType | str,
     ) -> None:
-        self._not_implemented("settle_key_limit")
+        """Release the hold and roll the window counters by the ACTUAL cost.
+
+        The lifetime `usage` column is booked by add_generation, not here —
+        same split as InMemory, where settle_limit only releases the hold and
+        add_usage books the spend. The window counters ARE rolled here because
+        nothing else does it, using the same lazy floor as reserve: a window
+        whose start is missing or stale restarts at this settlement rather
+        than accumulating across periods.
+        """
+        self._release_key_hold(
+            key_hash,
+            reserved_microdollars,
+            usage_type=usage_type,
+            window_amount=max(0, int(actual_microdollars)),
+        )
 
     def refund_key_limit(
         self,
@@ -1274,7 +1379,73 @@ class PostgresStore:
         *,
         usage_type: UsageType | str,
     ) -> None:
-        self._not_implemented("refund_key_limit")
+        """Release the hold without booking any spend (the request failed)."""
+        self._release_key_hold(
+            key_hash,
+            reserved_microdollars,
+            usage_type=usage_type,
+            window_amount=0,
+        )
+
+    def _release_key_hold(
+        self,
+        key_hash: str,
+        reserved_microdollars: int,
+        *,
+        usage_type: UsageType | str,
+        window_amount: int,
+    ) -> None:
+        floors = window_floors(utcnow())
+
+        def release(conn: Any) -> None:
+            row = conn.execute(
+                "SELECT limit_micro, include_byok FROM tr_key_limit"
+                " WHERE key_hash = %s AND shard = 0",
+                (key_hash,),
+                prepare=False,
+            ).fetchone()
+            if row is None:
+                return
+            limit_micro, include_byok = row
+            if _is_byok(usage_type) and not include_byok:
+                return
+            # GREATEST(...) floors the release at zero so a duplicate settle
+            # cannot drive `reserved` negative and hand the key free headroom.
+            # Window counters roll in the same statement so a settle is one
+            # round trip; each window restarts when its start is NULL or older
+            # than the current floor.
+            conn.execute(
+                "UPDATE tr_key_limit SET"
+                "   reserved = GREATEST(reserved - %s, 0)"
+                " , day_usage = CASE WHEN day_start IS NULL OR day_start < %s"
+                "       THEN %s ELSE COALESCE(day_usage, 0) + %s END"
+                " , day_start = CASE WHEN day_start IS NULL OR day_start < %s"
+                "       THEN %s ELSE day_start END"
+                " , week_usage = CASE WHEN week_start IS NULL OR week_start < %s"
+                "       THEN %s ELSE COALESCE(week_usage, 0) + %s END"
+                " , week_start = CASE WHEN week_start IS NULL OR week_start < %s"
+                "       THEN %s ELSE week_start END"
+                " , month_usage = CASE WHEN month_start IS NULL OR month_start < %s"
+                "       THEN %s ELSE COALESCE(month_usage, 0) + %s END"
+                " , month_start = CASE WHEN month_start IS NULL OR month_start < %s"
+                "       THEN %s ELSE month_start END"
+                " , updated_at = CURRENT_TIMESTAMP"
+                " WHERE key_hash = %s AND shard = 0",
+                (
+                    reserved_microdollars,
+                    floors["daily"], window_amount, window_amount,
+                    floors["daily"], floors["daily"],
+                    floors["weekly"], window_amount, window_amount,
+                    floors["weekly"], floors["weekly"],
+                    floors["monthly"], window_amount, window_amount,
+                    floors["monthly"], floors["monthly"],
+                    key_hash,
+                ),
+                prepare=False,
+            )
+            _ = limit_micro  # read for the BYOK/uncapped guard above only.
+
+        self._run_transaction(release)
 
     def update_key(
         self,
@@ -2053,3 +2224,15 @@ def _rollup_retention_cutoff(now: dt.datetime) -> dt.datetime:
     cutoff_month = current.year * 12 + current.month - 1 - ROLLUP_RETENTION_MONTHS + 1
     year, zero_based_month = divmod(cutoff_month, 12)
     return dt.datetime(year, zero_based_month + 1, 1, tzinfo=dt.UTC)
+
+
+def _as_utc(value: dt.datetime) -> dt.datetime:
+    """Normalize a DB timestamp for comparison against a tz-aware floor.
+
+    psycopg returns TIMESTAMPTZ as tz-aware, but a column written before the
+    type was settled (or a backend returning naive values) would raise
+    "can't compare offset-naive and offset-aware datetimes" mid-reserve —
+    turning a limit check into a 500. Assume UTC for naive values, which is
+    what every writer here stores.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -659,3 +659,193 @@ def test_key_limit_window_columns_and_index_exist(store: Store, unique: str) -> 
         # The limit columns predate this change; assert them too so a
         # regression in either half is caught by one test.
         assert f"{window}_limit_micro" in columns, f"missing {window}_limit_micro"
+
+
+# --------------------------------------------------------------------------
+# Per-key spend caps (reserve/settle/refund_key_limit)
+#
+# Seeded through direct SQL because update_key is still _not_implemented on
+# PostgresStore; these skip on backends with no SQL pool. The semantic
+# reference is InMemoryApiKeys.reserve_limit — same rules, different engine.
+# --------------------------------------------------------------------------
+
+
+def _seed_key_limit(store: Store, key_hash: str, **columns: object) -> None:
+    pool = getattr(store, "_pool", None)
+    if pool is None:
+        pytest.skip("backend has no SQL schema to seed")
+    cols = {"workspace_id": "ws-keylimit", "key_hash": key_hash, "shard": 0, **columns}
+    names = ", ".join(cols)
+    marks = ", ".join(["%s"] * len(cols))
+    with pool.connection() as conn:
+        conn.execute("DELETE FROM tr_key_limit WHERE key_hash = %s", (key_hash,), prepare=False)
+        # noqa justified: column names come from this function's own
+        # keyword arguments, never from test data or user input; values are
+        # still bound as parameters.
+        conn.execute(
+            f"INSERT INTO tr_key_limit ({names}) VALUES ({marks})",  # noqa: S608
+            tuple(cols.values()),
+            prepare=False,
+        )
+
+
+def _key_limit_row(store: Store, key_hash: str) -> dict[str, object]:
+    with store._pool.connection() as conn:  # type: ignore[attr-defined]
+        row = conn.execute(
+            "SELECT reserved, day_usage, day_start FROM tr_key_limit"
+            " WHERE key_hash = %s AND shard = 0",
+            (key_hash,),
+            prepare=False,
+        ).fetchone()
+    return {"reserved": row[0], "day_usage": row[1], "day_start": row[2]}
+
+
+def test_reserve_key_limit_enforces_lifetime_cap(store: Store, unique: str) -> None:
+    kh = f"kl-cap-{unique}"
+    _seed_key_limit(store, kh, limit_micro=100, usage=0, byok_usage=0, reserved=0, include_byok=True)
+
+    store.reserve_key_limit(kh, 60, usage_type="Credits")
+    assert _key_limit_row(store, kh)["reserved"] == 60
+
+    # 60 held + 60 requested > 100: the predicate must reject, not oversubscribe.
+    with pytest.raises(ValueError):
+        store.reserve_key_limit(kh, 60, usage_type="Credits")
+    assert _key_limit_row(store, kh)["reserved"] == 60
+
+
+def test_reserve_key_limit_uncapped_is_noop(store: Store, unique: str) -> None:
+    kh = f"kl-uncapped-{unique}"
+    _seed_key_limit(store, kh, limit_micro=None, usage=0, byok_usage=0, reserved=0, include_byok=True)
+    store.reserve_key_limit(kh, 10_000_000, usage_type="Credits")
+    assert _key_limit_row(store, kh)["reserved"] == 0
+
+
+def test_reserve_key_limit_byok_excluded_is_noop(store: Store, unique: str) -> None:
+    """A BYOK request against a key that excludes BYOK must not consume the
+    key's cap — the customer is paying the provider directly."""
+    kh = f"kl-byok-{unique}"
+    _seed_key_limit(store, kh, limit_micro=100, usage=0, byok_usage=0, reserved=0, include_byok=False)
+    store.reserve_key_limit(kh, 5_000, usage_type="BYOK")
+    assert _key_limit_row(store, kh)["reserved"] == 0
+
+
+def test_reserve_key_limit_counts_byok_when_included(store: Store, unique: str) -> None:
+    kh = f"kl-byok-in-{unique}"
+    _seed_key_limit(store, kh, limit_micro=100, usage=0, byok_usage=90, reserved=0, include_byok=True)
+    # 90 BYOK already used against a 100 cap leaves 10.
+    with pytest.raises(ValueError):
+        store.reserve_key_limit(kh, 20, usage_type="Credits")
+    store.reserve_key_limit(kh, 10, usage_type="Credits")
+
+
+def test_reserve_key_limit_window_blocks_before_lifetime(store: Store, unique: str) -> None:
+    """Window caps are independent of the lifetime cap and raise a typed
+    error carrying the window, so the gateway can send Retry-After."""
+    from trusted_router.spend_windows import KeyWindowLimitExceeded, window_floors
+    from trusted_router.storage_models import utcnow
+
+    kh = f"kl-window-{unique}"
+    floors = window_floors(utcnow())
+    _seed_key_limit(
+        store, kh,
+        limit_micro=1_000_000, usage=0, byok_usage=0, reserved=0, include_byok=True,
+        day_limit_micro=100, day_usage=95, day_start=floors["daily"],
+    )
+    with pytest.raises(KeyWindowLimitExceeded) as excinfo:
+        store.reserve_key_limit(kh, 10, usage_type="Credits")
+    assert excinfo.value.window == "daily"
+    # Under the window cap still succeeds against the same row.
+    store.reserve_key_limit(kh, 5, usage_type="Credits")
+
+
+def test_stale_window_start_reads_as_zero(store: Store, unique: str) -> None:
+    """The lazy-window rule: a *_start older than the current floor means the
+    window has not started this period, so usage reads ZERO. Without this a
+    key that hit its daily cap once would be blocked forever — there is no
+    reset job, by design."""
+    from trusted_router.spend_windows import window_floors
+    from trusted_router.storage_models import utcnow
+
+    kh = f"kl-stale-{unique}"
+    floors = window_floors(utcnow())
+    _seed_key_limit(
+        store, kh,
+        limit_micro=1_000_000, usage=0, byok_usage=0, reserved=0, include_byok=True,
+        day_limit_micro=100, day_usage=999_999,
+        day_start=floors["daily"] - dt.timedelta(days=3),
+    )
+    store.reserve_key_limit(kh, 50, usage_type="Credits")
+
+
+def test_settle_key_limit_releases_hold_and_rolls_window(store: Store, unique: str) -> None:
+    kh = f"kl-settle-{unique}"
+    _seed_key_limit(store, kh, limit_micro=1_000, usage=0, byok_usage=0, reserved=0, include_byok=True)
+    store.reserve_key_limit(kh, 60, usage_type="Credits")
+    store.settle_key_limit(kh, 60, 20, usage_type="Credits")
+
+    row = _key_limit_row(store, kh)
+    assert row["reserved"] == 0, "hold must be released"
+    assert row["day_usage"] == 20, "window counter books the ACTUAL cost"
+    assert row["day_start"] is not None
+
+
+def test_settle_cannot_drive_reserved_negative(store: Store, unique: str) -> None:
+    """A duplicate settle must not hand the key free headroom."""
+    kh = f"kl-dup-settle-{unique}"
+    _seed_key_limit(store, kh, limit_micro=1_000, usage=0, byok_usage=0, reserved=0, include_byok=True)
+    store.reserve_key_limit(kh, 50, usage_type="Credits")
+    store.settle_key_limit(kh, 50, 10, usage_type="Credits")
+    store.settle_key_limit(kh, 50, 10, usage_type="Credits")
+    assert _key_limit_row(store, kh)["reserved"] == 0
+
+
+def test_refund_key_limit_releases_without_booking_usage(store: Store, unique: str) -> None:
+    kh = f"kl-refund-{unique}"
+    _seed_key_limit(store, kh, limit_micro=1_000, usage=0, byok_usage=0, reserved=0, include_byok=True)
+    store.reserve_key_limit(kh, 60, usage_type="Credits")
+    store.refund_key_limit(kh, 60, usage_type="Credits")
+
+    row = _key_limit_row(store, kh)
+    assert row["reserved"] == 0
+    assert (row["day_usage"] or 0) == 0, "a refunded request spent nothing"
+
+
+def test_key_limit_calls_on_missing_row_are_noops(store: Store, unique: str) -> None:
+    """No typed row means nothing to enforce — must not raise. The gateway's
+    own KEY_MISSING path handles the authorize-side decision."""
+    _seed_key_limit(store, f"kl-present-{unique}", limit_micro=100)
+    absent = f"kl-absent-{unique}"
+    store.reserve_key_limit(absent, 10, usage_type="Credits")
+    store.settle_key_limit(absent, 10, 5, usage_type="Credits")
+    store.refund_key_limit(absent, 10, usage_type="Credits")
+
+
+def test_concurrent_key_limit_reserves_cannot_oversubscribe(store: Store, unique: str) -> None:
+    """Two simultaneous full-cap holds: exactly one may win."""
+    kh = f"kl-race-{unique}"
+    _seed_key_limit(store, kh, limit_micro=100, usage=0, byok_usage=0, reserved=0, include_byok=True)
+    ready = threading.Barrier(3)
+    lock = threading.Lock()
+    wins: list[int] = []
+    losses: list[Exception] = []
+
+    def reserve_once() -> None:
+        ready.wait()
+        try:
+            store.reserve_key_limit(kh, 100, usage_type="Credits")
+        except Exception as exc:
+            with lock:
+                losses.append(exc)
+        else:
+            with lock:
+                wins.append(1)
+
+    threads = [threading.Thread(target=reserve_once) for _ in range(2)]
+    for t in threads:
+        t.start()
+    ready.wait()
+    for t in threads:
+        t.join()
+
+    assert len(wins) == 1, f"expected exactly one winner, got {len(wins)} (losses={losses})"
+    assert _key_limit_row(store, kh)["reserved"] == 100


### PR DESCRIPTION
The last hard blocker on the EU plane authorizing API keys locally. All three raised `_not_implemented`, so a standalone Postgres/DSQL deployment could not enforce a per-key spend cap at all — the reason the EU gateway still authorizes against the US control plane.

## Semantics (mirroring `InMemoryApiKeys.reserve_limit`)

- **BYOK excluded → no-op** for lifetime cap *and* windows; the customer pays the provider directly.
- **Window caps checked first**, independently of the lifetime cap, raising `KeyWindowLimitExceeded(window)` so the gateway can send a Retry-After from that window's reset.
- **Lazy windows**: a `*_start` that is NULL or older than the current floor reads as **zero** and restarts on the next settle. No reset job by design — a cron that silently stopped would leave every key permanently over-limit, a worse failure than the one it prevents.
- **Single conditional UPDATE** for reserve, so two concurrent reserves cannot both pass the predicate.
- `GREATEST(reserved - hold, 0)` so a **duplicate settle cannot hand out free headroom**. Settle rolls windows by the actual cost; lifetime `usage` stays owned by `add_generation`, same split as InMemory.

## Verification — real Aurora DSQL

```
61 passed, 0 failed
```

Not ceremony: A1's `ADD COLUMN with constraint` bug was invisible to stock Postgres, and this change leans harder on DSQL-sensitive constructs — conditional UPDATE with a computed predicate, `GREATEST`, multi-column `CASE` rolls, and a contended hot row resolving through OCC retry. The two-thread race resolving to exactly one winner is the property that actually matters for money.

10 new conformance tests. Full suite 2586 passed; ruff + mypy clean.

Next: `update_key` / `typed_key_usage` are the remaining stubs, then federation hooks at `_api_key_for_gateway_lookup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)