### PR TITLE
Bound Spanner billing transaction deadlines

### DIFF
--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -57,7 +57,10 @@ from trusted_router.storage import (
     configure_store,
     create_store,
 )
-from trusted_router.storage_errors import conflict_store_error_types
+from trusted_router.storage_errors import (
+    conflict_store_error_types,
+    transient_store_error_types,
+)
 from trusted_router.types import ErrorType
 
 
@@ -192,6 +195,22 @@ def create_app(
     # mapping so this module never imports a cloud SDK.
     for conflict_type in conflict_store_error_types():
         app.add_exception_handler(conflict_type, aborted_exception_handler)
+
+    async def unavailable_exception_handler(
+        _request: Request, _exc: Exception
+    ) -> Response:
+        response = error_response(
+            503,
+            "Persistent storage is temporarily unavailable; retry.",
+            ErrorType.SERVICE_UNAVAILABLE,
+        )
+        response.headers["Retry-After"] = "1"
+        return response
+
+    conflict_types = set(conflict_store_error_types())
+    for transient_type in transient_store_error_types():
+        if transient_type not in conflict_types:
+            app.add_exception_handler(transient_type, unavailable_exception_handler)
 
     register_public_routes(app, settings)
     api = _make_api_router(settings)

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -98,6 +98,7 @@ from trusted_router.storage import (
 )
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
 from trusted_router.storage_errors import DeferredSettlementCapReached, StoreConflict
+from trusted_router.storage_gcp_io import spanner_rpc_budget
 from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
@@ -107,6 +108,7 @@ from trusted_router.types import ErrorType, UsageType
 
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
+_BILLING_PATH_SPANNER_BUDGET_SECONDS = 25.0
 _SETTLE_REPAIR_FIELDS = frozenset(
     {
         "authorization_id",
@@ -170,6 +172,7 @@ async def authorize_gateway(
     return await run_in_threadpool(_authorize_gateway_sync, request, body, settings)
 
 
+@spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)
 def _authorize_gateway_sync(
     request: Request,
     body: GatewayAuthorizeRequest,
@@ -1256,6 +1259,7 @@ def _is_web_search_restricted_provider(provider: Any) -> bool:
     )
 
 
+@spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)
 def _settle_gateway_authorization(
     body: GatewaySettleRequest,
     *,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -92,7 +92,11 @@ from trusted_router.storage_gcp_credit_shards import (
 from trusted_router.storage_gcp_custom_models import SpannerCustomModels
 from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
 from trusted_router.storage_gcp_generations import SpannerGenerations
-from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
+from trusted_router.storage_gcp_io import (
+    SpannerIO,
+    configure_spanner_rpc_deadlines,
+    run_in_transaction_with_retry,
+)
 from trusted_router.storage_gcp_keys import SpannerApiKeys
 from trusted_router.storage_gcp_oauth_codes import SpannerOAuthCodes
 from trusted_router.storage_gcp_operational_analytics_outbox import (
@@ -274,6 +278,7 @@ class SpannerBigtableStore:
                 pool=FixedSizePool(size=pool_size),
             )
         )
+        configure_spanner_rpc_deadlines(self._database)
         # Bigtable app-profile selection. Empty string = use the
         # instance's implicit default profile (current behavior; single-
         # cluster routing). Setting `tr-multi` (or whatever name we

--- a/src/trusted_router/storage_gcp_io.py
+++ b/src/trusted_router/storage_gcp_io.py
@@ -13,13 +13,16 @@ here, just plumbing.
 
 from __future__ import annotations
 
+import contextvars
+import functools
 import secrets
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, ParamSpec, TypeVar, cast
 
 T = TypeVar("T")
+P = ParamSpec("P")
 
 
 # Total wall-clock budget for a retried transaction. Must sit safely BELOW the
@@ -33,6 +36,151 @@ T = TypeVar("T")
 # does not affect them in practice; it only truncates the contended tail.
 TXN_BUDGET_SECONDS = 20.0
 _MIN_INNER_TIMEOUT_SECONDS = 0.5
+_SPANNER_RPC_DEADLINE: contextvars.ContextVar[float | None] = contextvars.ContextVar(
+    "trusted_router_spanner_rpc_deadline",
+    default=None,
+)
+
+
+def spanner_rpc_budget(max_seconds: float) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Share one Spanner deadline across every transaction in a hot-path call."""
+    if max_seconds <= 0:
+        raise ValueError("Spanner RPC budget must be positive")
+
+    def decorate(func: Callable[P, T]) -> Callable[P, T]:
+        @functools.wraps(func)
+        def budgeted(*args: P.args, **kwargs: P.kwargs) -> T:
+            deadline = time.monotonic() + max_seconds
+            existing_deadline = _SPANNER_RPC_DEADLINE.get()
+            if existing_deadline is not None:
+                deadline = min(deadline, existing_deadline)
+            token = _SPANNER_RPC_DEADLINE.set(deadline)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                _SPANNER_RPC_DEADLINE.reset(token)
+
+        return budgeted
+
+    return decorate
+
+
+def configure_spanner_rpc_deadlines(
+    database: Any,
+    *,
+    max_seconds: float = TXN_BUDGET_SECONDS,
+) -> None:
+    """Apply a real wall-clock deadline to every Spanner transaction RPC.
+
+    ``Database.run_in_transaction(timeout_secs=...)`` only limits the client's
+    ABORTED retry loop. It does not propagate that budget to ``Commit`` or the
+    statement RPCs. In google-cloud-spanner 3.65, Commit's generated default is
+    one hour, so a wedged channel can outlive Cloud Run's five-minute request
+    timeout even when ``timeout_secs`` is 20 seconds.
+
+    The database wrapper establishes one deadline for the whole transaction.
+    The API wrappers cap each RPC and its generated retry policy to the
+    remaining budget. A ContextVar isolates concurrent request threads and also
+    stops Transaction.commit's private RST_STREAM retry loop from receiving a
+    fresh budget on every attempt.
+    """
+    if max_seconds <= 0:
+        raise ValueError("Spanner RPC deadline must be positive")
+    if getattr(database, "_trusted_router_rpc_deadlines", False):
+        return
+
+    from google.api_core import gapic_v1
+    from google.api_core.exceptions import DeadlineExceeded
+
+    api = database.spanner_api
+    transport = getattr(api, "_transport", None)
+    wrapped_methods = getattr(transport, "_wrapped_methods", {})
+
+    def remaining_seconds() -> float:
+        deadline = _SPANNER_RPC_DEADLINE.get()
+        if deadline is None:
+            return max_seconds
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise DeadlineExceeded(
+                "TrustedRouter Spanner transaction deadline exceeded"
+            )
+        return min(remaining, max_seconds)
+
+    for method_name in (
+        "begin_transaction",
+        "commit",
+        "execute_sql",
+        "execute_streaming_sql",
+        "read",
+        "streaming_read",
+        "rollback",
+    ):
+        original = getattr(api, method_name, None)
+        if not callable(original):
+            continue
+        original_method = cast(Callable[..., Any], original)
+        transport_method = getattr(transport, method_name, None)
+        wrapped_method = wrapped_methods.get(transport_method)
+        default_retry = getattr(wrapped_method, "_retry", None)
+
+        @functools.wraps(original_method)
+        def bounded_rpc(
+            *args: Any,
+            _original: Callable[..., Any] = original_method,
+            _default_retry: Any = default_retry,
+            **kwargs: Any,
+        ) -> Any:
+            remaining = remaining_seconds()
+            requested_timeout = kwargs.get("timeout", gapic_v1.method.DEFAULT)
+            if (
+                requested_timeout is gapic_v1.method.DEFAULT
+                or requested_timeout is None
+            ):
+                kwargs["timeout"] = remaining
+            else:
+                kwargs["timeout"] = min(float(requested_timeout), remaining)
+
+            requested_retry = kwargs.get("retry", gapic_v1.method.DEFAULT)
+            retry = (
+                _default_retry
+                if requested_retry is gapic_v1.method.DEFAULT
+                else requested_retry
+            )
+            if retry is not None and hasattr(retry, "with_timeout"):
+                kwargs["retry"] = retry.with_timeout(remaining)
+            return _original(*args, **kwargs)
+
+        setattr(api, method_name, bounded_rpc)
+
+    original_run_in_transaction = database.run_in_transaction
+
+    @functools.wraps(original_run_in_transaction)
+    def bounded_run_in_transaction(
+        func: Callable[..., T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> T:
+        requested_budget = kwargs.get("timeout_secs")
+        budget = (
+            max_seconds
+            if requested_budget is None
+            else min(float(requested_budget), max_seconds)
+        )
+        budget = max(budget, _MIN_INNER_TIMEOUT_SECONDS)
+        kwargs["timeout_secs"] = budget
+        deadline = time.monotonic() + budget
+        existing_deadline = _SPANNER_RPC_DEADLINE.get()
+        if existing_deadline is not None:
+            deadline = min(deadline, existing_deadline)
+        token = _SPANNER_RPC_DEADLINE.set(deadline)
+        try:
+            return original_run_in_transaction(func, *args, **kwargs)
+        finally:
+            _SPANNER_RPC_DEADLINE.reset(token)
+
+    database.run_in_transaction = bounded_run_in_transaction
+    database._trusted_router_rpc_deadlines = True
 
 
 def run_in_transaction_with_retry(

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -23,6 +23,7 @@ from trusted_router.storage_gcp_counter_dml import (
     clear_reservation_retention,
     complete_reservation_retention,
 )
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
 from trusted_router.storage_gcp_request_records import (
     clear_gateway_authorization_retention,
     complete_gateway_authorization_retention,
@@ -202,7 +203,7 @@ class SpannerSettleOutbox:
             )
 
         try:
-            self._database.run_in_transaction(insert_txn)
+            run_in_transaction_with_retry(self._database, insert_txn)
             return ENQ_INSERTED
         except Exception as exc:  # ALREADY_EXISTS -> the intent is already recorded
             if not _is_already_exists(exc):
@@ -252,7 +253,7 @@ class SpannerSettleOutbox:
                 )
             return refreshed
 
-        refreshed = self._database.run_in_transaction(refresh_txn)
+        refreshed = run_in_transaction_with_retry(self._database, refresh_txn)
         if refreshed == 1:
             return ENQ_REFRESHED
         # 0-row: classify for accurate observability (codex #113) — a still-pending
@@ -312,7 +313,7 @@ class SpannerSettleOutbox:
                 },
             )
 
-        return self._database.run_in_transaction(txn) == 1
+        return run_in_transaction_with_retry(self._database, txn) == 1
 
     def mark(
         self,
@@ -455,7 +456,7 @@ class SpannerSettleOutbox:
                 self._defer_retention(transaction, authorization_id, reservation_id)
             return new_status
 
-        return self._database.run_in_transaction(txn)
+        return run_in_transaction_with_retry(self._database, txn)
 
     def _defer_retention(
         self,
@@ -536,7 +537,7 @@ class SpannerSettleOutbox:
             self._defer_retention(transaction, authorization_id, parked_reservation_id)
             return True
 
-        return bool(self._database.run_in_transaction(txn))
+        return bool(run_in_transaction_with_retry(self._database, txn))
 
     # ── reaper guard predicate ───────────────────────────────────────────────
     def has_intent(self, authorization_id: str) -> bool:

--- a/tests/test_gateway_aborted_handler.py
+++ b/tests/test_gateway_aborted_handler.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 import pytest
-from google.api_core.exceptions import Aborted
+from google.api_core.exceptions import Aborted, DeadlineExceeded, ServiceUnavailable
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
@@ -38,6 +38,37 @@ async def test_gateway_authorize_aborted_returns_retryable_503(
         raise Aborted("deadlock")
 
     monkeypatch.setattr(InMemoryStore, "get_workspace", raise_aborted)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        response = await ac.post(
+            "/v1/internal/gateway/authorize",
+            json={
+                "api_key_hash": key.hash,
+                "model": "anthropic/claude-haiku-4.5",
+                "estimated_input_tokens": 100,
+                "max_output_tokens": 100,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+    assert response.json()["error"]["type"] == "service_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [DeadlineExceeded, ServiceUnavailable])
+async def test_gateway_authorize_storage_outage_returns_retryable_503(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[Exception],
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    def raise_transient(_self: Any, _workspace_id: str) -> Any:
+        raise error_type("spanner unavailable")
+
+    monkeypatch.setattr(InMemoryStore, "get_workspace", raise_transient)
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -103,6 +103,10 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
     from google.cloud import bigtable, spanner
 
     spanner_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp.configure_spanner_rpc_deadlines",
+        lambda _database: None,
+    )
 
     class FakeSpannerClient:
         def __init__(self, **kwargs: Any) -> None:

--- a/tests/test_storage_gcp_io.py
+++ b/tests/test_storage_gcp_io.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import pytest
-from google.api_core.exceptions import Aborted
+from google.api_core.exceptions import (
+    Aborted,
+    DeadlineExceeded,
+    InternalServerError,
+    ResourceExhausted,
+    ServiceUnavailable,
+)
+from google.api_core.retry import Retry, if_exception_type
 
 from trusted_router.storage_gcp_io import (
     TXN_BUDGET_SECONDS,
+    configure_spanner_rpc_deadlines,
     run_in_transaction_with_retry,
+    spanner_rpc_budget,
 )
 
 
@@ -204,3 +213,109 @@ def test_aborted_retries_then_succeeds_within_budget(monkeypatch: pytest.MonkeyP
     assert handed[0] == pytest.approx(20.0)
     assert all(0.0 < t <= 20.0 + 1e-9 for t in handed)
     assert handed == sorted(handed, reverse=True)
+
+
+class _WrappedRpc:
+    def __init__(self) -> None:
+        self._retry = Retry(
+            predicate=if_exception_type(ResourceExhausted, ServiceUnavailable),
+            timeout=3600.0,
+        )
+
+
+class _CommitTransport:
+    def __init__(self) -> None:
+        self.commit = object()
+        self._wrapped_methods = {self.commit: _WrappedRpc()}
+
+
+class _CommitApi:
+    def __init__(self, clock: _Clock | None = None, *, fail: bool = False) -> None:
+        self._transport = _CommitTransport()
+        self.clock = clock
+        self.fail = fail
+        self.calls: list[dict[str, object]] = []
+
+    def commit(self, *args: object, **kwargs: object) -> str:
+        self.calls.append(dict(kwargs))
+        if self.clock is not None:
+            self.clock.now += 6.0
+        if self.fail:
+            raise InternalServerError("RST_STREAM")
+        return "committed"
+
+
+class _CommitDatabase:
+    def __init__(self, api: _CommitApi, *, retry_commit: bool = False) -> None:
+        self.spanner_api = api
+        self.retry_commit = retry_commit
+        self.timeouts: list[float | None] = []
+
+    def run_in_transaction(
+        self,
+        func: Callable[..., str],
+        *,
+        timeout_secs: float | None = None,
+    ) -> str:
+        self.timeouts.append(timeout_secs)
+        result = func("txn")
+        try:
+            self.spanner_api.commit(request="commit")
+        except InternalServerError:
+            if not self.retry_commit:
+                raise
+            # Model Transaction.commit's private RST_STREAM retry. The second
+            # call must inherit the original transaction deadline.
+            self.spanner_api.commit(request="commit")
+        return result
+
+
+def test_configure_spanner_rpc_deadlines_caps_commit_and_retry_budget() -> None:
+    database = _CommitDatabase(_CommitApi())
+    configure_spanner_rpc_deadlines(database, max_seconds=7.0)
+
+    assert database.run_in_transaction(_txn, timeout_secs=100.0) == "ok"
+    assert database.timeouts == [pytest.approx(7.0)]
+    commit_call = database.spanner_api.calls[0]
+    assert commit_call["timeout"] == pytest.approx(7.0, abs=0.001)
+    retry = commit_call["retry"]
+    assert isinstance(retry, Retry)
+    assert retry._timeout == pytest.approx(7.0, abs=0.001)
+
+
+def test_commit_rst_retry_cannot_receive_a_fresh_transaction_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    api = _CommitApi(clock, fail=True)
+    database = _CommitDatabase(api, retry_commit=True)
+    configure_spanner_rpc_deadlines(database, max_seconds=5.0)
+
+    with pytest.raises(DeadlineExceeded, match="transaction deadline exceeded"):
+        database.run_in_transaction(_txn)
+
+    # The first stuck commit consumes the budget. The retry is rejected before
+    # reaching the transport instead of starting another one-hour default RPC.
+    assert len(api.calls) == 1
+
+
+def test_hot_path_budget_is_shared_across_multiple_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
+    api = _CommitApi(clock)
+    database = _CommitDatabase(api)
+    configure_spanner_rpc_deadlines(database, max_seconds=20.0)
+
+    @spanner_rpc_budget(10.0)
+    def two_transactions() -> None:
+        database.run_in_transaction(_txn)
+        database.run_in_transaction(_txn)
+
+    two_transactions()
+
+    assert len(api.calls) == 2
+    assert api.calls[0]["timeout"] == pytest.approx(10.0)
+    assert api.calls[1]["timeout"] == pytest.approx(4.0)


### PR DESCRIPTION
## Incident

Two synthetic `/internal/gateway/settle` requests on one Cloud Run instance blocked for the full 300-second request timeout. Spanner lock and transaction stats were healthy; the Python client transaction budget did not propagate to the generated Commit RPC, whose default deadline is one hour.

## Fix

- Cap Spanner statement and commit RPC retries to the transaction's remaining wall-clock budget.
- Share a 25-second budget across each full authorize, settle, or refund call.
- Move every settlement-outbox transaction onto the bounded helper.
- Return retryable 503 responses for transient storage failures.
- Add regression tests for private commit retries, shared request budgets, and transient error mapping.

## Verification

- `uv run ruff check .`
- `uv run mypy`
- 299 focused billing and outbox tests passed.
- Full suite: 3,029 passed, 223 skipped, 10 xfailed. One new timer assertion was 11 microseconds outside an overly strict tolerance; the tolerance was corrected and the test rerun green.
