### PR TITLE
Route support requests into federated ops chat

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -80,6 +80,9 @@ add_secret_env_if_exists \
 # SES email credentials only; not used for AWS hosting or failover.
 add_secret_env_if_exists "TR_AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
 add_secret_env_if_exists "TR_AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
+add_secret_env_if_exists \
+  "TR_OPS_CHAT_WEBHOOK_SECRET" \
+  "trustedrouter-ops-chat-webhook-secret"
 add_secret_env_if_exists "TR_PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
 add_secret_env_if_exists "TR_PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
 add_secret_env_if_exists "TR_PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
@@ -307,6 +310,7 @@ ENV_VARS=(
   "TR_SES_FROM_EMAIL=noreply@trustedrouter.com"
   "TR_SES_FROM_NAME=TrustedRouter"
   "TR_SUPPORT_EMAIL=help@trustedrouter.com"
+  "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com,https://b.trustedrouter.com,https://c.allyrouter.com"
   # /trustedos partner-inquiry form leads. Plain env (an address, not a
   # secret); without it the handler falls back to TR_SES_FROM_EMAIL, which
   # is send-only and effectively a black hole.

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -192,6 +192,10 @@ ensure_secret_from_prompt_file "trustedrouter-athena-worker-prompt-v1" "$ATHENA_
 
 ensure_secret_from_env_file "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key" "SYNTHETIC_MONITOR_API_KEY"
 ensure_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
+ensure_secret_from_env_file \
+  "TR_OPS_CHAT_WEBHOOK_SECRET" \
+  "trustedrouter-ops-chat-webhook-secret" \
+  "OPS_SUPPORT_HOOK_SECRET"
 
 # Credentials used by the hourly pricing refresh GHA workflow. Values are
 # pushed to Secret Manager like every other TR secret. The GHA WIF service
@@ -213,6 +217,7 @@ grant_tr_deploy_secret_access() {
 }
 
 grant_tr_deploy_secret_access "trustedrouter-tr-api-key-for-self-heal"
+grant_tr_deploy_secret_access "trustedrouter-ops-chat-webhook-secret"
 grant_tr_deploy_secret_access "trustedrouter-together-api-key"
 grant_tr_deploy_secret_access "trustedrouter-parasail-api-key"
 grant_tr_deploy_secret_access "trustedrouter-lightning-api-key"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -39,6 +39,12 @@ class Settings(BaseSettings):
     legal_signatory_title: str = "CEO"
     security_contact_email: str = "security@trustedrouter.com"
     support_email: str = "help@trustedrouter.com"
+    # Optional three-cloud Matrix support fanout. Values are comma-separated
+    # pinned node URLs; every destination receives the same signed payload and
+    # Matrix room state deduplicates it across federation.
+    ops_chat_webhook_urls: str = ""
+    ops_chat_webhook_secret: str | None = None
+    ops_chat_webhook_timeout_seconds: float = 3.0
 
     enable_live_providers: bool = False
     local_keys_file: Path = Path("~/.quill_cloud_keys.private").expanduser()
@@ -516,6 +522,28 @@ class Settings(BaseSettings):
                     "Google Data Manager is enabled but missing "
                     + ", ".join(missing_google_data_manager)
                 )
+        if not 0.1 <= self.ops_chat_webhook_timeout_seconds <= 10.0:
+            raise ValueError(
+                "TR_OPS_CHAT_WEBHOOK_TIMEOUT_SECONDS must be between 0.1 and 10"
+            )
+        ops_chat_urls = tuple(
+            dict.fromkeys(
+                value.strip().rstrip("/")
+                for value in self.ops_chat_webhook_urls.split(",")
+                if value.strip()
+            )
+        )
+        if bool(ops_chat_urls) != bool(self.ops_chat_webhook_secret):
+            raise ValueError(
+                "TR_OPS_CHAT_WEBHOOK_URLS and TR_OPS_CHAT_WEBHOOK_SECRET "
+                "must both be set or both unset"
+            )
+        if environment == "production" and any(
+            not url.startswith("https://") for url in ops_chat_urls
+        ):
+            raise ValueError(
+                "TR_OPS_CHAT_WEBHOOK_URLS must contain only HTTPS URLs in production"
+            )
         if ":" in self.google_ads_conversion_feed_username:
             raise ValueError("TR_GOOGLE_ADS_CONVERSION_FEED_USERNAME cannot contain ':'")
         if (

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -7,6 +7,7 @@ import logging
 import re
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -105,6 +106,7 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_V2_SCHEMA,
 )
 from trusted_router.services.email import EmailMessage, get_email_service
+from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
 from trusted_router.services.trust_release import (
     ResolvedTrustRelease,
     TrustReleaseResolver,
@@ -443,6 +445,39 @@ async def _handle_support_inquiry(settings: Settings, request: Request) -> JSONR
         return JSONResponse(
             {"ok": False, "error": "delivery_unavailable"},
             status_code=503,
+        )
+
+    ops_message = OpsChatSupportMessage(
+        message_id=f"support:{uuid.uuid4().hex}",
+        name=name,
+        email=email,
+        subject=f"{category_label}: {subject}",
+        message=(
+            f"Request ID: {request_id}\n\n{message}"
+            if request_id
+            else message
+        ),
+    )
+    try:
+        fanout = await fanout_support_message(settings, ops_message)
+    except Exception:  # noqa: BLE001 - email delivery remains authoritative
+        fanout = None
+        log.exception(
+            "support_inquiry.ops_fanout_exception category=%s",
+            category,
+        )
+    if fanout is not None and fanout.configured and fanout.accepted == 0:
+        log.error(
+            "support_inquiry.ops_fanout_failed configured=%d category=%s",
+            fanout.configured,
+            category,
+        )
+    elif fanout is not None and fanout.accepted < fanout.configured:
+        log.warning(
+            "support_inquiry.ops_fanout_partial accepted=%d configured=%d category=%s",
+            fanout.accepted,
+            fanout.configured,
+            category,
         )
 
     log.info(

--- a/src/trusted_router/services/ops_chat.py
+++ b/src/trusted_router/services/ops_chat.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+
+import httpx
+
+from trusted_router.config import Settings
+
+
+@dataclass(frozen=True)
+class OpsChatSupportMessage:
+    message_id: str
+    name: str
+    email: str
+    subject: str
+    message: str
+
+
+@dataclass(frozen=True)
+class OpsChatFanoutResult:
+    configured: int
+    accepted: int
+
+
+def _destinations(settings: Settings) -> tuple[str, ...]:
+    return tuple(
+        value.strip().rstrip("/")
+        for value in settings.ops_chat_webhook_urls.split(",")
+        if value.strip()
+    )
+
+
+async def fanout_support_message(
+    settings: Settings,
+    message: OpsChatSupportMessage,
+) -> OpsChatFanoutResult:
+    destinations = _destinations(settings)
+    secret = settings.ops_chat_webhook_secret or ""
+    if not destinations:
+        return OpsChatFanoutResult(configured=0, accepted=0)
+    if not secret:
+        return OpsChatFanoutResult(configured=len(destinations), accepted=0)
+
+    body = json.dumps(
+        {
+            "message_id": message.message_id,
+            "name": message.name,
+            "email": message.email,
+            "subject": message.subject,
+            "message": message.message,
+        },
+        separators=(",", ":"),
+    ).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    timeout = httpx.Timeout(settings.ops_chat_webhook_timeout_seconds)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        async def deliver(destination: str) -> bool:
+            try:
+                response = await client.post(
+                    f"{destination}/hooks/support",
+                    content=body,
+                    headers={
+                        "content-type": "application/json",
+                        "x-ops-signature": signature,
+                    },
+                )
+                return 200 <= response.status_code < 300
+            except httpx.HTTPError:
+                return False
+
+        accepted = sum(await asyncio.gather(*(deliver(url) for url in destinations)))
+    return OpsChatFanoutResult(configured=len(destinations), accepted=accepted)

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -40,6 +40,20 @@ def test_deploy_pins_ten_cent_signup_credit_policy() -> None:
     assert '"TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=100000"' in rollout
 
 
+def test_deploy_wires_three_cloud_ops_chat_support_fanout() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
+
+    assert "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com," in rollout
+    assert "https://b.trustedrouter.com,https://c.allyrouter.com" in rollout
+    assert "trustedrouter-ops-chat-webhook-secret" in rollout
+    assert '"OPS_SUPPORT_HOOK_SECRET"' in secrets
+    assert (
+        'grant_tr_deploy_secret_access "trustedrouter-ops-chat-webhook-secret"'
+        in secrets
+    )
+
+
 def test_all_attested_control_plane_regions_remain_warm() -> None:
     library = (ROOT / "scripts/deploy/_lib.sh").read_text()
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()

--- a/tests/test_ops_chat.py
+++ b/tests/test_ops_chat.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from trusted_router.config import Settings
+from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
+
+
+@pytest.mark.asyncio
+async def test_support_fanout_signs_identical_payload_for_each_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"published": len(requests) == 1})
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient
+
+    def client_factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    hook_secret = secrets.token_urlsafe(16)
+    settings = Settings(
+        environment="test",
+        ops_chat_webhook_urls="https://a.example,https://b.example,https://c.example",
+        ops_chat_webhook_secret=hook_secret,
+    )
+    message = OpsChatSupportMessage(
+        message_id="support:one",
+        name="Ada",
+        email="ada@example.com",
+        subject="API issue",
+        message="Request failed",
+    )
+
+    result = await fanout_support_message(settings, message)
+
+    assert result.configured == 3
+    assert result.accepted == 3
+    assert len(requests) == 3
+    assert {request.url.host for request in requests} == {
+        "a.example",
+        "b.example",
+        "c.example",
+    }
+    bodies = {request.content for request in requests}
+    assert len(bodies) == 1
+    body = bodies.pop()
+    expected = hmac.new(hook_secret.encode(), body, hashlib.sha256).hexdigest()
+    assert {request.headers["x-ops-signature"] for request in requests} == {expected}
+    assert json.loads(body)["message"] == "Request failed"
+
+
+@pytest.mark.asyncio
+async def test_support_fanout_is_disabled_without_destinations() -> None:
+    result = await fanout_support_message(
+        Settings(environment="test"),
+        OpsChatSupportMessage("id", "name", "e@example.com", "subject", "message"),
+    )
+    assert result == result.__class__(configured=0, accepted=0)
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    (
+        (
+            {"ops_chat_webhook_urls": "https://a.example"},
+            "must both be set or both unset",
+        ),
+        (
+            {"ops_chat_webhook_secret": "secret"},
+            "must both be set or both unset",
+        ),
+        (
+            {"ops_chat_webhook_timeout_seconds": 0.0},
+            "must be between 0.1 and 10",
+        ),
+    ),
+)
+def test_ops_chat_configuration_fails_closed(
+    values: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        Settings(environment="test", **values)
+
+
+def test_production_ops_chat_requires_https_destinations() -> None:
+    hook_secret = "sec" + "ret"
+    with pytest.raises(ValidationError, match="only HTTPS URLs"):
+        Settings(
+            environment="production",
+            ops_chat_webhook_urls="http://a.example",
+            ops_chat_webhook_secret=hook_secret,
+        )

--- a/tests/test_support_form.py
+++ b/tests/test_support_form.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from trusted_router.routes import public as public_routes
 from trusted_router.services.email import EmailMessage
+from trusted_router.services.ops_chat import OpsChatFanoutResult, OpsChatSupportMessage
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +35,7 @@ def test_support_submission_sends_to_help_with_reply_to(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     sent_messages: list[EmailMessage] = []
+    ops_messages: list[OpsChatSupportMessage] = []
 
     class FakeEmailService:
         def send(self, message: EmailMessage) -> bool:
@@ -45,6 +47,15 @@ def test_support_submission_sends_to_help_with_reply_to(
         "get_email_service",
         lambda _settings: FakeEmailService(),
     )
+
+    async def fake_fanout(
+        _settings: object,
+        message: OpsChatSupportMessage,
+    ) -> OpsChatFanoutResult:
+        ops_messages.append(message)
+        return OpsChatFanoutResult(configured=3, accepted=3)
+
+    monkeypatch.setattr(public_routes, "fanout_support_message", fake_fanout)
     support_text = "Sensitive support marker that must not enter application logs."
     with caplog.at_level(logging.INFO, logger="trusted_router.routes.public"):
         response = client.post(
@@ -63,6 +74,10 @@ def test_support_submission_sends_to_help_with_reply_to(
     )
     assert "req_support_123" in message.text_body
     assert support_text in message.text_body
+    assert len(ops_messages) == 1
+    assert ops_messages[0].message == (
+        f"Request ID: req_support_123\n\n{support_text}"
+    )
     assert all(support_text not in record.getMessage() for record in caplog.records)
     assert any(
         record.getMessage().startswith("support_inquiry.sent category=api ")
@@ -131,6 +146,33 @@ def test_support_delivery_failure_tells_user_to_use_email(
 
     assert response.status_code == 503
     assert response.json() == {"ok": False, "error": "delivery_unavailable"}
+
+
+def test_support_matrix_failure_does_not_override_successful_email(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            return True
+
+    async def broken_fanout(
+        _settings: object,
+        _message: OpsChatSupportMessage,
+    ) -> OpsChatFanoutResult:
+        raise RuntimeError("matrix transport failed")
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FakeEmailService(),
+    )
+    monkeypatch.setattr(public_routes, "fanout_support_message", broken_fanout)
+
+    response = client.post("/support/inquiry", json=_payload())
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
 
 
 def test_support_submission_is_rate_limited(


### PR DESCRIPTION
## Summary
- fan out successfully emailed support requests to the three-cloud private Matrix room
- HMAC-sign identical payloads and keep Matrix delivery failures isolated from customer support delivery
- wire the shared webhook secret through Secret Manager and the production rollout
- fail closed on incomplete or insecure ops-chat configuration

## Verification
- ruff
- mypy (215 source files)
- 30 targeted tests
- full suite: 2641 passed, 177 skipped, 3 unrelated current-main catalog/social-card failures