### PR TITLE
Inherit billing shards for new API keys

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -923,6 +923,16 @@ class SpannerBigtableStore:
         budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
+        # Keep new uncapped keys at the workspace's established write scale.
+        # Falling back to one usage row after a workspace has been resharded
+        # recreates a hot key-limit row under otherwise shard-safe traffic.
+        # Exact lifetime limits deliberately remain single-row so authorize
+        # can reserve against the cap atomically.
+        usage_shard_count = (
+            1
+            if limit_microdollars is not None
+            else self._credit_shard_count(workspace_id)
+        )
         return self.api_keys.create(
             workspace_id=workspace_id,
             name=name,
@@ -938,6 +948,7 @@ class SpannerBigtableStore:
             limit_monthly_microdollars=limit_monthly_microdollars,
             budget_alert_only=budget_alert_only,
             tags=tags,
+            usage_shard_count=usage_shard_count,
         )
 
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -62,6 +62,7 @@ class SpannerApiKeys:
         limit_monthly_microdollars: int | None = None,
         budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
+        usage_shard_count: int = 1,
     ) -> tuple[str, ApiKey]:
         raw = raw_key or new_api_key()
         key_id = new_key_id()
@@ -86,6 +87,7 @@ class SpannerApiKeys:
             limit_monthly_microdollars=limit_monthly_microdollars,
             budget_alert_only=budget_alert_only,
             tags=dict(tags or {}),
+            usage_shard_count=usage_shard_count,
         )
         with self._io.database.batch() as batch:
             self._io.write_entity_batch(batch, "api_key", key.hash, key)

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -119,6 +119,53 @@ def test_key_usage_shards_default_and_fail_closed_for_lifetime_caps() -> None:
     )
 
 
+def test_new_uncapped_key_inherits_workspace_credit_shards() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-new-key-shards"
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id, shard_count=16),
+    )
+
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="inherits-workspace-scale",
+        creator_user_id=None,
+    )
+
+    assert key.usage_shard_count == 16
+    assert {
+        shard
+        for key_hash, shard in database.typed[KEY_LIMIT_TABLE]
+        if key_hash == key.hash
+    } == set(range(16))
+
+
+def test_new_lifetime_capped_key_remains_single_shard() -> None:
+    store, database, _ = make_fake_store()
+    workspace_id = "ws-new-capped-key"
+    store._write_entity(
+        "credit",
+        workspace_id,
+        CreditAccount(workspace_id=workspace_id, shard_count=16),
+    )
+
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="exact-cap",
+        creator_user_id=None,
+        limit_microdollars=1_000_000,
+    )
+
+    assert key.usage_shard_count == 1
+    assert {
+        shard
+        for key_hash, shard in database.typed[KEY_LIMIT_TABLE]
+        if key_hash == key.hash
+    } == {0}
+
+
 def test_sharded_key_metadata_update_does_not_clobber_typed_counters() -> None:
     store, database, key = _seed(key_shards=4)
     rows = database.typed[KEY_LIMIT_TABLE]

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -7,7 +7,7 @@ from typing import Any
 from tests.fakes.spanner import make_fake_store
 from trusted_router.byok_crypto import decrypt_byok_secret, encrypt_byok_secret
 from trusted_router.config import Settings
-from trusted_router.storage import ApiKey, Generation, ProviderBenchmarkSample
+from trusted_router.storage import ApiKey, CreditAccount, Generation, ProviderBenchmarkSample
 from trusted_router.storage_gcp import SpannerBigtableStore
 from trusted_router.storage_gcp_activity_index import (
     activity_generations as _bt_activity_generations,
@@ -156,6 +156,11 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
 
 def test_gcp_api_key_lookup_uses_index_and_never_stores_raw_key() -> None:
     store, db, _ = make_fake_store()
+    store._write_entity(
+        "credit",
+        "ws_1",
+        CreditAccount(workspace_id="ws_1"),
+    )
 
     raw, api_key = store.create_api_key(
         workspace_id="ws_1",


### PR DESCRIPTION
## Root cause

A customer workspace was already split across 16 credit shards, but a subsequently created uncapped API key defaulted back to one `tr_key_limit` row. At roughly one request per second, authorize and settle transactions contended on that row and exhausted the 20-second Spanner budget.

## Fix

- Inherit the workspace credit shard count when creating uncapped or window-capped keys.
- Keep exact lifetime-capped keys on one row for atomic enforcement.
- Fail closed when the workspace credit configuration is missing.
- Add regression coverage for both creation paths.

## Verification

- Focused storage, concurrency, console, billing, OAuth, and sharding suites: 167 passed.
- Ruff passes.
- Mypy passes.
- The full suite reaches completion; two unrelated pre-existing provider-card order-dependence failures remain on current main.
