### PR TITLE
Handle Makora August model lifecycle

### DIFF
--- a/scripts/pricing/providers/makora.py
+++ b/scripts/pricing/providers/makora.py
@@ -39,14 +39,18 @@ MANIFEST_PATH = (
 
 EXPECTED_MODELS = [
     "deepseek/deepseek-v4-flash",
-    "deepseek/deepseek-v4-pro",
     "z-ai/glm-5.2",
     "z-ai/glm-5.2-nvfp4",
     "moonshotai/kimi-k2.7-code",
+    "moonshotai/kimi-k3",
     "meta-llama/llama-3.3-70b-instruct",
     "qwen/qwen3.6-27b",
     "qwen/qwen3.6-35b-a3b",
 ]
+
+# Makora ended serverless DeepSeek V4 Pro service on 2026-08-04. Keep the
+# route disabled even if its catalog briefly serves a stale row after EOL.
+RETIRED_MODELS = frozenset({"deepseek/deepseek-v4-pro"})
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
@@ -118,7 +122,7 @@ def _live_catalog() -> tuple[dict[str, dict[str, Any]], dict[str, ModelPrice]]:
             or existing_ids.get(native_id.casefold())
             or canonicalize_native_model_id(native_id)
         )
-        if model_id is None:
+        if model_id is None or model_id in RETIRED_MODELS:
             continue
         row: dict[str, Any] = {
             "id": model_id,

--- a/tests/test_makora_pricing.py
+++ b/tests/test_makora_pricing.py
@@ -64,6 +64,12 @@ def test_makora_fetches_authenticated_model_pricing_api() -> None:
     assert makora.MODELS_URL == "https://inference.makora.com/v1/models"
 
 
+def test_makora_required_models_follow_august_2026_lineup() -> None:
+    assert "deepseek/deepseek-v4-pro" in makora.RETIRED_MODELS
+    assert "deepseek/deepseek-v4-pro" not in makora.EXPECTED_MODELS
+    assert "moonshotai/kimi-k3" in makora.EXPECTED_MODELS
+
+
 def test_makora_live_api_discovers_and_prices_new_models_without_parser_changes(
     tmp_path: Path,
     monkeypatch,
@@ -123,6 +129,68 @@ def test_makora_live_api_discovers_and_prices_new_models_without_parser_changes(
     assert makora._DISCOVERED_MANIFEST_ROWS["qwen/qwen4-next"][  # noqa: SLF001
         "input_modalities"
     ] == ["text", "image"]
+
+
+def test_makora_live_api_keeps_retired_v4_pro_disabled_and_accepts_launch_updates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest = tmp_path / "makora.json"
+    manifest.write_text('{"models": []}', encoding="utf-8")
+    monkeypatch.setattr(makora, "MANIFEST_PATH", manifest)
+    monkeypatch.setattr(
+        makora,
+        "EXPECTED_MODELS",
+        [
+            "deepseek/deepseek-v4-flash-0731",
+            "moonshotai/kimi-k3",
+        ],
+    )
+    monkeypatch.setenv("MAKORA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        makora,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {
+                    "id": "deepseek-ai/DeepSeek-V4-Pro",
+                    "pricing": {
+                        "prompt": "0.00000139",
+                        "completion": "0.00000279",
+                    },
+                },
+                {
+                    "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+                    "pricing": {
+                        "prompt": "0.00000009",
+                        "completion": "0.000000195",
+                    },
+                },
+                {
+                    "id": "moonshotai/Kimi-K3",
+                    "pricing": {
+                        "prompt": "0.00000255",
+                        "completion": "0.00001275",
+                        "input_cache_read": "0.000000255",
+                    },
+                },
+            ]
+        },
+    )
+
+    result = makora.fetch()
+
+    assert "deepseek/deepseek-v4-pro" not in result.prices
+    assert "deepseek/deepseek-v4-pro" not in makora._DISCOVERED_MANIFEST_ROWS  # noqa: SLF001
+    assert result.prices["deepseek/deepseek-v4-flash-0731"] == ModelPrice(
+        90_000,
+        195_000,
+    )
+    assert result.prices["moonshotai/kimi-k3"] == ModelPrice(
+        2_550_000,
+        12_750_000,
+        prompt_cached_micro_per_m=255_000,
+    )
 
 
 def test_makora_parser_extracts_public_lineup_prices() -> None:


### PR DESCRIPTION
## Summary
- permanently exclude Makora's EOL DeepSeek V4 Pro endpoint even if its catalog briefly serves a stale row
- remove the retired model from refresh requirements and make Kimi K3 a protected expected model
- verify automatic discovery of DeepSeek V4 Flash 0731 and automatic ingestion of tomorrow's 15% Kimi K3 price reduction

## Tests
- uv run pytest -q tests/test_makora_pricing.py
- uv run pytest -q tests/test_catalog_routing_contracts.py -k makora
- uv run ruff check scripts/pricing/providers/makora.py tests/test_makora_pricing.py
- uv run mypy