### PR TITLE
Say cut your AI bill on vibe-coders

### DIFF
--- a/src/trusted_router/templates/public/claude_code.html
+++ b/src/trusted_router/templates/public/claude_code.html
@@ -10,7 +10,7 @@
   <div class="cc-hero-inner">
     <div class="cc-hero-copy">
       <div class="kicker">For vibe coders</div>
-      <h1 id="cc-hero-title">Cut your coding agent bill in 10 seconds.</h1>
+      <h1 id="cc-hero-title">Cut your AI bill in 10 seconds.</h1>
       <p class="cc-hero-lead">Just paste one short message into a new Claude Code, Codex, or agent chat. Your agent calls DeepSeek through TrustedRouter and streams the answer into the same chat.</p>
       <div class="cc-hero-flow" aria-labelledby="cc-hero-flow-title">
         <span class="cc-hero-flow-label" id="cc-hero-flow-title">The 10-second flow</span>

--- a/tests/browser/claude_code_landing.spec.js
+++ b/tests/browser/claude_code_landing.spec.js
@@ -28,7 +28,7 @@ test("Claude Code landing turns the ten-second promise into the real signup flow
   await page.goto("/vibe-coders");
 
   await expect(
-    page.getByRole("heading", { name: "Cut your coding agent bill in 10 seconds." }),
+    page.getByRole("heading", { name: "Cut your AI bill in 10 seconds." }),
   ).toBeVisible();
   await expect(page.getByText("The 10-second flow")).toBeVisible();
   await expect(page.getByText("Copy one short message", { exact: true })).toBeVisible();

--- a/tests/test_claude_code_landing.py
+++ b/tests/test_claude_code_landing.py
@@ -11,7 +11,7 @@ def test_claude_code_landing_is_a_single_action_funnel(client: TestClient) -> No
     response = client.get("/vibe-coders")
 
     assert response.status_code == 200
-    assert "Cut your coding agent bill in 10 seconds." in response.text
+    assert "Cut your AI bill in 10 seconds." in response.text
     assert response.text.count("Get my one-paste message") == 3
     assert "The 10-second flow" in response.text
     assert "Create your key" in response.text


### PR DESCRIPTION
## Summary
- broaden the mobile hero headline from coding-agent spend to total AI spend
- keep server and browser contract tests aligned with the public copy

## Verification
- focused Python landing-page tests
- focused Playwright browser tests
- inspected the 390x844 mobile render