### PR TITLE
Improve API key onboarding quickstart

### DIFF
--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -230,6 +230,56 @@ body.console {
   color: var(--red);
 }
 
+.console-key-reveal {
+  width: min(100%, 760px);
+  max-width: none;
+  color: var(--ink);
+}
+
+.key-reveal-section {
+  display: grid;
+  gap: 8px;
+}
+
+.agent-quickstart {
+  display: grid;
+  gap: 8px;
+  padding-top: 14px;
+  border-top: 1px solid var(--good-border);
+}
+
+.agent-quickstart h3 {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.45;
+  letter-spacing: 0;
+  text-wrap: balance;
+}
+
+.agent-message-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.agent-message-row pre {
+  min-width: 0;
+  margin: 0;
+  padding: 12px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  background: var(--panel);
+  color: var(--ink);
+  border: 1px solid var(--good-border);
+  border-radius: 7px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
 .table-scroll {
   overflow-x: auto;
 }
@@ -820,6 +870,9 @@ body.console {
     flex: 1 1 auto;
   }
   .secret-row {
+    grid-template-columns: 1fr;
+  }
+  .agent-message-row {
     grid-template-columns: 1fr;
   }
   /* Topbar: children (brand / workspace selector / user cluster) overflow a

--- a/src/trusted_router/templates/console/_api_key_reveal.html
+++ b/src/trusted_router/templates/console/_api_key_reveal.html
@@ -1,0 +1,38 @@
+{% macro api_key_reveal(raw_key, id_prefix, workspace_name=None) %}
+<div class="signup-reveal console-key-reveal" data-copy-secret-scope>
+  <div class="key-reveal-section">
+    <div class="signup-reveal-head">Your TrustedRouter API key</div>
+    <div class="secret-row">
+      <code id="{{ id_prefix }}-api-key">{{ raw_key }}</code>
+      <button
+        class="btn secret-copy-btn"
+        type="button"
+        data-copy-secret="{{ id_prefix }}-api-key"
+        aria-describedby="{{ id_prefix }}-api-key-copy-status"
+        aria-label="Copy API key"
+      >Copy</button>
+    </div>
+    <p class="copy-status" id="{{ id_prefix }}-api-key-copy-status" role="status" aria-live="polite"></p>
+    {% if workspace_name %}
+    <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span></div>
+    {% endif %}
+  </div>
+
+  <section class="agent-quickstart" aria-labelledby="{{ id_prefix }}-agent-heading">
+    <h3 id="{{ id_prefix }}-agent-heading">Paste this whole message into your agent or Claude Code to try it out right now:</h3>
+    <div class="agent-message-row">
+      <pre id="{{ id_prefix }}-agent-message">Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"
+
+{{ raw_key }}</pre>
+      <button
+        class="btn secret-copy-btn"
+        type="button"
+        data-copy-secret="{{ id_prefix }}-agent-message"
+        aria-describedby="{{ id_prefix }}-agent-copy-status"
+        aria-label="Copy complete agent message"
+      >Copy</button>
+    </div>
+    <p class="copy-status" id="{{ id_prefix }}-agent-copy-status" role="status" aria-live="polite"></p>
+  </section>
+</div>
+{% endmacro %}

--- a/src/trusted_router/templates/console/api_keys.html
+++ b/src/trusted_router/templates/console/api_keys.html
@@ -1,4 +1,5 @@
 {% extends "console/_layout.html" %}
+{% from "console/_api_key_reveal.html" import api_key_reveal %}
 {% block body %}
 {% macro create_key_form() %}
 <form class="form" method="post" action="/console/api-keys">
@@ -23,13 +24,7 @@
 <section class="panel">
   <div class="panel-head"><h2>Save this key. It will not be shown again</h2><span class="pill warn">one time reveal</span></div>
   <div class="panel-body">
-    <div class="signup-reveal" data-copy-secret-scope>
-      <div class="secret-row">
-        <code id="created-api-key">{{ created_key }}</code>
-        <button class="btn secret-copy-btn" type="button" data-copy-secret="created-api-key" aria-describedby="created-api-key-copy-status">Copy</button>
-      </div>
-      <p class="copy-status" id="created-api-key-copy-status" role="status" aria-live="polite"></p>
-    </div>
+    {{ api_key_reveal(created_key, "created") }}
   </div>
 </section>
 {% endif %}

--- a/src/trusted_router/templates/console/welcome.html
+++ b/src/trusted_router/templates/console/welcome.html
@@ -1,14 +1,11 @@
 {% extends "console/_layout.html" %}
+{% from "console/_api_key_reveal.html" import api_key_reveal %}
 {% block body %}
 <section class="panel">
   <div class="panel-head"><h2>Save this key. It will not be shown again</h2><span class="pill warn">one time reveal</span></div>
   <div class="panel-body">
     {% if revealed_key %}
-    <div class="signup-reveal">
-      <div class="signup-reveal-head">Your TrustedRouter API key</div>
-      <div class="secret-row"><code>{{ revealed_key }}</code></div>
-      <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span></div>
-    </div>
+    {{ api_key_reveal(revealed_key, "welcome", workspace_name) }}
     {% if trial_credit_microdollars > 0 %}
     <p class="microcopy">Your workspace is ready. Try a fast, inexpensive model now.</p>
     {% else %}

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -848,10 +848,19 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
 
     resp = client.get("/console/welcome?first=1", follow_redirects=False)
     assert resp.status_code == 200
-    assert fake_raw_key in resp.text, (
+    assert resp.text.count(fake_raw_key) == 2, (
         "expected the raw API key from tr_pending_reveal to be rendered "
-        "in the welcome page; instead got the 'already displayed' fallback"
+        "by itself and in the agent quickstart message"
     )
+    agent_message = (
+        "Please use TrustedRouter.com using the following key to ask DeepSeek "
+        'the following question: "What is the capital of France?"'
+        f"\n\n{fake_raw_key}"
+    )
+    assert 'data-copy-secret="welcome-api-key"' in resp.text
+    assert 'data-copy-secret="welcome-agent-message"' in resp.text
+    assert f'<pre id="welcome-agent-message">{agent_message}</pre>' in resp.text
+    assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "already been displayed" not in resp.text
     # One-shot: cookie must be cleared on the response so a refresh
     # doesn't re-reveal the key.
@@ -882,6 +891,7 @@ def test_console_welcome_without_first_query_does_not_read_pending_reveal(
     # The page renders the fallback message; the cookie is left for a
     # later legitimate `?first=1` request to consume.
     assert fake_raw_key not in resp.text
+    assert 'id="welcome-agent-message"' not in resp.text
     assert "already been displayed" in resp.text
     # Cookie not cleared — the response should NOT include a delete-cookie
     # header for tr_pending_reveal.
@@ -904,8 +914,16 @@ def test_console_create_api_key_form_shows_raw_key_once(
     assert "console-created" in resp.text
     match = re.search(r"sk-tr-v1-[A-Za-z0-9_-]+", resp.text)
     assert match is not None
-    assert resp.text.count(match.group(0)) == 1
+    assert resp.text.count(match.group(0)) == 2
+    agent_message = (
+        "Please use TrustedRouter.com using the following key to ask DeepSeek "
+        'the following question: "What is the capital of France?"'
+        f"\n\n{match.group(0)}"
+    )
     assert 'data-copy-secret="created-api-key"' in resp.text
+    assert 'data-copy-secret="created-agent-message"' in resp.text
+    assert f'<pre id="created-agent-message">{agent_message}</pre>' in resp.text
+    assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "Copied to clipboard." not in resp.text
     workspace_id = next(iter(STORE.workspaces))
     keys = STORE.list_keys(workspace_id)


### PR DESCRIPTION
## Summary
- add a reusable one-time API key reveal component
- add a copyable agent quickstart message containing the newly created key
- cover first-signup and subsequent key creation flows

## Tests
- uv run pytest -q tests/test_oauth_and_console.py tests/test_console_keys_manage.py
- npx stylelint "src/trusted_router/static/console.css"
- uv run ruff check tests/test_oauth_and_console.py