### PR TITLE
Give the auto ladder one source of truth

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -686,15 +686,21 @@ class Settings(BaseSettings):
     synthetic_status_rollup_retention_months: int = 24
     synthetic_status_us_url: str = "https://status-us.trustedrouter.com/status.json"
     synthetic_status_eu_url: str = "https://status-eu.trustedrouter.com/status.json"
+    # Deliberately empty: the auto ladder lives in exactly one place,
+    # DEFAULT_AUTO_MODEL_ORDER in catalog_data.py, and an empty setting is what
+    # lets that default through in auto_candidate_models().
+    #
+    # This used to hold its own copy of the ladder. Because the setting was
+    # always non-empty it always won, so the "default" in catalog_data.py never
+    # applied to routing and the two silently drifted apart — the copy here
+    # still led with claude-opus-4.7 and named retired model versions. Editing
+    # the documented ladder changed the advertised catalog and nothing else.
+    # Keep this empty; set TR_AUTO_MODEL_ORDER to override at runtime.
+    #
     # IDs follow OpenRouter naming exactly to line up with the ingest
     # snapshot — `moonshotai/...` not `kimi/...`, `mistralai/...` not
     # `mistral/...`, `meta-llama/...` for Cerebras-served Llama, etc.
-    auto_model_order: str = (
-        "anthropic/claude-opus-4.7,anthropic/claude-sonnet-4.6,"
-        "openai/gpt-4.1-mini,google/gemini-2.5-flash,"
-        "deepseek/deepseek-v4-flash,minimax/minimax-m3,moonshotai/kimi-k2.6,"
-        "mistralai/mistral-small-2603,z-ai/glm-4.6"
-    )
+    auto_model_order: str = ""
 
     max_request_body_bytes: int = 4 * 1024 * 1024
 

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.providers import ProviderClient, ProviderError, ProviderResult
+from trusted_router.routing_candidates import auto_candidate_models
 from trusted_router.storage import STORE
 
 
@@ -17,7 +18,9 @@ def test_stablecoin_checkout_uses_stripe_crypto_payment_method(monkeypatch) -> N
         captured.update(kwargs)
         return {"id": "cs_crypto", "url": "https://checkout.stripe.test/crypto"}
 
-    monkeypatch.setattr("trusted_router.services.stripe_billing.stripe.checkout.Session.create", create_session)
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create", create_session
+    )
 
     checkout = local_client.post(
         "/v1/billing/checkout",
@@ -44,11 +47,17 @@ def test_trustedrouter_auto_rolls_over_to_next_provider(
     inference_headers: dict[str, str],
     monkeypatch,
 ) -> None:
+    # Derived from the ladder, never hardcoded. Naming the models here is what
+    # let auto's real leader drift away from the documented one unnoticed: the
+    # assertions kept passing against a model nobody had chosen on purpose.
+    ladder = [model.id for model in auto_candidate_models(None)]
+    first, second = ladder[0], ladder[1]
+
     attempts: list[str] = []
 
     async def fake_chat(_self, model, _body):
         attempts.append(model.id)
-        if model.id == "anthropic/claude-opus-4.7":
+        if model.id == first:
             raise ProviderError(model.provider, 503, "upstream unavailable")
         return ProviderResult(
             text="fallback ok",
@@ -73,12 +82,12 @@ def test_trustedrouter_auto_rolls_over_to_next_provider(
 
     assert resp.status_code == 200, resp.text
     payload = resp.json()
-    assert attempts[:2] == ["anthropic/claude-opus-4.7", "anthropic/claude-sonnet-4.6"]
-    assert payload["model"] == "anthropic/claude-sonnet-4.6"
+    assert attempts[:2] == [first, second]
+    assert payload["model"] == second
     assert payload["trustedrouter"]["requested_model"] == "trustedrouter/auto"
-    assert payload["trustedrouter"]["selected_model"] == "anthropic/claude-sonnet-4.6"
+    assert payload["trustedrouter"]["selected_model"] == second
     generation = next(iter(STORE.generation_store.generations.values()))
-    assert generation.model == "anthropic/claude-sonnet-4.6"
+    assert generation.model == second
 
 
 def test_models_array_rolls_over_and_provider_filters_apply(
@@ -281,17 +290,17 @@ def test_regions_endpoint_and_gateway_authorize_include_routing_metadata() -> No
     assert regions.json()["trustedrouter"]["primary_region"] == "europe-west4"
     assert authorize.status_code == 200, authorize.text
     data = authorize.json()["data"]
+    auto_leader = auto_candidate_models(None)[0].id
     assert data["requested_model"] == "trustedrouter/auto"
-    assert data["model"] == "anthropic/claude-opus-4.7"
+    assert data["model"] == auto_leader
     assert data["region"] == "asia-northeast1"
     assert len(data["route_candidates"]) >= 2
-    assert data["route_candidates"][0]["model"] == "anthropic/claude-opus-4.7"
+    assert data["route_candidates"][0]["model"] == auto_leader
     # The exact tail of the auto rollover depends on which providers are
     # configured at request time; assert that at least one non-primary
     # candidate is present so callers know fallback is wired up.
     fallback_models = [
-        item["model"] for item in data["route_candidates"]
-        if item["model"] != "anthropic/claude-opus-4.7"
+        item["model"] for item in data["route_candidates"] if item["model"] != auto_leader
     ]
     assert fallback_models, f"expected fallback candidates, got {data['route_candidates']}"
 

--- a/tests/test_auto_model_order_single_source.py
+++ b/tests/test_auto_model_order_single_source.py
@@ -1,0 +1,56 @@
+"""The auto ladder must have exactly one source of truth.
+
+`Settings.auto_model_order` used to carry its own copy of the ladder. Because
+`auto_candidate_models()` only falls back to `DEFAULT_AUTO_MODEL_ORDER` when the
+setting is empty, the copy in config always won: the documented ladder in
+`catalog_data.py` governed only the advertised catalog, never routing.
+
+The two drifted, and the drift was invisible. `trustedrouter/auto` kept routing
+to `anthropic/claude-opus-4.7` — the most expensive model in the catalog, and
+one that was 502ing at settlement — while the documented default led with a
+cheap one. Nothing failed; editing the documented ladder simply had no effect
+on where requests went.
+
+These tests fail if any second copy is reintroduced.
+"""
+
+from __future__ import annotations
+
+from trusted_router.catalog_data import DEFAULT_AUTO_MODEL_ORDER
+from trusted_router.config import Settings
+from trusted_router.routing_candidates import auto_candidate_models
+
+
+def test_deployed_default_routes_by_the_documented_ladder() -> None:
+    """What a default-configured deployment actually routes on must be what
+    `DEFAULT_AUTO_MODEL_ORDER` says, not a second list that quietly outranks it.
+    """
+    deployed = [model.id for model in auto_candidate_models(Settings().auto_model_order)]
+    documented = [model.id for model in auto_candidate_models(None)]
+    assert deployed == documented
+
+
+def test_documented_ladder_survives_catalog_filtering() -> None:
+    """Guard the comparison above from passing vacuously: if every ID were
+    filtered out as unknown, both sides would be equal and empty."""
+    assert len(auto_candidate_models(None)) >= 3
+
+
+def test_auto_leads_with_the_intended_cheap_model() -> None:
+    """The ladder is tried in order, so entry zero is what auto costs in the
+    common case. It must be the cheap leader, not a frontier model."""
+    assert DEFAULT_AUTO_MODEL_ORDER[0] == "deepseek/deepseek-v4-flash-0731"
+    assert auto_candidate_models(None)[0].id == "deepseek/deepseek-v4-flash-0731"
+
+
+def test_explicit_override_still_wins() -> None:
+    """Emptying the setting must not cost operators the runtime override."""
+    override = "openai/gpt-4.1-mini,google/gemini-2.5-flash"
+    resolved = [model.id for model in auto_candidate_models(override)]
+    assert resolved == ["openai/gpt-4.1-mini", "google/gemini-2.5-flash"]
+
+
+def test_config_holds_no_second_copy_of_the_ladder() -> None:
+    """The failure mode was a hardcoded ladder in config outranking the
+    documented one. Empty is the only value that keeps a single source."""
+    assert Settings().auto_model_order == ""


### PR DESCRIPTION
`trustedrouter/auto` kept routing to `anthropic/claude-opus-4.7` after #490 changed the documented ladder to lead with a cheap model. The edit wasn't wrong — it was applied to a list that doesn't route.

## Two ladders, and the undocumented one won

`DEFAULT_AUTO_MODEL_ORDER` in `catalog_data.py` is the documented ladder. But `auto_candidate_models()` only falls back to it when `settings.auto_model_order` is empty — and `config.py` shipped **its own hardcoded copy**, so the setting was never empty and the copy always won.

The result: the documented ladder governed the **advertised catalog**, and the undocumented one governed **where requests actually went**. Those are allowed to disagree, and they did.

Nothing failed when they drifted. The copy in config still led with the most expensive model in the catalog and named retired versions (`deepseek-v4-flash` without its date suffix, `glm-4.6`).

## Fix

`config.py` defaults to empty, so the documented ladder is what routes. `TR_AUTO_MODEL_ORDER` still overrides at runtime.

## The tests had locked the wrong behaviour in

`test_auth_and_routing.py` asserted the literal string `"anthropic/claude-opus-4.7"` — so it passed just as happily against a leader nobody had chosen on purpose. Those assertions now derive expected models from the ladder and test that **rollover reaches the second entry** (the behaviour) rather than the identity of whichever model sits there.

`test_auto_model_order_single_source.py` fails if a second copy is reintroduced: it asserts a default-configured deployment resolves auto to exactly what the documented ladder says, with a guard so it can't pass vacuously. **Mutation-verified** — restoring the old config default fails it.

## Note on the third copy

The enclave has its own `defaultAutoModelOrder`. It is **not** duplication of this one: it serves appliance deployments running with the gateway disabled, which have no control plane to ask. On the hosted path the enclave overwrites `req.Model` with `authorization.Model`, so it's never consulted. A companion commit documents that scope — it was the prime suspect here and it was innocent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)