### PR TITLE
Add prompt caching guide and public 404

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -169,6 +169,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/docs/mcp",
     "/docs/migrate-from-openrouter",
     "/docs/tagging",
+    "/docs/prompt-caching",
     "/docs/web-search",
     "/docs/video",
     "/for-developers",
@@ -314,6 +315,16 @@ class PublicPage:
 class BlogIndexPost:
     post: BlogPost
     image: str
+
+
+_NOT_FOUND_PAGE = PublicPage(
+    template="public/not_found.html",
+    title="Page Not Found",
+    description=(
+        "The requested page does not exist. Continue to TrustedRouter "
+        "documentation, models, status, or support."
+    ),
+)
 
 
 PUBLIC_PAGES: dict[str, PublicPage] = {
@@ -890,6 +901,14 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         description=(
             "Attach AWS style tags and OpenRouter attribution metadata to LLM requests "
             "without adding them to model prompts or provider payloads."
+        ),
+    ),
+    "docs/prompt-caching": PublicPage(
+        template="public/prompt_caching.html",
+        title="Prompt Caching For Lower LLM Costs",
+        description=(
+            "Reuse stable prompt prefixes through provider native caches, inspect cached "
+            "token usage, and preserve TrustedRouter's no prompt storage boundary."
         ),
     ),
     "docs/web-search": PublicPage(
@@ -1626,13 +1645,38 @@ def _provider_page_node(settings: Settings, provider: Provider) -> dict[str, obj
     }
 
 
-def public_page_html(settings: Settings, page_key: str, *, site_url: str | None = None) -> str:
+def public_page_html(
+    settings: Settings,
+    page_key: str,
+    *,
+    site_url: str | None = None,
+    robots_meta: str | None = None,
+) -> str:
     page = PUBLIC_PAGES[page_key]
     path = f"/{page_key}"
+    return _render_public_page(
+        settings,
+        page,
+        path=path,
+        page_key=page_key,
+        site_url=site_url,
+        robots_meta=robots_meta,
+    )
+
+
+def _render_public_page(
+    settings: Settings,
+    page: PublicPage,
+    *,
+    path: str,
+    page_key: str | None = None,
+    site_url: str | None = None,
+    robots_meta: str | None = None,
+) -> str:
     resolved_site_url = site_url or f"https://{settings.trusted_domain}{path}"
     catalog_evidence = (
         seo_catalog_evidence(page_key, test_mode=settings.environment == "test")
-        if page.template.startswith("public/seo_")
+        if page_key is not None and page.template.startswith("public/seo_")
         else None
     )
     return (
@@ -1651,6 +1695,7 @@ def public_page_html(settings: Settings, page_key: str, *, site_url: str | None 
             # each card auto-activates the moment its image is generated into
             # static/og/, with zero risk of a 404 unfurl in the meantime.
             og_image=_og_image_url(settings, page.og_card),
+            robots_meta=robots_meta,
             faq_items=page.faq_items,
             catalog_evidence=catalog_evidence,
             json_ld_blob=_json_ld_graph(
@@ -1670,6 +1715,17 @@ def public_page_html(settings: Settings, page_key: str, *, site_url: str | None 
                 indent=2,
             ),
         )
+    )
+
+
+def public_not_found_html(settings: Settings, requested_path: str) -> str:
+    safe_path = requested_path if requested_path.startswith("/") else f"/{requested_path}"
+    return _render_public_page(
+        settings,
+        _NOT_FOUND_PAGE,
+        path=safe_path,
+        site_url=f"https://{settings.trusted_domain}{safe_path}",
+        robots_meta="noindex,follow",
     )
 
 
@@ -2701,6 +2757,7 @@ def llms_txt(settings: Settings) -> str:
         f"- Evals guide: https://{domain}/docs/evals",
         f"- Synth guide: https://{domain}/docs/synth",
         f"- Responses web search: https://{domain}/docs/web-search",
+        f"- Prompt caching: https://{domain}/docs/prompt-caching",
         f"- Video generation: https://{domain}/docs/video",
         f"- Request tagging and cost allocation: https://{domain}/docs/tagging",
         f"- Blog: https://{domain}/blog",
@@ -2788,6 +2845,7 @@ def docs_llms_txt(settings: Settings) -> str:
             f"- Evals guide: https://{domain}/docs/evals",
             f"- Synth guide: https://{domain}/docs/synth",
             f"- Responses web search: https://{domain}/docs/web-search",
+            f"- Prompt caching: https://{domain}/docs/prompt-caching",
             f"- Video generation: https://{domain}/docs/video",
             f"- OpenRouter alternative: https://{domain}/openrouter-alternative",
             f"- Private LLM API: https://{domain}/private-llm-api",
@@ -2897,6 +2955,7 @@ def docs_llms_full_txt(settings: Settings) -> str:
         f"- Evals guide: https://{domain}/docs/evals",
         f"- Synth guide: https://{domain}/docs/synth",
         f"- Responses web search: https://{domain}/docs/web-search",
+        f"- Prompt caching: https://{domain}/docs/prompt-caching",
         f"- Video generation: https://{domain}/docs/video",
         f"- Blog: https://{domain}/blog",
         f"- Migration guide: https://{domain}/docs/migrate-from-openrouter",
@@ -2926,6 +2985,17 @@ def docs_llms_full_txt(settings: Settings) -> str:
         "- trustedrouter/zeus-1.0: frontier Synth preset with commercial frontier models on the panel.",
         "- trustedrouter/iris-code-1.0, trustedrouter/prometheus-code-1.0, trustedrouter/zeus-code-1.0: code-tuned variants with the same preset tiers.",
         "- trustedrouter/iris, trustedrouter/prometheus, trustedrouter/zeus, and their -code aliases track the latest preset version.",
+        "",
+        "## Prompt Caching",
+        f"- Guide: https://{domain}/docs/prompt-caching",
+        "- TrustedRouter preserves provider-native caching controls and normalizes provider-reported cached token usage.",
+        "- Chat Completions reports usage.prompt_tokens_details.cached_tokens.",
+        "- Responses reports usage.input_tokens_details.cached_tokens.",
+        "- Anthropic Messages preserves content-block cache_control and reports cache_creation_input_tokens plus cache_read_input_tokens.",
+        "- Cached reads and cache writes settle using the selected endpoint's cache-aware rates when available.",
+        "- Provider caches are provider and route scoped. Fallback can reduce cache hits, while provider.only improves locality at the cost of rollover.",
+        "- TrustedRouter does not create a durable router-side prompt cache or store prompt/output content.",
+        "- prompt_cache_retention is not supported and returns a stable 501 error.",
         "",
         "## Synth",
         "- Endpoint shape: POST /v1/chat/completions.",

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -14,14 +14,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from trusted_router.analytics_sink import create_analytics_sink
 from trusted_router.axiom_config import init_axiom
 from trusted_router.catalog import validate_auto_model_order
 from trusted_router.config import Settings, get_settings
+from trusted_router.dashboard import public_not_found_html
 from trusted_router.errors import error_response
 from trusted_router.middleware import register_http_middleware
 from trusted_router.routes.acquisition import register_acquisition_routes
@@ -87,8 +89,10 @@ def create_app(
 
     register_http_middleware(app, settings)
 
-    @app.exception_handler(HTTPException)
-    async def http_exception_handler(_request: Request, exc: HTTPException) -> Response:
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> Response:
         # Redirect-shaped HTTPExceptions (e.g. console gating raising 302
         # to /?reason=signin) need to stay redirects, not become JSON
         # error envelopes.
@@ -99,6 +103,12 @@ def create_app(
         if isinstance(exc.detail, dict) and "error" in exc.detail:
             return JSONResponse(
                 exc.detail, status_code=exc.status_code, headers=exc.headers
+            )
+        if exc.status_code == 404 and _is_public_html_request(request):
+            return HTMLResponse(
+                public_not_found_html(settings, request.url.path),
+                status_code=404,
+                headers=exc.headers,
             )
         response = error_response(
             exc.status_code,
@@ -159,6 +169,26 @@ def create_app(
     app.include_router(api)
     app.include_router(api, prefix="/v1")
     return app
+
+
+def _is_public_html_request(request: Request) -> bool:
+    if request.method not in {"GET", "HEAD"}:
+        return False
+    if "text/html" not in request.headers.get("accept", "").lower():
+        return False
+    path = request.url.path
+    non_public_prefixes = (
+        "/v1",
+        "/internal",
+        "/api",
+        "/auth",
+        "/oauth",
+        "/console",
+        "/static",
+        "/webhooks",
+        "/.well-known",
+    )
+    return not any(path == prefix or path.startswith(f"{prefix}/") for prefix in non_public_prefixes)
 
 
 def _make_api_router(settings: Settings) -> APIRouter:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -71,6 +71,7 @@ from trusted_router.dashboard import (
     public_model_not_found_html,
     public_model_section_html,
     public_models_html,
+    public_not_found_html,
     public_page_html,
     public_privacy_html,
     public_provider_detail_html,
@@ -654,6 +655,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def tagging_docs() -> str:
         return public_page_html(settings, "docs/tagging")
 
+    @public_html_route("/docs/prompt-caching")
+    async def prompt_caching_docs() -> str:
+        return public_page_html(settings, "docs/prompt-caching")
+
     @public_html_route("/docs/web-search")
     async def web_search_docs() -> str:
         return public_page_html(settings, "docs/web-search")
@@ -966,7 +971,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             )
         html = public_blog_post_html(settings, slug)
         if html is None:
-            return HTMLResponse(public_page_html(settings, "docs"), status_code=404)
+            return HTMLResponse(
+                public_not_found_html(settings, f"/blog/{slug}"),
+                status_code=404,
+            )
         return html
 
     @public_html_route("/security")

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -38,6 +38,7 @@
       <a href="/docs">Documentation</a>
       <a href="/for-developers">60-second quickstart</a>
       <a href="/docs/migrate-from-openrouter">Migration guide</a>
+      <a href="/docs/prompt-caching">Prompt caching</a>
       <a href="/docs/agent-setup#codex-skill">Agent skill</a>
       <a href="/docs/mcp">MCP server</a>
       <a href="/docs/video">Video generation</a>

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -66,6 +66,7 @@ const r = await client.chat.completions.create({
     <a class="marketing-card card-as-link" href="/docs/agent-setup#codex-skill"><h3>Agent skill</h3><p>Help Codex, Claude Code, Hermes, and other agents choose models using speed, cost, AI IQ, privacy, context length, and prompt-cache fit.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/migrate-from-openrouter"><h3>Migrate from OpenRouter</h3><p>Swap one base_url and keep your existing calls working.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/tagging"><h3>Request tagging</h3><p>Allocate cost and usage with AWS style tags while keeping metadata out of model prompts.</p><span class="card-link">Open →</span></a>
+    <a class="marketing-card card-as-link" href="/docs/prompt-caching"><h3>Prompt caching</h3><p>Reuse stable prompt prefixes, inspect cache hits, and keep the router itself free of prompt storage.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/web-search"><h3>Responses web search</h3><p>Search the live web inside the attested gateway and return source citations through the OpenAI Responses API.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/video"><h3>Video generation</h3><p>Generate video with Seedance, Veo, Sora, Runway, Kling, Wan, Vidu, PixVerse, LTX, Gemini Omni, and Hailuo 3 through asynchronous jobs with exact quoted billing.</p><span class="card-link">Open →</span></a>
     <a class="marketing-card card-as-link" href="/docs/evals"><h3>Evals</h3><p>Run eval suites across providers through one API.</p><span class="card-link">Open →</span></a>
@@ -121,6 +122,7 @@ const r = await client.chat.completions.create({
         <li><a href="https://github.com/Lore-Hex/LLM-advisor">trustedrouter-model-advisor</a> — source repo and <a href="https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md">raw playbook</a> for agent installation</li>
         <li><a href="/docs/agent-setup#socrates">Socrates</a> — advisor orchestration guide</li>
         <li><a href="/docs/synth">/docs/synth</a> — Synth model panel guide</li>
+        <li><a href="/docs/prompt-caching">/docs/prompt-caching</a> — provider cache behavior, usage fields, billing, and routing tradeoffs</li>
         <li><a href="/docs/web-search">/docs/web-search</a> — Responses API web search, citations, controls, and privacy boundaries</li>
         <li><a href="/docs/video">/docs/video</a> — asynchronous video generation, models, billing, and retention boundaries</li>
         <li><a href="https://github.com/Lore-Hex/quill-router">GitHub</a> — source + issues</li>

--- a/src/trusted_router/templates/public/not_found.html
+++ b/src/trusted_router/templates/public/not_found.html
@@ -1,0 +1,50 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Page not found">
+  <div class="marketing-copy">
+    <span class="eyebrow">404</span>
+    <h2>That page is not here.</h2>
+    <p>The address may have changed, or the page may no longer exist. The API, documentation, model catalog, and public status pages are available below.</p>
+    <p>
+      <a class="btn primary" href="/docs">Open documentation</a>
+      <a class="btn" href="/">Return home</a>
+    </p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>TrustedRouter</span><span>Useful routes</span></div>
+    <pre><code>Documentation   /docs
+Models          /models
+Providers       /providers
+API status      /status
+Support         /support</code></pre>
+  </div>
+</section>
+
+<section style="margin-top:48px">
+  <h2 class="section-center">Continue from here</h2>
+  <div class="marketing-grid four">
+    <a class="marketing-card card-as-link" href="/docs">
+      <h3>Documentation</h3>
+      <p>Quickstarts, SDK setup, routing, caching, privacy, and API guides.</p>
+      <span class="card-link">Open docs</span>
+    </a>
+    <a class="marketing-card card-as-link" href="/models">
+      <h3>Models</h3>
+      <p>Browse current models, providers, pricing, and privacy posture.</p>
+      <span class="card-link">Browse models</span>
+    </a>
+    <a class="marketing-card card-as-link" href="/status">
+      <h3>Status</h3>
+      <p>See router health, regional checks, uptime, and recent incidents.</p>
+      <span class="card-link">View status</span>
+    </a>
+    <a class="marketing-card card-as-link" href="/support">
+      <h3>Support</h3>
+      <p>Get help with accounts, billing, provider routes, or API requests.</p>
+      <span class="card-link">Contact support</span>
+    </a>
+  </div>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/prompt_caching.html
+++ b/src/trusted_router/templates/public/prompt_caching.html
@@ -1,0 +1,172 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Prompt caching quickstart">
+  <div class="marketing-copy">
+    <span class="eyebrow">Prompt caching</span>
+    <h2>Reuse long prompt prefixes. Pay the provider cache rate.</h2>
+    <p>TrustedRouter preserves provider native caching controls, reports cache hit tokens, and settles cached input at the selected route's cache price when the provider publishes one.</p>
+    <p>TrustedRouter does not keep a second prompt cache. Prompt and output content still terminate inside the attested gateway and are not written to the control plane, billing database, analytics store, logs, or Sentry.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Automatic prefix caching</span><span>Python</span></div>
+    <pre><code>from openai import OpenAI
+
+client = OpenAI(
+    api_key="sk-tr-v1-...",
+    base_url="{{ api_base_url }}"
+)
+
+response = client.chat.completions.create(
+    model="deepseek/deepseek-v4-pro",
+    messages=[
+        {"role": "system", "content": LONG_STABLE_CONTEXT},
+        {"role": "user", "content": "Summarize section 4."}
+    ],
+    extra_body={
+        "provider": {
+            "only": ["deepseek"],
+            "allow_fallbacks": False
+        }
+    }
+)
+
+details = response.usage.prompt_tokens_details
+print(details.cached_tokens if details else 0)</code></pre>
+  </div>
+</section>
+
+<section style="margin-top:48px">
+  <h2 class="section-center">How it works</h2>
+  <div class="marketing-grid three">
+    <div class="marketing-card">
+      <span class="card-label">1. Stable prefix</span>
+      <h3>Put reusable content first.</h3>
+      <p>Keep tool definitions, system instructions, examples, documents, and conversation history byte stable. Put the changing question at the end.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">2. Provider cache</span>
+      <h3>The selected provider reuses it.</h3>
+      <p>Automatic caching requires no TrustedRouter setting when the selected provider and model support prefix caching. Minimum prompt size, lifetime, and hit rules are provider specific.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">3. Exact settlement</span>
+      <h3>Cache usage reaches the ledger.</h3>
+      <p>The attested gateway normalizes provider usage fields. Cached reads, cache writes, uncached input, and output are settled with integer microdollar arithmetic.</p>
+    </div>
+  </div>
+</section>
+
+<section class="marketing-split" style="margin-top:48px">
+  <div class="marketing-copy">
+    <span class="eyebrow">Anthropic</span>
+    <h2>Set an explicit cache breakpoint.</h2>
+    <p>On <code>POST /v1/messages</code>, TrustedRouter preserves Anthropic content blocks and their <code>cache_control</code> values through the attested gateway. Put the breakpoint on the last block of the stable prefix.</p>
+    <p>The first request can include a cache creation charge. Repeated reads are normally cheaper. Check the returned usage rather than assuming every request hit.</p>
+    <p><a href="https://platform.claude.com/docs/en/build-with-claude/prompt-caching">Anthropic prompt caching reference</a></p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Explicit breakpoint</span><span>Anthropic Python SDK</span></div>
+    <pre><code>from anthropic import Anthropic
+
+client = Anthropic(
+    api_key="sk-tr-v1-...",
+    base_url="{{ api_base_url|replace('/v1', '') }}"
+)
+
+response = client.messages.create(
+    model="anthropic/claude-sonnet-4.6",
+    max_tokens=600,
+    system=[{
+        "type": "text",
+        "text": LONG_STABLE_CONTEXT,
+        "cache_control": {"type": "ephemeral"}
+    }],
+    messages=[{
+        "role": "user",
+        "content": "Summarize section 4."
+    }]
+)
+
+print(response.usage.cache_creation_input_tokens)
+print(response.usage.cache_read_input_tokens)</code></pre>
+  </div>
+</section>
+
+<section style="margin-top:48px">
+  <h2 class="section-center">Read the cache result</h2>
+  <div class="marketing-grid three">
+    <div class="marketing-card">
+      <span class="card-label">Chat Completions</span>
+      <h3><code>cached_tokens</code></h3>
+      <p>Read <code>usage.prompt_tokens_details.cached_tokens</code>. The cached count is included within total prompt tokens for OpenAI compatible responses.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Responses API</span>
+      <h3><code>cached_tokens</code></h3>
+      <p>Read <code>usage.input_tokens_details.cached_tokens</code>. TrustedRouter returns the normalized provider reported count.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Anthropic Messages</span>
+      <h3>Creation and read counts</h3>
+      <p>Read <code>cache_creation_input_tokens</code> and <code>cache_read_input_tokens</code> from <code>usage</code>.</p>
+    </div>
+  </div>
+</section>
+
+<section class="marketing-split" style="margin-top:48px">
+  <div class="marketing-copy">
+    <span class="eyebrow">Routing choice</span>
+    <h2>Choose cache locality or broad rollover.</h2>
+    <p>Provider caches are generally scoped to a provider, account, model, and prompt prefix. A fallback to another provider can be a cache miss even when it serves the same model.</p>
+    <p>For a repeated, cache sensitive workload, use <code>provider.only</code> and optionally disable fallbacks. For higher availability, keep fallbacks enabled and accept that the first request on a new route may rebuild the cache.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Prefer one provider, retain fallback</span><span>JSON</span></div>
+    <pre><code>{
+  "model": "your/model",
+  "provider": {
+    "order": ["your-preferred-provider"],
+    "allow_fallbacks": true
+  }
+}</code></pre>
+  </div>
+</section>
+
+<section style="margin-top:48px">
+  <h2 class="section-center">Provider behavior</h2>
+  <div class="marketing-grid two">
+    <div class="marketing-card">
+      <h3>Automatic caches</h3>
+      <p>TrustedRouter recognizes standard OpenAI cached token details and provider specific usage from DeepSeek, Kimi, and Gemini adapters. Automatic cache creation and eviction remain controlled by the selected provider.</p>
+      <ul class="check-list">
+        <li><a href="https://platform.openai.com/docs/guides/prompt-caching">OpenAI prompt caching</a></li>
+        <li><a href="https://api-docs.deepseek.com/guides/kv_cache">DeepSeek context caching</a></li>
+        <li><a href="https://ai.google.dev/gemini-api/docs/caching">Gemini context caching</a></li>
+      </ul>
+    </div>
+    <div class="marketing-card">
+      <h3>Current limits</h3>
+      <ul class="check-list">
+        <li>Cache hits are not guaranteed</li>
+        <li>Provider and model minimum token thresholds apply</li>
+        <li><code>prompt_cache_retention</code> returns <code>501 not_supported_in_alpha</code></li>
+        <li>TrustedRouter does not expose provider cache object create, list, or delete APIs</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="quote-feature" style="margin-top:48px">
+  <div>
+    <span class="eyebrow">Privacy boundary</span>
+    <h2>No router side prompt copy.</h2>
+  </div>
+  <div>
+    <p>Provider caching is upstream model processing, so the selected provider's policy still applies. A cache feature does not upgrade an Open route to ZDR or confidential compute.</p>
+    <p>Use <code>provider.min_privacy = "zdr"</code>, <code>trustedrouter/zdr</code>, or <code>trustedrouter/e2e</code> when the workload requires a hard privacy floor. Routing applies that floor before any prompt is sent.</p>
+    <p><a class="btn" href="/providers">Review provider posture</a> <a class="btn" href="https://trust.trustedrouter.com">Verify the gateway</a></p>
+  </div>
+</section>
+
+{% endblock %}

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -139,6 +139,26 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
   expect(overflow).toBeLessThanOrEqual(2);
 });
 
+test("prompt caching guide and public 404 remain useful on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/docs/prompt-caching");
+
+  await expect(page.getByRole("heading", { name: "Prompt Caching For Lower LLM Costs" })).toBeVisible();
+  await expect(page.getByText("Reuse long prompt prefixes.")).toBeVisible();
+  let overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  expect(overflow).toBeLessThanOrEqual(2);
+
+  const response = await page.goto("/missing-public-page");
+  expect(response.status()).toBe(404);
+  await expect(page.getByRole("heading", { name: "Page Not Found" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Open documentation" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Browse models" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View status" })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "noindex,follow");
+  overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  expect(overflow).toBeLessThanOrEqual(2);
+});
+
 test("Charter design remains shared and responsive across public surfaces", async ({ page }) => {
   for (const path of ["/", "/models", "/security", "/status", "/blog"]) {
     await page.goto(path);

--- a/tests/test_prompt_caching_docs.py
+++ b/tests/test_prompt_caching_docs.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_prompt_caching_docs_publish_usage_billing_and_privacy_contract(
+    client: TestClient,
+) -> None:
+    response = client.get("/docs/prompt-caching")
+
+    assert response.status_code == 200
+    assert "cache_control" in response.text
+    assert "usage.prompt_tokens_details.cached_tokens" in response.text
+    assert "usage.input_tokens_details.cached_tokens" in response.text
+    assert "cache_creation_input_tokens" in response.text
+    assert "cache_read_input_tokens" in response.text
+    assert "integer microdollar arithmetic" in response.text
+    assert "does not keep a second prompt cache" in response.text
+    assert 'provider.min_privacy = "zdr"' in response.text
+
+
+def test_prompt_caching_docs_state_routing_and_retention_limits(client: TestClient) -> None:
+    response = client.get("/docs/prompt-caching")
+
+    assert response.status_code == 200
+    assert '"only": ["deepseek"]' in response.text
+    assert '"allow_fallbacks": False' in response.text
+    assert "fallback to another provider can be a cache miss" in response.text
+    assert "prompt_cache_retention" in response.text
+    assert "501 not_supported_in_alpha" in response.text
+    assert "Cache hits are not guaranteed" in response.text
+
+
+def test_prompt_caching_docs_are_discoverable(client: TestClient) -> None:
+    assert 'href="/docs/prompt-caching"' in client.get("/docs").text
+    assert 'href="/docs/prompt-caching"' in client.get("/").text
+    assert "/docs/prompt-caching" in client.get("/llms.txt").text
+    assert "/docs/prompt-caching" in client.get("/docs/llms.txt").text
+    assert "/docs/prompt-caching" in client.get("/docs/llms-full.txt").text
+    assert (
+        "<loc>https://trustedrouter.com/docs/prompt-caching</loc>"
+        in client.get("/sitemap-core.xml").text
+    )

--- a/tests/test_public_not_found.py
+++ b/tests/test_public_not_found.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_unknown_public_browser_route_uses_styled_not_found(client: TestClient) -> None:
+    response = client.get(
+        "/this-page-does-not-exist",
+        headers={"accept": "text/html"},
+    )
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("text/html")
+    assert "That page is not here." in response.text
+    assert '<meta name="robots" content="noindex,follow">' in response.text
+    for path in ("/docs", "/models", "/status", "/support"):
+        assert f'href="{path}"' in response.text
+
+
+def test_unknown_api_route_keeps_json_even_for_browser_accept(client: TestClient) -> None:
+    response = client.get(
+        "/v1/this-route-does-not-exist",
+        headers={"accept": "text/html"},
+    )
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["error"]["type"] == "http_error"
+
+
+def test_unknown_public_non_browser_request_keeps_json(client: TestClient) -> None:
+    response = client.get(
+        "/this-page-does-not-exist",
+        headers={"accept": "application/json"},
+    )
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_missing_blog_post_uses_styled_not_found(client: TestClient) -> None:
+    response = client.get("/blog/not-a-real-post")
+
+    assert response.status_code == 404
+    assert "That page is not here." in response.text
+    assert "Quickstart: one base_url change" not in response.text


### PR DESCRIPTION
## Summary
- publish a provider-native prompt caching guide and link it from docs, footer, sitemap, and agent-readable docs
- add a styled public 404 with useful recovery routes and noindex metadata
- preserve structured JSON errors for API, auth, console, webhook, and internal routes

## Verification
- 81 focused Python tests passed
- ruff and mypy passed
- Playwright mobile regression passed
- unknown /v1 route remains JSON