### PR TITLE
Expose live Sao Paulo router region

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,10 +318,9 @@ The goal is to support OpenRouter-class scale:
 
 The current production deployment does **not** meet that target yet. It runs
 the control plane in four GCP regions behind a global LB with per-region
-Serverless NEGs, with three live attested API regions until additional
-attested regional pools are deployed. Capacity scales horizontally as more
-attested pools come online; correctness, trust, billing, and SDK compatibility
-are in steady-state.
+Serverless NEGs and four live attested API regions. Capacity scales
+horizontally as more attested pools come online; correctness, trust, billing,
+and SDK compatibility are in steady-state.
 
 Request volume depends heavily on average generation size. At 1 trillion
 tokens/day:
@@ -384,17 +383,19 @@ gateway replicas before public traffic is allowed to ramp.
 Multi-region is feasible while preserving the trust boundary, but it has to be
 done carefully:
 
-- Run independent warm attested gateway pools in at least `us-central1`,
-  `us-east4`, and `europe-west4`, then Asia once the first three regions are
-  boring.
+- Run independent warm attested gateway pools in `us-central1`, `us-east4`,
+  `europe-west4`, and `southamerica-east1`, then add Asia after the four-region
+  fleet is operationally boring.
 - Keep TLS private keys inside each regional Confidential Space workload.
-- Move ACME from TLS-ALPN-01 to DNS-01 or another challenge flow that works
-  with multiple regional endpoints for the same hostname. The current
-  TLS-ALPN-01 flow is fine for one region, but a global DNS record can route
-  challenges to the wrong replica.
+- Keep certificate issuance inside the attested workload. Certificates are
+  shared between replicas through the encrypted cache. A first regional
+  hostname is exposed to one node only after every node passes canonical
+  attestation and a settled PONG; it is expanded only after the regional
+  certificate and the same gates pass on every node.
 - Keep regional hostnames such as `api-us-central1.quillrouter.com`,
-  `api-us-east4.quillrouter.com`, and `api-europe-west4.quillrouter.com` for
-  deterministic attestation, smoke tests, and SDK failover.
+  `api-us-east4.quillrouter.com`, `api-europe-west4.quillrouter.com`, and
+  `api-southamerica-east1.quillrouter.com` for deterministic attestation,
+  smoke tests, and SDK failover.
 - Put `api.trustedrouter.com` behind latency/geo DNS or TCP passthrough that does
   not terminate TLS. Cloudflare orange-cloud proxying remains incompatible
   with the prompt-path trust claim.

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -15,7 +15,7 @@ REGION="${REGION:-us-central1}"
 # /v1/regions which the SDK's region= shortcut resolves against. Adding
 # a region without a backing gateway VM gives callers a TLS-broken
 # `api-<region>.quillrouter.com` and weakens the trust story.
-TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4}"
+TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4,southamerica-east1}"
 TR_PRIMARY_REGION="${TR_PRIMARY_REGION:-us-central1}"
 # Cloud Run control-plane regions behind trustedrouter.com. This is broader
 # than TR_REGIONS because cold control-plane regions can serve cached public
@@ -25,9 +25,9 @@ TR_CONTROL_PLANE_REGIONS="${TR_CONTROL_PLANE_REGIONS:-us-central1,us-east4,europ
 # (always-on warm capacity). Anything in TR_REGIONS but NOT in
 # TR_WARM_REGIONS gets min_scale=0 (scale-to-zero — ~$0/mo idle, cold-
 # start tax on first request). Defaults to the regions where we run an
-# attested enclave MIG; the LATAM addition stays cold so it can show on
-# the homepage map without paying for always-on Cloud Run.
-TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4}"
+# attested enclave MIG. São Paulo is warm as well so its gateway does not pay
+# a control-plane cold-start penalty on authorization or settlement.
+TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4,southamerica-east1}"
 # Cloud Run memory limit. 2Gi as of 2026-05-10.
 #
 # History of the bloat profile (RSS at idle, then under load):

--- a/scripts/smoke_all_providers.py
+++ b/scripts/smoke_all_providers.py
@@ -91,6 +91,7 @@ REGIONS = {
     "us-central1": "https://api.trustedrouter.com",
     "europe-west4": "https://api-europe-west4.quillrouter.com",
     "us-east4": "https://api-us-east4.quillrouter.com",
+    "southamerica-east1": "https://api-southamerica-east1.quillrouter.com",
     # Aliases preserved for backward-compat with operator muscle memory.
     "us": "https://api.trustedrouter.com",
     "europe": "https://api-europe-west4.quillrouter.com",

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -503,7 +503,7 @@ class Settings(BaseSettings):
     # regions where we've actually deployed a VM. Adding a region here
     # without an actual VM in that region is dishonest — the cert SAN
     # mismatch breaks TLS and the attestation page lies.
-    regions: str = "us-central1,us-east4,europe-west4"
+    regions: str = "us-central1,us-east4,europe-west4,southamerica-east1"
     marketing_regions: str = (
         "us-central1,europe-west4,us-east4,"
         "asia-northeast1,asia-east2,asia-southeast1,"

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -39,6 +39,7 @@ COMPONENT_PROBES: dict[str, set[str]] = {
     "us_central1_regional_api": REGIONAL_GATEWAY_PROBES,
     "us_east4_regional_api": REGIONAL_GATEWAY_PROBES,
     "eu_regional_api": REGIONAL_GATEWAY_PROBES,
+    "sa_regional_api": REGIONAL_GATEWAY_PROBES,
     "eu_west_1_gateway": REGIONAL_GATEWAY_PROBES,
     "eu_west_3_gateway": REGIONAL_GATEWAY_PROBES,
     "attestation": {"attestation_nonce"},
@@ -89,6 +90,11 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
         "id": "eu_regional_api",
         "name": "EU Regional API",
         "description": "EU attested TLS reachability and trust checks.",
+    },
+    {
+        "id": "sa_regional_api",
+        "name": "South America Regional API",
+        "description": "São Paulo attested TLS reachability and trust checks.",
     },
     # Per-REGION components. Unlike the regional entries above they do not
     # have their own hostname: every AWS EU request goes to one anycast name
@@ -185,6 +191,7 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
     "us_central1_regional_api": "us-central1",
     "us_east4_regional_api": "us-east4",
     "eu_regional_api": "europe-west4",
+    "sa_regional_api": "southamerica-east1",
     # These names are the TR_SYNTHETIC_GATEWAY_REGION_TARGETS entry names the
     # AWS EU control plane configures; nothing publishes them anywhere else.
     "eu_west_1_gateway": "eu-west-1",
@@ -223,7 +230,12 @@ GATEWAY_REGION_COMPONENT_IDS: frozenset[str] = frozenset(
 # overall-status banner for pinned failover gateways, while these GCP rows
 # must remain diagnostic and outside the router-core SLO.
 REGIONAL_API_COMPONENT_IDS: frozenset[str] = frozenset(
-    {"us_central1_regional_api", "us_east4_regional_api", "eu_regional_api"}
+    {
+        "us_central1_regional_api",
+        "us_east4_regional_api",
+        "eu_regional_api",
+        "sa_regional_api",
+    }
 )
 MACHINE_REGION_COMPONENT_IDS: frozenset[str] = (
     GATEWAY_REGION_COMPONENT_IDS | REGIONAL_API_COMPONENT_IDS
@@ -264,9 +276,9 @@ def applicable_component_definitions(settings: Settings) -> tuple[dict[str, str]
     """Catalogue components this deployment can produce samples for.
 
     A public status page must only assert things it measures. The AWS EU
-    cloud has no us-central1, us-east4, or europe-west4 anything, so
-    publishing those components there produced three permanent "unknown"
-    rows — which reads as "we are not sure our own service works" and is
+    cloud has no us-central1, us-east4, europe-west4, or southamerica-east1
+    gateway, so publishing those components there would produce permanent
+    "unknown" rows — which reads as "we are not sure our own service works" and is
     worse than not listing them at all. Scope comes from configuration
     (regions + synthetic_regional_probes_enabled), never a per-cloud list.
     """
@@ -327,6 +339,11 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("us_east4_regional_api")
     if sample.target == "europe-west4" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_regional_api")
+    if (
+        sample.target == "southamerica-east1"
+        and sample.probe_type in REGIONAL_GATEWAY_PROBES
+    ):
+        ids.append("sa_regional_api")
     if sample.target == "eu-west-1" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_west_1_gateway")
     if sample.target == "eu-west-3" and sample.probe_type in REGIONAL_GATEWAY_PROBES:

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -1130,6 +1130,7 @@ def _target_label(target: str) -> str:
         "us-central1": "US Central direct",
         "us-east4": "US East direct",
         "europe-west4": "EU direct",
+        "southamerica-east1": "São Paulo direct",
         # Per-region AWS targets: same hostname as "canonical", pinned to
         # one region's load balancer (which fronts that region's enclave
         # fleet — see COMPONENT_DEFINITIONS on why this does not say

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -256,8 +256,8 @@ response = client.chat.completions.create(
             </svg>
           </div>
           <div class="region-map-copy">
-            <strong>{{ map_regions|length }} regions across three clouds</strong>
-            <span>{{ api_region_count }} live GCP regions, plus standalone EU (AWS) and APAC (Azure) deployments. Additional capacity staged.</span>
+            <strong>Live routing on four continents</strong>
+            <span>{{ api_region_count }} live GCP regions, plus independent AWS and Azure deployments. Serving North America, South America, Europe, and Australia today.</span>
           </div>
         </div>
       </div>

--- a/src/trusted_router/templates/public/trustedos.html
+++ b/src/trusted_router/templates/public/trustedos.html
@@ -20,7 +20,7 @@
 {% block body %}
 
 <section class="public-proof-strip" aria-label="Confidential-compute coverage">
-  <div><strong>AMD SEV-SNP</strong><span>Attested confidential VMs on GCP Confidential Space.</span></div>
+  <div><strong>AMD SEV</strong><span>Google-attested confidential VMs in São Paulo.</span></div>
   <div><strong>Intel TDX</strong><span>Trust domains in our live gateway regions.</span></div>
   <div><strong>NVIDIA CC</strong><span>Confidential-computing path for H100/H200-class GPUs.</span></div>
   <div><strong>AWS Nitro Enclaves</strong><span>Same attested code path on a second cloud.</span></div>
@@ -112,7 +112,7 @@ resp = client.chat.completions.create(
   <div class="marketing-copy">
     <span class="eyebrow">Why &ldquo;Trusted&rdquo; OS</span>
     <h2>The name is a claim we can prove.</h2>
-    <p>In the security world, the &ldquo;trusted OS&rdquo; is the operating system inside a trusted execution environment. We picked the name on purpose: TLS terminates inside attested hardware &mdash; AMD SEV-SNP and Intel TDX today, with a confidential-computing path to H100/H200-class GPUs &mdash; and the gateway fails closed if the measurement doesn't match.</p>
+    <p>In the security world, the &ldquo;trusted OS&rdquo; is the operating system inside a trusted execution environment. We picked the name on purpose: TLS terminates inside attested hardware &mdash; AMD SEV and Intel TDX today, with a confidential-computing path to H100/H200-class GPUs &mdash; and the gateway fails closed if the measurement doesn't match.</p>
     <p>Your customers' compliance teams can verify the stack you run for themselves. Don't trust the policy &mdash; verify the code.</p>
     <p>
       <a class="btn" href="https://trust.trustedrouter.com">Live attestation evidence</a>

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -74,9 +74,13 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     library = (ROOT / "scripts/deploy/_lib.sh").read_text()
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
-    assert 'TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4}"' in library
     assert (
-        'TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4}"'
+        'TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4,'
+        'southamerica-east1}"' in library
+    )
+    assert (
+        'TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4,'
+        'southamerica-east1}"'
         in library
     )
     assert '--min-instances "$min_instances"' in rollout

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -571,6 +571,7 @@ def test_unset_configuration_is_exactly_todays_target_list() -> None:
         "us-central1",
         "us-east4",
         "europe-west4",
+        "southamerica-east1",
     ]
     assert all(target.connect_host is None for target in gcp)
     assert all(target.paid_probes is True for target in gcp)
@@ -860,6 +861,7 @@ def test_unconfigured_deployments_publish_none_of_them() -> None:
         "us_central1_regional_api",
         "us_east4_regional_api",
         "eu_regional_api",
+        "sa_regional_api",
         "attestation",
         "billing_settlement",
         "provider_fallback",

--- a/tests/test_region_map_projection.py
+++ b/tests/test_region_map_projection.py
@@ -90,6 +90,14 @@ def test_region_map_payload_marks_primary() -> None:
     assert primaries[0]["id"] == settings.primary_region
 
 
+def test_default_region_map_marks_sao_paulo_live() -> None:
+    rendered = region_map_payload(Settings(environment="local"))
+
+    sao_paulo = next(row for row in rendered if row["id"] == "southamerica-east1")
+    assert sao_paulo["city"] == "São Paulo"
+    assert sao_paulo["status_label"] == "live"
+
+
 def test_default_region_map_shows_gcp_region_marketing_footprint() -> None:
     settings = Settings(environment="local", regions="us-central1,europe-west4")
     rendered = region_map_payload(settings)

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -33,6 +33,7 @@ GCP_COMPONENT_IDS = (
     "us_central1_regional_api",
     "us_east4_regional_api",
     "eu_regional_api",
+    "sa_regional_api",
     "attestation",
     "billing_settlement",
     "provider_fallback",
@@ -43,11 +44,12 @@ REGIONAL_GCP_COMPONENT_IDS = (
     "us_central1_regional_api",
     "us_east4_regional_api",
     "eu_regional_api",
+    "sa_regional_api",
 )
 
 
 def _gcp_settings() -> Settings:
-    """Production GCP shape: three warm attested regions."""
+    """Production GCP shape: four warm attested regions."""
     return Settings(environment="test", sentry_dsn=None)
 
 
@@ -94,7 +96,7 @@ def test_gcp_publishes_exactly_its_own_components_unchanged() -> None:
     """GCP's page is defined by GCP's probe targets, never by the catalogue.
 
     The catalogue also carries per-enclave AWS components, which GCP has no
-    targets for; the published list must therefore stay exactly the eight
+    targets for; the published list must therefore stay exactly the nine
     rows above, in that order.
     """
     published = applicable_component_definitions(_gcp_settings())
@@ -133,7 +135,13 @@ def test_gcp_current_checks_expose_regions_without_blending_router_core_slo() ->
     now = utcnow()
     samples = [
         _tls_sample(created_at=_iso(now - dt.timedelta(seconds=10)), target=target)
-        for target in ("canonical", "us-central1", "us-east4", "europe-west4")
+        for target in (
+            "canonical",
+            "us-central1",
+            "us-east4",
+            "europe-west4",
+            "southamerica-east1",
+        )
     ]
 
     snapshot = status_snapshot(samples, now=now, settings=_gcp_settings())
@@ -147,11 +155,13 @@ def test_gcp_current_checks_expose_regions_without_blending_router_core_slo() ->
         "us-central1",
         "us-east4",
         "europe-west4",
+        "southamerica-east1",
     }
     assert {row["target_region"] for row in checks if row["target"] != "canonical"} == {
         "us-central1",
         "us-east4",
         "europe-west4",
+        "southamerica-east1",
     }
 
     # Direct regional diagnostics must not inflate uptime denominators or

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -197,6 +197,8 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert "End-to-End Encrypted AI gateway" in dashboard.text
     assert "ATTESTED GATEWAY" in dashboard.text  # routing-diagram hero
     assert "Live regions" in dashboard.text  # reliability stats
+    assert "Live routing on four continents" in dashboard.text
+    assert "North America, South America, Europe, and Australia" in dashboard.text
     assert "trustedrouter/auto" in dashboard.text  # routing model
     assert "$25 USDC" not in dashboard.text
     assert "Stripe Crypto" not in dashboard.text

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -347,6 +347,16 @@ def test_gateway_latency_anatomy_distinguishes_global_and_direct_targets() -> No
             latency_milliseconds=10,
             created_at=created_at,
         ),
+        _sample(
+            id="sao-paulo",
+            target="southamerica-east1",
+            target_region="southamerica-east1",
+            monitor_region="us-central1",
+            probe_type="gateway_reused_path",
+            status="up",
+            latency_milliseconds=120,
+            created_at=created_at,
+        ),
     ]
 
     rows = status_snapshot(samples, now=now)["headline_metrics"]["latency_anatomy"]
@@ -355,6 +365,9 @@ def test_gateway_latency_anatomy_distinguishes_global_and_direct_targets() -> No
     assert labels == {
         "canonical": "Global endpoint · us-central1 -> us-central1",
         "us-central1": "US Central direct · us-central1 -> us-central1",
+        "southamerica-east1": (
+            "São Paulo direct · us-central1 -> southamerica-east1"
+        ),
     }
 
 
@@ -2126,7 +2139,7 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
     settings = Settings(
         environment="test",
         api_base_url="https://api.trustedrouter.com/v1",
-        regions="us-central1,us-east4,europe-west4",
+        regions="us-central1,us-east4,europe-west4,southamerica-east1",
         primary_region="us-central1",
     )
 
@@ -2142,6 +2155,9 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
     assert by_name["us-east4"].api_base_url == "https://api-us-east4.quillrouter.com/v1"
     assert by_name["europe-west4"].api_base_url == (
         "https://api-europe-west4.quillrouter.com/v1"
+    )
+    assert by_name["southamerica-east1"].api_base_url == (
+        "https://api-southamerica-east1.quillrouter.com/v1"
     )
 
 
@@ -2172,6 +2188,14 @@ def test_status_components_include_all_warm_regional_gateways() -> None:
             status="up",
             created_at=(now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
         ),
+        _sample(
+            id="syn_sa",
+            target="southamerica-east1",
+            target_region="southamerica-east1",
+            probe_type="tls_health",
+            status="up",
+            created_at=(now - dt.timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
+        ),
     ]
 
     components = {row["id"]: row for row in status_snapshot(samples, now=now)["components"]}
@@ -2179,6 +2203,7 @@ def test_status_components_include_all_warm_regional_gateways() -> None:
     assert components["us_central1_regional_api"]["status"] == "up"
     assert components["us_east4_regional_api"]["status"] == "up"
     assert components["eu_regional_api"]["status"] == "up"
+    assert components["sa_regional_api"]["status"] == "up"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `southamerica-east1` to the real attested gateway registry and regional provider smoke path
- keep the São Paulo control plane warm for low-latency authorization and settlement
- add a direct regional synthetic/status component without blending it into canonical router-core SLOs
- update the homepage and operator docs for four live continents
- correct the GCP hardware claim from SEV-SNP to Google-attested AMD SEV

## Verification
- full suite before rebase: `3193 passed, 253 skipped, 10 xfailed`
- post-rebase regional/status slice: `249 passed`
- post-rebase loopback/socket subset outside the filesystem sandbox: `104 passed`
- `uv run mypy` (230 source files)
- Ruff, Bash syntax, and `git diff --check` clean

Do not merge until quill-cloud-proxy#138 has deployed and `api-southamerica-east1.quillrouter.com` passes live attestation and inference.