### PR TITLE
Make the vibe coder flow action first

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -187,7 +187,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/docs/batch",
     "/docs/web-search",
     "/docs/video",
-    "/claude-code",
+    "/vibe-coders",
     "/for-developers",
     "/llms.txt",
     "/docs/llms.txt",
@@ -1273,14 +1273,14 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "OpenAI-compatible API reference."
         ),
     ),
-    "claude-code": PublicPage(
+    "vibe-coders": PublicPage(
         template="public/claude_code.html",
         og_card="claude-code.png",
-        title="Cut Your Claude Code Token Bill in 10 Seconds",
+        title="Vibe Coders: Cut AI Coding Costs in 10 Seconds",
         description=(
             "Just paste one short message into a new Claude Code, Codex, or agent chat. "
-            "Your agent calls a lower-cost model and streams the answer back while "
-            "its current model, settings, tools, and workflow stay exactly as they are."
+            "Your agent calls DeepSeek through TrustedRouter and streams the answer "
+            "into the same chat while its current setup stays exactly as it is."
         ),
         faq_items=(
             (

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -898,13 +898,13 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def docs_hub() -> str:
         return public_page_html(settings, "docs")
 
-    @public_html_route("/claude-code")
-    async def claude_code() -> str:
-        return public_page_html(settings, "claude-code")
+    @public_html_route("/vibe-coders")
+    async def vibe_coders() -> str:
+        return public_page_html(settings, "vibe-coders")
 
-    @app.get("/vibe-coders", include_in_schema=False)
-    async def vibe_coders_redirect() -> RedirectResponse:
-        return RedirectResponse(url="/claude-code", status_code=301)
+    @app.get("/claude-code", include_in_schema=False)
+    async def claude_code_redirect() -> RedirectResponse:
+        return RedirectResponse(url="/vibe-coders", status_code=301)
 
     @public_html_route("/for-developers")
     async def for_developers() -> str:

--- a/src/trusted_router/static/claude-code.css
+++ b/src/trusted_router/static/claude-code.css
@@ -3,7 +3,7 @@
   left: 50%;
   display: flex;
   width: 100vw;
-  min-height: clamp(520px, calc(100svh - 132px), 680px);
+  min-height: clamp(660px, calc(100svh - 84px), 760px);
   margin-left: -50vw;
   align-items: stretch;
   overflow: hidden;
@@ -27,18 +27,18 @@
   display: flex;
   width: min(100%, var(--page-max));
   margin: 0 auto;
-  padding: 70px 24px 28px;
+  padding: 54px 24px 42px;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
 }
 
 .cc-hero-copy {
-  width: min(680px, 60%);
+  width: min(560px, 48%);
 }
 
 .cc-hero h1 {
-  max-width: 680px;
-  margin: 22px 0 18px;
+  max-width: 560px;
+  margin: 18px 0 16px;
   color: #f3f0e7;
   font-family: var(--font-display);
   font-size: 56px;
@@ -47,7 +47,7 @@
 }
 
 .cc-hero-lead {
-  max-width: 620px;
+  max-width: 540px;
   margin: 0;
   color: #c9d0c5;
   font-size: 17px;
@@ -55,13 +55,7 @@
 }
 
 .cc-hero .hero-actions {
-  margin: 30px 0 0;
-}
-
-.cc-hero .btn.ghost {
-  border-color: rgb(237 232 219 / 24%);
-  background: rgb(10 14 11 / 72%);
-  color: #ede8db;
+  margin: 22px 0 0;
 }
 
 .cc-hero-note {
@@ -72,64 +66,54 @@
   line-height: 1.5;
 }
 
-.cc-hero-proof {
-  display: flex;
-  gap: 24px;
-  padding-top: 22px;
-  border-top: 1px solid rgb(237 232 219 / 20%);
-  color: #c9d0c5;
+.cc-hero-flow {
+  max-width: 540px;
+  margin-top: 24px;
+  border-top: 1px solid rgb(237 232 219 / 22%);
+  border-bottom: 1px solid rgb(237 232 219 / 22%);
+}
+
+.cc-hero-flow-label {
+  display: block;
+  padding: 10px 0 8px;
+  color: #90a795;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
 }
 
-.cc-hero-proof span + span::before {
-  margin-right: 24px;
-  color: var(--sage);
-  content: "/";
+.cc-hero-flow ol {
+  display: grid;
+  margin: 0;
+  padding: 0 0 10px;
+  gap: 0;
+  list-style: none;
+}
+
+.cc-hero-flow li {
+  display: grid;
+  min-height: 35px;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  border-top: 1px solid rgb(237 232 219 / 10%);
+}
+
+.cc-hero-flow li > span {
+  color: #779080;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.cc-hero-flow strong {
+  color: #e5e8df;
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .cc-primary-cta {
   min-height: 46px;
   padding-right: 18px;
   padding-left: 18px;
-}
-
-.cc-proof-band {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0;
-  border-top: 1px solid var(--border-default);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.cc-proof-band > div {
-  min-width: 0;
-  padding: 22px 20px;
-  border-right: 1px solid var(--border-hairline);
-}
-
-.cc-proof-band > div:last-child {
-  border-right: 0;
-}
-
-.cc-proof-band strong,
-.cc-proof-band span {
-  display: block;
-}
-
-.cc-proof-band strong {
-  margin-bottom: 7px;
-  color: var(--text-display);
-  font-family: var(--font-display);
-  font-size: 18px;
-  font-weight: 400;
-}
-
-.cc-proof-band span {
-  color: var(--text-muted);
-  font-size: 13px;
-  line-height: 1.55;
 }
 
 .cc-section {
@@ -162,55 +146,6 @@
   color: var(--text-body);
   font-size: 15.5px;
   line-height: 1.72;
-}
-
-.cc-steps {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0;
-  margin: 0;
-  padding: 0;
-  border-top: 1px solid var(--border-default);
-  list-style: none;
-}
-
-.cc-steps li {
-  display: grid;
-  min-width: 0;
-  padding: 24px 24px 10px 0;
-  grid-template-columns: 44px minmax(0, 1fr);
-  gap: 16px;
-  border-right: 1px solid var(--border-hairline);
-}
-
-.cc-steps li + li {
-  padding-left: 24px;
-}
-
-.cc-steps li:last-child {
-  padding-right: 0;
-  border-right: 0;
-}
-
-.cc-step-number {
-  color: var(--sage);
-  font-family: var(--font-mono);
-  font-size: 12px;
-}
-
-.cc-steps h3 {
-  margin: 0 0 9px;
-  color: var(--text-display);
-  font-family: var(--font-display);
-  font-size: 21px;
-  font-weight: 400;
-}
-
-.cc-steps p {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 14px;
-  line-height: 1.65;
 }
 
 .cc-paste-section {
@@ -406,19 +341,7 @@
 
 @media (max-width: 1040px) {
   .cc-hero-copy {
-    width: min(720px, 72%);
-  }
-
-  .cc-proof-band {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cc-proof-band > div:nth-child(2) {
-    border-right: 0;
-  }
-
-  .cc-proof-band > div:nth-child(-n + 2) {
-    border-bottom: 1px solid var(--border-hairline);
+    width: min(600px, 60%);
   }
 
   .cc-paste-section {
@@ -433,15 +356,15 @@
 
 @media (max-width: 780px) {
   .cc-hero {
-    background-position: 64% center;
+    background-position: 72% center;
   }
 
   .cc-hero::before {
-    background: rgb(5 8 6 / 62%);
+    background: rgb(5 8 6 / 74%);
   }
 
   .cc-hero-inner {
-    padding: 54px 20px 24px;
+    padding: 44px 20px 34px;
   }
 
   .cc-hero-copy {
@@ -458,15 +381,6 @@
     font-size: 16px;
   }
 
-  .cc-hero-proof {
-    gap: 10px 16px;
-    flex-wrap: wrap;
-  }
-
-  .cc-hero-proof span + span::before {
-    margin-right: 16px;
-  }
-
   .cc-section {
     padding: 58px 0;
   }
@@ -476,17 +390,6 @@
   .cc-moment h2,
   .cc-final h2 {
     font-size: 32px;
-  }
-
-  .cc-steps {
-    grid-template-columns: 1fr;
-  }
-
-  .cc-steps li,
-  .cc-steps li + li {
-    padding: 20px 0;
-    border-right: 0;
-    border-bottom: 1px solid var(--border-hairline);
   }
 
   .cc-route-list a {
@@ -515,7 +418,12 @@
 
 @media (max-width: 520px) {
   .cc-hero {
-    min-height: clamp(520px, calc(100svh - 142px), 650px);
+    min-height: 700px;
+    background-image: none;
+  }
+
+  .cc-hero::before {
+    background: rgb(5 8 6 / 84%);
   }
 
   .cc-hero h1 {
@@ -531,16 +439,6 @@
   .cc-final-action,
   .cc-final-action .btn {
     width: 100%;
-  }
-
-  .cc-proof-band {
-    grid-template-columns: 1fr;
-  }
-
-  .cc-proof-band > div,
-  .cc-proof-band > div:nth-child(2) {
-    border-right: 0;
-    border-bottom: 1px solid var(--border-hairline);
   }
 
   .cc-prompt-body {

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -37,7 +37,7 @@
     <div class="footer-col">
       <h3>Developers</h3>
       <a href="/docs">Documentation</a>
-      <a href="/claude-code">Claude Code quickstart</a>
+      <a href="/vibe-coders">Vibe coder quickstart</a>
       <a href="/for-developers">60-second quickstart</a>
       <a href="/docs/migrate-from-openrouter">Migration guide</a>
       <a href="/docs/prompt-caching">Prompt caching</a>

--- a/src/trusted_router/templates/public/claude_code.html
+++ b/src/trusted_router/templates/public/claude_code.html
@@ -10,53 +10,26 @@
   <div class="cc-hero-inner">
     <div class="cc-hero-copy">
       <div class="kicker">For vibe coders</div>
-      <h1 id="cc-hero-title">Cut your Claude Code token bill in 10 seconds.</h1>
-      <p class="cc-hero-lead">Just paste one short message into a new Claude Code, Codex, or agent chat. Your agent calls a lower-cost model through TrustedRouter and streams the answer back into the same chat. Your current session stays exactly as it is.</p>
-      <div class="hero-actions">
-        <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Create my paste-ready key</button>
-        <a class="btn ghost" href="#ten-second-flow">See the 10-second flow <span aria-hidden="true">&#8595;</span></a>
+      <h1 id="cc-hero-title">Cut your coding agent bill in 10 seconds.</h1>
+      <p class="cc-hero-lead">Just paste one short message into a new Claude Code, Codex, or agent chat. Your agent calls DeepSeek through TrustedRouter and streams the answer into the same chat.</p>
+      <div class="cc-hero-flow" aria-labelledby="cc-hero-flow-title">
+        <span class="cc-hero-flow-label" id="cc-hero-flow-title">The 10-second flow</span>
+        <ol>
+          <li><span>01</span><strong>Create your key</strong></li>
+          <li><span>02</span><strong>Copy one short message</strong></li>
+          <li><span>03</span><strong>Paste into a new agent chat</strong></li>
+        </ol>
       </div>
-      <p class="cc-hero-note">Pay only for usage. Your complete key is inserted into the message after signup.</p>
-    </div>
-    <div class="cc-hero-proof" aria-label="TrustedRouter setup facts">
-      <span>Hundreds of models</span>
-      <span>Provider price plus 5%</span>
-      <span>Usage-based pricing</span>
+      <div class="hero-actions">
+        <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Get my one-paste message</button>
+      </div>
+      <p class="cc-hero-note">Sign in once. Your complete key arrives inside the message, ready to paste.</p>
     </div>
   </div>
 </section>
 {% endblock %}
 
 {% block body %}
-<section class="cc-proof-band" aria-label="What stays the same">
-  <div><strong>Keep your agent</strong><span>Same chat, tools, permissions, model, and project context.</span></div>
-  <div><strong>Delegate one task</strong><span>Call another model while your agent keeps its current configuration.</span></div>
-  <div><strong>Watch it stream</strong><span>The answer appears in your chat as the model generates it.</span></div>
-  <div><strong>See exact cost</strong><span>Every completed request records integer-priced usage metadata.</span></div>
-</section>
-
-<section class="cc-section cc-flow" id="ten-second-flow" aria-labelledby="cc-flow-title">
-  <div class="cc-section-heading">
-    <span class="eyebrow">One message</span>
-    <h2 id="cc-flow-title">Your agent makes the call.</h2>
-    <p>Everything happens inside the chat. Your active model, settings, files, and workflow stay exactly as they are while the agent streams one TrustedRouter response.</p>
-  </div>
-  <ol class="cc-steps">
-    <li>
-      <span class="cc-step-number">01</span>
-      <div><h3>Create your key</h3><p>Sign in and get a short message with your complete key ready to paste.</p></div>
-    </li>
-    <li>
-      <span class="cc-step-number">02</span>
-      <div><h3>Open a new agent chat</h3><p>Use Claude Code, Codex, or the agent you already prefer. Its model and settings stay exactly as they are.</p></div>
-    </li>
-    <li>
-      <span class="cc-step-number">03</span>
-      <div><h3>Paste and watch it stream</h3><p>Your agent calls DeepSeek through TrustedRouter and writes the answer into the same chat as it arrives.</p></div>
-    </li>
-  </ol>
-</section>
-
 <section class="cc-section cc-paste-section" aria-labelledby="cc-paste-title">
   <div class="cc-paste-copy">
     <span class="eyebrow">What you paste</span>
@@ -64,7 +37,7 @@
     <p>After signup, TrustedRouter builds a short message with your complete key already inside it. Copy it once and watch the answer appear.</p>
     <p>The message keeps your agent's current model, provider, settings, and project files exactly as they are. Your agent streams one TrustedRouter response directly into the chat.</p>
     <div class="hero-actions">
-      <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Create my paste-ready key</button>
+      <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Get my one-paste message</button>
       <a class="btn ghost" href="/models">Browse models <span aria-hidden="true">&#8594;</span></a>
     </div>
   </div>
@@ -114,7 +87,7 @@
     <p>One short message. Instant streaming. Hundreds of models when you need them.</p>
   </div>
   <div class="cc-final-action">
-    <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Create my paste-ready key</button>
+    <button class="btn primary cc-primary-cta" type="button" data-action="open-signin">Get my one-paste message</button>
     <span>Same agent. Same settings. Extra models.</span>
   </div>
 </section>

--- a/tests/browser/claude_code_landing.spec.js
+++ b/tests/browser/claude_code_landing.spec.js
@@ -3,13 +3,14 @@ const { expect, test } = require("@playwright/test");
 async function layoutReport(page) {
   return page.evaluate(() => {
     const hero = document.querySelector(".cc-hero").getBoundingClientRect();
-    const proof = document.querySelector(".cc-proof-band").getBoundingClientRect();
+    const flow = document.querySelector(".cc-hero-flow").getBoundingClientRect();
     const primaryButtons = Array.from(document.querySelectorAll(".cc-primary-cta"));
     const prompt = document.querySelector(".cc-prompt-tool").getBoundingClientRect();
     return {
       overflow: document.documentElement.scrollWidth - window.innerWidth,
       heroBottom: hero.bottom,
-      proofTop: proof.top,
+      flowTop: flow.top,
+      flowBottom: flow.bottom,
       viewportHeight: window.innerHeight,
       promptRight: prompt.right,
       buttonsInsideViewport: primaryButtons.every((button) => {
@@ -24,11 +25,14 @@ test("Claude Code landing turns the ten-second promise into the real signup flow
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto("/claude-code");
+  await page.goto("/vibe-coders");
 
   await expect(
-    page.getByRole("heading", { name: "Cut your Claude Code token bill in 10 seconds." }),
+    page.getByRole("heading", { name: "Cut your coding agent bill in 10 seconds." }),
   ).toBeVisible();
+  await expect(page.getByText("The 10-second flow")).toBeVisible();
+  await expect(page.getByText("Copy one short message", { exact: true })).toBeVisible();
+  await expect(page.getByText("Paste into a new agent chat", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Every model. In seconds." }),
   ).toBeVisible();
@@ -46,7 +50,8 @@ test("Claude Code landing turns the ten-second promise into the real signup flow
 
   const desktop = await layoutReport(page);
   expect(desktop.overflow).toBeLessThanOrEqual(2);
-  expect(desktop.proofTop).toBeLessThan(desktop.viewportHeight);
+  expect(desktop.flowTop).toBeLessThan(desktop.viewportHeight);
+  expect(desktop.flowBottom).toBeLessThanOrEqual(desktop.heroBottom + 1);
   expect(desktop.buttonsInsideViewport).toBeTruthy();
 
   await page.locator(".cc-primary-cta").first().click();
@@ -60,11 +65,12 @@ test("Claude Code landing remains readable on phone and narrow tablet", async ({
     { width: 390, height: 844 },
   ]) {
     await page.setViewportSize(viewport);
-    await page.goto("/claude-code");
+    await page.goto("/vibe-coders");
 
     const report = await layoutReport(page);
     expect(report.overflow).toBeLessThanOrEqual(2);
-    expect(report.proofTop).toBeLessThan(report.viewportHeight);
+    expect(report.flowTop).toBeLessThan(report.viewportHeight);
+    expect(report.flowBottom).toBeLessThanOrEqual(report.heroBottom + 1);
     expect(report.promptRight).toBeLessThanOrEqual(viewport.width + 1);
     expect(report.buttonsInsideViewport).toBeTruthy();
     await expect(page.locator(".cc-prompt-tool")).toBeVisible();

--- a/tests/test_claude_code_landing.py
+++ b/tests/test_claude_code_landing.py
@@ -8,12 +8,15 @@ from trusted_router.storage import STORE
 
 
 def test_claude_code_landing_is_a_single_action_funnel(client: TestClient) -> None:
-    response = client.get("/claude-code")
+    response = client.get("/vibe-coders")
 
     assert response.status_code == 200
-    assert "Cut your Claude Code token bill in 10 seconds." in response.text
-    assert response.text.count("Create my paste-ready key") == 3
-    assert "Your agent makes the call." in response.text
+    assert "Cut your coding agent bill in 10 seconds." in response.text
+    assert response.text.count("Get my one-paste message") == 3
+    assert "The 10-second flow" in response.text
+    assert "Create your key" in response.text
+    assert "Copy one short message" in response.text
+    assert "Paste into a new agent chat" in response.text
     assert "Just paste one short message." in response.text
     assert "your complete key is inserted" in response.text
     assert "Same agent. Same settings. Extra models." in response.text
@@ -21,7 +24,7 @@ def test_claude_code_landing_is_a_single_action_funnel(client: TestClient) -> No
     assert "trustedrouter/cheap" in response.text
     assert "Every model. In seconds." in response.text
     assert "How should I think about savings?" in response.text
-    assert 'rel="canonical" href="https://trustedrouter.com/claude-code"' in response.text
+    assert 'rel="canonical" href="https://trustedrouter.com/vibe-coders"' in response.text
     assert 'property="og:image" content="https://trustedrouter.com/static/og/claude-code.png"' in response.text
     assert "YOUR_TRUSTEDROUTER_API_KEY" not in response.text
     assert "sk-tr-v1-..." not in response.text
@@ -32,17 +35,17 @@ def test_claude_code_landing_is_a_single_action_funnel(client: TestClient) -> No
     ) is None
 
 
-def test_claude_code_landing_is_indexed_and_vibe_alias_is_canonical(
+def test_vibe_coders_landing_is_indexed_and_claude_alias_redirects(
     client: TestClient,
 ) -> None:
     sitemap = client.get("/sitemap-core.xml")
-    alias = client.get("/vibe-coders", follow_redirects=False)
+    alias = client.get("/claude-code", follow_redirects=False)
 
     assert sitemap.status_code == 200
-    assert "<loc>https://trustedrouter.com/claude-code</loc>" in sitemap.text
-    assert "<loc>https://trustedrouter.com/vibe-coders</loc>" not in sitemap.text
+    assert "<loc>https://trustedrouter.com/vibe-coders</loc>" in sitemap.text
+    assert "<loc>https://trustedrouter.com/claude-code</loc>" not in sitemap.text
     assert alias.status_code == 301
-    assert alias.headers["location"] == "/claude-code"
+    assert alias.headers["location"] == "/vibe-coders"
 
 
 def test_api_key_reveal_builds_a_streaming_agent_chat_message_without_reconfiguration(


### PR DESCRIPTION
## Summary
- make /vibe-coders the canonical landing URL
- move the complete ten-second flow into the first viewport
- simplify the page to one outcome-focused CTA
- keep /claude-code as a permanent redirect
- update sitemap, footer, contract tests, and browser layout checks

## Verification
- 75 focused Python tests
- Playwright desktop, tablet, and phone checks
- ruff, mypy, TypeScript, and stylelint
- Lighthouse: 99 performance, 100 accessibility, 100 best practices, 100 SEO