### PR TITLE
Add SES-backed public support form

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -560,6 +560,7 @@ jobs:
           }
 
           check_url homepage https://trustedrouter.com/
+          check_url support https://trustedrouter.com/support
           check_url health https://trustedrouter.com/health
           check_url ready https://trustedrouter.com/ready
           check_url regions https://trustedrouter.com/v1/regions
@@ -603,7 +604,10 @@ jobs:
           uptime_trust = Path("/tmp/uptime_trust.body").read_text()
           uptime_release = json.loads(Path("/tmp/uptime_trust_release.body").read_text())
           canonical_release = json.loads(Path("/tmp/canonical_trust_release.body").read_text())
+          support_page = Path("/tmp/support.body").read_text()
 
+          assert "help@trustedrouter.com" in support_page
+          assert 'id="support-inquiry"' in support_page
           assert any(item["id"] == "us-central1" for item in regions), regions
           assert any(item["id"] == "europe-west4" for item in regions), regions
           assert "components" in status, status.keys()

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -305,6 +305,7 @@ ENV_VARS=(
   "TR_AWS_REGION=us-east-1" # SES region only; hosted compute is GCP-only.
   "TR_SES_FROM_EMAIL=noreply@trustedrouter.com"
   "TR_SES_FROM_NAME=TrustedRouter"
+  "TR_SUPPORT_EMAIL=help@trustedrouter.com"
   # /trustedos partner-inquiry form leads. Plain env (an address, not a
   # secret); without it the handler falls back to TR_SES_FROM_EMAIL, which
   # is send-only and effectively a black hole.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     legal_signatory_name: str = "Joseph Perla"
     legal_signatory_title: str = "CEO"
     security_contact_email: str = "security@trustedrouter.com"
+    support_email: str = "help@trustedrouter.com"
 
     enable_live_providers: bool = False
     local_keys_file: Path = Path("~/.quill_cloud_keys.private").expanduser()

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1738,6 +1738,7 @@ def public_support_html(settings: Settings) -> str:
             heading="TrustedRouter support",
             description="Get product, account, billing, plugin, and security support.",
             entity=legal_entity(settings),
+            support_email=settings.support_email,
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
             static_version=_static_version(settings),

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -22,6 +22,7 @@ from fastapi.responses import (
     RedirectResponse,
 )
 from fastapi.staticfiles import StaticFiles
+from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
 from starlette.types import Scope
 
@@ -218,6 +219,13 @@ _INQUIRY_HITS: OrderedDict[str, list[float]] = OrderedDict()
 _INQUIRY_WINDOW_SECONDS = 3600.0
 _INQUIRY_MAX_PER_WINDOW = 5
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_SUPPORT_CATEGORIES = {
+    "api": "API and routing",
+    "account": "Account access",
+    "billing": "Billing and credits",
+    "provider": "Provider or model",
+    "other": "Other",
+}
 
 
 def _inquiry_rate_ok(client_ip: str, *, now: float | None = None) -> bool:
@@ -355,6 +363,96 @@ async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSO
             message,
         )
     return ok
+
+
+async def _handle_support_inquiry(settings: Settings, request: Request) -> JSONResponse:
+    """Send support mail without logging submitted free text or identity fields."""
+    try:
+        payload = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return JSONResponse({"ok": False, "error": "invalid_request"}, status_code=400)
+    if not isinstance(payload, dict):
+        return JSONResponse({"ok": False, "error": "invalid_request"}, status_code=400)
+
+    # Silently accept honeypot submissions so automated senders do not learn
+    # which field caused the drop.
+    if str(payload.get("website", "")).strip():
+        return JSONResponse({"ok": True})
+
+    name = str(payload.get("name", "")).strip()[:200]
+    email = str(payload.get("email", "")).strip()[:320]
+    subject = " ".join(str(payload.get("subject", "")).splitlines()).strip()[:200]
+    message = str(payload.get("message", "")).strip()[:5000]
+    request_id = str(payload.get("request_id", "")).strip()[:200]
+    category = str(payload.get("category", "other")).strip().lower()
+    category_label = _SUPPORT_CATEGORIES.get(category)
+
+    if (
+        not name
+        or not subject
+        or not message
+        or not _EMAIL_RE.fullmatch(email)
+        or category_label is None
+    ):
+        return JSONResponse({"ok": False, "error": "missing_fields"}, status_code=422)
+
+    client_ip = request.client.host if request.client else "unknown"
+    if not _inquiry_rate_ok(f"support:{client_ip}"):
+        return JSONResponse({"ok": False, "error": "rate_limited"}, status_code=429)
+
+    text_body = (
+        "New TrustedRouter support request\n\n"
+        f"Category:   {category_label}\n"
+        f"Name:       {name}\n"
+        f"Email:      {email}\n"
+        f"Request ID: {request_id or '(not given)'}\n\n"
+        f"Subject: {subject}\n\n"
+        f"Message:\n{message}\n"
+    )
+    support_message = EmailMessage(
+        to=settings.support_email,
+        reply_to=email,
+        subject=f"TrustedRouter support: {category_label}: {subject}",
+        text_body=text_body,
+    )
+    try:
+        sent = await run_in_threadpool(
+            get_email_service(settings).send,
+            support_message,
+        )
+    except Exception:  # noqa: BLE001 - return a stable support fallback
+        sent = False
+        log.exception(
+            "support_inquiry.send_failed category=%s has_request_id=%s "
+            "subject_len=%d message_len=%d",
+            category,
+            bool(request_id),
+            len(subject),
+            len(message),
+        )
+    if not sent:
+        log.error(
+            "support_inquiry.delivery_failed category=%s has_request_id=%s "
+            "subject_len=%d message_len=%d",
+            category,
+            bool(request_id),
+            len(subject),
+            len(message),
+        )
+        return JSONResponse(
+            {"ok": False, "error": "delivery_unavailable"},
+            status_code=503,
+        )
+
+    log.info(
+        "support_inquiry.sent category=%s has_request_id=%s subject_len=%d "
+        "message_len=%d",
+        category,
+        bool(request_id),
+        len(subject),
+        len(message),
+    )
+    return JSONResponse({"ok": True})
 
 
 def register_public_routes(app: FastAPI, settings: Settings) -> None:
@@ -854,6 +952,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/support")
     async def support() -> str:
         return public_support_html(settings)
+
+    @app.post("/support/inquiry", include_in_schema=False)
+    async def support_inquiry(request: Request) -> JSONResponse:
+        return await _handle_support_inquiry(settings, request)
 
     @public_html_route("/legal/dpa")
     async def legal_dpa() -> str:

--- a/src/trusted_router/services/email.py
+++ b/src/trusted_router/services/email.py
@@ -28,6 +28,7 @@ class EmailMessage:
     subject: str
     text_body: str
     html_body: str | None = None
+    reply_to: str | None = None
 
 
 class EmailService:
@@ -91,6 +92,8 @@ class EmailService:
                 "Body": body,
             },
         }
+        if message.reply_to:
+            kwargs["ReplyToAddresses"] = [message.reply_to]
         # The configuration set wires bounce + complaint events to our SNS
         # topic so the suppression list above stays current. Skip on missing
         # config set so local dev with a half-set-up SES doesn't 400.

--- a/src/trusted_router/templates/public/support.html
+++ b/src/trusted_router/templates/public/support.html
@@ -1,30 +1,86 @@
 {% extends "public/_base.html" %}
 {% block body %}
 <section class="public-proof-strip">
-  <div><strong>Product and plugin</strong><span><a href="https://github.com/Lore-Hex/LLM-advisor/issues">Open an issue</a></span></div>
+  <div><strong>Support</strong><span><a href="mailto:{{ support_email }}">{{ support_email }}</a></span></div>
   <div><strong>Security</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
   <div><strong>Status</strong><span><a href="https://status.trustedrouter.com">Live status</a></span></div>
   <div><strong>Docs</strong><span><a href="/docs">Developer docs</a></span></div>
 </section>
 
-<section class="marketing-grid three">
-  <div class="marketing-card">
-    <span class="card-label">Product support</span>
-    <h3>Account, billing, routing, and API help</h3>
-    <p>Email <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. Include the request or generation ID, approximate time, route, and region. Never send an API key, BYOK credential, prompt, output, payment number, or other secret.</p>
+<section class="support-layout" aria-label="Contact TrustedRouter support">
+  <div class="panel support-panel">
+    <div class="panel-head">
+      <div>
+        <span class="card-label">Product support</span>
+        <h2>Contact support</h2>
+      </div>
+      <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+    </div>
+    <div class="panel-body">
+      <form class="support-form" id="support-inquiry" novalidate>
+        <div class="support-grid">
+          <label>
+            Name
+            <input type="text" name="name" autocomplete="name" maxlength="200" required>
+          </label>
+          <label>
+            Email
+            <input type="email" name="email" autocomplete="email" maxlength="320" required>
+          </label>
+          <label>
+            Topic
+            <select name="category" required>
+              <option value="api">API and routing</option>
+              <option value="account">Account access</option>
+              <option value="billing">Billing and credits</option>
+              <option value="provider">Provider or model</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label>
+            Request or generation ID <span class="support-optional">optional</span>
+            <input type="text" name="request_id" maxlength="200" autocomplete="off">
+          </label>
+          <label class="support-wide">
+            Subject
+            <input type="text" name="subject" maxlength="200" required>
+          </label>
+          <label class="support-wide">
+            How can we help?
+            <textarea name="message" rows="7" maxlength="5000" required></textarea>
+          </label>
+          <input class="support-hp" type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true">
+        </div>
+        <div class="support-actions">
+          <button class="btn primary" type="submit" data-role="submit">Send support request</button>
+          <span>Or email <a href="mailto:{{ support_email }}">{{ support_email }}</a>.</span>
+        </div>
+        <p class="support-status" data-role="status" role="status" aria-live="polite" hidden></p>
+      </form>
+      <noscript><p>Email <a href="mailto:{{ support_email }}">{{ support_email }}</a> for support.</p></noscript>
+    </div>
   </div>
-  <div class="marketing-card">
-    <span class="card-label">Open source and plugins</span>
-    <h3>Reproducible bug reports</h3>
-    <p>Use the relevant public GitHub repository for source-code and plugin issues. Remove customer data and credentials before posting.</p>
-    <a class="btn" href="https://github.com/Lore-Hex/LLM-advisor/issues">LLM Advisor issues</a>
-  </div>
-  <div class="marketing-card">
-    <span class="card-label">Security</span>
-    <h3>Report vulnerabilities privately</h3>
-    <p>Send security reports privately to <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. Do not publish an unpatched vulnerability or include live credentials in a public issue.</p>
-    <a class="btn" href="/security">Security details</a>
-  </div>
+
+  <aside class="support-aside">
+    <div>
+      <span class="card-label">Before sending</span>
+      <h2>Useful context</h2>
+      <p>Include the approximate time, model, provider, route, and region. A request or generation ID lets us trace metadata without seeing your prompt.</p>
+      <p><strong>Never send an API key, BYOK credential, prompt, output, payment number, or other secret.</strong></p>
+    </div>
+    <div>
+      <span class="card-label">Security</span>
+      <h2>Report vulnerabilities privately</h2>
+      <p>Email <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>. Do not include live credentials or publish an unpatched vulnerability.</p>
+      <a class="btn" href="/security">Security details</a>
+    </div>
+    <div>
+      <span class="card-label">Open source</span>
+      <h2>Reproducible code issues</h2>
+      <p>Remove customer data and credentials, then use the relevant public repository for source and plugin issues.</p>
+      <a class="btn" href="https://github.com/Lore-Hex/quill-router/issues">Router issues</a>
+    </div>
+  </aside>
 </section>
 
 <section class="limitation-band">
@@ -33,4 +89,145 @@
     <p>Support is provided on a commercially reasonable basis unless a signed agreement states a specific response time or service level. Current incidents and historical availability are published at <a href="https://status.trustedrouter.com">status.trustedrouter.com</a>.</p>
   </div>
 </section>
+
+<style>
+  .support-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.65fr) minmax(260px, .75fr);
+    gap: 24px;
+    align-items: start;
+    margin: 32px 0;
+  }
+  .support-panel { margin: 0; }
+  .support-panel .panel-head { align-items: end; }
+  .support-panel .panel-head h2,
+  .support-aside h2 { margin: 4px 0 0; }
+  .support-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+  }
+  .support-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    color: var(--muted);
+    font-size: 15px;
+    font-weight: 650;
+  }
+  .support-grid .support-wide { grid-column: 1 / -1; }
+  .support-grid input,
+  .support-grid select,
+  .support-grid textarea {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 44px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--code-bg);
+    color: var(--ink);
+    font: inherit;
+    font-size: 16px;
+    font-weight: 400;
+  }
+  .support-grid textarea { resize: vertical; }
+  .support-grid input:focus-visible,
+  .support-grid select:focus-visible,
+  .support-grid textarea:focus-visible {
+    outline: 2px solid var(--accent, #6aa1ff);
+    outline-offset: 2px;
+  }
+  .support-optional { font-size: 13px; font-weight: 400; }
+  .support-hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+  }
+  .support-actions {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 18px;
+    color: var(--muted);
+    font-size: 14px;
+  }
+  .support-status { margin: 14px 0 0; font-size: 15px; }
+  .support-status[data-tone="ok"] { color: var(--good, #3ecf8e); }
+  .support-status[data-tone="err"] { color: var(--bad, #ff6b6b); }
+  .support-aside { display: grid; gap: 24px; }
+  .support-aside > div { border-top: 1px solid var(--line); padding-top: 18px; }
+  .support-aside p { color: var(--muted); }
+  @media (max-width: 820px) {
+    .support-layout,
+    .support-grid { grid-template-columns: 1fr; }
+    .support-grid .support-wide { grid-column: auto; }
+  }
+</style>
+{% endblock %}
+
+{% block body_scripts %}
+<script>
+  (function () {
+    var form = document.getElementById("support-inquiry");
+    if (!form) return;
+    var status = form.querySelector('[data-role="status"]');
+    var button = form.querySelector('[data-role="submit"]');
+    var defaultButtonText = button.textContent;
+
+    function show(message, tone) {
+      status.textContent = message;
+      status.setAttribute("data-tone", tone);
+      status.hidden = false;
+    }
+
+    function restoreButton() {
+      button.disabled = false;
+      button.textContent = defaultButtonText;
+    }
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      var data = {
+        name: form.name.value.trim(),
+        email: form.email.value.trim(),
+        category: form.category.value,
+        request_id: form.request_id.value.trim(),
+        subject: form.subject.value.trim(),
+        message: form.message.value.trim(),
+        website: form.website.value.trim()
+      };
+      if (!data.name || !data.email || !data.subject || !data.message) {
+        show("Please complete your name, email, subject, and message.", "err");
+        return;
+      }
+
+      button.disabled = true;
+      button.textContent = "Sending...";
+      fetch("/support/inquiry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data)
+      }).then(function (response) {
+        if (response.ok) {
+          form.reset();
+          show("Your request was sent. We will reply by email.", "ok");
+        } else if (response.status === 429) {
+          show("Too many requests just now. Please email {{ support_email }}.", "err");
+        } else if (response.status === 503) {
+          show("The form cannot send right now. Please email {{ support_email }}.", "err");
+        } else {
+          show("Please check your details and try again.", "err");
+        }
+        restoreButton();
+      }).catch(function () {
+        show("Network error. Please email {{ support_email }}.", "err");
+        restoreButton();
+      });
+    });
+  })();
+</script>
 {% endblock %}

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -556,7 +556,10 @@ def test_public_privacy_terms_and_support_pages_are_distinct(client: TestClient)
     support = client.get("/support")
     assert support.status_code == 200
     assert "TrustedRouter support" in support.text
-    assert "github.com/Lore-Hex/LLM-advisor/issues" in support.text
+    assert "help@trustedrouter.com" in support.text
+    assert 'id="support-inquiry"' in support.text
+    assert 'fetch("/support/inquiry"' in support.text
+    assert "github.com/Lore-Hex/quill-router/issues" in support.text
     assert "Never send an API key" in support.text
     assert "status.trustedrouter.com" in support.text
 

--- a/tests/test_ses_notifications.py
+++ b/tests/test_ses_notifications.py
@@ -254,6 +254,34 @@ def test_email_service_sends_expected_ses_payload(monkeypatch) -> None:
     assert call.get("ConfigurationSetName") == "trustedrouter-default"
 
 
+def test_email_service_sets_reply_to_for_support_mail(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeSESClient:
+        def send_email(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.client", lambda *_args, **_kwargs: FakeSESClient())
+    service = EmailService(
+        Settings(
+            environment="test",
+            aws_access_key_id="AKIA_TEST",
+            aws_secret_access_key="secret",  # noqa: S106 - test fixture secret.
+            ses_from_email="noreply@example.com",
+        )
+    )
+
+    assert service.send(
+        EmailMessage(
+            to="help@example.com",
+            reply_to="customer@example.com",
+            subject="Support request",
+            text_body="Please help.",
+        )
+    )
+    assert calls[0]["ReplyToAddresses"] == ["customer@example.com"]
+
+
 def test_sns_verify_rejects_non_amazonaws_cert_url() -> None:
     msg = _envelope(SigningCertURL="https://evil.example.com/cert.pem")
     with pytest.raises(SnsVerificationError):

--- a/tests/test_support_form.py
+++ b/tests/test_support_form.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.routes import public as public_routes
+from trusted_router.services.email import EmailMessage
+
+
+@pytest.fixture(autouse=True)
+def reset_support_rate_limit() -> None:
+    public_routes._INQUIRY_HITS.clear()
+
+
+def _payload(**overrides: str) -> dict[str, str]:
+    payload = {
+        "name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "category": "api",
+        "request_id": "req_support_123",
+        "subject": "Streaming request failed",
+        "message": "The request returned 503 at 12:05 UTC.",
+        "website": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_support_submission_sends_to_help_with_reply_to(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sent_messages: list[EmailMessage] = []
+
+    class FakeEmailService:
+        def send(self, message: EmailMessage) -> bool:
+            sent_messages.append(message)
+            return True
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FakeEmailService(),
+    )
+    support_text = "Sensitive support marker that must not enter application logs."
+    with caplog.at_level(logging.INFO, logger="trusted_router.routes.public"):
+        response = client.post(
+            "/support/inquiry",
+            json=_payload(message=support_text),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert len(sent_messages) == 1
+    message = sent_messages[0]
+    assert message.to == "help@trustedrouter.com"
+    assert message.reply_to == "ada@example.com"
+    assert message.subject == (
+        "TrustedRouter support: API and routing: Streaming request failed"
+    )
+    assert "req_support_123" in message.text_body
+    assert support_text in message.text_body
+    assert all(support_text not in record.getMessage() for record in caplog.records)
+    assert any(
+        record.getMessage().startswith("support_inquiry.sent category=api ")
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"name": ""},
+        {"email": "not-an-email"},
+        {"subject": ""},
+        {"message": ""},
+        {"category": "unsupported"},
+    ),
+)
+def test_support_submission_rejects_invalid_fields(
+    client: TestClient,
+    overrides: dict[str, str],
+) -> None:
+    response = client.post("/support/inquiry", json=_payload(**overrides))
+
+    assert response.status_code == 422
+    assert response.json() == {"ok": False, "error": "missing_fields"}
+
+
+def test_support_honeypot_is_accepted_without_sending(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingIfCalledEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            raise AssertionError("honeypot submission must not send email")
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FailingIfCalledEmailService(),
+    )
+
+    response = client.post(
+        "/support/inquiry",
+        json=_payload(website="https://spam.example"),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_support_delivery_failure_tells_user_to_use_email(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RefusingEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: RefusingEmailService(),
+    )
+
+    response = client.post("/support/inquiry", json=_payload())
+
+    assert response.status_code == 503
+    assert response.json() == {"ok": False, "error": "delivery_unavailable"}
+
+
+def test_support_submission_is_rate_limited(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FakeEmailService(),
+    )
+
+    for index in range(5):
+        response = client.post(
+            "/support/inquiry",
+            json=_payload(subject=f"Support request {index}"),
+        )
+        assert response.status_code == 200
+
+    limited = client.post("/support/inquiry", json=_payload())
+    assert limited.status_code == 429
+    assert limited.json() == {"ok": False, "error": "rate_limited"}


### PR DESCRIPTION
## Summary
- add a public support form at /support that sends through the existing Amazon SES configuration to help@trustedrouter.com
- set the submitter as Reply-To while keeping help@ visible as a direct fallback
- add honeypot, bounded input, rate limiting, privacy-safe logs, delivery failure UX, and deploy smoke coverage

## Verification
- uv run ruff check (focused files)
- uv run mypy
- uv run pytest -q: 2616 passed, 177 skipped
- desktop and mobile Playwright visual checks