### PR TITLE
synthetic: probe each Azure region at the name it actually serves

### DIFF
--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -68,7 +68,17 @@ STATUS_HOST="${STATUS_HOST:-https://azure.trustedrouter.com}"
 # renaming one without the other silently unpublishes it.
 # Both Azure enclave regions. A region missing here is not probed at all, and
 # its component silently reports nothing rather than reporting down.
-GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io}"
+# southeastasia carries an explicit @public_host. The two Azure regions serve
+# DIFFERENT public names, because the shared ACME cache is disabled on Azure
+# (no "tr-cross-cloud-sa-key" in the bundle), so each region completes ACME for
+# its own hostname only. Probing southeastasia with the canonical SNI
+# api-azure.trustedrouter.com asks it for a certificate it does not hold: the
+# handshake fails and a healthy region publishes as DOWN.
+#
+# uaenorth needs no override — it IS the canonical name. When the shared cache
+# lands and both regions serve one name, drop the @suffix and this returns to
+# the plain shared-name form that GCP and AWS use.
+GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io@api-azure-sea.trustedrouter.com}"
 
 # Secrets resolved from the operator's own files, exactly like every other
 # cloud (quill-cloud-proxy tools/quill_secret_sources.py). No cloud reads

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from pydantic import model_validator
 from pydantic_settings import (
@@ -18,9 +18,7 @@ from pydantic_settings import (
 # entry reusing one would quietly merge two different measurements into one
 # status component, so it is rejected instead.
 _RESERVED_SYNTHETIC_TARGET_NAMES = frozenset({"canonical", "control-plane"})
-_GATEWAY_REGION_TARGET_NAME_CHARACTERS = set(
-    "abcdefghijklmnopqrstuvwxyz0123456789-_."
-)
+_GATEWAY_REGION_TARGET_NAME_CHARACTERS = set("abcdefghijklmnopqrstuvwxyz0123456789-_.")
 _GATEWAY_REGION_CONNECT_HOST_CHARACTERS = set("abcdefghijklmnopqrstuvwxyz0123456789-.")
 # An entry name that LOOKS like a cloud region ("eu-west-1", or the zonal
 # "eu-west-1a") is published to the world as that region's health, so it has
@@ -97,12 +95,37 @@ def parse_settlement_inbound_tokens(raw: str) -> dict[str, str]:
     return by_token
 
 
-def parse_gateway_region_targets(raw: str) -> tuple[tuple[str, str], ...]:
-    """Parse ``TR_SYNTHETIC_GATEWAY_REGION_TARGETS`` into ``(name, host)`` pairs.
+class GatewayRegionTarget(NamedTuple):
+    """One region's probe endpoint.
 
-    Format: ``name=connect_host,name=connect_host``. Blank/unset yields an
-    empty tuple — the single-canonical-target behaviour every deployment had
-    before this setting existed.
+    ``public_host`` is the name the probe puts in SNI and Host. It is empty for
+    the normal case — every replica serving one shared public name, which is
+    how GCP and AWS are built — and the probe then uses the canonical
+    ``api_base_url``.
+
+    It exists because Azure is NOT built that way yet. Each Azure region serves
+    its own hostname (``api-azure`` / ``api-azure-sea``) because the shared
+    ACME cache is disabled there, so probing southeastasia with the canonical
+    SNI asks it for a certificate it does not hold: the handshake fails and a
+    perfectly healthy region reports DOWN. A status page that cries wolf is not
+    a safer failure than one that stays quiet — it is a page nobody reads.
+
+    When the shared cache lands and both Azure regions serve one name, this
+    field simply goes unset again and the canonical path takes over.
+    """
+
+    name: str
+    connect_host: str
+    public_host: str = ""
+
+
+def parse_gateway_region_targets(raw: str) -> tuple[GatewayRegionTarget, ...]:
+    """Parse ``TR_SYNTHETIC_GATEWAY_REGION_TARGETS`` into region targets.
+
+    Format: ``name=connect_host`` or ``name=connect_host@public_host``,
+    comma-separated. Blank/unset yields an empty tuple — the
+    single-canonical-target behaviour every deployment had before this setting
+    existed.
 
     Every malformed entry RAISES. Skipping one would publish a status page
     that silently stops measuring an enclave: the component would vanish (its
@@ -111,17 +134,19 @@ def parse_gateway_region_targets(raw: str) -> tuple[tuple[str, str], ...]:
     """
     if not raw.strip():
         return ()
-    entries: list[tuple[str, str]] = []
+    entries: list[GatewayRegionTarget] = []
     seen: set[str] = set()
     for chunk in raw.split(","):
         entry = chunk.strip()
-        name, separator, connect_host = entry.partition("=")
+        name, separator, endpoint = entry.partition("=")
         name = name.strip().casefold()
-        connect_host = connect_host.strip().casefold().rstrip(".")
+        connect_host, _, public_host = endpoint.strip().casefold().partition("@")
+        connect_host = connect_host.strip().rstrip(".")
+        public_host = public_host.strip().rstrip(".")
         if not separator or not name or not connect_host:
             raise ValueError(
                 "TR_SYNTHETIC_GATEWAY_REGION_TARGETS entries must be "
-                f"'name=connect_host'; got {entry!r}"
+                f"'name=connect_host' or 'name=connect_host@public_host'; got {entry!r}"
             )
         if not set(name) <= _GATEWAY_REGION_TARGET_NAME_CHARACTERS:
             raise ValueError(
@@ -129,13 +154,9 @@ def parse_gateway_region_targets(raw: str) -> tuple[tuple[str, str], ...]:
                 f"letters, digits, '-', '_' and '.'; got {name!r}"
             )
         if name in _RESERVED_SYNTHETIC_TARGET_NAMES:
-            raise ValueError(
-                f"TR_SYNTHETIC_GATEWAY_REGION_TARGETS name {name!r} is reserved"
-            )
+            raise ValueError(f"TR_SYNTHETIC_GATEWAY_REGION_TARGETS name {name!r} is reserved")
         if name in seen:
-            raise ValueError(
-                f"TR_SYNTHETIC_GATEWAY_REGION_TARGETS name {name!r} is duplicated"
-            )
+            raise ValueError(f"TR_SYNTHETIC_GATEWAY_REGION_TARGETS name {name!r} is duplicated")
         # A bare hostname or IP literal only: a scheme, port, or path here
         # would be silently dropped by the connect path (it dials host:443 of
         # the canonical URL), i.e. a probe measuring something other than what
@@ -144,6 +165,18 @@ def parse_gateway_region_targets(raw: str) -> tuple[tuple[str, str], ...]:
             raise ValueError(
                 "TR_SYNTHETIC_GATEWAY_REGION_TARGETS connect host must be a bare "
                 f"hostname or IPv4 literal; got {connect_host!r}"
+            )
+        # An empty public host means "@" was written with nothing after it,
+        # which reads as an override and silently is not one.
+        if "@" in endpoint and not public_host:
+            raise ValueError(
+                "TR_SYNTHETIC_GATEWAY_REGION_TARGETS public host after '@' must not "
+                f"be empty; got {entry!r}"
+            )
+        if public_host and not set(public_host) <= _GATEWAY_REGION_CONNECT_HOST_CHARACTERS:
+            raise ValueError(
+                "TR_SYNTHETIC_GATEWAY_REGION_TARGETS public host must be a bare "
+                f"hostname; got {public_host!r}"
             )
         # THE name/endpoint binding, cross-checked. Everything downstream —
         # the target name, its target_region, its public status component —
@@ -165,7 +198,7 @@ def parse_gateway_region_targets(raw: str) -> tuple[tuple[str, str], ...]:
                 "name is what the public status page calls this endpoint"
             )
         seen.add(name)
-        entries.append((name, connect_host))
+        entries.append(GatewayRegionTarget(name, connect_host, public_host))
     return tuple(entries)
 
 
@@ -712,9 +745,7 @@ class Settings(BaseSettings):
             if value < 0:
                 raise ValueError(f"{name} cannot be negative")
         if self.request_record_write_mode not in {"legacy", "typed"}:
-            raise ValueError(
-                "TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'"
-            )
+            raise ValueError("TR_REQUEST_RECORD_WRITE_MODE must be 'legacy' or 'typed'")
         if self.analytics_read_mode not in {
             "bigtable",
             "dual",
@@ -722,23 +753,17 @@ class Settings(BaseSettings):
             "clickhouse-only",
         }:
             raise ValueError(
-                "TR_ANALYTICS_READ_MODE must be bigtable, dual, clickhouse, "
-                "or clickhouse-only"
+                "TR_ANALYTICS_READ_MODE must be bigtable, dual, clickhouse, or clickhouse-only"
             )
         if self.analytics_dual_read_grace_seconds < 0:
             raise ValueError("TR_ANALYTICS_DUAL_READ_GRACE_SECONDS cannot be negative")
         if not 5 <= self.regional_quota_lease_ttl_seconds <= 300:
-            raise ValueError(
-                "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS must be between 5 and 300"
-            )
+            raise ValueError("TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS must be between 5 and 300")
         if self.regional_quota_lease_max_microdollars <= 0:
-            raise ValueError(
-                "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS must be positive"
-            )
+            raise ValueError("TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS must be positive")
         if not 1 <= self.regional_quota_lease_max_available_basis_points <= 5_000:
             raise ValueError(
-                "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS must be "
-                "between 1 and 5000"
+                "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS must be between 1 and 5000"
             )
         if self.regional_quota_leases_enabled:
             if environment not in {"local", "test"}:
@@ -795,9 +820,7 @@ class Settings(BaseSettings):
                             "credential debit workspaces"
                         )
         if not 0.1 <= self.ops_chat_webhook_timeout_seconds <= 10.0:
-            raise ValueError(
-                "TR_OPS_CHAT_WEBHOOK_TIMEOUT_SECONDS must be between 0.1 and 10"
-            )
+            raise ValueError("TR_OPS_CHAT_WEBHOOK_TIMEOUT_SECONDS must be between 0.1 and 10")
         ops_chat_urls = tuple(
             dict.fromkeys(
                 value.strip().rstrip("/")
@@ -813,9 +836,7 @@ class Settings(BaseSettings):
         if environment == "production" and any(
             not url.startswith("https://") for url in ops_chat_urls
         ):
-            raise ValueError(
-                "TR_OPS_CHAT_WEBHOOK_URLS must contain only HTTPS URLs in production"
-            )
+            raise ValueError("TR_OPS_CHAT_WEBHOOK_URLS must contain only HTTPS URLs in production")
         if self.x402_allow_mock_payments and environment not in {"local", "test"}:
             raise ValueError("TR_X402_ALLOW_MOCK_PAYMENTS is only allowed in local/test")
         if self.adyen_environment not in {"test", "live"}:
@@ -852,9 +873,7 @@ class Settings(BaseSettings):
             if self.adyen_environment == "live" and not self.adyen_live_endpoint_prefix:
                 missing_adyen.append("TR_ADYEN_LIVE_ENDPOINT_PREFIX")
             if missing_adyen:
-                raise ValueError(
-                    "TR_ADYEN_ENABLED requires " + ", ".join(missing_adyen)
-                )
+                raise ValueError("TR_ADYEN_ENABLED requires " + ", ".join(missing_adyen))
         if (
             self.x402_enabled
             and environment not in {"local", "test"}
@@ -915,20 +934,16 @@ class Settings(BaseSettings):
             if not self.operational_analytics_clickhouse_password:
                 missing.append("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD")
         if self.request_record_write_mode == "typed" and not self.settle_outbox_enabled:
-            missing.append(
-                "TR_SETTLE_OUTBOX_ENABLED=true when "
-                "TR_REQUEST_RECORD_WRITE_MODE=typed"
-            )
+            missing.append("TR_SETTLE_OUTBOX_ENABLED=true when TR_REQUEST_RECORD_WRITE_MODE=typed")
         if not self.byok_kms_key_name:
             missing.append("TR_BYOK_KMS_KEY_NAME")
         if not self.trust_gcp_release_url:
-            self.trust_gcp_release_url = (
-                "https://trust.trustedrouter.com/trust/gcp-release.json"
-            )
+            self.trust_gcp_release_url = "https://trust.trustedrouter.com/trust/gcp-release.json"
         elif not self.trust_gcp_release_url.startswith("https://"):
             missing.append("TR_TRUST_GCP_RELEASE_URL=https://...")
         invalid_release_fallbacks = [
-            url for url in self.trust_gcp_release_fallback_url_list
+            url
+            for url in self.trust_gcp_release_fallback_url_list
             if not url.startswith("https://")
         ]
         if invalid_release_fallbacks:
@@ -937,9 +952,13 @@ class Settings(BaseSettings):
         # enforce that no provider is half-configured: a client_id without
         # the matching client_secret would cause silent runtime failures.
         if bool(self.google_client_id) != bool(self.google_client_secret):
-            missing.append("TR_GOOGLE_CLIENT_ID and TR_GOOGLE_CLIENT_SECRET must both be set or both unset")
+            missing.append(
+                "TR_GOOGLE_CLIENT_ID and TR_GOOGLE_CLIENT_SECRET must both be set or both unset"
+            )
         if bool(self.github_client_id) != bool(self.github_client_secret):
-            missing.append("TR_GITHUB_CLIENT_ID and TR_GITHUB_CLIENT_SECRET must both be set or both unset")
+            missing.append(
+                "TR_GITHUB_CLIENT_ID and TR_GITHUB_CLIENT_SECRET must both be set or both unset"
+            )
         configured_aliases = {
             value.strip().lower().rstrip(".")
             for value in self.trusted_domain_aliases.split(",")
@@ -965,9 +984,7 @@ class Settings(BaseSettings):
                     + ", ".join(unknown_oauth_aliases)
                 )
             if canonical_enabled:
-                missing_oauth_aliases = sorted(
-                    configured_aliases - set(alias_credentials)
-                )
+                missing_oauth_aliases = sorted(configured_aliases - set(alias_credentials))
                 if missing_oauth_aliases:
                     missing.append(
                         f"{setting_name} is missing configured domain(s): "
@@ -1039,9 +1056,7 @@ class Settings(BaseSettings):
     @property
     def adyen_webhook_ready(self) -> bool:
         return bool(
-            self.adyen_hmac_key
-            and self.adyen_reference_key
-            and self.adyen_merchant_account
+            self.adyen_hmac_key and self.adyen_reference_key and self.adyen_merchant_account
         )
 
     @property

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -155,9 +155,7 @@ def _connect_host_request(
     if not parsed.hostname or not api_host or parsed.hostname.casefold() != api_host.casefold():
         return url, {}, {}
     netloc = target.connect_host if not parsed.port else f"{target.connect_host}:{parsed.port}"
-    request_url = urlunsplit(
-        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
-    )
+    request_url = urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
     return request_url, {"Host": parsed.netloc}, {"sni_hostname": parsed.hostname}
 
 
@@ -176,18 +174,37 @@ def _gateway_region_targets(
     """
     return [
         SyntheticTarget(
-            name,
-            settings.api_base_url,
-            name,
+            entry.name,
+            _region_api_base_url(settings.api_base_url, entry.public_host),
+            entry.name,
             attested=canonical.attested,
             expected_pcr0=canonical.expected_pcr0,
-            connect_host=connect_host,
+            connect_host=entry.connect_host,
             paid_probes=False,
         )
-        for name, connect_host in parse_gateway_region_targets(
-            settings.synthetic_gateway_region_targets
-        )
+        for entry in parse_gateway_region_targets(settings.synthetic_gateway_region_targets)
     ]
+
+
+def _region_api_base_url(canonical_url: str, public_host: str) -> str:
+    """Swap in a region's own public hostname, keeping scheme/port/path.
+
+    Empty ``public_host`` — the normal case — returns the canonical URL
+    unchanged, so deployments whose replicas all serve one shared name behave
+    exactly as before.
+
+    Azure needs the override because its two regions serve DIFFERENT public
+    names (``api-azure`` / ``api-azure-sea``); the shared ACME cache that would
+    let both hold one certificate is disabled there. Probing southeastasia with
+    the canonical SNI asks it for a certificate it does not have, the handshake
+    fails, and a healthy region is published as DOWN. That false alarm is not a
+    safe failure — it is how a status page stops being believed.
+    """
+    if not public_host:
+        return canonical_url
+    parsed = urlsplit(canonical_url)
+    netloc = public_host if parsed.port is None else f"{public_host}:{parsed.port}"
+    return urlunsplit(parsed._replace(netloc=netloc))
 
 
 def configured_targets(settings: Settings) -> list[SyntheticTarget]:
@@ -597,15 +614,13 @@ async def gateway_latency_phase_probes(
             ]
 
         reused_started = time.perf_counter()
-        second_status, second_headers, second_body, second_ttfb = (
-            await _health_http11_request(
-                reader,
-                stream_writer,
-                host=host,
-                path=path,
-                max_body_bytes=max_body_bytes,
-                timeout_seconds=_remaining_probe_seconds(started, timeout_seconds),
-            )
+        second_status, second_headers, second_body, second_ttfb = await _health_http11_request(
+            reader,
+            stream_writer,
+            host=host,
+            path=path,
+            max_body_bytes=max_body_bytes,
+            timeout_seconds=_remaining_probe_seconds(started, timeout_seconds),
         )
         second_total_ms = _elapsed_ms(reused_started)
         # SERVED, not merely reachable: the reused request must be one the
@@ -2589,9 +2604,7 @@ def _warm_path_served(
     """
     if target.attested:
         content_type = headers.get("content-type", "").casefold()
-        return (
-            status == 200 and content_type.startswith("application/cbor") and bool(body)
-        )
+        return status == 200 and content_type.startswith("application/cbor") and bool(body)
     return status == 200 and body == b'{"status":"ok"}'
 
 

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -42,7 +42,11 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509.oid import NameOID
 
-from trusted_router.config import Settings, parse_gateway_region_targets
+from trusted_router.config import (
+    GatewayRegionTarget,
+    Settings,
+    parse_gateway_region_targets,
+)
 from trusted_router.storage_models import SyntheticProbeSample, utcnow
 from trusted_router.synthetic.components import (
     GATEWAY_REGION_TARGET_NAMES,
@@ -53,6 +57,7 @@ from trusted_router.synthetic.probes import (
     SyntheticTarget,
     _attested_ssl_context,
     _connect_host_request,
+    _region_api_base_url,
     attestation_nonce_probe,
     configured_targets,
     gateway_latency_phase_probes,
@@ -94,9 +99,7 @@ def _write_enclave_cert(directory: Path) -> tuple[Path, Path, bytes]:
         .serial_number(x509.random_serial_number())
         .not_valid_before(now - dt.timedelta(minutes=5))
         .not_valid_after(now + dt.timedelta(days=1))
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(API_HOST)]), critical=False
-        )
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(API_HOST)]), critical=False)
         .sign(key, hashes.SHA256())
     )
     cert_path = directory / "enclave-cert.pem"
@@ -162,9 +165,7 @@ class _FakeEnclave:
         self._server.close()
         await self._server.wait_closed()
 
-    async def _handle(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
             while True:
                 request_line = await reader.readline()
@@ -200,9 +201,9 @@ class _FakeEnclave:
     def _respond(self, path: str) -> tuple[int, bytes, str]:
         if path.startswith("/attestation"):
             _, _, query = path.partition("?")
-            nonce = dict(
-                part.split("=", 1) for part in query.split("&") if "=" in part
-            ).get("nonce", "")
+            nonce = dict(part.split("=", 1) for part in query.split("&") if "=" in part).get(
+                "nonce", ""
+            )
             return 200, _attestation_document(self._cert_der, nonce), "application/cbor"
         # The live enclave protects every route but /attestation.
         return 401, INVALID_KEY_BODY, "application/json"
@@ -317,9 +318,7 @@ async def test_every_probe_that_opens_a_connection_is_pinned(
     async with httpx.AsyncClient(verify=_attested_ssl_context(), timeout=10.0) as client:
         await tls_health_probe(client, target, monitor_region="eu-west-3")
         await attestation_nonce_probe(client, target, monitor_region="eu-west-3")
-    await gateway_latency_phase_probes(
-        target, monitor_region="eu-west-3", timeout_seconds=10.0
-    )
+    await gateway_latency_phase_probes(target, monitor_region="eu-west-3", timeout_seconds=10.0)
 
     # Every TLS handshake the enclave saw presented the canonical name (two
     # handshakes: httpx pools the health + attestation requests onto one
@@ -329,9 +328,7 @@ async def test_every_probe_that_opens_a_connection_is_pinned(
     # ...and every request really arrived: /health once, /attestation from
     # the attestation probe plus the latency probe's cold+reused pair.
     assert enclave.requested_paths[0] == "/health"
-    assert sum(
-        1 for path in enclave.requested_paths if path.startswith("/attestation")
-    ) == 3
+    assert sum(1 for path in enclave.requested_paths if path.startswith("/attestation")) == 3
 
 
 async def test_a_pinned_target_is_never_sent_the_monitor_api_key(
@@ -414,7 +411,7 @@ async def test_a_pinned_target_is_never_sent_the_monitor_api_key(
 async def test_attested_target_fails_when_the_cert_binding_is_unverifiable(
     enclave: _FakeEnclave,
 ) -> None:
-    """"Binding unverifiable" is a failure for an attested target, not a pass.
+    """ "Binding unverifiable" is a failure for an attested target, not a pass.
 
     _response_peer_cert_der documents exactly this, and the evidence helper
     cannot enforce it (non-attested targets legitimately pass None), so the
@@ -580,9 +577,7 @@ def test_unset_configuration_is_exactly_todays_target_list() -> None:
 
 
 def test_configured_entries_become_pinned_targets() -> None:
-    targets = configured_targets(
-        _aws_settings(synthetic_gateway_region_targets=REGION_TARGETS)
-    )
+    targets = configured_targets(_aws_settings(synthetic_gateway_region_targets=REGION_TARGETS))
 
     assert [target.name for target in targets] == ["canonical", "eu-west-1", "eu-west-3"]
     canonical, ireland, paris = targets
@@ -641,9 +636,7 @@ async def test_a_pass_runs_health_and_trust_per_enclave_and_pays_once(
         return []
 
     monkeypatch.setattr(probe_module, "tls_health_probe", fake_probe("tls_health"))
-    monkeypatch.setattr(
-        probe_module, "attestation_nonce_probe", fake_probe("attestation_nonce")
-    )
+    monkeypatch.setattr(probe_module, "attestation_nonce_probe", fake_probe("attestation_nonce"))
     monkeypatch.setattr(probe_module, "gateway_latency_phase_probes", no_phase_probes)
     monkeypatch.setattr(
         probe_module, "control_plane_health_probe", fake_probe("control_plane_health")
@@ -754,8 +747,8 @@ def test_deploy_script_value_parses_to_the_two_regions() -> None:
     differ only in a 16-hex-char middle segment.
     """
     assert parse_gateway_region_targets(_deploy_script_region_targets()) == (
-        ("eu-west-1", IRELAND_NLB),
-        ("eu-west-3", PARIS_NLB),
+        GatewayRegionTarget("eu-west-1", IRELAND_NLB),
+        GatewayRegionTarget("eu-west-3", PARIS_NLB),
     )
 
 
@@ -776,7 +769,7 @@ def test_deploy_script_names_are_exactly_the_published_components() -> None:
     configured: set[str] = set()
     for script in REGION_TARGET_DEPLOY_SCRIPTS:
         entries = parse_gateway_region_targets(_deploy_script_region_targets(script))
-        names = {name for name, _ in entries}
+        names = {entry.name for entry in entries}
         assert names, f"{script} configures no region targets"
         overlap = configured & names
         assert not overlap, f"{script} reuses target name(s) {overlap} from another cloud"
@@ -796,10 +789,12 @@ def test_a_name_that_contradicts_its_endpoints_region_is_rejected() -> None:
     # Per-AZ zonal NLB names are the supported way to get finer granularity,
     # so an AZ-suffixed name for the same region still parses.
     assert parse_gateway_region_targets(f"eu-west-1a=eu-west-1a.{IRELAND_NLB}") == (
-        ("eu-west-1a", f"eu-west-1a.{IRELAND_NLB}"),
+        GatewayRegionTarget("eu-west-1a", f"eu-west-1a.{IRELAND_NLB}"),
     )
     # A name that is not region-shaped has nothing to contradict.
-    assert parse_gateway_region_targets(f"ireland={IRELAND_NLB}") == (("ireland", IRELAND_NLB),)
+    assert parse_gateway_region_targets(f"ireland={IRELAND_NLB}") == (
+        GatewayRegionTarget("ireland", IRELAND_NLB),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -810,9 +805,7 @@ REGION_COMPONENT_IDS = ("eu_west_1_gateway", "eu_west_3_gateway")
 
 
 def _published_ids(settings: Settings) -> tuple[str, ...]:
-    return tuple(
-        str(definition["id"]) for definition in applicable_component_definitions(settings)
-    )
+    return tuple(str(definition["id"]) for definition in applicable_component_definitions(settings))
 
 
 def test_configured_aws_publishes_a_component_per_region() -> None:
@@ -922,16 +915,19 @@ def test_a_dead_region_does_not_degrade_the_shared_attestation_row() -> None:
         created_at = _iso(now, minutes * 60 + 10)
         for probe_type in ("tls_health", "attestation_nonce"):
             samples.append(
-                _sample(target="canonical", probe_type=probe_type, status="up",
-                        created_at=created_at)
+                _sample(
+                    target="canonical", probe_type=probe_type, status="up", created_at=created_at
+                )
             )
             samples.append(
-                _sample(target="eu-west-3", probe_type=probe_type, status="up",
-                        created_at=created_at)
+                _sample(
+                    target="eu-west-3", probe_type=probe_type, status="up", created_at=created_at
+                )
             )
             samples.append(
-                _sample(target="eu-west-1", probe_type=probe_type, status="down",
-                        created_at=created_at)
+                _sample(
+                    target="eu-west-1", probe_type=probe_type, status="down", created_at=created_at
+                )
             )
 
     snapshot = status_snapshot(
@@ -1074,13 +1070,23 @@ def test_pinned_probes_do_not_move_the_published_gateway_latency() -> None:
     """
     now = utcnow()
     canonical = [
-        _sample(target="canonical", probe_type="tls_health", status="up",
-                created_at=_iso(now, 10 + index), latency=30)
+        _sample(
+            target="canonical",
+            probe_type="tls_health",
+            status="up",
+            created_at=_iso(now, 10 + index),
+            latency=30,
+        )
         for index in range(4)
     ]
     pinned = [
-        _sample(target=target, probe_type="tls_health", status="up",
-                created_at=_iso(now, 10 + index), latency=latency)
+        _sample(
+            target=target,
+            probe_type="tls_health",
+            status="up",
+            created_at=_iso(now, 10 + index),
+            latency=latency,
+        )
         for index in range(4)
         for target, latency in (("eu-west-3", 12), ("eu-west-1", 45))
     ]
@@ -1199,9 +1205,13 @@ def test_every_regional_gateway_component_is_fully_wired() -> None:
         if cid not in mod.COMPONENT_PROBE_TARGETS:
             missing.append(f"{cid}: no COMPONENT_PROBE_TARGETS entry (row renders empty)")
         if cid not in mod.GATEWAY_REGION_COMPONENT_IDS:
-            missing.append(f"{cid}: not in GATEWAY_REGION_COMPONENT_IDS (can be red under a green headline)")
+            missing.append(
+                f"{cid}: not in GATEWAY_REGION_COMPONENT_IDS (can be red under a green headline)"
+            )
         if f'"{cid}"' not in attribution_src:
-            missing.append(f"{cid}: sample_component_ids never attributes to it (permanently blank)")
+            missing.append(
+                f"{cid}: sample_component_ids never attributes to it (permanently blank)"
+            )
 
     assert not missing, "regional gateway components are half-wired:\n  " + "\n  ".join(missing)
 
@@ -1227,7 +1237,8 @@ def test_azure_deploy_probes_every_azure_gateway_component() -> None:
     azure_regions = {
         mod.COMPONENT_PROBE_TARGETS[c["id"]]
         for c in mod.COMPONENT_DEFINITIONS
-        if c["id"].endswith("_gateway") and c["id"] in mod.COMPONENT_PROBE_TARGETS
+        if c["id"].endswith("_gateway")
+        and c["id"] in mod.COMPONENT_PROBE_TARGETS
         and mod.COMPONENT_PROBE_TARGETS[c["id"]] in {"uaenorth", "southeastasia"}
     }
     unprobed = sorted(azure_regions - probed)
@@ -1235,3 +1246,117 @@ def test_azure_deploy_probes_every_azure_gateway_component() -> None:
         f"Azure gateway component(s) for {unprobed} exist but the deploy script never probes them, "
         "so they report nothing and nothing reads as healthy"
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-region PUBLIC hostnames — the false-alarm defect
+# ---------------------------------------------------------------------------
+# Every regional target used to inherit the canonical api_base_url, so SNI and
+# Host were always the shared public name. That is correct wherever every
+# replica serves one name (GCP, AWS) and WRONG on Azure, whose two regions
+# serve api-azure and api-azure-sea because the shared ACME cache is disabled
+# there. Probing southeastasia with the canonical SNI asks it for a certificate
+# it does not hold: the handshake fails and a healthy region publishes as DOWN.
+#
+# Reproduced live 2026-08-07 — southeastasia was serving 200 on its own name
+# while the status page called it down.
+
+
+def test_no_override_leaves_the_canonical_url_untouched() -> None:
+    """The shared-name case must behave exactly as it did before this existed."""
+    assert (
+        _region_api_base_url("https://api.trustedrouter.com/v1", "")
+        == "https://api.trustedrouter.com/v1"
+    )
+
+
+def test_an_override_swaps_only_the_host() -> None:
+    """Scheme, port and path are part of the endpoint, not the identity.
+
+    Dropping the path would probe the site root instead of /v1 and call that
+    the gateway's health.
+    """
+    assert (
+        _region_api_base_url(
+            "https://api-azure.trustedrouter.com/v1", "api-azure-sea.trustedrouter.com"
+        )
+        == "https://api-azure-sea.trustedrouter.com/v1"
+    )
+    assert (
+        _region_api_base_url("https://api.example.com:8443/v1", "sea.example.com")
+        == "https://sea.example.com:8443/v1"
+    )
+
+
+def test_azure_southeastasia_is_probed_at_its_own_public_name() -> None:
+    """The deploy script must carry the override, not just the connect host.
+
+    Without it the probe is a false alarm generator, and a status page that
+    cries wolf is not a safer failure than one that stays quiet — it is a page
+    nobody reads.
+    """
+    entries = parse_gateway_region_targets(
+        _deploy_script_region_targets("scripts/deploy/azure_control_plane.sh")
+    )
+    by_name = {entry.name: entry for entry in entries}
+    assert "southeastasia" in by_name, "southeastasia is not configured at all"
+    assert by_name["southeastasia"].public_host == "api-azure-sea.trustedrouter.com"
+    # uaenorth IS the canonical name, so it must NOT carry an override —
+    # one would be a second place to keep the same hostname in sync.
+    assert by_name["uaenorth"].public_host == ""
+
+
+def test_every_azure_region_target_resolves_to_a_distinct_public_name() -> None:
+    """Two regions sharing a public name here would be a copy-paste that makes
+    one region's probe silently measure the other's endpoint."""
+    entries = parse_gateway_region_targets(
+        _deploy_script_region_targets("scripts/deploy/azure_control_plane.sh")
+    )
+    canonical = "https://api-azure.trustedrouter.com/v1"
+    urls = [_region_api_base_url(canonical, entry.public_host) for entry in entries]
+    assert len(set(urls)) == len(urls), f"two Azure regions probe the same name: {urls}"
+
+
+def test_an_empty_public_host_after_the_separator_is_rejected() -> None:
+    """`region=host@` reads as an override and silently is not one."""
+    with pytest.raises(ValueError, match="public host after '@' must not"):
+        parse_gateway_region_targets("southeastasia=host.example.com@")
+
+
+def test_the_probe_actually_uses_the_override() -> None:
+    """The wiring, not the pieces.
+
+    _region_api_base_url can be perfect and the deploy script can carry the
+    right @override, and the defect still exists if configured_targets does not
+    put the two together — which is exactly how it shipped: every regional
+    target inherited settings.api_base_url unconditionally.
+
+    So this asserts the SNI the probe will really present, per region.
+    """
+    targets = {
+        target.name: target
+        for target in configured_targets(
+            Settings(
+                environment="test",
+                sentry_dsn=None,
+                api_base_url="https://api-azure.trustedrouter.com/v1",
+                synthetic_regional_probes_enabled=False,
+                synthetic_gateway_region_targets=(
+                    "uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,"
+                    "southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io"
+                    "@api-azure-sea.trustedrouter.com"
+                ),
+            )
+        )
+    }
+
+    assert targets["southeastasia"].api_base_url == (
+        "https://api-azure-sea.trustedrouter.com/v1"
+    ), "southeastasia is probed with a certificate name it does not hold"
+    # ...while still DIALLING its own region, or one dead region could hide
+    # behind whatever DNS happens to return for the shared name.
+    assert targets["southeastasia"].connect_host == (
+        "quill-enclave-southeastasia.southeastasia.azurecontainer.io"
+    )
+    # uaenorth has no override and must keep the canonical name.
+    assert targets["uaenorth"].api_base_url == "https://api-azure.trustedrouter.com/v1"


### PR DESCRIPTION
`southeastasia` was published **DOWN while serving 200** — found within minutes of deploying the region-two wiring, against a completely healthy region.

## The defect

Every regional target inherited the canonical `api_base_url`, so SNI and Host were always the shared public name. That's right wherever every replica serves one name — how GCP and AWS are built, and why nobody noticed. It's wrong on Azure, whose two regions serve `api-azure` and `api-azure-sea` because the shared ACME cache is disabled there. Probing southeastasia with the canonical SNI asks it for a certificate it doesn't hold.

**A false alarm is not the safe direction to fail.** #470 argued a never-probed region is dangerous because silence reads as "no incidents". Crying wolf is worse in a different way: it's a page nobody reads, so the next *real* outage is ignored too.

## The change

`TR_SYNTHETIC_GATEWAY_REGION_TARGETS` accepts an optional `name=connect_host@public_host`. The override changes **only** the name presented in SNI/Host — the probe still **dials the region's own endpoint**, or one dead region could hide behind whatever DNS returns for the shared name, which is the entire reason per-enclave probes exist. Empty `public_host` is byte-for-byte the old behaviour.

A bridge, not a destination: when the shared ACME cache lands and both regions serve one name, drop the `@suffix`.

## The tests were wrong first

My first attempt asserted `_region_api_base_url` and the deploy-script config **in isolation**, and the mutation that reverts the actual defect passed clean — nothing asserted `configured_targets` put the two together, which is exactly how the bug shipped. The test that matters asserts the SNI the probe will really present, per region.

| mutation | caught |
|---|---|
| probe ignores the override (the original defect) | ✅ *"probed with a certificate name it does not hold"* |
| `connect_host` replaced by the public host | ✅ |
| deploy script drops the `@override` | ✅ ×2 |

376 related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)