### PR TITLE
Treat São Paulo as a warm rollout region

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -364,7 +364,7 @@ jobs:
       - name: Capture pre-deploy revisions (for rollback)
         id: prev
         run: |
-          for region in us-central1 europe-west4 us-east4; do
+          for region in us-central1 europe-west4 us-east4 southamerica-east1; do
             rev=$(gcloud run services describe "${SERVICE}" \
               --region="$region" --project="${PROJECT_ID}" \
               --format='value(status.traffic[0].revisionName)' \
@@ -464,6 +464,7 @@ jobs:
           IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
           PREV_EU: ${{ steps.prev.outputs.europe_west4_revision }}
           PREV_US_EAST4: ${{ steps.prev.outputs.us_east4_revision }}
+          PREV_SOUTHAMERICA_EAST1: ${{ steps.prev.outputs.southamerica_east1_revision }}
           WD_EXTRA: ${{ steps.wd_args.outputs.extra }}
           TR_WATCHDOG_SLO_CLASS: control_plane
           TR_DEPLOY_RECONCILE_LB: "0"
@@ -474,6 +475,7 @@ jobs:
             case "$1" in
               europe-west4) printf '%s\n' "${PREV_EU}" ;;
               us-east4) printf '%s\n' "${PREV_US_EAST4}" ;;
+              southamerica-east1) printf '%s\n' "${PREV_SOUTHAMERICA_EAST1}" ;;
               *) return 1 ;;
             esac
           }
@@ -551,7 +553,7 @@ jobs:
           # The image has already passed the full us-central1 ramp and canary.
           # These regions share no mutable Cloud Run resources; each child
           # retains its own traffic ramp, watchdog, and region-local rollback.
-          regions=(europe-west4 us-east4)
+          regions=(europe-west4 us-east4 southamerica-east1)
           log_dir="$(mktemp -d)"
           pids=()
           for region in "${regions[@]}"; do
@@ -578,20 +580,6 @@ jobs:
           if [ "${failed}" -ne 0 ]; then
             exit 1
           fi
-
-      - name: Deploy cold regions (no canary, scale-to-zero)
-        # Stage 3.5 cold region: southamerica-east1. min-instances=0
-        # means ~$0/mo idle plus a ~5-10s cold-start tax on the first
-        # request from that geography. Every region attached to the public
-        # load balancer must run the same reader schema before a newer
-        # synthetic monitor can write shared Bigtable rows. No canary is
-        # needed because the warm regions already validated the image.
-        # rollout.sh handles min-instances=0 automatically when a region is
-        # in TR_CONTROL_PLANE_REGIONS but not TR_WARM_REGIONS.
-        env:
-          TR_DEPLOY_TARGET_REGIONS: southamerica-east1
-          TR_DEPLOY_RECONCILE_LB: "0"
-        run: bash scripts/deploy/rollout.sh
 
       - name: Deploy synthetic monitor Cloud Run Job
         if: ${{ steps.optional.outputs.deploy_synthetic_monitor == 'true' }}
@@ -623,10 +611,8 @@ jobs:
       # was functionally clean. Same anti-pattern fixed in
       # quill-cloud-proxy commit 7b735e8.
       #
-      # Cold region southamerica-east1 deploys after all warm-region
-      # canaries pass. It has no per-region canary by design — warm
-      # regions already validated the image, and the cold region is
-      # lowest-volume by construction.
+      # Every advertised regional control plane is warm and passes its own
+      # staged traffic shift plus region-local canary before this point.
 
       - name: Smoke test prod
         run: |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1074,11 +1074,16 @@ for prov, n in sorted(c.items(), key=lambda kv: -kv[1]):
 
 Per-region MIG status (GCP enclave):
 ```bash
-for region in us-central1 europe-west4 us-east4; do
-  short=${region%%-*}
-  echo "=== $region ==="
-  gcloud compute instance-groups managed describe quill-enclave-mig-${short:0:2} \
-    --region=$region --project=quill-cloud-proxy \
+for entry in \
+  us-central1:quill-enclave-mig-us \
+  us-east4:quill-enclave-mig-useast4 \
+  europe-west4:quill-enclave-mig-eu \
+  southamerica-east1:quill-enclave-mig-sa; do
+  region=${entry%%:*}
+  mig=${entry#*:}
+  echo "=== ${region} ==="
+  gcloud compute instance-groups managed describe "${mig}" \
+    --region="${region}" --project=quill-cloud-proxy \
     --format='value(versions[0].instanceTemplate,targetSize,status.isStable)'
 done
 ```

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -3,15 +3,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_every_load_balanced_control_plane_region_is_deployed() -> None:
+def test_every_load_balanced_control_plane_region_is_staged() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
-    cold_step = "- name: Deploy cold regions (no canary, scale-to-zero)"
-    monitor_step = "- name: Deploy synthetic monitor Cloud Run Job"
+    start = workflow.index("- name: Roll secondary warm regions in parallel")
+    end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
+    rollout = workflow[start:end]
 
     assert "deploy_cold_regions:" not in workflow
     assert "steps.optional.outputs.deploy_cold_regions" not in workflow
-    assert "TR_DEPLOY_TARGET_REGIONS: southamerica-east1" in workflow
-    assert workflow.index(cold_step) < workflow.index(monitor_step)
+    assert "regions=(europe-west4 us-east4 southamerica-east1)" in rollout
+    assert 'TR_DEPLOY_TARGET_REGIONS="${region}"' in rollout
 
 
 def test_prod_smoke_checks_each_control_plane_region_directly() -> None:
@@ -36,11 +37,13 @@ def test_warm_secondary_regions_roll_in_parallel_after_primary_canary() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     primary_canary = workflow.index("- name: Canary gate — watch us-central1 only")
     start = workflow.index("- name: Roll secondary warm regions in parallel")
-    end = workflow.index("- name: Deploy cold regions", start)
+    end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
     rollout = workflow[start:end]
 
     assert primary_canary < start
-    assert "regions=(europe-west4 us-east4)" in rollout
+    assert "regions=(europe-west4 us-east4 southamerica-east1)" in rollout
+    assert "PREV_SOUTHAMERICA_EAST1" in rollout
+    assert "southamerica-east1)" in rollout
     assert 'for region in "${regions[@]}"; do' in rollout
     assert '(deploy_secondary "${region}")' in rollout
     assert 'if ! TR_DEPLOY_TARGET_REGIONS="${region}"' in rollout
@@ -85,4 +88,4 @@ def test_shared_load_balancer_is_reconciled_once_per_workflow() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 
     assert workflow.count('TR_DEPLOY_RECONCILE_LB: "1"') == 1
-    assert workflow.count('TR_DEPLOY_RECONCILE_LB: "0"') == 2
+    assert workflow.count('TR_DEPLOY_RECONCILE_LB: "0"') == 1


### PR DESCRIPTION
## Summary
- include São Paulo in pre-deploy revision capture and regional rollback
- give it the same staged 10/50/100 rollout and region-local canary as every warm secondary region
- update the gateway MIG runbook with all four exact production group names

## Verification
- 21 focused deploy workflow and secret-wiring tests pass
- Ruff passes
- git diff --check passes