### PR TITLE
Show full API key in Claude setup message

### DIFF
--- a/src/trusted_router/templates/console/_api_key_reveal.html
+++ b/src/trusted_router/templates/console/_api_key_reveal.html
@@ -24,7 +24,7 @@
     <div class="agent-message-row">
       <div class="agent-message" id="{{ id_prefix }}-agent-message" data-copy-lines>
         <div>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</div>
-        <div><code class="agent-message-key">YOUR_TRUSTEDROUTER_API_KEY</code></div>
+        <div><code class="agent-message-key">{{ raw_key }}</code></div>
       </div>
       <button
         class="btn secret-copy-btn"

--- a/src/trusted_router/templates/console/welcome.html
+++ b/src/trusted_router/templates/console/welcome.html
@@ -104,7 +104,7 @@
 
       <div class="activation-code-panel" id="setup-agent" role="tabpanel" aria-labelledby="setup-agent-tab" data-setup-panel>
         <div class="activation-code-head"><strong>Paste this whole message into Claude Code or Codex</strong><button class="btn" type="button" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key" aria-describedby="welcome-agent-copy-status">Copy prompt</button></div>
-        <pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</span><span>YOUR_TRUSTEDROUTER_API_KEY</span></pre>
+        <pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com using the following key to ask DeepSeek the following question: "What is the capital of France?"</span><span>{{ revealed_key }}</span></pre>
         <p class="copy-status" id="welcome-agent-copy-status" role="status" aria-live="polite"></p>
       </div>
 

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -302,7 +302,7 @@ test("first-call activation runs live request and copies Claude Code setup", asy
               <div class="activation-call-error" data-call-error hidden><strong data-call-error-title></strong><p data-call-error-message></p><a data-call-error-action hidden></a></div>
               <div class="activation-call-result" data-call-result hidden><div class="activation-result-head"><div><span class="activation-success-mark">&#10003;</span><div><strong>Production request passed</strong><p>Your key is ready.</p></div></div><code data-result-output></code></div><dl class="activation-result-grid"><div><dt>Model</dt><dd data-result-model></dd></div><div><dt>Provider</dt><dd data-result-provider></dd></div><div><dt>Latency</dt><dd data-result-latency></dd></div><div><dt>Exact cost</dt><dd data-result-cost></dd></div></dl><div data-success-actions></div></div>
             </div></section>
-            <section class="panel activation-setup-panel"><div class="panel-body"><div class="activation-tabs" role="tablist"><button class="activation-tab" role="tab" aria-selected="true" data-setup-tab="setup-agent">Claude Code / Codex</button><button class="activation-tab" role="tab" aria-selected="false" data-setup-tab="setup-python">Python</button></div><div class="activation-code-panel" id="setup-agent" data-setup-panel><div class="activation-code-head"><strong>Paste this whole message</strong><button class="btn" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key">Copy prompt</button></div><pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com to ask DeepSeek a question.</span><span>YOUR_TRUSTEDROUTER_API_KEY</span></pre></div><div class="activation-code-panel" id="setup-python" data-setup-panel hidden><pre>Python setup</pre></div></div></section>
+            <section class="panel activation-setup-panel"><div class="panel-body"><div class="activation-tabs" role="tablist"><button class="activation-tab" role="tab" aria-selected="true" data-setup-tab="setup-agent">Claude Code / Codex</button><button class="activation-tab" role="tab" aria-selected="false" data-setup-tab="setup-python">Python</button></div><div class="activation-code-panel" id="setup-agent" data-setup-panel><div class="activation-code-head"><strong>Paste this whole message</strong><button class="btn" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key">Copy prompt</button></div><pre id="welcome-agent-message" data-copy-lines><span>Please use TrustedRouter.com to ask DeepSeek a question.</span><span>${apiKey}</span></pre></div><div class="activation-code-panel" id="setup-python" data-setup-panel hidden><pre>Python setup</pre></div></div></section>
           </div>
         </div></main></body></html>`,
     });
@@ -313,7 +313,7 @@ test("first-call activation runs live request and copies Claude Code setup", asy
     (secret) => document.body.innerHTML.split(secret).length - 1,
     apiKey,
   );
-  expect(rawCopies).toBe(1);
+  expect(rawCopies).toBe(2);
 
   await page.getByRole("button", { name: "Run my first API request" }).click();
   await expect(page.getByText("Production request passed")).toBeVisible();

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -868,16 +868,20 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
 
     resp = client.get("/console/welcome?first=1", follow_redirects=False)
     assert resp.status_code == 200
-    assert resp.text.count(fake_raw_key) == 1, (
-        "the raw API key must have exactly one DOM copy; setup copy buttons "
-        "inject it only when the user clicks"
+    assert resp.text.count(fake_raw_key) == 2, (
+        "the raw API key must appear in the direct reveal and the visible "
+        "Claude Code / Codex message"
     )
     assert 'data-copy-secret="welcome-api-key"' in resp.text
     assert 'data-copy-template-target="welcome-agent-message"' in resp.text
     assert 'data-secret-source="welcome-api-key"' in resp.text
     assert 'id="welcome-agent-message" data-copy-lines' in resp.text
-    assert "YOUR_TRUSTEDROUTER_API_KEY" in resp.text
-    assert '<pre id="welcome-agent-message"' in resp.text
+    agent_message = re.search(
+        r'<pre id="welcome-agent-message".*?</pre>', resp.text, re.DOTALL
+    )
+    assert agent_message is not None
+    assert fake_raw_key in agent_message.group(0)
+    assert "YOUR_TRUSTEDROUTER_API_KEY" not in agent_message.group(0)
     assert "Run my first API request" in resp.text
     assert 'data-endpoint="/chat-proxy/v1/chat/completions"' in resp.text
     assert "Claude Code / Codex" in resp.text
@@ -934,7 +938,7 @@ def test_console_welcome_without_first_query_does_not_read_pending_reveal(
     )
 
 
-def test_console_create_api_key_form_shows_raw_key_once(
+def test_console_create_api_key_form_repeats_raw_key_in_agent_message(
     console_session: tuple[TestClient, str],
 ) -> None:
     client, _ = console_session
@@ -947,13 +951,20 @@ def test_console_create_api_key_form_shows_raw_key_once(
     assert "console-created" in resp.text
     match = re.search(r"sk-tr-v1-[A-Za-z0-9_-]+", resp.text)
     assert match is not None
-    assert resp.text.count(match.group(0)) == 1
+    assert resp.text.count(match.group(0)) == 2
     assert 'data-copy-secret="created-api-key"' in resp.text
     assert 'data-copy-template-target="created-agent-message"' in resp.text
     assert 'data-secret-source="created-api-key"' in resp.text
     assert 'id="created-agent-message" data-copy-lines' in resp.text
     assert '<pre id="created-agent-message"' not in resp.text
-    assert "YOUR_TRUSTEDROUTER_API_KEY" in resp.text
+    agent_message = re.search(
+        r'<div class="agent-message" id="created-agent-message".*?</div>\s*</div>',
+        resp.text,
+        re.DOTALL,
+    )
+    assert agent_message is not None
+    assert match.group(0) in agent_message.group(0)
+    assert "YOUR_TRUSTEDROUTER_API_KEY" not in agent_message.group(0)
     assert "Paste this whole message into your agent or Claude Code" in resp.text
     assert "Copied to clipboard." not in resp.text
     workspace_id = next(iter(STORE.workspaces))


### PR DESCRIPTION
## Summary
- show the exact generated API key inside the one-time Claude Code / Codex message
- cover both first-account activation and later API key creation
- keep one-shot reveal behavior and copy-button behavior intact

## Tests
- uv run pytest -q tests/test_oauth_and_console.py
- npx playwright test tests/browser/dashboard.spec.js --grep 'first-call activation runs live request and copies Claude Code setup'
- uv run ruff check .
- uv run mypy