### PR TITLE
synthetic: PCR0 pin is a SET, so a re-pin does not turn the fleet red

### DIFF
--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -2821,7 +2821,7 @@ def _attestation_evidence(
             error = "nonce_missing"
         elif peer_cert_der is not None and not _aws_cert_binding_ok(aws, peer_cert_der):
             error = "cert_binding_mismatch"
-        elif expected_pcr0 and (pcr0_hex or "").lower() != expected_pcr0.lower():
+        elif expected_pcr0 and not _pcr0_pin_matches(pcr0_hex, expected_pcr0):
             error = "pcr0_mismatch"
         return {
             "nonce_ok": nonce_ok,
@@ -2835,6 +2835,34 @@ def _attestation_evidence(
         "attestation_digest": None,
         "source_commit": None,
     }
+
+
+def _pcr0_pin_matches(pcr0_hex: str | None, expected_pcr0: str) -> bool:
+    """Is the measured PCR0 one of the pinned values?
+
+    Comma-separated SET, matching how the Azure hostdata pin already works
+    (tools/verify-attestation.py check_maa_hostdata_pin).
+
+    This was an equality check, which made changing PCR0 impossible without
+    turning the status page red: a rolling EIF replacement legitimately spans
+    the published measurement and the incoming one, and under equality one of
+    the two always mismatches. Worse, the natural workaround — setting the pin
+    to "old,new" — failed BOTH under equality, because neither value equals the
+    literal joined string. So an operator running the obvious bind-window
+    procedure would have reported every instance as pcr0_mismatch.
+
+    That matters beyond the dashboard: reconcile-enclave-dns.py health-gates
+    DNS membership on attestation, so a fleet-wide false mismatch can drain
+    healthy instances out of DNS.
+    """
+    allowed = {
+        value.strip().lower().removeprefix("0x")
+        for value in expected_pcr0.split(",")
+        if value.strip()
+    }
+    if not allowed:
+        return True
+    return (pcr0_hex or "").lower() in allowed
 
 
 def _aws_cert_binding_ok(payload: dict[Any, Any], peer_cert_der: bytes) -> bool:

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -1101,3 +1101,63 @@ def test_pinned_probes_do_not_move_the_published_gateway_latency() -> None:
     ):
         assert with_pinned[key] == without[key], key
     assert with_pinned["in_region_gateway_overhead_p50_milliseconds"] == 30
+
+
+# ---------------------------------------------------------------------------
+# PCR0 pin is a SET, so a measurement can be changed at all
+# ---------------------------------------------------------------------------
+
+
+def test_pcr0_pin_accepts_both_measurements_during_a_rolling_repin() -> None:
+    """A rolling EIF replacement legitimately spans two measurements.
+
+    This is what unblocks pointing AWS at its own control plane: that hostname
+    list is compiled into the enclave binary, inside the EIF, so changing it
+    changes PCR0 — and rolling to the new image means a window where both the
+    published and the incoming measurement are serving.
+    """
+    from trusted_router.synthetic.probes import _pcr0_pin_matches
+
+    old = "2c12e222" + "0" * 88
+    new = "aa" * 48
+    both = f"{old},{new}"
+
+    assert _pcr0_pin_matches(old, both)
+    assert _pcr0_pin_matches(new, both)
+    assert not _pcr0_pin_matches("bb" * 48, both), "a third measurement must still mismatch"
+
+
+def test_pcr0_pin_single_value_behaviour_is_unchanged() -> None:
+    from trusted_router.synthetic.probes import _pcr0_pin_matches
+
+    pinned = "2c12e222" + "0" * 88
+    assert _pcr0_pin_matches(pinned, pinned)
+    assert not _pcr0_pin_matches("aa" * 48, pinned)
+
+
+def test_pcr0_pin_tolerates_operator_formatting() -> None:
+    """Pins are pasted by hand from trust pages and CI logs."""
+    from trusted_router.synthetic.probes import _pcr0_pin_matches
+
+    pinned = "2c12e222" + "0" * 88
+    assert _pcr0_pin_matches(pinned, f"  0X{pinned.upper()} ,  ")
+
+
+def test_pcr0_pin_with_no_usable_value_does_not_report_mismatch() -> None:
+    """An empty pin means "not asserting a measurement", not "accept nothing".
+
+    Reporting mismatch here would be worse than useless: reconcile-enclave-dns.py
+    health-gates DNS membership on attestation, so a fleet-wide false mismatch
+    drains healthy instances out of DNS.
+    """
+    from trusted_router.synthetic.probes import _pcr0_pin_matches
+
+    assert _pcr0_pin_matches("aa" * 48, "  ,  ")
+
+
+def test_a_missing_measurement_never_satisfies_a_pin() -> None:
+    """Fail closed: no PCR0 in the document must not pass a pinned check."""
+    from trusted_router.synthetic.probes import _pcr0_pin_matches
+
+    assert not _pcr0_pin_matches(None, "aa" * 48)
+    assert not _pcr0_pin_matches("", "aa" * 48)


### PR DESCRIPTION
Companion to [quill-cloud-proxy#112](https://github.com/Lore-Hex/quill-cloud-proxy/pull/112). Unblocks making the AWS control-plane cutover live.

Pointing the AWS enclave at its own control plane changes PCR0 — the control-plane hostname allowlist is compiled into the enclave binary and therefore measured. Rolling to the new image means a window where the published measurement and the incoming one are **both** serving.

The probe's pin was an **equality** check, so during that window one of the two always reported `pcr0_mismatch`.

**And the obvious workaround is worse than the problem:** setting the pin to `old,new` against an equality check matches **neither**, because neither value equals the literal joined string. An operator running the standard bind-window procedure would have marked every instance mismatched.

That is not just a red dashboard — `reconcile-enclave-dns.py` health-gates DNS membership on attestation, so a fleet-wide false mismatch **drains healthy instances out of DNS**. The re-pin would have caused exactly the outage it was meant to avoid.

`_pcr0_pin_matches` now takes a comma-separated set, matching how the Azure hostdata pin has always worked. An empty pin still means *not asserting a measurement* rather than *accept nothing*; a document with no PCR0 never satisfies a pin.

Mutation-verified: restoring the equality comparison turns the bind-window and formatting tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)