### PR TITLE
Ship user-funded delegated OAuth onboarding

### DIFF
--- a/docs/sign-in-with-trustedrouter.md
+++ b/docs/sign-in-with-trustedrouter.md
@@ -16,7 +16,7 @@ app (public client)                         TrustedRouter
   │  1. make PKCE pair (verifier, challenge)
   │  2. open browser → GET /auth?callback_url=…&code_challenge=…
   │ ───────────────────────────────────────────────────────────▶ consent
-  │                                          (user signs in + approves)
+  │                              (sign in, fund, choose cap, approve)
   │  3. ◀── redirect: callback_url?code=…&user_id=…&state=…
   │  4. POST /auth/keys {code, code_verifier}  (no auth header)
   │ ───────────────────────────────────────────────────────────▶
@@ -29,18 +29,46 @@ use `key` for /v1/chat/completions etc. — billed to the signed-in user.
 ```
 
 Because of PKCE, intercepting the redirect `code` is useless without the
-`code_verifier` the app kept — so native/SPA apps need **no client secret**.
+`code_verifier` the app kept, so native and SPA apps need **no client secret**.
+
+## Account creation, funding, and the app limit
+
+The browser flow handles first-time TrustedRouter users without sending them
+through the general console onboarding:
+
+1. The user signs in with Google, GitHub, or MetaMask.
+2. A new account created from this delegated flow starts with **$0 in credit**.
+   It does not receive the normal $0.10 direct-signup credit and does not mint
+   an extra management API key.
+3. The consent screen offers **$5**, **$20** (selected by default), or **$100**
+   in credits. Stripe saves the card to the user's TrustedRouter account for
+   faster future top ups and optional auto refill. The user can remove it from
+   the Credits page.
+4. The user reviews and edits the maximum spend for this app. If the app
+   requested `limit=5&usage_limit_type=monthly`, the form starts at $5 per
+   month, but the user remains in control.
+5. Approval creates one inference-only key. The app cannot manage billing,
+   workspaces, provider keys, or other API keys.
+
+Existing users see their current available balance. Funding is optional when
+that balance is already sufficient. A user may also approve at $0 when they
+intend to use BYOK, but prepaid model calls will fail until credits arrive.
 
 ## Endpoints
 
-Base URL: `https://api.quillrouter.com/v1` (a.k.a. `https://api.trustedrouter.com/v1`).
+OAuth control base: `https://trustedrouter.com/v1`.
+
+Inference base for the delegated key: `https://api.quillrouter.com/v1`
+(also available as `https://api.trustedrouter.com/v1`). The browser sign-in,
+consent, billing, and code exchange stay on the control plane. Prompt traffic
+uses the attested API plane.
 
 ### `GET /auth` — authorize + consent (browser)
 Query params (only `callback_url` is required):
 
 | param | meaning |
 |---|---|
-| `callback_url` | where TR redirects after approval. **Must be `https://`** (or `http://localhost:3000` / `127.0.0.1:3000` for local dev). Ports limited to 443 or 3000. Carry your CSRF `state` *inside* this URL's query. |
+| `callback_url` | where TR redirects after approval. Use `https://`, a native custom scheme with PKCE S256, or `http://localhost:3000` / `127.0.0.1:3000` for a loopback client. Web ports are limited to 443 or 3000. Carry your CSRF `state` *inside* this URL's query. |
 | `code_challenge` | base64url(SHA-256(`code_verifier`)), padding stripped |
 | `code_challenge_method` | `S256` (default) or `plain` |
 | `key_label` | label shown on the issued key (defaults to the callback host) |
@@ -48,9 +76,9 @@ Query params (only `callback_url` is required):
 | `usage_limit_type` | `daily` \| `weekly` \| `monthly` (resets the cap) |
 | `expires_at` | optional ISO-8601 expiry for the issued key |
 
-If the user isn't signed in, `/auth` serves a sign-in page (Google / GitHub /
-wallet); after sign-in they see the consent screen and approve, which redirects
-to `callback_url?code=…&user_id=…` (+ your embedded `state`).
+If the user isn't signed in, `/auth` serves a sign-in page. After sign-in they
+can add credits, edit the app limit, and approve. TrustedRouter then redirects
+to `callback_url?code=…&user_id=…` plus your embedded `state`.
 
 ### `POST /auth/keys` — exchange code → key (+ identity)
 Public client — **send no `Authorization` header.**
@@ -80,7 +108,19 @@ console session).
 
 ## SDK usage
 
-All three SDKs implement the same flow.
+All three official TrustedRouter SDKs have first-class Sign in with
+TrustedRouter support. You do not need to implement PKCE, state validation, URL
+construction, or token exchange from scratch:
+
+- [Python SDK](https://github.com/Lore-Hex/trusted-router-py):
+  `create_oauth_authorization`, `exchange_oauth_key`, and `fetch_userinfo`
+- [TypeScript SDK](https://github.com/Lore-Hex/trusted-router-js):
+  `BrowserOAuthFlow` and the lower-level OAuth client methods
+- [Swift SDK](https://github.com/jperla/trusted-router-swift):
+  `TrustedRouterOAuth`, `oauthAuthorizeURL`, and `exchangeOAuthKey`
+
+Each SDK implements the same wire protocol and returns the delegated key plus
+the signed-in TrustedRouter identity.
 
 ### Python (`trustedrouter`)
 ```python
@@ -141,16 +181,24 @@ to catch the `?code=…`, then exchange it. (Port 3000 is allowlisted by the
 backend for exactly this.)
 
 ## Consumers
+- **[SlopNazi](https://slopnazi.com/editor)** uses the flow for its full,
+  context-aware writing editor. It requests a $5 monthly cap, then exchanges
+  the code server-side for a delegated inference key.
 - **Lore web** signs in with this flow and uses the delegated key for game
   generation.
 - **Lore games (macOS, QuillUI)** uses the Swift SDK loopback flow.
 
 ## Security notes
-- PKCE `S256` is mandatory for public clients; never send the `code_verifier`
-  in the authorize URL, only in the exchange.
+- PKCE `S256` is required for native custom-scheme callbacks and recommended
+  for every public client. The `plain` method exists only for wire
+  compatibility with older clients. Never send the `code_verifier` in the
+  authorize URL, only in the exchange.
 - Always generate a random `state`, embed it in `callback_url`, and verify it on
   the callback (the SDK flow helpers do this).
-- `callback_url` must be HTTPS (or loopback for desktop); credentials in the URL
-  are rejected.
+- `callback_url` must be HTTPS, a PKCE-protected native custom scheme, or the
+  supported loopback URL; credentials and unsafe schemes are rejected.
 - Issued keys are inference-only (never management) and honor the optional
-  `limit` / `usage_limit_type` / `expires_at` you request — scope them tightly.
+  `limit` / `usage_limit_type` / `expires_at` the user approves. Request a
+  conservative default and let the user make the final choice.
+- Never put the delegated key in a URL, browser analytics, logs, or client-side
+  durable storage. A server-backed app should exchange and store it server-side.

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -36,6 +36,13 @@ function applySigninTarget(): void {
     url.searchParams.set("next", target);
     link.href = `${url.pathname}${url.search}`;
   });
+  if (target.startsWith("/auth?") || target.startsWith("/v1/auth?")) {
+    const creditNote = document.getElementById("signinCreditNote");
+    if (creditNote) {
+      creditNote.textContent =
+        "Accounts created for this app start at $0. After sign in, add credits and choose the maximum this app may spend.";
+    }
+  }
 }
 
 function moneyFromMicrodollars(value: unknown): string {

--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -30,6 +30,77 @@ class BlogPost:
 
 BLOG_POSTS: tuple[BlogPost, ...] = (
     BlogPost(
+        slug="sign-in-with-trustedrouter-slopnazi",
+        title="Sign in with TrustedRouter",
+        description=(
+            "Let users sign in, fund their own AI balance, choose an app spending cap, "
+            "and grant an inference-only key. Now live on SlopNazi."
+        ),
+        published_date="2026-08-03",
+        source_label=None,
+        source_url=None,
+        body_html="""
+<figure style="margin:0 0 32px">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="100%" style="height:auto" font-family="Inter,Arial,sans-serif" role="img" aria-label="Sign in with TrustedRouter user funded AI authorization flow">
+<rect width="1200" height="630" fill="#ffffff"/>
+<text x="60" y="58" font-size="22" font-weight="700" fill="#0f6e56">TrustedRouter</text>
+<text x="60" y="126" font-size="48" font-weight="700" fill="#111827">Sign in with TrustedRouter</text>
+<text x="60" y="166" font-size="22" fill="#6b7280">Your users bring their own AI, credits, and spending limit.</text>
+<defs>
+  <marker id="oauth-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+    <path d="M0 0 L8 3 L0 6 z" fill="#6b7280"/>
+  </marker>
+</defs>
+
+<rect x="60" y="235" width="235" height="190" rx="8" fill="#f3f4f6" stroke="#d1d5db" stroke-width="2"/>
+<text x="177" y="275" text-anchor="middle" font-size="15" font-weight="700" fill="#6b7280">APP</text>
+<text x="177" y="320" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">SlopNazi</text>
+<text x="177" y="354" text-anchor="middle" font-size="16" fill="#4b5563">Improve writing</text>
+<text x="177" y="384" text-anchor="middle" font-size="16" fill="#4b5563">Requests a $5 monthly cap</text>
+
+<line x1="295" y1="330" x2="350" y2="330" stroke="#6b7280" stroke-width="2.5" marker-end="url(#oauth-arrow)"/>
+
+<rect x="365" y="235" width="235" height="190" rx="8" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="2"/>
+<text x="482" y="275" text-anchor="middle" font-size="15" font-weight="700" fill="#047857">USER</text>
+<text x="482" y="320" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">Sign in</text>
+<text x="482" y="354" text-anchor="middle" font-size="16" fill="#4b5563">New account starts at $0</text>
+<text x="482" y="384" text-anchor="middle" font-size="16" fill="#4b5563">No provider key to copy</text>
+
+<line x1="600" y1="330" x2="655" y2="330" stroke="#6b7280" stroke-width="2.5" marker-end="url(#oauth-arrow)"/>
+
+<rect x="670" y="235" width="235" height="190" rx="8" fill="#eff6ff" stroke="#93c5fd" stroke-width="2"/>
+<text x="787" y="275" text-anchor="middle" font-size="15" font-weight="700" fill="#1d4ed8">CONTROL</text>
+<text x="787" y="320" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">Fund and cap</text>
+<text x="787" y="354" text-anchor="middle" font-size="16" fill="#4b5563">$5  |  $20  |  $100</text>
+<text x="787" y="384" text-anchor="middle" font-size="16" fill="#4b5563">User chooses the maximum</text>
+
+<line x1="905" y1="330" x2="960" y2="330" stroke="#6b7280" stroke-width="2.5" marker-end="url(#oauth-arrow)"/>
+
+<rect x="975" y="235" width="165" height="190" rx="8" fill="#e1f5ee" stroke="#1d9e75" stroke-width="2.5"/>
+<text x="1057" y="275" text-anchor="middle" font-size="15" font-weight="700" fill="#0f6e56">KEY</text>
+<text x="1057" y="320" text-anchor="middle" font-size="23" font-weight="700" fill="#111827">Inference only</text>
+<text x="1057" y="354" text-anchor="middle" font-size="15" fill="#4b5563">Revocable</text>
+<text x="1057" y="384" text-anchor="middle" font-size="15" fill="#4b5563">PKCE protected</text>
+
+<rect x="60" y="475" width="1080" height="82" rx="8" fill="#111827"/>
+<text x="90" y="511" font-size="18" font-weight="700" fill="#ffffff">Live now at slopnazi.com</text>
+<text x="90" y="540" font-size="16" fill="#d1d5db">The app gets a capped key. The user keeps billing control. TrustedRouter keeps no prompt or output logs.</text>
+<text x="1140" y="612" text-anchor="end" font-size="18" font-weight="700" fill="#0f6e56">TrustedRouter.com</text>
+</svg>
+</figure>
+<p>Your users should be able to pay for their own AI without finding, copying, and trusting you with a provider API key.</p>
+<p>We shipped <a href="/sign-in-with-trustedrouter">Sign in with TrustedRouter</a>. An app sends its user to TrustedRouter. The user signs in, adds credits if needed, chooses exactly how much the app may spend, and approves one inference-only key. The app never receives a management key. It cannot change billing, inspect other keys, or take over the workspace.</p>
+<p><a href="https://slopnazi.com/editor">SlopNazi</a> is using it now for its full, context-aware writing editor. SlopNazi asks for a $5 monthly limit. The writer sees that number before approval and can change it. The resulting key pays for the writing calls from the writer's TrustedRouter balance.</p>
+<p>A person who creates a TrustedRouter account inside this flow starts at exactly <strong>$0</strong>. Direct email and OAuth signups on TrustedRouter still get the normal ten cents of starter credit. App-originated accounts do not. That closes an obvious credit-farming hole and makes the economic relationship honest from the first request.</p>
+<p>The funding step lives inside consent. The user can add $5, $20, or $100, with $20 selected by default. Stripe processes the payment and saves the card to the user's TrustedRouter account. The card can be removed later from the Credits page. Existing users see their current balance and can skip funding when they already have enough.</p>
+<p>The authorization itself uses PKCE. The app creates a verifier, sends only its SHA-256 challenge to TrustedRouter, and keeps the verifier for the code exchange. A stolen callback code is useless without it. The final key can carry a fixed, daily, weekly, or monthly maximum and an expiry. The user can revoke it at any time.</p>
+<p>The obvious objection is that the writing app sees the writing. Of course it does. The user gave text to that application to improve it, and the application needs its own honest privacy policy. Once the app calls a model, TrustedRouter sends that request through the <a href="https://trust.trustedrouter.com">attested API gateway</a>. TrustedRouter keeps no prompt or output logs, always. The delegated auth control plane handles identity, billing, and key metadata. It does not receive the model request body.</p>
+<p>The official SDKs already support Sign in with TrustedRouter. The <a href="https://github.com/Lore-Hex/trusted-router-py">Python SDK</a> ships <span class="mono">create_oauth_authorization</span> and <span class="mono">exchange_oauth_key</span>. The <a href="https://github.com/Lore-Hex/trusted-router-js">TypeScript SDK</a> ships <span class="mono">BrowserOAuthFlow</span>. The <a href="https://github.com/jperla/trusted-router-swift">Swift SDK</a> ships <span class="mono">TrustedRouterOAuth</span>. They generate PKCE state, build the authorization URL, validate the callback, and exchange the code.</p>
+<p>The complete flow is in the <a href="https://github.com/Lore-Hex/quill-router/blob/main/docs/sign-in-with-trustedrouter.md">developer documentation</a>, with SPA, backend, native, and loopback examples.</p>
+<p>Add one button. Let the user choose the bill and the boundary.</p>
+""",
+    ),
+    BlogPost(
         slug="how-confidential-computing-protects-ai-prompts",
         title="The cloud should not be able to read your prompts",
         description=(

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1119,14 +1119,15 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         title="Sign in with TrustedRouter — Let Your Users Bring Their Own AI",
         description=(
             "Add a sign-in button and your users bring their own TrustedRouter "
-            "account — instant access to hundreds of models, billed to them, "
-            "through an attested no-log gateway. Integrate in minutes with the "
+            "account, fund it in the consent flow, and choose a per-app spend "
+            "cap. Access hundreds of models through an attested no-log gateway "
+            "with the "
             "Python, TypeScript, or Swift SDK."
         ),
         faq_items=(
             (
                 "Do users need to copy API keys?",
-                "No. Third-party apps can use TrustedRouter delegated auth so end users approve access and pay with their own credits.",
+                "No. Third-party apps use TrustedRouter delegated auth so users sign in, fund their account if needed, choose the app limit, and approve access.",
             ),
             (
                 "Does delegated auth expose prompt content to the app?",

--- a/src/trusted_router/routes/oauth.py
+++ b/src/trusted_router/routes/oauth.py
@@ -21,6 +21,7 @@ import base64
 import hashlib
 import hmac
 import secrets
+from urllib.parse import parse_qsl, urlsplit
 
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.responses import RedirectResponse
@@ -100,7 +101,9 @@ async def _handle_login(
         raise api_error(400, "Invalid OAuth host", ErrorType.BAD_REQUEST)
     if not _enabled(provider, settings, request_domain):
         raise api_error(
-            404, f"{provider.slug.title()} sign-in is not configured", ErrorType.NOT_FOUND,
+            404,
+            f"{provider.slug.title()} sign-in is not configured",
+            ErrorType.NOT_FOUND,
         )
     redirect_uri = _provider_redirect_uri(
         provider,
@@ -138,7 +141,9 @@ async def _handle_callback(
         raise api_error(400, "Invalid OAuth state", ErrorType.BAD_REQUEST)
     if not _enabled(provider, settings, state_domain):
         raise api_error(
-            404, f"{provider.slug.title()} sign-in is not configured", ErrorType.NOT_FOUND,
+            404,
+            f"{provider.slug.title()} sign-in is not configured",
+            ErrorType.NOT_FOUND,
         )
 
     request_domain = _request_oauth_domain(request, settings)
@@ -171,36 +176,57 @@ async def _handle_callback(
 
     existing_user = STORE.find_user_by_email(info.email)
     first_time = existing_user is None
+    next_target = _next_target(request)
+    delegated_signup = first_time and _is_credit_delegation_target(next_target)
     # `pending_reveal_raw_key` is the raw API key minted during signup; it
     # must survive the 302 to /console/welcome so the user can copy it.
     # Without this hand-off, the welcome page shows "key already been
     # displayed" on every first login. See PENDING_REVEAL_COOKIE above.
     pending_reveal_raw_key: str | None = None
     if existing_user is None:
-        # signup() returns None only on a TOCTOU race; fall back to a
-        # fresh lookup, surface a real 500 if even that fails so we
-        # don't deref None silently.
-        result = STORE.signup(
-            email=info.email,
-            trial_credit_microdollars=settings.signup_trial_credit_microdollars,
-        )
-        if result is not None:
-            user_id = result.user.id
-            pending_reveal_raw_key = result.raw_key
+        if delegated_signup:
+            # An app-originated signup receives no promotional credit and no
+            # management API key. The app gets an inference-only key after
+            # explicit consent, and the user can fund the workspace in that
+            # same consent flow. Direct TrustedRouter signups keep the normal
+            # starter-credit and one-time management-key experience below.
+            user = STORE.ensure_user(
+                info.email,
+                email=info.email,
+                trial_credit_microdollars=0,
+            )
+            workspace = STORE.list_workspaces_for_user(user.id)[0]
+            user_id = user.id
             record_signup_attribution(
                 request,
-                workspace_id=result.workspace.id,
+                workspace_id=workspace.id,
                 signup_provider=provider.slug,
             )
         else:
-            concurrent = STORE.find_user_by_email(info.email)
-            if concurrent is None:
-                raise api_error(
-                    500,
-                    "Could not create or find user account; please retry sign-in",
-                    ErrorType.INTERNAL_ERROR,
+            # signup() returns None only on a TOCTOU race; fall back to a
+            # fresh lookup, surface a real 500 if even that fails so we
+            # don't deref None silently.
+            result = STORE.signup(
+                email=info.email,
+                trial_credit_microdollars=settings.signup_trial_credit_microdollars,
+            )
+            if result is not None:
+                user_id = result.user.id
+                pending_reveal_raw_key = result.raw_key
+                record_signup_attribution(
+                    request,
+                    workspace_id=result.workspace.id,
+                    signup_provider=provider.slug,
                 )
-            user_id = concurrent.id
+            else:
+                concurrent = STORE.find_user_by_email(info.email)
+                if concurrent is None:
+                    raise api_error(
+                        500,
+                        "Could not create or find user account; please retry sign-in",
+                        ErrorType.INTERNAL_ERROR,
+                    )
+                user_id = concurrent.id
     else:
         user_id = existing_user.id
     STORE.mark_user_email_verified(user_id)
@@ -213,9 +239,7 @@ async def _handle_callback(
         state="active",
     )
 
-    target = _next_target(request) or (
-        "/console/welcome?first=1" if first_time else "/console/api-keys"
-    )
+    target = next_target or ("/console/welcome?first=1" if first_time else "/console/api-keys")
     response = RedirectResponse(url=target, status_code=302)
     set_session_cookie(response, raw_token, settings)
     _clear_state_and_next_cookies(response, settings)
@@ -237,8 +261,7 @@ async def _handle_callback(
 
 def _enabled(provider: OAuthProvider, settings: Settings, domain: str) -> bool:
     return bool(
-        _client_id(provider, settings, domain)
-        and _client_secret(provider, settings, domain)
+        _client_id(provider, settings, domain) and _client_secret(provider, settings, domain)
     )
 
 
@@ -420,6 +443,23 @@ def _set_next_cookie(response: Response, next_path: str | None, settings: Settin
 
 def _next_target(request: Request) -> str | None:
     return _safe_next_path(request.cookies.get(OAUTH_NEXT_COOKIE))
+
+
+def _is_credit_delegation_target(value: str | None) -> bool:
+    """Identify an app-originated delegated-key flow without trusting hosts.
+
+    The target has already passed `_safe_next_path`; requiring the exact auth
+    route plus a callback URL prevents an unrelated `next=/auth/...` link from
+    changing signup-credit behavior.
+    """
+    safe = _safe_next_path(value)
+    if safe is None:
+        return False
+    parsed = urlsplit(safe)
+    if parsed.path not in {"/auth", "/v1/auth"}:
+        return False
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    return bool(params.get("callback_url"))
 
 
 def _clear_state_and_next_cookies(response: Response, settings: Settings) -> None:

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -3,24 +3,50 @@ from __future__ import annotations
 import base64
 import datetime as dt
 import hashlib
+import re
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from pydantic import ValidationError
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
 from trusted_router.config import Settings
+from trusted_router.domains import request_control_origin
 from trusted_router.errors import api_error, assert_workspace_billing_active
-from trusted_router.money import dollars_to_microdollars
+from trusted_router.money import (
+    dollars_to_microdollars,
+    format_money_display,
+    microdollars_to_decimal,
+)
 from trusted_router.routes.helpers import json_body
+from trusted_router.schemas import CheckoutRequest
 from trusted_router.serialization import key_shape
+from trusted_router.services.stripe_billing import create_checkout_session
 from trusted_router.storage import STORE, OAuthAuthorizationCode
+from trusted_router.typed_balance import live_credit_summary
 from trusted_router.types import ErrorType
 from trusted_router.views import render_template
 
 PKCE_METHODS = {"S256", "plain"}
 RESET_INTERVALS = {"daily", "weekly", "monthly"}
+OAUTH_FUNDING_AMOUNTS = {"5", "20", "100"}
+OAUTH_DEFAULT_FUNDING_AMOUNT = "20"
+OAUTH_DEFAULT_KEY_LIMIT = "20"
+NATIVE_CALLBACK_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]{1,63}$")
+UNSAFE_CALLBACK_SCHEMES = {"data", "file", "javascript"}
+OAUTH_AUTHORIZATION_FIELDS = (
+    "callback_url",
+    "code_challenge",
+    "code_challenge_method",
+    "key_label",
+    "limit",
+    "usage_limit_type",
+    "expires_at",
+    "spawn_agent",
+    "spawn_cloud",
+)
 
 
 def register_oauth_key_routes(router: APIRouter) -> None:
@@ -33,7 +59,58 @@ def register_oauth_key_routes(router: APIRouter) -> None:
             return HTMLResponse(_signin_html(request, settings, params), status_code=401)
         if not principal.is_management:
             raise api_error(403, "Only management users can delegate credits", ErrorType.FORBIDDEN)
-        return HTMLResponse(_consent_html(params, principal.workspace.name))
+        return HTMLResponse(
+            _consent_html(
+                params,
+                workspace_name=principal.workspace.name,
+                workspace_id=principal.workspace.id,
+            )
+        )
+
+    @router.post("/auth/fund")
+    async def oauth_authorize_fund(request: Request, settings: SettingsDep) -> Response:
+        form = dict(await request.form())
+        params = _authorization_params(form)
+        _validate_code_request(params)
+        try:
+            principal = principal_from_request(request, settings)
+        except HTTPException as exc:
+            raise api_error(401, "Sign in is required", ErrorType.UNAUTHORIZED) from exc
+        if not principal.is_management:
+            raise api_error(403, "Only management users can fund credits", ErrorType.FORBIDDEN)
+
+        amount = str(form.get("fund_amount") or "")
+        if amount not in OAUTH_FUNDING_AMOUNTS:
+            raise api_error(400, "fund_amount must be 5, 20, or 100", ErrorType.BAD_REQUEST)
+        origin = request_control_origin(request, settings)
+        try:
+            body = CheckoutRequest(
+                amount=amount,
+                workspace_id=principal.workspace.id,
+                payment_method="card",
+                success_url=_authorization_return_url(origin, params, checkout="success"),
+                cancel_url=_authorization_return_url(origin, params, checkout="cancel"),
+            )
+        except ValidationError as exc:
+            raise api_error(400, "Invalid checkout request", ErrorType.BAD_REQUEST) from exc
+        credit = STORE.get_credit_account(principal.workspace.id)
+        data = create_checkout_session(
+            body=body,
+            workspace_id=principal.workspace.id,
+            customer_email=(
+                principal.user.email
+                if principal.user and principal.user.email and "@" in principal.user.email
+                else None
+            ),
+            customer_id=credit.stripe_customer_id if credit else None,
+            settings=settings,
+        )
+        if str(data.get("mode") or "").startswith("mock"):
+            return RedirectResponse(
+                url=_authorization_return_url(origin, params, checkout="mock"),
+                status_code=303,
+            )
+        return RedirectResponse(url=str(data["url"]), status_code=303)
 
     @router.post("/auth/approve")
     async def oauth_authorize_approve(request: Request, settings: SettingsDep) -> Response:
@@ -45,7 +122,9 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         if not principal.is_management:
             raise api_error(403, "Only management users can delegate credits", ErrorType.FORBIDDEN)
         raw_code, code = _create_code(params, principal, settings)
-        return RedirectResponse(url=_callback_with_code(code.callback_url, raw_code, code.user_id), status_code=302)
+        return RedirectResponse(
+            url=_callback_with_code(code.callback_url, raw_code, code.user_id), status_code=302
+        )
 
     @router.post("/auth/keys/code")
     async def auth_keys_code(
@@ -100,10 +179,14 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         )
 
 
-def _create_code(params: dict[str, Any], principal: Any, settings: Settings) -> tuple[str, OAuthAuthorizationCode]:
+def _create_code(
+    params: dict[str, Any], principal: Any, settings: Settings
+) -> tuple[str, OAuthAuthorizationCode]:
     callback_url = _validate_callback_url(str(params.get("callback_url") or ""))
     code_challenge = _optional_str(params.get("code_challenge"))
-    code_challenge_method = _pkce_method(params.get("code_challenge_method"), has_challenge=bool(code_challenge))
+    code_challenge_method = _pkce_method(
+        params.get("code_challenge_method"), has_challenge=bool(code_challenge)
+    )
     limit_microdollars = _limit_microdollars(params.get("limit"))
     limit_reset = _limit_reset(params.get("usage_limit_type"))
     expires_at = _expires_at(params.get("expires_at"))
@@ -145,8 +228,16 @@ def _oauth_params_from_form(form: Any) -> dict[str, Any]:
 
 
 def _validate_code_request(params: dict[str, Any]) -> None:
-    _validate_callback_url(str(params.get("callback_url") or ""))
-    _pkce_method(params.get("code_challenge_method"), has_challenge=bool(params.get("code_challenge")))
+    callback_url = _validate_callback_url(str(params.get("callback_url") or ""))
+    method = _pkce_method(
+        params.get("code_challenge_method"), has_challenge=bool(params.get("code_challenge"))
+    )
+    if _is_native_callback(callback_url) and method != "S256":
+        raise api_error(
+            400,
+            "native callback_url requires PKCE S256",
+            ErrorType.BAD_REQUEST,
+        )
     _limit_microdollars(params.get("limit"))
     _limit_reset(params.get("usage_limit_type"))
     _expires_at(params.get("expires_at"))
@@ -159,17 +250,38 @@ def _validate_callback_url(callback_url: str) -> str:
     parsed = urlsplit(callback_url)
     if not parsed.hostname:
         raise api_error(400, "callback_url must be an https URL", ErrorType.BAD_REQUEST)
-    localhost_callback = parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1", "::1"}
-    if parsed.scheme != "https" and not localhost_callback:
-        raise api_error(400, "callback_url must be an https URL", ErrorType.BAD_REQUEST)
-    port = parsed.port
+    localhost_callback = parsed.scheme == "http" and parsed.hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
     if parsed.username or parsed.password:
         raise api_error(400, "callback_url cannot contain credentials", ErrorType.BAD_REQUEST)
+    native_callback = _is_native_callback(callback_url)
+    if parsed.scheme != "https" and not localhost_callback and not native_callback:
+        raise api_error(400, "callback_url must be an https URL", ErrorType.BAD_REQUEST)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise api_error(400, "callback_url has an invalid port", ErrorType.BAD_REQUEST) from exc
+    if native_callback:
+        if port is not None:
+            raise api_error(400, "native callback_url cannot contain a port", ErrorType.BAD_REQUEST)
+        return callback_url
     if localhost_callback and port == 3000:
         return callback_url
     if port not in {None, 443, 3000}:
         raise api_error(400, "callback_url port must be 443 or 3000", ErrorType.BAD_REQUEST)
     return callback_url
+
+
+def _is_native_callback(callback_url: str) -> bool:
+    scheme = urlsplit(callback_url).scheme.lower()
+    return bool(
+        scheme
+        and scheme not in {"http", "https", *UNSAFE_CALLBACK_SCHEMES}
+        and NATIVE_CALLBACK_SCHEME.fullmatch(scheme)
+    )
 
 
 def _pkce_method(raw: Any, *, has_challenge: bool) -> str | None:
@@ -179,7 +291,11 @@ def _pkce_method(raw: Any, *, has_challenge: bool) -> str | None:
     if method not in PKCE_METHODS:
         raise api_error(400, "code_challenge_method must be S256 or plain", ErrorType.BAD_REQUEST)
     if method and not has_challenge:
-        raise api_error(400, "code_challenge is required when code_challenge_method is set", ErrorType.BAD_REQUEST)
+        raise api_error(
+            400,
+            "code_challenge is required when code_challenge_method is set",
+            ErrorType.BAD_REQUEST,
+        )
     return method
 
 
@@ -200,7 +316,9 @@ def _limit_reset(raw: Any) -> str | None:
         return None
     value = str(raw)
     if value not in RESET_INTERVALS:
-        raise api_error(400, "usage_limit_type must be daily, weekly, or monthly", ErrorType.BAD_REQUEST)
+        raise api_error(
+            400, "usage_limit_type must be daily, weekly, or monthly", ErrorType.BAD_REQUEST
+        )
     return value
 
 
@@ -211,7 +329,9 @@ def _expires_at(raw: Any) -> str | None:
     try:
         parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
-        raise api_error(400, "expires_at must be an ISO 8601 timestamp", ErrorType.BAD_REQUEST) from exc
+        raise api_error(
+            400, "expires_at must be an ISO 8601 timestamp", ErrorType.BAD_REQUEST
+        ) from exc
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=dt.UTC)
     if parsed <= dt.datetime.now(dt.UTC):
@@ -234,7 +354,9 @@ def _verify_pkce(code: OAuthAuthorizationCode, body: dict[str, Any]) -> None:
         return
     supplied_method = body.get("code_challenge_method")
     if supplied_method not in {None, ""} and str(supplied_method) != code.code_challenge_method:
-        raise api_error(400, "code_challenge_method does not match authorization code", ErrorType.BAD_REQUEST)
+        raise api_error(
+            400, "code_challenge_method does not match authorization code", ErrorType.BAD_REQUEST
+        )
     verifier = str(body.get("code_verifier") or "")
     if not verifier:
         raise api_error(400, "code_verifier is required", ErrorType.BAD_REQUEST)
@@ -245,7 +367,11 @@ def _verify_pkce(code: OAuthAuthorizationCode, body: dict[str, Any]) -> None:
             verifier_bytes = verifier.encode("ascii")
         except UnicodeEncodeError as exc:
             raise api_error(400, "code_verifier must be ASCII", ErrorType.BAD_REQUEST) from exc
-        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier_bytes).digest()).decode("ascii").rstrip("=")
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier_bytes).digest())
+            .decode("ascii")
+            .rstrip("=")
+        )
     if expected != code.code_challenge:
         raise api_error(403, "Invalid code_verifier", ErrorType.FORBIDDEN)
 
@@ -269,7 +395,9 @@ def _callback_with_code(callback_url: str, raw_code: str, user_id: str | None) -
     query.append(("code", raw_code))
     if user_id:
         query.append(("user_id", user_id))
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment))
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment)
+    )
 
 
 def _optional_str(raw: Any) -> str | None:
@@ -301,29 +429,81 @@ def _signin_html(request: Request, settings: Settings, params: dict[str, Any]) -
         github_enabled=settings.github_oauth_enabled,
         # Use the same urllib.parse.quote shape the test asserts against —
         # Jinja's `urlencode` filter has different `safe=` defaults.
-        next_path_encoded=urlencode({"next": next_path})[len("next="):],
+        next_path_encoded=urlencode({"next": next_path})[len("next=") :],
     )
 
 
-def _consent_html(params: dict[str, Any], workspace_name: str) -> str:
+def _consent_html(
+    params: dict[str, Any],
+    *,
+    workspace_name: str,
+    workspace_id: str,
+) -> str:
     callback_url = _validate_callback_url(str(params.get("callback_url") or ""))
     key_label = _key_label(params.get("key_label"), callback_url)
     limit = _limit_microdollars(params.get("limit"))
-    limit_text = "No key limit" if limit is None else f"${limit / 1_000_000:g} key limit"
+    effective_limit = OAUTH_DEFAULT_KEY_LIMIT if limit is None else microdollars_to_decimal(limit)
+    reset = _limit_reset(params.get("usage_limit_type")) or ""
+    summary = live_credit_summary(workspace_id)
+    available = summary["available"] if summary else 0
+    hidden_fields = _hidden_authorization_fields(params, exclude={"limit", "usage_limit_type"})
+    funding_hidden_fields = _hidden_authorization_fields(
+        {
+            **params,
+            "limit": effective_limit,
+            "usage_limit_type": reset,
+        }
+    )
+    checkout_status = str(params.get("checkout") or "")
+    if checkout_status not in {"success", "cancel", "mock"}:
+        checkout_status = ""
     return render_template(
         "auth/oauth_consent.html",
         page_title=f"Authorize {key_label}",
         key_label=key_label,
         callback_host=urlsplit(callback_url).hostname or callback_url,
+        cancel_url=_callback_with_error(callback_url, "access_denied"),
         workspace_name=workspace_name,
-        limit_text=limit_text,
-        # Pass through every non-empty param as a hidden field — the
-        # template handles autoescape.
-        hidden_fields=[
-            (str(name), str(value))
-            for name, value in params.items()
-            if value not in {None, ""}
-        ],
+        available_display=format_money_display(available),
+        needs_funding=available <= 0,
+        checkout_status=checkout_status,
+        effective_limit=effective_limit,
+        effective_reset=reset,
+        hidden_fields=hidden_fields,
+        funding_hidden_fields=funding_hidden_fields,
+        funding_amounts=("5", "20", "100"),
+        default_funding_amount=OAUTH_DEFAULT_FUNDING_AMOUNT,
     )
 
 
+def _authorization_params(values: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: values[name]
+        for name in OAUTH_AUTHORIZATION_FIELDS
+        if name in values and values[name] not in {None, ""}
+    }
+
+
+def _hidden_authorization_fields(
+    values: dict[str, Any],
+    *,
+    exclude: set[str] | None = None,
+) -> list[tuple[str, str]]:
+    excluded = exclude or set()
+    return [
+        (name, str(values[name]))
+        for name in OAUTH_AUTHORIZATION_FIELDS
+        if name not in excluded and name in values and values[name] not in {None, ""}
+    ]
+
+
+def _authorization_return_url(origin: str, params: dict[str, Any], *, checkout: str) -> str:
+    query = urlencode([*params.items(), ("checkout", checkout)])
+    return f"{origin}/auth?{query}"
+
+
+def _callback_with_error(callback_url: str, error: str) -> str:
+    parsed = urlsplit(callback_url)
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("error", error))
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment))

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -46,6 +46,7 @@ class CheckoutRequest(_Lenient):
     cancel_url: str | None = None
     payment_method: Literal[
         "auto",
+        "card",
         "ach",
         "bank",
         "us_bank_account",

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -89,6 +89,8 @@ def create_checkout_session(
                 # card-only because bank debits settle asynchronously.
                 session_args["payment_intent_data"] = {"metadata": payment_metadata}
             else:
+                if body.payment_method == "card":
+                    session_args["payment_method_types"] = ["card"]
                 session_args["payment_intent_data"] = {
                     "setup_future_usage": "off_session",
                     "metadata": payment_metadata,

--- a/src/trusted_router/static/auth.css
+++ b/src/trusted_router/static/auth.css
@@ -49,8 +49,8 @@ body.auth {
 }
 
 .auth-card {
-  max-width: 560px;
-  margin: 8vh auto;
+  max-width: 680px;
+  margin: 5vh auto;
   padding: 32px;
   border: 1px solid var(--auth-line);
   background: var(--auth-panel);
@@ -70,6 +70,16 @@ body.auth {
   font-size: 28px;
   line-height: 1.1;
   margin: 8px 0 12px;
+}
+
+.auth-card h2 {
+  margin: 2px 0 8px;
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.auth-card p {
+  line-height: 1.55;
 }
 
 .auth-card .actions {
@@ -104,8 +114,11 @@ body.auth {
   margin: 8px 0;
 }
 
-.auth-card form input[type="email"] {
+.auth-card form input[type="email"],
+.auth-card form input[type="number"],
+.auth-card form select {
   width: 100%;
+  box-sizing: border-box;
   padding: 10px;
   font-size: 16px;
   border: 1px solid var(--auth-line-soft);
@@ -113,6 +126,134 @@ body.auth {
   margin-top: 12px;
   background: var(--auth-panel);
   color: var(--auth-ink);
+}
+
+.auth-section {
+  margin-top: 22px;
+  padding: 20px;
+  border: 1px solid var(--auth-line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--auth-panel) 92%, var(--auth-bg));
+}
+
+.auth-section.emphasized {
+  border-color: var(--auth-accent);
+}
+
+.section-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.step-label,
+.fine-print {
+  color: var(--auth-muted);
+  font-size: 13px;
+}
+
+.step-label {
+  margin: 0;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.balance {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.amount-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 16px 0 4px;
+}
+
+.amount-option {
+  position: relative;
+}
+
+.amount-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.amount-option span {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--auth-line);
+  border-radius: 6px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.amount-option input:checked + span {
+  border-color: var(--auth-accent);
+  box-shadow: inset 0 0 0 1px var(--auth-accent);
+}
+
+.amount-option input:focus-visible + span {
+  outline: 2px solid var(--auth-accent);
+  outline-offset: 2px;
+}
+
+.limit-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+.limit-fields label {
+  color: var(--auth-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.limit-fields input,
+.limit-fields select {
+  margin-top: 6px;
+}
+
+.consent-facts {
+  padding-left: 20px;
+  color: var(--auth-muted);
+  font-size: 14px;
+}
+
+.notice {
+  margin-top: 18px;
+  padding: 12px 14px;
+  border: 1px solid var(--auth-line);
+  border-radius: 6px;
+  background: var(--auth-btn-secondary-bg);
+}
+
+.notice.success {
+  border-color: #2ea043;
+}
+
+@media (max-width: 720px) {
+  .auth-card {
+    margin: 0;
+    min-height: 100vh;
+    padding: 24px 18px;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .limit-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .section-title-row {
+    display: block;
+  }
 }
 
 .auth-card form .btn {

--- a/src/trusted_router/static/dashboard.js
+++ b/src/trusted_router/static/dashboard.js
@@ -29,6 +29,13 @@ function applySigninTarget() {
         url.searchParams.set("next", target);
         link.href = `${url.pathname}${url.search}`;
     });
+    if (target.startsWith("/auth?") || target.startsWith("/v1/auth?")) {
+        const creditNote = document.getElementById("signinCreditNote");
+        if (creditNote) {
+            creditNote.textContent =
+                "Accounts created for this app start at $0. After sign in, add credits and choose the maximum this app may spend.";
+        }
+    }
 }
 function moneyFromMicrodollars(value) {
     if (value === null || value === undefined || value === "")

--- a/src/trusted_router/templates/auth/oauth_consent.html
+++ b/src/trusted_router/templates/auth/oauth_consent.html
@@ -3,16 +3,82 @@
 <h1>Authorize {{ key_label }}</h1>
 <p><strong>{{ callback_host }}</strong> will receive a delegated API key for
 <strong>{{ workspace_name }}</strong>.</p>
-<ul>
-  <li>{{ limit_text }}</li>
-  <li>Prompts and outputs still go through the attested API path.</li>
-  <li>You can revoke the key from the console.</li>
-</ul>
-<form method="post" action="/auth/approve">
+
+{% if checkout_status == "success" %}
+<div class="notice success" role="status">
+  Payment submitted. Stripe is confirming your credits and saved card now.
+</div>
+{% elif checkout_status == "cancel" %}
+<div class="notice" role="status">Checkout was canceled. Nothing was charged.</div>
+{% elif checkout_status == "mock" %}
+<div class="notice" role="status">Test checkout completed.</div>
+{% endif %}
+
+<section class="auth-section{% if needs_funding %} emphasized{% endif %}" aria-labelledby="fund-heading">
+  <div class="section-title-row">
+    <div>
+      <p class="step-label">Step 1</p>
+      <h2 id="fund-heading">Add credits</h2>
+    </div>
+    <strong class="balance">{{ available_display }} available</strong>
+  </div>
+  {% if needs_funding %}
+  <p>This account starts at $0 because it was created for an app. Add credits before {{ key_label }} makes its first model call.</p>
+  {% else %}
+  <p>Your existing balance can fund this app. Add more now if you want a separate cushion.</p>
+  {% endif %}
+  <form method="post" action="/auth/fund" class="funding-form">
+    {% for name, value in funding_hidden_fields %}
+    <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}
+    <div class="amount-options" role="radiogroup" aria-label="Credit amount">
+      {% for amount in funding_amounts %}
+      <label class="amount-option">
+        <input type="radio" name="fund_amount" value="{{ amount }}"{% if amount == default_funding_amount %} checked{% endif %}>
+        <span>${{ amount }}</span>
+      </label>
+      {% endfor %}
+    </div>
+    <button class="btn{% if not needs_funding %} secondary{% endif %}" type="submit">Continue to secure card checkout</button>
+  </form>
+  <p class="fine-print">Stripe processes the payment. Your card is saved to your TrustedRouter account for faster top ups and optional auto refill. You can remove it from the console.</p>
+</section>
+
+<section class="auth-section" aria-labelledby="approve-heading">
+  <p class="step-label">Step 2</p>
+  <h2 id="approve-heading">Choose this app's maximum</h2>
+  <p>The limit belongs only to the key issued to {{ key_label }}. You can change or revoke it later.</p>
+  <form method="post" action="/auth/approve" class="approval-form">
   {% for name, value in hidden_fields %}
   <input type="hidden" name="{{ name }}" value="{{ value }}">
   {% endfor %}
-  <button class="btn" type="submit">Authorize app</button>
-  <a class="btn secondary" href="/console/api-keys">Cancel</a>
-</form>
+    <div class="limit-fields">
+      <label>
+        Maximum spend (USD)
+        <input type="number" name="limit" min="0" max="10000" step="0.01" inputmode="decimal" value="{{ effective_limit }}" required>
+      </label>
+      <label>
+        Limit resets
+        <select name="usage_limit_type">
+          <option value=""{% if not effective_reset %} selected{% endif %}>Never</option>
+          <option value="daily"{% if effective_reset == "daily" %} selected{% endif %}>Daily</option>
+          <option value="weekly"{% if effective_reset == "weekly" %} selected{% endif %}>Weekly</option>
+          <option value="monthly"{% if effective_reset == "monthly" %} selected{% endif %}>Monthly</option>
+        </select>
+      </label>
+    </div>
+    <ul class="consent-facts">
+      <li>The key can run inference but cannot manage your account.</li>
+      <li>TrustedRouter keeps no prompt or output logs, always.</li>
+      <li>You can revoke the key from the console at any time.</li>
+    </ul>
+    <div class="actions">
+      <button class="btn{% if needs_funding %} secondary{% endif %}" type="submit">Authorize {{ key_label }}</button>
+      <a class="btn secondary" href="{{ cancel_url }}">Cancel</a>
+    </div>
+    {% if needs_funding %}
+    <p class="fine-print">You can authorize with a $0 balance, but model calls will require credits or a configured BYOK provider key.</p>
+    {% endif %}
+  </form>
+</section>
 {% endblock %}

--- a/src/trusted_router/templates/auth/oauth_signin.html
+++ b/src/trusted_router/templates/auth/oauth_signin.html
@@ -3,6 +3,7 @@
 <h1>Sign in to authorize {{ app_name }}</h1>
 <p>This app wants a delegated API key that spends from your TrustedRouter
 workspace credits.</p>
+<p class="fine-print">New accounts created here start at $0. After sign in, you can add $5, $20, or $100 securely and choose the maximum this app may spend.</p>
 <div class="actions">
   {% if google_enabled %}
   <a class="btn" href="/v1/auth/google/login?next={{ next_path_encoded }}">Continue with Google</a>

--- a/src/trusted_router/templates/public/_signin.html
+++ b/src/trusted_router/templates/public/_signin.html
@@ -4,7 +4,7 @@
   </form>
   <div class="dialog-kicker">Workspace access</div>
   <h2 id="signinTitle">Sign in</h2>
-  <p class="signin-sub">Choose a sign in method. New email and OAuth accounts include $0.10 in starter credit; wallet-only accounts start at $0.</p>
+  <p id="signinCreditNote" class="signin-sub">Choose a sign in method. New email and OAuth accounts include $0.10 in starter credit; wallet-only accounts start at $0.</p>
   <div class="signin-providers">
     {% if google_enabled %}
     <a class="signin-btn signin-google" href="/auth/google/login" data-provider="google">

--- a/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
+++ b/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
@@ -5,7 +5,7 @@
   <div class="marketing-copy">
     <span class="eyebrow">Sign in with TrustedRouter</span>
     <h2>Add a button. Your users bring their own AI.</h2>
-    <p>&ldquo;Sign in with TrustedRouter&rdquo; is the &ldquo;Sign in with Google&rdquo; of AI. Add one button to your app. Your users authenticate with their TrustedRouter account and grant you a scoped key &mdash; and now your app can call hundreds of models on <em>their</em> credits, not yours.</p>
+    <p>&ldquo;Sign in with TrustedRouter&rdquo; is the &ldquo;Sign in with Google&rdquo; of AI. Add one button to your app. Your users authenticate with their TrustedRouter account, add credits if needed, choose your app&rsquo;s maximum spend, and grant you a scoped key. Your app can call hundreds of models on <em>their</em> credits, not yours.</p>
     <p>You ship AI features with <strong>no API keys to manage, no inference bill, and no per-user billing to build</strong>. Every call runs through the open-source, hardware-attested gateway that provably never logs prompts.</p>
     <p>
       <button class="btn primary" type="button" data-action="open-signin">Get an API key</button>
@@ -35,12 +35,32 @@ const { key, identity } = await flow.handleCallback();
   <div class="marketing-card">
     <span class="card-label">2</span>
     <h3>Your user approves</h3>
-    <p>They authenticate with TrustedRouter (Google, GitHub, or wallet) and approve a key scoped to your app &mdash; with an optional spend cap and expiry you request.</p>
+    <p>They authenticate with TrustedRouter, fund $5, $20, or $100 through Stripe if needed, and approve a key scoped to your app. You suggest the cap. They choose the final maximum and reset period.</p>
   </div>
   <div class="marketing-card">
     <span class="card-label">3</span>
     <h3>Use any AI, instantly</h3>
     <p>Use the returned key for <code>/v1/chat/completions</code>, <code>/responses</code>, or <code>/embeddings</code> across hundreds of models. Usage bills to your user&rsquo;s credits.</p>
+  </div>
+</section>
+
+<section class="marketing-split" aria-label="Live on SlopNazi">
+  <div class="marketing-copy">
+    <span class="eyebrow">Live integration</span>
+    <h2>SlopNazi lets each writer bring their own AI.</h2>
+    <p><a href="https://slopnazi.com/editor">SlopNazi</a> uses Sign in with TrustedRouter for its full, context-aware writing editor. It requests a $5 monthly key limit. The writer can change that limit, add credits without leaving the authorization flow, and revoke the app later.</p>
+    <p>A new account made through this flow starts at exactly $0. Direct TrustedRouter signups still receive the normal $0.10 starter credit. This keeps delegated signups honest while making the first paid model call a short, clear path.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>What the writer sees</span><span>TrustedRouter</span></div>
+    <pre><code>1. Sign in
+2. Add $5, $20, or $100
+3. Set SlopNazi's maximum spend
+4. Authorize the inference-only key
+
+Default credit purchase: $20
+SlopNazi requested limit: $5 monthly
+Prompt and output logs: never</code></pre>
   </div>
 </section>
 
@@ -73,7 +93,7 @@ Persist the key + identity.email per signed-in user.</code></pre>
   <div class="marketing-card">
     <span class="card-label">Your users get</span>
     <h3>One account. Any model. Provable privacy.</h3>
-    <p>One TrustedRouter account that works across every app they sign into. Their own credits and spend cap. Any model they want. And prompts that run through a hardware-attested gateway that never logs them &mdash; verifiable, not promised.</p>
+    <p>One TrustedRouter account that works across every app they sign into. Their own credits and per-app spend cap. Any model they want. Prompts run through a hardware-attested gateway with no prompt or output logs, always.</p>
   </div>
 </section>
 
@@ -115,7 +135,7 @@ let token = try await oauth.authenticate(
     presentationContextProvider: self)      // token.key, token.identity</code></pre>
   </div>
 
-  <p class="sdk-stack-note">PKCE <code>S256</code> on every platform &mdash; no client secret. Desktop and CLI apps use the loopback flow (<code>http://localhost:3000/callback</code>). Full reference: <a href="https://github.com/Lore-Hex/quill-router/blob/main/docs/sign-in-with-trustedrouter.md">Sign in with TrustedRouter docs</a>.</p>
+  <p class="sdk-stack-note">Sign in with TrustedRouter is built into the official <a href="https://github.com/Lore-Hex/trusted-router-py">Python</a>, <a href="https://github.com/Lore-Hex/trusted-router-js">TypeScript</a>, and <a href="https://github.com/jperla/trusted-router-swift">Swift</a> SDKs. PKCE <code>S256</code> works on every platform with no client secret. Desktop and CLI apps use the loopback flow (<code>http://localhost:3000/callback</code>). Full reference: <a href="https://github.com/Lore-Hex/quill-router/blob/main/docs/sign-in-with-trustedrouter.md">Sign in with TrustedRouter docs</a>.</p>
 </section>
 
 <section class="compare-matrix" aria-label="Roll your own vs Sign in with TrustedRouter">
@@ -145,7 +165,7 @@ let token = try await oauth.authenticate(
 <section class="cta-band" aria-label="Get started">
   <div>
     <strong>Let your users bring their own AI.</strong>
-    <span>Add the button today &mdash; no inference bill, no keys, every model.</span>
+    <span>Add the button today. No inference bill, no provider keys, every model.</span>
   </div>
   <div class="cta-band-actions">
     <button class="btn primary" type="button" data-action="open-signin">Get an API key</button>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -125,6 +125,40 @@ test("console redirects unauthenticated users and auto-opens sign-in", async ({ 
   await expect(page.locator("#signinModal")).toBeVisible();
 });
 
+test("delegated sign-in explains zero-credit onboarding", async ({ page }) => {
+  const target = encodeURIComponent(
+    "/auth?callback_url=https%3A%2F%2Fslopnazi.com%2Feditor&key_label=SlopNazi&limit=5&usage_limit_type=monthly",
+  );
+  await page.goto(`/?reason=signin&next=${target}`);
+
+  await expect(page.locator("#signinModal")).toBeVisible();
+  await expect(page.locator("#signinCreditNote")).toContainText(
+    "Accounts created for this app start at $0",
+  );
+  await expect(page.locator('a[data-provider="google"]')).toHaveAttribute(
+    "href",
+    /auth\/google\/login\?next=/,
+  );
+});
+
+test("delegated consent exposes funding and an editable app cap", async ({ page }) => {
+  await page.setExtraHTTPHeaders({ "x-trustedrouter-user": "oauth-browser@example.com" });
+  await page.goto(
+    "/auth?callback_url=https%3A%2F%2Fslopnazi.com%2Feditor&key_label=SlopNazi&limit=5&usage_limit_type=monthly",
+  );
+
+  await expect(page.getByRole("heading", { name: "Authorize SlopNazi" })).toBeVisible();
+  await expect(page.getByText("$0.00 available")).toBeVisible();
+  await expect(page.getByText("This account starts at $0")).toBeVisible();
+  await expect(page.getByRole("radio", { name: "$20" })).toBeChecked();
+  await expect(page.getByLabel("Maximum spend (USD)")).toHaveValue("5");
+  await expect(page.getByLabel("Limit resets")).toHaveValue("monthly");
+  await expect(page.getByRole("button", { name: "Authorize SlopNazi" })).toBeVisible();
+  await expect(page.getByText("card is saved", { exact: false })).toBeVisible();
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  expect(overflow).toBeLessThanOrEqual(2);
+});
+
 test("homepage and console redirect are usable on mobile width", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -62,8 +62,12 @@ def github_client(github_settings: Settings) -> Iterator[TestClient]:
         yield client
 
 
-def _begin_oauth(client: TestClient, provider: str) -> str:
-    response = client.get(f"/auth/{provider}/login", follow_redirects=False)
+def _begin_oauth(client: TestClient, provider: str, *, next_path: str | None = None) -> str:
+    response = client.get(
+        f"/auth/{provider}/login",
+        params={"next": next_path} if next_path else None,
+        follow_redirects=False,
+    )
     assert response.status_code == 302
     state = parse_qs(urlsplit(response.headers["location"]).query)["state"][0]
     assert client.cookies.get("tr_oauth_state") == state
@@ -203,6 +207,54 @@ async def test_google_callback_creates_session_for_new_user(google_client: TestC
     assert user.email_verified is True
     workspace = STORE.list_workspaces_for_user(user.id)[0]
     assert live_credit_summary(workspace.id)["total_credits"] == 100_000
+
+
+@pytest.mark.asyncio
+async def test_google_callback_delegated_signup_starts_at_zero_without_management_key(
+    google_client: TestClient,
+) -> None:
+    next_path = (
+        "/auth?callback_url=https%3A%2F%2Fslopnazi.com%2Feditor"
+        "&key_label=SlopNazi&limit=5&usage_limit_type=monthly"
+    )
+    state = _begin_oauth(google_client, "google", next_path=next_path)
+
+    async def fake_exchange(**_: Any) -> str:
+        return "access-token"  # noqa: S105
+
+    async def fake_fetch_user(**_: Any) -> Any:
+        from trusted_router.oauth_provider import OAuthUserInfo
+
+        return OAuthUserInfo(
+            sub="google-slopnazi-user",
+            email="writer@example.com",
+            email_verified=True,
+            display_name="Writer",
+        )
+
+    with patch("trusted_router.routes.oauth.exchange_code", fake_exchange), patch(
+        "trusted_router.routes.oauth.fetch_user", fake_fetch_user
+    ):
+        response = google_client.get(
+            f"/google_oauth_callback?code=auth-code&state={state}",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == next_path
+    assert "tr_pending_reveal=" not in response.headers.get("set-cookie", "")
+    user = STORE.find_user_by_email("writer@example.com")
+    assert user is not None
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    assert live_credit_summary(workspace.id)["total_credits"] == 0
+    assert STORE.list_keys(workspace.id) == []
+
+    consent = google_client.get(response.headers["location"])
+    assert consent.status_code == 200
+    assert "$0.00 available" in consent.text
+    assert "This account starts at $0" in consent.text
+    assert 'value="5"' in consent.text
+    assert '<option value="monthly" selected>' in consent.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from typing import Any
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -446,6 +448,45 @@ def test_oauth_code_creation_accepts_openrouter_allowed_callback_ports(
     assert response.status_code == 200, response.text
 
 
+def test_oauth_code_creation_accepts_native_callback_with_pkce_s256(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/v1/auth/keys/code",
+        headers=user_headers,
+        json={
+            "callback_url": "myapp://oauth-callback",
+            "code_challenge": "challenge",
+            "code_challenge_method": "S256",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {},
+        {"code_challenge": "challenge", "code_challenge_method": "plain"},
+    ],
+)
+def test_oauth_code_creation_requires_s256_for_native_callback(
+    client: TestClient,
+    user_headers: dict[str, str],
+    patch: dict[str, str],
+) -> None:
+    response = client.post(
+        "/v1/auth/keys/code",
+        headers=user_headers,
+        json={"callback_url": "myapp://oauth-callback", **patch},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "native callback_url requires PKCE S256"
+
+
 @pytest.mark.parametrize(
     "callback_url,message",
     [
@@ -453,6 +494,9 @@ def test_oauth_code_creation_accepts_openrouter_allowed_callback_ports(
         ("http://app.example.com/callback", "callback_url must be an https URL"),
         ("https://app.example.com:444/callback", "callback_url port must be 443 or 3000"),
         ("https://user:pass@app.example.com/callback", "callback_url cannot contain credentials"),
+        ("javascript://callback", "callback_url must be an https URL"),
+        ("file://callback", "callback_url must be an https URL"),
+        ("myapp://callback:444/path", "native callback_url cannot contain a port"),
         ("not-a-url", "callback_url must be an https URL"),
     ],
 )
@@ -569,6 +613,165 @@ def test_oauth_browser_consent_page_for_active_session(client: TestClient) -> No
     assert "Authorize Example" in response.text
     assert 'action="/auth/approve"' in response.text
     assert 'name="callback_url"' in response.text
+
+
+def test_oauth_browser_consent_defaults_funding_and_key_limit(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com", trial_credit_microdollars=0)
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    response = client.get(
+        "/auth?callback_url=https://app.example.com/callback&key_label=Example",
+    )
+
+    assert response.status_code == 200
+    assert "$0.00 available" in response.text
+    assert 'name="fund_amount" value="5"' in response.text
+    assert 'name="fund_amount" value="20" checked' in response.text
+    assert 'name="fund_amount" value="100"' in response.text
+    assert 'name="limit"' in response.text
+    assert 'value="20" required' in response.text
+    assert "card is saved" in response.text
+    assert 'href="https://app.example.com/callback?error=access_denied"' in response.text
+
+
+def test_oauth_browser_cancel_preserves_app_state(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com", trial_credit_microdollars=0)
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    response = client.get(
+        "/auth?callback_url=https%3A%2F%2Fapp.example.com%2Fcallback%3Fstate%3Dcsrf",
+    )
+
+    assert response.status_code == 200
+    assert (
+        'href="https://app.example.com/callback?state=csrf&amp;error=access_denied"'
+        in response.text
+    )
+
+
+def test_oauth_funding_checkout_saves_card_and_preserves_authorization(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com", trial_credit_microdollars=0)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    settings = client.app.state.settings
+    settings.stripe_secret_key = "sk_test_oauth_funding"  # noqa: S105
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_oauth", "url": "https://checkout.stripe.test/oauth"}
+
+    with patch(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    ):
+        response = client.post(
+            "/auth/fund",
+            data={
+                "callback_url": "https://slopnazi.com/editor?state=csrf",
+                "code_challenge": "challenge",
+                "code_challenge_method": "S256",
+                "key_label": "SlopNazi",
+                "limit": "7.50",
+                "usage_limit_type": "monthly",
+                "fund_amount": "20",
+            },
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://checkout.stripe.test/oauth"
+    assert captured["customer_creation"] == "always"
+    assert captured["customer_email"] == "alice@example.com"
+    assert captured["payment_method_types"] == ["card"]
+    assert captured["payment_intent_data"]["setup_future_usage"] == "off_session"
+    assert captured["metadata"]["workspace_id"] == workspace.id
+    assert captured["metadata"]["credit_amount_microdollars"] == "20000000"
+    success = urlsplit(captured["success_url"])
+    success_query = parse_qs(success.query)
+    assert success.path == "/auth"
+    assert success_query["callback_url"] == ["https://slopnazi.com/editor?state=csrf"]
+    assert success_query["code_challenge"] == ["challenge"]
+    assert success_query["limit"] == ["7.50"]
+    assert success_query["usage_limit_type"] == ["monthly"]
+    assert success_query["checkout"] == ["success"]
+
+
+@pytest.mark.parametrize("amount", ["0", "10", "20.01", "1000", "not-money"])
+def test_oauth_funding_rejects_unlisted_amounts(client: TestClient, amount: str) -> None:
+    user = STORE.ensure_user("alice@example.com", trial_credit_microdollars=0)
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    response = client.post(
+        "/auth/fund",
+        data={
+            "callback_url": "https://app.example.com/callback",
+            "fund_amount": amount,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "fund_amount must be 5, 20, or 100"
+
+
+def test_oauth_browser_user_selected_limit_is_issued_to_app(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com", trial_credit_microdollars=0)
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    approved = client.post(
+        "/auth/approve",
+        data={
+            "callback_url": "https://app.example.com/callback",
+            "key_label": "Example app",
+            "limit": "3.25",
+            "usage_limit_type": "weekly",
+        },
+        follow_redirects=False,
+    )
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.management is False
+    assert key.limit_microdollars == 3_250_000
+    assert key.limit_reset == "weekly"
 
 
 def test_oauth_browser_approve_redirects_with_code_and_user_id(client: TestClient) -> None:

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -22,6 +22,8 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         "/careers": "Work on attested AI routing",
         "/blog": "TrustedRouter blog",
         "/blog/fusion-evals-open-source": "New SOTA: TrustedRouter Synth beats Fable and Frontier",
+        "/blog/sign-in-with-trustedrouter-slopnazi": "Sign in with TrustedRouter",
+        "/sign-in-with-trustedrouter": "SlopNazi lets each writer bring their own AI.",
         "/security": "No prompt or output logs",
         "/eu": "Use the EU gateway and an EU-focused model alias.",
         # SEO landing pages — each targets a high-intent buyer query.

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -66,6 +66,10 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
         "<loc>https://trustedrouter.com/blog/how-confidential-computing-protects-ai-prompts</loc>"
         in core.text
     )
+    assert (
+        "<loc>https://trustedrouter.com/blog/sign-in-with-trustedrouter-slopnazi</loc>"
+        in core.text
+    )
     assert "<loc>https://trustedrouter.com/docs/synth</loc>" in core.text
     assert "<loc>https://trustedrouter.com/docs/fusion</loc>" not in core.text
     assert "<loc>https://trustedrouter.com/fusion</loc>" not in core.text
@@ -440,6 +444,26 @@ def test_blog_index_shows_scannable_post_images(client: TestClient) -> None:
     assert 'alt="Synth is two jobs, and no model wins both visual summary"' in response.text
     assert 'href="/blog/fusion-is-two-jobs"' in response.text
     assert response.text.count('class="blog-thumb"') >= 10
+
+
+def test_sign_in_with_trustedrouter_launch_post_documents_live_flow(
+    client: TestClient,
+) -> None:
+    response = client.get("/blog/sign-in-with-trustedrouter-slopnazi")
+
+    assert response.status_code == 200
+    assert "Sign in with TrustedRouter" in response.text
+    assert "https://slopnazi.com/editor" in response.text
+    assert "$5 monthly limit" in response.text
+    assert "starts at exactly <strong>$0</strong>" in response.text
+    assert "$5, $20, or $100" in response.text
+    assert "keeps no prompt or output logs, always" in response.text
+    assert "docs/sign-in-with-trustedrouter.md" in response.text
+    assert "https://github.com/Lore-Hex/trusted-router-py" in response.text
+    assert "https://github.com/Lore-Hex/trusted-router-js" in response.text
+    assert "https://github.com/jperla/trusted-router-swift" in response.text
+    payload = _json_ld(response.text)
+    assert "sign-in-with-trustedrouter-slopnazi" in json.dumps(payload)
 
 
 def test_confidential_computing_blog_explains_and_verifies_the_boundary(

--- a/tests/test_stripe_processing_fees.py
+++ b/tests/test_stripe_processing_fees.py
@@ -137,6 +137,37 @@ def test_card_checkout_uses_separate_credit_and_processing_fee_line_items(
     assert data["total_microdollars"] == 26_060_000
 
 
+def test_explicit_card_checkout_saves_only_a_reusable_card(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_card_only"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_card_only", "url": "https://checkout.stripe.test/card"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 20, "payment_method": "card"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert captured["payment_method_types"] == ["card"]
+    assert captured["payment_intent_data"]["setup_future_usage"] == "off_session"
+
+
 def test_stablecoin_checkout_uses_stablecoin_fee_schedule(
     monkeypatch,
     user_headers: dict[str, str],


### PR DESCRIPTION
## Summary
- give app-originated signups a zero-credit, no-management-key workspace
- add in-consent Stripe card funding with 5, 20, and 100 dollar options plus user-controlled per-app key caps
- document and announce Sign in with TrustedRouter, including SlopNazi and official Python, TypeScript, and Swift SDK support
- support PKCE-protected native app callbacks and return cancellation errors to the calling app

## Verification
- 2,637 backend tests passed; 177 skipped
- 16 Playwright browser tests passed
- Ruff, mypy, TypeScript, ESLint, and Stylelint passed