### PR TITLE
Improve SEO pages from Search Console demand

### DIFF
--- a/docs/marketing/search-console-content-gaps-2026-08-10.md
+++ b/docs/marketing/search-console-content-gaps-2026-08-10.md
@@ -1,0 +1,36 @@
+# Search Console content gaps: 2026-08-10
+
+## Source
+
+- Property: `trustedrouter.com`
+- Search Console window: May 1, 2026 through August 8, 2026, the full history available for the property
+- Totals: 483 clicks, 9,071 impressions, 5.3% CTR, average position 12
+- Export: 394 query rows plus page, country, device, search appearance, and daily trend data
+- Ahrefs cross-check: Health Score 100, Domain Rating 19, 486 referring domains. Ahrefs had not yet estimated organic keyword or traffic volume for the new domain.
+
+## Highest-confidence opportunities
+
+| Search intent | Impressions | Clicks | Average position | Existing page | Action |
+| --- | ---: | ---: | ---: | --- | --- |
+| `eu llm gateway` | 64 | 0 | 13.02 | `/eu` | Strengthen answer-first copy, exact title, regional URL, residency boundary, provider controls, and FAQ schema. |
+| `agent router base url` | 30 | 0 | 11.17 | `/docs/agent-setup` | Put the base URL table first, cover OpenAI, Anthropic, EU, and legacy aliases, and add FAQ schema. |
+| `hy3 vs deepseek v4 flash` | 23 | 0 | 10.83 | Dynamic model comparison | Add current price, p50 TTFT, route count, decision guidance, and comparison FAQ schema to every model pair. |
+| `hy3 vs minimax m3` | 13 | 0 | 8.54 | Dynamic model comparison | Same reusable comparison improvement. |
+| `deepseek zero data retention` | 6 | 0 | 12.00 | `/deepseek-api-privacy` | Explain the gateway/provider boundary and show the fail-closed `provider.min_privacy=zdr` request. |
+| Provider name plus `zdr` | 28 across visible variants | 0 | 4.60 to 10.20 | Dynamic provider pages | Add provider-specific ZDR and E2EE answers, clear claim boundaries, policy sources, and FAQ schema. |
+
+## Decision rule
+
+The site already has a relevant URL for every material non-brand query in the export. Creating parallel landing pages would split relevance and risk duplicate content. Improve the earning URL first. Add a new URL only when Search Console shows a distinct intent that the existing page cannot answer cleanly.
+
+## Measurement
+
+Re-export after 28 days and compare:
+
+1. Non-brand clicks and impressions for each intent cluster.
+2. CTR at the same or better average position.
+3. Movement into positions 1 through 10 for `eu llm gateway` and `agent router base url`.
+4. Clicks to model comparisons and provider privacy pages.
+5. Indexed canonical count and duplicate-page warnings after the template changes are crawled.
+
+Do not interpret movement in the first few days as a result. Search Console data is delayed and the property is still young.

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -371,8 +371,11 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     ),
     "deepseek-api-privacy": PublicPage(
         template="public/seo_deepseek_api_privacy.html",
-        title="DeepSeek V4 API Privacy: Attested, No Data to China",
-        description="Run DeepSeek V4 Pro and V4 Flash on attested, non-Chinese infrastructure. No prompt or output logs. Real-time inference is content-stateless. OpenAI-compatible.",
+        title="DeepSeek API Privacy & Zero Data Retention",
+        description=(
+            "Run DeepSeek V4 Pro and V4 Flash through an attested OpenAI-compatible "
+            "gateway. No prompt or output logging, with enforceable ZDR route filters."
+        ),
         faq_items=(
             (
                 "Is the DeepSeek API safe to use?",
@@ -381,6 +384,10 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             (
                 "Does using DeepSeek through TrustedRouter send data to China?",
                 "No. DeepSeek V4 routes are served by non-Chinese hosting providers on attested infrastructure, so prompts never reach the model vendor. Zero-Data-Retention routes add a contractual guarantee that providers keep nothing, and TEE routes keep the prompt sealed even from the hosting provider. Each route's privacy tier is listed on the models page, and the attestation backing the claim is checkable live.",
+            ),
+            (
+                "How do I require DeepSeek zero data retention?",
+                f"Set provider.min_privacy to zdr on a DeepSeek request. The router then considers only endpoints with a recorded zero-data-retention posture and fails closed if none are eligible. {CONTENT_HANDLING_CLAIM} The ZDR filter adds the downstream provider requirement.",
             ),
             (
                 "When will DeepSeek R2 be released?",
@@ -965,10 +972,24 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     ),
     "docs/agent-setup": PublicPage(
         template="public/agent_setup.html",
-        title="Agent Setup For TrustedRouter",
+        title="AI Agent Router Base URL Setup",
         description=(
-            "Configure coding agents for TrustedRouter with the API base URL, environment "
-            "variables, model aliases, privacy routes, quick smoke tests, and migration notes."
+            "TrustedRouter base URLs, environment variables, smoke tests, and model "
+            "aliases for Claude Code, Codex, OpenAI SDK agents, and Anthropic SDK agents."
+        ),
+        faq_items=(
+            (
+                "What base URL should an OpenAI-compatible agent use?",
+                "Use https://api.trustedrouter.com/v1. Keep the OpenAI SDK and set OPENAI_API_KEY to your TrustedRouter key. The older https://api.quillrouter.com/v1 hostname remains a permanent working alias.",
+            ),
+            (
+                "What base URL should an Anthropic-compatible agent use?",
+                "Use https://api.trustedrouter.com without /v1, and set ANTHROPIC_API_KEY to your TrustedRouter key. Anthropic SDKs append their own Messages API path.",
+            ),
+            (
+                "What is the EU agent router base URL?",
+                "Use https://api-europe-west4.quillrouter.com/v1 for OpenAI-compatible requests and choose trustedrouter/eu for EU-focused routing. Add provider.only when your policy requires a strict provider allowlist.",
+            ),
         ),
     ),
     "docs/mcp": PublicPage(
@@ -1007,10 +1028,28 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "eu": PublicPage(
         template="public/eu.html",
         og_card="eu.png",
-        title="EU LLM Gateway",
+        title="EU LLM Gateway: Private AI Routing in Europe",
         description=(
-            "Route AI workloads through TrustedRouter's attested European gateway with "
-            "EU-focused model providers, privacy controls, regional failover, and usage billing."
+            "Route OpenAI-compatible LLM requests through an attested Europe West "
+            "gateway, with EU-focused models, provider controls, and no prompt logs."
+        ),
+        faq_items=(
+            (
+                "What is an EU LLM gateway?",
+                "An EU LLM gateway accepts your API connection in a European region, authenticates and routes the request there, and forwards it only to eligible model providers. TrustedRouter's Europe West gateway terminates TLS inside the same attested open-source workload as its other regional gateways.",
+            ),
+            (
+                "Which URL should European applications use?",
+                "Use https://api-europe-west4.quillrouter.com/v1 as the OpenAI-compatible base URL. The trustedrouter/eu model alias prefers EU and privacy-forward routes. The eu.trustedrouter.com hostname is the Europe-focused product and setup page.",
+            ),
+            (
+                "Does the EU gateway guarantee EU data residency?",
+                "The regional gateway keeps the TrustedRouter routing hop in Europe, but an upstream provider can process outside the EU. For a hard residency policy, combine the EU gateway with provider.only and a contractually approved provider allowlist. The router fails closed when no allowed route is available.",
+            ),
+            (
+                "Can I require zero data retention on the EU gateway?",
+                "Yes. Use trustedrouter/zdr or set provider.min_privacy to zdr. This is separate from geography: the EU hostname controls the gateway region, while the privacy filter controls which downstream provider routes are eligible.",
+            ),
         ),
     ),
     "trustedos": PublicPage(
@@ -2509,13 +2548,14 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
         return None
     test_mode = settings.environment == "test"
     served_models = _provider_model_rows(provider_slug, test_mode=test_mode)
+    provider_faq_items = _provider_faq_items(provider, model_count=len(served_models))
     return (
         _env()
         .get_template("public/provider_detail.html")
         .render(
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}/providers/{provider.slug}",
-            title=f"{provider.name} Models and API Routes | TrustedRouter",
+            title=f"{provider.name} Models, Pricing & Privacy | TrustedRouter",
             heading=provider.name,
             description=(
                 f"Explore {provider.name} models on TrustedRouter with current routes, token pricing, "
@@ -2526,6 +2566,7 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
             provider=_provider_detail_view(provider, served_models=served_models),
             served_models=served_models,
             measured=measured_for_provider(provider.slug, test_mode=settings.environment == "test"),
+            faq_items=provider_faq_items,
             json_ld_blob=_json_ld_graph(
                 _breadcrumb_node(
                     settings,
@@ -2546,6 +2587,7 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
                     ],
                 ),
                 _provider_page_node(settings, provider),
+                _faq_node(provider_faq_items),
             ),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -2662,6 +2704,8 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
     test_mode = settings.environment == "test"
     site_path = canonical_model_comparison_path(left.id, right.id)
     assert site_path is not None
+    comparison = _comparison_view(left, right)
+    faq_items = _model_comparison_faq_items(left, right, comparison=comparison)
     return (
         _env()
         .get_template("public/model_compare.html")
@@ -2671,8 +2715,8 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
             title=_seo_comparison_title(left, right),
             heading=f"{left.name} vs {right.name}",
             description=(
-                f"Compare {left_name} and {right_name} across token pricing, context windows, "
-                "provider availability, privacy options, route diversity, and measured performance."
+                f"{left_name} vs {right_name}: compare current API pricing, context, provider "
+                "routes, privacy, p50 latency, and OpenAI-compatible access."
             ),
             left=_model_detail_view(
                 left,
@@ -2684,7 +2728,8 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                 test_mode=test_mode,
                 include_section_links=False,
             ),
-            comparison=_comparison_view(left, right),
+            comparison=comparison,
+            faq_items=faq_items,
             json_ld_blob=_json_ld_graph(
                 _breadcrumb_node(
                     settings,
@@ -2693,7 +2738,8 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                         ("Models", "/models"),
                         (f"{left.name} vs {right.name}", site_path),
                     ),
-                )
+                ),
+                _faq_node(faq_items),
             ),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -3454,6 +3500,70 @@ def _provider_detail_view(
     return view
 
 
+def _provider_faq_items(
+    provider: Provider,
+    *,
+    model_count: int,
+) -> tuple[tuple[str, str], ...]:
+    if provider.slug == "trustedrouter":
+        zdr_answer = (
+            f"{CONTENT_HANDLING_CLAIM} For the downstream model provider, select "
+            "trustedrouter/zdr or set provider.min_privacy to zdr so the router "
+            "considers only eligible routes."
+        )
+    elif provider.provider_zero_data_retention is True:
+        zdr_answer = (
+            f"TrustedRouter records {provider.name} as supporting provider-level zero "
+            "data retention based on the policy source linked on this page. This is a "
+            "provider policy claim, separate from TrustedRouter's content-stateless "
+            "real-time gateway and from end-to-end confidential compute."
+        )
+    elif provider.prepaid_zero_data_retention:
+        zdr_answer = (
+            f"TrustedRouter records managed prepaid {provider.name} routes as zero data "
+            "retention. That classification does not automatically cover every direct or "
+            "BYOK account. Use provider.min_privacy=zdr to require an eligible route."
+        )
+    elif provider.prepaid_zero_data_retention_effective_on:
+        zdr_answer = (
+            f"TrustedRouter records {provider.name}'s prepaid zero-data-retention policy "
+            f"as scheduled for {provider.prepaid_zero_data_retention_effective_on}. Until "
+            "then, the router does not treat those routes as ZDR-eligible."
+        )
+    else:
+        zdr_answer = (
+            f"TrustedRouter does not currently mark {provider.name} as provider-level zero "
+            "data retention. Use trustedrouter/zdr or provider.min_privacy=zdr to select a "
+            "different eligible route, and review the linked policy source for changes."
+        )
+
+    if provider.provider_e2ee and provider.provider_confidential_compute:
+        e2ee_answer = (
+            f"TrustedRouter records {provider.name} as supporting provider-side "
+            "confidential compute and end-to-end encrypted inference. The route-specific "
+            "model page shows whether that protection applies to a particular endpoint."
+        )
+    else:
+        e2ee_answer = (
+            f"TrustedRouter does not currently mark {provider.name} as end-to-end "
+            "encrypted at the provider boundary. The TrustedRouter gateway is still "
+            "attested, but the selected provider normally receives the request in order "
+            "to run the model. Use trustedrouter/e2e for the stronger route requirement."
+        )
+
+    return (
+        (f"Does {provider.name} have zero data retention?", zdr_answer),
+        (f"Is {provider.name} end-to-end encrypted?", e2ee_answer),
+        (
+            f"Which {provider.name} models are available through TrustedRouter?",
+            f"This page currently lists {model_count} public {provider.name} model"
+            f"{'s' if model_count != 1 else ''}, with live pricing, route count, context "
+            "length, measured performance when available, and links to each model's "
+            "provider and benchmark pages.",
+        ),
+    )
+
+
 def _provider_privacy_tier(provider: Provider) -> str:
     if provider.slug == "trustedrouter":
         return "TR gateway"
@@ -3854,6 +3964,42 @@ def _comparison_view(left: Model, right: Model) -> dict[str, object]:
         "left_ttft": f"{left_measured} ms" if left_measured is not None else "not enough data",
         "right_ttft": f"{right_measured} ms" if right_measured is not None else "not enough data",
     }
+
+
+def _model_comparison_faq_items(
+    left: Model,
+    right: Model,
+    *,
+    comparison: Mapping[str, object],
+) -> tuple[tuple[str, str], ...]:
+    left_price = str(comparison["left_price"])
+    right_price = str(comparison["right_price"])
+    left_ttft = str(comparison["left_ttft"])
+    right_ttft = str(comparison["right_ttft"])
+    return (
+        (
+            f"Which should I use, {left.name} or {right.name}?",
+            str(comparison["summary"]),
+        ),
+        (
+            f"Is {left.name} or {right.name} cheaper?",
+            f"The current cheapest TrustedRouter route is {left_price} for {left.name} "
+            f"and {right_price} for {right.name}. The comparison uses current catalog "
+            "prices and updates as provider pricing changes.",
+        ),
+        (
+            f"Is {left.name} or {right.name} faster?",
+            f"Current measured p50 time to first token is {left_ttft} for {left.name} "
+            f"and {right_ttft} for {right.name}. These are routed probe measurements, "
+            "not vendor-advertised speeds, and update as new samples arrive.",
+        ),
+        (
+            f"Can I test {left.name} and {right.name} with the same API?",
+            "Yes. Use the same OpenAI-compatible TrustedRouter base URL and API key, "
+            f"then change only the model id between {left.id} and {right.id}. This makes "
+            "side-by-side evals possible without maintaining two provider integrations.",
+        ),
+    )
 
 
 def _comparison_summary(

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -173,6 +173,7 @@ code, .mono { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospa
 .switch-steps li { padding-left:2px; }
 .switch-steps li::marker { color:#7be0b1; font-weight:750; }
 .wrap { max-width:1180px; margin:0 auto; padding:20px 22px 42px; display:grid; gap:18px; }
+.wrap > * { min-width:0; }
 .public-wrap { padding-top:28px; }
 .public-hero { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:28px; }
 .public-hero h1 { font-size:40px; }
@@ -189,6 +190,7 @@ blockquote { margin:0 0 12px; padding-left:14px; border-left:3px solid var(--gre
 .public-proof-strip div { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:16px; min-width:0; }
 .public-proof-strip strong { display:block; color:var(--ink); font-size:16px; line-height:1.25; }
 .public-proof-strip span { display:block; color:var(--muted); font-size:13px; line-height:1.35; margin-top:8px; }
+.public-proof-strip .mono, .panel-body .mono, .marketing-copy .mono { overflow-wrap:anywhere; word-break:break-word; }
 .marketing-split { display:grid; grid-template-columns:minmax(0,1fr) minmax(320px,.82fr); gap:18px; align-items:stretch; }
 .marketing-copy, .quote-feature, .limitation-band, .model-catalog { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:24px; box-shadow:0 12px 40px var(--shadow); }
 .marketing-copy h2, .quote-feature h2, .model-catalog h2 { margin:12px 0 14px; font-size:30px; line-height:1.12; letter-spacing:0; }
@@ -229,6 +231,8 @@ blockquote { margin:0 0 12px; padding-left:14px; border-left:3px solid var(--gre
 .matrix-head > *:first-child { color:#b8c6d2; }
 .matrix-head > * { border-color:var(--code-line); }
 .quote-feature { display:grid; grid-template-columns:minmax(230px,.62fr) minmax(0,1fr); gap:24px; align-items:start; }
+.quote-feature > * { min-width:0; }
+.quote-feature p code { overflow-wrap:anywhere; word-break:break-word; }
 .quote-feature blockquote:last-child, .marketing-copy blockquote:last-child, .limitation-band blockquote:last-child { margin-bottom:0; }
 .trust-diagram { display:grid; gap:10px; align-content:center; background:var(--code-bg); color:var(--code-ink); border:1px solid var(--code-line); border-radius:8px; padding:24px; box-shadow:0 18px 56px var(--shadow-strong); }
 .trust-diagram div { border:1px solid rgba(123,224,177,.28); background:rgba(123,224,177,.08); border-radius:8px; padding:18px; font-weight:800; text-align:center; }

--- a/src/trusted_router/templates/public/agent_setup.html
+++ b/src/trusted_router/templates/public/agent_setup.html
@@ -3,16 +3,27 @@
 {% block body %}
 <section class="public-section docs-section">
   <div class="panel">
-    <div class="panel-head"><h2>Agent setup</h2><span class="pill good">OpenAI compatible</span></div>
+    <div class="panel-head"><h2>Agent router base URLs</h2><span class="pill good">OpenAI compatible</span></div>
     <div class="panel-body">
-      <p>Use this when a coding agent needs to switch a project to TrustedRouter without changing the app architecture.</p>
+      <p>For Claude Code, Codex, Cursor, eval runners, and other AI agents using the OpenAI SDK, set the base URL to <span class="mono">{{ api_base_url }}</span>. Keep the SDK and application architecture you already use.</p>
+      <div class="model-table-wrap">
+        <table>
+          <thead><tr><th>Client</th><th>Base URL</th><th>Use when</th></tr></thead>
+          <tbody>
+            <tr><td>OpenAI compatible</td><td><span class="mono">{{ api_base_url }}</span></td><td>Chat Completions, Responses, models, and most agents</td></tr>
+            <tr><td>Anthropic compatible</td><td><span class="mono">https://api.trustedrouter.com</span></td><td>Anthropic SDK Messages calls</td></tr>
+            <tr><td>EU regional</td><td><span class="mono">https://api-europe-west4.quillrouter.com/v1</span></td><td>Europe-focused gateway and routing</td></tr>
+            <tr><td>Permanent alias</td><td><span class="mono">https://api.quillrouter.com/v1</span></td><td>Existing integrations using the original hostname</td></tr>
+          </tbody>
+        </table>
+      </div>
       <pre><code>export TRUSTEDROUTER_API_KEY="sk-tr-v1-..."
 export OPENAI_API_KEY="$TRUSTEDROUTER_API_KEY"
 export OPENAI_BASE_URL="{{ api_base_url }}"</code></pre>
       <pre><code># Anthropic SDKs use the non-/v1 base URL.
 export ANTHROPIC_API_KEY="$TRUSTEDROUTER_API_KEY"
 export ANTHROPIC_BASE_URL="https://api.trustedrouter.com"</code></pre>
-      <p class="muted">Already integrated against <span class="mono">api.quillrouter.com</span>? It stays a permanent working alias — no migration needed. Both hostnames terminate inside the same attested gateway.</p>
+      <p class="muted">All listed TrustedRouter API hostnames terminate prompt TLS inside an attested gateway. Browse the current public catalog at <a href="/v1/models">/v1/models</a>, then run the PONG check below before changing application code.</p>
     </div>
   </div>
 

--- a/src/trusted_router/templates/public/eu.html
+++ b/src/trusted_router/templates/public/eu.html
@@ -7,6 +7,14 @@
   <div><strong>Same trust model</strong><span>TLS terminates inside the attested gateway.</span></div>
 </section>
 
+<section class="panel" aria-label="EU LLM gateway explained">
+  <div class="panel-head"><h2>What the EU LLM gateway controls</h2><span class="pill good">Europe West</span></div>
+  <div class="panel-body">
+    <p>An EU LLM gateway controls where your application connects to TrustedRouter and where routing decisions happen. Use <span class="mono">https://api-europe-west4.quillrouter.com/v1</span> so authentication, policy checks, provider selection, and response streaming begin in Europe West inside the attested gateway.</p>
+    <p>Gateway region, provider region, and privacy posture are separate controls. The regional hostname selects the gateway. <span class="mono">trustedrouter/eu</span> prefers EU-focused routes. <span class="mono">provider.only</span> enforces your approved provider list, while <span class="mono">provider.min_privacy</span> enforces ZDR or confidential-compute requirements.</p>
+  </div>
+</section>
+
 <section class="marketing-split" aria-label="EU quickstart">
   <div class="marketing-copy">
     <span class="eyebrow">Europe-first routing</span>

--- a/src/trusted_router/templates/public/seo_deepseek_api_privacy.html
+++ b/src/trusted_router/templates/public/seo_deepseek_api_privacy.html
@@ -28,6 +28,24 @@ r = client.chat.completions.create(
   <div class="marketing-card"><span class="card-label">Proof</span><h3>Attestation you can run</h3><p>The gateway source is open and the image digest is published. One curl with a nonce returns a JWT signed by the CPU vendor's root key, bound to the live TLS session. Details at <a href="/security">/security</a>.</p></div>
   <div class="marketing-card"><span class="card-label">Retention</span><h3>No prompt or output logs</h3><p>{{ content_handling_claim }} Zero-Data-Retention routes add contractual guarantees; TEE routes keep prompts sealed even from the hosting provider. See <a href="/llm-zero-data-retention">zero data retention</a>.</p></div>
 </section>
+<section class="marketing-split" aria-label="DeepSeek zero data retention setup">
+  <div class="marketing-copy">
+    <span class="eyebrow">DeepSeek zero data retention</span>
+    <h2>Make downstream retention a hard routing rule.</h2>
+    <p>{{ content_handling_claim }} For ordinary real-time DeepSeek requests, set <span class="mono">provider.min_privacy</span> to <span class="mono">zdr</span> to consider only providers with a recorded zero-data-retention posture.</p>
+    <p>The filter fails closed. If no eligible DeepSeek endpoint is available, the router returns an error instead of silently sending the request to a weaker privacy tier.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Require ZDR</span><span>JSON</span></div>
+    <pre><code>{
+  "model": "deepseek/deepseek-v4-flash",
+  "provider": {"min_privacy": "zdr"},
+  "messages": [
+    {"role": "user", "content": "Summarize this contract."}
+  ]
+}</code></pre>
+  </div>
+</section>
 <section class="compare-matrix" aria-label="api.deepseek.com vs TrustedRouter">
   <div class="matrix-row matrix-head"><span></span><strong>api.deepseek.com</strong><strong>TrustedRouter</strong></div>
   <div class="matrix-row"><span>Model access</span><span>DeepSeek V4, first-party</span><span>deepseek-v4-pro and deepseek-v4-flash, plus 220+ routes across 30+ providers</span></div>

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -285,6 +285,36 @@ def test_public_provider_route_defaults_to_html_for_link_checkers(client: TestCl
     assert json_response.headers["content-type"].startswith("application/json")
 
 
+def test_search_console_opportunity_pages_answer_observed_queries(
+    client: TestClient,
+) -> None:
+    eu = client.get("/eu")
+    assert eu.status_code == 200
+    assert "<title>EU LLM Gateway: Private AI Routing in Europe | TrustedRouter</title>" in eu.text
+    assert "What the EU LLM gateway controls" in eu.text
+    assert "https://api-europe-west4.quillrouter.com/v1" in eu.text
+    assert "Does the EU gateway guarantee EU data residency?" in eu.text
+    assert "FAQPage" in json.dumps(_json_ld(eu.text))
+
+    agents = client.get("/docs/agent-setup")
+    assert agents.status_code == 200
+    assert "<title>AI Agent Router Base URL Setup | TrustedRouter</title>" in agents.text
+    assert "Agent router base URLs" in agents.text
+    assert "https://api.trustedrouter.com/v1" in agents.text
+    assert "What base URL should an OpenAI-compatible agent use?" in agents.text
+    assert "FAQPage" in json.dumps(_json_ld(agents.text))
+
+    deepseek = client.get("/deepseek-api-privacy")
+    assert deepseek.status_code == 200
+    assert (
+        "<title>DeepSeek API Privacy &amp; Zero Data Retention | TrustedRouter</title>"
+        in deepseek.text
+    )
+    assert "DeepSeek zero data retention" in deepseek.text
+    assert '"min_privacy": "zdr"' in deepseek.text
+    assert "How do I require DeepSeek zero data retention?" in deepseek.text
+
+
 def test_public_structured_data_covers_lists_datasets_and_faqs(client: TestClient) -> None:
     models = client.get("/models")
     assert models.status_code == 200
@@ -724,12 +754,15 @@ def test_provider_detail_page_links_served_models(client: TestClient) -> None:
     response = client.get("/providers/minimax")
 
     assert response.status_code == 200
-    assert "<title>MiniMax Models and API Routes | TrustedRouter</title>" in response.text
+    assert "<title>MiniMax Models, Pricing &amp; Privacy | TrustedRouter</title>" in response.text
     assert "MiniMax M3" in response.text
     assert 'href="https://aiiq.org/models/minimax-m3/"' in response.text
     assert "IQ 109" in response.text
     assert "/models/minimax/minimax-m3/benchmarks" in response.text
     assert "Policy source" in response.text
+    assert "Does MiniMax have zero data retention?" in response.text
+    provider_schema = _json_ld(response.text)
+    assert "FAQPage" in json.dumps(provider_schema)
 
 
 def test_vertex_provider_page_scopes_zdr_to_managed_prepaid_routes(
@@ -832,6 +865,10 @@ def test_model_comparison_pages_are_public(client: TestClient) -> None:
     assert "/models/moonshotai/kimi-k2.6/pricing" in response.text
     assert "/models/z-ai/glm-5.1/providers" in response.text
     assert "openrouter.ai" not in response.text.lower()
+    assert "Which should I use, MoonshotAI: Kimi K2.6 or Z.ai: GLM 5.1?" in response.text
+    assert "Can I test MoonshotAI: Kimi K2.6 and Z.ai: GLM 5.1 with the same API?" in response.text
+    comparison_schema = _json_ld(response.text)
+    assert "FAQPage" in json.dumps(comparison_schema)
 
 
 def test_reversed_model_comparison_redirects_to_stable_canonical(
@@ -1025,25 +1062,22 @@ def test_first_body_image_picks_first_in_document_order() -> None:
 def test_blog_post_og_image_uses_first_image_else_default(client: TestClient) -> None:
     training = client.get("/blog/they-are-still-training-on-your-data")
     training_card = (
-        "https://trustedrouter.com/static/og/blog/"
-        "they-are-still-training-on-your-data.png"
+        "https://trustedrouter.com/static/og/blog/they-are-still-training-on-your-data.png"
     )
     assert f'property="og:image" content="{training_card}"' in training.text
     assert f'name="twitter:image" content="{training_card}"' in training.text
-    assert client.get(
-        "/static/og/blog/they-are-still-training-on-your-data.png"
-    ).status_code == 200
+    assert client.get("/static/og/blog/they-are-still-training-on-your-data.png").status_code == 200
 
     privacy = client.get("/blog/no-log-is-a-promise-attestation-is-proof")
     privacy_card = (
-        "https://trustedrouter.com/static/og/blog/"
-        "no-log-is-a-promise-attestation-is-proof.png"
+        "https://trustedrouter.com/static/og/blog/no-log-is-a-promise-attestation-is-proof.png"
     )
     assert f'property="og:image" content="{privacy_card}"' in privacy.text
     assert f'name="twitter:image" content="{privacy_card}"' in privacy.text
-    assert client.get(
-        "/static/og/blog/no-log-is-a-promise-attestation-is-proof.png"
-    ).status_code == 200
+    assert (
+        client.get("/static/og/blog/no-log-is-a-promise-attestation-is-proof.png").status_code
+        == 200
+    )
 
     sign_in = client.get("/blog/sign-in-with-trustedrouter")
     sign_in_card = "https://trustedrouter.com/static/og/sign-in-with-trustedrouter.png"


### PR DESCRIPTION
## Summary

- Strengthen the existing pages already earning impressions for EU gateway, agent base URL, and DeepSeek ZDR searches.
- Add reusable provider-privacy and model-comparison answers with visible FAQs and FAQ structured data.
- Fix mobile overflow from long API hostnames and code samples.
- Record the Search Console baseline and 28-day measurement plan.

## Search Console baseline

- 483 clicks
- 9,071 impressions
- 5.3% CTR
- Average position 12
- Available history: May 1 through August 8, 2026

## Verification

- `uv run pytest -q`: 3218 passed, 253 skipped, 10 xfailed
- Post-rebase focused suite: 57 passed
- Ruff, mypy, TypeScript, ESLint, Stylelint, and diff checks pass
- Desktop and 390px visual checks pass with no horizontal overflow or browser console errors
