### PR TITLE
Add dark-launched Adyen checkout

### DIFF
--- a/docs/adyen-rollout.md
+++ b/docs/adyen-rollout.md
@@ -1,0 +1,90 @@
+# Adyen Checkout Rollout
+
+Adyen is integrated as a dark, one-time prepaid funding rail. It does not
+introduce a second balance system. An embedded Adyen Drop-in creates a payment,
+and only an HMAC-verified successful `AUTHORISATION` webhook can add credits to
+the existing typed ledger.
+
+## Safety boundary
+
+- `TR_ADYEN_ENABLED=false` is the deployment default. The Adyen option is not
+  rendered and authenticated session creation rejects requests while dark.
+- Webhook verification is independent of checkout enablement. Disabling new
+  sessions does not prevent a late successful payment from being credited.
+- The browser receives only Adyen's client key and opaque session data. The API
+  key and webhook HMAC key stay in Secret Manager.
+- Money stays in integer USD cents and microdollars. The merchant reference
+  binds workspace, credit principal, charge total, and a nonce under a separate
+  TrustedRouter HMAC key. Adyen then signs the complete reference in its
+  webhook. A valid Adyen event for a reference issued by another integration
+  cannot mint TrustedRouter credits.
+- Duplicate successful events are idempotent by checkout reference, even when
+  Adyen sends a different PSP reference on an authorization retry.
+- Refunds and chargebacks are logged for manual review. V1 never silently
+  debits a customer's credits.
+- Adyen does not save cards for TrustedRouter auto refill in V1. Stripe remains
+  the saved-card and auto-refill provider.
+
+## Current test resources
+
+| Resource | Value |
+|---|---|
+| Environment | Adyen test |
+| Merchant account | `TrustedRouterUS` |
+| Allowed browser origin | `https://trustedrouter.com` |
+| Checkout API | v72 Sessions |
+| Adyen Web | 6.41.0, pinned with SRI |
+| Webhook URL | `https://trustedrouter.com/v1/internal/adyen/webhook` (created inactive) |
+
+The merchant must report `Active`, not `PreActive` or `Pending`, before Checkout
+can return payment methods or sessions.
+
+## Remaining activation sequence
+
+1. Wait for `TrustedRouterUS` to become `Active` in the Adyen test account.
+2. Create an active Standard webhook for the URL above. Generate its test HMAC
+   key and save it as Secret Manager secret `trustedrouter-adyen-test-hmac-key`.
+   Generate a separate 32-byte random reference key and save it as
+   `trustedrouter-adyen-test-reference-key`. Keep this stable while any Adyen
+   sessions can still settle.
+3. Test the webhook from Adyen Customer Area. Require HTTP 200 with
+   `[accepted]`, then repeat the same event and verify no second credit.
+4. Run the non-charging readiness check:
+
+   ```bash
+   ADYEN_API_KEY=... \
+   ADYEN_HMAC_KEY=... \
+   ADYEN_REFERENCE_KEY=... \
+   ADYEN_MERCHANT_ACCOUNT=TrustedRouterUS \
+   uv run python scripts/check_adyen_readiness.py
+   ```
+
+5. Configure the signed commercial processing rates in
+   `TR_ADYEN_CARD_FEE_BASIS_POINTS` and `TR_ADYEN_CARD_FEE_FIXED_CENTS`. Do not
+   launch with guessed rates. The checkout displays credits and the processing
+   fee separately.
+6. In test, exercise Adyen's successful card, refused card, 3DS challenge,
+   abandoned checkout, delayed webhook, duplicate webhook, and malformed HMAC
+   scenarios. Confirm only one successful authorization adds the requested
+   principal.
+7. Change the rollout default to `TR_ADYEN_ENABLED=true` for one internal
+   workspace canary. Verify balance, acquisition event, Sentry, and Adyen event
+   logs before exposing it generally.
+8. Repeat webhook and credential setup separately in Adyen live. Test and live
+   HMAC keys are intentionally different. Configure
+   `TR_ADYEN_LIVE_ENDPOINT_PREFIX`, change the environment to `live`, and use
+   live-named secrets before a small real-payment canary.
+
+## Rollback
+
+Set `TR_ADYEN_ENABLED=false` and deploy. This immediately removes Adyen from
+checkout and rejects new sessions while preserving webhook processing for
+payments already in flight.
+
+## Automated coverage
+
+`tests/test_adyen_billing.py` covers the official Adyen HMAC vector, exact
+integer fee/charge construction, no balance mutation during session creation,
+merchant inactivity, duplicate authorization, forged batch rejection,
+merchant/currency/amount/environment mismatches, failed payments, adverse
+events, CDN SRI pins, and the dark console gate.

--- a/scripts/check_adyen_readiness.py
+++ b/scripts/check_adyen_readiness.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Run non-charging Adyen test-account readiness checks.
+
+The script never creates a payment or session. It validates the API credential,
+merchant state, browser origin, and payment-method discovery without printing
+credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+import httpx
+
+
+def main() -> int:
+    api_key = os.environ.get("ADYEN_API_KEY") or os.environ.get("TR_ADYEN_API_KEY")
+    merchant = os.environ.get("ADYEN_MERCHANT_ACCOUNT") or os.environ.get(
+        "TR_ADYEN_MERCHANT_ACCOUNT"
+    )
+    hmac_key = os.environ.get("ADYEN_HMAC_KEY") or os.environ.get("TR_ADYEN_HMAC_KEY")
+    reference_key = os.environ.get("ADYEN_REFERENCE_KEY") or os.environ.get(
+        "TR_ADYEN_REFERENCE_KEY"
+    )
+    expected_origin = os.environ.get("ADYEN_ALLOWED_ORIGIN", "https://trustedrouter.com")
+    expected_webhook = os.environ.get(
+        "ADYEN_WEBHOOK_URL",
+        "https://trustedrouter.com/v1/internal/adyen/webhook",
+    )
+    if not api_key or not merchant:
+        print(
+            "Set ADYEN_API_KEY and ADYEN_MERCHANT_ACCOUNT before running this check.",
+            file=sys.stderr,
+        )
+        return 2
+
+    checks: dict[str, dict[str, Any]] = {}
+    checks["local_secrets"] = {
+        "ok": _valid_hmac_key(hmac_key) and bool(reference_key and len(reference_key) >= 32),
+        "hmac_configured": _valid_hmac_key(hmac_key),
+        "reference_key_configured": bool(reference_key and len(reference_key) >= 32),
+    }
+    headers = {"X-API-Key": api_key}
+    with httpx.Client(timeout=15.0, headers=headers) as client:
+        credential = _request(client, "GET", "https://management-test.adyen.com/v3/me")
+        checks["credential"] = {
+            "ok": credential.status_code == 200,
+            "status": credential.status_code,
+        }
+
+        origins = _request(
+            client,
+            "GET",
+            "https://management-test.adyen.com/v3/me/allowedOrigins",
+        )
+        origin_values = _origin_values(_json_object(origins))
+        checks["allowed_origin"] = {
+            "ok": origins.status_code == 200 and expected_origin in origin_values,
+            "status": origins.status_code,
+            "expected": expected_origin,
+        }
+
+        merchant_response = _request(
+            client,
+            "GET",
+            f"https://management-test.adyen.com/v3/merchants/{merchant}",
+        )
+        merchant_body = _json_object(merchant_response)
+        merchant_status = str(merchant_body.get("status") or "unknown")
+        checks["merchant"] = {
+            "ok": merchant_response.status_code == 200 and merchant_status.lower() == "active",
+            "status": merchant_response.status_code,
+            "merchant_status": merchant_status,
+        }
+
+        webhooks = _request(
+            client,
+            "GET",
+            f"https://management-test.adyen.com/v3/merchants/{merchant}/webhooks",
+        )
+        webhook_values = _webhook_values(_json_object(webhooks))
+        checks["standard_webhook"] = {
+            "ok": webhooks.status_code == 200
+            and any(
+                item.get("url") == expected_webhook
+                and item.get("type") == "standard"
+                and item.get("active") is True
+                for item in webhook_values
+            ),
+            "status": webhooks.status_code,
+            "expected": expected_webhook,
+            "matching_count": sum(
+                1 for item in webhook_values if item.get("url") == expected_webhook
+            ),
+        }
+
+        payment_methods = _request(
+            client,
+            "POST",
+            "https://checkout-test.adyen.com/v72/paymentMethods",
+            json={
+                "amount": {"currency": "USD", "value": 100},
+                "channel": "Web",
+                "countryCode": "US",
+                "merchantAccount": merchant,
+            },
+        )
+        payment_body = _json_object(payment_methods)
+        methods = payment_body.get("paymentMethods")
+        checks["payment_methods"] = {
+            "ok": payment_methods.status_code == 200
+            and isinstance(methods, list)
+            and bool(methods),
+            "status": payment_methods.status_code,
+            "count": len(methods) if isinstance(methods, list) else 0,
+            "error_code": payment_body.get("errorCode"),
+            "message": payment_body.get("message"),
+        }
+
+    ready = all(bool(check["ok"]) for check in checks.values())
+    print(json.dumps({"ready": ready, "checks": checks}, indent=2, sort_keys=True))
+    return 0 if ready else 1
+
+
+def _request(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    **kwargs: Any,
+) -> httpx.Response:
+    try:
+        return client.request(method, url, **kwargs)
+    except httpx.HTTPError as exc:
+        print(f"Adyen readiness request failed: {type(exc).__name__}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+def _json_object(response: httpx.Response) -> dict[str, Any]:
+    try:
+        value = response.json()
+    except ValueError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _origin_values(payload: dict[str, Any]) -> set[str]:
+    raw = payload.get("data")
+    if not isinstance(raw, list):
+        return set()
+    origins: set[str] = set()
+    for entry in raw:
+        if isinstance(entry, dict) and isinstance(entry.get("domain"), str):
+            origins.add(entry["domain"])
+    return origins
+
+
+def _webhook_values(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = payload.get("data")
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
+def _valid_hmac_key(value: str | None) -> bool:
+    if not value or len(value) < 32 or len(value) % 2:
+        return False
+    try:
+        bytes.fromhex(value)
+    except ValueError:
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -102,6 +102,11 @@ add_secret_env_if_exists \
 add_secret_env_if_exists "TR_PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
 add_secret_env_if_exists "TR_PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
 add_secret_env_if_exists "TR_PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
+add_secret_env_if_exists "TR_ADYEN_API_KEY" "trustedrouter-adyen-test-api-key"
+add_secret_env_if_exists "TR_ADYEN_CLIENT_KEY" "trustedrouter-adyen-test-client-key"
+add_secret_env_if_exists "TR_ADYEN_HMAC_KEY" "trustedrouter-adyen-test-hmac-key"
+add_secret_env_if_exists \
+  "TR_ADYEN_REFERENCE_KEY" "trustedrouter-adyen-test-reference-key"
 add_secret_env_if_exists "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token"
 add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-prompt-v1"
 add_secret_env_if_exists \
@@ -333,6 +338,16 @@ ENV_VARS=(
   "TR_SES_ALERT_FROM_NAME=TrustedRouter Alerts"
   "TR_SES_ALERT_CONFIGURATION_SET=trustedrouter-alerts"
   "TR_SUPPORT_EMAIL=help@trustedrouter.com"
+  # Adyen ships dark. Activating checkout is an intentional one-line release
+  # after the merchant, HMAC webhook, and test-payment canary are green.
+  "TR_ADYEN_ENABLED=false"
+  "TR_ADYEN_ENVIRONMENT=test"
+  "TR_ADYEN_MERCHANT_ACCOUNT=TrustedRouterUS"
+  "TR_ADYEN_CHECKOUT_API_VERSION=72"
+  "TR_ADYEN_WEB_VERSION=6.41.0"
+  # Replace these zeros with the signed Adyen commercial terms before launch.
+  "TR_ADYEN_CARD_FEE_BASIS_POINTS=0"
+  "TR_ADYEN_CARD_FEE_FIXED_CENTS=0"
   "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com,https://b.trustedrouter.com,https://c.allyrouter.com"
   # /trustedos partner-inquiry form leads. Plain env (an address, not a
   # secret); without it the handler falls back to TR_SES_FROM_EMAIL, which

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -251,6 +251,10 @@ grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"
 grant_tr_deploy_secret_access "trustedrouter-engy-api-key"
 grant_tr_deploy_secret_access "trustedrouter-zero-g-api-key"
 grant_tr_deploy_secret_access "trustedrouter-clickhouse-control-read-password"
+grant_tr_deploy_secret_access "trustedrouter-adyen-test-api-key"
+grant_tr_deploy_secret_access "trustedrouter-adyen-test-client-key"
+grant_tr_deploy_secret_access "trustedrouter-adyen-test-hmac-key"
+grant_tr_deploy_secret_access "trustedrouter-adyen-test-reference-key"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,
@@ -280,6 +284,11 @@ ensure_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-ac
 ensure_secret_from_env_file "PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
 ensure_secret_from_env_file "PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
 ensure_secret_from_env_file "PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
+ensure_secret_from_env_file "ADYEN_API_KEY" "trustedrouter-adyen-test-api-key"
+ensure_secret_from_env_file "ADYEN_CLIENT_KEY" "trustedrouter-adyen-test-client-key"
+ensure_secret_from_env_file "ADYEN_HMAC_KEY" "trustedrouter-adyen-test-hmac-key"
+ensure_secret_from_env_file \
+  "ADYEN_REFERENCE_KEY" "trustedrouter-adyen-test-reference-key"
 if ! gc secrets describe trustedrouter-internal-gateway-token >/dev/null 2>&1; then
   ensure_secret_value trustedrouter-internal-gateway-token "$(python3 - <<'PY'
 import secrets

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -269,6 +269,24 @@ class Settings(BaseSettings):
     paypal_client_secret: str | None = None
     paypal_webhook_id: str | None = None
     paypal_api_base_url: str = "https://api-m.paypal.com"
+    # Adyen is staged dark until the test merchant, HMAC webhook, and end-to-end
+    # checkout canary are all green. Keep checkout enablement separate from
+    # credentials so late webhooks remain verifiable after an operator disables
+    # new Adyen sessions.
+    adyen_enabled: bool = False
+    adyen_api_key: str | None = None
+    adyen_client_key: str | None = None
+    adyen_hmac_key: str | None = None
+    adyen_reference_key: str | None = None
+    adyen_merchant_account: str | None = None
+    adyen_environment: str = "test"
+    adyen_live_endpoint_prefix: str | None = None
+    adyen_checkout_api_version: int = 72
+    adyen_web_version: str = "6.41.0"
+    # Keep processor pricing explicit. The test deployment leaves this at zero;
+    # production must use the rates from the signed Adyen agreement.
+    adyen_card_fee_basis_points: int = 0
+    adyen_card_fee_fixed_cents: int = 0
     bootstrap_management_key: str | None = None
     byok_kms_key_name: str | None = None
     byok_envelope_key_b64: str | None = None
@@ -650,6 +668,43 @@ class Settings(BaseSettings):
             )
         if self.x402_allow_mock_payments and environment not in {"local", "test"}:
             raise ValueError("TR_X402_ALLOW_MOCK_PAYMENTS is only allowed in local/test")
+        if self.adyen_environment not in {"test", "live"}:
+            raise ValueError("TR_ADYEN_ENVIRONMENT must be test or live")
+        if not 0 <= self.adyen_card_fee_basis_points < 10_000:
+            raise ValueError("TR_ADYEN_CARD_FEE_BASIS_POINTS must be between 0 and 9999")
+        if self.adyen_card_fee_fixed_cents < 0:
+            raise ValueError("TR_ADYEN_CARD_FEE_FIXED_CENTS cannot be negative")
+        if not 1 <= self.adyen_checkout_api_version <= 999:
+            raise ValueError("TR_ADYEN_CHECKOUT_API_VERSION must be between 1 and 999")
+        if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", self.adyen_web_version):
+            raise ValueError("TR_ADYEN_WEB_VERSION must be an exact semantic version")
+        if self.adyen_hmac_key:
+            try:
+                adyen_hmac_bytes = bytes.fromhex(self.adyen_hmac_key)
+            except ValueError as exc:
+                raise ValueError("TR_ADYEN_HMAC_KEY must be a hexadecimal key") from exc
+            if len(adyen_hmac_bytes) != 32:
+                raise ValueError("TR_ADYEN_HMAC_KEY must be exactly 32 bytes")
+        if self.adyen_reference_key and len(self.adyen_reference_key.encode("utf-8")) < 32:
+            raise ValueError("TR_ADYEN_REFERENCE_KEY must be at least 32 bytes")
+        if self.adyen_enabled:
+            missing_adyen = [
+                name
+                for name, value in (
+                    ("TR_ADYEN_API_KEY", self.adyen_api_key),
+                    ("TR_ADYEN_CLIENT_KEY", self.adyen_client_key),
+                    ("TR_ADYEN_HMAC_KEY", self.adyen_hmac_key),
+                    ("TR_ADYEN_REFERENCE_KEY", self.adyen_reference_key),
+                    ("TR_ADYEN_MERCHANT_ACCOUNT", self.adyen_merchant_account),
+                )
+                if not value
+            ]
+            if self.adyen_environment == "live" and not self.adyen_live_endpoint_prefix:
+                missing_adyen.append("TR_ADYEN_LIVE_ENDPOINT_PREFIX")
+            if missing_adyen:
+                raise ValueError(
+                    "TR_ADYEN_ENABLED requires " + ", ".join(missing_adyen)
+                )
         if (
             self.x402_enabled
             and environment not in {"local", "test"}
@@ -820,6 +875,26 @@ class Settings(BaseSettings):
         return bool(self.paypal_client_id and self.paypal_client_secret)
 
     @property
+    def adyen_checkout_ready(self) -> bool:
+        return bool(
+            self.adyen_enabled
+            and self.adyen_api_key
+            and self.adyen_client_key
+            and self.adyen_hmac_key
+            and self.adyen_reference_key
+            and self.adyen_merchant_account
+            and (self.adyen_environment == "test" or self.adyen_live_endpoint_prefix)
+        )
+
+    @property
+    def adyen_webhook_ready(self) -> bool:
+        return bool(
+            self.adyen_hmac_key
+            and self.adyen_reference_key
+            and self.adyen_merchant_account
+        )
+
+    @property
     def regional_quota_lease_pilot_workspaces(self) -> frozenset[str]:
         return frozenset(
             workspace_id.strip()
@@ -887,6 +962,12 @@ _LOCAL_KEY_FALLBACKS: tuple[str, ...] = (
     "paypal_client_secret",
     "paypal_webhook_id",
     "paypal_api_base_url",
+    "adyen_api_key",
+    "adyen_client_key",
+    "adyen_hmac_key",
+    "adyen_reference_key",
+    "adyen_merchant_account",
+    "adyen_live_endpoint_prefix",
     "sentry_dsn",
     "bootstrap_management_key",
     "byok_kms_key_name",

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -14,6 +14,7 @@ from trusted_router.errors import api_error, deprecated
 from trusted_router.money import money_pair
 from trusted_router.routes.helpers import json_body
 from trusted_router.schemas import CheckoutRequest, X402FundingRequest, X402SettleRequest
+from trusted_router.services.adyen_billing import create_adyen_checkout_session
 from trusted_router.services.paypal_billing import (
     capture_paypal_order_for_workspace,
     create_paypal_checkout_session,
@@ -67,7 +68,14 @@ def register_billing_routes(router: APIRouter) -> None:
         return JSONResponse(
             {
                 "data": (
-                    create_paypal_checkout_session(
+                    create_adyen_checkout_session(
+                        body=body,
+                        workspace_id=workspace_id,
+                        customer_email=_checkout_customer_email(principal),
+                        settings=settings,
+                    )
+                    if body.payment_method == "adyen"
+                    else create_paypal_checkout_session(
                         body=body,
                         workspace_id=workspace_id,
                         customer_email=_checkout_customer_email(principal),
@@ -236,6 +244,9 @@ def _checkout_body_with_first_party_returns(
     if body.payment_method == "paypal":
         default_success = f"{origin}/billing/paypal/success"
         default_cancel = f"{origin}/billing/paypal/cancel"
+    elif body.payment_method == "adyen":
+        default_success = f"{origin}/billing/adyen/return"
+        default_cancel = f"{origin}/billing"
     else:
         default_success = f"{origin}/billing/success"
         default_cancel = f"{origin}/billing"

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -17,6 +17,12 @@ from trusted_router.auth import SettingsDep
 from trusted_router.domains import request_control_origin
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.schemas import CheckoutRequest
+from trusted_router.services.adyen_billing import (
+    ADYEN_WEB_CSS_SRI,
+    ADYEN_WEB_JS_SRI,
+    adyen_web_asset_urls,
+    create_adyen_checkout_session,
+)
 from trusted_router.services.paypal_billing import (
     capture_paypal_order_for_workspace,
     create_paypal_checkout_session,
@@ -81,6 +87,7 @@ def register(app: FastAPI) -> None:
             last_auto_refill_at=credit.last_auto_refill_at if credit else None,
             last_auto_refill_status=credit.last_auto_refill_status if credit else None,
             paypal_enabled=settings.paypal_enabled or settings.environment.lower() in {"local", "test"},
+            adyen_enabled=settings.adyen_checkout_ready,
             payments=payments,
             saved_payment_method=saved_payment_method,
             api_base_url=ctx.api_base_url,
@@ -99,11 +106,12 @@ def register(app: FastAPI) -> None:
         payment_method: str = Form("auto"),
     ) -> Response:
         origin = request_control_origin(request, settings)
-        success_url = (
-            f"{origin}/console/credits/paypal/capture"
-            if payment_method == "paypal"
-            else f"{origin}/console/credits?checkout=success"
-        )
+        if payment_method == "paypal":
+            success_url = f"{origin}/console/credits/paypal/capture"
+        elif payment_method == "adyen":
+            success_url = f"{origin}/console/credits?checkout=processing"
+        else:
+            success_url = f"{origin}/console/credits?checkout=success"
         try:
             # CheckoutRequest validates payment_method against the Literal
             # set; the cast just tells mypy that the form value will be
@@ -120,7 +128,16 @@ def register(app: FastAPI) -> None:
         credit = STORE.get_credit_account(ctx.workspace.id)
         try:
             data = (
-                create_paypal_checkout_session(
+                create_adyen_checkout_session(
+                    body=body,
+                    workspace_id=ctx.workspace.id,
+                    customer_email=(
+                        ctx.user.email if ctx.user.email and "@" in ctx.user.email else None
+                    ),
+                    settings=settings,
+                )
+                if body.payment_method == "adyen"
+                else create_paypal_checkout_session(
                     body=body,
                     workspace_id=ctx.workspace.id,
                     customer_email=ctx.user.email if ctx.user.email and "@" in ctx.user.email else None,
@@ -139,6 +156,36 @@ def register(app: FastAPI) -> None:
             return RedirectResponse(url="/console/credits?error=checkout_unavailable", status_code=303)
         if str(data.get("mode", "")).startswith("mock"):
             return RedirectResponse(url="/console/credits?checkout=mock", status_code=303)
+        if data.get("mode") == "adyen":
+            adyen_js_url, adyen_css_url = adyen_web_asset_urls(settings)
+            checkout_config = {
+                "clientKey": data["client_key"],
+                "environment": data["environment"],
+                "session": {"id": data["id"], "sessionData": data["session_data"]},
+                "successUrl": success_url,
+                "cancelUrl": f"{origin}/console/credits?checkout=cancel",
+            }
+            return HTMLResponse(
+                render(
+                    "console/adyen_checkout.html",
+                    settings=settings,
+                    ctx=ctx,
+                    active="credits",
+                    page_title="Adyen checkout",
+                    page_subtitle="Add prepaid credits with Adyen.",
+                    checkout_config=checkout_config,
+                    adyen_js_url=adyen_js_url,
+                    adyen_css_url=adyen_css_url,
+                    adyen_js_sri=ADYEN_WEB_JS_SRI,
+                    adyen_css_sri=ADYEN_WEB_CSS_SRI,
+                    amount_display=money(int(data["amount_microdollars"])),
+                    processing_fee_display=money(
+                        int(data["processing_fee_microdollars"])
+                    ),
+                    total_display=money(int(data["total_microdollars"])),
+                    api_base_url=ctx.api_base_url,
+                )
+            )
         return RedirectResponse(url=str(data["url"]), status_code=303)
 
     @app.get("/console/credits/paypal/capture")

--- a/src/trusted_router/routes/internal/__init__.py
+++ b/src/trusted_router/routes/internal/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from . import adyen as adyen
 from . import broadcast_queue as broadcast_queue
 from . import chat_browser_key as chat_browser_key
 from . import federation as federation
@@ -23,6 +24,7 @@ from . import webhook as webhook
 def register_internal_routes(router: APIRouter) -> None:
     webhook.register(router)
     paypal.register(router)
+    adyen.register(router)
     broadcast_queue.register(router)
     gateway.register(router)
     video_jobs.register(router)

--- a/src/trusted_router/routes/internal/adyen.py
+++ b/src/trusted_router/routes/internal/adyen.py
@@ -1,0 +1,52 @@
+"""HMAC-authenticated Adyen standard webhook receiver."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse
+
+from trusted_router.auth import SettingsDep
+from trusted_router.errors import api_error
+from trusted_router.services.adyen_billing import (
+    apply_adyen_notification,
+    notification_items,
+    prepare_adyen_notification,
+    verify_adyen_notification,
+)
+from trusted_router.types import ErrorType
+
+
+def register(router: APIRouter) -> None:
+    @router.post("/internal/adyen/webhook")
+    async def adyen_webhook(request: Request, settings: SettingsDep) -> PlainTextResponse:
+        raw = await request.body()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise api_error(400, "Invalid Adyen webhook JSON", ErrorType.BAD_REQUEST) from exc
+        if not isinstance(payload, dict):
+            raise api_error(400, "Invalid Adyen webhook payload", ErrorType.BAD_REQUEST)
+
+        items = notification_items(payload)
+        # Validate the whole batch before mutating anything. If one item is
+        # forged or malformed, Adyen can retry the batch without leaving a
+        # partially accepted payment behind.
+        for item in items:
+            verify_adyen_notification(item, settings)
+        live_value: Any = payload.get("live")
+        if isinstance(live_value, bool):
+            live = live_value
+        elif isinstance(live_value, str) and live_value.lower() in {"true", "false"}:
+            live = live_value.lower() == "true"
+        else:
+            raise api_error(400, "Invalid Adyen webhook environment", ErrorType.BAD_REQUEST)
+        prepared = [
+            prepare_adyen_notification(item, live=live, settings=settings)
+            for item in items
+        ]
+        for notification in prepared:
+            apply_adyen_notification(notification)
+        return PlainTextResponse("[accepted]")

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -54,6 +54,7 @@ class CheckoutRequest(_Lenient):
         "crypto",
         "usdc",
         "paypal",
+        "adyen",
     ] = "auto"
 
     @field_validator("amount")

--- a/src/trusted_router/services/adyen_billing.py
+++ b/src/trusted_router/services/adyen_billing.py
@@ -1,0 +1,490 @@
+"""Adyen Checkout Sessions and HMAC-verified prepaid credit fulfillment.
+
+Adyen is only a payment adapter. The typed TrustedRouter credit ledger remains
+the balance authority, and a successful verified AUTHORISATION webhook is the
+only operation in this module that can add credits.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from trusted_router.acquisition import record_credit_purchase
+from trusted_router.config import Settings
+from trusted_router.errors import api_error
+from trusted_router.money import dollars_to_cents, money_pair
+from trusted_router.schemas import CheckoutRequest
+from trusted_router.services.stripe_fees import ProcessingFee, processing_fee
+from trusted_router.storage import STORE
+from trusted_router.types import ErrorType
+
+log = logging.getLogger(__name__)
+
+ADYEN_WEB_JS_SRI = "sha384-B290qKFISOSRqrQlUy+IqPzFioaHcUn49xyVUlpEIqcSAt2+4bTkH0FOsICZ86o9"
+ADYEN_WEB_CSS_SRI = "sha384-QCE3u3lliHH3SEx30M8NEuDhvEGmFCtZl62YVSVWw84cYNt2NYYbVwd/KPaaaIQ9"
+
+_CHECKOUT_REFERENCE_RE = re.compile(
+    r"^(?P<unsigned>trc_(?P<workspace>[0-9a-f]{32})_"
+    r"(?P<credit>[1-9a-z][0-9a-z]{0,7})_"
+    r"(?P<charge>[1-9a-z][0-9a-z]{0,7})_(?P<nonce>[0-9a-f]{8}))_"
+    r"(?P<signature>[0-9a-f]{16})$"
+)
+_ADVERSE_EVENT_CODES = frozenset(
+    {
+        "CANCEL_OR_REFUND",
+        "CANCELLATION",
+        "CAPTURE_FAILED",
+        "CHARGEBACK",
+        "NOTIFICATION_OF_CHARGEBACK",
+        "NOTIFICATION_OF_FRAUD",
+        "REFUND",
+        "REFUND_FAILED",
+        "REFUNDED_REVERSED",
+        "SECOND_CHARGEBACK",
+        "TECHNICAL_CANCEL",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AdyenCreditResult:
+    event_code: str
+    psp_reference: str
+    workspace_id: str | None = None
+    amount_microdollars: int = 0
+    credited: bool = False
+    ignored: bool = False
+    manual_review: bool = False
+
+
+@dataclass(frozen=True)
+class AdyenCheckoutReference:
+    workspace_id: str
+    credit_amount_cents: int
+    charge_amount_cents: int
+
+
+@dataclass(frozen=True)
+class PreparedAdyenNotification:
+    result: AdyenCreditResult
+    merchant_reference: str | None = None
+    reference: AdyenCheckoutReference | None = None
+
+
+def create_adyen_checkout_session(
+    *,
+    body: CheckoutRequest,
+    workspace_id: str,
+    customer_email: str | None,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Create an embedded Adyen session without changing any balance."""
+    if not settings.adyen_checkout_ready:
+        raise api_error(400, "Adyen checkout is not configured", ErrorType.BAD_REQUEST)
+    if STORE.get_workspace(workspace_id) is None:
+        raise api_error(404, "Workspace not found", ErrorType.NOT_FOUND)
+
+    credit_amount_cents = dollars_to_cents(body.amount)
+    fee = processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=settings.adyen_card_fee_basis_points,
+        fixed_fee_cents=settings.adyen_card_fee_fixed_cents,
+    )
+    merchant_reference = _new_checkout_reference(
+        workspace_id=workspace_id,
+        credit_amount_cents=fee.credit_amount_cents,
+        charge_amount_cents=fee.charge_amount_cents,
+        reference_key=str(settings.adyen_reference_key),
+    )
+    return_url = body.success_url or (
+        f"https://{settings.trusted_domain}/console/credits?checkout=processing"
+    )
+    payload: dict[str, Any] = {
+        "amount": {"currency": "USD", "value": fee.charge_amount_cents},
+        "channel": "Web",
+        "countryCode": "US",
+        "lineItems": _checkout_line_items(fee),
+        "merchantAccount": settings.adyen_merchant_account,
+        "mode": "embedded",
+        "reference": merchant_reference,
+        "returnUrl": return_url,
+        "shopperLocale": "en-US",
+        "shopperStatement": "TrustedRouter credits",
+    }
+    if customer_email:
+        payload["shopperEmail"] = customer_email
+
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.post(
+                _checkout_sessions_url(settings),
+                headers={
+                    "Content-Type": "application/json",
+                    "Idempotency-Key": str(uuid.uuid4()),
+                    "X-API-Key": str(settings.adyen_api_key),
+                },
+                json=payload,
+            )
+    except httpx.HTTPError as exc:
+        raise api_error(
+            503,
+            "Adyen checkout is temporarily unavailable",
+            ErrorType.SERVICE_UNAVAILABLE,
+        ) from exc
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise api_error(
+            502,
+            "Adyen returned an invalid response",
+            ErrorType.INTERNAL_ERROR,
+        ) from exc
+    if response.is_error:
+        _raise_adyen_checkout_error(response.status_code, data)
+    if not isinstance(data, dict):
+        raise api_error(502, "Adyen returned an invalid response", ErrorType.INTERNAL_ERROR)
+    session_id = data.get("id")
+    session_data = data.get("sessionData")
+    if not isinstance(session_id, str) or not isinstance(session_data, str):
+        raise api_error(
+            502,
+            "Adyen returned an incomplete checkout session",
+            ErrorType.INTERNAL_ERROR,
+        )
+    return {
+        "id": session_id,
+        "session_data": session_data,
+        "client_key": settings.adyen_client_key,
+        "environment": "test" if settings.adyen_environment == "test" else "live-us",
+        "workspace_id": workspace_id,
+        **money_pair("amount", fee.credit_amount_microdollars),
+        **money_pair("processing_fee", fee.processing_fee_microdollars),
+        **money_pair("total", fee.charge_amount_microdollars),
+        "mode": "adyen",
+    }
+
+
+def adyen_web_asset_urls(settings: Settings) -> tuple[str, str]:
+    environment = "test" if settings.adyen_environment == "test" else "live-us"
+    root = f"https://checkoutshopper-{environment}.cdn.adyen.com/checkoutshopper/sdk/{settings.adyen_web_version}"
+    return f"{root}/adyen.js", f"{root}/adyen.css"
+
+
+def notification_items(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    raw_items = payload.get("notificationItems")
+    if not isinstance(raw_items, list) or not raw_items:
+        raise api_error(400, "Invalid Adyen webhook payload", ErrorType.BAD_REQUEST)
+    items: list[Mapping[str, Any]] = []
+    for wrapper in raw_items:
+        if not isinstance(wrapper, Mapping):
+            raise api_error(400, "Invalid Adyen webhook payload", ErrorType.BAD_REQUEST)
+        item = wrapper.get("NotificationRequestItem")
+        if not isinstance(item, Mapping):
+            raise api_error(400, "Invalid Adyen webhook payload", ErrorType.BAD_REQUEST)
+        items.append(item)
+    return items
+
+
+def verify_adyen_notification(item: Mapping[str, Any], settings: Settings) -> None:
+    if not settings.adyen_webhook_ready or not settings.adyen_hmac_key:
+        raise api_error(
+            503,
+            "Adyen webhook verification is not configured",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    additional_data = item.get("additionalData")
+    if not isinstance(additional_data, Mapping):
+        raise api_error(400, "Invalid Adyen webhook signature", ErrorType.BAD_REQUEST)
+    received = additional_data.get("hmacSignature")
+    if not isinstance(received, str):
+        raise api_error(400, "Invalid Adyen webhook signature", ErrorType.BAD_REQUEST)
+    expected = adyen_notification_signature(item, settings.adyen_hmac_key)
+    if not hmac.compare_digest(received, expected):
+        raise api_error(400, "Invalid Adyen webhook signature", ErrorType.BAD_REQUEST)
+
+
+def adyen_notification_signature(item: Mapping[str, Any], hmac_key_hex: str) -> str:
+    amount = item.get("amount")
+    amount_mapping = amount if isinstance(amount, Mapping) else {}
+    values = (
+        item.get("pspReference"),
+        item.get("originalReference"),
+        item.get("merchantAccountCode"),
+        item.get("merchantReference"),
+        amount_mapping.get("value"),
+        amount_mapping.get("currency"),
+        item.get("eventCode"),
+        item.get("success"),
+    )
+    payload = ":".join(_escape_hmac_field(_string_field(value)) for value in values)
+    try:
+        key = bytes.fromhex(hmac_key_hex)
+    except ValueError as exc:
+        raise api_error(
+            503,
+            "Adyen webhook verification is misconfigured",
+            ErrorType.SERVICE_UNAVAILABLE,
+        ) from exc
+    if not key:
+        raise api_error(
+            503,
+            "Adyen webhook verification is misconfigured",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    digest = hmac.new(key, payload.encode("utf-8"), hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def credit_adyen_notification(
+    item: Mapping[str, Any],
+    *,
+    live: bool,
+    settings: Settings,
+) -> AdyenCreditResult:
+    """Validate and apply one HMAC-preverified webhook notification."""
+    prepared = prepare_adyen_notification(item, live=live, settings=settings)
+    return apply_adyen_notification(prepared)
+
+
+def prepare_adyen_notification(
+    item: Mapping[str, Any],
+    *,
+    live: bool,
+    settings: Settings,
+) -> PreparedAdyenNotification:
+    """Validate one item without mutating credits or other durable state."""
+    event_code = _required_string(item, "eventCode")
+    psp_reference = _required_string(item, "pspReference")
+    expected_live = settings.adyen_environment == "live"
+    if live != expected_live:
+        raise api_error(400, "Adyen webhook environment mismatch", ErrorType.BAD_REQUEST)
+    if item.get("merchantAccountCode") != settings.adyen_merchant_account:
+        raise api_error(400, "Adyen webhook merchant mismatch", ErrorType.BAD_REQUEST)
+
+    success = _string_field(item.get("success")).lower() == "true"
+    if event_code != "AUTHORISATION" or not success:
+        return PreparedAdyenNotification(
+            result=AdyenCreditResult(
+                event_code=event_code,
+                psp_reference=psp_reference,
+                ignored=True,
+                manual_review=event_code in _ADVERSE_EVENT_CODES,
+            )
+        )
+
+    merchant_reference = _required_string(item, "merchantReference")
+    reference = _parse_checkout_reference(
+        merchant_reference,
+        reference_key=str(settings.adyen_reference_key),
+    )
+    amount = item.get("amount")
+    if not isinstance(amount, Mapping):
+        raise api_error(400, "Adyen webhook amount is missing", ErrorType.BAD_REQUEST)
+    if amount.get("currency") != "USD":
+        raise api_error(400, "Adyen webhook currency mismatch", ErrorType.BAD_REQUEST)
+    value = amount.get("value")
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise api_error(400, "Adyen webhook amount is invalid", ErrorType.BAD_REQUEST)
+    if value != reference.charge_amount_cents:
+        raise api_error(400, "Adyen webhook amount mismatch", ErrorType.BAD_REQUEST)
+    if STORE.get_credit_account(reference.workspace_id) is None:
+        raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
+
+    return PreparedAdyenNotification(
+        result=AdyenCreditResult(
+            event_code=event_code,
+            psp_reference=psp_reference,
+            workspace_id=reference.workspace_id,
+            amount_microdollars=reference.credit_amount_cents * 10_000,
+        ),
+        merchant_reference=merchant_reference,
+        reference=reference,
+    )
+
+
+def apply_adyen_notification(
+    prepared: PreparedAdyenNotification,
+) -> AdyenCreditResult:
+    """Apply a fully validated notification to the typed credit ledger."""
+    result = prepared.result
+    if result.manual_review:
+        log.warning(
+            "adyen.payment_requires_manual_review",
+            extra={
+                "event": "adyen.payment_requires_manual_review",
+                "event_code": result.event_code,
+                "psp_reference_fingerprint": _fingerprint(result.psp_reference),
+            },
+        )
+    if prepared.reference is None or prepared.merchant_reference is None:
+        return result
+
+    credited = STORE.credit_workspace_typed_direct(
+        prepared.reference.workspace_id,
+        result.amount_microdollars,
+        f"adyen_checkout:{prepared.merchant_reference}",
+    )
+    if credited:
+        record_credit_purchase(
+            prepared.reference.workspace_id,
+            amount_microdollars=result.amount_microdollars,
+            payment_method="adyen",
+        )
+    return AdyenCreditResult(
+        event_code=result.event_code,
+        psp_reference=result.psp_reference,
+        workspace_id=result.workspace_id,
+        amount_microdollars=result.amount_microdollars,
+        credited=credited,
+    )
+
+
+def _checkout_sessions_url(settings: Settings) -> str:
+    version = settings.adyen_checkout_api_version
+    if settings.adyen_environment == "test":
+        return f"https://checkout-test.adyen.com/v{version}/sessions"
+    return (
+        f"https://{settings.adyen_live_endpoint_prefix}-checkout-live.adyenpayments.com"
+        f"/checkout/v{version}/sessions"
+    )
+
+
+def _checkout_line_items(fee: ProcessingFee) -> list[dict[str, Any]]:
+    items = [_line_item("credits", "TrustedRouter credits", fee.credit_amount_cents)]
+    if fee.processing_fee_cents:
+        items.append(
+            _line_item("processing-fee", "Payment processing fee", fee.processing_fee_cents)
+        )
+    return items
+
+
+def _line_item(item_id: str, description: str, amount_cents: int) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "description": description,
+        "quantity": 1,
+        "amountExcludingTax": amount_cents,
+        "amountIncludingTax": amount_cents,
+        "taxAmount": 0,
+        "taxPercentage": 0,
+    }
+
+
+def _new_checkout_reference(
+    *,
+    workspace_id: str,
+    credit_amount_cents: int,
+    charge_amount_cents: int,
+    reference_key: str,
+) -> str:
+    try:
+        canonical_workspace_id = str(uuid.UUID(workspace_id))
+    except ValueError as exc:
+        raise api_error(400, "Invalid workspace id", ErrorType.BAD_REQUEST) from exc
+    unsigned = (
+        f"trc_{uuid.UUID(canonical_workspace_id).hex}_"
+        f"{_base36(credit_amount_cents)}_{_base36(charge_amount_cents)}_"
+        f"{uuid.uuid4().hex[:8]}"
+    )
+    return f"{unsigned}_{_reference_signature(unsigned, reference_key)}"
+
+
+def _parse_checkout_reference(
+    reference: str, *, reference_key: str
+) -> AdyenCheckoutReference:
+    match = _CHECKOUT_REFERENCE_RE.fullmatch(reference)
+    if match is None:
+        raise api_error(400, "Invalid Adyen checkout reference", ErrorType.BAD_REQUEST)
+    expected = _reference_signature(match.group("unsigned"), reference_key)
+    if not hmac.compare_digest(match.group("signature"), expected):
+        raise api_error(400, "Invalid Adyen checkout reference", ErrorType.BAD_REQUEST)
+    return AdyenCheckoutReference(
+        workspace_id=str(uuid.UUID(hex=match.group("workspace"))),
+        credit_amount_cents=int(match.group("credit"), 36),
+        charge_amount_cents=int(match.group("charge"), 36),
+    )
+
+
+def _reference_signature(unsigned: str, reference_key: str) -> str:
+    if len(reference_key) < 32:
+        raise api_error(
+            503,
+            "Adyen checkout reference signing is misconfigured",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    return hmac.new(
+        reference_key.encode("utf-8"),
+        unsigned.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()[:16]
+
+
+def _base36(value: int) -> str:
+    if value <= 0:
+        raise ValueError("base36 value must be positive")
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    digits: list[str] = []
+    while value:
+        value, remainder = divmod(value, 36)
+        digits.append(alphabet[remainder])
+    return "".join(reversed(digits))
+
+
+def _raise_adyen_checkout_error(status_code: int, data: Any) -> None:
+    error_code = data.get("errorCode") if isinstance(data, Mapping) else None
+    message = data.get("message") if isinstance(data, Mapping) else None
+    if status_code == 422 and str(error_code) == "901":
+        raise api_error(
+            503,
+            "Adyen merchant account is not active",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    if status_code in {401, 403}:
+        raise api_error(503, "Adyen checkout is misconfigured", ErrorType.SERVICE_UNAVAILABLE)
+    if status_code == 429 or status_code >= 500:
+        raise api_error(
+            503,
+            "Adyen checkout is temporarily unavailable",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+    safe_message = "Adyen rejected the checkout request"
+    if isinstance(message, str) and message in {
+        "Invalid Merchant Account",
+        "No payment methods available",
+    }:
+        safe_message = message
+    raise api_error(400, safe_message, ErrorType.BAD_REQUEST)
+
+
+def _required_string(item: Mapping[str, Any], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value:
+        raise api_error(400, f"Adyen webhook {key} is missing", ErrorType.BAD_REQUEST)
+    return value
+
+
+def _string_field(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _escape_hmac_field(value: str) -> str:
+    return value.replace("\\", "\\\\").replace(":", "\\:")
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]

--- a/src/trusted_router/services/stripe_fees.py
+++ b/src/trusted_router/services/stripe_fees.py
@@ -1,4 +1,4 @@
-"""Integer-only Stripe processing-fee calculation and line-item shaping."""
+"""Integer-only payment processing-fee calculation and line-item shaping."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ PROCESSING_FEE_LINE_ITEM_NAME = "Payment processing fee"
 
 
 @dataclass(frozen=True)
-class StripeProcessingFee:
+class ProcessingFee:
     """A charge whose net principal remains the requested credit amount."""
 
     credit_amount_cents: int
@@ -106,13 +106,13 @@ class StripeProcessingFee:
         return metadata
 
 
-def stripe_processing_fee(
+def processing_fee(
     *,
     credit_amount_cents: int,
     variable_basis_points: int,
     fixed_fee_cents: int,
     max_fee_cents: int | None = None,
-) -> StripeProcessingFee:
+) -> ProcessingFee:
     """Gross up a USD-cent principal so it survives the configured fee.
 
     If the processor charges ``rate * total + fixed``, the total required
@@ -142,7 +142,7 @@ def stripe_processing_fee(
     else:
         charge_amount_cents = uncapped_charge_amount_cents
     processing_fee_cents = charge_amount_cents - credit_amount_cents
-    return StripeProcessingFee(
+    return ProcessingFee(
         credit_amount_cents=credit_amount_cents,
         processing_fee_cents=processing_fee_cents,
         charge_amount_cents=charge_amount_cents,
@@ -154,3 +154,8 @@ def stripe_processing_fee(
 
 def _ceil_div(numerator: int, denominator: int) -> int:
     return (numerator + denominator - 1) // denominator
+
+
+# Compatibility names for the existing Stripe billing adapter and SDK tests.
+StripeProcessingFee = ProcessingFee
+stripe_processing_fee = processing_fee

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -349,6 +349,12 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 .payment-method-card { display:flex; align-items:center; justify-content:space-between; gap:14px; flex-wrap:wrap; border:1px solid var(--line2); background:var(--panel2); border-radius:8px; padding:12px; margin:0 0 12px; }
 .payment-method-card strong { display:block; color:var(--ink); font-size:14px; margin-bottom:4px; }
 .payment-method-card span { display:block; color:var(--muted); font-size:12px; line-height:1.35; }
+.checkout-summary { display:grid; gap:8px; margin:0 0 16px; max-width:520px; }
+.checkout-summary > div { display:flex; align-items:baseline; justify-content:space-between; gap:20px; padding:8px 0; border-bottom:1px solid var(--line2); }
+.checkout-summary dt { color:var(--muted); font-size:14px; }
+.checkout-summary dd { margin:0; color:var(--ink); font-size:14px; font-variant-numeric:tabular-nums; }
+.checkout-summary .checkout-summary-total dt,
+.checkout-summary .checkout-summary-total dd { color:var(--ink); font-weight:700; }
 .signup-foot { color:var(--muted); font-size:13px; max-width:560px; margin:0 0 14px; }
 .signup-reveal { max-width:560px; border:1px solid var(--good-border); background:var(--good-bg); color:var(--green); border-radius:10px; padding:14px; margin:14px 0; display:grid; gap:10px; }
 .signup-reveal[hidden] { display:none; }

--- a/src/trusted_router/templates/console/adyen_checkout.html
+++ b/src/trusted_router/templates/console/adyen_checkout.html
@@ -1,0 +1,65 @@
+{% extends "console/_layout.html" %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ adyen_css_url }}" integrity="{{ adyen_css_sri }}" crossorigin="anonymous">
+{% endblock %}
+{% block scripts %}
+<script src="{{ adyen_js_url }}" integrity="{{ adyen_js_sri }}" crossorigin="anonymous"></script>
+<script id="adyen-checkout-config" type="application/json">{{ checkout_config | tojson }}</script>
+<script>
+  document.addEventListener("DOMContentLoaded", async function () {
+    const status = document.getElementById("adyen-checkout-status");
+    const root = document.getElementById("adyen-dropin");
+    const config = JSON.parse(document.getElementById("adyen-checkout-config").textContent);
+    try {
+      const { AdyenCheckout, Dropin } = window.AdyenWeb;
+      const checkout = await AdyenCheckout({
+        clientKey: config.clientKey,
+        environment: config.environment,
+        locale: "en-US",
+        countryCode: "US",
+        session: config.session,
+        onPaymentCompleted: function () {
+          window.location.assign(config.successUrl);
+        },
+        onPaymentFailed: function () {
+          window.location.assign(config.cancelUrl);
+        },
+        onError: function () {
+          status.hidden = false;
+          status.textContent = "Adyen could not complete checkout. No credits were added.";
+        }
+      });
+      new Dropin(checkout, {
+        paymentMethodsConfiguration: {
+          card: { hasHolderName: true, holderNameRequired: true }
+        }
+      }).mount(root);
+    } catch (error) {
+      status.hidden = false;
+      status.textContent = "Adyen checkout is temporarily unavailable. No credits were added.";
+      root.hidden = true;
+    }
+  });
+</script>
+{% endblock %}
+{% block body %}
+<section class="panel">
+  <div class="panel-head"><h2>Review and pay</h2></div>
+  <div class="panel-body">
+    <dl class="checkout-summary">
+      <div><dt>TrustedRouter credits</dt><dd>{{ amount_display }}</dd></div>
+      <div><dt>Payment processing fee</dt><dd>{{ processing_fee_display }}</dd></div>
+      <div class="checkout-summary-total"><dt>Total</dt><dd>{{ total_display }}</dd></div>
+    </dl>
+    <p class="form-help">
+      Credits are added only after Adyen confirms a successful payment.
+      Card details are collected directly by Adyen and do not pass through TrustedRouter.
+    </p>
+    <div id="adyen-checkout-status" class="notice warn" hidden></div>
+    <div id="adyen-dropin" aria-label="Adyen secure checkout"></div>
+    <div class="button-row" style="margin-top:16px">
+      <a class="btn" href="/console/credits?checkout=cancel">Cancel</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -21,6 +21,9 @@
             {% if paypal_enabled %}
             <option value="paypal">PayPal</option>
             {% endif %}
+            {% if adyen_enabled %}
+            <option value="adyen">Adyen</option>
+            {% endif %}
           </select>
         </label>
       </div>
@@ -44,7 +47,7 @@
   <div class="panel-body">
     <p style="color:var(--muted);font-size:14px;margin:0 0 14px">
       Save a Stripe card for auto refill. One-time credit purchases can use a
-      card, ACH bank account, PayPal, or USDC above.
+      card, ACH bank account, PayPal{% if adyen_enabled %}, Adyen{% endif %}, or USDC above.
       {% if payment_method_pending %}
       <br><strong>Stripe setup is pending. Auto-refill will unlock after Stripe confirms the card.</strong>
       {% endif %}

--- a/tests/test_adyen_billing.py
+++ b/tests/test_adyen_billing.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services import adyen_billing
+from trusted_router.services.adyen_billing import adyen_notification_signature
+from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
+
+HMAC_KEY = "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056"
+REFERENCE_KEY = "trustedrouter-test-reference-key-32-bytes-minimum"
+_HTTPX_CLIENT = httpx.Client
+
+
+def _settings(**overrides: Any) -> Settings:
+    values: dict[str, Any] = {
+        "environment": "test",
+        "adyen_enabled": True,
+        "adyen_api_key": "AQE_TEST_API_KEY",
+        "adyen_client_key": "test_CLIENT_KEY",
+        "adyen_hmac_key": HMAC_KEY,
+        "adyen_reference_key": REFERENCE_KEY,
+        "adyen_merchant_account": "TrustedRouterUS",
+        "adyen_environment": "test",
+        "sentry_dsn": None,
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def _http_client_factory(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> Callable[..., httpx.Client]:
+    def factory(*_args: Any, **_kwargs: Any) -> httpx.Client:
+        return _HTTPX_CLIENT(transport=httpx.MockTransport(handler))
+
+    return factory
+
+
+def _workspace_id(client: TestClient) -> str:
+    response = client.get(
+        "/v1/workspaces", headers={"x-trustedrouter-user": "adyen@example.com"}
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["data"][0]["id"])
+
+
+def _merchant_reference(
+    workspace_id: str, *, credit_cents: int = 500, charge_cents: int = 500
+) -> str:
+    return adyen_billing._new_checkout_reference(
+        workspace_id=workspace_id,
+        credit_amount_cents=credit_cents,
+        charge_amount_cents=charge_cents,
+        reference_key=REFERENCE_KEY,
+    )
+
+
+def _notification_item(
+    workspace_id: str,
+    *,
+    event_code: str = "AUTHORISATION",
+    success: str = "true",
+    psp_reference: str = "PSP000000000001",
+    merchant: str = "TrustedRouterUS",
+    currency: str = "USD",
+    value: int = 500,
+    merchant_reference: str | None = None,
+    hmac_key: str = HMAC_KEY,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "additionalData": {},
+        "amount": {"currency": currency, "value": value},
+        "eventCode": event_code,
+        "merchantAccountCode": merchant,
+        "merchantReference": merchant_reference or _merchant_reference(workspace_id),
+        "originalReference": "",
+        "pspReference": psp_reference,
+        "success": success,
+    }
+    item["additionalData"]["hmacSignature"] = adyen_notification_signature(
+        item, hmac_key
+    )
+    return item
+
+
+def _webhook_payload(*items: dict[str, Any], live: bool = False) -> dict[str, Any]:
+    return {
+        "live": "true" if live else "false",
+        "notificationItems": [
+            {"NotificationRequestItem": item} for item in items
+        ],
+    }
+
+
+def _credits(workspace_id: str) -> int:
+    summary = live_credit_summary(workspace_id)
+    assert summary is not None
+    return summary["total_credits"]
+
+
+def test_settings_keep_adyen_dark_and_fail_closed_when_enabled() -> None:
+    dark = Settings(environment="test")
+    assert dark.adyen_enabled is False
+    assert dark.adyen_checkout_ready is False
+    assert dark.adyen_webhook_ready is False
+
+    with pytest.raises(ValidationError, match="TR_ADYEN_API_KEY"):
+        Settings(environment="test", adyen_enabled=True)
+    with pytest.raises(ValidationError, match="TR_ADYEN_REFERENCE_KEY"):
+        _settings(adyen_reference_key=None)
+    with pytest.raises(ValidationError, match="TR_ADYEN_LIVE_ENDPOINT_PREFIX"):
+        _settings(adyen_environment="live")
+    with pytest.raises(ValidationError, match="TR_ADYEN_ENVIRONMENT"):
+        _settings(adyen_environment="sandbox")
+    with pytest.raises(ValidationError, match="TR_ADYEN_HMAC_KEY"):
+        _settings(adyen_hmac_key="not-hex")
+    with pytest.raises(ValidationError, match="TR_ADYEN_HMAC_KEY"):
+        _settings(adyen_hmac_key="ab" * 31)
+    with pytest.raises(ValidationError, match="TR_ADYEN_REFERENCE_KEY"):
+        _settings(adyen_reference_key="too-short")
+
+
+def test_official_adyen_hmac_vector() -> None:
+    item = {
+        "additionalData": {},
+        "amount": {"value": 1130, "currency": "EUR"},
+        "pspReference": "7914073381342284",
+        "originalReference": "",
+        "merchantAccountCode": "TestMerchant",
+        "merchantReference": "TestPayment-1407325143704",
+        "eventCode": "AUTHORISATION",
+        "success": "true",
+    }
+    assert (
+        adyen_notification_signature(item, HMAC_KEY)
+        == "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="
+    )
+
+
+def test_adyen_checkout_session_has_exact_money_and_no_balance_side_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            201,
+            json={"id": "CS_TEST_1", "sessionData": "opaque_session_data"},
+        )
+
+    monkeypatch.setattr(
+        adyen_billing.httpx,
+        "Client",
+        _http_client_factory(handler),
+    )
+    app = create_app(
+        _settings(adyen_card_fee_basis_points=300, adyen_card_fee_fixed_cents=30),
+        init_observability=False,
+    )
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"x-trustedrouter-user": "adyen@example.com"},
+            json={"amount": "25.00", "payment_method": "adyen"},
+        )
+        after = _credits(workspace_id)
+
+    assert response.status_code == 201, response.text
+    data = response.json()["data"]
+    assert data["mode"] == "adyen"
+    assert data["id"] == "CS_TEST_1"
+    assert data["session_data"] == "opaque_session_data"
+    assert data["client_key"] == "test_CLIENT_KEY"
+    assert "AQE_TEST_API_KEY" not in response.text
+    assert after == before
+
+    request = captured["request"]
+    payload = captured["payload"]
+    assert str(request.url) == "https://checkout-test.adyen.com/v72/sessions"
+    assert request.headers["x-api-key"] == "AQE_TEST_API_KEY"
+    assert re.fullmatch(r"[0-9a-f-]{36}", request.headers["idempotency-key"])
+    assert payload["merchantAccount"] == "TrustedRouterUS"
+    assert "merchantOrderReference" not in payload
+    assert payload["reference"].startswith(
+        f"trc_{workspace_id.replace('-', '')}_1xg_"
+    )
+    assert len(payload["reference"]) <= 80
+    assert payload["amount"] == {"currency": "USD", "value": 2609}
+    assert [item["description"] for item in payload["lineItems"]] == [
+        "TrustedRouter credits",
+        "Payment processing fee",
+    ]
+    assert sum(item["amountIncludingTax"] for item in payload["lineItems"]) == 2609
+
+
+def test_adyen_inactive_merchant_is_a_retryable_checkout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={"errorCode": "901", "message": "Invalid Merchant Account"},
+        )
+
+    monkeypatch.setattr(
+        adyen_billing.httpx, "Client", _http_client_factory(handler)
+    )
+    app = create_app(_settings(), init_observability=False)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"x-trustedrouter-user": "adyen@example.com"},
+            json={"amount": 5, "payment_method": "adyen"},
+        )
+    assert response.status_code == 503
+    assert response.json()["error"]["message"] == (
+        "Adyen merchant account is not active"
+    )
+
+
+def test_adyen_checkout_cannot_be_requested_while_dark() -> None:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"x-trustedrouter-user": "adyen@example.com"},
+            json={"amount": 5, "payment_method": "adyen"},
+        )
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Adyen checkout is not configured"
+
+
+@pytest.mark.parametrize(
+    ("handler", "expected_status"),
+    [
+        (lambda _request: httpx.Response(201, json={}), 502),
+        (
+            lambda request: (_ for _ in ()).throw(
+                httpx.ConnectError("offline", request=request)
+            ),
+            503,
+        ),
+    ],
+)
+def test_adyen_checkout_fails_closed_on_bad_or_unreachable_session_response(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+    expected_status: int,
+) -> None:
+    monkeypatch.setattr(
+        adyen_billing.httpx, "Client", _http_client_factory(handler)
+    )
+    app = create_app(_settings(), init_observability=False)
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"x-trustedrouter-user": "adyen@example.com"},
+            json={"amount": 5, "payment_method": "adyen"},
+        )
+    assert response.status_code == expected_status
+
+
+def test_adyen_authorisation_credits_exactly_once() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        item = _notification_item(workspace_id)
+        first = client.post("/v1/internal/adyen/webhook", json=_webhook_payload(item))
+        second_item = _notification_item(
+            workspace_id,
+            psp_reference="PSP000000000002",
+            merchant_reference=str(item["merchantReference"]),
+        )
+        second = client.post(
+            "/v1/internal/adyen/webhook", json=_webhook_payload(second_item)
+        )
+        after = _credits(workspace_id)
+
+    assert first.status_code == 200
+    assert first.text == "[accepted]"
+    assert second.status_code == 200
+    assert after - before == 5_000_000
+
+
+def test_adyen_webhook_remains_available_when_checkout_is_dark_but_needs_hmac() -> None:
+    missing_hmac = _settings(
+        adyen_enabled=False,
+        adyen_hmac_key=None,
+    )
+    app = create_app(missing_hmac, init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        response = client.post(
+            "/v1/internal/adyen/webhook",
+            json=_webhook_payload(_notification_item(workspace_id)),
+        )
+    assert response.status_code == 503
+    assert "verification is not configured" in response.text
+
+
+def test_adyen_signed_but_unissued_reference_cannot_credit() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        issued = _merchant_reference(workspace_id)
+        forged = f"{issued.rsplit('_', 1)[0]}_0000000000000000"
+        item = _notification_item(workspace_id, merchant_reference=forged)
+        response = client.post(
+            "/v1/internal/adyen/webhook", json=_webhook_payload(item)
+        )
+        assert _credits(workspace_id) == before
+    assert response.status_code == 400
+    assert "checkout reference" in response.text
+
+
+def test_adyen_failed_authorisation_and_adverse_event_never_mutate_balance() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        failed = _notification_item(workspace_id, success="false")
+        chargeback = _notification_item(
+            workspace_id,
+            event_code="CHARGEBACK",
+            psp_reference="PSP000000000003",
+        )
+        assert client.post(
+            "/v1/internal/adyen/webhook", json=_webhook_payload(failed)
+        ).status_code == 200
+        assert client.post(
+            "/v1/internal/adyen/webhook", json=_webhook_payload(chargeback)
+        ).status_code == 200
+        assert _credits(workspace_id) == before
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_message"),
+    [
+        (lambda item: item.update(merchantAccountCode="WrongMerchant"), "merchant mismatch"),
+        (lambda item: item["amount"].update(currency="EUR"), "currency mismatch"),
+        (lambda item: item["amount"].update(value=501), "amount mismatch"),
+    ],
+)
+def test_adyen_webhook_rejects_mismatched_payment_claims(
+    mutation: Callable[[dict[str, Any]], None],
+    expected_message: str,
+) -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        item = _notification_item(workspace_id)
+        mutation(item)
+        item["additionalData"]["hmacSignature"] = adyen_notification_signature(
+            item, HMAC_KEY
+        )
+        response = client.post(
+            "/v1/internal/adyen/webhook", json=_webhook_payload(item)
+        )
+        assert _credits(workspace_id) == before
+    assert response.status_code == 400
+    assert expected_message in response.text
+
+
+def test_adyen_webhook_rejects_live_test_mismatch() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        response = client.post(
+            "/v1/internal/adyen/webhook",
+            json=_webhook_payload(_notification_item(workspace_id), live=True),
+        )
+    assert response.status_code == 400
+    assert "environment mismatch" in response.text
+
+
+def test_adyen_batch_is_preverified_before_any_credit() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        valid = _notification_item(workspace_id)
+        forged = _notification_item(
+            workspace_id,
+            psp_reference="PSP000000000004",
+            merchant_reference=_merchant_reference(
+                workspace_id, credit_cents=700, charge_cents=700
+            ),
+            value=700,
+        )
+        forged["additionalData"]["hmacSignature"] = "forged"
+        response = client.post(
+            "/v1/internal/adyen/webhook",
+            json=_webhook_payload(valid, forged),
+        )
+        assert _credits(workspace_id) == before
+    assert response.status_code == 400
+    assert "signature" in response.text
+
+
+def test_adyen_batch_is_fully_validated_before_any_credit() -> None:
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        before = _credits(workspace_id)
+        valid = _notification_item(workspace_id)
+        invalid_amount = _notification_item(
+            workspace_id,
+            psp_reference="PSP000000000005",
+            merchant_reference=_merchant_reference(
+                workspace_id, credit_cents=700, charge_cents=700
+            ),
+            value=701,
+        )
+        response = client.post(
+            "/v1/internal/adyen/webhook",
+            json=_webhook_payload(valid, invalid_amount),
+        )
+        assert _credits(workspace_id) == before
+    assert response.status_code == 400
+    assert "amount mismatch" in response.text
+
+
+def test_adyen_console_is_hidden_until_ready_and_embeds_pinned_dropin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disabled_app = create_app(Settings(environment="test"), init_observability=False)
+    with TestClient(disabled_app) as disabled_client:
+        user = STORE.ensure_user("console-adyen@example.com")
+        raw_token, _ = STORE.create_auth_session(
+            user_id=user.id,
+            provider="email",
+            label=user.email,
+            ttl_seconds=3600,
+            state="active",
+        )
+        disabled_client.cookies.set("tr_session", raw_token)
+        page = disabled_client.get("/console/credits")
+        assert page.status_code == 200
+        assert '<option value="adyen">' not in page.text
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={"id": "CS_CONSOLE", "sessionData": "console_session_data"},
+        )
+
+    monkeypatch.setattr(
+        adyen_billing.httpx, "Client", _http_client_factory(handler)
+    )
+    enabled_app = create_app(_settings(), init_observability=False)
+    with TestClient(enabled_app) as enabled_client:
+        user = STORE.ensure_user("console-adyen@example.com")
+        raw_token, _ = STORE.create_auth_session(
+            user_id=user.id,
+            provider="email",
+            label=user.email,
+            ttl_seconds=3600,
+            state="active",
+        )
+        enabled_client.cookies.set("tr_session", raw_token)
+        page = enabled_client.get("/console/credits")
+        assert '<option value="adyen">Adyen</option>' in page.text
+        checkout = enabled_client.post(
+            "/console/credits/checkout",
+            data={"amount": "25", "payment_method": "adyen"},
+        )
+
+    assert checkout.status_code == 200
+    assert "checkoutshopper-test.cdn.adyen.com" in checkout.text
+    assert adyen_billing.ADYEN_WEB_JS_SRI in checkout.text
+    assert adyen_billing.ADYEN_WEB_CSS_SRI in checkout.text
+    assert "console_session_data" in checkout.text
+    assert "test_CLIENT_KEY" in checkout.text
+    assert "AQE_TEST_API_KEY" not in checkout.text
+    assert "Payment processing fee" in checkout.text
+    assert "onPaymentFailed" in checkout.text
+    assert "const { AdyenCheckout, Dropin }" in checkout.text


### PR DESCRIPTION
## Summary
- add Adyen Checkout Sessions with embedded Web v6 Drop-in
- verify standard webhooks with Adyen HMAC plus a separate server-issued reference signature
- credit the existing typed ledger exactly once after successful AUTHORISATION
- add dark rollout configuration, Secret Manager plumbing, readiness tooling, and operator docs

## Safety
- production remains TR_ADYEN_ENABLED=false
- checkout does not mutate credits
- late webhooks remain verifiable while checkout is disabled
- refund/chargeback events never silently debit customer balances

## Verification
- 2994 tests passed, 223 skipped, 10 expected failures
- coverage 83.65% (70% gate)
- 18 focused Adyen tests
- ruff, mypy, TypeScript, ESLint, Stylelint, shell syntax, and Python compile pass
- non-charging Adyen readiness probe confirms credential, origin, and secrets; merchant activation remains the external blocker