### PR TITLE
fix(status): expose GCP regional checks to deploy gates

### DIFF
--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -202,6 +202,17 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
 GATEWAY_REGION_COMPONENT_IDS: frozenset[str] = frozenset(
     {"eu_west_1_gateway", "eu_west_3_gateway", "uaenorth_gateway"}
 )
+# Regional API components also feed deploy automation through
+# status.current.checks. Keep this set separate from
+# GATEWAY_REGION_COMPONENT_IDS: the latter deliberately controls the public
+# overall-status banner for pinned failover gateways, while these GCP rows
+# must remain diagnostic and outside the router-core SLO.
+REGIONAL_API_COMPONENT_IDS: frozenset[str] = frozenset(
+    {"us_central1_regional_api", "us_east4_regional_api", "eu_regional_api"}
+)
+MACHINE_REGION_COMPONENT_IDS: frozenset[str] = (
+    GATEWAY_REGION_COMPONENT_IDS | REGIONAL_API_COMPONENT_IDS
+)
 # Their probe target names, derived from the map above so the two cannot
 # drift apart.
 GATEWAY_REGION_TARGET_NAMES: frozenset[str] = frozenset(
@@ -274,6 +285,17 @@ def published_gateway_region_components(settings: Settings) -> tuple[str, ...]:
         str(definition["id"])
         for definition in COMPONENT_DEFINITIONS
         if str(definition["id"]) in GATEWAY_REGION_COMPONENT_IDS
+        and str(definition["id"]) in published
+    )
+
+
+def published_machine_region_components(settings: Settings) -> tuple[str, ...]:
+    """Regional component ids exposed to deploy and watchdog automation."""
+    published = {str(definition["id"]) for definition in applicable_component_definitions(settings)}
+    return tuple(
+        str(definition["id"])
+        for definition in COMPONENT_DEFINITIONS
+        if str(definition["id"]) in MACHINE_REGION_COMPONENT_IDS
         and str(definition["id"]) in published
     )
 

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -25,6 +25,7 @@ from trusted_router.synthetic.components import (
     component_name,
     component_probe_types,
     published_gateway_region_components,
+    published_machine_region_components,
     rollup_slo_class_ids,
     sample_component_ids,
     sample_slo_class_ids,
@@ -103,7 +104,7 @@ def status_snapshot(
     # resolve, and mixing in diagnostic per-region probes would triple the
     # denominator of a published SLO.
     current = _current_status(
-        router_core_samples + _gateway_region_samples(ordered, settings=settings),
+        router_core_samples + _machine_region_samples(ordered, settings=settings),
         now=now,
     )
     router_core_rollups = [
@@ -261,15 +262,15 @@ def _headline_metrics(samples: list[SyntheticProbeSample], *, now: dt.datetime) 
     }
 
 
-def _gateway_region_samples(
+def _machine_region_samples(
     samples: list[SyntheticProbeSample],
     *,
     settings: Settings,
 ) -> list[SyntheticProbeSample]:
-    """Gateway samples from the pinned per-region targets this cloud publishes."""
+    """Regional gateway samples consumed by deploy and watchdog automation."""
     published = {
         COMPONENT_PROBE_TARGETS[component_id]
-        for component_id in published_gateway_region_components(settings)
+        for component_id in published_machine_region_components(settings)
     }
     if not published:
         return []

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -128,6 +128,42 @@ def test_gcp_status_snapshot_components_are_byte_identical() -> None:
         assert row["description"] == definition["description"]
 
 
+def test_gcp_current_checks_expose_regions_without_blending_router_core_slo() -> None:
+    """Deploy gates see every configured region; public SLO remains canonical."""
+    now = utcnow()
+    samples = [
+        _tls_sample(created_at=_iso(now - dt.timedelta(seconds=10)), target=target)
+        for target in ("canonical", "us-central1", "us-east4", "europe-west4")
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_gcp_settings())
+
+    current = snapshot["current"]
+    assert isinstance(current, dict)
+    checks = current["checks"]
+    assert isinstance(checks, list)
+    assert {row["target"] for row in checks} == {
+        "canonical",
+        "us-central1",
+        "us-east4",
+        "europe-west4",
+    }
+    assert {row["target_region"] for row in checks if row["target"] != "canonical"} == {
+        "us-central1",
+        "us-east4",
+        "europe-west4",
+    }
+
+    # Direct regional diagnostics must not inflate uptime denominators or
+    # burn-rate calculations for the canonical router-core service.
+    windows = snapshot["windows"]
+    assert isinstance(windows, dict)
+    assert windows["5m"]["sample_count"] == 1
+    slo_classes = snapshot["slo_classes"]
+    assert isinstance(slo_classes, dict)
+    assert slo_classes["router_core"]["windows"]["5m"]["sample_count"] == 1
+
+
 def test_aws_eu_does_not_advertise_gcp_regional_gateways() -> None:
     ids = tuple(
         str(definition["id"]) for definition in applicable_component_definitions(_aws_eu_settings())


### PR DESCRIPTION
## Summary
- expose configured GCP regional synthetic rows in machine-readable status current checks
- keep router-core SLO windows and burn rates canonical-only
- preserve pinned-gateway overall-status semantics

## Verification
- uv run ruff check changed files
- uv run mypy changed source files
- uv run pytest -q tests/test_status_component_scope.py
- uv run pytest -q tests/test_synthetic_monitoring.py tests/test_per_enclave_probes.py tests/test_gateway_reuse_probe.py (159 passed)