### PR TITLE
Feature Neurometric partnership and remove named app reference

### DIFF
--- a/docs/sign-in-with-trustedrouter.md
+++ b/docs/sign-in-with-trustedrouter.md
@@ -180,9 +180,8 @@ to catch the `?code=…`, then exchange it. (Port 3000 is allowlisted by the
 backend for exactly this.)
 
 ## Consumers
-- **[SlopNazi](https://slopnazi.com/editor)** uses the flow for its full,
-  context-aware writing editor. It requests a $5 monthly cap, then exchanges
-  the code server-side for a delegated inference key.
+- Third-party web, native, desktop, and CLI applications use the same flow to
+  request a user-approved inference key without handling provider credentials.
 - **Lore web** signs in with this flow and uses the delegated key for game
   generation.
 - **Lore games (macOS, QuillUI)** uses the Swift SDK loopback flow.

--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -30,11 +30,11 @@ class BlogPost:
 
 BLOG_POSTS: tuple[BlogPost, ...] = (
     BlogPost(
-        slug="sign-in-with-trustedrouter-slopnazi",
+        slug="sign-in-with-trustedrouter",
         title="Sign in with TrustedRouter",
         description=(
             "Let users sign in, fund their own AI balance, choose an app spending cap, "
-            "and grant an inference-only key. Now live on SlopNazi."
+            "and grant an inference-only key without copying provider credentials."
         ),
         published_date="2026-08-03",
         source_label=None,
@@ -54,9 +54,9 @@ BLOG_POSTS: tuple[BlogPost, ...] = (
 
 <rect x="60" y="235" width="235" height="190" rx="8" fill="#f3f4f6" stroke="#d1d5db" stroke-width="2"/>
 <text x="177" y="275" text-anchor="middle" font-size="15" font-weight="700" fill="#6b7280">APP</text>
-<text x="177" y="320" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">SlopNazi</text>
-<text x="177" y="354" text-anchor="middle" font-size="16" fill="#4b5563">Improve writing</text>
-<text x="177" y="384" text-anchor="middle" font-size="16" fill="#4b5563">Requests a $5 monthly cap</text>
+<text x="177" y="320" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">Your app</text>
+<text x="177" y="354" text-anchor="middle" font-size="16" fill="#4b5563">Ship an AI feature</text>
+<text x="177" y="384" text-anchor="middle" font-size="16" fill="#4b5563">Suggest a spending cap</text>
 
 <line x1="295" y1="330" x2="350" y2="330" stroke="#6b7280" stroke-width="2.5" marker-end="url(#oauth-arrow)"/>
 
@@ -83,14 +83,14 @@ BLOG_POSTS: tuple[BlogPost, ...] = (
 <text x="1057" y="384" text-anchor="middle" font-size="15" fill="#4b5563">PKCE protected</text>
 
 <rect x="60" y="475" width="1080" height="82" rx="8" fill="#111827"/>
-<text x="90" y="511" font-size="18" font-weight="700" fill="#ffffff">Live now at slopnazi.com</text>
+<text x="90" y="511" font-size="18" font-weight="700" fill="#ffffff">One account. One capped key. Any supported model.</text>
 <text x="90" y="540" font-size="16" fill="#d1d5db">The app gets a capped key. The user keeps billing control. TrustedRouter keeps no prompt or output logs.</text>
 <text x="1140" y="612" text-anchor="end" font-size="18" font-weight="700" fill="#0f6e56">TrustedRouter.com</text>
 </svg>
 </figure>
 <p>Your users should be able to pay for their own AI without finding, copying, and trusting you with a provider API key.</p>
 <p>We shipped <a href="/sign-in-with-trustedrouter">Sign in with TrustedRouter</a>. An app sends its user to TrustedRouter. The user signs in, adds credits if needed, chooses exactly how much the app may spend, and approves one inference-only key. The app never receives a management key. It cannot change billing, inspect other keys, or take over the workspace.</p>
-<p><a href="https://slopnazi.com/editor">SlopNazi</a> is using it now for its full, context-aware writing editor. SlopNazi asks for a $5 monthly limit. The writer sees that number before approval and can change it. The resulting key pays for the writing calls from the writer's TrustedRouter balance.</p>
+<p>A writing tool, coding agent, research app, or internal product can use the same flow. The app suggests a conservative limit. The user sees that number before approval, can change it, and can revoke the resulting key later. Model calls draw from the user's TrustedRouter balance, so the developer does not need to build a second inference billing system.</p>
 <p>A person who creates a TrustedRouter account inside this flow starts at exactly <strong>$0</strong> and receives only the inference key they explicitly approve. That closes an obvious credit-farming hole and makes the economic relationship honest from the first request.</p>
 <p>The funding step lives inside consent. The user can add $5, $20, or $100, with $20 selected by default. Stripe processes the payment and saves the card to the user's TrustedRouter account. The card can be removed later from the Credits page. Existing users see their current balance and can skip funding when they already have enough.</p>
 <p>The authorization itself uses PKCE. The app creates a verifier, sends only its SHA-256 challenge to TrustedRouter, and keeps the verifier for the code exchange. A stolen callback code is useless without it. The final key can carry a fixed, daily, weekly, or monthly maximum and an expiry. The user can revoke it at any time.</p>

--- a/src/trusted_router/templates/public/provider_marketplace.html
+++ b/src/trusted_router/templates/public/provider_marketplace.html
@@ -28,6 +28,29 @@
   <div><strong>Publish</strong><span>We test, monitor, and list working routes.</span></div>
 </section>
 
+<section class="marketing-split" aria-labelledby="featured-neurometric-heading">
+  <div class="marketing-copy">
+    <span class="eyebrow">Featured partnership</span>
+    <h2 id="featured-neurometric-heading">Neurometric AI is live on TrustedRouter.</h2>
+    <p>Neurometric AI is a featured provider partner in the TrustedRouter marketplace. Its integration publishes a machine-readable catalog and gives developers one place to inspect callable models, exact pricing, capabilities, and the documented data-handling boundary.</p>
+    <p>TrustedRouter refreshes the catalog, runs live canaries, and monitors route availability through the same provider contract used across the marketplace.</p>
+    <div class="hero-actions">
+      <a class="btn primary" href="/providers/neurometric">View Neurometric AI models</a>
+      <a class="btn" href="https://www.neurometric.ai/" rel="noopener noreferrer">Visit Neurometric AI</a>
+    </div>
+  </div>
+  <div class="copy-terminal" aria-label="Neurometric AI integration summary">
+    <div class="code-head"><span>Featured provider</span><span>Live</span></div>
+    <pre><code>Provider: Neurometric AI
+Catalog: machine readable
+Pricing: exact decimal ingestion
+Availability: live canaries
+Content policy: no-store
+ZDR classification: not contractual
+Confidential compute: not claimed</code></pre>
+  </div>
+</section>
+
 <section class="marketing-split" id="integration-contract" aria-label="Provider integration contract">
   <div class="marketing-copy">
     <span class="eyebrow">Marketplace application</span>

--- a/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
+++ b/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
@@ -44,22 +44,22 @@ const { key, identity } = await flow.handleCallback();
   </div>
 </section>
 
-<section class="marketing-split" aria-label="Live on SlopNazi">
+<section class="marketing-split" aria-label="User-funded application flow">
   <div class="marketing-copy">
-    <span class="eyebrow">Live integration</span>
-    <h2>SlopNazi lets each writer bring their own AI.</h2>
-    <p><a href="https://slopnazi.com/editor">SlopNazi</a> uses Sign in with TrustedRouter for its full, context-aware writing editor. It requests a $5 monthly key limit. The writer can change that limit, add credits without leaving the authorization flow, and revoke the app later.</p>
+    <span class="eyebrow">Complete integration</span>
+    <h2>A complete user-funded AI flow.</h2>
+    <p>Your app supplies its name, callback URL, and a conservative suggested limit. The user can change that limit, add credits without leaving the authorization flow, approve an inference-only key, and revoke the app later.</p>
     <p>A new account made through this flow starts at exactly $0 and receives only the delegated inference key the user approves. This keeps delegated signups honest while making the first paid model call a short, clear path.</p>
   </div>
   <div class="copy-terminal">
-    <div class="code-head"><span>What the writer sees</span><span>TrustedRouter</span></div>
+    <div class="code-head"><span>What the user sees</span><span>TrustedRouter</span></div>
     <pre><code>1. Sign in
 2. Add $5, $20, or $100
-3. Set SlopNazi's maximum spend
+3. Set the app's maximum spend
 4. Authorize the inference-only key
 
 Default credit purchase: $20
-SlopNazi requested limit: $5 monthly
+Suggested app limit: $5 monthly
 Prompt and output logs: never</code></pre>
   </div>
 </section>

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -44,6 +44,11 @@ def test_provider_onboarding_page_has_machine_readable_requirements(
     assert "No separate pricing endpoint is required." in response.text
     assert "per_1m_tokens" in response.text
     assert "Do not invent a second format." in response.text
+    assert "Featured partnership" in response.text
+    assert "Neurometric AI is live on TrustedRouter." in response.text
+    assert 'href="/providers/neurometric"' in response.text
+    assert "ZDR classification: not contractual" in response.text
+    assert client.get("/providers/neurometric").status_code == 200
     assert 'href="/providers/marketplace/catalog.schema.json"' in response.text
     assert 'href="/providers/marketplace/catalog.v2.schema.json"' in response.text
     assert "Always send <code>Retry-After</code>" in response.text

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -22,8 +22,8 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         "/careers": "Work on attested AI routing",
         "/blog": "TrustedRouter blog",
         "/blog/fusion-evals-open-source": "New SOTA: TrustedRouter Synth beats Fable and Frontier",
-        "/blog/sign-in-with-trustedrouter-slopnazi": "Sign in with TrustedRouter",
-        "/sign-in-with-trustedrouter": "SlopNazi lets each writer bring their own AI.",
+        "/blog/sign-in-with-trustedrouter": "Sign in with TrustedRouter",
+        "/sign-in-with-trustedrouter": "A complete user-funded AI flow.",
         "/security": "No prompt or output logs",
         "/eu": "Use the EU gateway and an EU-focused model alias.",
         # SEO landing pages — each targets a high-intent buyer query.
@@ -124,7 +124,7 @@ def test_signup_grant_amount_is_not_advertised(client: TestClient) -> None:
         "/",
         "/pricing",
         "/sign-in-with-trustedrouter",
-        "/blog/sign-in-with-trustedrouter-slopnazi",
+        "/blog/sign-in-with-trustedrouter",
     ]:
         response = client.get(path)
         assert response.status_code == 200, f"{path} returned {response.status_code}"

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -67,7 +68,7 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
         in core.text
     )
     assert (
-        "<loc>https://trustedrouter.com/blog/sign-in-with-trustedrouter-slopnazi</loc>"
+        "<loc>https://trustedrouter.com/blog/sign-in-with-trustedrouter</loc>"
         in core.text
     )
     assert "<loc>https://trustedrouter.com/docs/synth</loc>" in core.text
@@ -446,15 +447,14 @@ def test_blog_index_shows_scannable_post_images(client: TestClient) -> None:
     assert response.text.count('class="blog-thumb"') >= 10
 
 
-def test_sign_in_with_trustedrouter_launch_post_documents_live_flow(
+def test_sign_in_with_trustedrouter_launch_post_documents_generic_flow(
     client: TestClient,
 ) -> None:
-    response = client.get("/blog/sign-in-with-trustedrouter-slopnazi")
+    response = client.get("/blog/sign-in-with-trustedrouter")
 
     assert response.status_code == 200
     assert "Sign in with TrustedRouter" in response.text
-    assert "https://slopnazi.com/editor" in response.text
-    assert "$5 monthly limit" in response.text
+    assert "writing tool, coding agent, research app" in response.text
     assert "starts at exactly <strong>$0</strong>" in response.text
     assert "$5, $20, or $100" in response.text
     assert "keeps no prompt or output logs, always" in response.text
@@ -463,7 +463,25 @@ def test_sign_in_with_trustedrouter_launch_post_documents_live_flow(
     assert "https://github.com/Lore-Hex/trusted-router-js" in response.text
     assert "https://github.com/jperla/trusted-router-swift" in response.text
     payload = _json_ld(response.text)
-    assert "sign-in-with-trustedrouter-slopnazi" in json.dumps(payload)
+    assert "sign-in-with-trustedrouter" in json.dumps(payload)
+    assert "slopnazi" not in response.text.lower()
+
+
+def test_removed_integration_is_absent_from_public_surfaces(client: TestClient) -> None:
+    for path in (
+        "/sign-in-with-trustedrouter",
+        "/blog/sign-in-with-trustedrouter",
+        "/blog",
+        "/sitemap-core.xml",
+        "/llms.txt",
+    ):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert "slopnazi" not in response.text.lower()
+
+    assert client.get("/blog/sign-in-with-trustedrouter-slopnazi").status_code == 404
+    docs = Path("docs/sign-in-with-trustedrouter.md").read_text(encoding="utf-8")
+    assert "slopnazi" not in docs.lower()
 
 
 def test_confidential_computing_blog_explains_and_verifies_the_boundary(


### PR DESCRIPTION
Summary:
- remove the named third-party app from all public Sign in with TrustedRouter surfaces
- rename the launch post to a generic public URL and stop serving the old named slug
- feature Neurometric AI on the provider marketplace with accurate no-store, ZDR, and confidential-compute boundaries

Verification:
- ruff passed
- 70 focused page tests passed
- full local suite: 3009 passed; 91 loopback network tests passed with socket access
- desktop and 390px mobile Playwright screenshots reviewed