### PR TITLE
Optimize paid search activation path

### DIFF
--- a/docs/marketing/google-message-experiment-2026-08-05.md
+++ b/docs/marketing/google-message-experiment-2026-08-05.md
@@ -1,0 +1,100 @@
+# Google Message Experiment: August 2026
+
+## Objective
+
+Find the words that produce a first successful API call, not merely a click or
+signup. Run every variant in the same high-intent search campaign and ad group
+so keyword intent, bids, geography, and landing-page experience remain fixed.
+
+Primary event: `acquisition.first_successful_api_call`.
+
+Secondary events: `acquisition.signup_completed` and
+`acquisition.purchase_completed`.
+
+## Current Signal
+
+The July 21 through August 4 account results show:
+
+- `openai_compatible_rsa1` is the only paid creative associated with an
+  activated buyer: three engaged visitors, two signups, one activated user,
+  one purchaser, and $5 in credited revenue. The sample is directional only.
+- `openrouter_migration_rsa2` produced 81 engaged visitors and 11 signups, but
+  no first successful API call.
+- `router_privacy_rsa1` produced 69 engaged visitors and 10 signups, but no
+  first successful API call.
+- `message_test_10_rsa1` produced 73 engaged visitors and eight signups, but no
+  first successful API call.
+- `kimi_k3_rsa1` produced 208 engaged visitors and six signups after $493.29 in
+  spend, but no first successful API call. It is paused.
+
+The next round therefore tests concrete product promises. It does not add more
+hot-model variants.
+
+## Active Test
+
+- Campaign: `Search | High Intent | 2026-07-25`
+- Ad group: `OpenAI Compatible API`
+- Landing page: `https://trustedrouter.com/openai-compatible-llm-api`
+- Geography, keywords, bids, audience, schedule, and device settings: unchanged
+- Each challenger uses one primary promise.
+- Each ad has a unique `utm_content` value.
+- Do not combine hooks inside one responsive ad.
+
+The active ad group contains exactly three responsive search ads:
+
+| Cell | `utm_content` | Primary promise | Status at launch |
+|---|---|---|---|
+| Control | `openai_compatible_rsa1` | One API for every model | Eligible |
+| Ease | `oa_keep_sdk_r1` | Keep your OpenAI SDK and change one base URL | Under review |
+| Breadth | `oa_every_model_r1` | Every model through one API | Eligible |
+
+The ease challenger sends users directly to a runnable three-step quickstart.
+Its CTA is `Create my API key`, with `No card required` next to the action. The
+snippet uses the standard OpenAI package, reads the API key from the
+environment, calls `trustedrouter/cheap`, and can be copied with one click.
+
+The old `OpenRouter Migration` group keeps only `openrouter_migration_rsa2`
+enabled as its historical control. `enterprise_platform_rsa1` and
+`message_test_10_rsa1` are paused.
+
+## Next Message Cells
+
+| Cell | `utm_content` | Headline | Primary promise |
+|---|---|---|---|
+| Privacy | `msg_never_logged_r1` | Your Prompts Are Never Logged | No prompt or output storage |
+| Reliability | `msg_provider_failover_r1` | Provider Failover Built In | Automatic independent-provider rollover |
+| Price | `msg_five_percent_r1` | 5% Fee. No Subscription. | Transparent usage pricing |
+| Verification | `msg_code_saw_prompt_r1` | Know What Code Saw Your Prompt | Live attestation of the open source gateway |
+
+Run the cells in three waves:
+
+1. Ease and breadth, currently active.
+2. Privacy and reliability.
+3. Price and verification.
+
+Keep the same control ad in every wave. Pause the previous challengers before
+enabling the next pair.
+
+## Decision Rules
+
+- Do not select a winner from CTR alone.
+- Record directional results after 50 engaged visitors per cell.
+- Make a promotion decision after 100 engaged visitors per cell.
+- Pause a cell after 100 engaged visitors with no first successful API call.
+- Promote a cell only when its activated-user rate beats the high-intent
+  baseline and it has at least three activated users.
+- Break ties by purchaser rate, then signup rate, then engaged-visit cost.
+- TrustedRouter's metadata-only first-party funnel is the source of truth.
+
+## Reporting
+
+```bash
+uv run python scripts/marketing_funnel_report.py \
+  --source google \
+  --campaign message_words_20260805 \
+  --days 30
+```
+
+Report spend, engaged visitors, signups, activated users, purchasers, and
+credited purchases for every `utm_content` cell. Preserve money as integer
+microdollars until display.

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -148,6 +148,25 @@ function trackEngagedLanding(): void {
   }, 1500);
 }
 
+async function copyCode(button: HTMLElement): Promise<void> {
+  const targetId = button.dataset.copyTarget;
+  const target = targetId ? document.getElementById(targetId) : null;
+  const text = target?.textContent?.trim();
+  if (!text || !navigator.clipboard || !window.isSecureContext) return;
+
+  const original = button.textContent || "Copy";
+  try {
+    await navigator.clipboard.writeText(text);
+    button.textContent = "Copied";
+    button.setAttribute("aria-live", "polite");
+  } catch {
+    button.textContent = "Copy failed";
+  }
+  window.setTimeout(() => {
+    button.textContent = original;
+  }, 1600);
+}
+
 function setSigninError(message: string): void {
   const el = document.getElementById("signinError");
   if (!el) return;
@@ -282,6 +301,12 @@ function init(): void {
       event.preventDefault();
       trackFunnelEvent("sign_in_opened");
       openSigninModal();
+      return;
+    }
+    const copyButton = target.closest('[data-action="copy-code"]') as HTMLElement | null;
+    if (copyButton) {
+      event.preventDefault();
+      void copyCode(copyButton);
       return;
     }
     const metamask = target.closest('[data-action="metamask-signin"]') as HTMLElement | null;

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1077,8 +1077,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="openrouter-alternative.png",
         title="OpenRouter Alternative — TrustedRouter",
         description=(
-            "Use an OpenAI-compatible OpenRouter alternative with hundreds of models, provider "
-            "failover, zero-retention routes, open source code, and a verifiable attested prompt path."
+            "Keep the OpenAI SDK and change one base URL. Route the same model IDs "
+            "through an open-source, hardware-attested gateway with no prompt or output logs."
         ),
     ),
     "private-llm-api": PublicPage(
@@ -1181,8 +1181,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="openai-compatible-llm-api.png",
         title="OpenAI-Compatible LLM API Router",
         description=(
-            "Use the OpenAI SDK with one base_url change, then route to hundreds "
-            "of models with failover, BYOK, ZDR options, and measured provider latency."
+            "Keep the OpenAI SDK. Change base_url once and call hundreds of models "
+            "through one API. Create a key and make the first request without a card."
         ),
         faq_items=(
             (

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -121,6 +121,8 @@ h1 { margin:16px 0 12px; font-size:48px; line-height:1.04; letter-spacing:0; max
 .term { color:var(--rust); font-weight:750; }
 .code-card { background:var(--code-bg); color:var(--code-ink); border:1px solid var(--code-line); border-radius:8px; overflow:hidden; box-shadow:0 10px 30px var(--shadow); }
 .code-head { display:flex; align-items:center; justify-content:space-between; padding:11px 13px; border-bottom:1px solid var(--code-line); color:var(--code-muted); font-size:12px; }
+.code-copy { appearance:none; border:0; background:transparent; color:#b8c6d2; font:inherit; cursor:pointer; padding:3px 5px; }
+.code-copy:hover, .code-copy:focus-visible { color:#fff; }
 pre { margin:0; padding:16px; overflow:auto; font-size:13px; line-height:1.5; }
 code, .mono { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .router-scene-shell { min-height:720px; align-self:stretch; display:flex; align-items:center; justify-content:center; position:relative; overflow:visible; z-index:5; }

--- a/src/trusted_router/static/dashboard.js
+++ b/src/trusted_router/static/dashboard.js
@@ -138,6 +138,25 @@ function trackEngagedLanding() {
         }
     }, 1500);
 }
+async function copyCode(button) {
+    const targetId = button.dataset.copyTarget;
+    const target = targetId ? document.getElementById(targetId) : null;
+    const text = target?.textContent?.trim();
+    if (!text || !navigator.clipboard || !window.isSecureContext)
+        return;
+    const original = button.textContent || "Copy";
+    try {
+        await navigator.clipboard.writeText(text);
+        button.textContent = "Copied";
+        button.setAttribute("aria-live", "polite");
+    }
+    catch {
+        button.textContent = "Copy failed";
+    }
+    window.setTimeout(() => {
+        button.textContent = original;
+    }, 1600);
+}
 function setSigninError(message) {
     const el = document.getElementById("signinError");
     if (!el)
@@ -271,6 +290,12 @@ function init() {
             event.preventDefault();
             trackFunnelEvent("sign_in_opened");
             openSigninModal();
+            return;
+        }
+        const copyButton = target.closest('[data-action="copy-code"]');
+        if (copyButton) {
+            event.preventDefault();
+            void copyCode(copyButton);
             return;
         }
         const metamask = target.closest('[data-action="metamask-signin"]');

--- a/src/trusted_router/templates/public/seo_openai_compatible_llm_api.html
+++ b/src/trusted_router/templates/public/seo_openai_compatible_llm_api.html
@@ -3,23 +3,21 @@
 
 <section class="marketing-split" aria-label="OpenAI compatible LLM API">
   <div class="marketing-copy">
-    <span class="eyebrow">OpenAI compatible router</span>
+    <span class="eyebrow">Make your first API call</span>
     <h2>Keep the SDK. Change the base URL.</h2>
-    <p>TrustedRouter lets teams use the OpenAI client shape while routing across many providers, privacy tiers, regions, and fallback policies.</p>
+    <p>Use the OpenAI client you already have. Change <code>base_url</code>, create one key, and call hundreds of models through the same interface.</p>
     <ul class="check-list">
-      <li>✓ <code>POST /v1/chat/completions</code> and <code>POST /v1/responses</code></li>
-      <li>✓ Explicit model IDs or aliases like <code>trustedrouter/auto</code> and <code>trustedrouter/zdr</code></li>
-      <li>✓ BYOK, prepaid credits, provider filters, and workspace controls</li>
-      <li>✓ Public model pages with pricing, provider routes, and measured performance</li>
+      <li>✓ Install the standard <code>openai</code> package</li>
+      <li>✓ Point it at <code>{{ api_base_url }}</code></li>
+      <li>✓ Start with <code>trustedrouter/cheap</code> or choose any model ID</li>
     </ul>
-    <p>
-      <a class="btn primary" href="/docs">Read docs</a>
-      <a class="btn" href="/models">Browse models</a>
-    </p>
+    <p><button class="btn primary" type="button" data-action="open-signin">Create my API key</button></p>
+    <p class="microcopy">No card required. Your existing OpenAI SDK keeps working.</p>
   </div>
   <div class="copy-terminal">
-    <div class="code-head"><span>OpenAI SDK</span><span>Python</span></div>
-    <pre><code>from openai import OpenAI
+    <div class="code-head"><span>OpenAI SDK</span><button class="code-copy" type="button" data-action="copy-code" data-copy-target="openai-first-call">Copy</button></div>
+    <pre><code id="openai-first-call">import os
+from openai import OpenAI
 
 client = OpenAI(
     api_key=os.environ["TRUSTEDROUTER_API_KEY"],
@@ -27,9 +25,11 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="trustedrouter/auto",
-    messages=[{"role": "user", "content": "Hello"}],
-)</code></pre>
+    model="trustedrouter/cheap",
+    messages=[{"role": "user", "content": "Reply with PONG"}],
+)
+
+print(response.choices[0].message.content)</code></pre>
   </div>
 </section>
 
@@ -37,6 +37,17 @@ response = client.chat.completions.create(
   <a class="marketing-card card-as-link" href="/leaderboard"><h3>Measured providers</h3><p>Use live TTFT, TTFB, throughput, and uptime data instead of vendor claims.</p><span class="card-link">Open leaderboard</span></a>
   <a class="marketing-card card-as-link" href="/providers"><h3>Policy-aware routing</h3><p>Compare ZDR, confidential compute, provider E2EE, and upstream policy sources.</p><span class="card-link">Open providers</span></a>
   <a class="marketing-card card-as-link" href="https://trust.trustedrouter.com"><h3>Verify the gateway</h3><p>Check the running image, source commit, digest, and attestation path.</p><span class="card-link">Open trust</span></a>
+</section>
+
+<section class="cta-band" aria-label="Create an API key">
+  <div>
+    <strong>Make the first call with your existing SDK.</strong>
+    <span>Create one key, copy the quickstart, and get a real model response.</span>
+  </div>
+  <div class="cta-band-actions">
+    <button class="btn primary" type="button" data-action="open-signin">Create my API key</button>
+  </div>
+  <span class="microcopy">No card required.</span>
 </section>
 
 {% endblock %}

--- a/src/trusted_router/templates/public/seo_openrouter_alternative.html
+++ b/src/trusted_router/templates/public/seo_openrouter_alternative.html
@@ -4,21 +4,21 @@
 <section class="marketing-split" aria-label="OpenRouter alternative">
   <div class="marketing-copy">
     <span class="eyebrow">OpenRouter alternative</span>
-    <h2>An OpenRouter alternative built around verifiable privacy.</h2>
-    <p>TrustedRouter is OpenAI-compatible, supports the same model catalog, and adds two things OpenRouter does not: hardware-attested execution and full open-source code.</p>
-    <p>You change one URL. Your existing code keeps working.</p>
-    <p>
-      <a class="btn primary" href="/chat">Try side-by-side</a>
-      <a class="btn" href="/compare/openrouter">Detailed comparison</a>
-    </p>
+    <h2>Switch from OpenRouter in one base URL.</h2>
+    <p>Keep your OpenAI SDK and model IDs. Change one URL to route through an open-source, hardware-attested gateway that never stores prompts or outputs.</p>
+    <p><button class="btn primary" type="button" data-action="open-signin">Create my API key</button></p>
+    <p class="microcopy">No card required. <a href="/compare/openrouter">Read the detailed comparison.</a></p>
   </div>
   <div class="copy-terminal">
     <div class="code-head"><span>One line</span><span>OpenAI SDK</span></div>
-    <pre><code>client = OpenAI(
+    <pre><code>import os
+from openai import OpenAI
+
+client = OpenAI(
     base_url="{{ api_base_url }}",
-    api_key="sk-tr-v1-..."
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
 )
-# Same model IDs. Same SDK. Same code.</code></pre>
+# Keep the SDK. Change one URL.</code></pre>
   </div>
 </section>
 
@@ -78,6 +78,17 @@
     <p><strong>Audited routing.</strong> Build-vs-buy decisions where the security review team needs to read the routing code.</p>
     <p><strong>Self-hosters.</strong> Run TrustedRouter inside your own VPC and keep attestation working — your image hash is your image hash.</p>
   </div>
+</section>
+
+<section class="cta-band" aria-label="Switch from OpenRouter">
+  <div>
+    <strong>Keep your SDK. Change one URL.</strong>
+    <span>Create a key and run your existing integration through TrustedRouter.</span>
+  </div>
+  <div class="cta-band-actions">
+    <button class="btn primary" type="button" data-action="open-signin">Create my API key</button>
+  </div>
+  <span class="microcopy">No card required.</span>
 </section>
 
 {% endblock %}

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -45,6 +45,27 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
   await expect(page.locator("#signinError")).toContainText("MetaMask is not installed");
 });
 
+test("paid search quickstart copies runnable code and opens key creation", async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto("/openai-compatible-llm-api");
+
+  const sample = page.locator("#openai-first-call");
+  await expect(sample).toContainText("import os");
+  await expect(sample).toContainText('model="trustedrouter/cheap"');
+
+  await page.getByRole("button", { name: "Copy", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copied).toContain("import os");
+  expect(copied).toContain('model="trustedrouter/cheap"');
+
+  await page.getByRole("button", { name: "Create my API key" }).first().click();
+  await expect(page.locator("#signinModal")).toBeVisible();
+});
+
 test("wallet sign-in completes without email gate", async ({ page }) => {
   const address = "0x1111111111111111111111111111111111111111";
   let emailRequests = 0;

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -35,7 +35,7 @@ def test_revenue_pages_are_public(client: TestClient) -> None:
         # SEO landing pages — each targets a high-intent buyer query.
         # The marker is a load-bearing headline from the page so a
         # silent template breakage gets caught here.
-        "/openrouter-alternative": "An OpenRouter alternative built around verifiable privacy.",
+        "/openrouter-alternative": "Switch from OpenRouter in one base URL.",
         "/private-llm-api": 'A private LLM API where "private" means cryptographically verified.',
         "/hipaa-llm-api": "The LLM API whose privacy posture is verifiable",
         "/llm-zero-data-retention": "Zero data retention as a verifiable property",
@@ -207,6 +207,28 @@ def test_public_pricing_matches_five_percent_billing_policy(client: TestClient) 
     assert llms.status_code == 200
     assert "Text and embedding prepaid pricing is provider cost + 5%" in llms.text
     assert "Video generation is the direct provider quote + 20%" in llms.text
+
+
+def test_paid_search_landing_pages_drive_a_runnable_first_call(
+    client: TestClient,
+) -> None:
+    openai_page = client.get("/openai-compatible-llm-api")
+    assert openai_page.status_code == 200
+    assert "Keep the SDK. Change the base URL." in openai_page.text
+    assert "import os" in openai_page.text
+    assert 'model="trustedrouter/cheap"' in openai_page.text
+    assert 'data-action="copy-code"' in openai_page.text
+    assert openai_page.text.count("Create my API key") == 2
+    assert "No card required." in openai_page.text
+    assert '<a class="btn primary" href="/docs">' not in openai_page.text
+
+    migration_page = client.get("/openrouter-alternative")
+    assert migration_page.status_code == 200
+    assert "Switch from OpenRouter in one base URL." in migration_page.text
+    assert "import os" in migration_page.text
+    assert migration_page.text.count("Create my API key") == 2
+    assert "No card required." in migration_page.text
+    assert '<a class="btn primary" href="/chat">' not in migration_page.text
 
 
 def test_agent_discovery_surfaces_model_advisor_skill(client: TestClient) -> None:


### PR DESCRIPTION
## What changed
- focus OpenAI-compatible and OpenRouter landing pages on one first-call conversion
- add a runnable, copyable OpenAI SDK quickstart using trustedrouter/cheap
- move primary CTAs directly to API-key creation with no-card objection handling
- document the live three-cell Google message experiment and first-party activation rules

## Live campaign changes
- launched ease and model-breadth challengers in the OpenAI Compatible API ad group
- kept the existing ad as control
- paused enterprise_platform_rsa1 and message_test_10_rsa1 in the OpenRouter Migration group
- no budget change

## Verification
- npx tsc
- npx eslint frontend/src
- npx stylelint "src/trusted_router/static/*.css"
- 3 focused pytest checks
- Playwright paid-search quickstart smoke