### PR TITLE
synthetic: measure the Southeast Asia Azure enclave, and guard the wiring

### DIFF
--- a/docs/storage-portability/HANDOFF.md
+++ b/docs/storage-portability/HANDOFF.md
@@ -398,6 +398,52 @@ Two things to check before trusting any green:
 
 So AWS and Azure simply never schedule the throughput commands. No cross-cloud pipe.
 
+### 4.8 Azure region two (southeastasia) — BLOCKED on four IAM grants
+
+Everything except the grants is done and merged-or-in-review.
+
+**Provisioned and Ready:** resource group `TR-TEE-SEA` (southeastasia), MAA instance
+`trquillsea` → `https://trquillsea.sasia.attest.azure.net`, managed identity
+`tr-skr-identity` (principal `e8193e32-34ba-4a22-8159-7db7a0687874`).
+
+**The block.** The identity has *no role assignments*. `az role assignment create` is refused
+by this session's permission classifier — correctly, it is an IAM grant — so a human must run
+the four commands in `tools/bootstrap-azure-region.sh`'s plan output. Until then the deploy
+dies at its prerequisite check, which is the intended behaviour.
+
+**Shared vs regional.** Vault `trquillkv`, wrapping key `tr-bootstrap-wrap` and registry
+`trquillacr` are **shared** across regions; the resource group, MAA instance, identity and
+container group are **regional**. The honest cost: the vault lives in UAE North, so a UAE
+North vault outage blocks a **cold start** in every region. It does not touch a running
+enclave, which holds its unsealed secrets in memory. The alternative — per-region keys —
+means per-region bundle re-sealing, and a bundle that drifts between regions is a provider
+that 401s *in one region only*. Wrong trade.
+
+**Region availability**, confirmed against ARM `deployment group validate` rather than docs:
+confidential ACI is supported in southeastasia, northeurope, eastus2, switzerlandnorth and
+swedencentral on this subscription. **westeurope is blocked by policy.**
+
+**What region two exposed in one-region code** (qcp #120):
+
+* `bound_hostdata` read hostdata from *every* authority's clause. The key is shared, so at two
+  regions `bind` computes its baseline from the other region's measurement.
+* Nothing ever reported an **open bind window**. `bind` widens the pin to {old, new} and
+  `narrow` closes it; a deploy that dies at `verify` leaves it open *by design*, so rollback
+  stays possible — and then nobody runs `narrow`. **UAE North was in this state**, from a
+  deploy that failed at verify weeks earlier. A retired measurement kept the right to unseal
+  every current provider credential. The new `audit` phase found it on its first run against
+  production; `narrow-live` closed it.
+* `narrow` can only narrow to what the *local workspace* built — useless for the case that
+  actually leaves windows open (a deploy that failed weeks ago into a temp directory since
+  deleted). Hence `narrow-live`, which narrows to what is running *after proving it attests*.
+
+**Run `audit` against every region before believing a green dashboard.** It is read-only:
+
+```
+LOCATION=<region> RESOURCE_GROUP=<rg> MAA_ENDPOINT=<region MAA host> \
+  ./tools/deploy-azure-aci.sh audit
+```
+
 ---
 
 ## 5. Traps that have already cost real debugging time

--- a/docs/storage-portability/HANDOFF.md
+++ b/docs/storage-portability/HANDOFF.md
@@ -437,6 +437,50 @@ swedencentral on this subscription. **westeurope is blocked by policy.**
   actually leaves windows open (a deploy that failed weeks ago into a temp directory since
   deleted). Hence `narrow-live`, which narrows to what is running *after proving it attests*.
 
+### 4.9 Azure and four nines — where it actually stands
+
+**Azure is not at four nines, and the gap is structural, not a matter of waiting for samples.**
+Four nines is 52 minutes a year *total*. Here is each term, honestly.
+
+| | status |
+|---|---|
+| two regions, each attesting to its own MAA | **done** — uaenorth + southeastasia |
+| auto-recovery from a container fault | **done** — `restartPolicy: OnFailure` |
+| automatic failover *between* the two regions | **MISSING** — this is the blocker |
+| auto-recovery from group-level loss | **MISSING** |
+| shared-fate on Let's Encrypt (#56) | **MISSING** — caps availability regardless of region count |
+| enough samples to *demonstrate* a number | **no** — needs ~a week at 1/min |
+
+**`restartPolicy: Never` was the single largest term** and is now fixed. Anything that exited
+the process once — a panic, an OOM, a transient upstream stall — left the group in `Succeeded`
+forever, serving nothing, until a human noticed. One such event spends the entire annual
+budget before anyone has read the page.
+
+**Why two regions do not currently compose.** Each has its own hostname
+(`api-azure` / `api-azure-sea`), so a client pointed at one gets nothing when that region dies.
+Two regions with no failover is two independent single points of failure, not redundancy.
+
+**The mechanism to fix it already exists** and is how GCP runs many enclaves behind one name:
+`enclavetls.NewACME` takes a shared `autocert.Cache`, and `NewGCSCache`
+(`QUILL_ACME_CACHE_GCS_BUCKET`, bucket `gs://quill-acme-cache`) lets every replica answer the
+same TLS-ALPN-01 challenge and serve the same cert — which is what makes a multi-IP A record
+work at all. Its HTTP transport is behind `!cloud_aws`, so **it already ships in Azure
+builds**. The increment is:
+
+1. give both Azure regions GCS access — this is the first real use for the cross-cloud
+   identity federation described in §"Keyless cross-cloud identity (provisioned, currently
+   unused)"
+2. set `QUILL_API_HOST` in both regions to include a shared name as well as the per-region one
+3. publish an A record set over both regional IPs, with membership gated on attestation
+   (extend `tools/reconcile-enclave-dns.py`, which today only enumerates a GCP fleet)
+
+DNS is L4, so this does not terminate TLS and attestation stays intact. **Do not reach for
+Front Door or any L7 product here** — it would void attestation.
+
+**Do not claim a nines number from the probe data yet.** Four nines means one failure in
+10,000; at one sample a minute that is seven days of clean data before the number means
+anything. Until then the honest statement is architectural, not measured.
+
 **Run `audit` against every region before believing a green dashboard.** It is read-only:
 
 ```

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -66,7 +66,9 @@ STATUS_HOST="${STATUS_HOST:-https://azure.trustedrouter.com}"
 # so one dead region cannot hide behind a shared name. The NAME is what binds
 # this endpoint to its public status component in synthetic/components.py —
 # renaming one without the other silently unpublishes it.
-GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io}"
+# Both Azure enclave regions. A region missing here is not probed at all, and
+# its component silently reports nothing rather than reporting down.
+GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io}"
 
 # Secrets resolved from the operator's own files, exactly like every other
 # cloud (quill-cloud-proxy tools/quill_secret_sources.py). No cloud reads

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -145,6 +145,15 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
         ),
     },
     {
+        "id": "southeastasia_gateway",
+        "name": "Southeast Asia Gateway (Singapore)",
+        "description": (
+            "Azure confidential container addressed directly: publicly-trusted "
+            "TLS minted inside the TEE and SEV-SNP attestation through MAA "
+            "from a healthy Southeast Asia enclave behind it."
+        ),
+    },
+    {
         "id": "attestation",
         "name": "Attestation",
         "description": "Nonce and digest verification for public attested gateways.",
@@ -184,6 +193,7 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
     # (scripts/deploy/azure_control_plane.sh). Absent everywhere else, which is
     # what keeps this row off the AWS and GCP status pages.
     "uaenorth_gateway": "uaenorth",
+    "southeastasia_gateway": "southeastasia",
     "attestation": "canonical",
     "billing_settlement": CONTROL_PLANE_TARGET,
     "provider_fallback": CONTROL_PLANE_TARGET,
@@ -200,7 +210,12 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
 #   * the overall headline must INCLUDE them, or "All Systems Operational"
 #     sits directly above a red region row.
 GATEWAY_REGION_COMPONENT_IDS: frozenset[str] = frozenset(
-    {"eu_west_1_gateway", "eu_west_3_gateway", "uaenorth_gateway"}
+    {
+        "eu_west_1_gateway",
+        "eu_west_3_gateway",
+        "uaenorth_gateway",
+        "southeastasia_gateway",
+    }
 )
 # Regional API components also feed deploy automation through
 # status.current.checks. Keep this set separate from
@@ -318,6 +333,8 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("eu_west_3_gateway")
     if sample.target == "uaenorth" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("uaenorth_gateway")
+    if sample.target == "southeastasia" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
+        ids.append("southeastasia_gateway")
     # "Attestation" is a SHARED, service-wide row that predates the pinned
     # targets, and it is scoped to the addresses customers actually resolve.
     # Folding the pinned per-region probes in here averaged a public number

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -1161,3 +1161,77 @@ def test_a_missing_measurement_never_satisfies_a_pin() -> None:
 
     assert not _pcr0_pin_matches(None, "aa" * 48)
     assert not _pcr0_pin_matches("", "aa" * 48)
+
+
+# ---------------------------------------------------------------------------
+# A regional gateway component must be wired in EVERY place, or it lies
+# ---------------------------------------------------------------------------
+
+
+def test_every_regional_gateway_component_is_fully_wired() -> None:
+    """Adding a region touches four independent places, and missing any one
+    produces a DIFFERENT flavour of wrong — none of which is a loud failure:
+
+      1. COMPONENTS            — absent: the region has no row at all
+      2. COMPONENT_PROBE_TARGETS — absent: the row exists but is never scoped
+                                   to a probe target, so it renders empty
+      3. GATEWAY_REGION_COMPONENT_IDS — absent: the row can be red while the
+                                   headline still says All Systems Operational
+      4. sample_component_ids — absent: samples never attribute to the row,
+                                   so it sits permanently blank and a dead
+                                   region looks like a quiet one
+
+    The last is the dangerous one: a region that is never probed reports
+    nothing, and nothing renders as "no incidents" rather than as "unknown".
+    """
+    import inspect
+
+    from trusted_router.synthetic import components as mod
+
+    declared = {c["id"] for c in mod.COMPONENT_DEFINITIONS}
+    attribution_src = inspect.getsource(mod.sample_component_ids)
+
+    regional = {cid for cid in declared if cid.endswith("_gateway")}
+    assert regional, "no *_gateway components found — did the naming change?"
+
+    missing: list[str] = []
+    for cid in sorted(regional):
+        if cid not in mod.COMPONENT_PROBE_TARGETS:
+            missing.append(f"{cid}: no COMPONENT_PROBE_TARGETS entry (row renders empty)")
+        if cid not in mod.GATEWAY_REGION_COMPONENT_IDS:
+            missing.append(f"{cid}: not in GATEWAY_REGION_COMPONENT_IDS (can be red under a green headline)")
+        if f'"{cid}"' not in attribution_src:
+            missing.append(f"{cid}: sample_component_ids never attributes to it (permanently blank)")
+
+    assert not missing, "regional gateway components are half-wired:\n  " + "\n  ".join(missing)
+
+
+def test_azure_deploy_probes_every_azure_gateway_component() -> None:
+    """The component list and the deploy script's probe targets must agree.
+
+    A component whose region is absent from TR_SYNTHETIC_GATEWAY_REGION_TARGETS
+    is never probed, so it reports nothing — and on a status page nothing looks
+    like health, not like absence.
+    """
+    import re
+    from pathlib import Path
+
+    from trusted_router.synthetic import components as mod
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "deploy" / "azure_control_plane.sh"
+    text = script.read_text()
+    match = re.search(r'GATEWAY_REGION_TARGETS="\$\{GATEWAY_REGION_TARGETS:-([^}]*)\}"', text)
+    assert match, "could not parse GATEWAY_REGION_TARGETS out of azure_control_plane.sh"
+    probed = {chunk.split("=", 1)[0].strip() for chunk in match.group(1).split(",") if "=" in chunk}
+
+    azure_regions = {
+        mod.COMPONENT_PROBE_TARGETS[c["id"]]
+        for c in mod.COMPONENT_DEFINITIONS
+        if c["id"].endswith("_gateway") and c["id"] in mod.COMPONENT_PROBE_TARGETS
+        and mod.COMPONENT_PROBE_TARGETS[c["id"]] in {"uaenorth", "southeastasia"}
+    }
+    unprobed = sorted(azure_regions - probed)
+    assert not unprobed, (
+        f"Azure gateway component(s) for {unprobed} exist but the deploy script never probes them, "
+        "so they report nothing and nothing reads as healthy"
+    )


### PR DESCRIPTION
Adds `southeastasia_gateway` so Azure's second enclave region is actually probed rather than silently absent.

## Four edits, four flavours of silent wrong

| missing from | symptom |
|---|---|
| `COMPONENT_DEFINITIONS` | no row at all |
| `COMPONENT_PROBE_TARGETS` | row exists, never scoped, renders empty |
| `GATEWAY_REGION_COMPONENT_IDS` | row can be red under a green headline |
| `sample_component_ids` | samples never attribute; row stays blank |

**The last one matters most:** a region that is never probed reports *nothing*, and on a status page nothing reads as "no incidents" rather than "unknown". **A dead region would look like a quiet one.**

## Two structural guards

- every `*_gateway` component must be present in all four places
- the component list and `azure_control_plane.sh`'s `TR_SYNTHETIC_GATEWAY_REGION_TARGETS` must agree — a component whose region is missing from the deploy env is never probed, producing the same silence from the infrastructure side

Mutation-verified: deleting the `sample_component_ids` line fails with *"permanently blank"*.

45 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)