### PR TITLE
deploy: turn on identity federation — GCP home, AWS peer

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -79,6 +79,13 @@ GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-eu-west-1=quill-enclave-nlb-6e
 # Secrets Manager ARNs (eu-west-3 — App Runner requires same-region secrets).
 INTERNAL_TOKEN_SECRET_ARN="${INTERNAL_TOKEN_SECRET_ARN:-$(aws secretsmanager describe-secret --region "$REGION" --secret-id quill/trustedrouter-internal-gateway-token --query ARN --output text)}"
 MONITOR_KEY_SECRET_ARN="${MONITOR_KEY_SECRET_ARN:-$(aws secretsmanager describe-secret --region "$REGION" --secret-id quill/trustedrouter-synthetic-monitor-api-key --query ARN --output text)}"
+# PEER side of lazy key federation: the token this plane presents to the home
+# plane's resolve-key endpoint. Identity only — a GCP-issued key becomes
+# known here on first use and keeps serving from cache for up to 24h of home
+# outage. Credits deliberately do NOT federate; the credit-transfer tokens
+# are separate secrets and remain unset.
+FEDERATION_TOKEN_SECRET_ARN="${FEDERATION_TOKEN_SECRET_ARN:-$(aws secretsmanager describe-secret --region "$REGION" --secret-id quill/trustedrouter-federation-peer-token --query ARN --output text)}"
+FEDERATION_HOME_BASE_URL="${FEDERATION_HOME_BASE_URL:-https://trustedrouter.com}"
 # Analytics is optional, so its secret must be too. A standby region has no
 # ClickHouse node and no replica of this secret; requiring it would block the
 # region whose entire job is to survive the loss of the one that has it.
@@ -178,6 +185,8 @@ CONFIG=$(cat <<JSON
         "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL": "https://aws.trustedrouter.com",
         "TR_SYNTHETIC_CONTROL_PLANE_BASE_URL": "https://trustedrouter.com",
 
+        "TR_FEDERATION_HOME_BASE_URL": "${FEDERATION_HOME_BASE_URL}",
+
         "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "${OUTBOX_ENABLED}",
         "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL": "${CLICKHOUSE_URL_EFFECTIVE}",
         "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER": "${CLICKHOUSE_USER}",
@@ -185,7 +194,8 @@ CONFIG=$(cat <<JSON
       },
       "RuntimeEnvironmentSecrets": {
         "TR_INTERNAL_GATEWAY_TOKEN": "${INTERNAL_TOKEN_SECRET_ARN}",
-        "TR_SYNTHETIC_MONITOR_API_KEY": "${MONITOR_KEY_SECRET_ARN}"${CLICKHOUSE_SECRET_JSON}
+        "TR_SYNTHETIC_MONITOR_API_KEY": "${MONITOR_KEY_SECRET_ARN}",
+        "TR_FEDERATION_HOME_TOKEN": "${FEDERATION_TOKEN_SECRET_ARN}"${CLICKHOUSE_SECRET_JSON}
       }
     }
   },

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -78,6 +78,11 @@ add_secret_env_if_exists "ALIBABA_API_KEY" "trustedrouter-alibaba-api-key"
 add_secret_env_if_exists "ENGY_API_KEY" "trustedrouter-engy-api-key"
 add_secret_env_if_exists "ZERO_G_API_KEY" "trustedrouter-zero-g-api-key"
 add_secret_env_if_exists "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key"
+# HOME side of lazy key federation: peers present this token to
+# /v1/internal/federation/resolve-key and get identity + limits, never
+# credits and never key material. Setting it is what turns federation
+# serving ON for this plane (unset = 403 for every peer).
+add_secret_env_if_exists "TR_FEDERATION_PEER_TOKEN" "trustedrouter-federation-peer-token"
 add_secret_env_if_exists "TR_GOOGLE_CLIENT_ID" "trustedrouter-google-client-id"
 add_secret_env_if_exists "TR_GOOGLE_CLIENT_SECRET" "trustedrouter-google-client-secret"
 add_secret_env_if_exists \


### PR DESCRIPTION
Config-as-code half of the federation flip. The runtime seam has existed since the lazy-federation increment; nothing set the env vars.

**Home (GCP `rollout.sh`):** `add_secret_env_if_exists TR_FEDERATION_PEER_TOKEN trustedrouter-federation-peer-token` — the secret now exists in Secret Manager, so every future rollout includes it, which is what turns `/v1/internal/federation/resolve-key` serving on.

**Peer (AWS `aws_eu_control_plane.sh`):** `TR_FEDERATION_HOME_BASE_URL=https://trustedrouter.com` + `TR_FEDERATION_HOME_TOKEN` from `quill/trustedrouter-federation-peer-token` (created in eu-west-3 and eu-west-1; the instance role's `quill/*` wildcard already covers reads).

Identity only: resolve-key returns key+workspace identity and limits from an explicit allow-list — never salt/secret_hash, never credits, and management keys are refused. The credit-transfer tokens are separate secrets and remain unset, so nothing in this PR can move money.

Verification: negative controls already run against prod (home 403 federation-not-enabled with the correct token; AWS plane 401 for a GCP-issued key). Positive controls run after the live env flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)