### PR TITLE
deferred settlement (2b): a peer plane serves CREDITS traffic without home

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -443,6 +443,31 @@ class Settings(BaseSettings):
     # presents there. Both empty = this plane cannot send credits anywhere.
     federation_credit_peer_base_url: str = ""
     federation_credit_peer_token: str = ""
+
+    # --- Deferred settlement -----------------------------------------------
+    # Lets a PEER plane serve a federated key's CREDITS traffic while the home
+    # plane is unreachable: the spend is admitted against a transactional
+    # outstanding cap, recorded durably as debt, and forwarded to the home
+    # ledger when home returns. Identity federates and credits do not; usage
+    # is the third category — a debt record, safe to apply late because
+    # applying it only ever moves a home balance DOWN and an insert-once claim
+    # at home makes double application impossible.
+    #
+    # OFF by default. A plane with this unset behaves exactly as before: a
+    # federated key with no local balance gets 402 CREDITS_NOT_ON_THIS_PLANE.
+    federation_deferred_settlement_enabled: bool = False
+    # The bound on how much unsettled debt one workspace may run up on this
+    # plane. Enforced by a conditional UPDATE at authorize, not a read-then-
+    # check — 200 concurrent authorizes must not all see the same stale total.
+    # This IS the worst-case exposure per workspace per outage (plus in-flight
+    # estimate-vs-actual drift). $25.
+    federation_deferred_max_outstanding_microdollars: int = 25_000_000
+    # How long a deferred authorization may sit unsettled before the reaper
+    # reclaims its estimate and releases the key-limit escrow. The enclave
+    # dying between authorize and settle is routine (every deploy); without a
+    # reaper the counter inflates permanently and the cap becomes a
+    # self-inflicted, unrecoverable 402. Matches the 2h idempotency horizon.
+    federation_deferred_authorization_ttl_seconds: int = 7_200
     # The canonical target serves a self-signed cert minted inside the
     # TEE (AWS Nitro standalone deployments): probes skip CA verification
     # and the attestation probe instead verifies the document binds the

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -97,7 +97,7 @@ from trusted_router.storage import (
     typed_billing_store,
 )
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
-from trusted_router.storage_errors import DeferredSettlementCapReached
+from trusted_router.storage_errors import DeferredSettlementCapReached, StoreConflict
 from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
@@ -595,6 +595,19 @@ def _authorize_gateway_sync(
                 ErrorType.DEFERRED_SETTLEMENT_CAP,
                 headers={"Retry-After": "30"},
             ) from cap_exc
+        except StoreConflict as conflict_exc:
+            # DSQL OCC exhausted its retries (a hot outstanding row under
+            # burst load will do this). Same rule as the cap arm: the escrow
+            # committed OUTSIDE this transaction, so nothing downstream will
+            # ever release it for a request that produced no authorization —
+            # swallowing this into a bare 503 leaks it silently, forever.
+            STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            raise api_error(
+                503,
+                "Authorization contention; retry shortly.",
+                ErrorType.SERVICE_UNAVAILABLE,
+                headers={"Retry-After": "1"},
+            ) from conflict_exc
     byok_config = (
         _get_byok_provider(workspace.id, endpoint.provider) if model_usage_type.is_byok() else None
     )
@@ -796,6 +809,31 @@ def register(router: APIRouter) -> None:
     ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
         return await run_in_threadpool(drain_settle_outbox, limit)
+
+    @router.post("/internal/gateway/deferred/reap")
+    async def gateway_deferred_reap(
+        request: Request,
+        settings: SettingsDep,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """Reclaim deferred authorizations whose settle never arrived.
+
+        A reaper that exists but is never run is the same as no reaper: each
+        abandoned authorization (the enclave dying between authorize and
+        settle — every deploy) leaks its estimate into the outstanding
+        counter until the workspace hits the cap and 402s forever. This
+        endpoint is the operator's lever today and the scheduler's target
+        when the forwarder increment wires periodic passes.
+        """
+        require_internal_gateway(request, settings)
+        reap = getattr(STORE, "reap_expired_deferred_authorizations", None)
+        if reap is None:
+            raise api_error(
+                501,
+                "This plane's store has no deferred-settlement reaper",
+                ErrorType.ENDPOINT_NOT_SUPPORTED,
+            )
+        return {"data": await run_in_threadpool(lambda: reap(limit=limit))}
 
 
 def _api_key_for_gateway_authorization(body: GatewayAuthorizeRequest) -> Any | None:

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -11,6 +11,7 @@ returns already_settled=True without double-charging.
 from __future__ import annotations
 
 import datetime as dt
+import functools
 import hashlib
 import json
 import logging
@@ -96,6 +97,7 @@ from trusted_router.storage import (
     typed_billing_store,
 )
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
+from trusted_router.storage_errors import DeferredSettlementCapReached
 from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
@@ -511,6 +513,8 @@ def _authorize_gateway_sync(
                 402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED
             ) from exc
 
+        settlement = "local"
+        authorization_expires_at: str | None = None
         if has_credit_candidate:
             try:
                 credit_reservation = STORE.reserve(
@@ -521,10 +525,25 @@ def _authorize_gateway_sync(
                 )
                 credit_reservation_id = credit_reservation.id
             except ValueError as exc:
-                STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
-                raise _insufficient_credits_error(workspace) from exc
+                # The local balance refused. On a peer plane with deferred
+                # settlement on, a FEDERATED key falls back to spending on
+                # credit at the home plane's ledger rather than 402ing.
+                #
+                # Local reserve is tried FIRST and this is only the fallback:
+                # a workspace that has been explicitly pre-funded by credit
+                # transfer must keep spending those transferred credits with
+                # local settlement. Reversing the order would strand real
+                # money that was deliberately moved here.
+                if not _deferred_settlement_applies(settings, api_key):
+                    STORE.refund_key_limit(
+                        api_key.hash, estimate, usage_type=reservation_usage_type
+                    )
+                    raise _insufficient_credits_error(workspace) from exc
+                settlement = _DEFERRED_HOME_SETTLEMENT
+                authorization_expires_at = _deferred_expires_at(settings)
 
-        authorization = STORE.create_gateway_authorization(
+        create_authorization = functools.partial(
+            STORE.create_gateway_authorization,
             workspace_id=workspace.id,
             key_hash=api_key.hash,
             model_id=model.id,
@@ -548,7 +567,34 @@ def _authorize_gateway_sync(
             custom_model_id=custom_model.id if custom_model else None,
             custom_model_revision=custom_model.revision if custom_model else None,
             additional_cost_reservation_microdollars=additional_cost_reservation,
+            settlement=settlement,
+            expires_at=authorization_expires_at,
+            # The outstanding increment rides the SAME transaction that
+            # inserts the authorization, so an idempotent replay (which
+            # returns the pre-existing row and writes nothing) cannot
+            # double-count, and a cap refusal cannot leave an authorization
+            # behind. Doing it as a separate call could do both.
+            deferred_cap_microdollars=(
+                settings.federation_deferred_max_outstanding_microdollars
+                if settlement == _DEFERRED_HOME_SETTLEMENT
+                else None
+            ),
         )
+        try:
+            authorization = create_authorization()
+        except DeferredSettlementCapReached as cap_exc:
+            # The key-limit escrow taken above must come back: nothing on this
+            # plane would ever release it for a request that never became an
+            # authorization (the reaper only sees authorizations).
+            STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            raise api_error(
+                402,
+                "This plane is holding the maximum unsettled spend for this workspace "
+                "while the home plane is unreachable; it will clear as settlements are "
+                "delivered.",
+                ErrorType.DEFERRED_SETTLEMENT_CAP,
+                headers={"Retry-After": "30"},
+            ) from cap_exc
     byok_config = (
         _get_byok_provider(workspace.id, endpoint.provider) if model_usage_type.is_byok() else None
     )
@@ -876,6 +922,40 @@ def _gateway_authorize_response(
             ],
         }
     }
+
+
+#: GatewayAuthorization.settlement value for spend booked as debt to the home
+#: plane's ledger. Mirrors storage_postgres._DEFERRED_HOME_SETTLEMENT; the
+#: value is written by this module and read by the store, so it is declared in
+#: both rather than importing a backend-specific module into the route.
+_DEFERRED_HOME_SETTLEMENT = "deferred_home"
+
+
+def _deferred_settlement_applies(settings: Settings, api_key: Any) -> bool:
+    """Whether this request may spend on credit at the home plane's ledger.
+
+    Two conditions, both required. The plane must have deferred settlement
+    switched on, and the key must be FEDERATED — a locally issued key whose
+    balance lives here is simply out of money, and letting it run up debt at
+    a home plane that has no account for it would be nonsense.
+    """
+    if not getattr(settings, "federation_deferred_settlement_enabled", False):
+        return False
+    return bool(getattr(api_key, "federated_home", ""))
+
+
+def _deferred_expires_at(settings: Settings) -> str:
+    """When the reaper may reclaim this authorization's admitted estimate.
+
+    Without an expiry there is no reclaim, and an enclave that dies between
+    authorize and settle — which every deploy causes — leaks its estimate into
+    the outstanding counter permanently.
+    """
+    from trusted_router.spend_windows import utcnow
+
+    ttl = int(getattr(settings, "federation_deferred_authorization_ttl_seconds", 7200))
+    expires = utcnow() + dt.timedelta(seconds=max(60, ttl))
+    return expires.isoformat().replace("+00:00", "Z")
 
 
 def _insufficient_credits_error(workspace: Any) -> Exception:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1128,6 +1128,9 @@ class InMemoryStore:
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         additional_cost_reservation_microdollars: int = 0,
+        settlement: str = "local",
+        expires_at: str | None = None,
+        deferred_cap_microdollars: int | None = None,
     ) -> GatewayAuthorization:
         return self.api_keys.create_gateway_authorization(
             workspace_id=workspace_id,
@@ -1148,6 +1151,9 @@ class InMemoryStore:
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
             additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
+            settlement=settlement,
+            expires_at=expires_at,
+            deferred_cap_microdollars=deferred_cap_microdollars,
         )
 
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None:

--- a/src/trusted_router/storage_errors.py
+++ b/src/trusted_router/storage_errors.py
@@ -52,6 +52,22 @@ class StoreUnavailable(StoreError):
     """
 
 
+class DeferredSettlementCapReached(StoreError):
+    """This plane already holds the maximum unsettled spend for a workspace.
+
+    A refusal, not a failure: the request is admissible again as soon as
+    settlements are delivered to the home plane (or the reaper reclaims an
+    abandoned authorization). Distinct from insufficient credits, which is a
+    statement about the customer's money; this one is a statement about how
+    much debt THIS plane is willing to carry on their behalf while the home
+    plane is unreachable.
+
+    A StoreError rather than a bare ValueError because the routes must be able
+    to tell it apart from "the local balance refused" without matching on
+    message text — the two lead to opposite responses.
+    """
+
+
 @lru_cache(maxsize=1)
 def _google_error_types() -> tuple[tuple[type[Exception], ...], tuple[type[Exception], ...]]:
     """`(transient, conflict)` types contributed by the GCP backend.

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1377,6 +1377,9 @@ class SpannerBigtableStore:
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         additional_cost_reservation_microdollars: int = 0,
+        settlement: str = "local",
+        expires_at: str | None = None,
+        deferred_cap_microdollars: int | None = None,
     ) -> GatewayAuthorization:
         return self.api_keys.create_gateway_authorization(
             workspace_id=workspace_id,
@@ -1397,6 +1400,9 @@ class SpannerBigtableStore:
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
             additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
+            settlement=settlement,
+            expires_at=expires_at,
+            deferred_cap_microdollars=deferred_cap_microdollars,
         )
 
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None:

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -304,7 +304,19 @@ class SpannerApiKeys:
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         additional_cost_reservation_microdollars: int = 0,
+        settlement: str = "local",
+        expires_at: str | None = None,
+        deferred_cap_microdollars: int | None = None,
     ) -> GatewayAuthorization:
+        if deferred_cap_microdollars is not None:
+            # Deferred settlement is a PEER-plane mechanism: a plane spending
+            # on credit at some other plane's ledger. This is the HOME plane's
+            # own store, so a caller asking it to defer has a configuration
+            # error, and silently ignoring the argument would admit spend
+            # against a cap that is not being enforced anywhere.
+            raise NotImplementedError(
+                "deferred settlement is not available on the home plane's store"
+            )
         existing = (
             self.get_gateway_authorization_by_idempotency_key(
                 workspace_id, key_hash, idempotency_key
@@ -323,6 +335,8 @@ class SpannerApiKeys:
             usage_type=UsageType.coerce(usage_type),
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            settlement=settlement,
+            expires_at=expires_at,
             requested_model_id=requested_model_id,
             candidate_model_ids=list(candidate_model_ids or []),
             region=region,

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -41,6 +41,7 @@ from trusted_router.spend_windows import (
     utcnow,
     window_floors,
 )
+from trusted_router.storage_errors import DeferredSettlementCapReached
 from trusted_router.storage_models import (
     ApiKey,
     CreditAccount,
@@ -76,6 +77,9 @@ class InMemoryApiKeys:
         self.reservation_id_by_idempotency_key: dict[str, str] = {}
         self.gateway_authorizations: dict[str, GatewayAuthorization] = {}
         self.gateway_authorization_id_by_idempotency_key: dict[str, str] = {}
+        #: Deferred settlement: unsettled spend this plane has admitted on
+        #: credit at the home plane's ledger, per workspace.
+        self.deferred_outstanding: dict[str, int] = {}
         # Per-key window usage: key_hash -> {window: [start_datetime, usage_micro]}.
         # Same lazy fixed-UTC-window semantics as the typed tr_key_limit columns
         # (spend_windows.py); lives beside the key so ApiKey stays a plain record.
@@ -395,6 +399,9 @@ class InMemoryApiKeys:
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         additional_cost_reservation_microdollars: int = 0,
+        settlement: str = "local",
+        expires_at: str | None = None,
+        deferred_cap_microdollars: int | None = None,
     ) -> GatewayAuthorization:
         with self._lock:
             if idempotency_key is not None:
@@ -404,7 +411,18 @@ class InMemoryApiKeys:
                     )
                 )
                 if existing_id is not None:
+                    # A REPLAY writes no new authorization, so it must not
+                    # consume cap either — the same reason the Postgres store
+                    # does the counter move inside this method rather than
+                    # before it.
                     return self.gateway_authorizations[existing_id]
+            if deferred_cap_microdollars is not None:
+                held = self.deferred_outstanding.get(workspace_id, 0)
+                if held + estimated_microdollars > deferred_cap_microdollars:
+                    raise DeferredSettlementCapReached(
+                        f"deferred settlement cap reached for workspace {workspace_id}"
+                    )
+                self.deferred_outstanding[workspace_id] = held + estimated_microdollars
             authorization = GatewayAuthorization(
                 id=f"gwa-{uuid.uuid4().hex}",
                 workspace_id=workspace_id,
@@ -425,6 +443,8 @@ class InMemoryApiKeys:
                 custom_model_id=custom_model_id,
                 custom_model_revision=custom_model_revision,
                 additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
+                settlement=settlement,
+                expires_at=expires_at,
             )
             self.gateway_authorizations[authorization.id] = authorization
             if idempotency_key is not None:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -423,6 +423,17 @@ class GatewayAuthorization:
     custom_model_id: str | None = None
     custom_model_revision: int | None = None
     additional_cost_reservation_microdollars: int = 0
+    # The settlement DECISION, made at authorize and stored — settle must not
+    # re-derive it from key state, which can change between authorize and
+    # settle. "local" books against the plane's own balance (every
+    # authorization before this field existed); "deferred_home" records the
+    # spend as debt to the home plane's ledger, forwarded asynchronously.
+    settlement: str = "local"
+    # Only deferred authorizations carry an expiry: it is what lets the reaper
+    # reclaim the outstanding-counter estimate when the enclave dies between
+    # authorize and settle. Local authorizations keep their pre-existing
+    # lifecycle untouched.
+    expires_at: str | None = None
 
     def __post_init__(self) -> None:
         # JSON round-trip stores usage_type as a string; coerce so the field

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -43,7 +43,11 @@ from trusted_router.security import (
 )
 from trusted_router.spend_windows import KeyWindowLimitExceeded, window_floors
 from trusted_router.storage_codec import json_body
-from trusted_router.storage_errors import StoreConflict, StoreUnavailable
+from trusted_router.storage_errors import (
+    DeferredSettlementCapReached,
+    StoreConflict,
+    StoreUnavailable,
+)
 from trusted_router.storage_gcp_codec import (
     member_id,
     normalize_email,
@@ -184,6 +188,9 @@ def _aws_dsql_token_provider(
 _GATEWAY_AUTHORIZATION_KIND = "gateway_authorization"
 _GATEWAY_IDEMPOTENCY_KIND = "gateway_authorization_idempotency"
 _GATEWAY_FINALIZATION_KIND = "gateway_authorization_finalization"
+#: GatewayAuthorization.settlement value meaning "this spend is debt owed to
+#: the home plane's ledger", not a debit against this plane's balance.
+_DEFERRED_HOME_SETTLEMENT = "deferred_home"
 _RESERVATION_KIND = "reservation"
 _RESERVATION_IDEMPOTENCY_KIND = "reservation_idempotency"
 _RESERVATION_FINALIZATION_KIND = "reservation_finalization"
@@ -1488,6 +1495,108 @@ class PostgresStore:
             window_amount=0,
         )
 
+    # Deferred settlement ---------------------------------------------------
+
+    def _reserve_deferred_outstanding_tx(
+        self,
+        conn: Any,
+        workspace_id: str,
+        amount_microdollars: int,
+        *,
+        cap_microdollars: int,
+    ) -> None:
+        """Admit `amount` of deferred spend, or raise at the cap.
+
+        ONE conditional UPDATE, rowcount-gated — the same shape as `reserve`
+        and `reserve_key_limit`, and for the same reason. A read-then-check
+        would bound nothing: authorize-to-settle spans an entire provider
+        stream, so N concurrent requests would each read the same stale total
+        and each admit, and the cap this feature advertises as its worst-case
+        exposure would be advisory. The conditional UPDATE is what makes the
+        number true.
+
+        Takes `conn` rather than opening its own transaction: the caller runs
+        it inside the authorization insert, so the admission and the record it
+        admits commit together or not at all.
+        """
+        amount = max(0, int(amount_microdollars))
+        for _attempt in (1, 2):
+            cursor = conn.execute(
+                "UPDATE tr_deferred_outstanding SET"
+                "   outstanding = outstanding + %s"
+                " , updated_at = CURRENT_TIMESTAMP"
+                " WHERE workspace_id = %s AND outstanding + %s <= %s",
+                (amount, workspace_id, amount, int(cap_microdollars)),
+                prepare=False,
+            )
+            if cursor.rowcount == 1:
+                return
+            # Either the row does not exist yet (first deferred spend for this
+            # workspace) or the cap refused. Seeding is insert-once, so a
+            # concurrent seeder does not clobber a live counter; the retry
+            # then re-runs the SAME conditional statement, which is what keeps
+            # the cap authoritative on the second pass too.
+            seeded = conn.execute(
+                "INSERT INTO tr_deferred_outstanding"
+                "   (workspace_id, outstanding, dead_lettered, updated_at)"
+                " VALUES (%s, 0, 0, CURRENT_TIMESTAMP)"
+                " ON CONFLICT (workspace_id) DO NOTHING",
+                (workspace_id,),
+                prepare=False,
+            )
+            if seeded.rowcount != 1:
+                break
+        raise DeferredSettlementCapReached(
+            f"deferred settlement cap reached for workspace {workspace_id}"
+        )
+
+    def _adjust_deferred_outstanding_tx(
+        self, conn: Any, workspace_id: str, delta_microdollars: int
+    ) -> None:
+        """Move the counter by a signed delta, clamped at zero.
+
+        GREATEST is not defensive dressing: settle adjusts by
+        (actual - estimate), and an actual smaller than its estimate is the
+        common case, so the clamp is what keeps an arithmetic underflow from
+        turning into negative debt that silently hands a workspace headroom
+        it never earned.
+        """
+        conn.execute(
+            "UPDATE tr_deferred_outstanding SET"
+            "   outstanding = GREATEST(outstanding + %s, 0)"
+            " , updated_at = CURRENT_TIMESTAMP"
+            " WHERE workspace_id = %s",
+            (int(delta_microdollars), workspace_id),
+            prepare=False,
+        )
+
+    def release_deferred_outstanding(
+        self, workspace_id: str, amount_microdollars: int
+    ) -> None:
+        """Hand back an admitted amount (a cap-refused request unwinding)."""
+        self._run_transaction(
+            lambda conn: self._adjust_deferred_outstanding_tx(
+                conn, workspace_id, -max(0, int(amount_microdollars))
+            )
+        )
+
+    def deferred_outstanding(self, workspace_id: str) -> dict[str, int]:
+        """Read the counter. For operators and tests, never for admission —
+        admission is the conditional UPDATE above."""
+
+        def read(conn: Any) -> dict[str, int]:
+            row = conn.execute(
+                "SELECT outstanding, dead_lettered FROM tr_deferred_outstanding"
+                " WHERE workspace_id = %s",
+                (workspace_id,),
+                prepare=False,
+            ).fetchone()
+            if row is None:
+                return {"outstanding": 0, "dead_lettered": 0}
+            return {"outstanding": int(row[0]), "dead_lettered": int(row[1])}
+
+        return self._run_transaction(read)
+
     def _release_key_hold(
         self,
         key_hash: str,
@@ -2319,6 +2428,9 @@ class PostgresStore:
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
         additional_cost_reservation_microdollars: int = 0,
+        settlement: str = "local",
+        expires_at: str | None = None,
+        deferred_cap_microdollars: int | None = None,
     ) -> GatewayAuthorization:
         """Record an authorization, deduplicating on the idempotency key.
 
@@ -2327,6 +2439,18 @@ class PostgresStore:
         both create an authorization: the loser reads the winner's row and
         returns it. That matters because an authorization holds a credit
         reservation — duplicating one double-holds the customer's money.
+
+        `deferred_cap_microdollars` turns this into the admission point for
+        deferred spend: the outstanding counter is incremented by the estimate
+        under a conditional UPDATE **in this same transaction**, and
+        DeferredSettlementCapReached is raised if the cap refuses. Both
+        properties matter. In-transaction means an idempotent replay — which
+        returns the existing authorization and writes nothing — cannot
+        double-count the estimate, and a cap refusal cannot leave an orphaned
+        authorization behind. Conditional means the cap is a real bound rather
+        than advice: authorize-to-settle spans a whole provider stream, so N
+        concurrent requests reading one stale total would every one of them
+        admit.
         """
         authorization = GatewayAuthorization(
             id=f"gwauth_{uuid.uuid4().hex}",
@@ -2348,6 +2472,8 @@ class PostgresStore:
             custom_model_id=custom_model_id,
             custom_model_revision=custom_model_revision,
             additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
+            settlement=settlement,
+            expires_at=expires_at,
         )
 
         def create(conn: Any) -> GatewayAuthorization:
@@ -2382,6 +2508,13 @@ class PostgresStore:
                         index_id,
                         {"authorization_id": authorization.id},
                     )
+            if deferred_cap_microdollars is not None:
+                self._reserve_deferred_outstanding_tx(
+                    conn,
+                    workspace_id,
+                    estimated_microdollars,
+                    cap_microdollars=deferred_cap_microdollars,
+                )
             self._write_entity_tx(
                 conn, _GATEWAY_AUTHORIZATION_KIND, authorization.id, authorization
             )
@@ -2460,6 +2593,69 @@ class PostgresStore:
                 return False
 
             booked = max(0, int(actual_microdollars)) if success else 0
+
+            # 0. DEFERRED settlement: the spend is debt to the home plane's
+            #    ledger, not a debit against this plane's balance. The
+            #    decision was made at authorize and STORED — re-deriving it
+            #    here from key state would read a record that can change
+            #    between authorize and settle.
+            #
+            #    The outbox insert is gated on having WON the finalization
+            #    marker above, so a redelivered settle cannot enqueue a second
+            #    row for the same authorization; the marker and the row commit
+            #    in this one transaction, so the debt can never exist without
+            #    its usage record or vice versa.
+            if authorization.settlement == _DEFERRED_HOME_SETTLEMENT:
+                if booked:
+                    conn.execute(
+                        "INSERT INTO tr_home_settlement_outbox"
+                        "   (authorization_id, workspace_id, cost_microdollars,"
+                        "    state, attempts, enqueued_at, updated_at)"
+                        " VALUES (%s, %s, %s, 'pending', 0,"
+                        "         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                        " ON CONFLICT (authorization_id) DO NOTHING",
+                        (authorization_id, authorization.workspace_id, booked),
+                        prepare=False,
+                    )
+                # True up the counter to the FROZEN actual. Authorize admitted
+                # the estimate; a failed request (booked == 0) hands the whole
+                # estimate back, which is why this is a signed delta rather
+                # than an increment.
+                self._adjust_deferred_outstanding_tx(
+                    conn,
+                    authorization.workspace_id,
+                    booked - int(authorization.estimated_microdollars),
+                )
+                self._release_key_hold_tx(
+                    conn,
+                    authorization.key_hash,
+                    authorization.estimated_microdollars,
+                    usage_type=selected_usage_type,
+                    window_amount=booked,
+                )
+                if booked:
+                    column = "byok_usage" if _is_byok(selected_usage_type) else "usage"
+                    conn.execute(
+                        f"UPDATE tr_key_limit SET {column} = {column} + %s"  # noqa: S608
+                        " , updated_at = CURRENT_TIMESTAMP"
+                        " WHERE key_hash = %s AND shard = 0",
+                        (booked, authorization.key_hash),
+                        prepare=False,
+                    )
+                if generation is not None:
+                    self._write_entity_tx(conn, "generation", generation.id, generation)
+                    if self._operational_analytics_outbox is not None:
+                        self._operational_analytics_outbox.enqueue_activity_tx(conn, generation)
+                authorization.settled = True
+                # Clearing the expiry is what takes this row out of the
+                # reaper's scan: settled work is no longer reclaimable, and
+                # leaving a past expires_at behind would make every future
+                # reap pass re-examine rows it can never act on.
+                authorization.expires_at = None
+                self._write_entity_tx(
+                    conn, _GATEWAY_AUTHORIZATION_KIND, authorization_id, authorization
+                )
+                return True
 
             # 1. Credit hold: release the reservation, book actual spend.
             #
@@ -2567,6 +2763,113 @@ class PostgresStore:
             return True
 
         return self._run_transaction(finalize)
+
+    def reap_expired_deferred_authorizations(self, *, limit: int = 100) -> dict[str, int]:
+        """Reclaim deferred authorizations whose settle never arrived.
+
+        WHY THIS IS PART OF THE FEATURE, not a follow-up: the enclave dying
+        between authorize and settle is the most ROUTINE failure there is —
+        every deploy does it — and this plane has no other sweeper (Spanner's
+        reap_expired_reservations is Spanner-only). Without this, each
+        abandoned authorization leaks its estimate into the outstanding
+        counter permanently; once the leaks reach the cap, every subsequent
+        CREDITS request for that workspace 402s forever, on a healthy plane,
+        with home back up and no way to recover. A bound meant to protect the
+        home ledger would become a self-inflicted, unrecoverable outage.
+
+        Reaping claims the SAME insert-once finalization marker that settle
+        claims, so reaper-vs-late-settle is first-writer-wins and never both.
+        A late settle that loses simply returns False, exactly like a
+        redelivered settle does today.
+        """
+        now = iso_now()
+
+        def reap(conn: Any) -> dict[str, int]:
+            # `expires_at IS NOT NULL` is the "still outstanding" predicate:
+            # settling a deferred authorization CLEARS it (see finalize), so
+            # this needs no boolean comparison. That matters beyond taste —
+            # `body ->> 'settled'` yields the text 'false' on Postgres and the
+            # integer 0 on SQLite, so a predicate written against one dialect
+            # silently matches nothing on the other, and a reaper that matches
+            # nothing looks exactly like a reaper with nothing to do.
+            rows = conn.execute(
+                "SELECT id FROM tr_entities"
+                " WHERE kind = %s"
+                "   AND body ->> 'settlement' = %s"
+                "   AND body ->> 'expires_at' IS NOT NULL"
+                "   AND body ->> 'expires_at' < %s"
+                " ORDER BY id"
+                " LIMIT %s",
+                (
+                    _GATEWAY_AUTHORIZATION_KIND,
+                    _DEFERRED_HOME_SETTLEMENT,
+                    now,
+                    int(limit),
+                ),
+                prepare=False,
+            ).fetchall()
+
+            reaped = 0
+            skipped_settled = 0
+            for (authorization_id,) in rows:
+                authorization = self._read_entity_tx(
+                    conn,
+                    _GATEWAY_AUTHORIZATION_KIND,
+                    str(authorization_id),
+                    GatewayAuthorization,
+                )
+                if authorization is None or authorization.settled:
+                    continue
+                # OUTBOX-GUARDED, ported from the Spanner reaper: an
+                # authorization whose settle already enqueued its debt must
+                # never be reaped. Reaping it would hand back an estimate that
+                # settle has already trued up, double-crediting the counter.
+                enqueued = conn.execute(
+                    "SELECT 1 FROM tr_home_settlement_outbox WHERE authorization_id = %s",
+                    (str(authorization_id),),
+                    prepare=False,
+                ).fetchone()
+                if enqueued is not None:
+                    skipped_settled += 1
+                    continue
+                won = self._insert_entity_once_tx(
+                    conn,
+                    _GATEWAY_FINALIZATION_KIND,
+                    str(authorization_id),
+                    {"success": False, "actual_microdollars": 0, "operation": "reap"},
+                )
+                if not won:
+                    # A settle is committing concurrently, or already did.
+                    skipped_settled += 1
+                    continue
+                self._adjust_deferred_outstanding_tx(
+                    conn,
+                    authorization.workspace_id,
+                    -int(authorization.estimated_microdollars),
+                )
+                self._release_key_hold_tx(
+                    conn,
+                    authorization.key_hash,
+                    authorization.estimated_microdollars,
+                    usage_type=authorization.usage_type,
+                    window_amount=0,
+                )
+                authorization.settled = True
+                authorization.expires_at = None
+                self._write_entity_tx(
+                    conn,
+                    _GATEWAY_AUTHORIZATION_KIND,
+                    str(authorization_id),
+                    authorization,
+                )
+                reaped += 1
+            return {
+                "examined": len(rows),
+                "reaped": reaped,
+                "skipped_settled": skipped_settled,
+            }
+
+        return self._run_transaction(reap)
 
     # Generations + activity -------------------------------------------------
 

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -1623,12 +1623,22 @@ class PostgresStore:
         *,
         usage_type: UsageType | str,
         window_amount: int,
+        window_is_byok: bool | None = None,
     ) -> None:
         """Release + window-roll inside a CALLER's transaction.
 
         finalize_gateway_authorization must do this in the same transaction
         as the credit release, or a crash between them leaves the key hold
         stranded while the money moved.
+
+        `usage_type` is the type the hold was RESERVED under; `window_is_byok`
+        is whether the spend being rolled into the windows was BYOK. They
+        differ on a mixed-candidate authorization: the hold is Credits-typed
+        whenever any credit candidate existed, but the enclave may select a
+        BYOK endpoint. Deriving both from one value made the early-return
+        below skip the RELEASE for include_byok=false keys — stranding
+        `reserved` forever — when what should be skipped is only the window
+        contribution.
         """
         floors = window_floors(utcnow())
         row = conn.execute(
@@ -1641,7 +1651,16 @@ class PostgresStore:
             return
         limit_micro, include_byok = row
         if _is_byok(usage_type) and not include_byok:
+            # Symmetric with reserve_key_limit: no hold was ever taken for a
+            # BYOK-typed reservation on a key that excludes BYOK, so there is
+            # nothing to release and nothing to roll.
             return
+        if window_is_byok is None:
+            window_is_byok = _is_byok(usage_type)
+        if window_is_byok and not include_byok:
+            # The hold (Credits-typed) still releases; only the spend's window
+            # contribution is excluded, because the key excludes BYOK.
+            window_amount = 0
         # GREATEST(...) floors the release at zero so a duplicate settle
         # cannot drive `reserved` negative and hand the key free headroom.
         # Window counters roll in the same statement so a settle is one
@@ -2606,7 +2625,15 @@ class PostgresStore:
             #    in this one transaction, so the debt can never exist without
             #    its usage record or vice versa.
             if authorization.settlement == _DEFERRED_HOME_SETTLEMENT:
-                if booked:
+                # A BYOK-selected settle owes home NOTHING: the customer's own
+                # provider key paid for the tokens. Mixed candidate lists make
+                # this reachable — authorize went deferred because the CREDITS
+                # candidates needed money the local plane doesn't hold, but
+                # the enclave was still free to pick a BYOK endpoint. Debiting
+                # home's ledger for spend the customer already paid a provider
+                # for would charge them twice.
+                owes_home = 0 if _is_byok(selected_usage_type) else booked
+                if owes_home:
                     conn.execute(
                         "INSERT INTO tr_home_settlement_outbox"
                         "   (authorization_id, workspace_id, cost_microdollars,"
@@ -2614,24 +2641,31 @@ class PostgresStore:
                         " VALUES (%s, %s, %s, 'pending', 0,"
                         "         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
                         " ON CONFLICT (authorization_id) DO NOTHING",
-                        (authorization_id, authorization.workspace_id, booked),
+                        (authorization_id, authorization.workspace_id, owes_home),
                         prepare=False,
                     )
-                # True up the counter to the FROZEN actual. Authorize admitted
-                # the estimate; a failed request (booked == 0) hands the whole
-                # estimate back, which is why this is a signed delta rather
-                # than an increment.
+                # True up the counter to the FROZEN debt. Authorize admitted
+                # the estimate; a failed request or a BYOK-selected one owes
+                # nothing and hands the whole estimate back, which is why this
+                # is a signed delta rather than an increment.
                 self._adjust_deferred_outstanding_tx(
                     conn,
                     authorization.workspace_id,
-                    booked - int(authorization.estimated_microdollars),
+                    owes_home - int(authorization.estimated_microdollars),
                 )
                 self._release_key_hold_tx(
                     conn,
                     authorization.key_hash,
                     authorization.estimated_microdollars,
-                    usage_type=selected_usage_type,
+                    # The hold was reserved under the AUTHORIZE-time type
+                    # (Credits whenever a credit candidate existed) — release
+                    # under the same type, or an include_byok=false key whose
+                    # request settled on a BYOK endpoint strands its hold
+                    # forever. The window contribution keys off what was
+                    # actually SELECTED.
+                    usage_type=authorization.usage_type,
                     window_amount=booked,
+                    window_is_byok=_is_byok(selected_usage_type),
                 )
                 if booked:
                     column = "byok_usage" if _is_byok(selected_usage_type) else "usage"

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -169,3 +169,56 @@ CREATE TABLE IF NOT EXISTS tr_operational_analytics_outbox (
 -- primary key prefix so its LIMIT is a bounded range scan.
 CREATE INDEX IF NOT EXISTS tr_operational_analytics_outbox_enqueued_at_idx
     ON tr_operational_analytics_outbox (enqueued_at);
+
+-- Deferred settlement: the peer plane's record of debt it owes the home
+-- plane's ledger.
+--
+-- tr_deferred_outstanding is a per-workspace COUNTER, and it is the actual
+-- bound on how much unsettled spend a workspace can run up while home is
+-- unreachable. It is enforced by a conditional UPDATE at authorize
+--   SET outstanding = outstanding + :estimate WHERE outstanding + :estimate <= :cap
+-- because a read-then-check bounds nothing: the authorize-to-settle gap is a
+-- whole provider stream, so every concurrent request would read the same
+-- stale total and admit.
+--
+-- `dead_lettered` is a SEPARATE column, not a decrement to zero. A row whose
+-- terms home rejects must stop consuming the workspace's serving headroom
+-- (otherwise one corrupt row bricks the workspace forever) while the debt
+-- stays visible for an operator to write off or replay deliberately.
+CREATE TABLE IF NOT EXISTS tr_deferred_outstanding (
+    workspace_id TEXT NOT NULL,
+    outstanding BIGINT NOT NULL DEFAULT 0,
+    dead_lettered BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (workspace_id)
+);
+
+-- One row per settled deferred authorization, awaiting delivery to home.
+--
+-- authorization_id is the PRIMARY KEY and the cross-plane idempotency key:
+-- home records a verdict per (source_plane, authorization_id), so a
+-- redelivered row applies exactly once. cost_microdollars is the FROZEN
+-- actual, never recomputed — the same rule the analytics outbox learned about
+-- enqueued_at, for the same reason.
+--
+-- state: pending -> forwarded (home recorded it) | dead_letter (home returned
+-- a STRUCTURED terms-conflict or unknown-workspace verdict; a bare 404 or an
+-- unparseable body is an OUTAGE and stays pending, or a home rollback would
+-- silently destroy the whole backlog).
+CREATE TABLE IF NOT EXISTS tr_home_settlement_outbox (
+    authorization_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    cost_microdollars BIGINT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    attempts BIGINT NOT NULL DEFAULT 0,
+    last_error TEXT,
+    enqueued_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (authorization_id)
+);
+
+-- The drain's batch selector: pending rows oldest-first. Without it every
+-- drain pass scans the whole table, which is worst exactly when a backlog has
+-- made it expensive.
+CREATE INDEX IF NOT EXISTS tr_home_settlement_outbox_pending_idx
+    ON tr_home_settlement_outbox (state, enqueued_at);

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -496,6 +496,16 @@ class Store(Protocol):
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,
         additional_cost_reservation_microdollars: int = ...,
+        # Deferred settlement. `settlement="deferred_home"` records that this
+        # spend is debt owed to the home plane's ledger rather than a debit
+        # here; `expires_at` is what lets the reaper reclaim its admitted
+        # estimate if settle never arrives. `deferred_cap_microdollars`, when
+        # given, makes this call the ADMISSION point: the outstanding counter
+        # moves in the same transaction as the authorization insert, and
+        # DeferredSettlementCapReached is raised if the cap refuses.
+        settlement: str = ...,
+        expires_at: str | None = ...,
+        deferred_cap_microdollars: int | None = ...,
     ) -> GatewayAuthorization: ...
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None: ...
     def get_gateway_authorization_by_idempotency_key(

--- a/src/trusted_router/types.py
+++ b/src/trusted_router/types.py
@@ -54,6 +54,13 @@ class ErrorType(StrEnum):
     # transferred. Telling them "insufficient credits" would send them to top
     # up an account that already has a balance.
     CREDITS_NOT_ON_THIS_PLANE = "credits_not_on_this_plane"
+    # A peer plane already holds the maximum unsettled spend it will carry for
+    # this workspace while the home plane is unreachable. Distinct from both
+    # insufficient_credits (a statement about the customer's money) and
+    # credits_not_on_this_plane (a statement about where it lives): this one
+    # says the customer is fine and the PLANE is at its self-imposed limit,
+    # which clears as settlements are delivered. Retryable.
+    DEFERRED_SETTLEMENT_CAP = "deferred_settlement_cap"
     MODEL_NOT_SUPPORTED = "model_not_supported"
     PROVIDER_AUTH_ERROR = "provider_auth_error"
     PROVIDER_ERROR = "provider_error"

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -114,6 +114,12 @@ SCHEMA_TABLES = (
     "CREATE TABLE IF NOT EXISTS tr_entities",
     "CREATE TABLE IF NOT EXISTS tr_credit_balance",
     "CREATE TABLE IF NOT EXISTS tr_key_limit",
+    # Deferred settlement. The cap's whole claim to being a real bound is the
+    # predicate on its UPDATE and the rowcount that reads it, and the outbox's
+    # exactly-once claim is an ON CONFLICT — statement-level guarantees, which
+    # is exactly the class this harness exists to run rather than re-implement.
+    "CREATE TABLE IF NOT EXISTS tr_deferred_outstanding",
+    "CREATE TABLE IF NOT EXISTS tr_home_settlement_outbox",
 )
 
 

--- a/tests/test_deferred_settlement.py
+++ b/tests/test_deferred_settlement.py
@@ -1,0 +1,409 @@
+"""Deferred settlement on a peer plane: the cap, the reaper, the outbox.
+
+Deferred settlement lets a peer plane serve a federated key's CREDITS traffic
+while the home plane is unreachable. The spend is admitted against a
+transactional cap, recorded as debt, and forwarded to the home ledger later.
+
+Three properties carry the whole design, and each has a test here that fails
+if it is weakened:
+
+* **The cap is a real bound, not advice.** It is a conditional UPDATE, so N
+  concurrent authorizes cannot all read one stale total and all admit. A
+  read-then-check implementation passes a single-threaded test and bounds
+  nothing in production.
+* **An abandoned authorization is reclaimed.** The enclave dying between
+  authorize and settle is routine — every deploy does it. Without the reaper
+  each one leaks its estimate into the counter permanently, and once the leaks
+  reach the cap the workspace 402s forever on a healthy plane.
+* **Settle records debt instead of debiting locally**, exactly once, and the
+  counter trues up to the frozen actual.
+
+These run against the SQLite psycopg fake, which executes the store's REAL
+SQL: the guarantees live in the statement text (`ON CONFLICT`, the conditional
+`WHERE outstanding + %s <= %s`, rowcount), and a Python twin would re-implement
+them and prove nothing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from trusted_router.storage_errors import DeferredSettlementCapReached
+from trusted_router.storage_models import iso_now
+
+WS = "ws-deferred-1"
+KEY = "kh-deferred-1"
+CAP = 25_000_000  # $25, the shipped default
+
+
+@pytest.fixture
+def harness() -> tuple[Any, Any]:
+    conn = sqlite_postgres_conn()
+    return postgres_store_on(conn), conn
+
+
+def _authorize(
+    store: Any,
+    *,
+    estimate: int,
+    expires_at: str | None = None,
+    cap: int | None = CAP,
+    idempotency_key: str | None = None,
+) -> Any:
+    return store.create_gateway_authorization(
+        workspace_id=WS,
+        key_hash=KEY,
+        model_id="anthropic/claude-opus-4.7",
+        provider="anthropic",
+        usage_type="Credits",
+        estimated_microdollars=estimate,
+        credit_reservation_id=None,
+        idempotency_key=idempotency_key,
+        settlement="deferred_home",
+        expires_at=expires_at or _in(hours=2),
+        deferred_cap_microdollars=cap,
+    )
+
+
+def _in(*, hours: float) -> str:
+    from trusted_router.spend_windows import utcnow
+
+    return (utcnow() + dt.timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
+
+
+def _outbox(conn: Any) -> list[tuple[Any, ...]]:
+    return conn.execute(
+        "SELECT authorization_id, workspace_id, cost_microdollars, state"
+        " FROM tr_home_settlement_outbox ORDER BY authorization_id"
+    ).fetchall()
+
+
+# --------------------------------------------------------------------------
+# The cap
+# --------------------------------------------------------------------------
+
+
+def test_cap_admits_up_to_the_limit_then_refuses(harness: tuple[Any, Any]) -> None:
+    store, conn = harness
+    for _ in range(5):
+        _authorize(store, estimate=5_000_000)
+    assert store.deferred_outstanding(WS)["outstanding"] == CAP
+
+    with pytest.raises(DeferredSettlementCapReached):
+        _authorize(store, estimate=1)
+
+    assert store.deferred_outstanding(WS)["outstanding"] == CAP, "refusal changed nothing"
+
+
+def test_cap_refusal_writes_no_authorization(harness: tuple[Any, Any]) -> None:
+    """The counter move and the authorization insert share a transaction.
+
+    If they did not, a refusal could leave an authorization the reaper would
+    later 'reclaim', decrementing a counter that was never incremented.
+    """
+    store, conn = harness
+    _authorize(store, estimate=CAP)
+    before = conn.execute(
+        "SELECT COUNT(*) FROM tr_entities WHERE kind = 'gateway_authorization'"
+    ).fetchone()[0]
+
+    with pytest.raises(DeferredSettlementCapReached):
+        _authorize(store, estimate=1_000_000)
+
+    after = conn.execute(
+        "SELECT COUNT(*) FROM tr_entities WHERE kind = 'gateway_authorization'"
+    ).fetchone()[0]
+    assert after == before, "a refused authorize must not leave an authorization behind"
+
+
+def test_cap_is_enforced_by_a_conditional_update_not_a_read(
+    harness: tuple[Any, Any],
+) -> None:
+    """The statement itself must carry the bound.
+
+    This is the mutation guard for the panel's TOCTOU finding: authorize is
+    the ONLY place the counter grows, and it must grow under a predicate. A
+    read-then-write implementation passes every other test in this file (they
+    are sequential) and admits unboundedly under concurrency.
+    """
+    store, _conn = harness
+    seen: list[str] = []
+    original = store._reserve_deferred_outstanding_tx
+
+    def spy(conn: Any, workspace_id: str, amount: int, **kw: Any) -> None:
+        class Recorder:
+            def execute(self, sql: str, params: tuple[Any, ...] = (), **kwargs: Any) -> Any:
+                seen.append(" ".join(sql.split()))
+                return conn.execute(sql, params, **kwargs)
+
+        return original(Recorder(), workspace_id, amount, **kw)  # type: ignore[arg-type]
+
+    store._reserve_deferred_outstanding_tx = spy  # type: ignore[method-assign]
+    _authorize(store, estimate=1_000_000)
+
+    update = next((s for s in seen if s.startswith("UPDATE tr_deferred_outstanding")), "")
+    assert update, "authorize did not move the counter"
+    assert "WHERE workspace_id = %s AND outstanding + %s <= %s" in update, (
+        "the cap must be a predicate ON the UPDATE; a read-then-check bounds "
+        "nothing once two requests are in flight"
+    )
+    assert not any(
+        s.startswith("SELECT outstanding") for s in seen
+    ), "admission must not consult a prior read"
+
+
+def test_idempotent_replay_does_not_double_count(harness: tuple[Any, Any]) -> None:
+    """A replay returns the existing authorization and writes nothing.
+
+    It must therefore consume no additional cap — otherwise a client retrying
+    a request walks a workspace into a lockout it never spent.
+    """
+    store, _conn = harness
+    first = _authorize(store, estimate=5_000_000, idempotency_key="idem-1")
+    second = _authorize(store, estimate=5_000_000, idempotency_key="idem-1")
+
+    assert first.id == second.id
+    assert store.deferred_outstanding(WS)["outstanding"] == 5_000_000
+
+
+# --------------------------------------------------------------------------
+# Settle
+# --------------------------------------------------------------------------
+
+
+def test_settle_enqueues_debt_and_leaves_the_local_balance_alone(
+    harness: tuple[Any, Any],
+) -> None:
+    store, conn = harness
+    conn.execute(
+        "INSERT INTO tr_credit_balance"
+        " (workspace_id, shard, total_credits, total_usage, reserved, updated_at)"
+        " VALUES (%s, 0, 0, 0, 0, CURRENT_TIMESTAMP)",
+        (WS,),
+    )
+    auth = _authorize(store, estimate=1_000_000)
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=400_000, selected_usage_type="Credits"
+    ) is True
+
+    rows = _outbox(conn)
+    assert rows == [(auth.id, WS, 400_000, "pending")]
+
+    balance = conn.execute(
+        "SELECT total_usage FROM tr_credit_balance WHERE workspace_id = %s AND shard = 0",
+        (WS,),
+    ).fetchone()
+    assert balance[0] == 0, "deferred spend is debt at home, never a local debit"
+
+    # The counter trues up from the ESTIMATE to the FROZEN ACTUAL.
+    assert store.deferred_outstanding(WS)["outstanding"] == 400_000
+
+
+def test_replayed_settle_enqueues_once(harness: tuple[Any, Any]) -> None:
+    store, conn = harness
+    auth = _authorize(store, estimate=1_000_000)
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=400_000, selected_usage_type="Credits"
+    ) is True
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=400_000, selected_usage_type="Credits"
+    ) is False
+
+    assert len(_outbox(conn)) == 1, "a redelivered settle must not double the debt"
+    assert store.deferred_outstanding(WS)["outstanding"] == 400_000
+
+
+def test_failed_request_enqueues_nothing_and_returns_the_whole_estimate(
+    harness: tuple[Any, Any],
+) -> None:
+    store, conn = harness
+    _authorize(store, estimate=3_000_000)
+    auth = _authorize(store, estimate=2_000_000)
+    assert store.deferred_outstanding(WS)["outstanding"] == 5_000_000
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=False, actual_microdollars=0, selected_usage_type="Credits"
+    ) is True
+
+    assert _outbox(conn) == [], "a failed request owes nothing"
+    assert store.deferred_outstanding(WS)["outstanding"] == 3_000_000
+
+
+# --------------------------------------------------------------------------
+# The reaper
+# --------------------------------------------------------------------------
+
+
+def test_reaper_reclaims_an_abandoned_authorization(harness: tuple[Any, Any]) -> None:
+    """The enclave died between authorize and settle — every deploy does this.
+
+    Without reclamation the estimate is stuck in the counter forever, and
+    enough of them permanently 402 a workspace on a healthy plane.
+    """
+    store, _conn = harness
+    _authorize(store, estimate=20_000_000, expires_at=_in(hours=-1))
+    assert store.deferred_outstanding(WS)["outstanding"] == 20_000_000
+
+    # The cap is genuinely blocking before the reap.
+    with pytest.raises(DeferredSettlementCapReached):
+        _authorize(store, estimate=10_000_000)
+
+    result = store.reap_expired_deferred_authorizations()
+    assert result["reaped"] == 1
+    assert store.deferred_outstanding(WS)["outstanding"] == 0
+
+    # ...and the workspace can spend again.
+    _authorize(store, estimate=10_000_000)
+    assert store.deferred_outstanding(WS)["outstanding"] == 10_000_000
+
+
+def test_reaper_leaves_unexpired_authorizations_alone(harness: tuple[Any, Any]) -> None:
+    store, _conn = harness
+    _authorize(store, estimate=5_000_000, expires_at=_in(hours=2))
+    assert store.reap_expired_deferred_authorizations()["reaped"] == 0
+    assert store.deferred_outstanding(WS)["outstanding"] == 5_000_000
+
+
+def test_reaper_never_touches_an_authorization_that_already_settled(
+    harness: tuple[Any, Any],
+) -> None:
+    """OUTBOX-GUARDED. Settle has already trued the counter to the actual;
+    reaping would hand back an estimate that no longer exists."""
+    store, conn = harness
+    auth = _authorize(store, estimate=5_000_000, expires_at=_in(hours=-1))
+    store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=1_000_000, selected_usage_type="Credits"
+    )
+    assert store.deferred_outstanding(WS)["outstanding"] == 1_000_000
+
+    result = store.reap_expired_deferred_authorizations()
+    assert result["reaped"] == 0
+    assert store.deferred_outstanding(WS)["outstanding"] == 1_000_000
+    assert len(_outbox(conn)) == 1
+
+
+def test_late_settle_after_a_reap_is_a_no_op(harness: tuple[Any, Any]) -> None:
+    """Reaper and settle race on ONE insert-once marker: first writer wins.
+
+    A settle that arrives after its authorization was reaped must book
+    nothing and enqueue nothing — otherwise the counter is decremented twice
+    and debt is invented from a request nobody is holding money for.
+    """
+    store, conn = harness
+    auth = _authorize(store, estimate=5_000_000, expires_at=_in(hours=-1))
+    assert store.reap_expired_deferred_authorizations()["reaped"] == 1
+    assert store.deferred_outstanding(WS)["outstanding"] == 0
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=4_000_000, selected_usage_type="Credits"
+    ) is False
+    assert _outbox(conn) == []
+    assert store.deferred_outstanding(WS)["outstanding"] == 0
+
+
+def test_settle_clears_the_expiry(harness: tuple[Any, Any]) -> None:
+    """Settled work is not reclaimable, so it must leave the reaper's scan.
+
+    `expires_at IS NOT NULL` is the reaper's "still outstanding" predicate.
+    Leaving a past expiry on a settled row makes every future pass re-read
+    rows it can never act on — the scan grows without bound while the reap
+    count stays at zero, which reads as a healthy idle reaper.
+    """
+    store, _conn = harness
+    auth = _authorize(store, estimate=1_000_000, expires_at=_in(hours=-1))
+    store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=500_000, selected_usage_type="Credits"
+    )
+
+    settled = store.get_gateway_authorization(auth.id)
+    assert settled is not None
+    assert settled.settled is True
+    assert settled.expires_at is None, "a settled row must leave the reaper's scan"
+    assert store.reap_expired_deferred_authorizations()["examined"] == 0
+
+
+def test_reaper_refuses_a_row_that_already_owes_debt(harness: tuple[Any, Any]) -> None:
+    """The outbox guard, exercised directly.
+
+    Reachable only from a TORN state — an expired, apparently-unsettled
+    authorization that nonetheless has debt enqueued. Two upstream guards
+    (the cleared expiry and the settled flag) mean the normal paths never
+    produce it, so the state is built by hand here. That is the point: the
+    guard's job is to fail safe if either of those is ever weakened, and a
+    guard nothing exercises is a guard nobody knows is broken. Reaping such a
+    row would return an estimate settle has already trued to the actual,
+    crediting the counter twice.
+    """
+    store, conn = harness
+    auth = _authorize(store, estimate=5_000_000, expires_at=_in(hours=-1))
+    conn.execute(
+        "INSERT INTO tr_home_settlement_outbox"
+        " (authorization_id, workspace_id, cost_microdollars, state, attempts,"
+        "  enqueued_at, updated_at)"
+        " VALUES (%s, %s, %s, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        (auth.id, WS, 4_000_000),
+    )
+
+    result = store.reap_expired_deferred_authorizations()
+    assert result["examined"] == 1
+    assert result["reaped"] == 0
+    assert result["skipped_settled"] == 1
+    assert store.deferred_outstanding(WS)["outstanding"] == 5_000_000, (
+        "the guard must not hand back an estimate whose debt is already owed"
+    )
+
+
+def test_reaper_ignores_local_authorizations(harness: tuple[Any, Any]) -> None:
+    """Only deferred authorizations carry an expiry and a counter to reclaim.
+    A local one is settled by the enclave or not at all, exactly as before."""
+    store, _conn = harness
+    local = store.create_gateway_authorization(
+        workspace_id=WS,
+        key_hash=KEY,
+        model_id="anthropic/claude-opus-4.7",
+        provider="anthropic",
+        usage_type="Credits",
+        estimated_microdollars=1_000_000,
+        credit_reservation_id=None,
+    )
+    assert local.settlement == "local"
+    assert local.expires_at is None
+    assert store.reap_expired_deferred_authorizations()["reaped"] == 0
+    assert store.get_gateway_authorization(local.id).settled is False
+
+
+def test_counter_never_goes_negative(harness: tuple[Any, Any]) -> None:
+    """An actual larger than its estimate is normal; the clamp is what keeps
+    an underflow from handing a workspace headroom it never earned."""
+    store, _conn = harness
+    auth = _authorize(store, estimate=1_000_000)
+    store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=0, selected_usage_type="Credits"
+    )
+    assert store.deferred_outstanding(WS)["outstanding"] == 0
+
+    store.release_deferred_outstanding(WS, 5_000_000)
+    assert store.deferred_outstanding(WS)["outstanding"] == 0
+
+
+def test_unknown_workspace_reads_zero(harness: tuple[Any, Any]) -> None:
+    store, _conn = harness
+    assert store.deferred_outstanding("ws-never-seen") == {
+        "outstanding": 0,
+        "dead_lettered": 0,
+    }
+
+
+def test_expires_at_is_stored_as_an_iso_string(harness: tuple[Any, Any]) -> None:
+    """The reaper's WHERE clause compares expires_at as TEXT, so the format
+    has to sort lexicographically the same way it sorts chronologically."""
+    store, _conn = harness
+    auth = _authorize(store, estimate=1_000_000)
+    assert auth.expires_at is not None
+    assert auth.expires_at.endswith("Z")
+    assert auth.expires_at > iso_now()

--- a/tests/test_deferred_settlement.py
+++ b/tests/test_deferred_settlement.py
@@ -234,6 +234,57 @@ def test_failed_request_enqueues_nothing_and_returns_the_whole_estimate(
     assert store.deferred_outstanding(WS)["outstanding"] == 3_000_000
 
 
+def test_byok_selected_settle_owes_home_nothing(harness: tuple[Any, Any]) -> None:
+    """Mixed candidates: authorize went deferred for the CREDITS candidates,
+    but the enclave picked a BYOK endpoint — the customer's own provider key
+    paid for the tokens. Enqueuing that as home debt charges them twice.
+    """
+    store, conn = harness
+    auth = _authorize(store, estimate=1_000_000)
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=400_000, selected_usage_type="BYOK"
+    ) is True
+
+    assert _outbox(conn) == [], "BYOK spend must never become home debt"
+    assert store.deferred_outstanding(WS)["outstanding"] == 0, (
+        "the whole estimate comes back: nothing is owed"
+    )
+
+
+def test_byok_selected_settle_releases_the_credits_hold(
+    harness: tuple[Any, Any],
+) -> None:
+    """The hold was reserved under CREDITS (a credit candidate existed); the
+    release must use that same type. Releasing under the SELECTED type made
+    _release_key_hold_tx's early-return skip the release entirely on
+    include_byok=false keys — reserved stranded forever, and the key's cap
+    shrinking with every mixed-candidate request that landed on BYOK.
+    """
+    store, conn = harness
+    conn.execute(
+        "INSERT INTO tr_key_limit"
+        " (workspace_id, key_hash, shard, limit_micro, usage, byok_usage,"
+        "  reserved, include_byok, updated_at)"
+        " VALUES (%s, %s, 0, 10000000, 0, 0, 1000000, 0, CURRENT_TIMESTAMP)",
+        (WS, KEY),
+    )
+    auth = _authorize(store, estimate=1_000_000)
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=400_000, selected_usage_type="BYOK"
+    ) is True
+
+    row = conn.execute(
+        "SELECT reserved, day_usage FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+        (KEY,),
+    ).fetchone()
+    assert row[0] == 0, "the Credits-typed hold must release regardless of selection"
+    assert (row[1] or 0) == 0, (
+        "an include_byok=false key must not have BYOK spend rolled into windows"
+    )
+
+
 # --------------------------------------------------------------------------
 # The reaper
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Peer-plane half of deferred settlement. **Off by default** (`TR_FEDERATION_DEFERRED_SETTLEMENT_ENABLED=false`); the home-side apply endpoint and the forwarder are 2c, so nothing in this PR can move money anywhere yet.

## Why

Today a federated key on the AWS/Azure planes gets 402 `CREDITS_NOT_ON_THIS_PLANE` for every credits-routed request: `PostgresStore` is not a `TypedBillingStore`, so authorize takes the legacy branch and unconditionally calls `STORE.reserve()` against a local balance that federated keys deliberately seed at **zero**. Only BYOK traffic survives a home outage — which caps per-cloud availability at GCP's.

Identity federates; credits don't. Usage is the third category — a **debt record**, safe to record on a peer and apply late, because applying it only moves a home balance *down* and an insert-once claim at home makes double application impossible.

## What

A federated key whose local balance refuses falls back to spending on credit at home's ledger. **Local reserve is tried first** — a workspace explicitly pre-funded by credit transfer must keep spending that transferred money locally rather than stranding it.

Two properties carry the design, and a 3-lens adversarial panel (23 agents) was right that the first draft earned neither:

**The cap is a real bound.** Admission is a conditional `UPDATE ... WHERE outstanding + est <= cap`, rowcount-gated, in the *same transaction* as the authorization insert. A read-then-check bounds nothing — the authorize-to-settle gap is a whole provider stream, so N concurrent requests each read one stale total and each admit. In-transaction also means an idempotent replay can't double-count and a refusal can't orphan an authorization.

**Abandoned work is reclaimed.** The enclave dying between authorize and settle is routine (every deploy), and this plane has no other sweeper — Spanner's `reap_expired_reservations` is Spanner-only. Each abandonment would leak its estimate permanently, and enough of them would 402 a workspace *forever* on a healthy plane. The new reaper claims the same insert-once marker settle claims (first-writer-wins), is outbox-guarded, and refunds the key-limit escrow.

## Verification

Mutation-tested, **6 of 7 caught**: advisory cap, absent reaper, missing outbox guard, missing marker gate, removed counter clamp, and a settle that stops clearing the expiry each fail a test. The seventh (the outbox `ON CONFLICT`) is proven-redundant defense behind the marker gate, which is itself covered — verified by mutating the gate.

Tests run against the SQLite psycopg fake, which executes the store's real SQL; the guarantees live in statement text, so a Python twin would prove nothing. Full suite green (2973 passed), ruff + mypy clean.

One dialect trap worth flagging: `body ->> 'settled'` is the text `'false'` on Postgres and the integer `0` on SQLite. The reaper avoids it entirely — settle clears `expires_at`, and `expires_at IS NOT NULL` is the "still outstanding" predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)