### PR TITLE
Lead onboarding with the agent message

### DIFF
--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -254,6 +254,10 @@ body.console {
   gap: 8px;
   min-width: 0;
   max-width: 100%;
+}
+
+.agent-quickstart + .key-reveal-section {
+  margin-top: 14px;
   padding-top: 14px;
   border-top: 1px solid var(--good-border);
 }
@@ -1095,6 +1099,10 @@ body.console {
 
 .activation-key-panel .console-key-reveal {
   max-width: none;
+}
+
+.activation-onboarding-agent + .console-key-reveal {
+  margin-top: 14px;
 }
 
 .activation-security-note {

--- a/src/trusted_router/templates/console/_api_key_reveal.html
+++ b/src/trusted_router/templates/console/_api_key_reveal.html
@@ -1,28 +1,10 @@
 {% macro agent_chat_prompt(raw_key) -%}
-<span class="agent-prompt-line">Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?" and stream the answer into this chat as it arrives.</span>
+<span class="agent-prompt-line">Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?"</span>
 <span class="agent-prompt-line">TrustedRouter API key: {{ raw_key }}</span>
 {%- endmacro %}
 
 {% macro api_key_reveal(raw_key, id_prefix, workspace_name=None, show_agent=True) %}
 <div class="signup-reveal console-key-reveal" data-copy-secret-scope>
-  <div class="key-reveal-section">
-    <div class="signup-reveal-head">Your TrustedRouter API key</div>
-    <div class="secret-row">
-      <code id="{{ id_prefix }}-api-key">{{ raw_key }}</code>
-      <button
-        class="btn secret-copy-btn"
-        type="button"
-        data-copy-secret="{{ id_prefix }}-api-key"
-        aria-describedby="{{ id_prefix }}-api-key-copy-status"
-        aria-label="Copy API key"
-      >Copy</button>
-    </div>
-    <p class="copy-status" id="{{ id_prefix }}-api-key-copy-status" role="status" aria-live="polite"></p>
-    {% if workspace_name %}
-    <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span></div>
-    {% endif %}
-  </div>
-
   {% if show_agent %}
   <section class="agent-quickstart" aria-labelledby="{{ id_prefix }}-agent-heading">
     <h3 id="{{ id_prefix }}-agent-heading">Paste this short message into a Claude Code, Codex, or your favorite agent chat.</h3>
@@ -42,5 +24,23 @@
     <p class="copy-status" id="{{ id_prefix }}-agent-copy-status" role="status" aria-live="polite"></p>
   </section>
   {% endif %}
+
+  <div class="key-reveal-section">
+    <div class="signup-reveal-head">Your TrustedRouter API key</div>
+    <div class="secret-row">
+      <code id="{{ id_prefix }}-api-key">{{ raw_key }}</code>
+      <button
+        class="btn secret-copy-btn"
+        type="button"
+        data-copy-secret="{{ id_prefix }}-api-key"
+        aria-describedby="{{ id_prefix }}-api-key-copy-status"
+        aria-label="Copy API key"
+      >Copy</button>
+    </div>
+    <p class="copy-status" id="{{ id_prefix }}-api-key-copy-status" role="status" aria-live="polite"></p>
+    {% if workspace_name %}
+    <div class="signup-foot signup-foot-flush">Workspace <span class="mono">{{ workspace_name }}</span></div>
+    {% endif %}
+  </div>
 </div>
 {% endmacro %}

--- a/src/trusted_router/templates/console/welcome.html
+++ b/src/trusted_router/templates/console/welcome.html
@@ -23,6 +23,11 @@
       <span class="pill warn">one time reveal</span>
     </div>
     <div class="panel-body">
+      <div class="activation-code-panel activation-onboarding-agent">
+        <div class="activation-code-head"><strong>Paste this short message into a Claude Code, Codex, or your favorite agent chat.</strong><button class="btn" type="button" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key" aria-describedby="welcome-agent-copy-status">Copy message</button></div>
+        <pre id="welcome-agent-message" data-copy-lines>{{ agent_chat_prompt(revealed_key) }}</pre>
+        <p class="copy-status" id="welcome-agent-copy-status" role="status" aria-live="polite"></p>
+      </div>
       {{ api_key_reveal(revealed_key, "welcome", workspace_name, False) }}
       <p class="activation-security-note">This one-time reveal contains the complete key. TrustedRouter stores its salted hash.</p>
     </div>
@@ -96,19 +101,12 @@
     </div>
     <div class="panel-body">
       <div class="activation-tabs" role="tablist" aria-label="Setup method">
-        <button class="activation-tab" id="setup-agent-tab" type="button" role="tab" aria-selected="true" aria-controls="setup-agent" data-setup-tab="setup-agent">Claude Code / Codex / agent</button>
-        <button class="activation-tab" id="setup-python-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-python" tabindex="-1" data-setup-tab="setup-python">Python</button>
+        <button class="activation-tab" id="setup-python-tab" type="button" role="tab" aria-selected="true" aria-controls="setup-python" data-setup-tab="setup-python">Python</button>
         <button class="activation-tab" id="setup-js-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-js" tabindex="-1" data-setup-tab="setup-js">JavaScript</button>
         <button class="activation-tab" id="setup-curl-tab" type="button" role="tab" aria-selected="false" aria-controls="setup-curl" tabindex="-1" data-setup-tab="setup-curl">curl</button>
       </div>
 
-      <div class="activation-code-panel" id="setup-agent" role="tabpanel" aria-labelledby="setup-agent-tab" data-setup-panel>
-        <div class="activation-code-head"><strong>Paste this short message into a Claude Code, Codex, or your favorite agent chat.</strong><button class="btn" type="button" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key" aria-describedby="welcome-agent-copy-status">Copy message</button></div>
-        <pre id="welcome-agent-message" data-copy-lines>{{ agent_chat_prompt(revealed_key) }}</pre>
-        <p class="copy-status" id="welcome-agent-copy-status" role="status" aria-live="polite"></p>
-      </div>
-
-      <div class="activation-code-panel" id="setup-python" role="tabpanel" aria-labelledby="setup-python-tab" data-setup-panel hidden>
+      <div class="activation-code-panel" id="setup-python" role="tabpanel" aria-labelledby="setup-python-tab" data-setup-panel>
         <div class="activation-code-head"><strong>OpenAI Python SDK</strong><button class="btn" type="button" data-copy-template-target="welcome-python-code" data-secret-source="welcome-api-key" aria-describedby="welcome-python-copy-status">Copy code</button></div>
         <pre id="welcome-python-code">from openai import OpenAI
 

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -181,12 +181,16 @@ test("new API key quickstart stays inside its reveal panel", async ({ page }) =>
                           <h3>Paste this short message into a Claude Code, Codex, or your favorite agent chat.</h3>
                           <div class="agent-message-row">
                             <div class="agent-message" id="layout-agent-message" data-copy-lines>
-                            <span class="agent-prompt-line">Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?" and stream the answer into this chat as it arrives.</span>
+                            <span class="agent-prompt-line">Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?"</span>
                             <span class="agent-prompt-line">TrustedRouter API key: sk-tr-v1-layout-regression-key</span>
                             </div>
                             <button class="btn secret-copy-btn" type="button" data-copy-secret="layout-agent-message" aria-label="Copy complete agent message">Copy</button>
                           </div>
                         </section>
+                        <div class="key-reveal-section">
+                          <div class="signup-reveal-head">Your TrustedRouter API key</div>
+                          <div class="secret-row"><code id="layout-api-key">sk-tr-v1-layout-regression-key</code><button class="btn secret-copy-btn" type="button" data-copy-secret="layout-api-key">Copy</button></div>
+                        </div>
                       </div>
                     </div>
                   </section>
@@ -202,10 +206,18 @@ test("new API key quickstart stays inside its reveal panel", async ({ page }) =>
   const reveal = page.locator(".console-key-reveal");
   const heading = reveal.locator(".agent-quickstart h3");
   const message = reveal.locator(".agent-message");
+  const directKey = reveal.locator("#layout-api-key");
   await expect(heading).toBeVisible();
-  await expect(message).toContainText("stream the answer into this chat as it arrives");
+  await expect(message).toContainText('ask DeepSeek: "What is the capital of France?"');
+  await expect(message).not.toContainText("stream the answer into this chat as it arrives");
   await expect(message).not.toContainText("Paste this short message");
   await expect(message).not.toContainText("Keep this agent's settings");
+  await expect(directKey).toBeVisible();
+  expect(await reveal.evaluate((element) => {
+    const agentMessage = element.querySelector(".agent-message");
+    const key = element.querySelector("#layout-api-key");
+    return Boolean(agentMessage.compareDocumentPosition(key) & Node.DOCUMENT_POSITION_FOLLOWING);
+  })).toBe(true);
 
   const assertContained = async () => {
     const layout = await reveal.evaluate((element) => {
@@ -241,7 +253,7 @@ test("new API key quickstart stays inside its reveal panel", async ({ page }) =>
   await copyButton.click();
   const copiedAgentMessage = await page.evaluate(() => navigator.clipboard.readText());
   expect(copiedAgentMessage).not.toContain("Paste this short message");
-  expect(copiedAgentMessage).toContain("stream the answer into this chat as it arrives");
+  expect(copiedAgentMessage).not.toContain("stream the answer into this chat as it arrives");
   expect(copiedAgentMessage).not.toContain("Keep this agent's settings");
   expect(copiedAgentMessage).not.toContain("Use it in memory for this request");
   expect(copiedAgentMessage).not.toContain("stream=true");
@@ -303,13 +315,13 @@ test("first-call activation runs live request and copies agent chat prompt", asy
         </head><body class="console"><main class="console-main"><div class="console-page-body">
           <div class="activation-flow" data-first-call-flow data-endpoint="/chat-proxy/v1/chat/completions" data-key-source="welcome-api-key">
             <ol class="activation-progress"><li class="complete"><span>1</span><strong>Account</strong></li><li class="current"><span>2</span><strong>First call</strong></li><li><span>3</span><strong>Connect app</strong></li></ol>
-            <section class="panel activation-key-panel"><div class="panel-head"><h2>Save it now</h2></div><div class="panel-body"><div class="secret-row"><code id="welcome-api-key">${apiKey}</code><button class="btn" data-copy-secret="welcome-api-key">Copy</button></div></div></section>
+            <section class="panel activation-key-panel"><div class="panel-head"><h2>Save it now</h2></div><div class="panel-body"><div class="activation-code-panel activation-onboarding-agent"><div class="activation-code-head"><strong>Paste this short message into a Claude Code, Codex, or your favorite agent chat.</strong><button class="btn" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key">Copy message</button></div><pre id="welcome-agent-message" data-copy-lines><span>Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?"</span><span>TrustedRouter API key: ${apiKey}</span></pre></div><div class="secret-row"><code id="welcome-api-key">${apiKey}</code><button class="btn" data-copy-secret="welcome-api-key">Copy</button></div></div></section>
             <section class="panel activation-test-panel"><div class="panel-head activation-panel-head"><div><p class="activation-eyebrow">Live gateway check</p><h2>Run your first API request</h2><p class="panel-kicker">A real, inexpensive PONG request confirms the route.</p></div><span class="activation-step-number">02</span></div><div class="panel-body">
               <button class="btn primary activation-run-button" type="button" data-action="run-first-call"><span data-run-label>Run my first API request</span><span class="activation-button-arrow">&#8594;</span></button>
               <div class="activation-call-error" data-call-error hidden><strong data-call-error-title></strong><p data-call-error-message></p><a data-call-error-action hidden></a></div>
               <div class="activation-call-result" data-call-result hidden><div class="activation-result-head"><div><span class="activation-success-mark">&#10003;</span><div><strong>Production request passed</strong><p>Your key is ready.</p></div></div><code data-result-output></code></div><dl class="activation-result-grid"><div><dt>Model</dt><dd data-result-model></dd></div><div><dt>Provider</dt><dd data-result-provider></dd></div><div><dt>Latency</dt><dd data-result-latency></dd></div><div><dt>Exact cost</dt><dd data-result-cost></dd></div></dl><div data-success-actions></div></div>
             </div></section>
-            <section class="panel activation-setup-panel"><div class="panel-body"><div class="activation-tabs" role="tablist"><button class="activation-tab" role="tab" aria-selected="true" data-setup-tab="setup-agent">Claude Code / Codex / agent</button><button class="activation-tab" role="tab" aria-selected="false" data-setup-tab="setup-python">Python</button></div><div class="activation-code-panel" id="setup-agent" data-setup-panel><div class="activation-code-head"><strong>Paste this short message into a Claude Code, Codex, or your favorite agent chat.</strong><button class="btn" data-copy-template-target="welcome-agent-message" data-secret-source="welcome-api-key">Copy message</button></div><pre id="welcome-agent-message" data-copy-lines><span>Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?" and stream the answer into this chat as it arrives.</span><span>TrustedRouter API key: ${apiKey}</span></pre></div><div class="activation-code-panel" id="setup-python" data-setup-panel hidden><pre>Python setup</pre></div></div></section>
+            <section class="panel activation-setup-panel"><div class="panel-body"><div class="activation-tabs" role="tablist"><button class="activation-tab" role="tab" aria-selected="true" data-setup-tab="setup-python">Python</button></div><div class="activation-code-panel" id="setup-python" data-setup-panel><pre>Python setup</pre></div></div></section>
           </div>
         </div></main></body></html>`,
     });
@@ -333,7 +345,7 @@ test("first-call activation runs live request and copies agent chat prompt", asy
 
   await page.getByRole("button", { name: "Copy message" }).click();
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(
-    `Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?" and stream the answer into this chat as it arrives.\n\nTrustedRouter API key: ${apiKey}`,
+    `Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital of France?"\n\nTrustedRouter API key: ${apiKey}`,
   );
   await page.getByRole("tab", { name: "Python" }).click();
   await expect(page.locator("#setup-python")).toBeVisible();

--- a/tests/test_claude_code_landing.py
+++ b/tests/test_claude_code_landing.py
@@ -48,7 +48,7 @@ def test_vibe_coders_landing_is_indexed_and_claude_alias_redirects(
     assert alias.headers["location"] == "/vibe-coders"
 
 
-def test_api_key_reveal_builds_a_streaming_agent_chat_message_without_reconfiguration(
+def test_api_key_reveal_leads_with_a_complete_agent_chat_message(
     client: TestClient,
 ) -> None:
     user = STORE.ensure_user("claude-code-landing@example.com")
@@ -72,11 +72,14 @@ def test_api_key_reveal_builds_a_streaming_agent_chat_message_without_reconfigur
     )
     assert (
         'Use TrustedRouter.com with the key below to ask DeepSeek: "What is the capital '
-        'of France?" and stream the answer into this chat as it arrives.'
+        'of France?"'
         in response.text
     )
+    assert response.text.index("Paste this short message") < response.text.index(
+        "Your TrustedRouter API key"
+    )
     assert "Call https://api.trustedrouter.com/v1" not in response.text
-    assert "stream the answer into this chat as it arrives" in response.text
+    assert "stream the answer into this chat as it arrives" not in response.text
     assert "Keep this agent's model" not in response.text
     assert "Use it in memory for this request" not in response.text
     assert "stream=true" not in response.text

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -882,9 +882,12 @@ def test_console_welcome_reveals_raw_key_from_pending_reveal_cookie(
     assert agent_message is not None
     assert fake_raw_key in agent_message.group(0)
     assert "YOUR_TRUSTEDROUTER_API_KEY" not in agent_message.group(0)
+    assert resp.text.index('id="welcome-agent-message"') < resp.text.index(
+        'id="welcome-api-key"'
+    )
     assert "Run my first API request" in resp.text
     assert 'data-endpoint="/chat-proxy/v1/chat/completions"' in resp.text
-    assert "Claude Code / Codex" in resp.text
+    assert "Claude Code, Codex" in resp.text
     assert "Python" in resp.text
     assert "JavaScript" in resp.text
     assert "curl" in resp.text
@@ -970,7 +973,10 @@ def test_console_create_api_key_form_repeats_raw_key_in_agent_message(
         in resp.text
     )
     assert "Paste this short message" not in agent_message.group(0)
-    assert "stream the answer into this chat as it arrives" in resp.text
+    assert resp.text.index('id="created-agent-message"') < resp.text.index(
+        'id="created-api-key"'
+    )
+    assert "stream the answer into this chat as it arrives" not in resp.text
     assert "Keep this agent's model" not in resp.text
     assert "Use it in memory for this request" not in resp.text
     assert "stream=true" not in resp.text


### PR DESCRIPTION
## Summary
- show the complete copyable Claude Code, Codex, or agent message before the standalone API key
- remove the request to stream the answer into the chat
- avoid duplicating the agent message later in onboarding and default developer setup to Python
- preserve the one-time raw-key reveal and clipboard substitution behavior

## Verification
- 75 relevant Python tests pass
- all 19 dashboard Playwright tests pass, including mobile layout
- Stylelint, ESLint, Ruff, and git diff checks pass