### PR TITLE
azure: its own control plane, status page, and green leaderboard

### DIFF
--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Deploy the AZURE control plane: Container Apps (uaenorth) on Flexible Server.
+#
+# This is the Azure sibling of aws_eu_control_plane.sh, and it exists for the
+# same reason that one does: a cloud is not independent until it runs its OWN
+# control plane. The gateway can be perfect — attested, serving real TLS,
+# verified against SEV-SNP hardware — and the cloud still has nothing to say
+# about itself, because the synthetic monitor, the status page, and the
+# model/provider leaderboard all live in the control plane. Azure's enclave was
+# in exactly that state: healthy and invisible.
+#
+# THIS FILE IS THE SOURCE OF TRUTH FOR THE SERVICE ENV. The same rule the AWS
+# script learned the hard way (a runtime variable set out-of-band pointed the
+# monitor at the wrong host and painted a healthy cloud 50% degraded). Change
+# it here or not at all.
+#
+# WHAT DIFFERS FROM AWS, and why:
+#
+#   * TR_SYNTHETIC_CANONICAL_ATTESTED=false. The AWS enclave mints a
+#     self-signed cert inside the TEE, so its probes must skip CA validation
+#     and verify the attestation binding instead. The Azure enclave completes
+#     ACME inside the TEE and serves a publicly-trusted Let's Encrypt cert, so
+#     ordinary CA validation is not only possible but stronger — it proves the
+#     public chain AND the name.
+#
+#   * No PCR0. PCR0 is a Nitro EIF measurement. Azure's equivalent is the CCE
+#     policy hash carried in SEV-SNP HOST_DATA and attested through MAA, which
+#     needs its own probe shape (issuer pin + expected hostdata). Until that
+#     probe exists, this deployment publishes only the components it can
+#     actually measure — see components.py; a component whose probe cannot run
+#     must be ABSENT, never green.
+#
+#   * DATABASE. Flexible Server, not Citus. docs/storage-portability/
+#     multi-cloud-separation.md recommends Cosmos DB for PostgreSQL for a
+#     production Azure region because Citus distributes by workspace_id, and
+#     that recommendation stands for scale. This plane starts on plain
+#     Flexible Server because PostgresStore passes conformance against stock
+#     Postgres and the sharding behaviour is not what gates independence.
+#     Re-validate on Citus with the conformance suite before trusting it with
+#     production write volume.
+#
+# Prerequisite: scripts/deploy/azure_canary.sh has provisioned the resource
+# group, Flexible Server, ACR and Container Apps environment (CANARY=tr-azure
+# LOCATION=uaenorth APP_LOCATION=uaenorth).
+set -euo pipefail
+
+STACK="${STACK:-tr-azure}"
+RG="${RG:-$STACK}"
+LOCATION="${LOCATION:-uaenorth}"
+APP="${APP:-$STACK}"
+APP_ENV="${APP_ENV:-$STACK-env}"
+PG_NAME="${PG_NAME:-$STACK-pg}"
+PG_ADMIN="${PG_ADMIN:-tradmin}"
+PG_DB="${PG_DB:-trustedrouter}"
+ACR="${ACR:-$(echo "${STACK}${LOCATION}acr" | tr -cd "[:alnum:]")}"
+IMAGE_TAG="${IMAGE_TAG:-azure}"
+STATE_DIR="${STATE_DIR:-$HOME/.config/$STACK}"
+PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
+
+# The attested Azure gateway this control plane fronts, and the health host the
+# status page is published under.
+API_BASE_URL="${API_BASE_URL:-https://api-azure.trustedrouter.com/v1}"
+STATUS_HOST="${STATUS_HOST:-https://azure.trustedrouter.com}"
+# Per-enclave probe target. Same reasoning as the AWS script's raw NLB names:
+# connect to the group directly while SNI/Host stay api-azure.trustedrouter.com,
+# so one dead region cannot hide behind a shared name. The NAME is what binds
+# this endpoint to its public status component in synthetic/components.py —
+# renaming one without the other silently unpublishes it.
+GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io}"
+
+# Secrets resolved from the operator's own files, exactly like every other
+# cloud (quill-cloud-proxy tools/quill_secret_sources.py). No cloud reads
+# another cloud's secret store — that would make one cloud a hub the others
+# need in order to be PROVISIONED.
+KEYS_FILE="${KEYS_FILE:-$HOME/.quill_cloud_keys.private}"
+SECRETS_DIR="${SECRETS_DIR:-$HOME/.quill-secrets}"
+
+# Federation + deferred settlement. Identity federates from the GCP home plane
+# (a peer token grants directory reads only); credits do not. Deferred
+# settlement stays OFF until its token is present AND explicitly enabled.
+FEDERATION_HOME_BASE_URL="${FEDERATION_HOME_BASE_URL:-https://trustedrouter.com}"
+DEFERRED_SETTLEMENT_ENABLED="${DEFERRED_SETTLEMENT_ENABLED:-false}"
+
+log() { printf '\n=== %s\n' "$*" >&2; }
+exists() { "$@" >/dev/null 2>&1; }
+die() { echo "[FAIL] $*" >&2; exit 1; }
+
+read_secret() {
+  # A file in the secrets dir wins; otherwise the env file's own name.
+  local logical="$1" env_name="$2"
+  if [ -f "$SECRETS_DIR/$logical" ]; then
+    tr -d '\n' < "$SECRETS_DIR/$logical"
+    return 0
+  fi
+  python3 - "$KEYS_FILE" "$env_name" <<'PY'
+import re, sys
+from pathlib import Path
+path, name = Path(sys.argv[1]), sys.argv[2]
+if path.exists():
+    for line in path.read_text().splitlines():
+        m = re.match(rf"\s*(?:export\s+)?{re.escape(name)}\s*=\s*(.*)$", line)
+        if m:
+            raw = m.group(1).strip()
+            if raw[:1] in ("'", '"') and raw[-1:] == raw[:1]:
+                raw = raw[1:-1]
+            sys.stdout.write(raw)
+            break
+PY
+}
+
+exists az containerapp env show -g "$RG" -n "$APP_ENV" \
+  || die "no Container Apps environment '$APP_ENV' in '$RG' — run: CANARY=$STACK LOCATION=$LOCATION APP_LOCATION=$LOCATION bash scripts/deploy/azure_canary.sh"
+
+PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" --query fullyQualifiedDomainName -o tsv)"
+ACR_SERVER="$(az acr show -g "$RG" -n "$ACR" --query loginServer -o tsv)"
+
+INTERNAL_TOKEN="$(read_secret trustedrouter-internal-gateway-token TR_INTERNAL_GATEWAY_TOKEN)"
+MONITOR_KEY="$(read_secret trustedrouter-synthetic-monitor-api-key TR_SYNTHETIC_MONITOR_API_KEY)"
+FEDERATION_TOKEN="$(read_secret trustedrouter-federation-peer-token TR_FEDERATION_PEER_TOKEN)"
+SETTLEMENT_TOKEN="$(read_secret trustedrouter-federation-settlement-token-azure-uae UNSET_ON_PURPOSE)"
+[ -n "$INTERNAL_TOKEN" ] || die "no internal gateway token in $SECRETS_DIR or $KEYS_FILE"
+[ -n "$MONITOR_KEY" ] || die "no synthetic monitor key: the leaderboard cannot run without it"
+# The monitor key is what makes the leaderboard green: rotation calls the
+# gateway as a CUSTOMER of itself. Without it there is a status page with no
+# model rows, which reads as "no data" rather than "not measured".
+
+if [ -z "$SETTLEMENT_TOKEN" ] || [ "$DEFERRED_SETTLEMENT_ENABLED" != "true" ]; then
+  log "deferred settlement OFF (token present: $([ -n "$SETTLEMENT_TOKEN" ] && echo yes || echo no))"
+  DEFERRED_SETTLEMENT_ENABLED="false"
+fi
+
+if exists az containerapp show -g "$RG" -n "$APP"; then
+  PG_PASSWORD="$(az containerapp secret show -g "$RG" -n "$APP" --secret-name pg-password --query value -o tsv)"
+else
+  [ -f "$PW_FILE" ] || die "no database password at $PW_FILE — azure_canary.sh writes it"
+  PG_PASSWORD="$(cat "$PW_FILE")"
+fi
+DSN="postgresql://${PG_ADMIN}:${PG_PASSWORD}@${PG_HOST}:5432/${PG_DB}?sslmode=require"
+
+log "building linux/amd64 image in ACR ${ACR}"
+az acr build --registry "$ACR" --platform linux/amd64 \
+  --image "trusted-router:${IMAGE_TAG}" . >/dev/null
+
+# Deploy by DIGEST, not tag. Container Apps keys "did the source change?" off
+# the image reference string; with a mutable tag the string is constant, so a
+# revision can come up RUNNING with new env and OLD CODE. The AWS script
+# carries the same rule for the same reason — it cost a full verification
+# cycle chasing a "deployed" fix that was never running.
+IMAGE_DIGEST="$(az acr repository show-manifests --name "$ACR" --repository trusted-router \
+  --query "[?tags[?@=='${IMAGE_TAG}']].digest | [0]" -o tsv 2>/dev/null || true)"
+[ -n "$IMAGE_DIGEST" ] && [ "$IMAGE_DIGEST" != "None" ] \
+  || die "could not resolve trusted-router:${IMAGE_TAG} to a digest"
+IMAGE_REF="${ACR_SERVER}/trusted-router@${IMAGE_DIGEST}"
+log "deploying by digest: ${IMAGE_DIGEST}"
+
+ENV_VARS=(
+  "TR_ENVIRONMENT=canary"
+  "TR_RELEASE=${IMAGE_TAG}"
+  "TR_STORAGE_BACKEND=postgres"
+  "TR_POSTGRES_DSN=secretref:pg-dsn"
+  "TR_ENABLE_LIVE_PROVIDERS=false"
+  "TR_TRUSTED_DOMAIN=trustedrouter.com"
+
+  "TR_API_BASE_URL=${API_BASE_URL}"
+  "TR_PRIMARY_REGION=${LOCATION}"
+  "TR_REGIONS=${LOCATION}"
+
+  "TR_SYNTHETIC_MONITOR_REGION=${LOCATION}"
+  # FALSE, unlike AWS: this enclave completes ACME inside the TEE and serves a
+  # publicly-trusted cert, so ordinary CA validation applies.
+  "TR_SYNTHETIC_CANONICAL_ATTESTED=false"
+  "TR_SYNTHETIC_REGIONAL_PROBES_ENABLED=false"
+  "TR_SYNTHETIC_GATEWAY_REGION_TARGETS=${GATEWAY_REGION_TARGETS}"
+  "TR_SYNTHETIC_IMAGE_PROBE_ENABLED=false"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${STATUS_HOST}"
+  # The authorize/settle dependency this gateway ACTUALLY has today is the GCP
+  # plane (QUILL_TR_CONTROL_PLANE_BASE_URL in qcp tools/deploy-azure-aci.sh).
+  # The billing probe must measure the real dependency, not the intended one.
+  # Flip this and the enclave's own env together, never separately.
+  "TR_SYNTHETIC_CONTROL_PLANE_BASE_URL=https://trustedrouter.com"
+
+  "TR_FEDERATION_HOME_BASE_URL=${FEDERATION_HOME_BASE_URL}"
+  "TR_FEDERATION_DEFERRED_SETTLEMENT_ENABLED=${DEFERRED_SETTLEMENT_ENABLED}"
+
+  "TR_INTERNAL_GATEWAY_TOKEN=secretref:internal-token"
+  "TR_SYNTHETIC_MONITOR_API_KEY=secretref:monitor-key"
+  "TR_FEDERATION_HOME_TOKEN=secretref:federation-token"
+)
+SECRET_ARGS=(
+  "pg-password=${PG_PASSWORD}"
+  "pg-dsn=${DSN}"
+  "internal-token=${INTERNAL_TOKEN}"
+  "monitor-key=${MONITOR_KEY}"
+  "federation-token=${FEDERATION_TOKEN}"
+)
+if [ "$DEFERRED_SETTLEMENT_ENABLED" = "true" ]; then
+  ENV_VARS+=("TR_FEDERATION_SETTLEMENT_HOME_TOKEN=secretref:settlement-token")
+  SECRET_ARGS+=("settlement-token=${SETTLEMENT_TOKEN}")
+fi
+
+if exists az containerapp show -g "$RG" -n "$APP"; then
+  log "updating $APP"
+  az containerapp secret set -g "$RG" -n "$APP" --secrets "${SECRET_ARGS[@]}" -o none
+  az containerapp update -g "$RG" -n "$APP" \
+    --image "$IMAGE_REF" --set-env-vars "${ENV_VARS[@]}" -o none
+else
+  log "creating $APP"
+  ACR_USER="$(az acr credential show -n "$ACR" --query username -o tsv)"
+  ACR_PASS="$(az acr credential show -n "$ACR" --query 'passwords[0].value' -o tsv)"
+  az containerapp create -g "$RG" -n "$APP" \
+    --environment "$APP_ENV" \
+    --image "$IMAGE_REF" \
+    --registry-server "$ACR_SERVER" \
+    --registry-username "$ACR_USER" \
+    --registry-password "$ACR_PASS" \
+    --secrets "${SECRET_ARGS[@]}" \
+    --env-vars "${ENV_VARS[@]}" \
+    --target-port 8080 --ingress external \
+    --min-replicas 1 --max-replicas 3 \
+    --cpu 1.0 --memory 2.0Gi -o none
+fi
+
+FQDN="$(az containerapp show -g "$RG" -n "$APP" --query properties.configuration.ingress.fqdn -o tsv)"
+log "app URL: https://${FQDN}"
+
+log "applying the schema (idempotent; every statement is IF NOT EXISTS)"
+az containerapp exec -g "$RG" -n "$APP" \
+  --command "python -c 'from trusted_router.storage import STORE; STORE.apply_schema(); print(\"schema ok\")'" \
+  2>/dev/null || log "NOTE: exec unavailable; run apply_schema manually or on first boot"
+
+log "DNS: point azure.trustedrouter.com at this app"
+if command -v gcloud >/dev/null 2>&1; then
+  CURRENT="$(gcloud dns record-sets describe azure.trustedrouter.com. \
+    --project "${DNS_PROJECT:-quill-cloud-proxy}" --zone "${DNS_ZONE:-trustedrouter-com}" \
+    --type CNAME --format 'value(rrdatas[0])' 2>/dev/null || true)"
+  if [ "$CURRENT" = "${FQDN}." ]; then
+    log "dns: azure.trustedrouter.com already -> ${FQDN}"
+  elif [ -n "$CURRENT" ]; then
+    gcloud dns record-sets update azure.trustedrouter.com. \
+      --project "${DNS_PROJECT:-quill-cloud-proxy}" --zone "${DNS_ZONE:-trustedrouter-com}" \
+      --type CNAME --ttl 300 --rrdatas "${FQDN}." >/dev/null
+    log "dns: reconciled azure.trustedrouter.com ${CURRENT} -> ${FQDN}."
+  else
+    gcloud dns record-sets create azure.trustedrouter.com. \
+      --project "${DNS_PROJECT:-quill-cloud-proxy}" --zone "${DNS_ZONE:-trustedrouter-com}" \
+      --type CNAME --ttl 300 --rrdatas "${FQDN}." >/dev/null
+    log "dns: created azure.trustedrouter.com -> ${FQDN}."
+  fi
+else
+  log "gcloud absent: point azure.trustedrouter.com CNAME at ${FQDN} yourself"
+fi
+
+cat >&2 <<NOTE
+
+=== next
+  status page   https://azure.trustedrouter.com/status.json
+  leaderboard   the first rotation pass populates model/provider rows; the
+                monitor calls api-azure.trustedrouter.com as a customer of
+                itself, so a red row means the ENCLAVE could not serve that
+                model — which is the whole point of measuring it here.
+  verify        bash scripts/deploy/verify_deployment.sh (cloud-agnostic)
+NOTE

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -131,6 +131,19 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
             "Paris enclave is healthy."
         ),
     },
+    # Azure. NAMED "GATEWAY" for the same reason as the AWS rows above, even
+    # though this one currently fronts a SINGLE container group: the name must
+    # not promise per-enclave granularity the probe cannot deliver, and a
+    # second replica or region would silently make an "Enclave" label a lie.
+    {
+        "id": "uaenorth_gateway",
+        "name": "UAE North Gateway (Dubai)",
+        "description": (
+            "Azure confidential container addressed directly: publicly-trusted "
+            "TLS minted inside the TEE and SEV-SNP attestation through MAA "
+            "from a healthy UAE North enclave behind it."
+        ),
+    },
     {
         "id": "attestation",
         "name": "Attestation",
@@ -167,6 +180,10 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
     # AWS EU control plane configures; nothing publishes them anywhere else.
     "eu_west_1_gateway": "eu-west-1",
     "eu_west_3_gateway": "eu-west-3",
+    # The Azure control plane's TR_SYNTHETIC_GATEWAY_REGION_TARGETS entry name
+    # (scripts/deploy/azure_control_plane.sh). Absent everywhere else, which is
+    # what keeps this row off the AWS and GCP status pages.
+    "uaenorth_gateway": "uaenorth",
     "attestation": "canonical",
     "billing_settlement": CONTROL_PLANE_TARGET,
     "provider_fallback": CONTROL_PLANE_TARGET,
@@ -183,7 +200,7 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
 #   * the overall headline must INCLUDE them, or "All Systems Operational"
 #     sits directly above a red region row.
 GATEWAY_REGION_COMPONENT_IDS: frozenset[str] = frozenset(
-    {"eu_west_1_gateway", "eu_west_3_gateway"}
+    {"eu_west_1_gateway", "eu_west_3_gateway", "uaenorth_gateway"}
 )
 # Their probe target names, derived from the map above so the two cannot
 # drift apart.
@@ -277,6 +294,8 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("eu_west_1_gateway")
     if sample.target == "eu-west-3" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_west_3_gateway")
+    if sample.target == "uaenorth" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
+        ids.append("uaenorth_gateway")
     # "Attestation" is a SHARED, service-wide row that predates the pinned
     # targets, and it is scoped to the addresses customers actually resolve.
     # Folding the pinned per-region probes in here averaged a public number

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -705,8 +705,19 @@ def test_blank_configuration_is_not_an_error() -> None:
     assert parse_gateway_region_targets("   ") == ()
 
 
-def _deploy_script_region_targets() -> str:
-    """The GATEWAY_REGION_TARGETS default the deploy script really ships.
+#: Every cloud that pins per-region gateway probes. One entry per control
+#: plane; the AWS and Azure scripts each own their own cloud's names, and the
+#: components module owns the union.
+REGION_TARGET_DEPLOY_SCRIPTS = (
+    "scripts/deploy/aws_eu_control_plane.sh",
+    "scripts/deploy/azure_control_plane.sh",
+)
+
+
+def _deploy_script_region_targets(
+    script_path: str = "scripts/deploy/aws_eu_control_plane.sh",
+) -> str:
+    """The GATEWAY_REGION_TARGETS default a deploy script really ships.
 
     Read out of the script rather than restated here. The previous version of
     this test asserted the two hostnames appeared SOMEWHERE in the file and
@@ -714,11 +725,17 @@ def _deploy_script_region_targets() -> str:
     claim: transposing the two hostnames in the script left every test green
     while the deployment published Ireland's health under Paris's name.
     """
-    script = Path(__file__).resolve().parents[1] / "scripts/deploy/aws_eu_control_plane.sh"
+    script = Path(__file__).resolve().parents[1] / script_path
     text = script.read_text()
     # The shell variable must still be the one wired into the setting, or the
-    # default below is dead text that configures nothing.
-    assert '"TR_SYNTHETIC_GATEWAY_REGION_TARGETS": "${GATEWAY_REGION_TARGETS}"' in text
+    # default below is dead text that configures nothing. Two spellings,
+    # because the clouds take env differently: App Runner is handed a JSON
+    # document, Container Apps a KEY=VALUE list.
+    wired = (
+        '"TR_SYNTHETIC_GATEWAY_REGION_TARGETS": "${GATEWAY_REGION_TARGETS}"' in text
+        or '"TR_SYNTHETIC_GATEWAY_REGION_TARGETS=${GATEWAY_REGION_TARGETS}"' in text
+    )
+    assert wired, f"{script_path} does not wire GATEWAY_REGION_TARGETS into the setting"
     match = re.search(
         r'^GATEWAY_REGION_TARGETS="\$\{GATEWAY_REGION_TARGETS:-([^}]*)\}"$',
         text,
@@ -747,10 +764,24 @@ def test_deploy_script_names_are_exactly_the_published_components() -> None:
 
     A configured name with no component is a probe whose samples appear on
     no public row at all — the enclave would be measured and the result
-    thrown away, which looks identical to not measuring it.
+    thrown away, which looks identical to not measuring it. A component with
+    no configured name is the mirror failure: a public row nothing can ever
+    populate.
+
+    The union is across CLOUDS. Each control plane configures only its own
+    cloud's endpoints (an AWS plane cannot reach an Azure container group),
+    so the assertion has to gather every deploy script rather than assume
+    one — which is exactly what it assumed while AWS was the only peer.
     """
-    entries = parse_gateway_region_targets(_deploy_script_region_targets())
-    assert {name for name, _ in entries} == set(GATEWAY_REGION_TARGET_NAMES)
+    configured: set[str] = set()
+    for script in REGION_TARGET_DEPLOY_SCRIPTS:
+        entries = parse_gateway_region_targets(_deploy_script_region_targets(script))
+        names = {name for name, _ in entries}
+        assert names, f"{script} configures no region targets"
+        overlap = configured & names
+        assert not overlap, f"{script} reuses target name(s) {overlap} from another cloud"
+        configured |= names
+    assert configured == set(GATEWAY_REGION_TARGET_NAMES)
 
 
 def test_a_name_that_contradicts_its_endpoints_region_is_rejected() -> None:


### PR DESCRIPTION
A cloud is not independent until it runs its own control plane. The Azure gateway has been attested and serving real TLS while saying **nothing about itself** — the synthetic monitor, status page, and model/provider leaderboard all live in the control plane, and Azure had none.

## What

`scripts/deploy/azure_control_plane.sh` — the Azure sibling of `aws_eu_control_plane.sh`, carrying both rules that one learned painfully: **this file is the source of truth for the service env** (an out-of-band variable once pointed the AWS monitor at the wrong host and painted a healthy cloud 50% degraded), and **deploy by digest** (a mutable tag lets a revision come up RUNNING with new env and old code). Container Apps on Flexible Server in uaenorth; secrets resolved from the operator's own files like every other cloud.

Two deliberate differences from AWS, both about measuring what's true:
- `CANONICAL_ATTESTED=false` — this enclave completes ACME *inside* the TEE and serves a publicly-trusted cert, so ordinary CA validation applies and is stronger.
- **No PCR0** — Azure's measurement is a CCE policy hash in SEV-SNP HOST_DATA attested through MAA, which needs its own probe (issuer + hostdata). Until that probe lands, the plane publishes only what it can measure.

The `uaenorth_gateway` status component is wired end-to-end, so the leaderboard populates on the first rotation pass. It's named GATEWAY, not ENCLAVE, for the same reason the AWS rows are — the name must not promise per-enclave granularity a load-balanced probe can't deliver.

## The test that caught the transition

`test_deploy_script_names_are_exactly_the_published_components` asserted one global set of region names — correct while AWS was the only peer, silently wrong the moment a second cloud owned names (each control plane configures only its own cloud's endpoints; an AWS plane can't reach an Azure container group). It now gathers **every** cloud's deploy script and additionally asserts no two clouds reuse a target name, which would merge two enclaves onto one public row.

Full suite green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)