### PR TITLE
settle: release the key hold under the RESERVED type, local path too

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -2757,12 +2757,23 @@ class PostgresStore:
 
             # 2. Key-limit hold: release, and roll the windows by actual spend.
             #    Reuses the same lazy-window rules as settle_key_limit.
+            #
+            #    Released under the AUTHORIZE-time type, not the selected one.
+            #    They differ on a mixed Credits/BYOK authorization (the hold
+            #    is Credits-typed whenever any credit candidate existed, but
+            #    the enclave may select a BYOK endpoint), and passing the
+            #    selected type made _release_key_hold_tx's early-return skip
+            #    the release entirely on include_byok=false keys — reserved
+            #    stranded forever, the key's cap shrinking with every mixed
+            #    request that landed on BYOK. Only the WINDOW contribution
+            #    keys off what was actually selected.
             self._release_key_hold_tx(
                 conn,
                 authorization.key_hash,
                 authorization.estimated_microdollars,
-                usage_type=selected_usage_type,
+                usage_type=authorization.usage_type,
                 window_amount=booked,
+                window_is_byok=_is_byok(selected_usage_type),
             )
 
             # 3. Lifetime key usage. settle_key_limit deliberately does NOT

--- a/tests/test_settle_books_usage_always.py
+++ b/tests/test_settle_books_usage_always.py
@@ -164,6 +164,48 @@ def test_settle_books_usage_when_reservation_entity_is_gone(
     assert settled is not None and settled.settled is True
 
 
+def test_local_settle_releases_hold_under_the_reserved_type(
+    harness: tuple[Any, Any],
+) -> None:
+    """Mixed Credits/BYOK authorization, BYOK endpoint selected, on a key that
+    excludes BYOK from its limits.
+
+    The key-limit hold was reserved under CREDITS (a credit candidate
+    existed). Releasing under the SELECTED type made _release_key_hold_tx's
+    early-return skip the release entirely on include_byok=false keys:
+    `reserved` stranded forever, the key's effective cap shrinking with every
+    mixed request that landed on BYOK. The Spanner typed path is immune — it
+    releases the EXACT recorded hold and only books by settled type — so this
+    pins the Postgres local path to the same semantics.
+    """
+    store, conn = harness
+    _seed_balance(conn)
+    conn.execute(
+        "INSERT INTO tr_key_limit"
+        " (workspace_id, key_hash, shard, limit_micro, usage, byok_usage,"
+        "  reserved, include_byok, updated_at)"
+        " VALUES (%s, %s, 0, 10000000, 0, 0, 0, 0, CURRENT_TIMESTAMP)",
+        (WS, KEY),
+    )
+    store.reserve_key_limit(KEY, 100, usage_type="Credits")
+    auth = _authorize_with_reservation(store, estimate=100)
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=40, selected_usage_type="BYOK"
+    ) is True
+
+    row = conn.execute(
+        "SELECT reserved, day_usage, byok_usage FROM tr_key_limit"
+        " WHERE key_hash = %s AND shard = 0",
+        (KEY,),
+    ).fetchone()
+    assert row[0] == 0, "the Credits-typed hold must release regardless of selection"
+    assert (row[1] or 0) == 0, (
+        "an include_byok=false key must not roll BYOK spend into its windows"
+    )
+    assert row[2] == 40, "lifetime attribution still keys off the SELECTED type"
+
+
 def test_failed_settle_on_deleted_row_books_nothing_but_recreates(
     harness: tuple[Any, Any],
 ) -> None:


### PR DESCRIPTION
Closes the pre-existing sibling of the defect fixed in #439's deferred branch, found by the codex review there.

**The defect:** a mixed Credits/BYOK authorization reserves its key-limit hold under Credits (any credit candidate ⇒ `reservation_usage_type=Credits`, gateway legacy branch), but the enclave may select a BYOK endpoint. The local settle path released under the *selected* type, and `_release_key_hold_tx` early-returns for a BYOK type on `include_byok=false` keys — so `tr_key_limit.reserved` stranded forever, shrinking the key's effective cap with every mixed request that landed on BYOK.

**The fix** mirrors the deferred branch: release under `authorization.usage_type` (the reserved type); the window contribution keys off the selected type separately via `window_is_byok`, so an `include_byok=false` key still excludes BYOK spend from its windows. Lifetime attribution (usage vs byok_usage) unchanged.

**Spanner typed path verified immune:** `release_key` releases the *exact recorded hold* from the reservation row and raises on a zero-row release; the settled type only picks the booking column.

Mutation-verified: reverting the release type fails `test_local_settle_releases_hold_under_the_reserved_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)