### PR TITLE
postgres: implement the 11 gateway-reachable methods that only ever raised

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -49,6 +49,7 @@ from trusted_router.storage_errors import (
     StoreUnavailable,
 )
 from trusted_router.storage_gcp_codec import (
+    byok_id,
     member_id,
     normalize_email,
     workspace_key_id,
@@ -97,6 +98,12 @@ from trusted_router.storage_models import (
 from trusted_router.storage_postgres_group_buy import PostgresBedrockGroupBuy
 from trusted_router.storage_postgres_operational_analytics_outbox import (
     PostgresOperationalAnalyticsOutbox,
+)
+from trusted_router.storage_video_jobs import (
+    VIDEO_CONTENT_RETENTION_SECONDS,
+    VIDEO_SUBMISSION_TIMEOUT_SECONDS,
+    _is_due,
+    _iso_after_seconds,
 )
 from trusted_router.synthetic.rollups import (
     RAW_SYNTHETIC_RETENTION_DAYS,
@@ -232,6 +239,19 @@ def _split_sql_statements(schema: str) -> list[str]:
     """
     without_comments = "\n".join(line.split("--", 1)[0] for line in schema.splitlines())
     return [stmt.strip() for stmt in without_comments.split(";") if stmt.strip()]
+
+
+def _video_due_id(job: VideoJob) -> str:
+    """Ordering key for the video due-index: `<next_poll_at>#<job_id>`.
+
+    Lexicographic order over this string is chronological order over
+    next_poll_at (ISO-8601, fixed width, Z-suffixed), which is what lets
+    `ORDER BY id LIMIT n` in claim_video_jobs walk the queue in due order and
+    stop at the first entry that is not yet due.  Matches
+    storage_gcp_video_jobs._due_id; the two indexes never share a database, so
+    they only have to be internally consistent.
+    """
+    return f"{job.next_poll_at}#{job.id}"
 
 
 class PostgresStore:
@@ -453,6 +473,19 @@ class PostgresStore:
             return result
 
         return self._run_transaction(operation)
+
+    @staticmethod
+    def _like_prefix(prefix: str) -> str:
+        """Turn an id prefix into a LIKE pattern that cannot act as a wildcard.
+
+        Secondary-index ids are `<owner>#<rest>`, and owner ids routinely
+        contain `_`.  In LIKE, `_` matches ANY single character, so the
+        natural-looking `id LIKE 'ws_abc#%'` also matches `wsXabc#...` — one
+        tenant's prefix scan can return another tenant's rows.  Escaping is a
+        correctness requirement here, not hygiene.
+        """
+        escaped = prefix.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        return f"{escaped}%"
 
     def _write_entity_tx(
         self,
@@ -1915,7 +1948,18 @@ class PostgresStore:
         workspace_id: str,
         provider: str,
     ) -> ByokProviderConfig | None:
-        self._not_implemented("get_byok_provider")
+        # Gateway-reachable (routes/internal/gateway.py `_get_byok_provider`),
+        # so this MUST return rather than raise: a NotImplementedError here
+        # 500s the whole authorize.
+        #
+        # A peer plane has no writer for this kind yet — upsert_byok_provider
+        # is still unimplemented — so in practice this misses and the caller
+        # drops BYOK endpoints from the candidate set.  That is the safe
+        # direction (nothing is billed against a key we could not find), but
+        # BYOK models stay unavailable on a peer until these configs are
+        # replicated.  Kind and id match the GCP writer (storage_gcp_byok.py)
+        # so replication drops straight in.
+        return self._read_entity("byok", byok_id(workspace_id, provider), ByokProviderConfig)
 
     def delete_byok_provider(
         self,
@@ -1943,7 +1987,13 @@ class PostgresStore:
         self._not_implemented("list_custom_models_for_user")
 
     def get_custom_model(self, model_id: str) -> CustomModel | None:
-        self._not_implemented("get_custom_model")
+        # Gateway-reachable (gateway.py:223 authorize, :707
+        # resolve-custom-model).  A miss yields a clean 404 "Custom model not
+        # found" instead of a 500.  Both callers already apply
+        # normalize_custom_model_id and the GCP writer stores under the
+        # normalized id, so this deliberately does not normalize again — a
+        # second pass would mask a caller that forgot.
+        return self._read_entity("custom_model", model_id, CustomModel)
 
     def update_custom_model(
         self,
@@ -1981,7 +2031,48 @@ class PostgresStore:
         self._not_implemented("create_broadcast_destination")
 
     def list_broadcast_destinations(self, workspace_id: str) -> list[BroadcastDestination]:
-        self._not_implemented("list_broadcast_destinations")
+        # Gateway-reachable at TWO points inside authorize (gateway.py:368 on
+        # the idempotent-replay branch, :616 on the main path).  :616 runs
+        # AFTER reserve_key_limit / reserve / create_gateway_authorization have
+        # committed, so raising here would strand a credit reservation on every
+        # single request.  This must return a value, never raise.
+        #
+        # Written as a real query against the same two kinds the GCP writer
+        # uses (storage_gcp_broadcast.py) rather than a bare `return []`, so
+        # replicating these rows to a peer needs no change here.  Until then a
+        # peer has no rows and gets [].
+        def read(conn: Any) -> list[BroadcastDestination]:
+            rows = conn.execute(
+                "SELECT body FROM tr_entities "
+                "WHERE kind = 'broadcast_destination_by_workspace' "
+                "AND id LIKE %s ESCAPE '\\' "
+                "ORDER BY id",
+                (self._like_prefix(f"{workspace_id}#"),),
+            ).fetchall()
+            destinations: list[BroadcastDestination] = []
+            for row in rows:
+                raw = row[0]
+                pointer = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                destination_id = str(pointer.get("destination_id") or "")
+                if not destination_id:
+                    continue
+                destination = self._read_entity_tx(
+                    conn, "broadcast_destination", destination_id, BroadcastDestination
+                )
+                if destination is None:
+                    # Index row and entity are two separate writes, so a torn
+                    # write leaves a dangling pointer.  Skip it: a half-written
+                    # destination must not 500 an authorize that has already
+                    # escrowed credits.
+                    continue
+                if getattr(destination, "workspace_id", workspace_id) != workspace_id:
+                    # Defence in depth against a mis-keyed index row — never
+                    # hand one workspace another workspace's destination.
+                    continue
+                destinations.append(destination)
+            return destinations
+
+        return self._run_transaction(read)
 
     def get_broadcast_destination(
         self,
@@ -2039,13 +2130,47 @@ class PostgresStore:
     # Asynchronous video jobs -----------------------------------------------
 
     def prepare_video_job(self, job: VideoJob) -> tuple[VideoJob, bool]:
-        self._not_implemented("prepare_video_job")
+        # Mirrors SpannerVideoJobs.prepare. Idempotent on BOTH keys: an
+        # authorization that already has a job returns that job, and so does a
+        # replayed job id. Returning (job, False) rather than creating a second
+        # row is what stops one authorization submitting twice to a provider.
+        def txn(conn: Any) -> tuple[VideoJob, bool]:
+            pointer = self._read_entity_tx(
+                conn, "video_job_by_authorization", job.authorization_id, dict, for_update=True
+            )
+            if pointer is not None:
+                existing = self._read_entity_tx(
+                    conn, "video_job", str(pointer.get("job_id", "")), VideoJob
+                )
+                if existing is not None:
+                    return existing, False
+            existing = self._read_entity_tx(conn, "video_job", job.id, VideoJob, for_update=True)
+            if existing is not None:
+                return existing, False
+            job.next_poll_at = _iso_after_seconds(VIDEO_SUBMISSION_TIMEOUT_SECONDS)
+            self._write_entity_tx(conn, "video_job", job.id, job)
+            self._write_entity_tx(
+                conn, "video_job_by_authorization", job.authorization_id, {"job_id": job.id}
+            )
+            self._write_entity_tx(
+                conn,
+                "video_job_due",
+                _video_due_id(job),
+                {"job_id": job.id, "next_poll_at": job.next_poll_at},
+            )
+            return job, True
+
+        return self._run_transaction(txn)
 
     def get_video_job(self, job_id: str) -> VideoJob | None:
-        self._not_implemented("get_video_job")
+        return self._read_entity("video_job", job_id, VideoJob)
 
     def get_video_job_for_key(self, job_id: str, key_hash: str) -> VideoJob | None:
-        self._not_implemented("get_video_job_for_key")
+        # The key_hash check is the tenant boundary for the public video
+        # endpoints: without it any caller who guesses a job id could read
+        # another workspace's job.
+        job = self.get_video_job(job_id)
+        return job if job is not None and job.key_hash == key_hash else None
 
     def mark_video_job_queued(
         self,
@@ -2058,7 +2183,43 @@ class PostgresStore:
         quoted_microdollars: int,
         poll_after_seconds: int,
     ) -> VideoJob | None:
-        self._not_implemented("mark_video_job_queued")
+        def txn(conn: Any) -> VideoJob | None:
+            job = self._read_entity_tx(conn, "video_job", job_id, VideoJob, for_update=True)
+            if job is None:
+                return None
+            if job.provider_job_id and job.provider_job_id != provider_job_id:
+                raise ValueError("video job was already queued with a different provider id")
+            if job.provider_job_id and (
+                job.provider != provider
+                or job.endpoint_id != endpoint_id
+                or job.provider_model != provider_model
+                or job.quoted_microdollars != quoted_microdollars
+            ):
+                raise ValueError("video job was already queued with different route metadata")
+            old_due = _video_due_id(job)
+            job.provider_job_id = provider_job_id
+            job.provider = provider
+            job.endpoint_id = endpoint_id
+            job.provider_model = provider_model
+            job.quoted_microdollars = quoted_microdollars
+            if job.status == "submitting":
+                job.status = "pending"
+            job.next_poll_at = _iso_after_seconds(poll_after_seconds)
+            job.updated_at = iso_now()
+            self._write_entity_tx(conn, "video_job", job.id, job)
+            # Delete BEFORE writing the new pointer: when next_poll_at is
+            # unchanged both ids are equal, and deleting second would remove
+            # the row we just wrote and drop the job out of the queue forever.
+            self._delete_entity_tx(conn, "video_job_due", old_due)
+            self._write_entity_tx(
+                conn,
+                "video_job_due",
+                _video_due_id(job),
+                {"job_id": job.id, "next_poll_at": job.next_poll_at},
+            )
+            return job
+
+        return self._run_transaction(txn)
 
     def claim_video_jobs(
         self,
@@ -2067,7 +2228,42 @@ class PostgresStore:
         limit: int,
         lease_seconds: int,
     ) -> list[VideoJob]:
-        self._not_implemented("claim_video_jobs")
+        # Lease claim. Correctness requirement: two pollers must never claim
+        # the same job, or the provider is polled twice and a completion can be
+        # billed twice. Each candidate is locked FOR UPDATE and re-checked with
+        # the shared _is_due predicate INSIDE the transaction, so the loser of a
+        # race observes the winner's lease and skips.
+        now = iso_now()
+        lease_until = _iso_after_seconds(lease_seconds)
+
+        claimed: list[VideoJob] = []
+        for pointer in self._list_entities(
+            "video_job_due", dict, limit=max(limit * 10, limit)
+        ):
+            if len(claimed) >= limit:
+                break
+            # Ids sort as "<next_poll_at>#<job_id>", so the scan is in due
+            # order and the first not-yet-due entry ends it.
+            if str(pointer.get("next_poll_at", "")) > now:
+                break
+            candidate_id = str(pointer.get("job_id", ""))
+            if not candidate_id:
+                continue
+
+            def claim(conn: Any, *, job_id: str = candidate_id) -> VideoJob | None:
+                job = self._read_entity_tx(conn, "video_job", job_id, VideoJob, for_update=True)
+                if job is None or not _is_due(job, now):
+                    return None
+                job.lease_owner = lease_owner
+                job.leased_until = lease_until
+                job.updated_at = now
+                self._write_entity_tx(conn, "video_job", job.id, job)
+                return job
+
+            job = self._run_transaction(claim)
+            if job is not None:
+                claimed.append(job)
+        return claimed
 
     def update_video_job(
         self,
@@ -2080,10 +2276,72 @@ class PostgresStore:
         error: str | None = None,
         poll_after_seconds: int = 5,
     ) -> VideoJob | None:
-        self._not_implemented("update_video_job")
+        def txn(conn: Any) -> VideoJob | None:
+            job = self._read_entity_tx(conn, "video_job", job_id, VideoJob, for_update=True)
+            if job is None:
+                return None
+            if lease_owner is not None and job.lease_owner not in {None, lease_owner}:
+                # Someone else holds the lease; report state, change nothing.
+                return job
+            if job.status in {"completed", "failed"}:
+                # Terminal state is immutable except for repairing a missing
+                # generation link after concurrent regional settlement. This is
+                # monotonic and leaves polling/cleanup indexes unchanged.
+                if (
+                    job.status == "completed"
+                    and status == "completed"
+                    and generation_id
+                    and not job.generation_id
+                ):
+                    job.generation_id = generation_id
+                    job.updated_at = iso_now()
+                    self._write_entity_tx(conn, "video_job", job.id, job)
+                return job
+            old_due = _video_due_id(job)
+            job.status = status
+            job.provider_status = provider_status
+            if generation_id:
+                job.generation_id = generation_id
+            job.last_error = error[:500] if error else None
+            job.attempts += 1
+            job.lease_owner = None
+            job.leased_until = None
+            job.updated_at = iso_now()
+            if status in {"pending", "in_progress"}:
+                job.next_poll_at = _iso_after_seconds(poll_after_seconds)
+            elif status == "completed" and job.cleaned_at is None:
+                if job.content_expires_at is None:
+                    job.content_expires_at = _iso_after_seconds(VIDEO_CONTENT_RETENTION_SECONDS)
+                job.next_poll_at = job.content_expires_at
+            self._write_entity_tx(conn, "video_job", job.id, job)
+            self._delete_entity_tx(conn, "video_job_due", old_due)
+            if status in {"pending", "in_progress", "completed"} and job.cleaned_at is None:
+                self._write_entity_tx(
+                    conn,
+                    "video_job_due",
+                    _video_due_id(job),
+                    {"job_id": job.id, "next_poll_at": job.next_poll_at},
+                )
+            return job
+
+        return self._run_transaction(txn)
 
     def mark_video_job_cleaned(self, job_id: str) -> VideoJob | None:
-        self._not_implemented("mark_video_job_cleaned")
+        def txn(conn: Any) -> VideoJob | None:
+            job = self._read_entity_tx(conn, "video_job", job_id, VideoJob, for_update=True)
+            if job is None:
+                return None
+            if job.cleaned_at is None:
+                old_due = _video_due_id(job)
+                job.cleaned_at = iso_now()
+                job.updated_at = job.cleaned_at
+                job.lease_owner = None
+                job.leased_until = None
+                self._write_entity_tx(conn, "video_job", job.id, job)
+                self._delete_entity_tx(conn, "video_job_due", old_due)
+            return job
+
+        return self._run_transaction(txn)
 
     # Credit ledger ----------------------------------------------------------
 
@@ -3331,7 +3589,11 @@ class PostgresStore:
         return self._run_transaction(list_rollups)
 
     def get_generation(self, generation_id: str) -> Generation | None:
-        self._not_implemented("get_generation")
+        # Gateway-reachable (gateway.py:1285) on the settle REPLAY path,
+        # where it decides whether a stable generation_id may be echoed back.
+        # A miss simply omits the field, which is the documented behaviour
+        # when no generation exists for the authorization.
+        return self._read_entity("generation", generation_id, Generation)
 
     def activity(
         self,

--- a/tests/conformance/test_video_job_semantics.py
+++ b/tests/conformance/test_video_job_semantics.py
@@ -1,0 +1,207 @@
+"""Behavioural contract for asynchronous video jobs and the gateway reads.
+
+Why this file exists
+--------------------
+Every enclave dialled the GCP (Spanner) control plane, while the AWS and Azure
+control planes run `TR_STORAGE_BACKEND=postgres`. So the Postgres
+implementations of these methods had never served a real request, and eleven
+of them raised `NotImplementedError` — four reachable from
+`/internal/gateway/*` and seven from `/internal/gateway/video/jobs/*`. Cutting
+a peer enclave over to its own control plane would have 500'd every one of
+those calls, and one of the four fires *after* the credit escrow commits, so
+each attempt would have stranded a reservation.
+
+The structural guard in `tests/test_store_protocol_conformance.py` stops a
+method from *refusing*. It cannot tell whether the implementation is correct.
+These tests do, and because they are written against the `Store` Protocol they
+run on every registered backend — so the Postgres implementation is checked
+against the same properties as the in-memory reference rather than against a
+fake that drifts kinder than production.
+
+Run against a real server-backed Postgres with:
+
+    docker run -d --rm --name tr-conf-pg -e POSTGRES_PASSWORD=conf \\
+      -e POSTGRES_DB=trconf -p 55433:5432 postgres:17-alpine
+    export TR_CONFORMANCE_POSTGRES_DSN=postgresql://postgres:conf@127.0.0.1:55433/trconf
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trusted_router.storage_models import VideoJob
+from trusted_router.store_protocol import Store
+
+from .conftest import BACKENDS
+
+pytestmark = pytest.mark.parametrize("store", list(BACKENDS), indirect=True)
+
+
+def _job(workspace_id: str, unique: str, *, suffix: str = "") -> VideoJob:
+    return VideoJob(
+        id=f"job-{unique}{suffix}",
+        workspace_id=workspace_id,
+        key_hash=f"hash-{unique}",
+        authorization_id=f"auth-{unique}{suffix}",
+        model="sora-2",
+        provider="openai",
+        endpoint_id="openai/sora-2",
+        provider_model="sora-2",
+        quoted_microdollars=1_000_000,
+    )
+
+
+# --------------------------------------------------------------------------
+# The four gateway-reachable reads: a miss is a value, never an exception
+# --------------------------------------------------------------------------
+
+
+def test_gateway_reachable_reads_return_a_miss_instead_of_raising(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """These four are called during `authorize`. A raise is a 500 on the whole
+    request — and `list_broadcast_destinations` is called after the escrow
+    commits, so a raise there strands credits with no authorization id
+    returned to settle or refund against."""
+    assert store.get_custom_model(f"missing-{unique}") is None
+    assert store.get_byok_provider(workspace_id, f"missing-{unique}") is None
+    assert store.get_generation(f"missing-{unique}") is None
+    assert store.list_broadcast_destinations(workspace_id) == []
+
+
+def test_broadcast_destination_lookup_does_not_leak_across_workspaces(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """A workspace id is a LIKE prefix on some backends, and `_` is a
+    single-character wildcard there. Unescaped, one tenant's scan can return
+    another tenant's rows. Querying a neighbouring id must stay empty."""
+    assert store.list_broadcast_destinations(f"{workspace_id}-other") == []
+    assert store.list_broadcast_destinations(f"{workspace_id}_x") == []
+
+
+# --------------------------------------------------------------------------
+# Video jobs
+# --------------------------------------------------------------------------
+
+
+def test_prepare_video_job_is_idempotent_per_authorization(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """One authorization must map to exactly one job. Creating a second on
+    replay would submit the same generation to the provider twice and bill it
+    twice."""
+    job = _job(workspace_id, unique)
+    first, created = store.prepare_video_job(job)
+    assert created is True
+
+    replay = _job(workspace_id, unique)
+    replay.id = f"different-{unique}"  # same authorization_id, new job id
+    second, created_again = store.prepare_video_job(replay)
+    assert created_again is False
+    assert second.id == first.id
+
+
+def test_get_video_job_for_key_is_the_tenant_boundary(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """The public video endpoints authorise by key hash. A caller who guesses
+    a job id must not read it with the wrong key."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    assert store.get_video_job_for_key(job.id, job.key_hash) is not None
+    assert store.get_video_job_for_key(job.id, "wrong-hash") is None
+
+
+def test_a_job_is_claimed_by_exactly_one_lease_owner(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """The property the whole queue rests on. Two pollers claiming the same
+    job poll the provider twice and can bill the completion twice."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    store.mark_video_job_queued(
+        job.id,
+        provider_job_id=f"p-{unique}",
+        provider="openai",
+        endpoint_id="openai/sora-2",
+        provider_model="sora-2",
+        quoted_microdollars=1_000_000,
+        poll_after_seconds=0,
+    )
+
+    first = store.claim_video_jobs(lease_owner="poller-a", limit=10, lease_seconds=300)
+    second = store.claim_video_jobs(lease_owner="poller-b", limit=10, lease_seconds=300)
+
+    claimed_once = [j.id for j in first if j.id == job.id]
+    claimed_twice = [j.id for j in second if j.id == job.id]
+    assert claimed_once == [job.id], "the first poller should have claimed the due job"
+    assert claimed_twice == [], "a leased job must not be claimable by a second poller"
+
+
+def test_terminal_video_job_state_is_immutable(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """Once completed, a job must not be reopened — a later poller observing a
+    stale provider status could otherwise re-bill or resurrect it."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    store.update_video_job(job.id, status="completed", generation_id=f"gen-{unique}")
+    reopened = store.update_video_job(job.id, status="in_progress")
+    assert reopened is not None
+    assert reopened.status == "completed"
+
+
+def test_completed_job_accepts_a_missing_generation_link_once(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """The one permitted mutation of a terminal job: filling in a generation
+    link that concurrent regional settlement left empty. Monotonic — it may
+    fill an absent link, never replace a present one."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    store.update_video_job(job.id, status="completed")
+    repaired = store.update_video_job(
+        job.id, status="completed", generation_id=f"gen-{unique}"
+    )
+    assert repaired is not None
+    assert repaired.generation_id == f"gen-{unique}"
+
+    kept = store.update_video_job(job.id, status="completed", generation_id="other-gen")
+    assert kept is not None
+    assert kept.generation_id == f"gen-{unique}"
+
+
+def test_cleaned_job_leaves_the_due_queue(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """Cleanup must remove the job from the polling index. A job left in the
+    queue is claimed forever, burning poller capacity on every cycle."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    store.update_video_job(job.id, status="completed", poll_after_seconds=0)
+    cleaned = store.mark_video_job_cleaned(job.id)
+    assert cleaned is not None
+    assert cleaned.cleaned_at is not None
+
+    claimed = store.claim_video_jobs(lease_owner="poller-c", limit=50, lease_seconds=300)
+    assert job.id not in [j.id for j in claimed]
+
+
+def test_requeueing_with_a_conflicting_provider_id_is_refused(
+    store: Store, workspace_id: str, unique: str
+) -> None:
+    """Two different provider job ids for one job means one provider
+    generation is orphaned and unbilled. Refuse rather than overwrite."""
+    job, _ = store.prepare_video_job(_job(workspace_id, unique))
+    kwargs = dict(
+        provider="openai",
+        endpoint_id="openai/sora-2",
+        provider_model="sora-2",
+        quoted_microdollars=1_000_000,
+        poll_after_seconds=30,
+    )
+    store.mark_video_job_queued(job.id, provider_job_id=f"p-{unique}", **kwargs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="different provider id"):
+        store.mark_video_job_queued(job.id, provider_job_id="other-provider-id", **kwargs)  # type: ignore[arg-type]
+
+
+def test_missing_video_job_reads_are_none_not_errors(store: Store, unique: str) -> None:
+    assert store.get_video_job(f"absent-{unique}") is None
+    assert store.get_video_job_for_key(f"absent-{unique}", "any") is None
+    assert store.update_video_job(f"absent-{unique}", status="completed") is None
+    assert store.mark_video_job_cleaned(f"absent-{unique}") is None

--- a/tests/conformance/test_video_job_semantics.py
+++ b/tests/conformance/test_video_job_semantics.py
@@ -32,9 +32,13 @@ import pytest
 from trusted_router.storage_models import VideoJob
 from trusted_router.store_protocol import Store
 
-from .conftest import BACKENDS
-
-pytestmark = pytest.mark.parametrize("store", list(BACKENDS), indirect=True)
+# NOTE: do NOT re-parametrize `store` here. conftest already parametrizes it
+# over _BACKEND_PARAMS, and those params carry the `xdist_group` marks that
+# serialize DDL for the server-backed backends. A local
+# `pytest.mark.parametrize("store", list(BACKENDS), indirect=True)` overrides
+# them with bare names, the marks are lost, and the Spanner PG emulator then
+# rejects concurrent schema changes across xdist workers with
+# "Schema change operation rejected ... already in progress".
 
 
 def _job(workspace_id: str, unique: str, *, suffix: str = "") -> VideoJob:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1957,6 +1957,7 @@ def make_fake_store(
     from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
     from trusted_router.storage_gcp_broadcast import SpannerBroadcastDestinations
     from trusted_router.storage_gcp_byok import SpannerByok
+    from trusted_router.storage_gcp_custom_models import SpannerCustomModels
     from trusted_router.storage_gcp_email_blocks import SpannerEmailBlocks
     from trusted_router.storage_gcp_generations import SpannerGenerations
     from trusted_router.storage_gcp_group_buy import SpannerBedrockGroupBuy
@@ -2026,6 +2027,7 @@ def make_fake_store(
         operational_analytics_outbox=store._operational_analytics_outbox,
     )
     store.byok_store = SpannerByok(io)
+    store.custom_model_store = SpannerCustomModels(io)
     store.broadcast_store = SpannerBroadcastDestinations(io)
     store.video_job_store = SpannerVideoJobs(io)
     store.settle_outbox = SpannerSettleOutbox(store._database, store._param_types)

--- a/tests/test_store_protocol_conformance.py
+++ b/tests/test_store_protocol_conformance.py
@@ -12,11 +12,14 @@ structural — but combined with mypy on the `Store` type alias it makes
 
 from __future__ import annotations
 
+import ast
 import inspect
+import pathlib
 from typing import get_type_hints
 
 import pytest
 
+import trusted_router
 from trusted_router.storage import InMemoryStore
 from trusted_router.store_protocol import Store
 
@@ -210,3 +213,124 @@ def test_typed_billing_store_helper_unwraps_the_module_proxy() -> None:
     proxy._configure(InMemoryStore())
     assert typed_billing_store(proxy) is None
     assert typed_billing_store(InMemoryStore()) is None
+
+
+# --------------------------------------------------------------------------
+# Declared-but-refusing methods
+#
+# The tests above prove every Protocol method EXISTS on every backend. That is
+# not the same as it WORKING: `PostgresStore._not_implemented(name)` raises
+# NotImplementedError, which satisfies the structural check and every mypy
+# signature test, then blows up at runtime the first time a route calls it.
+#
+# That is not hypothetical. The AWS and Azure control planes both run
+# TR_STORAGE_BACKEND=postgres while every enclave dialled the GCP (Spanner)
+# plane, so the Postgres authorize path had never served a real request and
+# four gateway-reachable methods sat unimplemented — including one called
+# AFTER the credit escrow commits, which would have stranded a reservation on
+# every request the moment a peer enclave was cut over to its own plane.
+#
+# The behavioural conformance suite cannot guard this: tests/conformance's
+# Postgres backend `pytest.skip()`s unless TR_CONFORMANCE_POSTGRES_DSN is set,
+# so it is normally not running. This check is static on purpose — it needs no
+# database and therefore always runs.
+# --------------------------------------------------------------------------
+
+# Exactly the modules an enclave can reach, derived from the paths the enclave
+# itself dials (quill-cloud-proxy enclave-go/internal/trustedrouter/client.go):
+#   /internal/gateway/{authorize,settle,refund,validate,key,resolve-custom-model}
+#   /internal/gateway/fetch-image
+#   /internal/gateway/video/jobs/...
+# The rest of routes/internal is payment webhooks (adyen, paypal, webhook) and
+# operator/worker endpoints (sentry, synthetic, reconcile, broadcast_queue,
+# federation), which no enclave calls. Scoping to the real surface keeps this
+# check about the cutover risk instead of failing on unrelated backlog.
+_ENCLAVE_FACING_ROUTES = (
+    "routes/internal/gateway.py",
+    "routes/internal/fetch_image.py",
+    "routes/internal/video_jobs.py",
+)
+
+
+def _store_methods_called_by(paths: tuple[pathlib.Path, ...]) -> dict[str, set[str]]:
+    """Map method name -> {"file:line", ...} for every `STORE.<method>` access."""
+    calls: dict[str, set[str]] = {}
+    for path in paths:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "STORE"
+            ):
+                calls.setdefault(node.attr, set()).add(f"{path.name}:{node.lineno}")
+    return calls
+
+
+def _methods_that_refuse(module_path: pathlib.Path) -> set[str]:
+    """Names passed to `self._not_implemented("...")` in a backend module."""
+    tree = ast.parse(module_path.read_text(), filename=str(module_path))
+    refused: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_not_implemented"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            refused.add(node.args[0].value)
+    return refused
+
+
+def test_no_enclave_facing_route_calls_a_method_postgres_refuses() -> None:
+    """Every `STORE.x` an enclave can reach must be implemented on Postgres.
+
+    A failure here means: cutting any enclave over to a Postgres-backed
+    control plane 500s that call path in production.
+    """
+    src = pathlib.Path(trusted_router.__file__).parent
+    modules = tuple(src / rel for rel in _ENCLAVE_FACING_ROUTES)
+    missing = [str(p) for p in modules if not p.exists()]
+    assert not missing, (
+        f"enclave-facing route module(s) moved or renamed: {missing}. "
+        "Update _ENCLAVE_FACING_ROUTES — a stale path would make this guard "
+        "silently scan nothing."
+    )
+    called = _store_methods_called_by(modules)
+    refused = _methods_that_refuse(src / "storage_postgres.py")
+
+    broken = sorted(set(called) & refused)
+    assert not broken, (
+        "PostgresStore refuses "
+        + str(len(broken))
+        + " method(s) that enclave-facing routes call, so the AWS/Azure "
+        "control planes would 500 on those paths:\n"
+        + "\n".join(f"  {name}  called at {sorted(called[name])}" for name in broken)
+        + "\nImplement them on PostgresStore (a legitimate empty result is a "
+        "`return None`/`return []`, never a raise)."
+    )
+
+
+def test_the_refusal_detector_actually_detects() -> None:
+    """Negative control: a guard that cannot fail guards nothing.
+
+    Without this, a typo in the AST walk above would make the real test
+    vacuously green and the next unimplemented method would ship.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        backend = pathlib.Path(tmp) / "backend.py"
+        backend.write_text(
+            "class S:\n"
+            "    def _not_implemented(self, m): raise NotImplementedError(m)\n"
+            "    def get_thing(self): self._not_implemented('get_thing')\n"
+        )
+        routes = pathlib.Path(tmp) / "routes"
+        routes.mkdir()
+        (routes / "r.py").write_text("def h():\n    return STORE.get_thing()\n")
+
+        assert _methods_that_refuse(backend) == {"get_thing"}
+        assert set(_store_methods_called_by((routes / "r.py",))) == {"get_thing"}


### PR DESCRIPTION
Blocks the AWS/Azure enclave→own-control-plane cutover.

## The defect

Every enclave dials the GCP (Spanner) control plane, while the AWS and Azure control planes run `TR_STORAGE_BACKEND=postgres` (`scripts/deploy/aws_eu_control_plane.sh:190`, `scripts/deploy/azure_control_plane.sh:163`). So Postgres' gateway path had **never served a real request**, and eleven methods it reaches were still `self._not_implemented(...)`:

| route | methods |
|---|---|
| `gateway.py` | `list_broadcast_destinations`, `get_custom_model`, `get_byok_provider`, `get_generation` |
| `video_jobs.py` | `prepare_video_job`, `get_video_job`, `get_video_job_for_key`, `mark_video_job_queued`, `claim_video_jobs`, `update_video_job`, `mark_video_job_cleaned` |

Pointing a peer enclave at its own control plane would have 500'd all of them.

**Worse: it strands money.** `list_broadcast_destinations` is called at `gateway.py:616` — *after* `reserve_key_limit` (`:499`), `STORE.reserve` (`:520`) and `create_gateway_authorization` (`:546`) have committed. The caller never receives an authorization id, so it can neither settle nor refund. Every attempt would leak a reservation.

## Why nothing caught it

The classic *configured ≠ working* shape. The peer planes answer `/v1/models` (a read path) with 200, and their synthetic probes target `api-aws`/`api-azure.trustedrouter.com` — the **enclaves** — which dial `trustedrouter.com`. Every green signal was exercising Spanner.

## Notes on the implementation

- Video job methods mirror `SpannerVideoJobs` and take `FOR UPDATE` on read-modify-write paths, so two pollers serialize on the row and the loser re-evaluates `_is_due` **inside** the transaction rather than double-claiming a job (double provider poll, double billing).
- `_is_due` / `_iso_after_seconds` are imported from `storage_video_jobs` rather than re-derived — the predicate deciding whether a job is claimable must not fork per backend.
- In `mark_video_job_queued`/`update_video_job` the due-index delete happens **before** the write: when `next_poll_at` is unchanged both ids are equal, and deleting second would remove the row just written and drop the job out of the queue permanently.
- `_like_prefix` escapes LIKE metacharacters. Ids are `<owner>#<rest>` and owner ids contain `_`, which LIKE treats as a single-character wildcard — unescaped, one tenant's prefix scan can return another tenant's rows.

## Tests

- **`tests/test_store_protocol_conformance.py`** — static check that no enclave-facing route calls a method Postgres refuses, scoped to the three modules the enclave actually dials (derived from the paths in `enclave-go/internal/trustedrouter/client.go`), plus a negative control so a broken detector can't pass vacuously. The existing protocol tests prove a method *exists*; `_not_implemented` satisfies that and still raises at runtime, which is exactly how this hid. Static on purpose — it always runs, whereas the behavioural Postgres backend `pytest.skip()`s unless `TR_CONFORMANCE_POSTGRES_DSN` is set.
- **`tests/conformance/test_video_job_semantics.py`** — backend-parameterised properties: prepare idempotency per authorization, `key_hash` as the tenant boundary, exactly-one lease owner, terminal-state immutability with the monotonic generation-link repair, cleanup leaving the due queue, conflicting-provider-id refusal.
- **`tests/fakes/spanner.py`** — wires `custom_model_store`, which `make_fake_store` never set (`object.__new__` skips `__init__`), so `spanner-fake` AttributeError'd on `get_custom_model`. Found by the new conformance tests.

**151 → 163 conformance tests pass across memory, real PostgreSQL 17, and spanner-fake.**

Pre-existing and unrelated, verified failing at `HEAD` in a clean worktree: `test_friendli_tombstones_second_miss_then_restores_annotations` and the two `test_provider_branding` cards tests. Those also mutate tracked assets under `static/og/providers/` when run, which is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)