### PR TITLE
Fix generated page SEO hygiene

### DIFF
--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -1489,8 +1489,8 @@ The model already knows the truth. Whether you hear it depends on whose server y
         slug="attestation-is-all-you-need",
         title="Attestation is all you need",
         description=(
-            "For AI routing, trust should be something an agent can verify, not "
-            "only a policy page a human reads after the fact."
+            "For AI routing, trust should be something an agent can verify. Learn how source code, "
+            "image digests, remote attestation, and live evidence protect the prompt path."
         ),
         published_date="2026-06-14",
         source_label="Joseph Perla original",

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -71,6 +71,12 @@ from trusted_router.provider_contract import (
 )
 from trusted_router.regions import configured_regions, region_map_payload
 from trusted_router.seo_catalog import seo_catalog_evidence
+from trusted_router.seo_meta import (
+    SEO_TITLE_MAX_LENGTH,
+    seo_meta_description,
+    seo_title,
+    truncate_seo_text,
+)
 from trusted_router.storage_models import BedrockGroupBuyPledge
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -882,25 +888,34 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "compare/openrouter": PublicPage(
         template="public/compare_openrouter.html",
         title="TrustedRouter Compared With OpenRouter",
-        description="Keep the same API shape and add a verifiable prompt path.",
+        description=(
+            "Compare TrustedRouter and OpenRouter across API compatibility, model access, "
+            "provider routing, privacy controls, pricing, and verifiable gateway attestation."
+        ),
     ),
     "compare/vercel-ai-gateway": PublicPage(
         template="public/compare_vercel_ai_gateway.html",
         title="TrustedRouter And Vercel AI Gateway",
         description=(
-            "Vercel AI Gateway is a strong developer gateway. "
-            "TrustedRouter adds an open source attested prompt path."
+            "Compare TrustedRouter and Vercel AI Gateway across model routing, SDK support, "
+            "observability, privacy controls, failover, and verifiable gateway attestation."
         ),
     ),
     "compare/litellm": PublicPage(
         template="public/compare_litellm.html",
         title="TrustedRouter And LiteLLM",
-        description="Use LiteLLM when you want to run the router yourself. Use TrustedRouter when you want hosted attestation.",
+        description=(
+            "Compare TrustedRouter and LiteLLM for hosted or self-managed model routing, "
+            "provider failover, privacy controls, observability, and verifiable attestation."
+        ),
     ),
     "docs/migrate-from-openrouter": PublicPage(
         template="public/migrate_from_openrouter.html",
         title="Migrate From OpenRouter",
-        description="Change base_url, keep OpenAI compatible clients, and verify the hosted gateway.",
+        description=(
+            "Change base_url to migrate from OpenRouter while keeping OpenAI-compatible clients, "
+            "model routing, streaming, provider controls, and live gateway verification."
+        ),
     ),
     "docs/tagging": PublicPage(
         template="public/tagging.html",
@@ -938,7 +953,10 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "docs/agent-setup": PublicPage(
         template="public/agent_setup.html",
         title="Agent Setup For TrustedRouter",
-        description="Base URLs, env vars, smoke tests, and model aliases for coding agents.",
+        description=(
+            "Configure coding agents for TrustedRouter with the API base URL, environment "
+            "variables, model aliases, privacy routes, quick smoke tests, and migration notes."
+        ),
     ),
     "docs/mcp": PublicPage(
         template="public/mcp.html",
@@ -951,7 +969,10 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "docs/evals": PublicPage(
         template="public/evals.html",
         title="TrustedRouter Evals Guide",
-        description="Run model, provider, privacy, latency, and cost evals through one OpenAI compatible API.",
+        description=(
+            "Run repeatable model evaluations through one OpenAI-compatible API and compare "
+            "providers, privacy posture, latency, reliability, token usage, quality, and cost."
+        ),
     ),
     "docs/synth": PublicPage(
         template="public/fusion.html",
@@ -975,8 +996,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="eu.png",
         title="EU LLM Gateway",
         description=(
-            "EU-focused LLM routing through the Europe West attested gateway, "
-            "with European and privacy-forward provider choices."
+            "Route AI workloads through TrustedRouter's attested European gateway with "
+            "EU-focused model providers, privacy controls, regional failover, and usage billing."
         ),
     ),
     "trustedos": PublicPage(
@@ -1031,7 +1052,10 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "security": PublicPage(
         template="public/security.html",
         title="Security",
-        description="What is logged, what is not logged, and where prompt traffic belongs.",
+        description=(
+            "Review TrustedRouter security boundaries, confidential compute, live attestation, "
+            "prompt handling, metadata logs, API key storage, provider trust, and incident controls."
+        ),
     ),
     # SEO landing pages — top-level slugs target high-intent buyer
     # queries. Each one is a self-contained sales surface: H2 above the
@@ -1043,8 +1067,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="openrouter-alternative.png",
         title="OpenRouter Alternative — TrustedRouter",
         description=(
-            "An open-source, hardware-attested OpenRouter alternative. "
-            "Same OpenAI-compatible API, verifiable prompt path, no logs."
+            "Use an OpenAI-compatible OpenRouter alternative with hundreds of models, provider "
+            "failover, zero-retention routes, open source code, and a verifiable attested prompt path."
         ),
     ),
     "private-llm-api": PublicPage(
@@ -1089,8 +1113,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="litellm-alternative.png",
         title="LiteLLM Alternative — Self-Host and Verify It",
         description=(
-            "A LiteLLM alternative that's self-hostable AND verifiable. "
-            "Hardware-attested gateway proves the no-logging guarantee."
+            "Use a hosted or self-managed LiteLLM alternative with provider failover, privacy "
+            "routing, OpenAI-compatible APIs, open source code, and verifiable hardware attestation."
         ),
     ),
     "portkey-alternative": PublicPage(
@@ -1107,8 +1131,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="confidential-computing-llm.png",
         title="Confidential Computing for LLMs — TrustedRouter",
         description=(
-            "Run LLM inference behind hardware attestation across every provider. "
-            "GCP Confidential Space, with remote attestation."
+            "Run LLM routing through confidential computing with GCP Confidential Space, "
+            "open source gateway code, remote attestation, protected TLS keys, and no prompt logs."
         ),
     ),
     "tinfoil-alternative": PublicPage(
@@ -1293,16 +1317,16 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         template="public/resources.html",
         title="Resources",
         description=(
-            "Guides, comparisons, privacy references, model APIs, benchmarks, and "
-            "integration pages for building with TrustedRouter."
+            "Guides, comparisons, privacy references, API quickstarts, model benchmarks, SDKs, "
+            "migration instructions, and integration pages for building with TrustedRouter."
         ),
     ),
     "careers": PublicPage(
         template="public/careers.html",
         title="Work on TrustedRouter",
         description=(
-            "Work on attested AI routing, open model orchestration, evals, and "
-            "infrastructure developers can verify."
+            "Work on attested AI routing, open model orchestration, provider reliability, "
+            "evaluations, billing, and infrastructure that developers and customers can verify."
         ),
     ),
 }
@@ -1325,6 +1349,28 @@ def _format_uptime(value: float | None, decimals: int = 4) -> str:
     return f"{value:.{decimals}f}%"
 
 
+def _seo_model_name(model: Model) -> str:
+    prefix = f"{model.provider}: "
+    if model.name.lower().startswith(prefix.lower()):
+        return model.name[len(prefix) :]
+    return model.name
+
+
+def _seo_comparison_title(left: Model, right: Model) -> str:
+    left_name = _seo_model_name(left)
+    right_name = _seo_model_name(right)
+    base = f"{left_name} vs {right_name}"
+    if len(f"{base} | TrustedRouter") <= SEO_TITLE_MAX_LENGTH:
+        return f"{base} | TrustedRouter"
+    if len(base) <= SEO_TITLE_MAX_LENGTH:
+        return base
+    name_budget = (SEO_TITLE_MAX_LENGTH - len(" vs ")) // 2
+    return (
+        f"{truncate_seo_text(left_name, name_budget)} vs "
+        f"{truncate_seo_text(right_name, name_budget)}"
+    )
+
+
 @lru_cache(maxsize=1)
 def _env() -> Environment:
     env = Environment(
@@ -1333,6 +1379,8 @@ def _env() -> Environment:
         keep_trailing_newline=True,
     )
     env.filters["uptime_pct"] = _format_uptime
+    env.filters["seo_title"] = seo_title
+    env.filters["seo_meta_description"] = seo_meta_description
     env.globals["provider_logo_url"] = provider_logo_url
     return env
 
@@ -1748,8 +1796,8 @@ def public_blog_index_html(settings: Settings) -> str:
             title="Blog | TrustedRouter",
             heading="TrustedRouter blog",
             description=(
-                "Engineering notes on attested AI routing, Synth evals, provider privacy, "
-                "and open source model routing."
+                "Read TrustedRouter engineering notes on attested AI routing, model evaluations, "
+                "provider privacy, confidential compute, reliability, and open source infrastructure."
             ),
             posts=_blog_index_posts(settings),
             json_ld_blob=_blog_index_json_ld(settings),
@@ -1796,7 +1844,8 @@ def public_legal_html(settings: Settings) -> str:
             title="Legal And Procurement Packet | TrustedRouter",
             heading="Legal and procurement packet",
             description=(
-                "Read-only procurement packet for legal teams reviewing TrustedRouter for sensitive work."
+                "Review TrustedRouter's legal and procurement packet, operating entity, DPA, BAA, "
+                "subprocessors, security controls, and compliance readiness for sensitive workloads."
             ),
             packet=packet,
             entity=legal_entity(settings),
@@ -1818,7 +1867,8 @@ def public_privacy_html(settings: Settings) -> str:
             title="Privacy Policy | TrustedRouter",
             heading="Privacy policy",
             description=(
-                "How Lore Hex Corp collects, uses, shares, and protects information when you use TrustedRouter."
+                "Read how Lore Hex Corp collects, uses, shares, retains, and protects account, billing, "
+                "usage, and technical information when you use TrustedRouter services."
             ),
             entity=legal_entity(settings),
             google_enabled=settings.google_oauth_enabled,
@@ -1837,7 +1887,10 @@ def public_terms_html(settings: Settings) -> str:
             site_url=f"https://{settings.trusted_domain}/terms",
             title="Terms of Service | TrustedRouter",
             heading="Terms of service",
-            description="Terms governing access to and use of TrustedRouter services.",
+            description=(
+                "Review the terms governing access to TrustedRouter services, accounts, API usage, "
+                "billing, acceptable use, intellectual property, warranties, and service limitations."
+            ),
             entity=legal_entity(settings),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -1855,7 +1908,10 @@ def public_support_html(settings: Settings) -> str:
             site_url=f"https://{settings.trusted_domain}/support",
             title="Support | TrustedRouter",
             heading="TrustedRouter support",
-            description="Get product, account, billing, plugin, and security support.",
+            description=(
+                "Contact TrustedRouter for product, account, API, billing, provider, integration, "
+                "privacy, plugin, security, incident, and responsible disclosure support."
+            ),
             entity=legal_entity(settings),
             support_email=settings.support_email,
             google_enabled=settings.google_oauth_enabled,
@@ -1956,7 +2012,8 @@ def public_baa_html(settings: Settings) -> str:
             title="BAA Draft | TrustedRouter",
             heading="Business Associate Agreement draft",
             description=(
-                "Draft BAA terms for HIPAA review. PHI workloads require a signed BAA and route restrictions."
+                "Review TrustedRouter's draft Business Associate Agreement for HIPAA workloads, "
+                "including safeguards, breach duties, subcontractors, termination, and route restrictions."
             ),
             entity=legal_entity(settings),
             google_enabled=settings.google_oauth_enabled,
@@ -1977,7 +2034,8 @@ def public_soc2_readiness_html(settings: Settings) -> str:
             title="SOC 2 Readiness | TrustedRouter",
             heading="SOC 2 readiness",
             description=(
-                "SOC 2 Type I readiness package for auditor and procurement review. No SOC 2 report has been obtained yet."
+                "Review TrustedRouter's SOC 2 Type I readiness package, control ownership, evidence, "
+                "policies, risks, and auditor preparation. No SOC 2 report has been obtained yet."
             ),
             entity=legal_entity(settings),
             packet=packet,
@@ -1999,7 +2057,8 @@ def public_hipaa_readiness_html(settings: Settings) -> str:
             title="HIPAA Readiness | TrustedRouter",
             heading="HIPAA readiness",
             description=(
-                "HIPAA readiness package for covered-entity and business-associate review. PHI requires a signed BAA."
+                "Review TrustedRouter's HIPAA readiness package, administrative and technical safeguards, "
+                "risk analysis, incident duties, and BAA requirements before sending PHI."
             ),
             entity=legal_entity(settings),
             packet=packet,
@@ -2019,7 +2078,10 @@ def public_subprocessors_html(settings: Settings) -> str:
             site_url=f"https://{settings.trusted_domain}/legal/subprocessors",
             title="Subprocessors | TrustedRouter",
             heading="Subprocessors",
-            description=("Platform vendors and downstream model providers used by TrustedRouter."),
+            description=(
+                "Review platform vendors and downstream model providers used by TrustedRouter, "
+                "including purpose, data categories, location, retention posture, and policy sources."
+            ),
             entity=legal_entity(settings),
             subprocessors=subprocessor_packet(),
             provider_subprocessors=provider_subprocessor_rows(),
@@ -2076,7 +2138,10 @@ def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
             site_url=f"https://{settings.trusted_domain}/models",
             title="Models | TrustedRouter",
             heading="Models",
-            description="Hundreds of models with provider routes, prices, status, and policy notes.",
+            description=(
+                "Browse hundreds of AI models with current provider routes, token pricing, "
+                "privacy policies, regional availability, measured performance, and API support."
+            ),
             models=models,
             active_filter=normalized_filter,
             model_filters=[
@@ -2110,7 +2175,8 @@ def public_benchmarks_html(settings: Settings) -> str:
             title="Benchmarks | TrustedRouter",
             heading="Benchmarks",
             description=(
-                "Model benchmark entry points, route measurements, and independent sources."
+                "Review AI model benchmark scores, cited evaluation sources, provider route "
+                "measurements, and current performance evidence across the TrustedRouter catalog."
             ),
             page_kind="benchmarks",
             models=_seo_model_rows(test_mode=test_mode),
@@ -2219,7 +2285,8 @@ def public_rankings_html(settings: Settings) -> str:
             title="Model Rankings | TrustedRouter",
             heading="Model Rankings",
             description=(
-                "Rank models by route count, provider diversity, price, and policy posture."
+                "Rank AI models by provider diversity, route availability, token pricing, privacy "
+                "posture, context length, and measured performance on TrustedRouter."
             ),
             page_kind="rankings",
             models=_seo_model_rows(test_mode=test_mode),
@@ -2272,7 +2339,8 @@ def public_chat_html(
             title="Chat | TrustedRouter",
             heading="Chat",
             description=(
-                "Try any model and compare up to four at once. Zero tokens spent until you sign in."
+                "Try supported AI models through TrustedRouter and compare up to four responses at "
+                "once with visible providers, privacy routes, streaming output, and exact usage costs."
             ),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -2294,7 +2362,8 @@ def public_fusion_html(settings: Settings) -> str:
             title="Synth | TrustedRouter",
             heading="Synth",
             description=(
-                "Try trustedrouter/synth with a model panel, fallback judges, and a final synthesizer."
+                "Run trustedrouter/synth with a configurable model panel, judge and final synthesizer, "
+                "provider fallback, streaming output, usage accounting, and attested request handling."
             ),
             og_image=_og_image_url(settings, "synth.png"),
             og_image_alt="TrustedRouter Synth compares a model panel and returns one answer",
@@ -2316,7 +2385,8 @@ def public_providers_html(settings: Settings) -> str:
             title="Providers | TrustedRouter",
             heading="Providers",
             description=(
-                "Provider transparency for model compute, retention, confidential compute, and encrypted routes."
+                "Compare AI providers by available models, token pricing, retention policies, "
+                "regional coverage, confidential compute, encrypted routes, and measured performance."
             ),
             providers=providers,
             json_ld_blob=_json_ld_graph(
@@ -2351,10 +2421,11 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
         .render(
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}/providers/{provider.slug}",
-            title=f"{provider.name} Models | TrustedRouter",
+            title=f"{provider.name} Models and API Routes | TrustedRouter",
             heading=provider.name,
             description=(
-                f"{provider.name} models on TrustedRouter with prices, routes, policy notes, and source links."
+                f"Explore {provider.name} models on TrustedRouter with current routes, token pricing, "
+                "policy sources, privacy posture, regional availability, and API support."
             ),
             og_image=_absolute_url(settings, provider_og_image_url(provider.slug)),
             og_image_alt=f"{provider.name} models and routes on TrustedRouter",
@@ -2409,10 +2480,11 @@ def public_provider_performance_html(settings: Settings, provider_slug: str) -> 
                 else f"https://{settings.trusted_domain}/providers/{provider.slug}"
             ),
             robots_meta=None if indexable else "noindex,follow",
-            title=f"{provider.name} Performance | TrustedRouter",
+            title=f"{provider.name} Speed, Uptime and Throughput | TrustedRouter",
             heading=f"{provider.name} performance",
             description=(
-                f"Measured TTFT, TTFB, effective throughput, uptime, and sampled model routes for {provider.name}."
+                f"Review measured TTFT, TTFB, effective throughput, uptime, and sampled model routes "
+                f"for {provider.name} on TrustedRouter using metadata-only production probes."
             ),
             og_image=_absolute_url(settings, provider_og_image_url(provider.slug)),
             og_image_alt=f"{provider.name} route performance on TrustedRouter",
@@ -2459,6 +2531,7 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
     if model is None:
         return None
     test_mode = settings.environment == "test"
+    seo_name = _seo_model_name(model)
     site_url = f"https://{settings.trusted_domain}/models/{model_id}"
     return (
         _env()
@@ -2466,9 +2539,12 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
         .render(
             api_base_url=settings.api_base_url,
             site_url=site_url,
-            title=f"{model.name} | TrustedRouter",
+            title=f"{seo_name} API, Pricing and Providers | TrustedRouter",
             heading=model.name,
-            description=f"All providers serving {model.name} via TrustedRouter.",
+            description=(
+                f"Compare every TrustedRouter route for {seo_name}, including token pricing, context "
+                "limits, privacy policy, regional availability, measured uptime, and API support."
+            ),
             model=_model_detail_view(model, test_mode=test_mode),
             # Service/Offer JSON-LD. The page sells API access to a hosted
             # routing service, not a retail product with customer ratings.
@@ -2487,6 +2563,8 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
     if pair is None:
         return None
     left, right = pair
+    left_name = _seo_model_name(left)
+    right_name = _seo_model_name(right)
     test_mode = settings.environment == "test"
     site_path = canonical_model_comparison_path(left.id, right.id)
     assert site_path is not None
@@ -2496,11 +2574,11 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
         .render(
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}{site_path}",
-            title=f"{left.name} vs {right.name} | TrustedRouter",
+            title=_seo_comparison_title(left, right),
             heading=f"{left.name} vs {right.name}",
             description=(
-                f"Compare {left.name} and {right.name} by providers, context, price, "
-                "and TrustedRouter route support."
+                f"Compare {left_name} and {right_name} across token pricing, context windows, "
+                "provider availability, privacy options, route diversity, and measured performance."
             ),
             left=_model_detail_view(
                 left,
@@ -2609,6 +2687,7 @@ def public_model_section_html(settings: Settings, model_id: str, section: str) -
     section_path = f"/models/{model_id}/{section}"
     section_url = f"https://{settings.trusted_domain}{section_path}"
     label = MODEL_SEO_SECTION_LABELS[section]
+    seo_name = _seo_model_name(model)
     measured = measured_for_model(model.id, test_mode=settings.environment == "test")
     section_indexable = _model_section_indexable(model, section, measured)
     return (
@@ -2618,7 +2697,7 @@ def public_model_section_html(settings: Settings, model_id: str, section: str) -
             api_base_url=settings.api_base_url,
             site_url=section_url if section_indexable else base_model_url,
             robots_meta=None if section_indexable else "noindex,follow",
-            title=f"{model.name} {label} | TrustedRouter",
+            title=f"{seo_name} {label} | TrustedRouter",
             heading=f"{model.name} {label}",
             description=_model_section_description(model, section),
             model=_model_detail_view(model, active_section=section, test_mode=test_mode),
@@ -3454,20 +3533,39 @@ def _model_section_links(
 
 
 def _model_section_description(model: Model, section: str) -> str:
+    name = _seo_model_name(model)
     label = MODEL_SEO_SECTION_LABELS[section].lower()
     if section == "benchmarks":
-        return f"Benchmark and measurement links for {model.name}, with TrustedRouter route data first."
+        return (
+            f"Review independent benchmark scores and TrustedRouter route measurements for {name}, "
+            "with cited sources and links to current evaluation results."
+        )
     if section == "providers":
-        return f"Every provider endpoint TrustedRouter can route for {model.name}."
+        return (
+            f"See every provider route serving {name} on TrustedRouter, with current availability, "
+            "regional coverage, privacy posture, token pricing, and provider details."
+        )
     if section == "performance":
-        return f"TrustedRouter performance signals and provider route posture for {model.name}."
+        return (
+            f"Compare measured TTFT, TTFB, throughput, uptime, and route health for {name} across "
+            "TrustedRouter providers using metadata-only production probes."
+        )
     if section == "pricing":
-        return f"Prompt and completion pricing for every {model.name} route."
+        return (
+            f"Compare prompt and completion token prices for every {name} route on TrustedRouter, "
+            "including provider-specific rates and prepaid or BYOK availability."
+        )
     if section == "uptime":
-        return f"Uptime and status entry points for {model.name} routes."
+        return (
+            f"Review uptime, current status, provider diversity, and regional route health for {name} "
+            "on TrustedRouter using continuously collected metadata-only measurements."
+        )
     if section == "api":
-        return f"OpenAI compatible quickstart for {model.name} on TrustedRouter."
-    return f"{model.name} {label} on TrustedRouter."
+        return (
+            f"Use the OpenAI-compatible API quickstart for {name} on TrustedRouter, with model IDs, "
+            "streaming examples, authentication, fallback behavior, and SDK configuration."
+        )
+    return f"Review {name} {label}, provider routes, pricing, privacy, and API support on TrustedRouter."
 
 
 def _model_section_indexable(

--- a/src/trusted_router/og.py
+++ b/src/trusted_router/og.py
@@ -6,9 +6,8 @@ from trusted_router.config import Settings
 
 OG_TITLE = "TrustedRouter | Every model. Provable privacy."
 OG_DESCRIPTION = (
-    "One OpenAI-compatible API for hundreds of models, routed through attested "
-    "infrastructure with ZDR options, provider failover, BYOK, and no prompt "
-    "or output logs. Always."
+    "One OpenAI-compatible API for hundreds of models on attested infrastructure, "
+    "with ZDR routes, provider failover, BYOK, and no prompt or output logs."
 )
 OG_IMAGE_WIDTH = 1200
 OG_IMAGE_HEIGHT = 630

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1671,7 +1671,10 @@ def _status_history_page_html(
         site_url=site_url,
         title=title,
         heading=heading,
-        description="Visual rollups from metadata synthetic checks.",
+        description=(
+            "Explore TrustedRouter uptime history from metadata-only synthetic checks, with visual "
+            "rollups for gateway health, attestation, SDK requests, billing, fallback, and regions."
+        ),
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,
         static_version=settings.release,
@@ -1975,7 +1978,10 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
         site_url=site_url,
         title="Status | TrustedRouter",
         heading="TrustedRouter Status",
-        description="Regional uptime, attestation, SDK, billing, and fallback checks.",
+        description=(
+            "Check TrustedRouter availability across regions with live gateway, attestation, SDK, "
+            "billing, provider fallback, latency, incident history, and router-core uptime signals."
+        ),
         google_enabled=settings.google_oauth_enabled,
         github_enabled=settings.github_oauth_enabled,
         static_version=settings.release,

--- a/src/trusted_router/seo_meta.py
+++ b/src/trusted_router/seo_meta.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+SEO_TITLE_MAX_LENGTH = 60
+SEO_DESCRIPTION_MAX_LENGTH = 160
+
+
+def truncate_seo_text(value: str, max_length: int) -> str:
+    normalized = " ".join(value.split())
+    if len(normalized) <= max_length:
+        return normalized
+    cutoff = max_length - 3
+    shortened = normalized[:cutoff].rsplit(" ", 1)[0].rstrip(" ,:;|-")
+    if not shortened:
+        shortened = normalized[:cutoff].rstrip()
+    return f"{shortened}..."
+
+
+def seo_title(value: str) -> str:
+    """Return one search title with at most one optional brand suffix."""
+    brand = " | TrustedRouter"
+    base = " ".join(value.split())
+    had_brand_suffix = base.endswith(brand)
+    while base.endswith(brand):
+        base = base[: -len(brand)].rstrip()
+    if not had_brand_suffix and " | " in base:
+        return truncate_seo_text(base, SEO_TITLE_MAX_LENGTH)
+    branded = f"{base}{brand}"
+    if len(branded) <= SEO_TITLE_MAX_LENGTH:
+        return branded
+    if len(base) <= SEO_TITLE_MAX_LENGTH:
+        return base
+    return truncate_seo_text(base, SEO_TITLE_MAX_LENGTH)
+
+
+def seo_meta_description(value: str) -> str:
+    return truncate_seo_text(value, SEO_DESCRIPTION_MAX_LENGTH)

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  {% set meta_title = og_title|seo_title %}
+  {% set meta_description = og_description|seo_meta_description %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
@@ -12,14 +14,14 @@
       } catch (e) { /* Dark remains the default when storage is unavailable. */ }
     })();
   </script>
-  <title>{{ og_title }}</title>
-  <meta name="description" content="{{ og_description }}">
+  <title>{{ meta_title }}</title>
+  <meta name="description" content="{{ meta_description }}">
   {% include "_favicon.html" %}
   <link rel="canonical" href="{{ canonical_site_url }}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ brand_name }}">
-  <meta property="og:title" content="{{ og_title }}">
-  <meta property="og:description" content="{{ og_description }}">
+  <meta property="og:title" content="{{ meta_title }}">
+  <meta property="og:description" content="{{ meta_description }}">
   <meta property="og:url" content="{{ site_url }}">
   <meta property="og:image" content="{{ og_image }}">
   <meta property="og:image:type" content="image/png">
@@ -27,8 +29,8 @@
   <meta property="og:image:height" content="{{ og_image_height }}">
   <meta property="og:image:alt" content="{{ brand_name }}, end-to-end encrypted AI routing">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ og_title }}">
-  <meta name="twitter:description" content="{{ og_description }}">
+  <meta name="twitter:title" content="{{ meta_title }}">
+  <meta name="twitter:description" content="{{ meta_description }}">
   <meta name="twitter:image" content="{{ og_image }}">
   <meta name="twitter:image:alt" content="{{ brand_name }}, end-to-end encrypted AI routing">
   <link rel="alternate" type="text/plain" href="/docs/llms.txt" title="{{ brand_name }} LLM docs">
@@ -229,7 +231,7 @@ response = client.chat.completions.create(
         </div>
         <div class="region-map-card" aria-label="{{ brand_name }} regional footprint">
           <div class="region-map-visual">
-            <img src="/static/world-map.svg?v={{ static_version }}" alt="" loading="lazy">
+            <img src="/static/world-map.svg?v={{ static_version }}" alt="TrustedRouter regional routing map" loading="lazy">
             <svg viewBox="0 0 1000 500" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
               {% for region in map_regions %}
               <g class="region-dot {% if region.primary %}primary{% endif %} {% if region.serving %}live{% else %}edge{% endif %}" transform="translate({{ '%.1f'|format(region.x) }} {{ '%.1f'|format(region.y) }})">

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
+  {% set meta_title = title|seo_title %}
+  {% set meta_description = description|seo_meta_description %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
@@ -12,15 +14,15 @@
       } catch (e) { /* Dark remains the default when storage is unavailable. */ }
     })();
   </script>
-  <title>{{ title }}</title>
-  <meta name="description" content="{{ description }}">
+  <title>{{ meta_title }}</title>
+  <meta name="description" content="{{ meta_description }}">
   {% include "_favicon.html" %}
   {% if robots_meta %}<meta name="robots" content="{{ robots_meta }}">{% endif %}
   <link rel="canonical" href="{{ site_url }}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="TrustedRouter">
-  <meta property="og:title" content="{{ title }}">
-  <meta property="og:description" content="{{ description }}">
+  <meta property="og:title" content="{{ meta_title }}">
+  <meta property="og:description" content="{{ meta_description }}">
   <meta property="og:url" content="{{ site_url }}">
   <meta property="og:image" content="{{ og_image|default('https://trustedrouter.com/og.png') }}">
   <meta property="og:image:type" content="image/png">
@@ -29,8 +31,8 @@
   <meta property="og:image:alt" content="{{ og_image_alt|default('TrustedRouter, end-to-end encrypted AI routing') }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@jperla">
-  <meta name="twitter:title" content="{{ title }}">
-  <meta name="twitter:description" content="{{ description }}">
+  <meta name="twitter:title" content="{{ meta_title }}">
+  <meta name="twitter:description" content="{{ meta_description }}">
   <meta name="twitter:image" content="{{ og_image|default('https://trustedrouter.com/og.png') }}">
   <meta name="twitter:image:alt" content="{{ og_image_alt|default('TrustedRouter, end-to-end encrypted AI routing') }}">
   <link rel="alternate" type="text/plain" href="/docs/llms.txt" title="TrustedRouter LLM docs">

--- a/src/trusted_router/templates/public/_provider_identity.html
+++ b/src/trusted_router/templates/public/_provider_identity.html
@@ -1,6 +1,6 @@
 {% macro provider_identity(slug, name, href=None, size='default', subtitle=None) -%}
 {% if href %}<a class="provider-identity provider-identity-{{ size }}" href="{{ href }}">{% else %}<span class="provider-identity provider-identity-{{ size }}">{% endif %}
-  <img class="provider-logo" src="{{ provider_logo_url(slug) }}" alt="" width="32" height="32" loading="lazy" decoding="async">
+  <img class="provider-logo" src="{{ provider_logo_url(slug) }}" alt="{{ name }} logo" aria-hidden="true" width="32" height="32" loading="lazy" decoding="async">
   <span class="provider-identity-copy"><strong>{{ name }}</strong>{% if subtitle %}<small>{{ subtitle }}</small>{% endif %}</span>
 {% if href %}</a>{% else %}</span>{% endif %}
 {%- endmacro %}

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -9,7 +9,7 @@
       {% if model.open_weights %}<span class="pill good">open weights</span>{% endif %}
       {% if model.us_provider_available %}<span class="pill">US providers</span>{% endif %}
       {% if model.eu_focused_provider_available %}<span class="pill">EU-focused</span>{% endif %}
-      <a class="pill provider-chip" href="/providers/{{ model.publisher_slug }}"><img class="provider-logo" src="{{ provider_logo_url(model.publisher_slug) }}" alt="" width="22" height="22"><span>{{ model.provider }}</span></a>
+      <a class="pill provider-chip" href="/providers/{{ model.publisher_slug }}"><img class="provider-logo" src="{{ provider_logo_url(model.publisher_slug) }}" alt="{{ model.provider }} logo" aria-hidden="true" width="22" height="22"><span>{{ model.provider }}</span></a>
     </div>
   </div>
   <div class="panel-body">
@@ -56,7 +56,7 @@
           {% else %}
           <div class="provider-chip-list">
             {% for provider in model.providers %}
-            <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
+            <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="{{ provider.name }} logo" aria-hidden="true" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
             {% endfor %}
           </div>
           {% endif %}

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -76,7 +76,7 @@
           <td>
             <div class="provider-chip-list" aria-label="{{ model.provider_count }} provider{{ '' if model.provider_count == 1 else 's' }}">
               {% for provider in model.providers %}
-              <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
+              <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="{{ provider.name }} logo" aria-hidden="true" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
               {% endfor %}
             </div>
           </td>

--- a/src/trusted_router/templates/public/provider_marketplace.html
+++ b/src/trusted_router/templates/public/provider_marketplace.html
@@ -9,7 +9,9 @@
     <div class="hero-actions">
       <a class="btn primary" href="mailto:providers@trustedrouter.com?subject=Provider%20marketplace%20application%20for%20%5Bcompany%5D">Email providers@trustedrouter.com</a>
       <a class="btn" href="#integration-contract">View requirements <span aria-hidden="true">↓</span></a>
-      <a class="btn" href="/provider">Provider sign in</a>
+      <form action="/provider" method="get">
+        <button class="btn" type="submit">Provider sign in</button>
+      </form>
     </div>
   </div>
   <div class="public-hero-metrics" aria-label="Provider integration requirements">

--- a/src/trusted_router/views.py
+++ b/src/trusted_router/views.py
@@ -16,6 +16,7 @@ from typing import Any
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from trusted_router.provider_branding import provider_logo_url
+from trusted_router.seo_meta import seo_meta_description, seo_title
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
@@ -66,6 +67,8 @@ def _env() -> Environment:
     )
     env.filters["uptime_pct"] = _format_uptime
     env.filters["datetime_iso"] = _format_datetime_iso
+    env.filters["seo_title"] = seo_title
+    env.filters["seo_meta_description"] = seo_meta_description
     env.globals["provider_logo_url"] = provider_logo_url
     return env
 

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -732,7 +732,7 @@ def test_provider_detail_page_links_served_models(client: TestClient) -> None:
     response = client.get("/providers/minimax")
 
     assert response.status_code == 200
-    assert "<title>MiniMax Models | TrustedRouter</title>" in response.text
+    assert "<title>MiniMax Models and API Routes | TrustedRouter</title>" in response.text
     assert "MiniMax M3" in response.text
     assert 'href="https://aiiq.org/models/minimax-m3/"' in response.text
     assert "IQ 109" in response.text

--- a/tests/test_sitemap_seo_hygiene.py
+++ b/tests/test_sitemap_seo_hygiene.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlsplit
+
+from defusedxml import ElementTree
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.seo_meta import seo_meta_description, seo_title
+
+
+class _SeoParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_head = False
+        self.in_title = False
+        self.title_parts: list[str] = []
+        self.canonical: str | None = None
+        self.description: str | None = None
+        self.robots: str | None = None
+        self.images_without_alt = 0
+        self.links: set[str] = set()
+
+    @property
+    def title(self) -> str:
+        return " ".join("".join(self.title_parts).split())
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "head":
+            self.in_head = True
+        elif tag == "title" and self.in_head and not self.title_parts:
+            self.in_title = True
+        elif tag == "link" and self.in_head and values.get("rel") == "canonical":
+            self.canonical = values.get("href")
+        elif tag == "meta" and self.in_head:
+            name = (values.get("name") or "").lower()
+            if name == "description":
+                self.description = values.get("content")
+            elif name == "robots":
+                self.robots = values.get("content")
+        elif tag == "img" and not (values.get("alt") or "").strip():
+            self.images_without_alt += 1
+        elif tag == "a" and values.get("href"):
+            self.links.add(values["href"] or "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title" and self.in_title:
+            self.in_title = False
+        elif tag == "head":
+            self.in_head = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title:
+            self.title_parts.append(data)
+
+
+def _sitemap_urls(client: TestClient) -> list[str]:
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    child_paths = (
+        "/sitemap-core.xml",
+        "/sitemap-providers.xml",
+        "/sitemap-models.xml",
+        "/sitemap-comparisons.xml",
+    )
+    urls: list[str] = []
+    for child_path in child_paths:
+        response = client.get(child_path)
+        assert response.status_code == 200
+        root = ElementTree.fromstring(response.content)
+        urls.extend(
+            node.text for node in root.findall("sitemap:url/sitemap:loc", namespace) if node.text
+        )
+    return urls
+
+
+def test_every_sitemap_page_has_clean_search_metadata(test_settings: Settings) -> None:
+    settings = test_settings.model_copy(update={"rate_limit_enabled": False})
+    client = TestClient(create_app(settings, init_observability=False))
+    urls = _sitemap_urls(client)
+    assert len(urls) >= 3_500
+    assert len(urls) == len(set(urls))
+    sitemap_paths = {urlsplit(url).path for url in urls}
+
+    issues: list[str] = []
+    link_sources: dict[str, set[str]] = defaultdict(set)
+    for url in urls:
+        split = urlsplit(url)
+        path = split.path + (f"?{split.query}" if split.query else "")
+        response = client.get(path, follow_redirects=False)
+        if response.status_code != 200:
+            issues.append(f"{path}: status {response.status_code}")
+            continue
+        if "text/html" not in response.headers.get("content-type", ""):
+            continue
+
+        parser = _SeoParser()
+        parser.feed(response.text)
+        if parser.robots and "noindex" in parser.robots.lower():
+            issues.append(f"{path}: noindex page is listed in sitemap")
+        if parser.canonical != url:
+            issues.append(f"{path}: canonical {parser.canonical!r} != {url!r}")
+        if not parser.title or len(parser.title) > 60:
+            issues.append(f"{path}: title length {len(parser.title)}")
+        description_length = len(parser.description or "")
+        if not 120 <= description_length <= 160:
+            issues.append(f"{path}: description length {description_length}")
+        if parser.images_without_alt:
+            issues.append(f"{path}: {parser.images_without_alt} images have empty alt text")
+
+        for href in parser.links:
+            target = urlsplit(urljoin(url, href))
+            if target.hostname == settings.trusted_domain and not target.fragment:
+                target_path = target.path + (f"?{target.query}" if target.query else "")
+                link_sources[target_path].add(path)
+
+    linked_redirects: list[str] = []
+    for target_path, sources in sorted(link_sources.items()):
+        if target_path in sitemap_paths:
+            continue
+        response = client.get(target_path, follow_redirects=False)
+        if 300 <= response.status_code < 400:
+            linked_redirects.append(
+                f"{target_path}: {response.status_code} -> "
+                f"{response.headers.get('location')!r}, linked from {sorted(sources)[:3]}"
+            )
+
+    assert not issues, "\n".join(issues[:100])
+    assert not linked_redirects, "\n".join(linked_redirects[:100])
+
+
+def test_seo_metadata_helpers_bound_generated_text() -> None:
+    assert seo_title("Models | TrustedRouter") == "Models | TrustedRouter"
+    assert seo_title("Security") == "Security | TrustedRouter"
+    assert seo_title("A" * 80).endswith("...")
+    assert len(seo_title("A" * 80)) == 60
+    assert seo_meta_description("Repeated words " * 20).endswith("...")
+    assert len(seo_meta_description("Repeated words " * 20)) <= 160


### PR DESCRIPTION
## Summary
- add bounded SEO title and description helpers to shared public templates
- give provider and model logos descriptive alt text and remove the linked authenticated redirect
- expand generated model, provider, comparison, legal, status, and resource metadata
- add an exhaustive sitemap regression gate covering 3,700+ URLs and linked redirects

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 3057 passed, 223 skipped, 10 xfailed
- full local SEO audit: 3739 unique sitemap URLs, zero flagged issues and zero linked redirects