### PR TITLE
azure: MAA nonce probe + in-process synthetic scheduler (status page goes green)

### DIFF
--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -80,6 +80,8 @@ SECRETS_DIR="${SECRETS_DIR:-$HOME/.quill-secrets}"
 # settlement stays OFF until its token is present AND explicitly enabled.
 FEDERATION_HOME_BASE_URL="${FEDERATION_HOME_BASE_URL:-https://trustedrouter.com}"
 DEFERRED_SETTLEMENT_ENABLED="${DEFERRED_SETTLEMENT_ENABLED:-false}"
+SYNTHETIC_INTERVAL_SECONDS="${SYNTHETIC_INTERVAL_SECONDS:-300}"
+SYNTHETIC_ROTATION_COUNT="${SYNTHETIC_ROTATION_COUNT:-8}"
 
 log() { printf '\n=== %s\n' "$*" >&2; }
 exists() { "$@" >/dev/null 2>&1; }
@@ -182,6 +184,20 @@ ENV_VARS=(
   "TR_FEDERATION_HOME_BASE_URL=${FEDERATION_HOME_BASE_URL}"
   "TR_FEDERATION_DEFERRED_SETTLEMENT_ENABLED=${DEFERRED_SETTLEMENT_ENABLED}"
 
+  # The monitor runs IN THIS PROCESS. Azure has no Cloud Scheduler and no
+  # EventBridge, and Container Apps Jobs cannot carry a `python -c` argv
+  # through the CLI's argument handling. More importantly, a per-cloud
+  # scheduler is one more thing that stops silently: AWS once had an
+  # EventBridge connection go DEAUTHORIZED on a stale token and the status
+  # page simply went quiet while the app stayed healthy. In-process means the
+  # monitor arrives with the deployment.
+  #
+  # rotation_count=8 is REAL INFERENCE and costs real money. It is also the
+  # only thing that puts model/provider rows on the leaderboard: a model with
+  # no sample shows no verdict at all - not green, not red, absent.
+  "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS=${SYNTHETIC_INTERVAL_SECONDS}"
+  "TR_SYNTHETIC_SCHEDULER_ROTATION_COUNT=${SYNTHETIC_ROTATION_COUNT}"
+
   "TR_INTERNAL_GATEWAY_TOKEN=secretref:internal-token"
   "TR_SYNTHETIC_MONITOR_API_KEY=secretref:monitor-key"
   "TR_FEDERATION_HOME_TOKEN=secretref:federation-token"
@@ -223,10 +239,46 @@ fi
 FQDN="$(az containerapp show -g "$RG" -n "$APP" --query properties.configuration.ingress.fqdn -o tsv)"
 log "app URL: https://${FQDN}"
 
+# Schema, and then PROOF that it landed.
+#
+# The previous version ran `az containerapp exec` and, if that failed, logged
+# a NOTE and carried on. It failed — exec needs an interactive TTY, which a
+# deploy pipeline does not have — and the deploy reported success against an
+# EMPTY DATABASE. The app then served HTTP 200 on every page while every
+# write failed as `rate_limit.store_error`, and the status page published
+# five permanently-"unknown" components. That is the "reports success without
+# measuring" failure this codebase keeps re-finding, so the fix is not a
+# better exec: it is a CHECK that fails the deploy.
 log "applying the schema (idempotent; every statement is IF NOT EXISTS)"
-az containerapp exec -g "$RG" -n "$APP" \
-  --command "python -c 'from trusted_router.storage import STORE; STORE.apply_schema(); print(\"schema ok\")'" \
-  2>/dev/null || log "NOTE: exec unavailable; run apply_schema manually or on first boot"
+SCHEMA_SQL="${SCHEMA_SQL:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/src/trusted_router/storage_postgres_schema.sql}"
+[ -f "$SCHEMA_SQL" ] || die "schema file not found at $SCHEMA_SQL"
+
+if command -v psql >/dev/null 2>&1; then
+  # A temporary firewall rule for THIS host only, removed on every exit path.
+  MYIP="$(curl -fsS --max-time 10 https://api.ipify.org 2>/dev/null || true)"
+  if [ -n "$MYIP" ]; then
+    az postgres flexible-server firewall-rule create -g "$RG" -s "$PG_NAME" \
+      --name "tmp-schema-$$" --start-ip-address "$MYIP" --end-ip-address "$MYIP" \
+      -o none 2>/dev/null || true
+    # shellcheck disable=SC2064
+    trap "az postgres flexible-server firewall-rule delete -g '$RG' -s '$PG_NAME' --name 'tmp-schema-$$' --yes -o none 2>/dev/null || true" EXIT
+    sleep 5
+  fi
+  PGPASSWORD="$PG_PASSWORD" psql \
+    "host=${PG_HOST} port=5432 user=${PG_ADMIN} dbname=${PG_DB} sslmode=require" \
+    -v ON_ERROR_STOP=1 -q -f "$SCHEMA_SQL" >/dev/null \
+    || die "schema application FAILED — the app would serve 200s over an empty database"
+  APPLIED=$(PGPASSWORD="$PG_PASSWORD" psql \
+    "host=${PG_HOST} port=5432 user=${PG_ADMIN} dbname=${PG_DB} sslmode=require" \
+    -tAc "select count(*) from information_schema.tables where table_schema='public' and table_name like 'tr\\_%'" 2>/dev/null || echo 0)
+  # Assert the COUNT, not the exit code: a psql that connects and applies
+  # nothing still exits 0.
+  [ "${APPLIED:-0}" -ge 6 ] || die "schema check FAILED: only ${APPLIED:-0} tr_* tables present (expected >= 6)"
+  log "schema verified: ${APPLIED} tr_* tables present"
+else
+  die "psql not found — required to apply and VERIFY the schema. Install it, or
+       apply ${SCHEMA_SQL} against ${PG_HOST}/${PG_DB} yourself and re-run."
+fi
 
 log "DNS: point azure.trustedrouter.com at this app"
 if command -v gcloud >/dev/null 2>&1; then

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -80,7 +80,9 @@ SECRETS_DIR="${SECRETS_DIR:-$HOME/.quill-secrets}"
 # settlement stays OFF until its token is present AND explicitly enabled.
 FEDERATION_HOME_BASE_URL="${FEDERATION_HOME_BASE_URL:-https://trustedrouter.com}"
 DEFERRED_SETTLEMENT_ENABLED="${DEFERRED_SETTLEMENT_ENABLED:-false}"
-SYNTHETIC_INTERVAL_SECONDS="${SYNTHETIC_INTERVAL_SECONDS:-300}"
+# 120s, not 300s: the status page calls the monitor stale at 300s, so an
+# interval equal to the threshold flaps in and out of a stale banner.
+SYNTHETIC_INTERVAL_SECONDS="${SYNTHETIC_INTERVAL_SECONDS:-120}"
 SYNTHETIC_ROTATION_COUNT="${SYNTHETIC_ROTATION_COUNT:-8}"
 
 log() { printf '\n=== %s\n' "$*" >&2; }

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -564,6 +564,28 @@ class Settings(BaseSettings):
     # cert served on its own connection. Leave False wherever the
     # canonical gateway has a CA-issued cert (GCP).
     synthetic_canonical_attested: bool = False
+    # In-process synthetic monitor. Every cloud schedules the monitor
+    # differently — GCP has Cloud Scheduler driving a Cloud Run Job, AWS has an
+    # EventBridge rule calling /internal/synthetic/run — and Azure Container
+    # Apps has no equivalent that survives the CLI's argument handling. A
+    # per-cloud scheduler is also one more thing that can silently stop: an
+    # EventBridge connection whose stored token went stale flipped to
+    # DEAUTHORIZED and the status page just went quiet, with the app healthy
+    # and the rule ENABLED.
+    #
+    # Running the pass in the serving process makes the monitor arrive with the
+    # deployment, on every cloud, with nothing extra to provision. AWS already
+    # accepts this shape (its rule just calls the app), so this is the same
+    # model with the trigger moved inside.
+    #
+    # 0 = disabled (the default, so GCP/AWS keep their existing schedulers and
+    # nothing double-runs).
+    synthetic_scheduler_interval_seconds: int = 0
+    # Completions per pass. This IS real inference and it costs real money;
+    # it is also the only thing that puts model/provider rows on the
+    # leaderboard, because a model with no sample shows no verdict at all —
+    # not green, not red, absent. Matches the AWS EventBridge rule's value.
+    synthetic_scheduler_rotation_count: int = 8
     # Pin the enclave's PCR0 (EIF measurement). Set at deploy time from
     # the same value tools/deploy-aws-nitro.sh pins, so the probe turns
     # trust_degraded (pcr0_mismatch) if the serving enclave ever differs

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -580,6 +580,11 @@ class Settings(BaseSettings):
     #
     # 0 = disabled (the default, so GCP/AWS keep their existing schedulers and
     # nothing double-runs).
+    # MUST stay comfortably under the status page's staleness threshold
+    # (monitor_freshness.stale_after_seconds, 300s). An interval EQUAL to the
+    # threshold guarantees intermittent "Monitor Data Stale" banners: a pass
+    # takes 10-17s, so the newest sample is always older than the interval by
+    # the time the next one lands. 0 = disabled.
     synthetic_scheduler_interval_seconds: int = 0
     # Completions per pass. This IS real inference and it costs real money;
     # it is also the only thing that puts model/provider rows on the

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -129,6 +129,43 @@ def create_app(
 
             threading.Thread(target=loop, name="home-settlement", daemon=True).start()
 
+    # In-process synthetic monitor. See the settings docstring for why the
+    # trigger lives here rather than in each cloud's own scheduler.
+    if settings.synthetic_scheduler_interval_seconds > 0:
+
+        @app.on_event("startup")
+        async def _start_synthetic_loop() -> None:  # pragma: no cover - thread wiring
+            import asyncio as _asyncio
+            import logging as _logging
+            import random as _random
+
+            from trusted_router.routes.internal.synthetic import run_synthetic_pass
+
+            interval = max(60, settings.synthetic_scheduler_interval_seconds)
+            log = _logging.getLogger(__name__)
+
+            async def loop() -> None:
+                # Jitter the FIRST tick only: several replicas starting from
+                # one deploy would otherwise probe in lockstep forever, and
+                # simultaneous passes multiply the inference spend without
+                # improving coverage.
+                await _asyncio.sleep(_random.uniform(5, min(60, interval)))  # noqa: S311
+                while True:
+                    try:
+                        await run_synthetic_pass(
+                            settings,
+                            rotation_count=settings.synthetic_scheduler_rotation_count,
+                        )
+                    except Exception:
+                        # A failed pass must never kill the loop: the status
+                        # page going permanently stale is a worse outcome than
+                        # one bad sample, and staleness is exactly the failure
+                        # that hides an outage.
+                        log.exception("synthetic pass failed")
+                    await _asyncio.sleep(interval)
+
+            _asyncio.create_task(loop())  # noqa: RUF006 - lifetime is the process
+
     register_http_middleware(app, settings)
 
     @app.exception_handler(StarletteHTTPException)

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -32,6 +32,93 @@ from trusted_router.synthetic.route_health import (
 from trusted_router.types import ErrorType
 
 
+async def _run_and_record(settings: Settings, body: dict[str, Any]) -> dict[str, Any]:
+    monitor_region = _optional_str(body.get("monitor_region"))
+    # Which control plane the billing probes (authorize+settle) hit.
+    # Precedence: request body > settings > canonical GCP plane. The
+    # settings tier exists because the hardcoded fallback is a
+    # wrong-cloud trap for standalone deployments: the EU service
+    # probing https://trustedrouter.com would record the US plane's
+    # health under an EU monitor region.
+    control_plane_base_url = str(
+        body.get("control_plane_base_url")
+        or settings.synthetic_control_plane_base_url
+        or "https://trustedrouter.com"
+    )
+    samples = await run_synthetic_once(settings, monitor_region=monitor_region)
+    if settings.synthetic_monitor_api_key and settings.internal_gateway_token:
+        timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            samples.extend(
+                await gateway_billing_probe(
+                    client,
+                    control_plane_base_url=control_plane_base_url,
+                    monitor_region=monitor_region
+                    or settings.synthetic_monitor_region
+                    or settings.primary_region,
+                    api_key=settings.synthetic_monitor_api_key,
+                    internal_token=settings.internal_gateway_token,
+                    model=settings.synthetic_monitor_model,
+                )
+            )
+            samples.extend(
+                await gateway_fallback_probe(
+                    client,
+                    control_plane_base_url=control_plane_base_url,
+                    monitor_region=monitor_region
+                    or settings.synthetic_monitor_region
+                    or settings.primary_region,
+                    api_key=settings.synthetic_monitor_api_key,
+                    internal_token=settings.internal_gateway_token,
+                    model=settings.synthetic_monitor_model,
+                )
+            )
+    benchmark_recorded = 0
+    rotation_count = _rotation_count(body)
+    if rotation_count and settings.synthetic_monitor_api_key:
+        # Provider/model rotation through the gateway — REAL inference,
+        # same pool mechanics as the GCP monitor CLI. Exposed via this
+        # route because standalone deployments (EU) have no monitor
+        # pool: their once-a-minute cadence is an EventBridge rule
+        # whose Input JSON sets rotation_count (and optionally
+        # rotation_models to pin a family, e.g. the DSv4 ids).
+        benchmark_samples = await rotation_pass(
+            settings=settings,
+            monitor_region=monitor_region
+            or settings.synthetic_monitor_region
+            or settings.primary_region,
+            api_key=settings.synthetic_monitor_api_key,
+            timeout=httpx.Timeout(settings.synthetic_monitor_timeout_seconds),
+            count=rotation_count,
+            rng=random.Random(),  # noqa: S311 - picks which model to probe, not cryptographic
+            models=_rotation_models(body),
+        )
+        await run_in_threadpool(_record_benchmark_samples, benchmark_samples)
+        benchmark_recorded = len(benchmark_samples)
+    await run_in_threadpool(_record_probe_samples, samples)
+    return {
+        "data": {
+            "recorded": len(samples),
+            "benchmark_recorded": benchmark_recorded,
+            "samples": [s.public_dict() for s in samples],
+        }
+    }
+
+
+
+async def run_synthetic_pass(
+    settings: Settings, *, rotation_count: int = 0
+) -> dict[str, Any]:
+    """One synthetic pass, for callers that are not an HTTP request.
+
+    The in-process scheduler (main.py) uses this so a cloud without its own
+    scheduler still gets a monitor. Same code path as the route, so the two
+    cannot drift into measuring different things.
+    """
+    return await _run_and_record(
+        settings, {"rotation_count": rotation_count} if rotation_count else {}
+    )
+
 def register(router: APIRouter) -> None:
     @router.get("/internal/synthetic/health")
     async def synthetic_health(request: Request, settings: SettingsDep) -> dict[str, Any]:
@@ -103,79 +190,6 @@ def register(router: APIRouter) -> None:
             response.status_code = 202
             return {"data": {"scheduled": True}}
         return await _run_and_record(settings, body)
-
-    async def _run_and_record(settings: Settings, body: dict[str, Any]) -> dict[str, Any]:
-        monitor_region = _optional_str(body.get("monitor_region"))
-        # Which control plane the billing probes (authorize+settle) hit.
-        # Precedence: request body > settings > canonical GCP plane. The
-        # settings tier exists because the hardcoded fallback is a
-        # wrong-cloud trap for standalone deployments: the EU service
-        # probing https://trustedrouter.com would record the US plane's
-        # health under an EU monitor region.
-        control_plane_base_url = str(
-            body.get("control_plane_base_url")
-            or settings.synthetic_control_plane_base_url
-            or "https://trustedrouter.com"
-        )
-        samples = await run_synthetic_once(settings, monitor_region=monitor_region)
-        if settings.synthetic_monitor_api_key and settings.internal_gateway_token:
-            timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                samples.extend(
-                    await gateway_billing_probe(
-                        client,
-                        control_plane_base_url=control_plane_base_url,
-                        monitor_region=monitor_region
-                        or settings.synthetic_monitor_region
-                        or settings.primary_region,
-                        api_key=settings.synthetic_monitor_api_key,
-                        internal_token=settings.internal_gateway_token,
-                        model=settings.synthetic_monitor_model,
-                    )
-                )
-                samples.extend(
-                    await gateway_fallback_probe(
-                        client,
-                        control_plane_base_url=control_plane_base_url,
-                        monitor_region=monitor_region
-                        or settings.synthetic_monitor_region
-                        or settings.primary_region,
-                        api_key=settings.synthetic_monitor_api_key,
-                        internal_token=settings.internal_gateway_token,
-                        model=settings.synthetic_monitor_model,
-                    )
-                )
-        benchmark_recorded = 0
-        rotation_count = _rotation_count(body)
-        if rotation_count and settings.synthetic_monitor_api_key:
-            # Provider/model rotation through the gateway — REAL inference,
-            # same pool mechanics as the GCP monitor CLI. Exposed via this
-            # route because standalone deployments (EU) have no monitor
-            # pool: their once-a-minute cadence is an EventBridge rule
-            # whose Input JSON sets rotation_count (and optionally
-            # rotation_models to pin a family, e.g. the DSv4 ids).
-            benchmark_samples = await rotation_pass(
-                settings=settings,
-                monitor_region=monitor_region
-                or settings.synthetic_monitor_region
-                or settings.primary_region,
-                api_key=settings.synthetic_monitor_api_key,
-                timeout=httpx.Timeout(settings.synthetic_monitor_timeout_seconds),
-                count=rotation_count,
-                rng=random.Random(),  # noqa: S311 - picks which model to probe, not cryptographic
-                models=_rotation_models(body),
-            )
-            await run_in_threadpool(_record_benchmark_samples, benchmark_samples)
-            benchmark_recorded = len(benchmark_samples)
-        await run_in_threadpool(_record_probe_samples, samples)
-        return {
-            "data": {
-                "recorded": len(samples),
-                "benchmark_recorded": benchmark_recorded,
-                "samples": [s.public_dict() for s in samples],
-            }
-        }
-
 
 def _record_probe_samples(samples: list[SyntheticProbeSample]) -> None:
     for sample in samples:

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -2782,10 +2782,27 @@ def _attestation_evidence(
             nonce_ok = nonce_hex in {str(item) for item in nonces}
         else:
             nonce_ok = False
+        if not nonce_ok:
+            # AZURE. Both GCP and MAA answer with a JWT, so the branch is
+            # shared — but MAA does NOT carry the caller nonce as a top-level
+            # `eat_nonce`/`nonces` claim. It echoes the enclave's runtime data
+            # under `x-ms-runtime`, and the nonce lives inside that. Without
+            # this the Azure enclave attests perfectly (the standalone
+            # verifier passes every binding) while the status page publishes
+            # a permanent trust_degraded/nonce_missing — a healthy cloud
+            # reported as untrustworthy, which is the exact failure this
+            # probe exists to prevent.
+            runtime_nonce = _maa_runtime_nonce(payload)
+            if runtime_nonce is not None:
+                nonce_ok = runtime_nonce.lower() == nonce_hex.lower()
         return {
             "nonce_ok": nonce_ok,
             "error_type": None if nonce_ok else "nonce_missing",
-            "attestation_digest": _claim(payload, "image_digest", "submods.container.image_digest"),
+            "attestation_digest": _claim(payload, "image_digest", "submods.container.image_digest")
+            # Azure's measurement is the CCE policy hash in SEV-SNP HOST_DATA,
+            # not an image digest — report it in the same field so the status
+            # page has something to show per cloud.
+            or _claim(payload, "x-ms-sevsnpvm-hostdata"),
             "source_commit": _claim(payload, "source_commit", "submods.container.source_commit"),
         }
     aws = _decode_aws_attestation_payload(body)
@@ -2882,6 +2899,65 @@ def _decode_aws_attestation_payload(body: bytes) -> dict[Any, Any] | None:
     except Exception:
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _maa_runtime_nonce(payload: dict[str, Any]) -> str | None:
+    """The caller nonce Azure's MAA echoes inside its runtime-data claim.
+
+    MAA hands the enclave's runtime data back under `x-ms-runtime` in one of
+    two shapes, and both are real: a base64 STRING (the producer's exact
+    bytes, echoed opaquely) or a parsed OBJECT. The object form may nest the
+    caller's fields under a wrapper key, so it is searched recursively rather
+    than by a fixed path — a fixed path that guesses wrong reads as
+    "no nonce", i.e. an untrustworthy enclave, which is the worst available
+    misreport.
+
+    Returns the nonce hex if found, else None. Deliberately does NOT verify
+    the MAA signature, hostdata, or issuer: that is the deploy gate's job in
+    quill-cloud-proxy's verify-attestation.py. This answers only "did the
+    enclave echo MY nonce", the same question the GCP and Nitro branches ask.
+    """
+    import base64 as _b64
+    import json as _json
+
+    def _search(node: Any, depth: int = 0) -> str | None:
+        if depth > 6:
+            return None
+        if isinstance(node, dict):
+            for key in ("nonce", "caller_nonce", "callerNonce"):
+                value = node.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            for value in node.values():
+                found = _search(value, depth + 1)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for value in node:
+                found = _search(value, depth + 1)
+                if found is not None:
+                    return found
+        return None
+
+    for claim_name in ("x-ms-runtime", "x-ms-runtime-data"):
+        claim = payload.get(claim_name)
+        if isinstance(claim, str) and claim.strip():
+            raw = claim.strip()
+            try:
+                decoded = _b64.b64decode(raw + "=" * (-len(raw) % 4), validate=False)
+                found = _search(_json.loads(decoded.decode("utf-8")))
+            except Exception:  # noqa: S112 - a claim we cannot parse is simply
+                # not the one carrying the nonce; try the next claim name. The
+                # caller turns "no nonce found" into trust_degraded, so the
+                # failure is already reported loudly at the right altitude.
+                continue
+            if found is not None:
+                return found
+        elif isinstance(claim, dict):
+            found = _search(claim)
+            if found is not None:
+                return found
+    return None
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any]:

--- a/tests/test_attestation_evidence.py
+++ b/tests/test_attestation_evidence.py
@@ -122,3 +122,74 @@ class TestUnsupported:
     def test_truncated_cbor_is_unsupported(self) -> None:
         evidence = _attestation_evidence(_cose_sign1(_aws_payload())[:20], NONCE)
         assert evidence["error_type"] == "unsupported_attestation_format"
+
+
+# ---------------------------------------------------------------------------
+# Azure / MAA
+# ---------------------------------------------------------------------------
+
+
+def _maa_jwt(runtime_claim: object, claim_name: str = "x-ms-runtime") -> bytes:
+    """A MAA-shaped JWT: the caller nonce lives in the runtime-data claim.
+
+    Deliberately carries NO eat_nonce/nonces claim — that is the whole point.
+    MAA does not echo the caller nonce as a top-level claim the way GCP's
+    Confidential Space token does, so a probe that only looks there reports a
+    perfectly healthy Azure enclave as trust_degraded/nonce_missing.
+    """
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256"}').rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "iss": "https://trquilluaen.uaen.attest.azure.net",
+                "x-ms-attestation-type": "sevsnpvm",
+                "x-ms-sevsnpvm-hostdata": "1d3429b3eaaf66b1",
+                claim_name: runtime_claim,
+            }
+        ).encode()
+    ).rstrip(b"=")
+    return header + b"." + payload + b".sig"
+
+
+class TestAzureMaaNonce:
+    def test_nonce_in_a_base64_string_runtime_claim(self) -> None:
+        """MAA echoes the producer's exact bytes as an opaque base64 string."""
+        runtime = base64.b64encode(
+            json.dumps({"nonce": NONCE, "leaf_fp": "aa", "channel_binding": "bb"}).encode()
+        ).decode()
+        evidence = _attestation_evidence(_maa_jwt(runtime), NONCE)
+        assert evidence["nonce_ok"] is True
+        assert evidence["error_type"] is None
+
+    def test_nonce_in_a_parsed_object_runtime_claim(self) -> None:
+        """MAA parsed the claim, so the bytes are gone and it arrives as JSON."""
+        evidence = _attestation_evidence(
+            _maa_jwt({"nonce": NONCE, "leaf_fp": "aa"}), NONCE
+        )
+        assert evidence["nonce_ok"] is True
+        assert evidence["error_type"] is None
+
+    def test_nonce_nested_under_a_wrapper_key(self) -> None:
+        """MAA is documented to nest caller data under a wrapper; which one is
+        not guaranteed, so the search is recursive rather than a fixed path."""
+        evidence = _attestation_evidence(
+            _maa_jwt({"client-payload": {"nonce": NONCE}}), NONCE
+        )
+        assert evidence["nonce_ok"] is True
+
+    def test_wrong_nonce_still_fails(self) -> None:
+        """The relaxation must not become 'any MAA token passes'."""
+        evidence = _attestation_evidence(_maa_jwt({"nonce": "ff" * 16}), NONCE)
+        assert evidence["nonce_ok"] is False
+        assert evidence["error_type"] == "nonce_missing"
+
+    def test_absent_nonce_still_fails(self) -> None:
+        evidence = _attestation_evidence(_maa_jwt({"leaf_fp": "aa"}), NONCE)
+        assert evidence["nonce_ok"] is False
+        assert evidence["error_type"] == "nonce_missing"
+
+    def test_hostdata_is_reported_as_the_measurement(self) -> None:
+        """Azure's measurement is the CCE policy hash in HOST_DATA, not an
+        image digest — the status page needs something to show per cloud."""
+        evidence = _attestation_evidence(_maa_jwt({"nonce": NONCE}), NONCE)
+        assert evidence["attestation_digest"] == "1d3429b3eaaf66b1"


### PR DESCRIPTION
Azure's control plane is deployed and its status page is live at **https://azure.trustedrouter.com** — this is what it took to make the page tell the truth.

## 1. MAA nonce (`trust_degraded` → `up`)

The Azure enclave attests correctly — the standalone verifier passes every binding against real SEV-SNP hardware — but the status page published `trust_degraded/nonce_missing` on every pass. **A healthy cloud reported as untrustworthy is the exact failure this probe exists to prevent.**

GCP and MAA both answer with a JWT so they share a branch, but MAA does **not** echo the caller nonce as a top-level `eat_nonce`/`nonces` claim. It returns the enclave's runtime data under `x-ms-runtime` and the nonce lives inside — as an opaque base64 **string**, or a parsed **object**, possibly nested under a wrapper key. All three shapes handled; the object search is recursive rather than a fixed path, because a fixed path that guesses wrong reads as "no nonce".

Also reports `x-ms-sevsnpvm-hostdata` as the measurement (Azure's measurement is the CCE policy hash, not an image digest). Verified live: `attestation_nonce: up`, digest `1d3429b3…` — the exact hash the SKR key is pinned to.

Deliberately does **not** verify the MAA signature/issuer/hostdata — that stays the deploy gate's job. This answers only "did the enclave echo MY nonce", same as the GCP and Nitro branches.

## 2. In-process synthetic scheduler (fixes "Monitor Data Stale")

Nothing scheduled Azure's monitor, so the page showed five permanently-`unknown` components and a Critical burn banner. GCP uses Cloud Scheduler → Cloud Run Job; AWS uses EventBridge → the app; Azure has neither, and a Container Apps Job **cannot** carry a `python -c` argv through the CLI (it comma-joins `--args` into one string — three forms tried).

Rather than invent a third scheduler, the trigger moves into the process: `TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS` (default **0 = off**, so GCP/AWS keep theirs and nothing double-runs). AWS already accepts this shape — its rule just calls the app.

It also removes a silent-stop mode that already bit AWS: an EventBridge connection flipped `DEAUTHORIZED` on a stale token, the app stayed healthy, the rule stayed `ENABLED`, and the status page just went quiet.

`rotation_count=8` mirrors the AWS rule. **This is real inference and costs real money** — and it is the only thing that puts model/provider rows on the leaderboard, since a model with no sample shows no verdict at all.

`_run_and_record` is hoisted to module scope (it was closure-free) so the loop and the route share one code path and cannot drift into measuring different things.

## 3. Deploy no longer reports success over an empty database

`azure_control_plane.sh` ran schema application via `az containerapp exec`, which needs a TTY. It failed, logged a NOTE, and the deploy reported success — the app then served HTTP 200 everywhere while every write failed as `rate_limit.store_error`. It now applies via `psql` and **asserts ≥6 `tr_*` tables exist**, failing the deploy otherwise (asserting the count, not the exit code — a psql that connects and applies nothing still exits 0).

## Verification
Mutation-verified 3/3 on the MAA branch (removing the lookup, accepting any token without comparing, and a search too shallow for a wrapper key are each caught). Full suite green (3033), ruff + mypy clean. Live: schema assertion passes, `attestation_nonce: up`, billing/settlement and provider-fallback `up` on real inference through the Azure TEE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)