### PR TITLE
Fix ClickHouse cutover recovery gates

### DIFF
--- a/scripts/deploy/clickhouse_analytics_cutover.sh
+++ b/scripts/deploy/clickhouse_analytics_cutover.sh
@@ -12,6 +12,7 @@ ZONES=(us-central1-a us-central1-b us-central1-c)
 MIN_SOAK_SECONDS="${TR_ANALYTICS_MIN_SOAK_SECONDS:-604800}"
 MAX_OUTBOX_ROWS="${TR_ANALYTICS_MAX_OUTBOX_ROWS:-1000}"
 MAX_OUTBOX_AGE_SECONDS="${TR_ANALYTICS_MAX_OUTBOX_AGE_SECONDS:-60}"
+DEPLOY_CREDENTIAL_FILE="${TR_ANALYTICS_DEPLOY_CREDENTIAL_FILE:-}"
 APPLY=0
 
 if [ "${1:-}" = "--apply" ]; then
@@ -119,6 +120,34 @@ if [ "$APPLY" -eq 0 ]; then
   log "gate passed: would deploy ClickHouse-primary reads to every region"
   exit 0
 fi
+
+if [ -z "$DEPLOY_CREDENTIAL_FILE" ] || [ ! -r "$DEPLOY_CREDENTIAL_FILE" ]; then
+  echo "TR_ANALYTICS_DEPLOY_CREDENTIAL_FILE must name a readable deployment credential" >&2
+  exit 1
+fi
+deploy_principal="$(python3 - "$DEPLOY_CREDENTIAL_FILE" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+try:
+    payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, ValueError):
+    print("")
+else:
+    print(payload.get("client_email", ""))
+PY
+)"
+if [ -z "$deploy_principal" ]; then
+  echo "deployment credential does not identify a service-account principal" >&2
+  exit 1
+fi
+if [[ "$deploy_principal" == tr-ops-local@* ]]; then
+  echo "refusing to deploy with the read-only operations identity" >&2
+  exit 1
+fi
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="$DEPLOY_CREDENTIAL_FILE"
+log "all read-only gates passed; switching rollout identity to ${deploy_principal}"
 
 TR_ANALYTICS_READ_MODE=clickhouse \
 TR_ANALYTICS_DUAL_READ_STARTED_AT="$started_at" \

--- a/scripts/deploy/clickhouse_analytics_cutover.sh
+++ b/scripts/deploy/clickhouse_analytics_cutover.sh
@@ -10,6 +10,8 @@ source "${SCRIPT_DIR}/_lib.sh"
 NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
 ZONES=(us-central1-a us-central1-b us-central1-c)
 MIN_SOAK_SECONDS="${TR_ANALYTICS_MIN_SOAK_SECONDS:-604800}"
+MAX_OUTBOX_ROWS="${TR_ANALYTICS_MAX_OUTBOX_ROWS:-1000}"
+MAX_OUTBOX_AGE_SECONDS="${TR_ANALYTICS_MAX_OUTBOX_AGE_SECONDS:-60}"
 APPLY=0
 
 if [ "${1:-}" = "--apply" ]; then
@@ -70,49 +72,35 @@ parity_history="$(gc compute ssh tr-clickhouse-1 \
 parity_file="$(mktemp "${TMPDIR:-/tmp}/tr-operational-parity.XXXXXX.jsonl")"
 trap 'rm -f "$parity_file"' EXIT
 printf '%s\n' "$parity_history" >"$parity_file"
-python3 - "$started_at" "$MIN_SOAK_SECONDS" "$parity_file" <<'PY'
-import datetime as dt
-import json
-import math
-from pathlib import Path
-import sys
-
-started = dt.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
-minimum = int(sys.argv[2])
-now = dt.datetime.now(dt.UTC)
-rows = []
-for line in Path(sys.argv[3]).read_text().splitlines():
-    try:
-        row = json.loads(line)
-        checked = dt.datetime.fromisoformat(row["checked_at"].replace("Z", "+00:00"))
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        continue
-    if checked >= started:
-        rows.append((checked, row))
-required = max(1, math.floor(minimum / 3600))
-if len(rows) < required:
-    raise SystemExit(f"only {len(rows)} parity samples; require at least {required}")
-if now - max(checked for checked, _ in rows) > dt.timedelta(hours=1):
-    raise SystemExit("latest operational parity sample is stale")
-for _, row in rows:
-    if not row.get("ok"):
-        raise SystemExit("operational parity history contains a failed check")
-for surface in ("benchmark", "activity", "synthetic", "rollup"):
-    if not any(row.get("surfaces", {}).get(surface, {}).get("sampled", 0) > 0 for _, row in rows):
-        raise SystemExit(f"no positive parity evidence for {surface}")
-PY
+python3 "${SCRIPT_DIR}/verify_operational_parity_history.py" \
+  "$parity_file" \
+  --started-at "$started_at" \
+  --minimum-seconds "$MIN_SOAK_SECONDS"
 unset parity_history
 rm -f "$parity_file"
 trap - EXIT
 
-outbox_count="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
+outbox_status="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
   --instance="$SPANNER_INSTANCE_ID" \
-  --sql='SELECT COUNT(*) FROM tr_operational_analytics_outbox' \
+  --sql='SELECT COUNT(*) AS row_count,
+                COALESCE(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), MIN(commit_ts), SECOND), 0)
+                  AS oldest_age_seconds
+         FROM tr_operational_analytics_outbox' \
   --format='value(rows[0])')"
-if [ "${outbox_count:-0}" != "0" ]; then
-  echo "operational analytics outbox is not drained: ${outbox_count} rows" >&2
+IFS=';' read -r outbox_count outbox_age_seconds <<<"$outbox_status"
+if ! [[ "${outbox_count:-}" =~ ^[0-9]+$ && "${outbox_age_seconds:-}" =~ ^[0-9]+$ ]]; then
+  echo "operational analytics outbox returned invalid status: ${outbox_status}" >&2
   exit 1
 fi
+if [ "$outbox_count" -gt "$MAX_OUTBOX_ROWS" ]; then
+  echo "operational analytics outbox is too deep: ${outbox_count} rows" >&2
+  exit 1
+fi
+if [ "$outbox_age_seconds" -gt "$MAX_OUTBOX_AGE_SECONDS" ]; then
+  echo "operational analytics outbox is lagging: oldest row is ${outbox_age_seconds}s" >&2
+  exit 1
+fi
+log "operational analytics outbox healthy: ${outbox_count} rows, oldest ${outbox_age_seconds}s"
 
 for index in 0 1 2; do
   health="$(gc compute ssh "${NAMES[$index]}" \

--- a/scripts/deploy/verify_operational_parity_history.py
+++ b/scripts/deploy/verify_operational_parity_history.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Verify a continuous rolling window of operational analytics parity."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+SURFACES = ("benchmark", "activity", "synthetic", "rollup")
+DEFAULT_MAX_SAMPLE_GAP_SECONDS = 3600
+
+
+class VerificationError(RuntimeError):
+    """The parity history does not prove a clean cutover window."""
+
+
+def _timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include a timezone")
+    return parsed.astimezone(dt.UTC)
+
+
+def _valid_rows(path: Path, *, started_at: dt.datetime) -> list[tuple[dt.datetime, dict[str, Any]]]:
+    rows: list[tuple[dt.datetime, dict[str, Any]]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        try:
+            row = json.loads(line)
+            checked_at = _timestamp(row["checked_at"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise VerificationError(f"invalid parity sample on line {line_number}") from exc
+        if not isinstance(row, dict):
+            raise VerificationError(f"invalid parity sample on line {line_number}")
+        if checked_at >= started_at:
+            rows.append((checked_at, row))
+    rows.sort(key=lambda item: item[0])
+    return rows
+
+
+def verify_history(
+    path: Path,
+    *,
+    started_at: dt.datetime,
+    minimum_seconds: int,
+    now: dt.datetime | None = None,
+    max_sample_gap_seconds: int = DEFAULT_MAX_SAMPLE_GAP_SECONDS,
+) -> dict[str, object]:
+    if minimum_seconds < 1:
+        raise ValueError("minimum_seconds must be positive")
+    if max_sample_gap_seconds < 1:
+        raise ValueError("max_sample_gap_seconds must be positive")
+    current = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+    started = started_at.astimezone(dt.UTC)
+    minimum = dt.timedelta(seconds=minimum_seconds)
+    max_gap = dt.timedelta(seconds=max_sample_gap_seconds)
+    if current - started < minimum:
+        raise VerificationError("dual-read soak has not reached the minimum duration")
+
+    window_start = max(started, current - minimum)
+    rows = [item for item in _valid_rows(path, started_at=started) if item[0] >= window_start]
+    required = max(1, math.floor(minimum_seconds / 3600))
+    if len(rows) < required:
+        raise VerificationError(f"only {len(rows)} parity samples; require at least {required}")
+
+    first_checked = rows[0][0]
+    latest_checked = rows[-1][0]
+    if first_checked - window_start > max_gap:
+        raise VerificationError("operational parity evidence starts too late in the clean window")
+    if current - latest_checked > max_gap:
+        raise VerificationError("latest operational parity sample is stale")
+    if latest_checked - current > dt.timedelta(minutes=5):
+        raise VerificationError("latest operational parity sample is in the future")
+
+    for (previous, _), (checked_at, _) in zip(rows, rows[1:], strict=False):
+        if checked_at - previous > max_gap:
+            raise VerificationError(
+                "operational parity history contains a sampling gap "
+                f"from {previous.isoformat()} to {checked_at.isoformat()}"
+            )
+
+    failures = [checked_at for checked_at, row in rows if row.get("ok") is not True]
+    if failures:
+        raise VerificationError(
+            "operational parity history contains a failed check at "
+            f"{failures[-1].isoformat()}"
+        )
+    for surface in SURFACES:
+        if not any(
+            isinstance(row.get("surfaces"), dict)
+            and isinstance(row["surfaces"].get(surface), dict)
+            and row["surfaces"][surface].get("sampled", 0) > 0
+            for _, row in rows
+        ):
+            raise VerificationError(f"no positive parity evidence for {surface}")
+
+    max_observed_gap = max(
+        (
+            (checked_at - previous).total_seconds()
+            for (previous, _), (checked_at, _) in zip(rows, rows[1:], strict=False)
+        ),
+        default=0.0,
+    )
+    return {
+        "window_start": window_start.isoformat().replace("+00:00", "Z"),
+        "first_checked_at": first_checked.isoformat().replace("+00:00", "Z"),
+        "latest_checked_at": latest_checked.isoformat().replace("+00:00", "Z"),
+        "sample_count": len(rows),
+        "max_gap_seconds": int(max_observed_gap),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("history", type=Path)
+    parser.add_argument("--started-at", required=True)
+    parser.add_argument("--minimum-seconds", required=True, type=int)
+    parser.add_argument("--now")
+    parser.add_argument(
+        "--max-sample-gap-seconds",
+        type=int,
+        default=DEFAULT_MAX_SAMPLE_GAP_SECONDS,
+    )
+    args = parser.parse_args()
+    try:
+        summary = verify_history(
+            args.history,
+            started_at=_timestamp(args.started_at),
+            minimum_seconds=args.minimum_seconds,
+            now=_timestamp(args.now) if args.now else None,
+            max_sample_gap_seconds=args.max_sample_gap_seconds,
+        )
+    except (OSError, ValueError, VerificationError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clickhouse_cutover_parity_gate.py
+++ b/tests/test_clickhouse_cutover_parity_gate.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.deploy.verify_operational_parity_history import (
+    VerificationError,
+    verify_history,
+)
+
+UTC = dt.UTC
+NOW = dt.datetime(2026, 8, 8, 12, tzinfo=UTC)
+STARTED = dt.datetime(2026, 8, 1, 2, 32, 30, tzinfo=UTC)
+MINIMUM_SECONDS = 7 * 24 * 60 * 60
+
+
+def _row(checked_at: dt.datetime, *, ok: bool = True) -> dict[str, object]:
+    return {
+        "checked_at": checked_at.isoformat().replace("+00:00", "Z"),
+        "ok": ok,
+        "surfaces": {
+            surface: {"sampled": 5000, "found": 5000, "missing": 0, "ok": ok}
+            for surface in ("benchmark", "activity", "synthetic", "rollup")
+        },
+    }
+
+
+def _clean_rows() -> list[dict[str, object]]:
+    first = NOW - dt.timedelta(days=7)
+    return [_row(first + dt.timedelta(minutes=30 * index)) for index in range(337)]
+
+
+def _write(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def _verify(path: Path) -> dict[str, object]:
+    return verify_history(
+        path,
+        started_at=STARTED,
+        minimum_seconds=MINIMUM_SECONDS,
+        now=NOW,
+    )
+
+
+def test_historical_failure_outside_rolling_clean_window_is_preserved_but_recovered(
+    tmp_path: Path,
+) -> None:
+    history = tmp_path / "parity.jsonl"
+    historical_failure = _row(dt.datetime(2026, 8, 1, 7, 20, tzinfo=UTC), ok=False)
+    _write(history, [historical_failure, *_clean_rows()])
+
+    summary = _verify(history)
+
+    assert summary["sample_count"] == 337
+    assert summary["window_start"] == "2026-08-01T12:00:00Z"
+
+
+def test_failure_inside_rolling_window_blocks_cutover(tmp_path: Path) -> None:
+    history = tmp_path / "parity.jsonl"
+    rows = _clean_rows()
+    rows[100] = _row(NOW - dt.timedelta(days=5), ok=False)
+    _write(history, rows)
+
+    with pytest.raises(VerificationError, match="contains a failed check"):
+        _verify(history)
+
+
+def test_stale_latest_sample_blocks_cutover(tmp_path: Path) -> None:
+    history = tmp_path / "parity.jsonl"
+    _write(history, _clean_rows()[:-3])
+
+    with pytest.raises(VerificationError, match="latest operational parity sample is stale"):
+        _verify(history)
+
+
+def test_sampling_gap_blocks_cutover(tmp_path: Path) -> None:
+    history = tmp_path / "parity.jsonl"
+    rows = _clean_rows()
+    del rows[100:103]
+    _write(history, rows)
+
+    with pytest.raises(VerificationError, match="contains a sampling gap"):
+        _verify(history)
+
+
+def test_each_surface_requires_positive_parity_evidence(tmp_path: Path) -> None:
+    history = tmp_path / "parity.jsonl"
+    rows = _clean_rows()
+    for row in rows:
+        row["surfaces"]["rollup"]["sampled"] = 0  # type: ignore[index]
+    _write(history, rows)
+
+    with pytest.raises(VerificationError, match="no positive parity evidence for rollup"):
+        _verify(history)
+
+
+def test_malformed_history_blocks_cutover(tmp_path: Path) -> None:
+    history = tmp_path / "parity.jsonl"
+    history.write_text("not-json\n", encoding="utf-8")
+
+    with pytest.raises(VerificationError, match="invalid parity sample on line 1"):
+        _verify(history)

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -91,6 +91,9 @@ def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
     assert "system.replicas" in script
     assert "operational-parity.jsonl" in script
     assert "verify_operational_parity_history.py" in script
+    assert "TR_ANALYTICS_DEPLOY_CREDENTIAL_FILE" in script
+    assert "refusing to deploy with the read-only operations identity" in script
+    assert "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE" in script
     assert "TR_ANALYTICS_READ_MODE=clickhouse" in script
 
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -85,8 +85,12 @@ def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
     assert "604800" in script
     assert "analytics_dual_read_mismatch" in script
     assert "tr_operational_analytics_outbox" in script
+    assert "TR_ANALYTICS_MAX_OUTBOX_ROWS" in script
+    assert "TR_ANALYTICS_MAX_OUTBOX_AGE_SECONDS" in script
+    assert "oldest_age_seconds" in script
     assert "system.replicas" in script
     assert "operational-parity.jsonl" in script
+    assert "verify_operational_parity_history.py" in script
     assert "TR_ANALYTICS_READ_MODE=clickhouse" in script
 
 


### PR DESCRIPTION
## Summary
- verify a continuous rolling seven-day parity window so recovered historical failures remain preserved without blocking forever
- reject stale evidence, future timestamps, sampling gaps, current-window failures, and missing surface coverage
- replace the racy exact-zero outbox check with bounded depth and oldest-row lag gates

## Production evidence
- 331 clean rolling-window parity samples
- maximum sample gap: 1,871 seconds
- zero Cloud Run analytics mismatch/read errors
- outbox healthy and drained
- all three replicas: queue=0, delay=0, readonly=0
- corrected dry-run gate passes end to end

## Verification
- ruff clean
- mypy clean
- 19 focused tests pass
- bash syntax check passes