### PR TITLE
Fix SES and attestation operational signals

### DIFF
--- a/docs/runbooks/ses-reputation.md
+++ b/docs/runbooks/ses-reputation.md
@@ -13,6 +13,8 @@ above 0.1%.
 | `budget_alert` | `alerts` | Workspace spend alert |
 | `support_inquiry` | `default` | First-party support form to the support inbox |
 | `partner_inquiry` | `default` | First-party partner form to the operator inbox |
+| `activation_10m` | `default` | Optional first-call reminder; reputation brake keeps this disabled |
+| `activation_24h` | `default` | Optional first-call reminder; reputation brake keeps this disabled |
 
 The `alerts` profile sends as `alerts@alerts.trustedrouter.com` through the
 `trustedrouter-alerts` configuration set. It has Easy DKIM, a custom MAIL FROM
@@ -34,11 +36,16 @@ addresses and message content must never be added to logs or metric tags.
 3. Do not delete a suppression entry unless the recipient has independently
    confirmed control of the address and requested another send.
 4. Group `email_send.accepted` and `ses_feedback.received` by mail class and
-   acquisition source in Axiom. Compare feedback counts to accepted sends for
-   the same window.
+   acquisition source in Axiom. Correlate on `ses_message_id` and count unique
+   message IDs or feedback IDs, not raw webhook deliveries: SNS retries are
+   normal and must not inflate reputation-event totals.
 5. Pause the offending acquisition source or mail class if it exceeds the
    recovery thresholds. Authentication and billing behavior must continue even
    when best-effort alert email is paused.
+6. Keep `TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=0` in every production region
+   until the recovery gate below has passed. A delayed complaint can arrive
+   after the brake; use `ses_message_id` to compare it with the original send
+   time before concluding that mail resumed.
 
 AWS documents account-level suppression and automated configuration-set
 pausing here:

--- a/src/trusted_router/routes/ses_notifications.py
+++ b/src/trusted_router/routes/ses_notifications.py
@@ -99,8 +99,16 @@ def register_ses_notification_routes(router: APIRouter) -> None:
             return JSONResponse({"data": {"ignored": True, "reason": "Message is not JSON"}})
 
         kind = str(feedback.get("notificationType") or feedback.get("eventType") or "")
-        blocked_count = _apply_feedback(kind, feedback)
+        # Apply the suppression first so a transient storage failure leaves the
+        # SNS message retryable. The message-id claim only controls reporting:
+        # suppression writes are idempotent, while duplicate SNS deliveries
+        # must not inflate bounce/complaint counts.
+        blocked_count = _apply_feedback(kind, feedback, emit_log=False)
         replayed = bool(message_id and not STORE.record_sns_message_once(message_id))
+        if replayed:
+            blocked_count = 0
+        else:
+            _log_feedback(kind, feedback, blocked_count)
         return JSONResponse(
             {
                 "data": {
@@ -112,7 +120,12 @@ def register_ses_notification_routes(router: APIRouter) -> None:
         )
 
 
-def _apply_feedback(kind: str, feedback: dict[str, Any]) -> int:
+def _apply_feedback(
+    kind: str,
+    feedback: dict[str, Any],
+    *,
+    emit_log: bool = True,
+) -> int:
     """Inspect a parsed SES feedback envelope and add email blocks.
 
     Returns a count, never recipient identities. Both the legacy
@@ -122,8 +135,6 @@ def _apply_feedback(kind: str, feedback: dict[str, Any]) -> int:
     """
     blocked_count = 0
     tags = _mail_tags(feedback)
-    recipient_count = 0
-    bounce_type: str | None = None
     if kind in {"Bounce", "bounce"}:
         raw_bounce = feedback.get("bounce")
         bounce = raw_bounce if isinstance(raw_bounce, dict) else {}
@@ -131,7 +142,6 @@ def _apply_feedback(kind: str, feedback: dict[str, Any]) -> int:
         bounce_type = str(raw_bounce_type) if raw_bounce_type else None
         raw_recipients = bounce.get("bouncedRecipients")
         recipients = raw_recipients if isinstance(raw_recipients, list) else []
-        recipient_count = len(recipients)
         # Only PERMANENT bounces stop sends. Transient bounces (mailbox full,
         # greylisting) self-resolve and shouldn't suppress permanently.
         if bounce_type and bounce_type.lower() != "permanent":
@@ -154,7 +164,6 @@ def _apply_feedback(kind: str, feedback: dict[str, Any]) -> int:
         complaint = raw_complaint if isinstance(raw_complaint, dict) else {}
         raw_recipients = complaint.get("complainedRecipients")
         recipients = raw_recipients if isinstance(raw_recipients, list) else []
-        recipient_count = len(recipients)
         feedback_id = complaint.get("feedbackId") or _mail_message_id(feedback)
         for recipient in recipients:
             email = recipient.get("emailAddress") if isinstance(recipient, dict) else None
@@ -166,29 +175,53 @@ def _apply_feedback(kind: str, feedback: dict[str, Any]) -> int:
                     **tags,
                 )
                 blocked_count += 1
-    if kind in {"Bounce", "bounce", "Complaint", "complaint"}:
-        log.warning(
-            "ses_feedback.received kind=%s bounce_type=%s recipients=%d blocked=%d "
-            "class=%s profile=%s source=%s medium=%s campaign=%s",
-            kind.lower(),
-            bounce_type or "none",
-            recipient_count,
-            blocked_count,
-            tags["mail_class"] or "unknown",
-            tags["sender_profile"] or "unknown",
-            tags["acquisition_source"] or "unknown",
-            tags["acquisition_medium"] or "unknown",
-            tags["acquisition_campaign"] or "unknown",
-            extra={
-                "event": "ses_feedback.received",
-                "feedback_kind": kind.lower(),
-                "bounce_type": bounce_type or "none",
-                "recipient_count": recipient_count,
-                "blocked_count": blocked_count,
-                **{name: value or "unknown" for name, value in tags.items()},
-            },
-        )
+    if emit_log:
+        _log_feedback(kind, feedback, blocked_count)
     return blocked_count
+
+
+def _log_feedback(kind: str, feedback: dict[str, Any], blocked_count: int) -> None:
+    if kind not in {"Bounce", "bounce", "Complaint", "complaint"}:
+        return
+    tags = _mail_tags(feedback)
+    raw_bounce = feedback.get("bounce")
+    bounce = raw_bounce if isinstance(raw_bounce, dict) else {}
+    raw_complaint = feedback.get("complaint")
+    complaint = raw_complaint if isinstance(raw_complaint, dict) else {}
+    bounce_type = str(bounce.get("bounceType") or "none")
+    raw_recipients = (
+        bounce.get("bouncedRecipients")
+        if kind in {"Bounce", "bounce"}
+        else complaint.get("complainedRecipients")
+    )
+    recipient_count = len(raw_recipients) if isinstance(raw_recipients, list) else 0
+    feedback_id = bounce.get("feedbackId") or complaint.get("feedbackId")
+    ses_message_id = _mail_message_id(feedback)
+    log.warning(
+        "ses_feedback.received kind=%s bounce_type=%s recipients=%d blocked=%d "
+        "class=%s profile=%s source=%s medium=%s campaign=%s message_id=%s feedback_id=%s",
+        kind.lower(),
+        bounce_type,
+        recipient_count,
+        blocked_count,
+        tags["mail_class"] or "unknown",
+        tags["sender_profile"] or "unknown",
+        tags["acquisition_source"] or "unknown",
+        tags["acquisition_medium"] or "unknown",
+        tags["acquisition_campaign"] or "unknown",
+        ses_message_id or "unknown",
+        feedback_id or "unknown",
+        extra={
+            "event": "ses_feedback.received",
+            "feedback_kind": kind.lower(),
+            "bounce_type": bounce_type,
+            "recipient_count": recipient_count,
+            "blocked_count": blocked_count,
+            "ses_message_id": ses_message_id or "unknown",
+            "feedback_id": str(feedback_id or "unknown"),
+            **{name: value or "unknown" for name, value in tags.items()},
+        },
+    )
 
 
 def _mail_tags(feedback: dict[str, Any]) -> dict[str, str | None]:

--- a/src/trusted_router/services/email.py
+++ b/src/trusted_router/services/email.py
@@ -128,6 +128,7 @@ class EmailService:
             message_id or "unknown",
             extra={
                 "event": "email_send.accepted",
+                "ses_message_id": str(message_id or "unknown"),
                 "mail_class": message.mail_class,
                 "sender_profile": message.sender_profile,
                 "acquisition_source": message.acquisition_source or "unknown",

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -862,6 +862,22 @@ async def attestation_nonce_probe(
             status_code = response.status_code
             peer_cert_der = None
         latency_ms = _elapsed_ms(started)
+        if status_code != 200:
+            # A gateway error document is not attestation evidence. Parsing a
+            # 5xx JSON/HTML body used to misclassify short rollout failures as
+            # unsupported_attestation_format, which looked like a cryptographic
+            # trust regression instead of the availability failure it was.
+            return _sample(
+                "attestation_nonce",
+                target,
+                monitor_region,
+                url,
+                status="down",
+                latency_milliseconds=latency_ms,
+                ttfb_milliseconds=latency_ms,
+                http_status=status_code,
+                error_type=f"attestation_http_{status_code}",
+            )
         evidence = _attestation_evidence(
             body,
             nonce,

--- a/tests/test_ses_notifications.py
+++ b/tests/test_ses_notifications.py
@@ -117,9 +117,15 @@ def test_complaint_blocks_email(verified_client: TestClient) -> None:
     assert block is not None and block.reason == "complaint"
 
 
-def test_replayed_message_id_is_idempotent(verified_client: TestClient) -> None:
+def test_replayed_message_id_is_idempotent(
+    verified_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     envelope = _envelope(MessageId="dup-msg", Message=_bounce_message(["dup@example.com"]))
-    with patch("trusted_router.routes.ses_notifications.verify_sns_message"):
+    with (
+        patch("trusted_router.routes.ses_notifications.verify_sns_message"),
+        caplog.at_level(logging.WARNING, logger="trusted_router.routes.ses_notifications"),
+    ):
         first = verified_client.post("/internal/ses/notifications", json=envelope)
         second = verified_client.post("/internal/ses/notifications", json=envelope)
     assert first.json()["data"] == {
@@ -129,9 +135,12 @@ def test_replayed_message_id_is_idempotent(verified_client: TestClient) -> None:
     }
     assert second.json()["data"] == {
         "kind": "Bounce",
-        "blocked_count": 1,
+        "blocked_count": 0,
         "replayed": True,
     }
+    assert sum(
+        record.getMessage().startswith("ses_feedback.received ") for record in caplog.records
+    ) == 1
 
 
 def test_feedback_persists_privacy_safe_send_classification(
@@ -166,15 +175,18 @@ def test_feedback_persists_privacy_safe_send_classification(
     assert block.acquisition_source == "google"
     assert block.acquisition_medium == "paid_search"
     assert block.acquisition_campaign == "legal-startups"
-    feedback_logs = [
-        record.getMessage()
+    feedback_records = [
+        record
         for record in caplog.records
         if record.getMessage().startswith("ses_feedback.received ")
     ]
-    assert len(feedback_logs) == 1
-    assert "campaign-recipient@example.com" not in feedback_logs[0]
-    assert "class=email_verification" in feedback_logs[0]
-    assert "source=google" in feedback_logs[0]
+    assert len(feedback_records) == 1
+    feedback_log = feedback_records[0].getMessage()
+    assert "campaign-recipient@example.com" not in feedback_log
+    assert "class=email_verification" in feedback_log
+    assert "source=google" in feedback_log
+    assert feedback_records[0].ses_message_id == "ses-msg-1"
+    assert feedback_records[0].feedback_id == "feedback-abc"
 
 
 def test_signature_failure_returns_403(verified_client: TestClient) -> None:
@@ -317,7 +329,10 @@ def test_email_service_sends_expected_ses_payload(monkeypatch) -> None:
     }
 
 
-def test_email_service_uses_dedicated_alert_sender_and_sanitized_tags(monkeypatch) -> None:
+def test_email_service_uses_dedicated_alert_sender_and_sanitized_tags(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     calls: list[dict[str, Any]] = []
 
     class FakeSESClient:
@@ -338,17 +353,18 @@ def test_email_service_uses_dedicated_alert_sender_and_sanitized_tags(monkeypatc
         )
     )
 
-    assert service.send(
-        EmailMessage(
-            to="owner@example.com",
-            subject="Budget alert",
-            text_body="Budget crossed.",
-            mail_class="budget alert",
-            sender_profile="alerts",
-            acquisition_source="ads.example/path",
-            acquisition_campaign="Legal teams: Q3",
+    with caplog.at_level(logging.INFO, logger="trusted_router.services.email"):
+        assert service.send(
+            EmailMessage(
+                to="owner@example.com",
+                subject="Budget alert",
+                text_body="Budget crossed.",
+                mail_class="budget alert",
+                sender_profile="alerts",
+                acquisition_source="ads.example/path",
+                acquisition_campaign="Legal teams: Q3",
+            )
         )
-    )
 
     call = calls[0]
     assert call["Source"] == "Example Alerts <alerts@alerts.example.com>"
@@ -359,6 +375,13 @@ def test_email_service_uses_dedicated_alert_sender_and_sanitized_tags(monkeypatc
         "acquisition_source": "ads-example-path",
         "acquisition_campaign": "Legal-teams-Q3",
     }
+    accepted = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "email_send.accepted"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0].ses_message_id == "ses-alert-1"
 
 
 def test_alert_sender_never_falls_back_to_default_identity(monkeypatch) -> None:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1631,6 +1631,20 @@ async def test_synthetic_http_probes_parse_success_shapes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_attestation_http_error_is_availability_failure_not_format_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": {"message": "revision starting"}})
+
+    target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await attestation_nonce_probe(client, target, monitor_region="europe-west4")
+
+    assert sample.status == "down"
+    assert sample.http_status == 500
+    assert sample.error_type == "attestation_http_500"
+
+
+@pytest.mark.asyncio
 async def test_image_generation_probe_validates_binary_and_records_only_metadata() -> None:
     image = b"\xff\xd8\xff" + (b"\x00" * 2048) + b"\xff\xd9"
     data_url = f"data:image/jpeg;base64,{base64.b64encode(image).decode()}"


### PR DESCRIPTION
## Summary
- deduplicate SES feedback reporting without weakening suppression retries
- correlate accepted sends and feedback with SES message and feedback IDs
- classify non-200 attestation responses as availability failures instead of evidence-format regressions
- document the activation-reminder reputation brake and unique-event reporting

## Production evidence
- all four control-plane regions have activation reminders disabled
- all four regions are Ready and serving one revision at 100%
- the single trust-format alert was an HTTP 500 during the enclave rolling deployment

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (3218 passed, 253 skipped, 10 xfailed)