### PR TITLE
Keep console workspace selection consistent

### DIFF
--- a/src/trusted_router/routes/console/_shared.py
+++ b/src/trusted_router/routes/console/_shared.py
@@ -68,25 +68,29 @@ def require_console_context(request: Request, settings: SettingsDep) -> ConsoleC
 ConsoleDep = Annotated[ConsoleContext, Depends(require_console_context)]
 
 
-def render(template: str, **context: Any) -> str:
-    """Common template fan-out: every console template needs the user,
-    workspace list, current workspace, and a hint for which sidebar item
-    is active. Each page passes its own page_title / page_subtitle / data."""
-    settings: Settings = context.pop("settings")
-    user: User = context.pop("user")
+def render(
+    template: str,
+    *,
+    settings: Settings,
+    ctx: ConsoleContext,
+    **context: Any,
+) -> str:
+    """Render a console page with one authoritative workspace context.
+
+    Requiring ``ctx`` prevents pages from using the selected workspace for
+    their data while accidentally rendering the first workspace in the
+    shared selector.
+    """
     active = str(context.get("active") or "")
-    workspaces = STORE.list_workspaces_for_user(user.id)
-    current_workspace = context.get("workspace")
-    if not isinstance(current_workspace, Workspace):
-        current_workspace = workspaces[0] if workspaces else None
     return render_template(
         template,
-        api_base_url=context.pop("api_base_url", settings.api_base_url),
-        user=user,
-        user_email=user.email,
-        workspaces=workspaces,
-        current_workspace=current_workspace,
-        current_workspace_id=current_workspace.id if current_workspace else "",
+        api_base_url=context.pop("api_base_url", ctx.api_base_url),
+        user=ctx.user,
+        user_email=ctx.user.email,
+        workspace=ctx.workspace,
+        workspaces=ctx.workspaces,
+        current_workspace=ctx.workspace,
+        current_workspace_id=ctx.workspace.id,
         console_next_path=_console_path_for_active(active),
         **context,
     )

--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -86,12 +86,11 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/activity.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="activity",
             page_title="Observability",
             page_subtitle="Per-request metadata, no prompt content.",
             activity=events,
-            api_base_url=ctx.api_base_url,
         ))
 
     @app.get("/console/activity/usage.json")

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -54,7 +54,7 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/api_keys.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="api-keys",
             page_title="API Keys",
             page_subtitle="Long-lived keys for your applications.",
@@ -62,7 +62,6 @@ def register(app: FastAPI) -> None:
             created_key=created_key,
             flash=flash,
             suggested=suggested,
-            api_base_url=ctx.api_base_url,
         ))
 
     @app.get("/console/api-keys")

--- a/src/trusted_router/routes/console/broadcast.py
+++ b/src/trusted_router/routes/console/broadcast.py
@@ -34,13 +34,12 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/broadcast.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="broadcast",
             page_title="Broadcast",
             page_subtitle="Export generation metadata to PostHog or an OTLP webhook.",
             destinations=destinations,
             default_posthog_endpoint=POSTHOG_DEFAULT_ENDPOINT,
-            api_base_url=ctx.api_base_url,
         ))
 
     @app.post("/console/broadcast")

--- a/src/trusted_router/routes/console/byok.py
+++ b/src/trusted_router/routes/console/byok.py
@@ -32,12 +32,11 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/byok.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="byok",
             page_title="BYOK",
             page_subtitle="Bring your own provider keys.",
             providers=providers,
-            api_base_url=ctx.api_base_url,
         ))
 
     @app.post("/console/byok")

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -58,7 +58,7 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/credits.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="credits",
             page_title="Credits",
             page_subtitle="Top up to keep prepaid routes flowing.",

--- a/src/trusted_router/routes/console/custom_models.py
+++ b/src/trusted_router/routes/console/custom_models.py
@@ -105,8 +105,7 @@ def _render_page(ctx: ConsoleDep, settings: SettingsDep, *, request: Request) ->
     return render(
         "console/custom_models.html",
         settings=settings,
-        user=ctx.user,
-        workspace=ctx.workspace,
+        ctx=ctx,
         active="custom-models",
         page_title="Custom Models",
         page_subtitle="Create hidden-prompt model aliases that run through the attested gateway.",

--- a/src/trusted_router/routes/console/preferences.py
+++ b/src/trusted_router/routes/console/preferences.py
@@ -15,11 +15,10 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/account/preferences.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="preferences",
             page_title="Preferences",
             page_subtitle="Account and sign-in.",
             provider=ctx.session.provider,
             environment=settings.environment,
-            api_base_url=ctx.api_base_url,
         ))

--- a/src/trusted_router/routes/console/routing_page.py
+++ b/src/trusted_router/routes/console/routing_page.py
@@ -33,12 +33,11 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/routing.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="routing",
             page_title="Routing",
             page_subtitle="Auto-rollover order and regional endpoints.",
             auto_order=auto_order,
             regions=regions,
             configured_regions=configured_regions(settings),
-            api_base_url=ctx.api_base_url,
         ))

--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -23,12 +23,10 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(render(
             "console/settings.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="settings",
             page_title="Workspace settings",
             page_subtitle="Names, content storage, integrations.",
-            workspace=ctx.workspace,
-            api_base_url=ctx.api_base_url,
             can_manage=STORE.user_can_manage(ctx.user.id, ctx.workspace.id),
             saved=bool(saved),
             error=error,

--- a/src/trusted_router/routes/console/welcome.py
+++ b/src/trusted_router/routes/console/welcome.py
@@ -39,7 +39,7 @@ def register(app: FastAPI) -> None:
         response = HTMLResponse(render(
             "console/welcome.html",
             settings=settings,
-            user=ctx.user,
+            ctx=ctx,
             active="api-keys",
             page_title="Welcome",
             page_subtitle="Save your API key — it won't be shown again.",
@@ -50,7 +50,6 @@ def register(app: FastAPI) -> None:
             # from accounts configured with the grant disabled.
             trial_credit=money(trial_microdollars),
             trial_credit_microdollars=trial_microdollars,
-            api_base_url=ctx.api_base_url,
         ))
         if clear_pending_reveal:
             # Delete cookie with the same path it was set with — otherwise

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -997,6 +997,23 @@ def test_console_workspace_selector_persists_session_workspace(
     assert refreshed is not None
     assert refreshed.workspace_id == org.id
 
+    console_pages = (
+        "/console/api-keys",
+        "/console/byok",
+        "/console/custom-models",
+        "/console/routing",
+        "/console/activity",
+        "/console/broadcast",
+        "/console/settings",
+        "/console/credits",
+        "/console/account/preferences",
+    )
+    for path in console_pages:
+        workspace_page = client.get(path)
+        assert workspace_page.status_code == 200, path
+        assert f'<option value="{org.id}" selected>' in workspace_page.text, path
+        assert f'<option value="{personal.id}" selected>' not in workspace_page.text, path
+
     created = client.post(
         "/console/api-keys",
         data={"name": "org-key", "limit": ""},


### PR DESCRIPTION
## Summary
- require every console page to render from the resolved ConsoleContext
- keep the selected workspace synchronized between page data and the header selector
- cover all nine console pages with a regression test

## Verification
- uv run ruff check src/trusted_router/routes/console tests/test_oauth_and_console.py tests/test_deploy_secret_wiring.py
- uv run mypy
- uv run pytest -q tests/test_oauth_and_console.py tests/test_deploy_secret_wiring.py (84 passed)