### PR TITLE
Fix guarded pricing and synthetic freshness

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -120,8 +120,11 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
   regional_ingest_base="https://${SERVICE}-${PROJECT_NUMBER}.${monitor_region}.run.app"
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
-  scheduler_name="${job_name}-every-five-minutes"
-  legacy_scheduler_name="${job_name}-every-minute"
+  scheduler_name="${job_name}-every-three-minutes"
+  legacy_scheduler_names=(
+    "${job_name}-every-minute"
+    "${job_name}-every-five-minutes"
+  )
   env_vars=(
     "${BASE_ENV_VARS[@]}"
     "TR_SYNTHETIC_MONITOR_REGION=${monitor_region}"
@@ -136,7 +139,10 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     # Short random provider/model probes feed uptime and TTFT. Sustained
     # throughput is deliberately disabled in these health jobs.
     "TR_SYNTHETIC_ROTATION_ENABLED=true"
-    "TR_SYNTHETIC_ROTATION_PER_PASS=4"
+    # The three-minute cadence keeps regional health inside the five-minute
+    # freshness contract despite Cloud Run startup latency. Two rotations per
+    # pass keeps provider probe volume close to the old 4-per-5-minute rate.
+    "TR_SYNTHETIC_ROTATION_PER_PASS=2"
     "TR_SYNTHETIC_THROUGHPUT_ENABLED=false"
     "TR_SYNTHETIC_THROUGHPUT_ONLY=false"
   )
@@ -162,16 +168,18 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   # probe latency balloons from ~2s to ~12s, blowing past task-
   # timeout. 2 CPU / 1Gi keeps the concurrent regional probes bounded.
 
-  upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/5 * * * *"
-  if gc scheduler jobs describe \
-    "$legacy_scheduler_name" \
-    --location "$monitor_region" >/dev/null 2>&1; then
-    log "deleting legacy synthetic scheduler ${legacy_scheduler_name}"
-    gc scheduler jobs delete \
+  upsert_scheduler "$scheduler_name" "$job_name" "$monitor_region" "*/3 * * * *"
+  for legacy_scheduler_name in "${legacy_scheduler_names[@]}"; do
+    if gc scheduler jobs describe \
       "$legacy_scheduler_name" \
-      --location "$monitor_region" \
-      --quiet >/dev/null
-  fi
+      --location "$monitor_region" >/dev/null 2>&1; then
+      log "deleting legacy synthetic scheduler ${legacy_scheduler_name}"
+      gc scheduler jobs delete \
+        "$legacy_scheduler_name" \
+        --location "$monitor_region" \
+        --quiet >/dev/null
+    fi
+  done
   monitor_index=$((monitor_index + 1))
 done
 

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -24910,9 +24910,9 @@
           "tr_provider_slug": "digitalocean",
           "context_length": 1048576,
           "pricing": {
-            "prompt": "0.0000007",
-            "completion": "0.0000022",
-            "input_cache_read": "0.00000012"
+            "prompt": "0.0000014",
+            "completion": "0.0000044",
+            "input_cache_read": "0.00000021"
           },
           "pricing_source": "provider_direct",
           "supported_parameters": [],

--- a/src/trusted_router/data/provider_models/digitalocean.json
+++ b/src/trusted_router/data/provider_models/digitalocean.json
@@ -502,9 +502,9 @@
       "upstream_id": "glm-5.2",
       "context_length": 262144,
       "max_output_tokens": 52429,
-      "input_token_price_per_m": 700000,
-      "output_token_price_per_m": 2200000,
-      "cached_input_token_price_per_m": 120000
+      "input_token_price_per_m": 1400000,
+      "output_token_price_per_m": 4400000,
+      "cached_input_token_price_per_m": 210000
     }
   ]
 }

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -33,10 +33,10 @@ from trusted_router.synthetic.components import (
 from trusted_router.synthetic.rollups import merge_rollups, new_rollup_for_sample
 
 CURRENT_SAMPLE_TTL_SECONDS = 5 * 60
-# Regional monitor jobs run on a five-minute cadence. Treating a sample as
-# failed at exactly one cadence boundary makes normal scheduler jitter look
-# like an outage. One missed/late cycle is degraded; only two missed cycles
-# plus a small scheduling allowance are a silent-probe failure.
+# Regional monitor jobs run every three minutes so normal Cloud Run startup
+# latency remains inside this five-minute freshness contract. A sample that
+# crosses the contract is degraded; only two missed freshness windows plus a
+# small scheduling allowance are a silent-probe failure.
 SILENT_PROBE_TTL_SECONDS = (2 * CURRENT_SAMPLE_TTL_SECONDS) + 60
 IMAGE_GENERATION_SAMPLE_TTL_SECONDS = 7 * 60 * 60
 STATUS_HISTORY_HOURS = 48
@@ -375,10 +375,9 @@ def _sample_effective_status(
 
     Too OLD depends on whether the monitor is otherwise alive:
 
-      * monitor_reporting=True and one cadence late -> "degraded". Regional
-        jobs run every five minutes and routinely cross that boundary by a
-        few seconds. The status stays visible without turning scheduler
-        jitter into a deploy rollback.
+      * monitor_reporting=True and past the freshness contract -> "degraded".
+        Regional jobs run every three minutes, leaving room for Cloud Run
+        startup latency before this five-minute boundary.
 
       * monitor_reporting=True and two cadences late -> "down". This probe
         stopped emitting while its siblings kept going. That is the

--- a/tests/test_new_provider_catalogs.py
+++ b/tests/test_new_provider_catalogs.py
@@ -15,7 +15,7 @@ from trusted_router.catalog import (
 def test_digitalocean_official_pricing_uses_integer_microdollars() -> None:
     markdown = """
 | DeepSeek | [DeepSeek V4 Flash](https://example.test) | Input/output tokens | $0.112 per 1M tokens<br>$0.224 per 1M tokens<br>Prompt caching $0.028 per 1M tokens |
-| Z.AI | [GLM-5.2](https://example.test) | Input/output tokens | $1.05 per 1M tokens<br>$4.40 per 1M tokens<br>Prompt caching $0.21 per 1M tokens |
+| Z.AI | [GLM-5.2](https://example.test) | Input/output tokens | $1.40 per 1M tokens<br>$4.40 per 1M tokens<br>Prompt caching $0.21 per 1M tokens |
 """
 
     prices = digitalocean._official_prices(markdown)
@@ -26,7 +26,7 @@ def test_digitalocean_official_pricing_uses_integer_microdollars() -> None:
         prompt_cached_micro_per_m=28_000,
     )
     assert prices["z-ai/glm-5.2"] == ModelPrice(
-        prompt_micro_per_m=1_050_000,
+        prompt_micro_per_m=1_400_000,
         completion_micro_per_m=4_400_000,
         prompt_cached_micro_per_m=210_000,
     )
@@ -167,3 +167,6 @@ def test_digitalocean_manifest_preserves_exact_upstream_ids() -> None:
 
     assert rows["deepseek/deepseek-v4-flash"]["upstream_id"] == "deepseek-4-flash"
     assert rows["z-ai/glm-5.2"]["upstream_id"] == "glm-5.2"
+    assert rows["z-ai/glm-5.2"]["input_token_price_per_m"] == 1_400_000
+    assert rows["z-ai/glm-5.2"]["output_token_price_per_m"] == 4_400_000
+    assert rows["z-ai/glm-5.2"]["cached_input_token_price_per_m"] == 210_000

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2630,8 +2630,11 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=true"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ONLY=false"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_ENABLED=false"' in body
-    assert 'scheduler_name="${job_name}-every-five-minutes"' in body
-    assert 'legacy_scheduler_name="${job_name}-every-minute"' in body
+    assert 'scheduler_name="${job_name}-every-three-minutes"' in body
+    assert '"${job_name}-every-minute"' in body
+    assert '"${job_name}-every-five-minutes"' in body
+    assert '"TR_SYNTHETIC_ROTATION_PER_PASS=2"' in body
+    assert '"*/3 * * * *"' in body
     assert '"*/5 * * * *"' in body
     assert 'throughput_scheduler_name="${throughput_job_name}-every-five-minutes"' in body
     assert '"TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS=300"' in body


### PR DESCRIPTION
## Summary
- accept the independently confirmed DigitalOcean GLM 5.2 price increase without weakening the price-spike gate
- move regional synthetic health checks from five-minute to three-minute cadence
- reduce random provider probes per pass from four to two so provider-probe volume remains approximately flat
- migrate and delete legacy scheduler names during deployment

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (3144 passed, 253 skipped, 10 xfailed)
- official DigitalOcean pricing: $1.40 input, $4.40 output, $0.21 cached input per million tokens

The price guard remains strict; this updates the reviewed baseline rather than allowing arbitrary 2x changes.