### PR TITLE
Improve first-call activation

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -344,6 +344,7 @@ ENV_VARS=(
   "TR_SES_ALERT_FROM_EMAIL=alerts@alerts.trustedrouter.com"
   "TR_SES_ALERT_FROM_NAME=TrustedRouter Alerts"
   "TR_SES_ALERT_CONFIGURATION_SET=trustedrouter-alerts"
+  "TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=60"
   "TR_SUPPORT_EMAIL=help@trustedrouter.com"
   # Adyen ships dark. Activating checkout is an intentional one-line release
   # after the merchant, HMAC webhook, and test-payment canary are green.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -400,6 +400,11 @@ class Settings(BaseSettings):
     # Destination for TrustedOS partner-inquiry form submissions (/trustedos).
     # Falls back to ses_from_email when unset so the lead never silently drops.
     partner_inquiry_email: str | None = None
+    # Durable post-signup activation reminders. Zero keeps the in-process
+    # worker disabled in local/test environments. Production runs one bounded
+    # pass per minute; an atomic milestone claim prevents duplicate sends when
+    # several warm regional replicas inspect the same due task.
+    activation_reminder_interval_seconds: int = 0
 
     stablecoin_checkout_enabled: bool = True
     x402_enabled: bool = False

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -133,6 +133,36 @@ def create_app(
 
             threading.Thread(target=loop, name="home-settlement", daemon=True).start()
 
+    if settings.activation_reminder_interval_seconds > 0:
+
+        @app.on_event("startup")
+        async def _start_activation_reminder_loop() -> None:  # pragma: no cover - thread wiring
+            import asyncio as _asyncio
+            import logging as _logging
+            import random as _random
+
+            from trusted_router.services.activation_reminders import (
+                run_activation_reminder_pass,
+            )
+
+            interval = max(30, settings.activation_reminder_interval_seconds)
+            log = _logging.getLogger(__name__)
+
+            async def loop() -> None:
+                await _asyncio.sleep(_random.uniform(5, min(30, interval)))  # noqa: S311
+                while True:
+                    try:
+                        await _asyncio.to_thread(
+                            run_activation_reminder_pass,
+                            settings,
+                            limit=200,
+                        )
+                    except Exception:
+                        log.exception("activation reminder pass failed")
+                    await _asyncio.sleep(interval)
+
+            _asyncio.create_task(loop())  # noqa: RUF006 - lifetime is the process
+
     # In-process synthetic monitor. See the settings docstring for why the
     # trigger lives here rather than in each cloud's own scheduler.
     if settings.synthetic_scheduler_interval_seconds > 0:

--- a/src/trusted_router/routes/acquisition.py
+++ b/src/trusted_router/routes/acquisition.py
@@ -11,7 +11,12 @@ from trusted_router.acquisition import log_browser_funnel_event
 class MarketingEventRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    event: Literal["landing_engaged", "sign_in_opened"]
+    event: Literal[
+        "landing_engaged",
+        "sign_in_opened",
+        "first_call_started",
+        "first_call_failed",
+    ]
 
 
 def register_acquisition_routes(router: APIRouter) -> None:

--- a/src/trusted_router/routes/console/welcome.py
+++ b/src/trusted_router/routes/console/welcome.py
@@ -41,13 +41,14 @@ def register(app: FastAPI) -> None:
             settings=settings,
             ctx=ctx,
             active="api-keys",
-            page_title="Welcome",
-            page_subtitle="Save your API key — it won't be shown again.",
+            page_title="Make your first API call",
+            page_subtitle="Save your key, confirm it works, then connect your app.",
             revealed_key=revealed_key,
             workspace_name=ctx.workspace.name,
             # The raw amount selects the appropriate next step without
             # advertising the account-creation grant.
             trial_credit_microdollars=trial_microdollars,
+            can_run_first_call=trial_microdollars > 0,
         ))
         if clear_pending_reveal:
             # Delete cookie with the same path it was set with — otherwise

--- a/src/trusted_router/services/activation_reminders.py
+++ b/src/trusted_router/services/activation_reminders.py
@@ -1,0 +1,214 @@
+"""At-most-once onboarding reminders for accounts without a successful call."""
+
+from __future__ import annotations
+
+import datetime as dt
+import html
+import logging
+from dataclasses import dataclass
+
+from trusted_router.config import Settings
+from trusted_router.services.email import EmailMessage, EmailService, get_email_service
+from trusted_router.storage import STORE
+from trusted_router.storage_models import AcquisitionAttribution, iso_now
+
+log = logging.getLogger(__name__)
+
+_STAGES = frozenset({"10m", "24h"})
+
+
+@dataclass(frozen=True)
+class ActivationReminderPassResult:
+    inspected: int = 0
+    due: int = 0
+    sent: int = 0
+    skipped_activated: int = 0
+    skipped_no_email: int = 0
+    failed: int = 0
+
+
+def run_activation_reminder_pass(
+    settings: Settings,
+    *,
+    now: str | None = None,
+    limit: int = 200,
+    email_service: EmailService | None = None,
+) -> ActivationReminderPassResult:
+    """Process a bounded prefix of the sortable reminder queue.
+
+    The acquisition milestone is claimed before SES is called. This makes the
+    send at-most-once across every warm control-plane replica. A reminder is
+    also rejected atomically when first-use has already been recorded.
+    """
+    occurred_at = now or iso_now()
+    current = _parse_iso(occurred_at)
+    service = email_service or get_email_service(settings)
+    tasks = STORE.list_activation_reminders(limit=max(1, min(limit, 1_000)))
+    delete_ids: list[str] = []
+    counts = {
+        "inspected": len(tasks),
+        "due": 0,
+        "sent": 0,
+        "skipped_activated": 0,
+        "skipped_no_email": 0,
+        "failed": 0,
+    }
+
+    for task in tasks:
+        try:
+            due_at = _parse_iso(task.due_at)
+        except ValueError:
+            log.warning(
+                "activation_reminder.invalid_due_at",
+                extra={"stage": task.stage},
+            )
+            delete_ids.append(task.id)
+            counts["failed"] += 1
+            continue
+        if due_at > current:
+            break
+        counts["due"] += 1
+        delete_ids.append(task.id)
+        if task.stage not in _STAGES:
+            counts["failed"] += 1
+            continue
+
+        recipient = _workspace_owner_email(task.workspace_id)
+        if recipient is None:
+            counts["skipped_no_email"] += 1
+            continue
+
+        record, claimed = STORE.claim_activation_reminder(
+            task.workspace_id,
+            task.stage,
+            occurred_at=occurred_at,
+        )
+        if not claimed or record is None:
+            counts["skipped_activated"] += 1
+            continue
+
+        message = build_activation_reminder_email(
+            settings,
+            recipient=recipient,
+            stage=task.stage,
+            attribution=record,
+        )
+        try:
+            accepted = service.send(message)
+        except Exception:  # noqa: BLE001 - reminders must never kill the scheduler.
+            log.exception(
+                "activation_reminder.send_failed",
+                extra={"stage": task.stage},
+            )
+            counts["failed"] += 1
+            continue
+        if accepted:
+            counts["sent"] += 1
+        else:
+            counts["failed"] += 1
+
+    if delete_ids:
+        STORE.delete_activation_reminders(delete_ids)
+    result = ActivationReminderPassResult(
+        inspected=counts["inspected"],
+        due=counts["due"],
+        sent=counts["sent"],
+        skipped_activated=counts["skipped_activated"],
+        skipped_no_email=counts["skipped_no_email"],
+        failed=counts["failed"],
+    )
+    if result.due:
+        log.info(
+            "activation_reminder.pass_completed",
+            extra={
+                "inspected": result.inspected,
+                "due": result.due,
+                "sent": result.sent,
+                "skipped_activated": result.skipped_activated,
+                "skipped_no_email": result.skipped_no_email,
+                "failed": result.failed,
+            },
+        )
+    return result
+
+
+def build_activation_reminder_email(
+    settings: Settings,
+    *,
+    recipient: str,
+    stage: str,
+    attribution: AcquisitionAttribution,
+) -> EmailMessage:
+    if stage not in _STAGES:
+        raise ValueError("unsupported activation reminder stage")
+    origin = f"https://{settings.trusted_domain}"
+    quickstart_url = f"{origin}/console/api-keys#new-api-key"
+    docs_url = f"{origin}/for-developers"
+    if stage == "10m":
+        subject = "Your TrustedRouter key is ready to test"
+        lead = "Make your first API call in about a minute."
+    else:
+        subject = "Make your first TrustedRouter API call"
+        lead = "Your account is ready, but it has not made a successful API call yet."
+
+    text_body = (
+        f"{lead}\n\n"
+        f"Open your API Keys page: {quickstart_url}\n\n"
+        "Create a new key, then copy the setup for Python, JavaScript, curl, "
+        "Claude Code, or Codex. Your first successful request will complete "
+        "account setup.\n\n"
+        "No card is required when your account has trial credit. If your balance "
+        "is empty, the page will take you to Credits first.\n\n"
+        f"Developer quickstart: {docs_url}\n\n"
+        "You are receiving this operational email because you created a TrustedRouter account."
+    )
+    safe_quickstart_url = html.escape(quickstart_url, quote=True)
+    safe_docs_url = html.escape(docs_url, quote=True)
+    html_body = (
+        f"<p>{html.escape(lead)}</p>"
+        f'<p><a href="{safe_quickstart_url}">Run my first API request</a></p>'
+        "<p>Create a new key, then copy the setup for Python, JavaScript, curl, "
+        "Claude Code, or Codex. Your first successful request will complete "
+        "account setup.</p>"
+        "<p>No card is required when your account has trial credit. If your balance "
+        "is empty, the page will take you to Credits first.</p>"
+        f'<p><a href="{safe_docs_url}">Open the developer quickstart</a></p>'
+        "<p><small>You are receiving this operational email because you created a "
+        "TrustedRouter account.</small></p>"
+    )
+    touch = attribution.last_touch
+    return EmailMessage(
+        to=recipient,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        reply_to=settings.support_email,
+        mail_class=f"activation_{stage}",
+        acquisition_source=touch.get("utm_source"),
+        acquisition_medium=touch.get("utm_medium"),
+        acquisition_campaign=touch.get("utm_campaign"),
+    )
+
+
+def _workspace_owner_email(workspace_id: str) -> str | None:
+    workspace = STORE.get_workspace(workspace_id)
+    if workspace is None or workspace.deleted:
+        return None
+    user = STORE.get_user(workspace.owner_user_id)
+    if user is None or not user.email:
+        return None
+    return user.email.strip().lower() or None
+
+
+def _parse_iso(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+__all__ = [
+    "ActivationReminderPassResult",
+    "build_activation_reminder_email",
+    "run_activation_reminder_pass",
+]

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -995,3 +995,513 @@ body.console {
   margin: 0;
   accent-color: var(--blue);
 }
+
+/* First-call activation --------------------------------------------------- */
+.activation-flow {
+  display: grid;
+  gap: 18px;
+  width: 100%;
+  max-width: 880px;
+}
+
+.activation-progress {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0 0 2px;
+  padding: 0;
+  list-style: none;
+}
+
+.activation-progress li {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.activation-progress li:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  left: 32px;
+  right: 8px;
+  top: 15px;
+  height: 1px;
+  background: var(--line);
+}
+
+.activation-progress li > span {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.activation-progress li.complete,
+.activation-progress li.current {
+  color: var(--ink);
+}
+
+.activation-progress li strong {
+  position: relative;
+  z-index: 1;
+  padding-right: 10px;
+  background: var(--bg);
+  text-wrap: nowrap;
+}
+
+.activation-progress li.complete > span {
+  border-color: var(--good-border);
+  background: var(--good-bg);
+  color: var(--green);
+}
+
+.activation-progress li.current > span {
+  border-color: var(--blue);
+  background: var(--blue);
+  color: #fff;
+}
+
+.activation-key-panel {
+  border-color: var(--good-border);
+}
+
+.activation-eyebrow {
+  margin: 0 0 4px;
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.activation-key-panel .panel-head h2,
+.activation-panel-head h2 {
+  text-wrap: balance;
+}
+
+.activation-key-panel .console-key-reveal {
+  max-width: none;
+}
+
+.activation-security-note {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.activation-panel-head {
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.activation-panel-head > div:first-child {
+  min-width: 0;
+}
+
+.activation-step-number {
+  margin-left: auto;
+  color: var(--line);
+  font-size: 28px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.activation-primary-action {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.activation-run-button {
+  min-height: 46px;
+  padding: 10px 16px;
+  gap: 14px;
+  justify-content: space-between;
+  transition-property: background-color, border-color, color, transform;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.activation-run-button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+
+.activation-run-button[aria-busy="true"] .activation-button-arrow {
+  animation: activation-pulse 900ms ease-in-out infinite alternate;
+}
+
+.activation-run-button.activation-run-success {
+  border-color: var(--good-border);
+  background: var(--green);
+  color: #fff;
+}
+
+.activation-button-arrow {
+  font-size: 17px;
+  line-height: 1;
+}
+
+.activation-no-card {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.activation-credit-needed {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.activation-credit-needed p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.activation-call-error,
+.activation-call-result {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.activation-call-error {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--red);
+}
+
+.activation-call-error p {
+  margin: 4px 0 12px;
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.activation-call-result {
+  border-color: var(--good-border);
+  background: var(--good-bg);
+}
+
+.activation-call-error[hidden],
+.activation-call-result[hidden],
+.activation-code-panel[hidden],
+.activation-call-error [hidden] {
+  display: none;
+}
+
+.activation-result-head,
+.activation-result-head > div,
+.activation-result-actions,
+.activation-code-head {
+  display: flex;
+  align-items: center;
+}
+
+.activation-result-head {
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--good-border);
+}
+
+.activation-result-head > div {
+  gap: 10px;
+}
+
+.activation-result-head p {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.activation-result-head > code {
+  color: var(--green);
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.activation-success-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  border-radius: 50%;
+  background: var(--green);
+  color: #fff;
+  font-weight: 800;
+}
+
+.activation-result-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin: 14px 0;
+  overflow: hidden;
+  border: 1px solid var(--good-border);
+  border-radius: 7px;
+  background: var(--good-border);
+}
+
+.activation-result-grid > div {
+  min-width: 0;
+  padding: 10px;
+  background: var(--panel);
+}
+
+.activation-result-grid dt {
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.activation-result-grid dd {
+  margin: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activation-result-actions {
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.activation-trust-link {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  color: var(--green);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.activation-tabs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  margin-bottom: 12px;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
+}
+
+.activation-tab {
+  min-height: 40px;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  padding: 8px 11px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+  transition-property: background-color, border-color, color, transform;
+  transition-duration: 140ms;
+  transition-timing-function: ease-out;
+}
+
+.activation-tab:hover {
+  background: var(--soft);
+  color: var(--ink);
+}
+
+.activation-tab[aria-selected="true"] {
+  border-color: var(--line);
+  background: var(--panel2);
+  color: var(--ink);
+}
+
+.activation-tab:active {
+  transform: scale(0.96);
+}
+
+.activation-code-panel {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel2);
+  overflow: hidden;
+}
+
+.activation-code-head {
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 52px;
+  padding: 8px 10px 8px 14px;
+  border-bottom: 1px solid var(--line);
+  font-size: 12px;
+}
+
+.activation-code-head .btn {
+  min-height: 36px;
+  flex: 0 0 auto;
+}
+
+.activation-code-panel pre {
+  display: grid;
+  gap: 10px;
+  min-height: 112px;
+  max-height: 320px;
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  background: var(--panel);
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre;
+}
+
+.activation-code-panel .copy-status {
+  min-height: 0;
+  margin: 0;
+  padding: 0 14px;
+}
+
+.activation-code-panel .copy-status:not(:empty) {
+  min-height: 32px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-top: 1px solid var(--line);
+}
+
+.activation-console-link {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+.activation-expired-panel {
+  max-width: 680px;
+}
+
+@keyframes activation-pulse {
+  from { opacity: 0.35; transform: translateX(-2px); }
+  to { opacity: 1; transform: translateX(2px); }
+}
+
+@media (max-width: 700px) {
+  .activation-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    overflow: visible;
+  }
+
+  .activation-tab {
+    width: 100%;
+    white-space: normal;
+  }
+
+  .activation-progress li {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .activation-progress li:not(:last-child)::after {
+    left: 30px;
+    right: 0;
+  }
+
+  .activation-progress li strong {
+    padding-right: 6px;
+    background: transparent;
+    font-size: 11px;
+  }
+
+  .activation-panel-head {
+    gap: 10px;
+  }
+
+  .activation-step-number {
+    font-size: 22px;
+  }
+
+  .activation-primary-action,
+  .activation-credit-needed {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .activation-run-button,
+  .activation-credit-needed .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .activation-result-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .activation-result-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .activation-result-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .activation-result-actions .btn,
+  .activation-trust-link {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .activation-trust-link {
+    margin-left: 0;
+  }
+
+  .activation-code-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .activation-code-head .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activation-run-button[aria-busy="true"] .activation-button-arrow {
+    animation: none;
+  }
+}

--- a/src/trusted_router/static/console.js
+++ b/src/trusted_router/static/console.js
@@ -46,6 +46,232 @@ function copyTargetText(target) {
   return target.textContent.trim();
 }
 
+function templateCopyText(target, secret) {
+  return copyTargetText(target).replaceAll("YOUR_TRUSTEDROUTER_API_KEY", secret);
+}
+
+function postActivationEvent(event) {
+  fetch("/analytics/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event }),
+    credentials: "same-origin",
+    keepalive: true,
+  }).catch(() => {
+    /* Acquisition telemetry is best-effort and must never block setup. */
+  });
+}
+
+function microdollarsDisplay(value) {
+  let amount = 0n;
+  try {
+    amount = BigInt(value || 0);
+  } catch {
+    amount = 0n;
+  }
+  const sign = amount < 0n ? "-" : "";
+  const absolute = amount < 0n ? -amount : amount;
+  const dollars = absolute / 1000000n;
+  const fraction = String(absolute % 1000000n).padStart(6, "0");
+  return `${sign}$${dollars}.${fraction}`;
+}
+
+function completionText(payload) {
+  const content = payload?.choices?.[0]?.message?.content;
+  if (typeof content === "string")
+    return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .filter((part) => part && (part.type === "text" || part.type === "output_text"))
+      .map((part) => part.text || "")
+      .join("")
+      .trim();
+  }
+  return "";
+}
+
+function completionMetadata(payload, response) {
+  const usage = payload?.usage && typeof payload.usage === "object" ? payload.usage : {};
+  const providerUsage = usage.provider_usage && typeof usage.provider_usage === "object"
+    ? usage.provider_usage
+    : {};
+  const trusted = payload?.trustedrouter && typeof payload.trustedrouter === "object"
+    ? payload.trustedrouter
+    : {};
+  const routing = trusted.routing && typeof trusted.routing === "object"
+    ? trusted.routing
+    : {};
+  return {
+    model: response.headers.get("x-trustedrouter-served-model")
+      || routing.selected_model
+      || providerUsage.selected_model
+      || payload?.model
+      || "trustedrouter/cheap",
+    provider: response.headers.get("x-trustedrouter-provider")
+      || routing.selected_provider
+      || providerUsage.selected_provider
+      || payload?.provider
+      || "Selected automatically",
+    costMicrodollars: usage.total_cost_microdollars
+      ?? usage.cost_microdollars
+      ?? providerUsage.total_cost_microdollars
+      ?? providerUsage.cost_microdollars
+      ?? 0,
+  };
+}
+
+function activationErrorCopy(status) {
+  if (status === 401) {
+    return {
+      title: "This key was not accepted",
+      message: "Create a new API key, then run the check again.",
+      action: "/console/api-keys#new-api-key",
+      actionLabel: "Create a new key",
+    };
+  }
+  if (status === 402) {
+    return {
+      title: "Credits are required",
+      message: "Add credits, then return here to run the live request.",
+      action: "/console/credits",
+      actionLabel: "Add credits",
+    };
+  }
+  if (status === 429) {
+    return {
+      title: "The request was rate limited",
+      message: "Wait a moment, then run the check again.",
+    };
+  }
+  return {
+    title: "The live request did not complete",
+    message: "Your key is safe. Try again while TrustedRouter selects another healthy route.",
+  };
+}
+
+function showActivationError(flow, status) {
+  const copy = activationErrorCopy(status);
+  const container = flow.querySelector("[data-call-error]");
+  const result = flow.querySelector("[data-call-result]");
+  if (result)
+    result.hidden = true;
+  if (!container)
+    return;
+  container.querySelector("[data-call-error-title]").textContent = copy.title;
+  container.querySelector("[data-call-error-message]").textContent = copy.message;
+  const action = container.querySelector("[data-call-error-action]");
+  if (action) {
+    action.hidden = !copy.action;
+    if (copy.action) {
+      action.href = copy.action;
+      action.textContent = copy.actionLabel;
+    }
+  }
+  container.hidden = false;
+}
+
+function markActivationComplete(flow) {
+  const steps = flow.querySelectorAll(".activation-progress li");
+  if (steps[1]) {
+    steps[1].classList.remove("current");
+    steps[1].classList.add("complete");
+  }
+  if (steps[2])
+    steps[2].classList.add("current");
+}
+
+async function runFirstActivationCall(button) {
+  const flow = button.closest("[data-first-call-flow]");
+  if (!flow || button.disabled)
+    return;
+  const keySource = document.getElementById(flow.dataset.keySource || "");
+  const apiKey = keySource ? copyTargetText(keySource) : "";
+  if (!apiKey) {
+    showActivationError(flow, 401);
+    return;
+  }
+
+  const endpoint = flow.dataset.endpoint;
+  const label = button.querySelector("[data-run-label]");
+  const error = flow.querySelector("[data-call-error]");
+  if (error)
+    error.hidden = true;
+  button.disabled = true;
+  button.setAttribute("aria-busy", "true");
+  if (label)
+    label.textContent = "Routing live request...";
+  postActivationEvent("first_call_started");
+
+  const started = performance.now();
+  let status = 0;
+  try {
+    const requestId = window.crypto?.randomUUID
+      ? window.crypto.randomUUID()
+      : `first-call-${Date.now()}`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": `welcome-${requestId}`,
+      },
+      body: JSON.stringify({
+        model: "trustedrouter/cheap",
+        messages: [{ role: "user", content: "Reply with exactly PONG." }],
+        temperature: 0,
+        max_tokens: 8,
+        stream: false,
+      }),
+    });
+    status = response.status;
+    if (!response.ok)
+      throw new Error("request_failed");
+    const payload = await response.json();
+    const output = completionText(payload);
+    if (!output)
+      throw new Error("empty_response");
+    const metadata = completionMetadata(payload, response);
+    const elapsed = Math.max(1, Math.round(performance.now() - started));
+    const result = flow.querySelector("[data-call-result]");
+    result.querySelector("[data-result-output]").textContent = output;
+    result.querySelector("[data-result-model]").textContent = metadata.model;
+    result.querySelector("[data-result-provider]").textContent = metadata.provider;
+    result.querySelector("[data-result-latency]").textContent = `${elapsed.toLocaleString()} ms`;
+    result.querySelector("[data-result-cost]").textContent = microdollarsDisplay(
+      metadata.costMicrodollars,
+    );
+    result.hidden = false;
+    markActivationComplete(flow);
+    if (label)
+      label.textContent = "Test passed";
+    button.classList.add("activation-run-success");
+  } catch {
+    postActivationEvent("first_call_failed");
+    showActivationError(flow, status);
+    button.disabled = false;
+    if (label)
+      label.textContent = "Try the live request again";
+  } finally {
+    button.removeAttribute("aria-busy");
+  }
+}
+
+function selectSetupTab(tab) {
+  const tablist = tab.closest("[role=tablist]");
+  if (!tablist)
+    return;
+  const panelId = tab.dataset.setupTab;
+  tablist.querySelectorAll("[data-setup-tab]").forEach((candidate) => {
+    const selected = candidate === tab;
+    candidate.setAttribute("aria-selected", String(selected));
+    candidate.tabIndex = selected ? 0 : -1;
+  });
+  const scope = tablist.parentElement;
+  scope.querySelectorAll("[data-setup-panel]").forEach((panel) => {
+    panel.hidden = panel.id !== panelId;
+  });
+}
+
 // ── Theme toggle ────────────────────────────────────────────────────
 // Mirrors the marketing chrome (static/dashboard.js). Dark is the default
 // (no data-theme attribute); a stored "light" preference is applied as
@@ -100,6 +326,13 @@ function toggleTheme() {
 
 function initConsole() {
   applyStoredTheme();
+  if (window.location.hash === "#new-api-key") {
+    const panel = document.getElementById("new-api-key");
+    if (panel) {
+      panel.open = true;
+      window.setTimeout(() => panel.querySelector('input[name="name"]')?.focus(), 100);
+    }
+  }
   document.addEventListener("click", (event) => {
     const target = event.target;
     if (!target)
@@ -124,6 +357,40 @@ function initConsole() {
       }
       return;
     }
+    const runButton = target.closest('[data-action="run-first-call"]');
+    if (runButton) {
+      event.preventDefault();
+      runFirstActivationCall(runButton);
+      return;
+    }
+    const setupTab = target.closest("[data-setup-tab]");
+    if (setupTab) {
+      event.preventDefault();
+      selectSetupTab(setupTab);
+      return;
+    }
+    const templateButton = target.closest("[data-copy-template-target]");
+    if (templateButton) {
+      event.preventDefault();
+      const templateId = templateButton.getAttribute("data-copy-template-target");
+      const sourceId = templateButton.getAttribute("data-secret-source");
+      const template = templateId ? document.getElementById(templateId) : null;
+      const source = sourceId ? document.getElementById(sourceId) : null;
+      const secret = source ? copyTargetText(source) : "";
+      const value = template && secret ? templateCopyText(template, secret) : "";
+      if (!value) {
+        setCopyStatus(templateButton, "No key to copy.", true);
+        return;
+      }
+      copyText(value)
+        .then(() => setCopyStatus(templateButton, "Copied to clipboard.", false))
+        .catch(() => setCopyStatus(
+          templateButton,
+          "Select the setup and copy it manually.",
+          true,
+        ));
+      return;
+    }
     const button = target.closest("[data-copy-secret]");
     if (!button)
       return;
@@ -138,6 +405,22 @@ function initConsole() {
     copyText(value)
       .then(() => setCopyStatus(button, "Copied to clipboard.", false))
       .catch(() => setCopyStatus(button, "Select the key and copy it manually.", true));
+  });
+
+  document.addEventListener("keydown", (event) => {
+    const tab = event.target.closest?.("[data-setup-tab]");
+    if (!tab || !["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key))
+      return;
+    const tabs = Array.from(tab.closest("[role=tablist]").querySelectorAll("[data-setup-tab]"));
+    const current = tabs.indexOf(tab);
+    let next = current;
+    if (event.key === "ArrowRight") next = (current + 1) % tabs.length;
+    if (event.key === "ArrowLeft") next = (current - 1 + tabs.length) % tabs.length;
+    if (event.key === "Home") next = 0;
+    if (event.key === "End") next = tabs.length - 1;
+    event.preventDefault();
+    selectSetupTab(tabs[next]);
+    tabs[next].focus();
   });
 }
 

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -27,6 +27,7 @@ from trusted_router.storage_group_buy import InMemoryBedrockGroupBuy
 from trusted_router.storage_keys import InMemoryApiKeys
 from trusted_router.storage_models import (
     AcquisitionAttribution,
+    ActivationReminderTask,
     ApiKey,
     AuthSession,
     BedrockGroupBuyAggregate,
@@ -284,6 +285,27 @@ class InMemoryStore:
         return self.acquisition_store.record_purchase(
             workspace_id,
             amount_microdollars=amount_microdollars,
+            occurred_at=occurred_at,
+        )
+
+    def list_activation_reminders(
+        self, *, limit: int = 100
+    ) -> list[ActivationReminderTask]:
+        return self.acquisition_store.list_reminders(limit=limit)
+
+    def delete_activation_reminders(self, reminder_ids: list[str]) -> None:
+        self.acquisition_store.delete_reminders(reminder_ids)
+
+    def claim_activation_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]:
+        return self.acquisition_store.claim_reminder(
+            workspace_id,
+            stage,
             occurred_at=occurred_at,
         )
 

--- a/src/trusted_router/storage_attribution.py
+++ b/src/trusted_router/storage_attribution.py
@@ -2,22 +2,31 @@ from __future__ import annotations
 
 import threading
 
-from trusted_router.storage_models import AcquisitionAttribution, iso_now
+from trusted_router.storage_models import (
+    AcquisitionAttribution,
+    ActivationReminderTask,
+    activation_reminder_tasks,
+    iso_now,
+)
 
 
 class InMemoryAcquisitionAttribution:
     def __init__(self, *, lock: threading.RLock) -> None:
         self._lock = lock
         self.records: dict[str, AcquisitionAttribution] = {}
+        self.reminders: dict[str, ActivationReminderTask] = {}
 
     def reset(self) -> None:
         self.records.clear()
+        self.reminders.clear()
 
     def create(self, record: AcquisitionAttribution) -> bool:
         with self._lock:
             if record.workspace_id in self.records:
                 return False
             self.records[record.workspace_id] = record
+            for reminder in activation_reminder_tasks(record):
+                self.reminders[reminder.id] = reminder
             return True
 
     def get(self, workspace_id: str) -> AcquisitionAttribution | None:
@@ -63,3 +72,33 @@ class InMemoryAcquisitionAttribution:
             record.last_purchase_at = occurred_at
             record.updated_at = iso_now()
             return record
+
+    def list_reminders(self, *, limit: int) -> list[ActivationReminderTask]:
+        with self._lock:
+            return sorted(self.reminders.values(), key=lambda item: item.id)[:limit]
+
+    def delete_reminders(self, reminder_ids: list[str]) -> None:
+        with self._lock:
+            for reminder_id in reminder_ids:
+                self.reminders.pop(reminder_id, None)
+
+    def claim_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]:
+        milestone = f"activation_reminder_{stage}_sent"
+        with self._lock:
+            record = self.records.get(workspace_id)
+            if record is None:
+                return None, False
+            if (
+                "first_successful_api_call" in record.milestones
+                or milestone in record.milestones
+            ):
+                return record, False
+            record.milestones[milestone] = occurred_at
+            record.updated_at = iso_now()
+            return record, True

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -19,6 +19,7 @@ from trusted_router.operational_analytics import (
 )
 from trusted_router.storage import (
     AcquisitionAttribution,
+    ActivationReminderTask,
     ApiKey,
     AuthSession,
     BroadcastDeliveryJob,
@@ -415,6 +416,27 @@ class SpannerBigtableStore:
         return self.acquisition_store.record_purchase(
             workspace_id,
             amount_microdollars=amount_microdollars,
+            occurred_at=occurred_at,
+        )
+
+    def list_activation_reminders(
+        self, *, limit: int = 100
+    ) -> list[ActivationReminderTask]:
+        return self.acquisition_store.list_reminders(limit=limit)
+
+    def delete_activation_reminders(self, reminder_ids: list[str]) -> None:
+        self.acquisition_store.delete_reminders(reminder_ids)
+
+    def claim_activation_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]:
+        return self.acquisition_store.claim_reminder(
+            workspace_id,
+            stage,
             occurred_at=occurred_at,
         )
 

--- a/src/trusted_router/storage_gcp_attribution.py
+++ b/src/trusted_router/storage_gcp_attribution.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 from typing import Any
 
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
-from trusted_router.storage_models import AcquisitionAttribution, iso_now
+from trusted_router.storage_models import (
+    AcquisitionAttribution,
+    ActivationReminderTask,
+    activation_reminder_tasks,
+    iso_now,
+)
 
 _KIND = "acquisition_attribution"
+_REMINDER_KIND = "activation_reminder"
 
 
 class SpannerAcquisitionAttribution:
@@ -23,6 +29,13 @@ class SpannerAcquisitionAttribution:
             if existing is not None:
                 return False
             self._io.write_entity_tx(transaction, _KIND, record.workspace_id, record)
+            for reminder in activation_reminder_tasks(record):
+                self._io.write_entity_tx(
+                    transaction,
+                    _REMINDER_KIND,
+                    reminder.id,
+                    reminder,
+                )
             return True
 
         return run_in_transaction_with_retry(self._io.database, txn)
@@ -85,5 +98,46 @@ class SpannerAcquisitionAttribution:
             record.updated_at = iso_now()
             self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
             return record
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def list_reminders(self, *, limit: int) -> list[ActivationReminderTask]:
+        return self._io.list_entities(
+            _REMINDER_KIND,
+            cls=ActivationReminderTask,
+            limit=limit,
+        )
+
+    def delete_reminders(self, reminder_ids: list[str]) -> None:
+        if reminder_ids:
+            self._io.delete_entities(_REMINDER_KIND, reminder_ids)
+
+    def claim_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]:
+        milestone = f"activation_reminder_{stage}_sent"
+
+        def txn(transaction: Any) -> tuple[AcquisitionAttribution | None, bool]:
+            record = self._io.read_entity_tx(
+                transaction,
+                _KIND,
+                workspace_id,
+                AcquisitionAttribution,
+            )
+            if record is None:
+                return None, False
+            if (
+                "first_successful_api_call" in record.milestones
+                or milestone in record.milestones
+            ):
+                return record, False
+            record.milestones[milestone] = occurred_at
+            record.updated_at = iso_now()
+            self._io.write_entity_tx(transaction, _KIND, workspace_id, record)
+            return record, True
 
         return run_in_transaction_with_retry(self._io.database, txn)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -1127,6 +1127,46 @@ class AcquisitionAttribution:
     updated_at: str = field(default_factory=iso_now)
 
 
+ACTIVATION_REMINDER_DELAYS_SECONDS: tuple[tuple[str, int], ...] = (
+    ("10m", 10 * 60),
+    ("24h", 24 * 60 * 60),
+)
+
+
+@dataclass(frozen=True)
+class ActivationReminderTask:
+    """A bounded, sortable activation reminder due for one workspace."""
+
+    id: str
+    workspace_id: str
+    stage: str
+    due_at: str
+    created_at: str = field(default_factory=iso_now)
+
+
+def activation_reminder_tasks(
+    record: AcquisitionAttribution,
+) -> tuple[ActivationReminderTask, ...]:
+    signup_at = dt.datetime.fromisoformat(record.signup_at.replace("Z", "+00:00"))
+    if signup_at.tzinfo is None:
+        signup_at = signup_at.replace(tzinfo=dt.UTC)
+    tasks: list[ActivationReminderTask] = []
+    for stage, delay_seconds in ACTIVATION_REMINDER_DELAYS_SECONDS:
+        due_at = (signup_at + dt.timedelta(seconds=delay_seconds)).isoformat().replace(
+            "+00:00", "Z"
+        )
+        tasks.append(
+            ActivationReminderTask(
+                id=f"{due_at}#{record.workspace_id}#{stage}",
+                workspace_id=record.workspace_id,
+                stage=stage,
+                due_at=due_at,
+                created_at=record.signup_at,
+            )
+        )
+    return tuple(tasks)
+
+
 @dataclass
 class BedrockGroupBuyPledge:
     """Private purchasing commitment for one signed-in user.

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -57,6 +57,7 @@ from trusted_router.storage_gcp_codec import (
 from trusted_router.storage_models import (
     FUTURE_SAMPLE_SKEW_SECONDS,
     AcquisitionAttribution,
+    ActivationReminderTask,
     ApiKey,
     AuthSession,
     BedrockGroupBuyAggregate,
@@ -831,6 +832,23 @@ class PostgresStore:
         occurred_at: str,
     ) -> AcquisitionAttribution | None:
         self._not_implemented("record_acquisition_purchase")
+
+    def list_activation_reminders(
+        self, *, limit: int = 100
+    ) -> list[ActivationReminderTask]:
+        self._not_implemented("list_activation_reminders")
+
+    def delete_activation_reminders(self, reminder_ids: list[str]) -> None:
+        self._not_implemented("delete_activation_reminders")
+
+    def claim_activation_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]:
+        self._not_implemented("claim_activation_reminder")
 
     def upsert_bedrock_group_buy_pledge(
         self, pledge: BedrockGroupBuyPledge

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from trusted_router.storage_models import (
     AcquisitionAttribution,
+    ActivationReminderTask,
     ApiKey,
     AuthSession,
     BedrockGroupBuyAggregate,
@@ -92,6 +93,17 @@ class Store(Protocol):
         amount_microdollars: int,
         occurred_at: str,
     ) -> AcquisitionAttribution | None: ...
+    def list_activation_reminders(
+        self, *, limit: int = ...
+    ) -> list[ActivationReminderTask]: ...
+    def delete_activation_reminders(self, reminder_ids: list[str]) -> None: ...
+    def claim_activation_reminder(
+        self,
+        workspace_id: str,
+        stage: str,
+        *,
+        occurred_at: str,
+    ) -> tuple[AcquisitionAttribution | None, bool]: ...
     def upsert_bedrock_group_buy_pledge(
         self, pledge: BedrockGroupBuyPledge
     ) -> BedrockGroupBuyPledge: ...

--- a/src/trusted_router/templates/console/_api_key_reveal.html
+++ b/src/trusted_router/templates/console/_api_key_reveal.html
@@ -1,4 +1,4 @@
-{% macro api_key_reveal(raw_key, id_prefix, workspace_name=None) %}
+{% macro api_key_reveal(raw_key, id_prefix, workspace_name=None, show_agent=True) %}
 <div class="signup-reveal console-key-reveal" data-copy-secret-scope>
   <div class="key-reveal-section">
     <div class="signup-reveal-head">Your TrustedRouter API key</div>
@@ -18,22 +18,25 @@
     {% endif %}
   </div>
 
+  {% if show_agent %}
   <section class="agent-quickstart" aria-labelledby="{{ id_prefix }}-agent-heading">
     <h3 id="{{ id_prefix }}-agent-heading">Paste this whole message into your agent or Claude Code to try it out right now:</h3>
     <div class="agent-message-row">
       <div class="agent-message" id="{{ id_prefix }}-agent-message" data-copy-lines>
         <div>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</div>
-        <div><code class="agent-message-key">{{ raw_key }}</code></div>
+        <div><code class="agent-message-key">YOUR_TRUSTEDROUTER_API_KEY</code></div>
       </div>
       <button
         class="btn secret-copy-btn"
         type="button"
-        data-copy-secret="{{ id_prefix }}-agent-message"
+        data-copy-template-target="{{ id_prefix }}-agent-message"
+        data-secret-source="{{ id_prefix }}-api-key"
         aria-describedby="{{ id_prefix }}-agent-copy-status"
         aria-label="Copy complete agent message"
       >Copy</button>
     </div>
     <p class="copy-status" id="{{ id_prefix }}-agent-copy-status" role="status" aria-live="polite"></p>
   </section>
+  {% endif %}
 </div>
 {% endmacro %}

--- a/src/trusted_router/templates/console/welcome.html
+++ b/src/trusted_router/templates/console/welcome.html
@@ -1,21 +1,167 @@
 {% extends "console/_layout.html" %}
 {% from "console/_api_key_reveal.html" import api_key_reveal %}
 {% block body %}
-<section class="panel">
-  <div class="panel-head"><h2>Save this key. It will not be shown again</h2><span class="pill warn">one time reveal</span></div>
+{% if revealed_key %}
+<div
+  class="activation-flow"
+  data-first-call-flow
+  data-endpoint="/chat-proxy/v1/chat/completions"
+  data-key-source="welcome-api-key"
+>
+  <ol class="activation-progress" aria-label="Account setup progress">
+    <li class="complete"><span>1</span><strong>Account</strong></li>
+    <li class="current"><span>2</span><strong>First call</strong></li>
+    <li><span>3</span><strong>Connect app</strong></li>
+  </ol>
+
+  <section class="panel activation-key-panel">
+    <div class="panel-head">
+      <div>
+        <p class="activation-eyebrow">Your API key</p>
+        <h2>Save it now</h2>
+      </div>
+      <span class="pill warn">one time reveal</span>
+    </div>
+    <div class="panel-body">
+      {{ api_key_reveal(revealed_key, "welcome", workspace_name, False) }}
+      <p class="activation-security-note">This is the only copy on this page. TrustedRouter stores a salted hash, not the raw key.</p>
+    </div>
+  </section>
+
+  <section class="panel activation-test-panel" aria-labelledby="first-call-heading">
+    <div class="panel-head activation-panel-head">
+      <div>
+        <p class="activation-eyebrow">Live gateway check</p>
+        <h2 id="first-call-heading">Run your first API request</h2>
+        <p class="panel-kicker">A real, inexpensive PONG request confirms your key, billing path, provider route, and attested gateway.</p>
+      </div>
+      <span class="activation-step-number" aria-hidden="true">02</span>
+    </div>
+    <div class="panel-body">
+      {% if can_run_first_call %}
+      <div class="activation-primary-action">
+        <button class="btn primary activation-run-button" type="button" data-action="run-first-call">
+          <span data-run-label>Run my first API request</span>
+          <span class="activation-button-arrow" aria-hidden="true">&#8594;</span>
+        </button>
+        <span class="activation-no-card">No card required</span>
+      </div>
+      {% else %}
+      <div class="activation-credit-needed">
+        <div>
+          <strong>Add credits before the live check</strong>
+          <p>Your account is ready. Add a payment method, then return here to run the request.</p>
+        </div>
+        <a class="btn primary" href="/console/credits">Add credits</a>
+      </div>
+      {% endif %}
+
+      <div class="activation-call-error" data-call-error role="alert" hidden>
+        <strong data-call-error-title>Request did not complete</strong>
+        <p data-call-error-message></p>
+        <a class="btn" data-call-error-action href="/console/credits" hidden>Add credits</a>
+      </div>
+
+      <div class="activation-call-result" data-call-result role="status" aria-live="polite" hidden>
+        <div class="activation-result-head">
+          <div>
+            <span class="activation-success-mark" aria-hidden="true">&#10003;</span>
+            <div><strong>Production request passed</strong><p>Your key is ready to use.</p></div>
+          </div>
+          <code data-result-output>PONG</code>
+        </div>
+        <dl class="activation-result-grid">
+          <div><dt>Model</dt><dd data-result-model>trustedrouter/cheap</dd></div>
+          <div><dt>Provider</dt><dd data-result-provider>Selected automatically</dd></div>
+          <div><dt>Latency</dt><dd data-result-latency>--</dd></div>
+          <div><dt>Exact cost</dt><dd data-result-cost>$0.000000</dd></div>
+        </dl>
+        <div class="activation-result-actions" data-success-actions>
+          <a class="btn primary" href="#connect-your-app">Connect your app</a>
+          <a class="btn" href="/console/credits">Add credits for production</a>
+          <a class="activation-trust-link" href="https://trust.trustedrouter.com" target="_blank" rel="noopener">Verify the running gateway</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="panel activation-setup-panel" id="connect-your-app" aria-labelledby="connect-heading">
+    <div class="panel-head activation-panel-head">
+      <div>
+        <p class="activation-eyebrow">Use the same key anywhere</p>
+        <h2 id="connect-heading">Connect your app</h2>
+        <p class="panel-kicker">Choose one setup. Copying inserts your one-time key automatically.</p>
+      </div>
+      <span class="activation-step-number" aria-hidden="true">03</span>
+    </div>
+    <div class="panel-body">
+      <div class="activation-tabs" role="tablist" aria-label="Setup method">
+        <button class="activation-tab" id="setup-agent-tab" type="button" role="tab" aria-selected="true" aria-controls="setup-agent" data-setup-tab="setup-agent">Claude Code / Codex</button>
+        <button class="activation-tab" id="setup-python-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-python" tabindex="-1" data-setup-tab="setup-python">Python</button>
+        <button class="activation-tab" id="setup-js-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-js" tabindex="-1" data-setup-tab="setup-js">JavaScript</button>
+        <button class="activation-tab" id="setup-curl-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-curl" tabindex="-1" data-setup-tab="setup-curl">curl</button>
+      </div>
+
+      <div class="activation-code-panel" id="setup-agent" role="tabpanel" aria-labelledby="setup-agent-tab" data-setup-panel>
+        <div class="activation-code-head"><strong>Paste this whole message into Claude Code or Codex</strong><button class="btn" type="button" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key" aria-describedby="welcome-agent-copy-status">Copy prompt</button></div>
+        <pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</span><span>YOUR_TRUSTEDROUTER_API_KEY</span></pre>
+        <p class="copy-status" id="welcome-agent-copy-status" role="status" aria-live="polite"></p>
+      </div>
+
+      <div class="activation-code-panel" id="setup-python" role="tabpanel" aria-labelledby="setup-python-tab" data-setup-panel hidden>
+        <div class="activation-code-head"><strong>OpenAI Python SDK</strong><button class="btn" type="button" data-copy-template-target="welcome-python-code" data-secret-source="welcome-api-key" aria-describedby="welcome-python-copy-status">Copy code</button></div>
+        <pre id="welcome-python-code">from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_TRUSTEDROUTER_API_KEY",
+    base_url="{{ api_base_url }}",
+)
+
+response = client.chat.completions.create(
+    model="trustedrouter/cheap",
+    messages=[{"role": "user", "content": "Reply with exactly PONG."}],
+)
+print(response.choices[0].message.content)</pre>
+        <p class="copy-status" id="welcome-python-copy-status" role="status" aria-live="polite"></p>
+      </div>
+
+      <div class="activation-code-panel" id="setup-js" role="tabpanel" aria-labelledby="setup-js-tab" data-setup-panel hidden>
+        <div class="activation-code-head"><strong>OpenAI JavaScript SDK</strong><button class="btn" type="button" data-copy-template-target="welcome-js-code" data-secret-source="welcome-api-key" aria-describedby="welcome-js-copy-status">Copy code</button></div>
+        <pre id="welcome-js-code">import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: "YOUR_TRUSTEDROUTER_API_KEY",
+  baseURL: "{{ api_base_url }}",
+});
+
+const response = await client.chat.completions.create({
+  model: "trustedrouter/cheap",
+  messages: [{ role: "user", content: "Reply with exactly PONG." }],
+});
+console.log(response.choices[0].message.content);</pre>
+        <p class="copy-status" id="welcome-js-copy-status" role="status" aria-live="polite"></p>
+      </div>
+
+      <div class="activation-code-panel" id="setup-curl" role="tabpanel" aria-labelledby="setup-curl-tab" data-setup-panel hidden>
+        <div class="activation-code-head"><strong>curl</strong><button class="btn" type="button" data-copy-template-target="welcome-curl-code" data-secret-source="welcome-api-key" aria-describedby="welcome-curl-copy-status">Copy command</button></div>
+        <pre id="welcome-curl-code">curl {{ api_base_url }}/chat/completions \
+  -H "Authorization: Bearer YOUR_TRUSTEDROUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"trustedrouter/cheap","messages":[{"role":"user","content":"Reply with exactly PONG."}]}'</pre>
+        <p class="copy-status" id="welcome-curl-copy-status" role="status" aria-live="polite"></p>
+      </div>
+
+      <div class="activation-console-link"><a href="/console/api-keys">Continue to API keys</a></div>
+    </div>
+  </section>
+</div>
+{% else %}
+<section class="panel activation-expired-panel">
+  <div class="panel-head"><h2>This key has already been displayed</h2></div>
   <div class="panel-body">
-    {% if revealed_key %}
-    {{ api_key_reveal(revealed_key, "welcome", workspace_name) }}
-    {% if trial_credit_microdollars > 0 %}
-    <p class="microcopy">Your workspace is ready. Try a fast, inexpensive model now.</p>
-    {% else %}
-    <p class="microcopy">Add a card on the <a href="/console/credits">Credits</a> page to start routing — prepaid, you pay only for what you use. No charge to add it; Stripe just verifies the card.</p>
-    {% endif %}
-    <p>Use this key in the OpenAI SDK by setting <code>base_url={{ api_base_url }}</code>.</p>
-    {% else %}
-    <p>This key has already been displayed. Generate a new one from <a href="/console/api-keys">API Keys</a>.</p>
-    {% endif %}
-    <a class="btn primary" href="/console/api-keys">Continue to console</a>
+    <p>For security, a raw key can only be shown once. Create a new key to continue setup.</p>
+    <a class="btn primary" href="/console/api-keys#new-api-key">Create a new API key</a>
   </div>
 </section>
+{% endif %}
 {% endblock %}

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -242,6 +242,102 @@ test("new API key quickstart stays inside its reveal panel", async ({ page }) =>
   );
 });
 
+test("first-call activation runs live request and copies Claude Code setup", async ({ page }) => {
+  const apiKey = "sk-tr-v1-browser-activation-key";
+  const analytics = [];
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__activationClipboard = value; },
+        readText: async () => window.__activationClipboard || "",
+      },
+    });
+  });
+  await page.route("**/analytics/events", async (route) => {
+    analytics.push(route.request().postDataJSON().event);
+    await route.fulfill({ status: 204, body: "" });
+  });
+  await page.route("**/chat-proxy/v1/chat/completions", async (route) => {
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiKey}`);
+    expect(route.request().headers()["idempotency-key"]).toMatch(/^welcome-/);
+    expect(route.request().postDataJSON()).toEqual({
+      model: "trustedrouter/cheap",
+      messages: [{ role: "user", content: "Reply with exactly PONG." }],
+      temperature: 0,
+      max_tokens: 8,
+      stream: false,
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: {
+        "x-trustedrouter-provider": "cerebras",
+        "x-trustedrouter-served-model": "openai/gpt-oss-120b",
+      },
+      body: JSON.stringify({
+        model: "openai/gpt-oss-120b",
+        choices: [{ message: { role: "assistant", content: "PONG" } }],
+        usage: { cost_microdollars: 17 },
+      }),
+    });
+  });
+  await page.route("**/activation-test", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html>
+        <html lang="en"><head>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <link rel="stylesheet" href="/static/dashboard.css">
+          <link rel="stylesheet" href="/static/charter.css">
+          <link rel="stylesheet" href="/static/console.css">
+          <script defer src="/static/console.js"></script>
+        </head><body class="console"><main class="console-main"><div class="console-page-body">
+          <div class="activation-flow" data-first-call-flow data-endpoint="/chat-proxy/v1/chat/completions" data-key-source="welcome-api-key">
+            <ol class="activation-progress"><li class="complete"><span>1</span><strong>Account</strong></li><li class="current"><span>2</span><strong>First call</strong></li><li><span>3</span><strong>Connect app</strong></li></ol>
+            <section class="panel activation-key-panel"><div class="panel-head"><h2>Save it now</h2></div><div class="panel-body"><div class="secret-row"><code id="welcome-api-key">${apiKey}</code><button class="btn" data-copy-secret="welcome-api-key">Copy</button></div></div></section>
+            <section class="panel activation-test-panel"><div class="panel-head activation-panel-head"><div><p class="activation-eyebrow">Live gateway check</p><h2>Run your first API request</h2><p class="panel-kicker">A real, inexpensive PONG request confirms the route.</p></div><span class="activation-step-number">02</span></div><div class="panel-body">
+              <button class="btn primary activation-run-button" type="button" data-action="run-first-call"><span data-run-label>Run my first API request</span><span class="activation-button-arrow">&#8594;</span></button>
+              <div class="activation-call-error" data-call-error hidden><strong data-call-error-title></strong><p data-call-error-message></p><a data-call-error-action hidden></a></div>
+              <div class="activation-call-result" data-call-result hidden><div class="activation-result-head"><div><span class="activation-success-mark">&#10003;</span><div><strong>Production request passed</strong><p>Your key is ready.</p></div></div><code data-result-output></code></div><dl class="activation-result-grid"><div><dt>Model</dt><dd data-result-model></dd></div><div><dt>Provider</dt><dd data-result-provider></dd></div><div><dt>Latency</dt><dd data-result-latency></dd></div><div><dt>Exact cost</dt><dd data-result-cost></dd></div></dl><div data-success-actions></div></div>
+            </div></section>
+            <section class="panel activation-setup-panel"><div class="panel-body"><div class="activation-tabs" role="tablist"><button class="activation-tab" role="tab" aria-selected="true" data-setup-tab="setup-agent">Claude Code / Codex</button><button class="activation-tab" role="tab" aria-selected="false" data-setup-tab="setup-python">Python</button></div><div class="activation-code-panel" id="setup-agent" data-setup-panel><div class="activation-code-head"><strong>Paste this whole message</strong><button class="btn" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key">Copy prompt</button></div><pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com to ask DeepSeek a question.</span><span>YOUR_TRUSTEDROUTER_API_KEY</span></pre></div><div class="activation-code-panel" id="setup-python" data-setup-panel hidden><pre>Python setup</pre></div></div></section>
+          </div>
+        </div></main></body></html>`,
+    });
+  });
+
+  await page.goto("/activation-test");
+  const rawCopies = await page.evaluate(
+    (secret) => document.body.innerHTML.split(secret).length - 1,
+    apiKey,
+  );
+  expect(rawCopies).toBe(1);
+
+  await page.getByRole("button", { name: "Run my first API request" }).click();
+  await expect(page.getByText("Production request passed")).toBeVisible();
+  await expect(page.locator("[data-result-output]")).toHaveText("PONG");
+  await expect(page.locator("[data-result-model]")).toHaveText("openai/gpt-oss-120b");
+  await expect(page.locator("[data-result-provider]")).toHaveText("cerebras");
+  await expect(page.locator("[data-result-latency]")).toContainText("ms");
+  await expect(page.locator("[data-result-cost]")).toHaveText("$0.000017");
+  await expect.poll(() => analytics).toContain("first_call_started");
+
+  await page.getByRole("button", { name: "Copy prompt" }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(
+    `Please use TrustedRouter.com to ask DeepSeek a question.\n\n${apiKey}`,
+  );
+  await page.getByRole("tab", { name: "Python" }).click();
+  await expect(page.locator("#setup-python")).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(2);
+});
+
 test("delegated sign-in explains zero-credit onboarding", async ({ page }) => {
   const target = encodeURIComponent(
     "/auth?callback_url=https%3A%2F%2Fslopnazi.com%2Feditor&key_label=SlopNazi&limit=5&usage_limit_type=monthly",

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -341,6 +341,16 @@ def test_unknown_browser_funnel_event_is_rejected(client: TestClient) -> None:
     assert response.status_code == 400
 
 
+@pytest.mark.parametrize("event", ["first_call_started", "first_call_failed"])
+def test_first_call_browser_events_are_accepted_without_payload(
+    client: TestClient,
+    event: str,
+) -> None:
+    _campaign_landing(client)
+    response = client.post("/analytics/events", json={"event": event})
+    assert response.status_code == 204
+
+
 def test_successful_usage_milestones_are_once_only(
     client: TestClient,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_activation_reminders.py
+++ b/tests/test_activation_reminders.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.acquisition import record_successful_api_call
+from trusted_router.config import Settings
+from trusted_router.services.activation_reminders import run_activation_reminder_pass
+from trusted_router.services.email import EmailMessage
+from trusted_router.storage import STORE
+from trusted_router.storage_models import AcquisitionAttribution, iso_now
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CapturingEmailService:
+    def __init__(self, *, accepted: bool = True) -> None:
+        self.accepted = accepted
+        self.messages: list[EmailMessage] = []
+        self._lock = threading.Lock()
+
+    def send(self, message: EmailMessage) -> bool:
+        with self._lock:
+            self.messages.append(message)
+        return self.accepted
+
+
+def _signup(client: TestClient, email: str = "activation@example.com") -> dict[str, object]:
+    response = client.post("/v1/signup", json={"email": email, "name": "Activation"})
+    assert response.status_code == 201, response.text
+    return response.json()["data"]
+
+
+def test_signup_schedules_sorted_ten_minute_and_day_reminders(
+    client: TestClient,
+) -> None:
+    payload = _signup(client)
+    tasks = STORE.list_activation_reminders(limit=10)
+
+    assert [task.stage for task in tasks] == ["10m", "24h"]
+    assert {task.workspace_id for task in tasks} == {payload["workspace_id"]}
+    assert tasks[0].id < tasks[1].id
+    assert tasks[0].created_at == tasks[1].created_at
+
+
+def test_due_reminder_sends_once_without_key_or_content(
+    client: TestClient,
+    test_settings: Settings,
+) -> None:
+    payload = _signup(client)
+    raw_key = str(payload["key"])
+    due = STORE.list_activation_reminders(limit=10)[0]
+    email = CapturingEmailService()
+
+    result = run_activation_reminder_pass(
+        test_settings,
+        now=due.due_at,
+        email_service=email,  # type: ignore[arg-type]
+    )
+    replay = run_activation_reminder_pass(
+        test_settings,
+        now=due.due_at,
+        email_service=email,  # type: ignore[arg-type]
+    )
+
+    assert result.sent == 1
+    assert replay.sent == 0
+    assert len(email.messages) == 1
+    message = email.messages[0]
+    rendered = "\n".join(
+        [message.subject, message.text_body, message.html_body or ""]
+    )
+    assert message.mail_class == "activation_10m"
+    assert raw_key not in rendered
+    assert "prompt" not in rendered.lower()
+    assert "output" not in rendered.lower()
+    assert "$0.30" not in rendered
+    assert "Claude Code" in rendered
+    assert "Codex" in rendered
+    assert "/console/api-keys#new-api-key" in rendered
+    assert [task.stage for task in STORE.list_activation_reminders(limit=10)] == ["24h"]
+
+
+def test_successful_call_cancels_every_due_reminder(
+    client: TestClient,
+    test_settings: Settings,
+) -> None:
+    payload = _signup(client)
+    workspace_id = str(payload["workspace_id"])
+    tasks = STORE.list_activation_reminders(limit=10)
+    record_successful_api_call(
+        workspace_id,
+        model="trustedrouter/cheap",
+        provider="test-provider",
+        occurred_at=tasks[0].due_at,
+    )
+    email = CapturingEmailService()
+
+    result = run_activation_reminder_pass(
+        test_settings,
+        now=tasks[-1].due_at,
+        email_service=email,  # type: ignore[arg-type]
+    )
+
+    assert result.due == 2
+    assert result.skipped_activated == 2
+    assert result.sent == 0
+    assert email.messages == []
+    assert STORE.list_activation_reminders(limit=10) == []
+
+
+def test_wallet_only_account_reminder_has_no_recipient(
+    test_settings: Settings,
+) -> None:
+    user = STORE.create_wallet_user("0x1234567890123456789012345678901234567890")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    signup_at = (
+        dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    assert STORE.create_acquisition_attribution(
+        AcquisitionAttribution(
+            workspace_id=workspace.id,
+            anonymous_id="wallet-activation",
+            first_touch={"utm_source": "direct"},
+            last_touch={"utm_source": "direct"},
+            signup_provider="wallet",
+            signup_at=signup_at,
+        )
+    )
+    email = CapturingEmailService()
+
+    result = run_activation_reminder_pass(
+        test_settings,
+        now=iso_now(),
+        email_service=email,  # type: ignore[arg-type]
+    )
+
+    assert result.skipped_no_email == 2
+    assert result.sent == 0
+    assert email.messages == []
+
+
+def test_concurrent_regional_passes_claim_one_send(
+    client: TestClient,
+    test_settings: Settings,
+) -> None:
+    _signup(client)
+    due = STORE.list_activation_reminders(limit=10)[0]
+    email = CapturingEmailService()
+
+    def run() -> int:
+        result = run_activation_reminder_pass(
+            test_settings,
+            now=due.due_at,
+            email_service=email,  # type: ignore[arg-type]
+        )
+        return result.sent
+
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        sent = list(pool.map(lambda _index: run(), range(12)))
+
+    assert sum(sent) == 1
+    assert len(email.messages) == 1
+
+
+def test_spanner_attribution_and_reminders_share_one_create_transaction() -> None:
+    store, _database, _bigtable = make_fake_store()
+    signup_at = "2026-08-06T12:00:00Z"
+    record = AcquisitionAttribution(
+        workspace_id="ws-spanner-reminder",
+        anonymous_id="anon-spanner-reminder",
+        first_touch={"utm_source": "google"},
+        last_touch={"utm_source": "google"},
+        signup_provider="email",
+        signup_at=signup_at,
+    )
+
+    assert store.create_acquisition_attribution(record) is True
+    assert store.create_acquisition_attribution(record) is False
+    tasks = store.list_activation_reminders(limit=10)
+    assert [task.stage for task in tasks] == ["10m", "24h"]
+
+    stored, claimed = store.claim_activation_reminder(
+        record.workspace_id,
+        "10m",
+        occurred_at="2026-08-06T12:10:00Z",
+    )
+    assert stored is not None
+    assert claimed is True
+    _, replay_claimed = store.claim_activation_reminder(
+        record.workspace_id,
+        "10m",
+        occurred_at="2026-08-06T12:11:00Z",
+    )
+    assert replay_claimed is False
+
+
+def test_reminder_worker_is_off_by_default_and_enabled_in_production_rollout() -> None:
+    settings = Settings(_env_file=None)
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+
+    assert settings.activation_reminder_interval_seconds == 0
+    assert '"TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=60"' in rollout

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -868,22 +868,23 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
 
     resp = client.get("/console/welcome?first=1", follow_redirects=False)
     assert resp.status_code == 200
-    assert resp.text.count(fake_raw_key) == 2, (
-        "expected the raw API key from tr_pending_reveal to be rendered "
-        "by itself and in the agent quickstart message"
-    )
-    agent_message = (
-        "Please use TrustedRouter.com using the following key to ask DeepSeek "
-        'the following question: "What is the capital of France?"'
-        f"\n\n{fake_raw_key}"
+    assert resp.text.count(fake_raw_key) == 1, (
+        "the raw API key must have exactly one DOM copy; setup copy buttons "
+        "inject it only when the user clicks"
     )
     assert 'data-copy-secret="welcome-api-key"' in resp.text
-    assert 'data-copy-secret="welcome-agent-message"' in resp.text
+    assert 'data-copy-template-target="welcome-agent-message"' in resp.text
+    assert 'data-secret-source="welcome-api-key"' in resp.text
     assert 'id="welcome-agent-message" data-copy-lines' in resp.text
-    assert 'class="agent-message-key">' + fake_raw_key + "</code>" in resp.text
-    assert '<pre id="welcome-agent-message"' not in resp.text
-    assert agent_message.split("\n\n", 1)[0] in resp.text
-    assert "Paste this whole message into your agent or Claude Code" in resp.text
+    assert "YOUR_TRUSTEDROUTER_API_KEY" in resp.text
+    assert '<pre id="welcome-agent-message"' in resp.text
+    assert "Run my first API request" in resp.text
+    assert 'data-endpoint="/chat-proxy/v1/chat/completions"' in resp.text
+    assert "Claude Code / Codex" in resp.text
+    assert "Python" in resp.text
+    assert "JavaScript" in resp.text
+    assert "curl" in resp.text
+    assert "https://trust.trustedrouter.com" in resp.text
     assert "already been displayed" not in resp.text
     # One-shot: cookie must be cleared on the response so a refresh
     # doesn't re-reveal the key.
@@ -946,24 +947,36 @@ def test_console_create_api_key_form_shows_raw_key_once(
     assert "console-created" in resp.text
     match = re.search(r"sk-tr-v1-[A-Za-z0-9_-]+", resp.text)
     assert match is not None
-    assert resp.text.count(match.group(0)) == 2
-    agent_message = (
-        "Please use TrustedRouter.com using the following key to ask DeepSeek "
-        'the following question: "What is the capital of France?"'
-        f"\n\n{match.group(0)}"
-    )
+    assert resp.text.count(match.group(0)) == 1
     assert 'data-copy-secret="created-api-key"' in resp.text
-    assert 'data-copy-secret="created-agent-message"' in resp.text
+    assert 'data-copy-template-target="created-agent-message"' in resp.text
+    assert 'data-secret-source="created-api-key"' in resp.text
     assert 'id="created-agent-message" data-copy-lines' in resp.text
-    assert 'class="agent-message-key">' + match.group(0) + "</code>" in resp.text
     assert '<pre id="created-agent-message"' not in resp.text
-    assert agent_message.split("\n\n", 1)[0] in resp.text
+    assert "YOUR_TRUSTEDROUTER_API_KEY" in resp.text
     assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "Copied to clipboard." not in resp.text
     workspace_id = next(iter(STORE.workspaces))
     keys = STORE.list_keys(workspace_id)
     assert len(keys) == 1
     assert keys[0].limit_microdollars == 1
+
+
+def test_console_welcome_without_credits_routes_to_funding(
+    console_session: tuple[TestClient, str],
+) -> None:
+    client, _ = console_session
+    workspace = next(iter(STORE.workspaces.values()))
+    STORE.credit_money[workspace.id].total_credits_microdollars = 0
+    fake_raw_key = "sk-tr-v1-zero-credit-reveal"  # noqa: S105 - test fixture
+    client.cookies.set("tr_pending_reveal", fake_raw_key)
+
+    response = client.get("/console/welcome?first=1")
+
+    assert response.status_code == 200
+    assert "Add credits before the live check" in response.text
+    assert 'href="/console/credits"' in response.text
+    assert 'data-action="run-first-call"' not in response.text
 
 
 def test_console_create_api_key_uses_decimal_money_and_rejects_invalid_limit(


### PR DESCRIPTION
## Summary
- replace the passive API-key reveal with a polished live first-call activation flow
- preserve copy-ready Claude Code and Codex setup alongside Python, JavaScript, and curl
- add durable 10-minute and 24-hour activation reminders that stop after the first successful call
- record privacy-bounded first-call funnel milestones and keep payment prompts after success

## Safety
- raw API keys appear once in the DOM and are injected into copied setup text only at click time
- the live PONG uses the existing opaque attested gateway proxy with an idempotency key
- reminder processing is bounded and atomically claimed across regional replicas
- prompts, outputs, keys, and exact trial-credit grants are excluded from reminder storage and email

## Verification
- 3,119 Python tests passed, 253 skipped, 10 expected xfails
- 115 focused activation, console, and attribution tests passed
- ruff and mypy passed
- TypeScript, ESLint, and Stylelint passed
- 19 Playwright browser tests passed
- desktop and 390px mobile screenshots reviewed