### PR TITLE
Add exact-intent Google Search landing pages

### DIFF
--- a/docs/marketing/google-exact-intent-search-2026-08-09.md
+++ b/docs/marketing/google-exact-intent-search-2026-08-09.md
@@ -1,0 +1,211 @@
+# Google exact-intent search campaigns: August 2026
+
+## Objective
+
+Separate four distinct buyer intents so the keyword, ad promise, landing page,
+and first-party conversion record all describe the same job. Optimize from
+TrustedRouter's metadata-only funnel, with `first_successful_api_call` as the
+primary event and paid workspace plus seven-day retained use as confirmation.
+
+The launch budget remains $300 per day in total. Create the four campaigns in a
+paused state, pause the superseded broad campaign, then enable these budgets:
+
+| Campaign | Daily budget | Landing page | First-party campaign ID |
+|---|---:|---|---|
+| Search · OpenRouter Migration · 2026-08-09 | $90 | `/openrouter-alternative` | `exact_openrouter_migration_20260809` |
+| Search · Private LLM API · 2026-08-09 | $90 | `/private-llm-api` | `exact_private_llm_20260809` |
+| Search · Provider Failover · 2026-08-09 | $90 | `/llm-failover` | `exact_provider_failover_20260809` |
+| Search · Hot Model APIs · 2026-08-09 | $30 | `/latest-model-apis` | `exact_hot_models_20260809` |
+
+The hot-model budget stays smallest because the previous Kimi creative produced
+signups but no first successful API calls after substantial spend.
+
+## Shared controls
+
+- Search only, United States, English.
+- Exact and phrase match only. Search partners and Display expansion off.
+- Manual CPC or Maximize Clicks with a $5 initial CPC ceiling.
+- One responsive search ad per campaign for the first controlled round.
+- No Google behavioral tag or customer-data upload. Attribution remains
+  first-party and metadata-only.
+- Final URL parameters:
+
+```text
+utm_source=google&utm_medium=paid_search&utm_campaign=<campaign_id>&utm_content=rsa1&utm_term={keyword}
+```
+
+- Shared negatives: `jobs`, `career`, `salary`, `course`, `tutorial`, `torrent`,
+  `download weights`, `huggingface download`, `jailbreak`, `crack`, `free account`,
+  and `consumer chat`.
+
+## OpenRouter migration
+
+Keywords:
+
+```text
+[openrouter alternative]
+"openrouter alternative"
+[openrouter migration]
+"switch from openrouter"
+[openrouter api alternative]
+"openrouter pricing alternative"
+```
+
+Headlines:
+
+```text
+Switch From OpenRouter
+OpenRouter Alternative
+Keep Your OpenAI SDK
+Change One Base URL
+5% Platform Fee
+No Subscription Required
+No Prompt Or Output Logs
+Automatic Provider Failover
+Open Source AI Router
+Privacy With Proof
+Hundreds Of Models
+Start In Minutes
+```
+
+Descriptions:
+
+```text
+Keep your SDK and model IDs. Change one base URL to migrate from OpenRouter.
+Route hundreds of models through an attested open source gateway with zero content logs.
+Automatic provider failover, a 5% fee, prepaid credits, and BYOK. No subscription.
+Create a key, use your existing code, and run the first request with starter credit.
+```
+
+## Private LLM API
+
+Keywords:
+
+```text
+[private llm api]
+"private llm api"
+[secure llm api]
+"confidential ai api"
+[zero retention llm api]
+"zdr llm api"
+[no log llm api]
+```
+
+Headlines:
+
+```text
+Private LLM API
+Privacy With Proof
+No Prompt Or Output Logs
+Attested AI Gateway
+Open Source Prompt Path
+ZDR And TEE Routes
+Secure Multi Model API
+Claude GPT Gemini And More
+Built For Sensitive Data
+Verify The Running Code
+Keep Content Out Of Logs
+Start Without A Card
+```
+
+Descriptions:
+
+```text
+Route sensitive AI workloads through an attested gateway with no prompt or output logs.
+Choose routes by upstream ZDR, verified TEE status, region, model, price, and speed.
+Use one OpenAI-compatible API for Claude, GPT, Gemini, DeepSeek, Kimi, and more.
+Open source prompt path, published image digest, live attestation, clear provider labels.
+```
+
+## Provider failover
+
+Keywords:
+
+```text
+[llm failover]
+"llm provider failover"
+[ai api failover]
+"multi provider llm api"
+[llm redundancy]
+"openai api failover"
+"anthropic api failover"
+```
+
+Headlines:
+
+```text
+LLM Provider Failover
+Automatic Model Rollover
+Keep Serving Through Outages
+Multi Provider LLM API
+Built In Retries And Routing
+One API Multiple Providers
+Reduce LLM Provider Risk
+OpenAI Compatible Gateway
+Live Provider Benchmarks
+Route Around 429s And 5xx
+Hundreds Of Model Routes
+Test Failover In Minutes
+```
+
+Descriptions:
+
+```text
+Retry eligible provider failures on another authorized route without changing application code.
+Keep one OpenAI-compatible endpoint while TrustedRouter handles selection and rollover.
+Compare measured latency and health before an outage forces you to choose another route.
+Use exact models or trustedrouter/auto with transparent route metadata and integer billing.
+```
+
+## Hot model APIs
+
+Keywords:
+
+```text
+[kimi k3 api]
+"kimi k3 api"
+[glm 5.2 api]
+"glm-5.2 api"
+[deepseek v4 api]
+"deepseek v4 flash api"
+[gemini 3.6 flash api]
+"gemini 3.6 api"
+```
+
+Headlines:
+
+```text
+Kimi K3 API
+GLM 5.2 API
+DeepSeek V4 API
+Gemini 3.6 Flash API
+One API For Every Model
+Try New Models In Minutes
+Compare Cost And Speed
+No Separate Provider Accounts
+OpenAI Compatible API
+Provider Fallback Included
+Privacy Labels Per Route
+Hundreds Of Current Models
+```
+
+Descriptions:
+
+```text
+Call Kimi K3, GLM 5.2, DeepSeek V4, and Gemini 3.6 Flash with one API key.
+Keep the OpenAI SDK. Change the model string and compare results on your own prompts.
+See providers, prices, context, privacy labels, latency, and health before you ship.
+Use prepaid credits or BYOK. TrustedRouter keeps no prompt or output logs, always.
+```
+
+## Decision rules
+
+- Do not choose winners from CTR alone.
+- Review direction after 50 engaged landings per campaign.
+- Pause after 100 engaged landings with zero first successful API calls.
+- Scale only after at least three activated users and a better activated-user
+  rate than the prior high-intent baseline.
+- Break ties by payer rate, retained use, activation rate, then cost per engaged
+  landing.
+- Review search terms twice in the first week and add negatives before raising
+  any budget.

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -125,6 +125,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/aws-bedrock-alternative",
     "/llm-document-processing",
     "/gpt-oss-120b-api",
+    "/latest-model-apis",
     "/eu-ai-act-llm-compliance",
     "/x402-llm-api",
     "/",
@@ -1090,6 +1091,32 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         description=(
             "A private LLM API where privacy is cryptographically verifiable. "
             "Route to Claude, GPT, Gemini, DeepSeek through an attested gateway."
+        ),
+    ),
+    "latest-model-apis": PublicPage(
+        template="public/seo_latest_model_apis.html",
+        title="Latest AI Model APIs: Kimi K3, GLM 5.2, DeepSeek V4",
+        description=(
+            "Call Kimi K3, GLM 5.2, DeepSeek V4, and Gemini 3.6 Flash through "
+            "one OpenAI-compatible API with published pricing, privacy labels, and fallback."
+        ),
+        faq_items=(
+            (
+                "Which new AI models are available through TrustedRouter?",
+                "Current highlighted routes include Kimi K3, GLM 5.2, DeepSeek V4 Pro and Flash, and Gemini 3.6 Flash. The live models catalog is the source of truth and lists hundreds of additional routes, their providers, context limits, prices, and privacy posture.",
+            ),
+            (
+                "Do I need a separate account for every model provider?",
+                "No. Prepaid TrustedRouter credits provide one key and one OpenAI-compatible base URL across supported providers. Bring-your-own provider keys are also available when you prefer to keep a direct provider relationship.",
+            ),
+            (
+                "Can I switch models without changing SDKs?",
+                "Yes. Keep the OpenAI SDK and TrustedRouter base URL, then change only the model string. The same key can call Kimi K3, GLM 5.2, DeepSeek V4, Gemini 3.6 Flash, and the rest of the live catalog.",
+            ),
+            (
+                "Does every model route have the same privacy guarantee?",
+                "No. TrustedRouter itself keeps no prompt or output logs, always, while upstream provider behavior differs. Every route publishes its provider, Zero-Data-Retention status, and verified confidential-compute status so you can choose deliberately.",
+            ),
         ),
     ),
     "hipaa-llm-api": PublicPage(

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -789,6 +789,10 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def seo_gpt_oss_120b_api() -> str:
         return public_page_html(settings, "gpt-oss-120b-api")
 
+    @public_html_route("/latest-model-apis")
+    async def seo_latest_model_apis() -> str:
+        return public_page_html(settings, "latest-model-apis")
+
     @public_html_route("/eu-ai-act-llm-compliance")
     async def seo_eu_ai_act_llm_compliance() -> str:
         return public_page_html(settings, "eu-ai-act-llm-compliance")

--- a/src/trusted_router/templates/public/resources.html
+++ b/src/trusted_router/templates/public/resources.html
@@ -47,6 +47,7 @@
     <div class="panel-head"><h2>Model APIs</h2></div>
     <div class="panel-body">
       <ul class="link-list">
+        <li><a href="/latest-model-apis">Latest model APIs</a><span>Kimi K3, GLM 5.2, DeepSeek V4, and Gemini 3.6 Flash</span></li>
         <li><a href="/glm-5-api">GLM 5 API</a><span>Routes, privacy, and migration</span></li>
         <li><a href="/gpt-oss-120b-api">gpt-oss-120b API</a><span>Fast open weight inference</span></li>
         <li><a href="/minimax-m3-api">MiniMax M3 API</a><span>Current routes and context</span></li>

--- a/src/trusted_router/templates/public/seo_latest_model_apis.html
+++ b/src/trusted_router/templates/public/seo_latest_model_apis.html
@@ -1,0 +1,81 @@
+{% extends "public/_base.html" %}
+{% block body %}
+
+<section class="marketing-split" aria-label="Latest AI model APIs">
+  <div class="marketing-copy">
+    <span class="eyebrow">New model APIs</span>
+    <h2>Try the models developers are evaluating now.</h2>
+    <p>Kimi K3, GLM 5.2, DeepSeek V4, and Gemini 3.6 Flash share one OpenAI-compatible endpoint. Create one key, keep one SDK, and compare them on your own prompts.</p>
+    <p><button class="btn primary" type="button" data-action="open-signin">Create key and run a model</button> <a class="btn" href="/choose">Compare the catalog</a></p>
+    <p class="microcopy">New email signups receive starter credit. No card required.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Switch the model string</span><span>OpenAI SDK</span></div>
+    <pre><code>from openai import OpenAI
+
+client = OpenAI(
+    base_url="{{ api_base_url }}",
+    api_key="sk-tr-v1-...",
+)
+
+response = client.chat.completions.create(
+    model="moonshotai/kimi-k3",
+    messages=[{"role": "user", "content": "Test this task"}],
+)
+
+# Try z-ai/glm-5.2 or deepseek/deepseek-v4-pro next.</code></pre>
+  </div>
+</section>
+
+<section class="marketing-grid four" aria-label="Highlighted new models">
+  <a class="marketing-card card-as-link" id="kimi-k3" href="/models/moonshotai/kimi-k3">
+    <span class="card-label">Kimi K3</span>
+    <h3>Long-context reasoning</h3>
+    <p>Compare every currently available Kimi K3 provider route, price, privacy label, and live performance.</p>
+    <span class="card-link">Open Kimi K3 <span aria-hidden="true">→</span></span>
+  </a>
+  <a class="marketing-card card-as-link" id="glm-5-2" href="/models/z-ai/glm-5.2">
+    <span class="card-label">GLM 5.2</span>
+    <h3>Open-weight frontier route</h3>
+    <p>Call GLM 5.2 through several providers and choose a route by cost, speed, region, or privacy.</p>
+    <span class="card-link">Open GLM 5.2 <span aria-hidden="true">→</span></span>
+  </a>
+  <a class="marketing-card card-as-link" id="deepseek-v4" href="/models/deepseek/deepseek-v4-pro">
+    <span class="card-label">DeepSeek V4</span>
+    <h3>Cost-efficient reasoning</h3>
+    <p>Use V4 Pro for quality or compare the Flash routes when throughput and price matter more.</p>
+    <span class="card-link">Open DeepSeek V4 <span aria-hidden="true">→</span></span>
+  </a>
+  <a class="marketing-card card-as-link" id="gemini-3-6-flash" href="/models/google/gemini-3.6-flash">
+    <span class="card-label">Gemini 3.6 Flash</span>
+    <h3>Fast multimodal work</h3>
+    <p>Compare Google AI Studio and Vertex routes without changing your application integration.</p>
+    <span class="card-link">Open Gemini 3.6 Flash <span aria-hidden="true">→</span></span>
+  </a>
+</section>
+
+<section class="quote-feature">
+  <div>
+    <span class="eyebrow">One integration</span>
+    <h2>Evaluate on your task, then ship the winner.</h2>
+  </div>
+  <div>
+    <p><strong>Same request shape.</strong> Keep one OpenAI-compatible client and switch the model ID instead of maintaining separate provider SDKs.</p>
+    <p><strong>Route evidence.</strong> Model pages publish providers, pricing, context, measured performance, retention posture, and verified confidential-compute status.</p>
+    <p><strong>Provider rollover.</strong> Models served by multiple providers can move to a healthy authorized route when the first provider returns a retryable failure.</p>
+    <p><strong>Privacy with proof.</strong> TrustedRouter keeps no prompt or output logs, always. Upstream guarantees differ and remain explicit on every route.</p>
+  </div>
+</section>
+
+<section class="cta-band" aria-label="Try a new model API">
+  <div>
+    <strong>One key. Hundreds of models.</strong>
+    <span>Run Kimi K3, GLM 5.2, DeepSeek V4, or Gemini 3.6 Flash with the SDK you already use.</span>
+  </div>
+  <div class="cta-band-actions">
+    <button class="btn primary" type="button" data-action="open-signin">Create my API key</button>
+  </div>
+  <span class="microcopy">No card required.</span>
+</section>
+
+{% endblock %}

--- a/src/trusted_router/templates/public/seo_llm_failover.html
+++ b/src/trusted_router/templates/public/seo_llm_failover.html
@@ -6,7 +6,8 @@
     <h2>Your uptime should not depend on one provider's status page.</h2>
     <p>TrustedRouter is an OpenAI-compatible API with automatic LLM failover built in. When a provider goes down, requests roll over to a healthy route. No code change, no config push, no incident channel at 3 a.m. Your users keep getting answers.</p>
     <p>One key fronts 220+ model routes across 30+ providers: Claude, GPT, Gemini, DeepSeek, Kimi, Qwen, GLM, Llama, Mistral, and more. Pin an exact model, or send traffic to <code>trustedrouter/auto</code> and let the gateway pick the best fit per request. Migration is a one-line change: point <code>base_url</code> at <code>{{ api_base_url }}</code> and keep your SDK, your model ids, and your code.</p>
-    <p><a class="btn primary" href="/choose">Browse 220+ routes</a> <a class="btn" href="/llm-provider-latency-benchmarks">See measured latency</a></p>
+    <p><button class="btn primary" type="button" data-action="open-signin">Create key and test failover</button> <a class="btn" href="/choose">Browse routes</a> <a class="btn" href="/llm-provider-latency-benchmarks">See measured latency</a></p>
+    <p class="microcopy">New email signups receive starter credit. No card required.</p>
   </div>
   <div class="copy-terminal">
     <div class="code-head"><span>failover.py</span><span>Python</span></div>

--- a/src/trusted_router/templates/public/seo_private_llm_api.html
+++ b/src/trusted_router/templates/public/seo_private_llm_api.html
@@ -8,9 +8,11 @@
     <p>Every hosted LLM provider claims privacy. Almost none of them give you a way to verify it.</p>
     <p>TrustedRouter routes to every major model — Claude, GPT, Gemini, DeepSeek, Kimi, Llama, Mistral — through a hardware-attested gateway. The code is open source. The image is hashed. You can check what runs.</p>
     <p>
-      <a class="btn primary" href="/chat">Try the playground</a>
+      <button class="btn primary" type="button" data-action="open-signin">Create key and test privately</button>
+      <a class="btn" href="/chat">Try the playground</a>
       <a class="btn" href="/security">Trust surface</a>
     </p>
+    <p class="microcopy">New email signups receive starter credit. No card required.</p>
   </div>
   <div class="copy-terminal">
     <div class="code-head"><span>Standard call</span><span>OpenAI SDK</span></div>

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -126,6 +126,39 @@ def test_paid_landing_sets_signed_httponly_cookie(client: TestClient) -> None:
     assert "twclid" not in context.last_touch
 
 
+@pytest.mark.parametrize(
+    ("path", "campaign"),
+    [
+        ("/openrouter-alternative", "exact_openrouter_migration_20260809"),
+        ("/private-llm-api", "exact_private_llm_20260809"),
+        ("/llm-failover", "exact_provider_failover_20260809"),
+        ("/latest-model-apis", "exact_hot_models_20260809"),
+    ],
+)
+def test_exact_intent_landings_keep_distinct_first_party_attribution(
+    client: TestClient,
+    path: str,
+    campaign: str,
+) -> None:
+    response = client.get(
+        f"{path}?utm_source=google&utm_medium=paid_search"
+        f"&utm_campaign={campaign}&utm_content=rsa1&gclid=click-{campaign}"
+    )
+
+    assert response.status_code == 200
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert context.last_touch["utm_source"] == "google"
+    assert context.last_touch["utm_medium"] == "paid_search"
+    assert context.last_touch["utm_campaign"] == campaign
+    assert context.last_touch["utm_content"] == "rsa1"
+    assert context.last_touch["landing_path"] == path
+    assert context.last_touch["gclid_fingerprint"]
+    assert "gclid" not in context.last_touch
+
+
 def test_first_touch_is_preserved_and_last_touch_updates(client: TestClient) -> None:
     first = client.get("/?utm_source=x&utm_campaign=first&twclid=tw-first")
     assert first.status_code == 200

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -918,6 +918,7 @@ def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> 
         "/llm-data-residency",
         "/llm-document-processing",
         "/llm-failover",
+        "/latest-model-apis",
         "/minimax-m3-api",
         "/portkey-alternative",
         "/private-llm-api",
@@ -934,6 +935,55 @@ def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> 
     assert 'href="/resources"' in footer.text
     assert 'href="/customers/robot-robot-human"' in footer.text
     assert 'href="/careers"' in footer.text
+
+
+def test_exact_intent_search_landings_are_message_matched(client: TestClient) -> None:
+    cases = {
+        "/openrouter-alternative": (
+            "Switch from OpenRouter in one base URL.",
+            "Create my API key",
+        ),
+        "/private-llm-api": (
+            'A private LLM API where "private" means cryptographically verified.',
+            "Create key and test privately",
+        ),
+        "/llm-failover": (
+            "Your uptime should not depend on one provider's status page.",
+            "Create key and test failover",
+        ),
+        "/latest-model-apis": (
+            "Try the models developers are evaluating now.",
+            "Create key and run a model",
+        ),
+    }
+
+    for path, expected in cases.items():
+        response = client.get(
+            f"{path}?utm_source=google&utm_medium=paid_search"
+            "&utm_campaign=exact_intent_test&utm_content=rsa1"
+        )
+        assert response.status_code == 200, path
+        for text in expected:
+            assert text in response.text, (path, text)
+        assert 'data-action="open-signin"' in response.text
+        assert f'<link rel="canonical" href="https://trustedrouter.com{path}">' in response.text
+        assert "utm_campaign" not in response.text
+
+
+def test_latest_model_api_landing_links_current_catalog_routes(client: TestClient) -> None:
+    response = client.get("/latest-model-apis")
+
+    assert response.status_code == 200
+    assert 'href="/models/moonshotai/kimi-k3"' in response.text
+    assert 'href="/models/z-ai/glm-5.2"' in response.text
+    assert 'href="/models/deepseek/deepseek-v4-pro"' in response.text
+    assert 'href="/models/google/gemini-3.6-flash"' in response.text
+    assert "No card required." in response.text
+    assert "Upstream guarantees differ" in response.text
+
+    sitemap = client.get("/sitemap-core.xml")
+    assert sitemap.status_code == 200
+    assert "https://trustedrouter.com/latest-model-apis" in sitemap.text
 
 
 def test_retired_model_pages_redirect_to_current_catalog_entries(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add a current-model API landing page for Kimi K3, GLM 5.2, DeepSeek V4, and Gemini 3.6 Flash
- tighten private-API and provider-failover landing CTAs around first-request activation
- add distinct first-party attribution coverage and a four-campaign Google Search launch spec

## Budget
Keeps total Google Search spend at /day:  migration,  private API,  failover,  hot models.

## Verification
- 81 focused tests pass
- ruff passes
- mypy passes
- desktop and mobile browser QA passes