### PR TITLE
settle: book usage even when the rows settle expects have vanished

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -10,6 +10,7 @@ import dataclasses
 import datetime as dt
 import hashlib
 import json
+import logging
 import secrets
 import uuid
 from collections.abc import Callable
@@ -99,6 +100,8 @@ from trusted_router.synthetic.rollups import (
 from trusted_router.types import UsageType
 
 T = TypeVar("T")
+
+log = logging.getLogger(__name__)
 
 _AWS_DSQL_IAM_AUTH = "aws-dsql"
 
@@ -2459,33 +2462,68 @@ class PostgresStore:
             booked = max(0, int(actual_microdollars)) if success else 0
 
             # 1. Credit hold: release the reservation, book actual spend.
+            #
+            # UPSERT, not UPDATE. reserve() proved the balance row existed at
+            # authorize time, but retention jobs and cleanup can remove rows
+            # between reserve and settle, and a plain UPDATE matches zero rows
+            # SILENTLY: the spend vanishes while the authorization is marked
+            # settled. Recreating the row (zero credits, so the balance goes
+            # negative) keeps the ledger honest — a negative balance is a
+            # visible, billable fact; a missing debit is invisible forever.
+            #
+            # The same reasoning covers a vanished reservation ENTITY: only
+            # the release amount depends on it, so its absence must not skip
+            # the booking. Nothing is released (the reserved counter on a
+            # recreated row is already zero) and the anomaly is logged.
             if authorization.credit_reservation_id:
                 reservation = self._read_entity_tx(
                     conn, _RESERVATION_KIND, authorization.credit_reservation_id, Reservation
                 )
-                if reservation is not None:
-                    conn.execute(
-                        "UPDATE tr_credit_balance SET"
-                        "   reserved = GREATEST(reserved - %s, 0)"
-                        " , total_usage = total_usage + %s"
-                        " , updated_at = CURRENT_TIMESTAMP"
-                        " WHERE workspace_id = %s AND shard = 0",
-                        (
-                            reservation.amount_microdollars,
-                            booked,
-                            authorization.workspace_id,
-                        ),
-                        prepare=False,
-                    )
-                    self._insert_entity_once_tx(
-                        conn,
-                        _RESERVATION_FINALIZATION_KIND,
+                release = (
+                    reservation.amount_microdollars if reservation is not None else 0
+                )
+                if reservation is None:
+                    log.error(
+                        "finalize %s: reservation %s entity is gone; booking "
+                        "%s microdollars of usage without a release",
+                        authorization_id,
                         authorization.credit_reservation_id,
-                        {
-                            "actual_microdollars": booked,
-                            "operation": "gateway_finalize",
-                        },
+                        booked,
                     )
+                cursor = conn.execute(
+                    "INSERT INTO tr_credit_balance"
+                    "   (workspace_id, shard, total_usage, updated_at)"
+                    " VALUES (%s, 0, %s, CURRENT_TIMESTAMP)"
+                    " ON CONFLICT (workspace_id, shard) DO UPDATE SET"
+                    "   reserved = GREATEST(tr_credit_balance.reserved - %s, 0)"
+                    " , total_usage = tr_credit_balance.total_usage"
+                    "     + EXCLUDED.total_usage"
+                    " , updated_at = CURRENT_TIMESTAMP",
+                    (
+                        authorization.workspace_id,
+                        booked,
+                        release,
+                    ),
+                    prepare=False,
+                )
+                if cursor.rowcount != 1:
+                    # An upsert cannot miss; if it ever does, that is a driver
+                    # or dialect regression and it must fail the settle loudly
+                    # rather than repeat the silent-vanish this block fixes.
+                    raise RuntimeError(
+                        f"finalize {authorization_id}: balance upsert affected "
+                        f"{cursor.rowcount} rows for workspace "
+                        f"{authorization.workspace_id}"
+                    )
+                self._insert_entity_once_tx(
+                    conn,
+                    _RESERVATION_FINALIZATION_KIND,
+                    authorization.credit_reservation_id,
+                    {
+                        "actual_microdollars": booked,
+                        "operation": "gateway_finalize",
+                    },
+                )
 
             # 2. Key-limit hold: release, and roll the windows by actual spend.
             #    Reuses the same lazy-window rules as settle_key_limit.

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -53,6 +53,10 @@ class SqlitePostgresConn:
         # what differs most between plain Postgres and Aurora DSQL.
         translated = (
             sql.replace("%s", "?").replace("::jsonb", "").replace(" FOR UPDATE", "")
+            # SQLite's scalar max is multi-arg MAX(); it has no GREATEST.
+            # GREATEST always takes >=2 args here, so the mapping is exact —
+            # single-arg MAX (the aggregate) can never be produced by it.
+            .replace("GREATEST(", "MAX(")
         )
         return self._raw.execute(translated, params)
 

--- a/tests/test_settle_books_usage_always.py
+++ b/tests/test_settle_books_usage_always.py
@@ -1,0 +1,184 @@
+"""Settle must book usage even when rows it expects have vanished.
+
+THE BUG: `finalize_gateway_authorization`'s credit UPDATE had no rowcount
+check and the whole booking block was skipped when the reservation entity was
+missing. Either way the authorization was still marked settled — usage
+silently vanished. `reserve()` proves the balance row existed at authorize
+time, but retention jobs and cleanup run between reserve and settle, and a
+ledger that loses debits when a row is missing is the "reports success
+without measuring" failure shape this codebase keeps re-finding.
+
+THE FIX: the booking is an upsert. A vanished balance row is recreated with
+zero credits, so the spend lands as a negative balance — a visible, billable
+fact — and a vanished reservation entity skips only the RELEASE (there is
+nothing to release on a recreated row), never the booking.
+
+These run against the SQLite psycopg fake, which executes the store's REAL
+SQL — the guarantee under test lives in the statement text, not in Python.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+
+
+@pytest.fixture
+def harness() -> tuple[Any, Any]:
+    conn = sqlite_postgres_conn()
+    return postgres_store_on(conn), conn
+
+
+WS = "ws-vanish-1"
+KEY = "kh-vanish-1"
+
+
+def _seed_balance(conn: Any, total_credits: int = 1_000_000) -> None:
+    conn.execute(
+        "INSERT INTO tr_credit_balance"
+        " (workspace_id, shard, total_credits, total_usage, reserved, updated_at)"
+        " VALUES (%s, 0, %s, 0, 0, CURRENT_TIMESTAMP)",
+        (WS, total_credits),
+    )
+
+
+def _balance_row(conn: Any) -> dict[str, int] | None:
+    row = conn.execute(
+        "SELECT total_credits, total_usage, reserved FROM tr_credit_balance"
+        " WHERE workspace_id = %s AND shard = 0",
+        (WS,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"total_credits": row[0], "total_usage": row[1], "reserved": row[2]}
+
+
+def _authorize_with_reservation(store: Any, estimate: int) -> Any:
+    reservation = store.reserve(WS, KEY, estimate)
+    return store.create_gateway_authorization(
+        workspace_id=WS,
+        key_hash=KEY,
+        model_id="anthropic/claude-opus-4.7",
+        provider="anthropic",
+        usage_type="Credits",
+        estimated_microdollars=estimate,
+        credit_reservation_id=reservation.id,
+    )
+
+
+def test_normal_settle_books_and_releases_exactly(harness: tuple[Any, Any]) -> None:
+    """The fix must not change the arithmetic of the healthy path."""
+    store, conn = harness
+    _seed_balance(conn)
+    auth = _authorize_with_reservation(store, estimate=100)
+
+    assert _balance_row(conn) == {
+        "total_credits": 1_000_000,
+        "total_usage": 0,
+        "reserved": 100,
+    }
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=40, selected_usage_type="Credits"
+    ) is True
+    assert _balance_row(conn) == {
+        "total_credits": 1_000_000,
+        "total_usage": 40,
+        "reserved": 0,
+    }
+
+    # Replay is a no-op: nothing double-booked, nothing double-released.
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=40, selected_usage_type="Credits"
+    ) is False
+    assert _balance_row(conn) == {
+        "total_credits": 1_000_000,
+        "total_usage": 40,
+        "reserved": 0,
+    }
+
+
+def test_settle_books_usage_when_balance_row_was_deleted(
+    harness: tuple[Any, Any],
+) -> None:
+    """A retention job eats the balance row between reserve and settle.
+
+    The spend must land anyway — as a NEGATIVE balance on a recreated row,
+    which an operator can see and bill, not as a silent no-op that leaves
+    the authorization "settled" and the money gone.
+    """
+    store, conn = harness
+    _seed_balance(conn)
+    auth = _authorize_with_reservation(store, estimate=100)
+
+    conn.execute(
+        "DELETE FROM tr_credit_balance WHERE workspace_id = %s AND shard = 0", (WS,)
+    )
+    assert _balance_row(conn) is None
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=70, selected_usage_type="Credits"
+    ) is True
+
+    row = _balance_row(conn)
+    assert row is not None, "settle must recreate the row, not skip the booking"
+    assert row["total_usage"] == 70, "the debit landed"
+    assert row["total_credits"] == 0, "no credits were invented"
+    assert row["reserved"] == 0
+
+    settled = store.get_gateway_authorization(auth.id)
+    assert settled is not None and settled.settled is True
+
+
+def test_settle_books_usage_when_reservation_entity_is_gone(
+    harness: tuple[Any, Any],
+) -> None:
+    """Only the RELEASE depends on the reservation entity, never the booking.
+
+    With the entity gone the release amount is unknown, so `reserved` stays
+    inflated (conservative: blocks spend rather than minting headroom) — but
+    the usage still books.
+    """
+    store, conn = harness
+    _seed_balance(conn)
+    auth = _authorize_with_reservation(store, estimate=100)
+
+    conn.execute(
+        "DELETE FROM tr_entities WHERE kind = 'reservation' AND id = %s",
+        (auth.credit_reservation_id,),
+    )
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=55, selected_usage_type="Credits"
+    ) is True
+
+    row = _balance_row(conn)
+    assert row is not None
+    assert row["total_usage"] == 55, "booking must not be skipped"
+    assert row["reserved"] == 100, "unknown release amount stays held, not guessed"
+
+    settled = store.get_gateway_authorization(auth.id)
+    assert settled is not None and settled.settled is True
+
+
+def test_failed_settle_on_deleted_row_books_nothing_but_recreates(
+    harness: tuple[Any, Any],
+) -> None:
+    """success=False books zero; the recreated row is empty, not negative."""
+    store, conn = harness
+    _seed_balance(conn)
+    auth = _authorize_with_reservation(store, estimate=100)
+    conn.execute(
+        "DELETE FROM tr_credit_balance WHERE workspace_id = %s AND shard = 0", (WS,)
+    )
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=False, actual_microdollars=0, selected_usage_type="Credits"
+    ) is True
+
+    row = _balance_row(conn)
+    assert row is not None
+    assert row == {"total_credits": 0, "total_usage": 0, "reserved": 0}


### PR DESCRIPTION
Fixes a silent-vanish defect found while auditing the serving path for cloud independence: `finalize_gateway_authorization` on the Postgres backend marked authorizations settled while booking **nothing** if the balance row (retention/cleanup) or the reservation entity had disappeared between reserve and settle.

- Booking is now an upsert — a vanished balance row is recreated at zero credits, so the spend lands as a negative balance (visible, billable) instead of disappearing.
- A vanished reservation entity now skips only the *release* (logged at ERROR), never the booking; `reserved` stays conservatively held.
- Belt: a zero-row upsert raises instead of shrugging.
- The SQLite psycopg fake now translates `GREATEST(`→`MAX(` — the reason this statement was previously unexercisable through the fake.

Mutation-verified: stashing the fix fails all four new tests in `tests/test_settle_books_usage_always.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)