### PR TITLE
synthetic: Model Inference visibility + monitor self-funding + Sentry streak alerts

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -681,6 +681,11 @@ class Settings(BaseSettings):
     # /responses probe in europe-west4 can legitimately take >10s on slow
     # cheap monitor routes, so 10s creates false downtime.
     synthetic_monitor_timeout_seconds: float = 20.0
+    # Monthly self-funding for the monitor workspace, applied lazily on its
+    # own gateway-authorize path (synthetic/funding.py). Each deployment has
+    # its own database, so each cloud's monitor funds itself from config —
+    # no cron, no per-cloud manual grant to forget. 0 disables.
+    synthetic_monitor_monthly_grant_dollars: float = 200.0
     synthetic_status_sample_limit: int = 5000
     synthetic_status_raw_retention_days: int = 14
     synthetic_status_rollup_retention_months: int = 24

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -111,6 +111,7 @@ from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
 )
+from trusted_router.synthetic.funding import ensure_monitor_funding, monitor_lookup_hash
 from trusted_router.types import ErrorType, UsageType
 
 logger = logging.getLogger(__name__)
@@ -217,6 +218,14 @@ def _authorize_gateway_sync(
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
     assert_workspace_billing_active(workspace)
+    # The synthetic monitor funds itself: a monthly idempotent grant applied
+    # on its own authorize path, so a dry monitor self-heals on the next
+    # probe instead of failing 402 for days (invisible availability loss —
+    # the deep probes stop proving anything). One set-lookup for monitor
+    # traffic, zero cost for everyone else.
+    monitor_hash = monitor_lookup_hash(settings)
+    if monitor_hash is not None and body.api_key_lookup_hash == monitor_hash:
+        ensure_monitor_funding(STORE, settings, workspace.id)
     body_dict = body.model_dump(exclude_none=True)
     # Preserve pre-web-search idempotency fingerprints byte-for-byte for every
     # ordinary request. A nonzero hosted-tool reservation remains fingerprinted.
@@ -1488,8 +1497,7 @@ def _settle_gateway_authorization(
                 "provider": selected_endpoint.provider,
                 "estimated_microdollars": authorization.estimated_microdollars,
                 "actual_microdollars": actual_cost,
-                "overrun_microdollars": actual_cost
-                - authorization.estimated_microdollars,
+                "overrun_microdollars": actual_cost - authorization.estimated_microdollars,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
             },

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -17,6 +17,7 @@ from trusted_router.routes.helpers import json_body
 from trusted_router.routes.internal._shared import require_internal_gateway
 from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, scrub_provider_error_message
+from trusted_router.synthetic.alerts import alert_on_failure_streak
 from trusted_router.synthetic.cli import rotation_pass
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
@@ -105,10 +106,7 @@ async def _run_and_record(settings: Settings, body: dict[str, Any]) -> dict[str,
     }
 
 
-
-async def run_synthetic_pass(
-    settings: Settings, *, rotation_count: int = 0
-) -> dict[str, Any]:
+async def run_synthetic_pass(settings: Settings, *, rotation_count: int = 0) -> dict[str, Any]:
     """One synthetic pass, for callers that are not an HTTP request.
 
     The in-process scheduler (main.py) uses this so a cloud without its own
@@ -118,6 +116,7 @@ async def run_synthetic_pass(
     return await _run_and_record(
         settings, {"rotation_count": rotation_count} if rotation_count else {}
     )
+
 
 def register(router: APIRouter) -> None:
     @router.get("/internal/synthetic/health")
@@ -191,9 +190,13 @@ def register(router: APIRouter) -> None:
             return {"data": {"scheduled": True}}
         return await _run_and_record(settings, body)
 
+
 def _record_probe_samples(samples: list[SyntheticProbeSample]) -> None:
     for sample in samples:
         STORE.record_synthetic_probe_sample(sample)
+        # After recording, so the streak query sees this sample. Swallows its
+        # own exceptions — alerting must never break probe ingestion.
+        alert_on_failure_streak(STORE, sample)
 
 
 def _record_benchmark_samples(samples: list[ProviderBenchmarkSample]) -> None:
@@ -248,7 +251,9 @@ def _sample_from_body(body: Any) -> SyntheticProbeSample:
         try:
             created = dt.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
         except ValueError:
-            raise api_error(400, "created_at is not a valid timestamp", ErrorType.BAD_REQUEST) from None
+            raise api_error(
+                400, "created_at is not a valid timestamp", ErrorType.BAD_REQUEST
+            ) from None
         if created.tzinfo is None:
             created = created.replace(tzinfo=dt.UTC)
         skew = (created - dt.datetime.now(dt.UTC)).total_seconds()

--- a/src/trusted_router/synthetic/alerts.py
+++ b/src/trusted_router/synthetic/alerts.py
@@ -1,0 +1,79 @@
+"""Sentry alerting for synthetic probe failure streaks.
+
+A probe that fails once is noise; a probe that fails three times in a row is
+an outage of whatever that probe proves. Before this module, deep inference
+probes could fail for days with no page and no alert — the samples were
+recorded faithfully and surfaced nowhere (2026-08-10: every model probe on
+AWS and Azure was failing with 402 while both status pages showed green).
+
+Alerts fire exactly at the transition into a streak (the Nth consecutive
+failure) so a sustained outage produces one Sentry issue, not one event per
+probe cycle. The fingerprint groups by (probe_type, target), so each broken
+probe path is its own issue and re-opens if it regresses after recovery.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+STREAK_THRESHOLD = 3
+
+
+def alert_on_failure_streak(
+    store: Any,
+    sample: Any,
+    *,
+    threshold: int = STREAK_THRESHOLD,
+) -> bool:
+    """Capture a Sentry event when `sample` is the `threshold`-th consecutive
+    failure for its (probe_type, target). Returns True when an event fired.
+
+    Called after the sample is recorded, so the store query includes it.
+    """
+    if getattr(sample, "status", None) == "up":
+        return False
+    try:
+        recent = store.synthetic_probe_samples(
+            probe_type=sample.probe_type,
+            target=sample.target,
+            limit=threshold + 1,
+        )
+    except Exception:  # noqa: BLE001 - alerting must never break ingestion
+        logger.exception("synthetic alert streak query failed")
+        return False
+
+    # Newest first is the storage contract; tolerate oldest-first defensively.
+    ordered = sorted(recent, key=lambda s: s.created_at, reverse=True)
+    streak = 0
+    for row in ordered:
+        if row.status == "up":
+            break
+        streak += 1
+    # Fire only at the exact transition into the streak: the (threshold+1)-th
+    # failure and beyond stay silent until the probe recovers and breaks again.
+    if streak != threshold:
+        return False
+
+    message = (
+        f"synthetic probe down x{threshold}: {sample.probe_type} on {sample.target} "
+        f"(monitor_region={sample.monitor_region}, error={sample.error_type}, "
+        f"http_status={sample.http_status})"
+    )
+    logger.error(message)
+    try:
+        import sentry_sdk
+
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["synthetic-streak", sample.probe_type, sample.target]
+            scope.set_tag("probe_type", sample.probe_type)
+            scope.set_tag("target", sample.target)
+            scope.set_tag("monitor_region", sample.monitor_region or "unknown")
+            scope.set_tag("error_type", sample.error_type or "unknown")
+            sentry_sdk.capture_message(message, level="error")
+    except Exception:  # noqa: BLE001 - Sentry unavailable must not break ingestion
+        logger.exception("synthetic alert capture failed")
+        return False
+    return True

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -33,6 +33,13 @@ MONITOR_CONFIGURATION_ERROR_TYPES = frozenset(
         "monitor_workspace_paused",
     }
 )
+# Deep end-to-end model calls: a real OpenAI-SDK chat completion and a real
+# Responses round-trip, output-verified. These probes previously fed NO
+# component: they could fail 100% (as they did on AWS and Azure on
+# 2026-08-10, every pong failing with 402) while the page rendered green. A
+# probe that is recorded but surfaced nowhere is a signal that reports
+# success without measuring — this set is what makes the model path render.
+MODEL_INFERENCE_PROBES = {"openai_sdk_pong", "responses_pong"}
 
 COMPONENT_PROBES: dict[str, set[str]] = {
     "canonical_api": REGIONAL_GATEWAY_PROBES,
@@ -46,6 +53,7 @@ COMPONENT_PROBES: dict[str, set[str]] = {
     "billing_settlement": BILLING_PROBES,
     "provider_fallback": {"provider_fallback"},
     "image_generation": IMAGE_GENERATION_PROBES,
+    "model_inference": MODEL_INFERENCE_PROBES,
 }
 
 SLO_DEFINITIONS: tuple[dict[str, str], ...] = (
@@ -179,6 +187,14 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
         "name": "Image Generation",
         "description": "Public attested Gemini image generation and binary image validation.",
     },
+    {
+        "id": "model_inference",
+        "name": "Model Inference",
+        "description": (
+            "End-to-end model calls through the attested gateway: OpenAI SDK and "
+            "Responses round-trips with verified output."
+        ),
+    },
 )
 
 # Which probe target has to exist for a catalogue component to be
@@ -205,6 +221,11 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
     "billing_settlement": CONTROL_PLANE_TARGET,
     "provider_fallback": CONTROL_PLANE_TARGET,
     "image_generation": "canonical",
+    # Pongs only run against non-pinned targets holding the monitor's live
+    # API key (probes.py: `api_key and target.paid_probes and not
+    # target.connect_host`), which in practice is the canonical target every
+    # deployment configures.
+    "model_inference": "canonical",
 }
 
 # Components fed by a target PINNED to one region's endpoint
@@ -255,6 +276,10 @@ GATEWAY_REGION_TARGET_NAMES: frozenset[str] = frozenset(
 # schedules the job at all.
 COMPONENT_REQUIRED_CAPABILITIES: dict[str, Callable[[Settings], bool]] = {
     "image_generation": lambda settings: settings.synthetic_image_probe_enabled,
+    # Pongs are billable calls gated on the monitor key being configured; a
+    # deployment without one never samples the model path, so publishing the
+    # row there would be a permanent "unknown".
+    "model_inference": lambda settings: bool(settings.synthetic_monitor_api_key),
 }
 
 
@@ -339,10 +364,7 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("us_east4_regional_api")
     if sample.target == "europe-west4" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_regional_api")
-    if (
-        sample.target == "southamerica-east1"
-        and sample.probe_type in REGIONAL_GATEWAY_PROBES
-    ):
+    if sample.target == "southamerica-east1" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("sa_regional_api")
     if sample.target == "eu-west-1" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("eu_west_1_gateway")
@@ -370,6 +392,16 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("provider_fallback")
     if sample.target == "canonical" and sample.probe_type in IMAGE_GENERATION_PROBES:
         ids.append("image_generation")
+    # Any non-pinned target: each deployment's pongs prove that deployment's
+    # model path. Deliberately NOT part of the router_core SLO class — a pong
+    # failure can be a provider brownout, and the July scoping decision
+    # (provider-effective failures do not burn router availability) stands.
+    # Visibility is the component's job; the SLO math is unchanged.
+    if (
+        sample.probe_type in MODEL_INFERENCE_PROBES
+        and sample.target not in GATEWAY_REGION_TARGET_NAMES
+    ):
+        ids.append("model_inference")
     return ids
 
 
@@ -383,10 +415,7 @@ def is_router_origin_error(error_type: str | None) -> bool:
     """Return whether a benchmark failure happened before provider invocation."""
     return bool(
         error_type
-        and (
-            error_type in MONITOR_CONFIGURATION_ERROR_TYPES
-            or error_type.startswith("router_")
-        )
+        and (error_type in MONITOR_CONFIGURATION_ERROR_TYPES or error_type.startswith("router_"))
     )
 
 
@@ -412,12 +441,8 @@ def rollup_slo_class_ids(rollup: SyntheticRollup) -> list[str]:
 
 def _slo_class_ids(*, probe_type: str, target: str) -> list[str]:
     ids: list[str] = []
-    if (
-        (target == "canonical" and probe_type in REGIONAL_GATEWAY_PROBES)
-        or (
-            target == "control-plane"
-            and probe_type in BILLING_PROBES | {"provider_fallback"}
-        )
+    if (target == "canonical" and probe_type in REGIONAL_GATEWAY_PROBES) or (
+        target == "control-plane" and probe_type in BILLING_PROBES | {"provider_fallback"}
     ):
         ids.append("router_core")
     if probe_type in CONTROL_PLANE_PROBES:

--- a/src/trusted_router/synthetic/funding.py
+++ b/src/trusted_router/synthetic/funding.py
@@ -1,0 +1,89 @@
+"""Self-funding for the synthetic monitor workspace.
+
+Each deployment runs its own database, so the monitor workspace on each cloud
+must be funded on each cloud. When it runs dry the deep inference probes fail
+with 402 — and a monitor that cannot pay for a model call proves nothing about
+the model path. That is exactly how AWS and Azure served green status pages
+while every ``openai_sdk_pong``/``responses_pong`` probe failed (2026-08-10).
+
+The fix is a monthly, idempotent, config-as-code grant applied lazily on the
+monitor's own authorize calls: no cron, no per-cloud manual step, no way to
+forget a deployment. ``credit_workspace_typed_direct`` is idempotent per
+event id, so replays and racing processes cannot double-grant; the in-process
+marker only saves the ledger round-trip after the first check of the month.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from trusted_router.config import Settings
+from trusted_router.money import dollars_to_microdollars
+from trusted_router.security import lookup_hash_api_key
+
+logger = logging.getLogger(__name__)
+
+# (workspace_id, "YYYY-MM") pairs already ensured by THIS process. Purely a
+# round-trip saver: correctness comes from the ledger's per-event idempotency.
+_ENSURED: set[tuple[str, str]] = set()
+
+# Cache of lookup_hash(settings.synthetic_monitor_api_key) so the authorize
+# hot path never re-hashes for non-monitor traffic. Keyed by the raw setting
+# value so config changes (tests, rotation) invalidate naturally.
+_MONITOR_HASH: dict[str, str] = {}
+
+
+def monitor_lookup_hash(settings: Settings) -> str | None:
+    key = settings.synthetic_monitor_api_key
+    if not key:
+        return None
+    cached = _MONITOR_HASH.get(key)
+    if cached is None:
+        cached = lookup_hash_api_key(key)
+        _MONITOR_HASH[key] = cached
+    return cached
+
+
+def ensure_monitor_funding(
+    store: Any,
+    settings: Settings,
+    workspace_id: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Grant this month's monitor budget if it has not been granted yet.
+
+    Returns True only when a grant was actually applied. Safe to call on every
+    monitor authorize: after the first call of the month it is one set lookup.
+    """
+    dollars = settings.synthetic_monitor_monthly_grant_dollars
+    if dollars <= 0:
+        return False
+    month = (now or datetime.now(UTC)).strftime("%Y-%m")
+    marker = (workspace_id, month)
+    if marker in _ENSURED:
+        return False
+    # The event id carries the month, so each month is exactly one grant per
+    # workspace no matter how many processes race here.
+    event_id = f"synthetic-monitor-grant-{month}"
+    granted = bool(
+        store.credit_workspace_typed_direct(
+            workspace_id, dollars_to_microdollars(dollars), event_id
+        )
+    )
+    _ENSURED.add(marker)
+    if granted:
+        logger.info(
+            "synthetic monitor funded: workspace=%s month=%s amount_usd=%s",
+            workspace_id,
+            month,
+            dollars,
+        )
+    return granted
+
+
+def reset_for_tests() -> None:
+    _ENSURED.clear()
+    _MONITOR_HASH.clear()

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -163,12 +163,34 @@ def status_snapshot(
             ]
         ),
     )
+    # Model Inference also pulls the banner, but only as far as "degraded":
+    # on 2026-08-10 every pong probe on two deployments failed 100% while the
+    # banner read "All Systems Operational", because pong samples fed no
+    # component and no SLO. A dead model path must not render green — and it
+    # must not render "Router Core Outage" either, because router_core is
+    # passing; "Partial Outage: Model Inference" is what is actually true.
+    # The SLO math is untouched (pong failures still never burn router_core).
+    model_inference_down = any(
+        str(row["id"]) == "model_inference" and str(row["status"]) == "down" for row in components
+    )
+    if model_inference_down:
+        overall_status = _worse_status(overall_status, "degraded")
+    down_component_names = [
+        str(row["name"])
+        for row in components
+        if str(row["status"]) == "down"
+        and (str(row["id"]) in gateway_region_components or str(row["id"]) == "model_inference")
+    ]
     return {
         "generated_at": iso_now(),
         "overall_status": overall_status,
         "overall_status_label": _status_label(overall_status),
         "overall_status_class": _status_class(overall_status),
-        "summary": _summary(overall_status, freshness=freshness),
+        "summary": _summary(
+            overall_status,
+            freshness=freshness,
+            down_components=down_component_names,
+        ),
         "monitor_freshness": freshness,
         "headline_metrics": _headline_metrics(ordered, now=now),
         "current": current,
@@ -568,15 +590,10 @@ def _slo_long_term_history(
     *,
     slo_id: str,
 ) -> dict[str, list[dict[str, Any]]]:
-    scoped_samples = [
-        sample for sample in samples if slo_id in sample_slo_class_ids(sample)
-    ]
-    scoped_rollups = [
-        rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)
-    ]
+    scoped_samples = [sample for sample in samples if slo_id in sample_slo_class_ids(sample)]
+    scoped_rollups = [rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)]
     return {
-        "daily": _rollup_history(scoped_rollups, period="day")
-        or _daily_rollups(scoped_samples),
+        "daily": _rollup_history(scoped_rollups, period="day") or _daily_rollups(scoped_samples),
         "monthly": _monthly_history(scoped_rollups),
     }
 
@@ -636,9 +653,7 @@ def _slo_classes(
     for definition in SLO_DEFINITIONS:
         slo_id = str(definition["id"])
         slo_samples = [sample for sample in samples if slo_id in sample_slo_class_ids(sample)]
-        slo_rollups = [
-            rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)
-        ]
+        slo_rollups = [rollup for rollup in rollups if slo_id in rollup_slo_class_ids(rollup)]
         current = _slo_current(slo_samples, now=now)
         windows = {
             name: _slo_window(slo_samples, slo_rollups, now=now, seconds=seconds)
@@ -1096,18 +1111,10 @@ def _rollup_group_breakdown(
             "p95_dns_milliseconds": merged["p95_dns_milliseconds"],
             "p50_tcp_connect_milliseconds": merged["p50_tcp_connect_milliseconds"],
             "p95_tcp_connect_milliseconds": merged["p95_tcp_connect_milliseconds"],
-            "p50_tls_handshake_milliseconds": merged[
-                "p50_tls_handshake_milliseconds"
-            ],
-            "p95_tls_handshake_milliseconds": merged[
-                "p95_tls_handshake_milliseconds"
-            ],
-            "p50_gateway_processing_milliseconds": merged[
-                "p50_gateway_processing_milliseconds"
-            ],
-            "p95_gateway_processing_milliseconds": merged[
-                "p95_gateway_processing_milliseconds"
-            ],
+            "p50_tls_handshake_milliseconds": merged["p50_tls_handshake_milliseconds"],
+            "p95_tls_handshake_milliseconds": merged["p95_tls_handshake_milliseconds"],
+            "p50_gateway_processing_milliseconds": merged["p50_gateway_processing_milliseconds"],
+            "p95_gateway_processing_milliseconds": merged["p95_gateway_processing_milliseconds"],
             "last_checked_at": merged["last_checked_at"],
             "top_error": merged["top_error"],
         }
@@ -1416,8 +1423,7 @@ def _recent_events(
         )
 
     component_order = {
-        str(definition["id"]): index
-        for index, definition in enumerate(COMPONENT_DEFINITIONS)
+        str(definition["id"]): index for index, definition in enumerate(COMPONENT_DEFINITIONS)
     }
     rollup_groups_seen: set[tuple[str, str, str, str]] = set()
     recent_rollups = sorted(
@@ -1446,9 +1452,7 @@ def _recent_events(
         if rollup.component == UNCATEGORIZED_COMPONENT and not rollup_slo_class_ids(rollup):
             continue
         counts = _rollup_status_counts(rollup)
-        failure_count = sum(
-            count for status, count in counts.items() if status != "up"
-        )
+        failure_count = sum(count for status, count in counts.items() if status != "up")
         if failure_count <= 0:
             continue
         bucket_key = (
@@ -1559,7 +1563,12 @@ def _status_class(status: str) -> str:
     return status.replace("_", "-")
 
 
-def _summary(status: str, *, freshness: dict[str, Any] | None = None) -> dict[str, str]:
+def _summary(
+    status: str,
+    *,
+    freshness: dict[str, Any] | None = None,
+    down_components: list[str] | None = None,
+) -> dict[str, str]:
     if status == "unknown" and freshness and freshness.get("is_stale"):
         latest = freshness.get("latest_sample_at")
         if latest:
@@ -1587,6 +1596,20 @@ def _summary(status: str, *, freshness: dict[str, Any] | None = None) -> dict[st
             "detail": "Inference may still work, but an attestation check is failing and should be treated as critical.",
         }
     if status in {"degraded", "routing_degraded"}:
+        # Name the failing surface when the degradation is a component-level
+        # outage rather than a router-core burn: "Partial Outage: Model
+        # Inference" is honest and actionable; "Router Core Degraded" for a
+        # dead pong path would be both wrong and alarming.
+        if down_components:
+            names = ", ".join(down_components)
+            verb = "is" if len(down_components) == 1 else "are"
+            return {
+                "headline": f"Partial Outage: {names}",
+                "detail": (
+                    f"{names} {verb} failing synthetic checks. "
+                    "Other router-core checks are passing."
+                ),
+            }
         return {
             "headline": "Router Core Degraded",
             "detail": (

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -774,10 +774,19 @@ def test_status_rollups_cover_current_5m_24h_and_daily_windows() -> None:
         ),
     ]
 
-    snapshot = status_snapshot(samples, now=now)
+    # This deployment runs pongs (monitor key set), so the Model Inference
+    # component is published and the two down pongs must show.
+    snapshot = status_snapshot(
+        samples,
+        now=now,
+        settings=Settings(environment="test", synthetic_monitor_api_key="sk-tr-monitor-test"),
+    )
 
     assert snapshot["current"]["checks"]
-    assert snapshot["overall_status"] == "up"
+    # Both pong samples above are down and recent, so the Model Inference
+    # component pulls the banner off green — while router_core (the SLO)
+    # stays up because pong failures never burn it.
+    assert snapshot["overall_status"] == "degraded"
     assert snapshot["slo_classes"]["router_core"]["status"] == "up"
     assert set(snapshot["slo_classes"]) == {"router_core", "control_plane"}
     assert snapshot["history_scope"] == "router_core"
@@ -795,7 +804,11 @@ def test_status_rollups_cover_current_5m_24h_and_daily_windows() -> None:
     assert canonical["p50_latency_milliseconds"] == 25
     assert canonical["end_to_end_p50_latency_milliseconds"] == 25
     assert len(canonical["history"]) == 48
-    assert snapshot["recent_events"] == []
+    # The two recent pong failures now surface on the incident timeline,
+    # attributed to the Model Inference component (pre-2026-08 they mapped
+    # to no component and were silently dropped here).
+    assert {event["id"] for event in snapshot["recent_events"]} == {"syn_down", "syn_down_2"}
+    assert all(event["component"] == "Model Inference" for event in snapshot["recent_events"])
 
 
 def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
@@ -838,10 +851,17 @@ def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
         ),
     ]
 
-    snapshot = status_snapshot(samples, now=now)
+    snapshot = status_snapshot(
+        samples,
+        now=now,
+        settings=Settings(environment="test", synthetic_monitor_api_key="sk-tr-monitor-test"),
+    )
 
-    assert snapshot["overall_status"] == "up"
-    assert snapshot["summary"]["headline"] == "All Systems Operational"
+    # Provider-effective failures stay out of the SLO math (July decision),
+    # but since 2026-08 they are no longer allowed to hide: the Model
+    # Inference component goes down and pulls the banner to degraded.
+    assert snapshot["overall_status"] == "degraded"
+    assert snapshot["summary"]["headline"] == "Partial Outage: Model Inference"
     assert snapshot["slo_classes"]["router_core"]["status"] == "up"
     assert snapshot["slo_classes"]["router_core"]["windows"]["5m"]["bad_count"] == 0
     assert set(snapshot["slo_classes"]) == {"router_core", "control_plane"}
@@ -862,10 +882,16 @@ def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
     assert canonical["status"] == "up"
     assert canonical["sample_count_24h"] == 1
     assert snapshot["windows"]["5m"]["sample_count"] == 3
-    assert all(
-        event["probe_type"] not in {"openai_sdk_pong", "responses_pong"}
+    # Pong failures stay out of the SLO windows above but are no longer
+    # hidden from the incident timeline: they surface as Model Inference
+    # component events.
+    pong_events = [
+        event
         for event in snapshot["recent_events"]
-    )
+        if event["probe_type"] in {"openai_sdk_pong", "responses_pong"}
+    ]
+    assert len(pong_events) == 2
+    assert all(event["component"] == "Model Inference" for event in pong_events)
 
 
 def test_regional_gateway_maintenance_never_reduces_global_router_core_slo() -> None:

--- a/tests/test_synthetic_visibility_and_funding.py
+++ b/tests/test_synthetic_visibility_and_funding.py
@@ -1,0 +1,375 @@
+"""Tests for the 2026-08 synthetic-visibility fix.
+
+Three failure modes, one incident: model probes failed 100% on two
+deployments while (a) the status page rendered green, (b) nobody was
+alerted, and (c) the root cause was a dry monitor workspace that could
+only be refilled by hand. Each test class below pins one of the fixes:
+
+- Model Inference component + banner degradation (components.py, status.py)
+- Monthly idempotent monitor self-funding on the authorize path (funding.py)
+- Sentry alert at exactly the Nth consecutive probe failure (alerts.py)
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.catalog import CHEAP_MODEL_ID, MONITOR_MODEL_ID
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.security import lookup_hash_api_key
+from trusted_router.storage import STORE
+from trusted_router.storage_models import SyntheticProbeSample, iso_now, utcnow
+from trusted_router.synthetic import funding
+from trusted_router.synthetic.alerts import alert_on_failure_streak
+from trusted_router.synthetic.funding import ensure_monitor_funding
+from trusted_router.synthetic.status import status_snapshot
+
+
+@pytest.fixture(autouse=True)
+def _reset_funding_caches() -> None:
+    funding.reset_for_tests()
+
+
+def _sample(
+    *,
+    id: str,
+    probe_type: str,
+    status: str,
+    target: str = "canonical",
+    created_at: str | None = None,
+    error_type: str | None = None,
+    http_status: int | None = None,
+    monitor_region: str = "us-central1",
+) -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=id,
+        probe_type=probe_type,
+        target=target,
+        target_url="https://api.trustedrouter.com/v1",
+        monitor_region=monitor_region,
+        target_region="us-central1",
+        status=status,
+        error_type=error_type,
+        http_status=http_status,
+        created_at=created_at or iso_now(),
+    )
+
+
+def _recent(now: dt.datetime, seconds: int) -> str:
+    return (now - dt.timedelta(seconds=seconds)).isoformat().replace("+00:00", "Z")
+
+
+def _monitor_settings() -> Settings:
+    # model_inference is published only where the deployment actually runs
+    # pongs (COMPONENT_REQUIRED_CAPABILITIES keys off the monitor key).
+    return Settings(environment="test", synthetic_monitor_api_key="sk-tr-monitor-status")
+
+
+# ---------------------------------------------------------------------------
+# Model Inference component: pong failures must render, not vanish.
+# ---------------------------------------------------------------------------
+
+
+def _core_up_samples(now: dt.datetime) -> list[SyntheticProbeSample]:
+    return [
+        _sample(
+            id="syn_tls",
+            probe_type="tls_health",
+            status="up",
+            created_at=_recent(now, 10),
+        ),
+        _sample(
+            id="syn_settle",
+            target="control-plane",
+            probe_type="gateway_authorize_settle",
+            status="up",
+            created_at=_recent(now, 11),
+        ),
+        _sample(
+            id="syn_fallback",
+            target="control-plane",
+            probe_type="provider_fallback",
+            status="up",
+            created_at=_recent(now, 12),
+        ),
+    ]
+
+
+def test_failing_pongs_take_down_model_inference_and_the_banner() -> None:
+    now = utcnow()
+    samples = _core_up_samples(now) + [
+        _sample(
+            id="syn_pong_402",
+            probe_type="openai_sdk_pong",
+            status="down",
+            error_type="pong_mismatch",
+            http_status=402,
+            created_at=_recent(now, 13),
+        ),
+        _sample(
+            id="syn_responses_402",
+            probe_type="responses_pong",
+            status="down",
+            error_type="pong_mismatch",
+            http_status=402,
+            created_at=_recent(now, 14),
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_monitor_settings())
+
+    components = {row["id"]: row for row in snapshot["components"]}
+    assert components["model_inference"]["status"] == "down"
+    # The banner is honest: degraded, naming the failing surface — while the
+    # router_core SLO deliberately does not burn (July scoping decision).
+    assert snapshot["overall_status"] == "degraded"
+    assert snapshot["summary"]["headline"] == "Partial Outage: Model Inference"
+    assert "Model Inference" in snapshot["summary"]["detail"]
+    assert snapshot["slo_classes"]["router_core"]["status"] == "up"
+
+
+def test_passing_pongs_keep_model_inference_and_banner_green() -> None:
+    now = utcnow()
+    samples = _core_up_samples(now) + [
+        _sample(
+            id="syn_pong_ok",
+            probe_type="openai_sdk_pong",
+            status="up",
+            created_at=_recent(now, 13),
+        ),
+        _sample(
+            id="syn_responses_ok",
+            probe_type="responses_pong",
+            status="up",
+            created_at=_recent(now, 14),
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_monitor_settings())
+
+    components = {row["id"]: row for row in snapshot["components"]}
+    assert components["model_inference"]["status"] == "up"
+    assert snapshot["overall_status"] == "up"
+    assert snapshot["summary"]["headline"] == "All Systems Operational"
+
+
+def test_monitor_configuration_errors_stay_out_of_the_component() -> None:
+    # A paused/unavailable monitor account is monitor trouble, not a public
+    # outage: those samples are excluded from every component, so they must
+    # not paint Model Inference red either.
+    now = utcnow()
+    samples = _core_up_samples(now) + [
+        _sample(
+            id="syn_pong_monitor_cfg",
+            probe_type="openai_sdk_pong",
+            status="down",
+            error_type="monitor_account_unavailable",
+            created_at=_recent(now, 13),
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_monitor_settings())
+
+    components = {row["id"]: row for row in snapshot["components"]}
+    assert components["model_inference"]["status"] == "unknown"
+    assert snapshot["overall_status"] == "up"
+
+
+# ---------------------------------------------------------------------------
+# Monitor self-funding: monthly, idempotent, applied on the authorize path.
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_authorize_applies_monthly_grant_exactly_once() -> None:
+    monitor_key = "sk-tr-monitor-funding-test"  # noqa: S105 - test key.
+    app = create_app(
+        Settings(environment="test", synthetic_monitor_api_key=monitor_key),
+        init_observability=False,
+    )
+    local_client = TestClient(app)
+    monitor_user = STORE.ensure_user("monitor", email="monitor@trustedrouter.local")
+    monitor_workspace = STORE.list_workspaces_for_user(monitor_user.id)[0]
+    STORE.create_api_key(
+        workspace_id=monitor_workspace.id,
+        name="Synthetic monitor",
+        creator_user_id=monitor_user.id,
+        raw_key=monitor_key,
+    )
+    before = STORE.credit_money_snapshot(monitor_workspace.id)
+    assert before is not None
+
+    body = {
+        "api_key_lookup_hash": lookup_hash_api_key(monitor_key),
+        "model": MONITOR_MODEL_ID,
+        "estimated_input_tokens": 1,
+        "max_output_tokens": 1,
+    }
+    first = local_client.post("/v1/internal/gateway/authorize", json=body)
+    assert first.status_code == 200, first.text
+    after_first = STORE.credit_money_snapshot(monitor_workspace.id)
+    assert after_first is not None
+    granted = after_first[0] - before[0]
+    assert granted == 200_000_000  # $200 in microdollars
+
+    second = local_client.post("/v1/internal/gateway/authorize", json=body)
+    assert second.status_code == 200, second.text
+    after_second = STORE.credit_money_snapshot(monitor_workspace.id)
+    assert after_second is not None
+    assert after_second[0] == after_first[0]  # same month: no double grant
+
+    # Process restart within the same month: the in-process marker is gone
+    # but the ledger's per-event idempotency still blocks a second grant.
+    funding.reset_for_tests()
+    third = local_client.post("/v1/internal/gateway/authorize", json=body)
+    assert third.status_code == 200, third.text
+    after_third = STORE.credit_money_snapshot(monitor_workspace.id)
+    assert after_third is not None
+    assert after_third[0] == after_first[0]
+
+    # A new month is a new event id, so the grant applies again.
+    settings = Settings(environment="test", synthetic_monitor_api_key=monitor_key)
+    next_month = dt.datetime(2027, 1, 15, tzinfo=dt.UTC)
+    assert ensure_monitor_funding(STORE, settings, monitor_workspace.id, now=next_month)
+    after_next_month = STORE.credit_money_snapshot(monitor_workspace.id)
+    assert after_next_month is not None
+    assert after_next_month[0] == after_first[0] + 200_000_000
+
+
+def test_non_monitor_authorize_never_grants(client: TestClient, inference_key: str) -> None:
+    authorize = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_lookup_hash": lookup_hash_api_key(inference_key),
+            "model": CHEAP_MODEL_ID,
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    workspace_id = authorize.json()["data"]["workspace_id"]
+    snapshot = STORE.credit_money_snapshot(workspace_id)
+    assert snapshot is not None
+    # Trial credit only — no $200 monitor grant leaked onto a customer key.
+    assert snapshot[0] < 200_000_000
+
+
+def test_zero_grant_setting_disables_funding() -> None:
+    calls: list[tuple[str, int, str]] = []
+
+    class _Store:
+        def credit_workspace_typed_direct(
+            self, workspace_id: str, amount: int, event_id: str
+        ) -> bool:
+            calls.append((workspace_id, amount, event_id))
+            return True
+
+    settings = Settings(
+        environment="test",
+        synthetic_monitor_monthly_grant_dollars=0.0,
+    )
+    assert ensure_monitor_funding(_Store(), settings, "ws_x") is False
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Sentry alert: fires at exactly the Nth consecutive failure, once.
+# ---------------------------------------------------------------------------
+
+
+class _StreakStore:
+    def __init__(self, statuses_newest_first: list[str]) -> None:
+        now = utcnow()
+        self.rows = [
+            _sample(
+                id=f"syn_streak_{index}",
+                probe_type="openai_sdk_pong",
+                status=status,
+                created_at=_recent(now, index),
+            )
+            for index, status in enumerate(statuses_newest_first)
+        ]
+        self.queries: list[dict[str, object]] = []
+
+    def synthetic_probe_samples(self, **kwargs: object) -> list[SyntheticProbeSample]:
+        self.queries.append(kwargs)
+        limit = int(kwargs.get("limit") or 0)
+        return self.rows[:limit]
+
+
+@pytest.fixture
+def sentry_events(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    import sentry_sdk
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, level=None: events.append(message),
+    )
+    return events
+
+
+def test_alert_fires_at_exactly_the_third_consecutive_failure(
+    sentry_events: list[str],
+) -> None:
+    store = _StreakStore(["down", "down", "down", "up"])
+    fired = alert_on_failure_streak(store, store.rows[0])
+    assert fired is True
+    assert len(sentry_events) == 1
+    assert "openai_sdk_pong" in sentry_events[0]
+    assert store.queries[0]["probe_type"] == "openai_sdk_pong"
+    assert store.queries[0]["target"] == "canonical"
+
+
+def test_alert_stays_silent_below_threshold(sentry_events: list[str]) -> None:
+    store = _StreakStore(["down", "down", "up", "down"])
+    assert alert_on_failure_streak(store, store.rows[0]) is False
+    assert sentry_events == []
+
+
+def test_alert_does_not_refire_past_threshold(sentry_events: list[str]) -> None:
+    # 4th consecutive failure: the issue already exists; stay silent until
+    # the probe recovers and a fresh streak forms.
+    store = _StreakStore(["down", "down", "down", "down"])
+    assert alert_on_failure_streak(store, store.rows[0]) is False
+    assert sentry_events == []
+
+
+def test_alert_ignores_up_samples_and_never_queries(sentry_events: list[str]) -> None:
+    store = _StreakStore(["up"])
+    assert alert_on_failure_streak(store, store.rows[0]) is False
+    assert store.queries == []
+    assert sentry_events == []
+
+
+def test_alert_survives_store_failure(sentry_events: list[str]) -> None:
+    class _BrokenStore:
+        def synthetic_probe_samples(self, **kwargs: object) -> list[SyntheticProbeSample]:
+            raise RuntimeError("bigtable unavailable")
+
+    sample = _sample(id="syn_broken", probe_type="openai_sdk_pong", status="down")
+    assert alert_on_failure_streak(_BrokenStore(), sample) is False
+    assert sentry_events == []
+
+
+def test_record_probe_samples_invokes_streak_alerting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.routes.internal import synthetic as synthetic_routes
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        synthetic_routes,
+        "alert_on_failure_streak",
+        lambda store, sample: seen.append(sample.id),
+    )
+    samples = [
+        _sample(id="syn_wire_1", probe_type="openai_sdk_pong", status="down"),
+        _sample(id="syn_wire_2", probe_type="responses_pong", status="up"),
+    ]
+    synthetic_routes._record_probe_samples(samples)
+    assert seen == ["syn_wire_1", "syn_wire_2"]


### PR DESCRIPTION
## The incident

On 2026-08-10 every deep model probe (`openai_sdk_pong`, `responses_pong`) on the AWS and Azure deployments was failing 100% with 402 — and both status pages rendered **"All Systems Operational"**. Three defects, one fix per layer:

## 1. Visibility (shouldn't render green)

- New **Model Inference** component fed by the two pong probe types, published only on deployments that actually run pongs (`COMPONENT_REQUIRED_CAPABILITIES` keys off the monitor key).
- A down model path pulls the banner to at most **degraded** with headline **"Partial Outage: Model Inference"** — not "Router Core Outage", because router_core is passing.
- **SLO math unchanged**: pong failures still never burn `router_core` (the July scoping decision stands — a pong failure can be a provider brownout). Visibility is the component's job.
- Failing pongs now also appear on the recent-events incident timeline.

## 2. Root cause (dry monitor workspaces)

Per-cloud databases mean per-cloud monitor funding; only GCP was funded. Now the monitor **funds itself**: a monthly idempotent **$200** grant (`synthetic_monitor_monthly_grant_dollars`, config-as-code) applied lazily on the monitor's own gateway-authorize path:

- event id `synthetic-monitor-grant-YYYY-MM` → the ledger's per-event idempotency makes racing processes and restarts single-grant;
- one set-lookup per monitor authorize after the first check of the month, zero cost for customer traffic;
- a dry monitor self-heals on its next probe instead of 402ing for days. If $200 runs out mid-month, the streak alert + red component make it loud instead of silent.

## 3. Alerting (Sentry)

`alert_on_failure_streak`: fires **one** Sentry event at exactly the 3rd consecutive failure per (probe_type, target) — fingerprinted per probe path, silent past the threshold, re-fires after recovery. All exceptions swallowed: alerting must never break probe ingestion.

## Verification

- 12 new tests (`tests/test_synthetic_visibility_and_funding.py`): component down/up/monitor-config-excluded, grant exactly-once (same month, process restart, next month, zero-disables, non-monitor never grants), alert at exactly N (not N−1, not N+1, up short-circuit, store-failure survival), ingest wiring.
- Full suite: **3211 passed, 0 failed** with `-n 4 --dist loadgroup`; `ruff check` clean; `mypy` clean (232 files).
- Two existing tests updated — they encoded the green-while-broken behavior verbatim (`overall_status == "up"` with both pongs down; pongs excluded from recent events).

## After merge

Deploy AWS + Azure control planes (GCP auto-deploys) and verify: pongs go green after the monitor self-funds on its next authorize, Model Inference row appears on all four status pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)