### PR TITLE
Fix API key quickstart wrapping

### DIFF
--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -170,6 +170,7 @@ body.console {
 }
 
 .console-main {
+  min-width: 0;
   padding: 24px 32px 48px;
   max-width: 1100px;
   width: 100%;
@@ -194,6 +195,12 @@ body.console {
 .console-page-body {
   display: grid;
   gap: 18px;
+  min-width: 0;
+}
+
+.console-page-body > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .secret-row {
@@ -231,8 +238,9 @@ body.console {
 }
 
 .console-key-reveal {
-  width: min(100%, 760px);
-  max-width: none;
+  width: 100%;
+  max-width: 760px;
+  min-width: 0;
   color: var(--ink);
 }
 
@@ -244,33 +252,43 @@ body.console {
 .agent-quickstart {
   display: grid;
   gap: 8px;
+  min-width: 0;
+  max-width: 100%;
   padding-top: 14px;
   border-top: 1px solid var(--good-border);
 }
 
 .agent-quickstart h3 {
-  max-width: 62ch;
+  min-width: 0;
+  max-width: 100%;
   margin: 0;
   color: var(--ink);
   font-size: 14px;
   line-height: 1.45;
   letter-spacing: 0;
-  text-wrap: balance;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 .agent-message-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
-  align-items: stretch;
+  align-items: start;
+  min-width: 0;
+  max-width: 100%;
 }
 
-.agent-message-row pre {
+.agent-message {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
   margin: 0;
   padding: 12px;
+  overflow: hidden;
   overflow-wrap: anywhere;
-  white-space: pre-wrap;
   background: var(--panel);
   color: var(--ink);
   border: 1px solid var(--good-border);
@@ -278,6 +296,21 @@ body.console {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 13px;
   line-height: 1.55;
+}
+
+.agent-message > div {
+  min-width: 0;
+}
+
+.agent-message .agent-message-key {
+  display: block;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .table-scroll {

--- a/src/trusted_router/static/console.js
+++ b/src/trusted_router/static/console.js
@@ -37,6 +37,15 @@ function setCopyStatus(button, message, isError) {
   }
 }
 
+function copyTargetText(target) {
+  if (target.hasAttribute("data-copy-lines")) {
+    return Array.from(target.children, (line) => line.textContent.trim())
+      .join("\n\n")
+      .trim();
+  }
+  return target.textContent.trim();
+}
+
 // ── Theme toggle ────────────────────────────────────────────────────
 // Mirrors the marketing chrome (static/dashboard.js). Dark is the default
 // (no data-theme attribute); a stored "light" preference is applied as
@@ -121,7 +130,7 @@ function initConsole() {
     event.preventDefault();
     const secretId = button.getAttribute("data-copy-secret");
     const secret = secretId ? document.getElementById(secretId) : null;
-    const value = secret ? secret.textContent.trim() : "";
+    const value = secret ? copyTargetText(secret) : "";
     if (!value) {
       setCopyStatus(button, "No key to copy.", true);
       return;

--- a/src/trusted_router/templates/console/_api_key_reveal.html
+++ b/src/trusted_router/templates/console/_api_key_reveal.html
@@ -21,9 +21,10 @@
   <section class="agent-quickstart" aria-labelledby="{{ id_prefix }}-agent-heading">
     <h3 id="{{ id_prefix }}-agent-heading">Paste this whole message into your agent or Claude Code to try it out right now:</h3>
     <div class="agent-message-row">
-      <pre id="{{ id_prefix }}-agent-message">Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"
-
-{{ raw_key }}</pre>
+      <div class="agent-message" id="{{ id_prefix }}-agent-message" data-copy-lines>
+        <div>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</div>
+        <div><code class="agent-message-key">{{ raw_key }}</code></div>
+      </div>
       <button
         class="btn secret-copy-btn"
         type="button"

--- a/src/trusted_router/templates/console/_layout.html
+++ b/src/trusted_router/templates/console/_layout.html
@@ -20,10 +20,10 @@
     })();
   </script>
   <link rel="stylesheet" href="/static/dashboard.css?v={{ static_version|default('local') }}">
-  <link rel="stylesheet" href="/static/console.css?v={{ static_version|default('local') }}">
   <link rel="preload" href="/static/fonts/archivo-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/static/fonts/spectral-300-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/static/charter.css?v={{ static_version|default('local') }}">
+  <link rel="stylesheet" href="/static/console.css?v={{ static_version|default('local') }}">
   {% block head_extra %}{% endblock %}
   <script defer src="/static/console.js?v={{ static_version|default('local') }}"></script>
   {% block scripts %}{% endblock %}

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -125,6 +125,102 @@ test("console redirects unauthenticated users and auto-opens sign-in", async ({ 
   await expect(page.locator("#signinModal")).toBeVisible();
 });
 
+test("new API key quickstart stays inside its reveal panel", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__copiedAgentMessage = value; },
+        readText: async () => window.__copiedAgentMessage || "",
+      },
+    });
+  });
+  await page.route("**/console/api-keys", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html>
+        <html lang="en">
+          <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link rel="stylesheet" href="/static/dashboard.css">
+            <link rel="stylesheet" href="/static/charter.css">
+            <link rel="stylesheet" href="/static/console.css">
+            <script defer src="/static/console.js"></script>
+          </head>
+          <body class="console">
+            <div class="console-shell">
+              <aside class="console-sidebar"></aside>
+              <main class="console-main">
+                <div class="console-page-body">
+                  <section class="panel">
+                    <div class="panel-body">
+                      <div class="signup-reveal console-key-reveal">
+                        <section class="agent-quickstart">
+                          <h3>Paste this whole message into your agent or Claude Code to try it out right now:</h3>
+                          <div class="agent-message-row">
+                            <div class="agent-message" id="layout-agent-message" data-copy-lines>
+                              <div>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</div>
+                              <div><code class="agent-message-key">sk-tr-v1-layout-regression-key</code></div>
+                            </div>
+                            <button class="btn secret-copy-btn" type="button" data-copy-secret="layout-agent-message" aria-label="Copy complete agent message">Copy</button>
+                          </div>
+                        </section>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+              </main>
+            </div>
+          </body>
+        </html>`,
+    });
+  });
+  await page.goto("/console/api-keys");
+
+  const reveal = page.locator(".console-key-reveal");
+  const heading = reveal.locator(".agent-quickstart h3");
+  const message = reveal.locator(".agent-message");
+  await expect(heading).toBeVisible();
+  await expect(message).toContainText("What is the capital of France?");
+
+  const assertContained = async () => {
+    const layout = await reveal.evaluate((element) => {
+      const headingElement = element.querySelector(".agent-quickstart h3");
+      const messageElement = element.querySelector(".agent-message");
+      const bounds = element.getBoundingClientRect();
+      return {
+        pageOverflow: document.documentElement.scrollWidth - window.innerWidth,
+        headingOverflow: headingElement.scrollWidth - headingElement.clientWidth,
+        messageOverflow: messageElement.scrollWidth - messageElement.clientWidth,
+        headingRight: headingElement.getBoundingClientRect().right - bounds.right,
+        messageRight: messageElement.getBoundingClientRect().right - bounds.right,
+      };
+    });
+    expect(layout.pageOverflow).toBeLessThanOrEqual(2);
+    expect(layout.headingOverflow).toBeLessThanOrEqual(1);
+    expect(layout.messageOverflow).toBeLessThanOrEqual(1);
+    expect(layout.headingRight).toBeLessThanOrEqual(1);
+    expect(layout.messageRight).toBeLessThanOrEqual(1);
+  };
+
+  await assertContained();
+  await page.setViewportSize({ width: 820, height: 900 });
+  await assertContained();
+  // A rolling multi-region deploy can briefly pair new HTML with an older
+  // console stylesheet. The message must still use normal HTML wrapping.
+  await page.evaluate(() => document.querySelector('link[href="/static/console.css"]').remove());
+  await assertContained();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await assertContained();
+  const copyButton = reveal.getByRole("button", { name: "Copy complete agent message" });
+  await expect(copyButton).toBeVisible();
+  await copyButton.click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(
+    'Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"\n\nsk-tr-v1-layout-regression-key',
+  );
+});
+
 test("delegated sign-in explains zero-credit onboarding", async ({ page }) => {
   const target = encodeURIComponent(
     "/auth?callback_url=https%3A%2F%2Fslopnazi.com%2Feditor&key_label=SlopNazi&limit=5&usage_limit_type=monthly",

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -879,7 +879,10 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
     )
     assert 'data-copy-secret="welcome-api-key"' in resp.text
     assert 'data-copy-secret="welcome-agent-message"' in resp.text
-    assert f'<pre id="welcome-agent-message">{agent_message}</pre>' in resp.text
+    assert 'id="welcome-agent-message" data-copy-lines' in resp.text
+    assert 'class="agent-message-key">' + fake_raw_key + "</code>" in resp.text
+    assert '<pre id="welcome-agent-message"' not in resp.text
+    assert agent_message.split("\n\n", 1)[0] in resp.text
     assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "already been displayed" not in resp.text
     # One-shot: cookie must be cleared on the response so a refresh
@@ -893,6 +896,15 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
         or "Max-Age=0" in set_cookie
         or "max-age=0" in set_cookie
     ), f"expected tr_pending_reveal cookie to be cleared; got {set_cookie!r}"
+
+
+def test_console_specific_styles_load_after_shared_charter_styles() -> None:
+    layout = (
+        Path(__file__).resolve().parents[1]
+        / "src/trusted_router/templates/console/_layout.html"
+    ).read_text(encoding="utf-8")
+
+    assert layout.index("/static/charter.css") < layout.index("/static/console.css")
 
 
 def test_console_welcome_without_first_query_does_not_read_pending_reveal(
@@ -942,7 +954,10 @@ def test_console_create_api_key_form_shows_raw_key_once(
     )
     assert 'data-copy-secret="created-api-key"' in resp.text
     assert 'data-copy-secret="created-agent-message"' in resp.text
-    assert f'<pre id="created-agent-message">{agent_message}</pre>' in resp.text
+    assert 'id="created-agent-message" data-copy-lines' in resp.text
+    assert 'class="agent-message-key">' + match.group(0) + "</code>" in resp.text
+    assert '<pre id="created-agent-message"' not in resp.text
+    assert agent_message.split("\n\n", 1)[0] in resp.text
     assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "Copied to clipboard." not in resp.text
     workspace_id = next(iter(STORE.workspaces))


### PR DESCRIPTION
## Summary
- make the post-key-creation agent prompt wrap inside its reveal panel
- keep copied prompt text unchanged while replacing fragile preformatted markup
- load console-specific styles after shared Charter styles
- add desktop, breakpoint, mobile, clipboard, and stale-stylesheet regressions

## Verification
- 71 console tests passed
- 18 Playwright browser tests passed
- ruff and mypy passed
- TypeScript, JavaScript syntax, and Stylelint passed
- full Python suite: 3,090 passed in sandbox; all 96 socket-bound tests passed separately with localhost access