### PR TITLE
fleet: command center substrate — /fleet view, cross-cloud peer policing, heartbeats, ops alerts

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -26,6 +26,7 @@ Design choices:
   * Skip registration under pytest unless explicitly enabled — same
     pattern as `init_sentry`.
 """
+
 from __future__ import annotations
 
 import importlib
@@ -215,11 +216,28 @@ class _AxiomScrubFilter(logging.Filter):
     # passing them through `_scrub` would needlessly walk them).
     _SKIP_FIELDS = frozenset(
         {
-            "name", "msg", "args", "levelname", "levelno", "pathname",
-            "filename", "module", "exc_info", "exc_text", "stack_info",
-            "lineno", "funcName", "created", "msecs", "relativeCreated",
-            "thread", "threadName", "processName", "process",
-            "taskName", "asctime",
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "taskName",
+            "asctime",
         }
     )
     _MAX_MESSAGE_CHARS = 2_000
@@ -275,13 +293,13 @@ class _AxiomNoiseFilter(logging.Filter):
     uvicorn error logs are unaffected."""
 
     _NOISY_PREFIXES = (
-        "urllib3",             # Sentry transport + assorted HTTP chatter
-        "sentry_sdk",          # the SDK's own internal logging
-        "google",              # spanner/bigtable/auth client libraries
-        "grpc",                # gRPC channel state churn
-        "httpx",               # per-request INFO lines for provider calls
-        "httpcore",            # httpx's transport layer
-        "hpack",               # HTTP/2 header codec debug noise
+        "urllib3",  # Sentry transport + assorted HTTP chatter
+        "sentry_sdk",  # the SDK's own internal logging
+        "google",  # spanner/bigtable/auth client libraries
+        "grpc",  # gRPC channel state churn
+        "httpx",  # per-request INFO lines for provider calls
+        "httpcore",  # httpx's transport layer
+        "hpack",  # HTTP/2 header codec debug noise
     )
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -691,6 +691,18 @@ class Settings(BaseSettings):
     synthetic_status_rollup_retention_months: int = 24
     synthetic_status_us_url: str = "https://status-us.trustedrouter.com/status.json"
     synthetic_status_eu_url: str = "https://status-eu.trustedrouter.com/status.json"
+    # Fleet peer list ("name=base_url,..."): every deployment watches every
+    # deployment's public status page — its own included, which proves the
+    # local public serving path end to end. Feeds /fleet.json and the
+    # peer_monitor probes (synthetic/fleet.py). Config-as-code default on
+    # purpose: a peer added here reaches all clouds on their next image roll
+    # with no per-cloud env edits. Empty disables (tests set environment=test,
+    # which also gates the probes off — see run_synthetic_once).
+    synthetic_fleet_peers: str = (
+        "gcp=https://trustedrouter.com"
+        ",aws=https://aws.trustedrouter.com"
+        ",azure=https://azure.trustedrouter.com"
+    )
     # Deliberately empty: the auto ladder lives in exactly one place,
     # DEFAULT_AUTO_MODEL_ORDER in catalog_data.py, and an empty setting is what
     # lets that default through in auto_candidate_models().

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -10,6 +10,7 @@ Heavy logic lives elsewhere:
   * `routes/inference.py` — chat/messages/responses/embeddings
   * each `routes/*.py` module owns one feature surface
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -112,6 +113,8 @@ def create_app(
             from trusted_router.storage import STORE
 
             def loop() -> None:
+                from trusted_router.synthetic.fleet import record_heartbeat
+
                 passes = 0
                 while True:
                     time.sleep(random.uniform(20, 45))  # noqa: S311
@@ -119,6 +122,9 @@ def create_app(
                         drain_home_settlements(settings, limit=50)
                     except Exception:
                         _logging.getLogger(__name__).exception("home settlement pass failed")
+                    # Liveness, not success: the heartbeat says the loop is
+                    # running; a failing pass already logs its own exception.
+                    record_heartbeat("scheduler:home-settlement", settings=settings)
                     passes += 1
                     # Reap roughly every tenth pass (~5 min): abandoned
                     # authorizations accumulate on deploy restarts, not
@@ -174,6 +180,7 @@ def create_app(
             import random as _random
 
             from trusted_router.routes.internal.synthetic import run_synthetic_pass
+            from trusted_router.synthetic.fleet import record_heartbeat
 
             interval = max(60, settings.synthetic_scheduler_interval_seconds)
             log = _logging.getLogger(__name__)
@@ -196,6 +203,11 @@ def create_app(
                         # one bad sample, and staleness is exactly the failure
                         # that hides an outage.
                         log.exception("synthetic pass failed")
+                    # Liveness, not success: a dead loop is the failure shape
+                    # this heartbeat exists to expose on /fleet.
+                    await _asyncio.to_thread(
+                        record_heartbeat, "scheduler:synthetic", settings=settings
+                    )
                     await _asyncio.sleep(interval)
 
             _asyncio.create_task(loop())  # noqa: RUF006 - lifetime is the process
@@ -203,9 +215,7 @@ def create_app(
     register_http_middleware(app, settings)
 
     @app.exception_handler(StarletteHTTPException)
-    async def http_exception_handler(
-        request: Request, exc: StarletteHTTPException
-    ) -> Response:
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> Response:
         # Redirect-shaped HTTPExceptions (e.g. console gating raising 302
         # to /?reason=signin) need to stay redirects, not become JSON
         # error envelopes.
@@ -214,9 +224,7 @@ def create_app(
             if location:
                 return RedirectResponse(url=location, status_code=exc.status_code)
         if isinstance(exc.detail, dict) and "error" in exc.detail:
-            return JSONResponse(
-                exc.detail, status_code=exc.status_code, headers=exc.headers
-            )
+            return JSONResponse(exc.detail, status_code=exc.status_code, headers=exc.headers)
         if exc.status_code == 404 and _is_public_html_request(request):
             return HTMLResponse(
                 public_not_found_html(settings, request.url.path),
@@ -237,10 +245,7 @@ def create_app(
         _request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         first = exc.errors()[0] if exc.errors() else {}
-        loc = (
-            ".".join(str(part) for part in first.get("loc", []) if part != "body")
-            or "body"
-        )
+        loc = ".".join(str(part) for part in first.get("loc", []) if part != "body") or "body"
         message = first.get("msg") or "Invalid request body"
         return error_response(400, f"{loc}: {message}", ErrorType.BAD_REQUEST)
 
@@ -264,9 +269,7 @@ def create_app(
     for conflict_type in conflict_store_error_types():
         app.add_exception_handler(conflict_type, aborted_exception_handler)
 
-    async def unavailable_exception_handler(
-        _request: Request, _exc: Exception
-    ) -> Response:
+    async def unavailable_exception_handler(_request: Request, _exc: Exception) -> Response:
         response = error_response(
             503,
             "Persistent storage is temporarily unavailable; retry.",
@@ -318,7 +321,9 @@ def _is_public_html_request(request: Request) -> bool:
         "/webhooks",
         "/.well-known",
     )
-    return not any(path == prefix or path.startswith(f"{prefix}/") for prefix in non_public_prefixes)
+    return not any(
+        path == prefix or path.startswith(f"{prefix}/") for prefix in non_public_prefixes
+    )
 
 
 def _make_api_router(settings: Settings) -> APIRouter:

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -112,6 +112,7 @@ from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
 )
+from trusted_router.synthetic.fleet import record_heartbeat
 from trusted_router.synthetic.funding import ensure_monitor_funding, monitor_lookup_hash
 from trusted_router.types import ErrorType, UsageType
 
@@ -889,7 +890,11 @@ def register(router: APIRouter) -> None:
         limit: int = 100,
     ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
-        return await run_in_threadpool(drain_settle_outbox, limit)
+        result = await run_in_threadpool(drain_settle_outbox, limit)
+        # Cloud Scheduler drives this on a cadence; the heartbeat makes that
+        # cadence visible on /fleet so a silently-dead scheduler is seen.
+        await run_in_threadpool(record_heartbeat, "job:settle-outbox-drain", settings=settings)
+        return result
 
     @router.post("/internal/gateway/home-settlement/drain")
     async def gateway_home_settlement_drain(
@@ -1902,10 +1907,7 @@ def _gateway_candidate_payload(
 def _gateway_provider_route_payload(endpoint: ModelEndpoint) -> dict[str, Any]:
     """Return provider-specific, typed enforcement metadata for the enclave."""
 
-    if (
-        endpoint.provider == "wafer"
-        and endpoint_zero_data_retention(endpoint) is True
-    ):
+    if endpoint.provider == "wafer" and endpoint_zero_data_retention(endpoint) is True:
         return {"wafer_zdr_required": True}
     return {}
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import html
 import json
@@ -117,6 +118,7 @@ from trusted_router.services.trust_release import (
 from trusted_router.storage import STORE
 from trusted_router.storage_custom_models import normalize_custom_model_id
 from trusted_router.storage_models import utcnow
+from trusted_router.synthetic.fleet import fleet_snapshot
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 from trusted_router.synthetic.status import history_payload, status_snapshot
 from trusted_router.synthetic.video_leaderboard import aggregate_video_leaderboard
@@ -162,6 +164,11 @@ CHOOSE_CATALOG_CACHE_SECONDS = 300
 CHOOSE_CATALOG_STALE_SECONDS = 86_400
 INDEXNOW_KEY = "360a02e48445d297f9612a4c3fef878b"
 _STATUS_CACHE: tuple[float, dict[str, Any]] | None = None
+# /fleet fans out to every peer's status.json, so its cache TTL is what keeps
+# a page-refresh storm from turning into a cross-cloud fetch storm.
+_FLEET_CACHE: tuple[float, dict[str, Any]] | None = None
+_FLEET_CACHE_LOCK = asyncio.Lock()
+FLEET_SNAPSHOT_CACHE_SECONDS = 30
 _LEADERBOARD_CACHE: tuple[float, dict[str, Any]] | None = None
 _VIDEO_LEADERBOARD_CACHE: tuple[float, dict[str, Any]] | None = None
 _APPS_CACHE: tuple[float, dict[str, Any]] | None = None
@@ -1234,6 +1241,20 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             build=lambda: _json_body({"data": _video_leaderboard_snapshot(settings)}),
         )
 
+    @app.get("/fleet.json")
+    async def fleet_json() -> Response:
+        # Served by EVERY control plane so the fleet view is as multi-cloud
+        # as the service: any healthy deployment can be the command center.
+        return Response(
+            content=_json_body({"data": await _fleet_snapshot_cached(settings)}),
+            media_type="application/json",
+        )
+
+    @public_html_route("/fleet")
+    async def fleet_page(request: Request) -> HTMLResponse:
+        _ = request
+        return HTMLResponse(_fleet_page_html(await _fleet_snapshot_cached(settings)))
+
     @app.get("/status.json")
     async def status_json(background_tasks: BackgroundTasks) -> Response:
         return _cached_public_response(
@@ -1853,6 +1874,122 @@ def _status_snapshot(settings: Settings) -> dict[str, Any]:
     if settings.environment != "test":
         _STATUS_CACHE = (now, payload)
     return payload
+
+
+async def _fleet_snapshot_cached(settings: Settings) -> dict[str, Any]:
+    global _FLEET_CACHE
+
+    def fresh() -> dict[str, Any] | None:
+        if settings.environment != "test" and _FLEET_CACHE is not None:
+            cached_at, payload = _FLEET_CACHE
+            if time.monotonic() - cached_at < FLEET_SNAPSHOT_CACHE_SECONDS:
+                return payload
+        return None
+
+    cached = fresh()
+    if cached is not None:
+        return cached
+    # Single-flight: /fleet.json is public and its miss path fans out to
+    # every peer cloud, so concurrent misses must coalesce into one rebuild
+    # rather than one cross-cloud fetch storm per request.
+    async with _FLEET_CACHE_LOCK:
+        cached = fresh()
+        if cached is not None:
+            return cached
+        payload = await fleet_snapshot(settings)
+        if settings.environment != "test":
+            _FLEET_CACHE = (time.monotonic(), payload)
+        return payload
+
+
+_FLEET_STATUS_COLORS = {
+    "up": "#2e9e5b",
+    "degraded": "#d99a2b",
+    "routing_degraded": "#d99a2b",
+    "trust_degraded": "#c2542e",
+    "down": "#c43d3d",
+    "unreachable": "#c43d3d",
+    "unknown": "#8a8f98",
+}
+
+
+def _fleet_page_html(snapshot: dict[str, Any]) -> str:
+    """Minimal server-rendered fleet page: one row per deployment, one row
+    per scheduler heartbeat. Deliberately dependency-free and compact — this
+    is the operator's "where do I look next" page, not a second status page.
+    """
+
+    def color(status: str) -> str:
+        return _FLEET_STATUS_COLORS.get(status, "#8a8f98")
+
+    def pill(status: str) -> str:
+        label = html.escape(status.replace("_", " "))
+        return (
+            f'<span style="background:{color(status)};color:#fff;'
+            'border-radius:9px;padding:2px 10px;font-size:13px;">'
+            f"{label}</span>"
+        )
+
+    rows = []
+    for row in snapshot.get("deployments", []):
+        status = str(row.get("overall_status") or "unknown")
+        components = row.get("components") or {}
+        bad = {key: value for key, value in components.items() if value not in ("up", "unknown")}
+        detail = (
+            ", ".join(f"{key}: {value}" for key, value in sorted(bad.items()))
+            if bad
+            else "all components up"
+        )
+        stale = row.get("monitor_stale")
+        monitor = "stale" if stale else ("fresh" if stale is not None else "n/a")
+        rows.append(
+            "<tr>"
+            f'<td><a href="{html.escape(str(row.get("url") or ""))}">'
+            f"{html.escape(str(row.get('name') or ''))}</a></td>"
+            f"<td>{pill(status)}</td>"
+            f"<td>{html.escape(str(row.get('headline') or ''))}</td>"
+            f"<td>{html.escape(monitor)}</td>"
+            f"<td>{html.escape(detail)}</td>"
+            "</tr>"
+        )
+    beats = []
+    for beat in snapshot.get("heartbeats", []):
+        age = beat.get("age_seconds")
+        beats.append(
+            "<tr>"
+            f"<td>{html.escape(str(beat.get('name') or ''))}</td>"
+            f"<td>{pill('down' if beat.get('stale') else 'up')}</td>"
+            f"<td>{html.escape(str(age) + 's' if age is not None else 'unknown')}</td>"
+            f"<td>{html.escape(str(beat.get('last_beat_at') or ''))}</td>"
+            "</tr>"
+        )
+    overall = str(snapshot.get("fleet_overall_status") or "unknown")
+    table_css = "width:100%;border-collapse:collapse;margin:12px 0 28px"
+    cell_css = (
+        "th,td{text-align:left;padding:8px 12px;border-bottom:1px solid #2a2f3a;"
+        "font-size:14px}th{color:#8a8f98;font-weight:600}"
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>TrustedRouter Fleet</title>
+<style>
+body{{background:#0f1218;color:#e6e9ef;font:15px/1.5 -apple-system,'Segoe UI',sans-serif;
+margin:0;padding:32px;max-width:1080px;margin-inline:auto}}
+a{{color:#7ab7ff;text-decoration:none}} {cell_css}
+h1{{font-size:20px;margin:0 0 4px}} h2{{font-size:16px;color:#8a8f98;margin:28px 0 0}}
+</style></head><body>
+<h1>TrustedRouter Fleet {pill(overall)}</h1>
+<div style="color:#8a8f98;font-size:13px">generated {html.escape(str(snapshot.get("generated_at") or ""))}
+ &middot; served by every control plane &middot; <a href="/fleet.json">fleet.json</a></div>
+<h2>Deployments</h2>
+<table style="{table_css}"><tr><th>deployment</th><th>status</th><th>headline</th>
+<th>monitor</th><th>attention</th></tr>{"".join(rows)}</table>
+<h2>Scheduler heartbeats (this deployment)</h2>
+<table style="{table_css}"><tr><th>job</th><th>liveness</th><th>age</th><th>last beat</th></tr>
+{"".join(beats) or '<tr><td colspan="4">no heartbeats recorded yet</td></tr>'}</table>
+</body></html>"""
 
 
 def _compact_status_json(snapshot: dict[str, Any]) -> dict[str, Any]:

--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -68,11 +68,11 @@ SENSITIVE_STRING_FRAGMENTS: tuple[str, ...] = (
 # the key-name blocklist above wouldn't catch them.
 SENSITIVE_STRING_PREFIXES: tuple[str, ...] = (
     "GOCSPX-",  # Google OAuth client secret
-    "gho_",     # GitHub OAuth-app token
-    "ghp_",     # GitHub personal access token
-    "ghu_",     # GitHub user-to-server token
-    "ghs_",     # GitHub server token
-    "ghr_",     # GitHub refresh token
+    "gho_",  # GitHub OAuth-app token
+    "ghp_",  # GitHub personal access token
+    "ghu_",  # GitHub user-to-server token
+    "ghs_",  # GitHub server token
+    "ghr_",  # GitHub refresh token
 )
 
 
@@ -121,7 +121,9 @@ class _SentryFloodgate:
                 self._fingerprints.clear()
 
             bucket = self._fingerprints.get(fingerprint)
-            is_first_for_fingerprint = bucket is None or now - bucket.window_started >= window_seconds
+            is_first_for_fingerprint = (
+                bucket is None or now - bucket.window_started >= window_seconds
+            )
             if is_first_for_fingerprint:
                 bucket = _FloodBucket(window_started=now)
                 self._fingerprints[fingerprint] = bucket
@@ -249,7 +251,9 @@ def before_send(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
     return event
 
 
-def before_send_log(event: dict[str, Any], hint: dict[str, Any] | None = None) -> dict[str, Any] | None:
+def before_send_log(
+    event: dict[str, Any], hint: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
     if _is_dropped_noise(event):
         return None
     event = _scrub(event)
@@ -258,7 +262,9 @@ def before_send_log(event: dict[str, Any], hint: dict[str, Any] | None = None) -
     return event
 
 
-def before_breadcrumb(crumb: dict[str, Any], hint: dict[str, Any] | None = None) -> dict[str, Any] | None:
+def before_breadcrumb(
+    crumb: dict[str, Any], hint: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
     if _is_dropped_noise(crumb):
         return None
     return _scrub(crumb)

--- a/src/trusted_router/services/budget_alerts.py
+++ b/src/trusted_router/services/budget_alerts.py
@@ -29,9 +29,7 @@ from trusted_router.spend_windows import key_window_limits, utcnow, window_floor
 log = logging.getLogger(__name__)
 
 
-def maybe_send_budget_alerts(
-    *, api_key_hash: str, workspace_id: str, settings: Settings
-) -> None:
+def maybe_send_budget_alerts(*, api_key_hash: str, workspace_id: str, settings: Settings) -> None:
     """Email the workspace owner for each window whose budget this key just
     crossed (alert mode only). No-op for limit-mode keys, keys without window
     budgets, or a store with no window-usage view."""
@@ -99,7 +97,9 @@ def _deliver(
     )
     try:
         get_email_service(settings).send(message)
-    except Exception:  # best-effort: the window is already marked (at-most-once); make a drop observable
+    except (
+        Exception
+    ):  # best-effort: the window is already marked (at-most-once); make a drop observable
         log.exception("budget_alert.delivery_failed key=%s ws=%s", api_key_hash, workspace_id)
 
 

--- a/src/trusted_router/services/home_settlement.py
+++ b/src/trusted_router/services/home_settlement.py
@@ -36,6 +36,7 @@ from typing import Any
 
 import httpx
 
+from trusted_router.synthetic.alerts import ops_alert
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
@@ -159,9 +160,7 @@ def _run_pass(store: Any, home: str, token: str, limit: int) -> dict[str, Any]:
                 log.warning("home settlement pass parked: transport error to home")
                 break
 
-            classification, reason = classify_apply_response(
-                response.status_code, response.content
-            )
+            classification, reason = classify_apply_response(response.status_code, response.content)
             if classification == FORWARDED:
                 if store.mark_home_settlement_forwarded(authorization_id):
                     counts["forwarded"] += 1
@@ -170,8 +169,10 @@ def _run_pass(store: Any, home: str, token: str, limit: int) -> dict[str, Any]:
             elif classification == DEAD_LETTER:
                 if store.mark_home_settlement_dead_letter(authorization_id, reason=reason):
                     counts["dead_lettered"] += 1
-                    log.error(
-                        "home settlement %s dead-lettered: %s", authorization_id, reason
+                    ops_alert(
+                        f"home settlement {authorization_id} dead-lettered: {reason}",
+                        fingerprint=["home-settlement", "dead-letter"],
+                        tags={"authorization_id": authorization_id},
                     )
                 else:
                     counts["raced"] += 1

--- a/src/trusted_router/services/settle_outbox_drain.py
+++ b/src/trusted_router/services/settle_outbox_drain.py
@@ -14,6 +14,7 @@ from trusted_router.services.settle_outbox_apply import (
 from trusted_router.storage import STORE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_models import SettleOutboxRow, generation_id_for_authorization
+from trusted_router.synthetic.alerts import ops_alert
 
 logger = logging.getLogger(__name__)
 
@@ -129,10 +130,7 @@ def _resolve_row(
                 candidate_since = dt.datetime.fromisoformat(
                     candidate_since_text.replace("Z", "+00:00")
                 )
-                if (
-                    candidate_since.tzinfo is None
-                    or candidate_since.utcoffset() is None
-                ):
+                if candidate_since.tzinfo is None or candidate_since.utcoffset() is None:
                     raise ValueError("activity repair since must include a timezone")
             except (OverflowError, ValueError):
                 # A malformed timestamp is a separate data bug. Start the
@@ -197,17 +195,17 @@ def _resolve_row(
                     row.intent_kind,
                 )
                 return
-            logger.error(
+            ops_alert(
                 "ALERT settle outbox activity repair expired "
-                "authorization_id=%s generation_id=%s request_id=%s "
-                "reservation_id=%s; CHARGE IS ALREADY APPLIED and Spanner is "
+                f"authorization_id={row.authorization_id} "
+                f"generation_id={generation_id_for_authorization(row.authorization_id)} "
+                f"request_id={_request_id(row)} "
+                f"reservation_id={row.reservation_id}; CHARGE IS ALREADY APPLIED and Spanner is "
                 "correct; only the per-request Bigtable activity row is missing; "
                 "row is now dead with settle_body PRESERVED for repair; fix "
                 "Bigtable, then set the row back to pending to let the drain retry",
-                row.authorization_id,
-                generation_id_for_authorization(row.authorization_id),
-                _request_id(row),
-                row.reservation_id,
+                fingerprint=["settle-outbox", "activity-repair-expired"],
+                tags={"authorization_id": row.authorization_id},
             )
             return
         outbox.park(
@@ -276,10 +274,11 @@ def _resolve_row(
                     row.intent_kind,
                 )
                 return
-            logger.error(
-                "ALERT settle outbox lost charge authorization_id=%s actual_cost_micro=%s",
-                row.authorization_id,
-                row.actual_cost_micro,
+            ops_alert(
+                f"ALERT settle outbox lost charge authorization_id={row.authorization_id} "
+                f"actual_cost_micro={row.actual_cost_micro}",
+                fingerprint=["settle-outbox", "lost-charge"],
+                tags={"authorization_id": row.authorization_id},
             )
         else:
             outbox.mark(row.authorization_id, row.intent_kind, done=True, lease_owner=lease_owner)
@@ -304,10 +303,11 @@ def _resolve_row(
                 row.intent_kind,
             )
             return
-        logger.error(
-            "ALERT settle outbox reservation missing authorization_id=%s reservation_id=%s",
-            row.authorization_id,
-            row.reservation_id,
+        ops_alert(
+            f"ALERT settle outbox reservation missing authorization_id={row.authorization_id} "
+            f"reservation_id={row.reservation_id}",
+            fingerprint=["settle-outbox", "reservation-missing"],
+            tags={"authorization_id": row.authorization_id},
         )
         return
 
@@ -364,10 +364,11 @@ def _resolve_row(
             lease_owner=lease_owner,
         )
         if status == "dead":
-            logger.error(
-                "ALERT settle outbox exhausted retries authorization_id=%s intent_kind=%s",
-                row.authorization_id,
-                row.intent_kind,
+            ops_alert(
+                f"ALERT settle outbox exhausted retries authorization_id={row.authorization_id} "
+                f"intent_kind={row.intent_kind}",
+                fingerprint=["settle-outbox", "exhausted-retries"],
+                tags={"authorization_id": row.authorization_id, "intent_kind": row.intent_kind},
             )
         return
 
@@ -379,10 +380,11 @@ def _resolve_row(
         lease_owner=lease_owner,
     )
     if status == "dead":
-        logger.error(
-            "ALERT settle outbox exhausted retries authorization_id=%s intent_kind=%s",
-            row.authorization_id,
-            row.intent_kind,
+        ops_alert(
+            f"ALERT settle outbox exhausted retries authorization_id={row.authorization_id} "
+            f"intent_kind={row.intent_kind}",
+            fingerprint=["settle-outbox", "exhausted-retries"],
+            tags={"authorization_id": row.authorization_id, "intent_kind": row.intent_kind},
         )
 
 

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -77,10 +77,10 @@ _SIBLING_GUARD_COUNT_SQL = (
 )
 
 # Enqueue outcomes.
-ENQ_INSERTED = "inserted"          # new pending row
-ENQ_REFRESHED = "refreshed"        # existing pending row's frozen inputs updated
-ENQ_EXISTS_TERMINAL = "terminal"   # existing done/dead/release_approved row — left as is
-ENQ_LEASED = "leased"              # existing pending row is actively leased by a drain — deferred
+ENQ_INSERTED = "inserted"  # new pending row
+ENQ_REFRESHED = "refreshed"  # existing pending row's frozen inputs updated
+ENQ_EXISTS_TERMINAL = "terminal"  # existing done/dead/release_approved row — left as is
+ENQ_LEASED = "leased"  # existing pending row is actively leased by a drain — deferred
 
 
 def _iso_now() -> str:
@@ -152,9 +152,7 @@ class SpannerSettleOutbox:
         pt = self._pt
         now = _iso_now()
         next_attempt_at = (
-            _iso_after_seconds(initial_delay_seconds)
-            if initial_delay_seconds > 0
-            else now
+            _iso_after_seconds(initial_delay_seconds) if initial_delay_seconds > 0 else now
         )
 
         def insert_txn(transaction: Any) -> None:
@@ -181,26 +179,34 @@ class SpannerSettleOutbox:
                 "terminal_at": None,
             }
             types = {
-                "authorization_id": pt.STRING, "intent_kind": pt.STRING,
-                "settle_origin": pt.STRING, "reservation_id": pt.STRING,
-                "actual_cost_micro": pt.INT64, "selected_endpoint_id": pt.STRING,
-                "model_id": pt.STRING, "selected_usage_type": pt.STRING,
-                "settle_body": pt.STRING, "status": pt.STRING, "attempts": pt.INT64,
-                "last_error": pt.STRING, "next_attempt_at": pt.TIMESTAMP,
-                "lease_owner": pt.STRING, "leased_until": pt.TIMESTAMP,
-                "created_at": pt.TIMESTAMP, "updated_at": pt.TIMESTAMP,
+                "authorization_id": pt.STRING,
+                "intent_kind": pt.STRING,
+                "settle_origin": pt.STRING,
+                "reservation_id": pt.STRING,
+                "actual_cost_micro": pt.INT64,
+                "selected_endpoint_id": pt.STRING,
+                "model_id": pt.STRING,
+                "selected_usage_type": pt.STRING,
+                "settle_body": pt.STRING,
+                "status": pt.STRING,
+                "attempts": pt.INT64,
+                "last_error": pt.STRING,
+                "next_attempt_at": pt.TIMESTAMP,
+                "lease_owner": pt.STRING,
+                "leased_until": pt.TIMESTAMP,
+                "created_at": pt.TIMESTAMP,
+                "updated_at": pt.TIMESTAMP,
                 "terminal_at": pt.TIMESTAMP,
             }
             transaction.execute_update(
                 f"INSERT INTO tr_settle_outbox ({cols}) VALUES ({binds})",  # noqa: S608 - fixed column list
-                params=values, param_types=types,
+                params=values,
+                param_types=types,
             )
             # An outbox intent is durable repair work: keep both referenced
             # records TTL-ineligible. This also re-disarms retention if a reaper
             # armed it immediately before this enqueue committed.
-            self._defer_retention(
-                transaction, row.authorization_id, row.reservation_id
-            )
+            self._defer_retention(transaction, row.authorization_id, row.reservation_id)
 
         try:
             run_in_transaction_with_retry(self._database, insert_txn)
@@ -238,19 +244,22 @@ class SpannerSettleOutbox:
                     "intent_kind": row.intent_kind,
                 },
                 param_types={
-                    "settle_origin": pt.STRING, "reservation_id": pt.STRING,
-                    "actual_cost_micro": pt.INT64, "selected_endpoint_id": pt.STRING,
-                    "model_id": pt.STRING, "selected_usage_type": pt.STRING,
-                    "settle_body": pt.STRING, "now": pt.TIMESTAMP,
-                    "authorization_id": pt.STRING, "intent_kind": pt.STRING,
+                    "settle_origin": pt.STRING,
+                    "reservation_id": pt.STRING,
+                    "actual_cost_micro": pt.INT64,
+                    "selected_endpoint_id": pt.STRING,
+                    "model_id": pt.STRING,
+                    "selected_usage_type": pt.STRING,
+                    "settle_body": pt.STRING,
+                    "now": pt.TIMESTAMP,
+                    "authorization_id": pt.STRING,
+                    "intent_kind": pt.STRING,
                 },
             )
             if refreshed == 1:
                 # Refresh is an outstanding intent too, so its referenced
                 # records must remain ineligible for retention TTL.
-                self._defer_retention(
-                    transaction, row.authorization_id, row.reservation_id
-                )
+                self._defer_retention(transaction, row.authorization_id, row.reservation_id)
             return refreshed
 
         refreshed = run_in_transaction_with_retry(self._database, refresh_txn)
@@ -268,17 +277,19 @@ class SpannerSettleOutbox:
     def due(self, *, limit: int = 100) -> list[SettleOutboxRow]:
         now = _iso_now()
         with self._database.snapshot() as snapshot:
-            rows = list(snapshot.execute_sql(
-                f"SELECT {', '.join(OUTBOX_COLUMNS)} "  # noqa: S608 - fixed column list
-                "FROM tr_settle_outbox"
-                "@{FORCE_INDEX=tr_settle_outbox_due_v2} "
-                "WHERE queue_shard IS NOT NULL "
-                "AND next_attempt_at IS NOT NULL "
-                "AND status='pending' AND next_attempt_at <= @now "
-                "ORDER BY next_attempt_at LIMIT @limit",
-                params={"now": now, "limit": int(limit)},
-                param_types={"now": self._pt.TIMESTAMP, "limit": self._pt.INT64},
-            ))
+            rows = list(
+                snapshot.execute_sql(
+                    f"SELECT {', '.join(OUTBOX_COLUMNS)} "  # noqa: S608 - fixed column list
+                    "FROM tr_settle_outbox"
+                    "@{FORCE_INDEX=tr_settle_outbox_due_v2} "
+                    "WHERE queue_shard IS NOT NULL "
+                    "AND next_attempt_at IS NOT NULL "
+                    "AND status='pending' AND next_attempt_at <= @now "
+                    "ORDER BY next_attempt_at LIMIT @limit",
+                    params={"now": now, "limit": int(limit)},
+                    param_types={"now": self._pt.TIMESTAMP, "limit": self._pt.INT64},
+                )
+            )
         return [_row_from_tuple(r) for r in rows]
 
     def claim(self, *, limit: int = 100, lease_seconds: int = 60) -> list[SettleOutboxRow]:
@@ -303,12 +314,17 @@ class SpannerSettleOutbox:
                 "updated_at=@now WHERE authorization_id=@aid AND intent_kind=@kind "
                 "AND status='pending' AND (leased_until IS NULL OR leased_until < @now)",
                 params={
-                    "owner": owner, "lease": lease_until, "now": now,
-                    "aid": row.authorization_id, "kind": row.intent_kind,
+                    "owner": owner,
+                    "lease": lease_until,
+                    "now": now,
+                    "aid": row.authorization_id,
+                    "kind": row.intent_kind,
                 },
                 param_types={
-                    "owner": self._pt.STRING, "lease": self._pt.TIMESTAMP,
-                    "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
+                    "owner": self._pt.STRING,
+                    "lease": self._pt.TIMESTAMP,
+                    "now": self._pt.TIMESTAMP,
+                    "aid": self._pt.STRING,
                     "kind": self._pt.STRING,
                 },
             )
@@ -341,12 +357,14 @@ class SpannerSettleOutbox:
         now = _iso_now()
 
         def txn(transaction: Any) -> str | None:
-            rows = list(transaction.execute_sql(
-                "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
-                "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
-                params={"aid": authorization_id, "kind": intent_kind},
-                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
-            ))
+            rows = list(
+                transaction.execute_sql(
+                    "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
+                    "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
+                    params={"aid": authorization_id, "kind": intent_kind},
+                    param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+                )
+            )
             if not rows:
                 return None
             attempts, cur_owner, reservation_id = (
@@ -390,18 +408,26 @@ class SpannerSettleOutbox:
                 "AND ((@lease_owner IS NULL AND lease_owner IS NULL) OR "
                 "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner))",
                 params={
-                    "status": new_status, "attempts": next_attempts, "err": err,
-                    "next_at": next_at, "now": now,
+                    "status": new_status,
+                    "attempts": next_attempts,
+                    "err": err,
+                    "next_at": next_at,
+                    "now": now,
                     "terminal_at": terminal_at,
                     "done": done,
-                    "aid": authorization_id, "kind": intent_kind,
+                    "aid": authorization_id,
+                    "kind": intent_kind,
                     "lease_owner": lease_owner,
                 },
                 param_types={
-                    "status": self._pt.STRING, "attempts": self._pt.INT64,
-                    "err": self._pt.STRING, "next_at": self._pt.TIMESTAMP,
-                    "now": self._pt.TIMESTAMP, "aid": self._pt.STRING,
-                    "kind": self._pt.STRING, "lease_owner": self._pt.STRING,
+                    "status": self._pt.STRING,
+                    "attempts": self._pt.INT64,
+                    "err": self._pt.STRING,
+                    "next_at": self._pt.TIMESTAMP,
+                    "now": self._pt.TIMESTAMP,
+                    "aid": self._pt.STRING,
+                    "kind": self._pt.STRING,
+                    "lease_owner": self._pt.STRING,
                     "terminal_at": self._pt.TIMESTAMP,
                     "done": self._pt.BOOL,
                 },
@@ -409,17 +435,17 @@ class SpannerSettleOutbox:
             if updated != 1:
                 return None
             if done:
-                sibling_rows = list(transaction.execute_sql(
-                    _SIBLING_GUARD_COUNT_SQL,
-                    params={"aid": authorization_id, "kind": intent_kind},
-                    param_types={
-                        "aid": self._pt.STRING,
-                        "kind": self._pt.STRING,
-                    },
-                ))
-                outstanding_siblings = (
-                    int(sibling_rows[0][0]) if sibling_rows else 0
+                sibling_rows = list(
+                    transaction.execute_sql(
+                        _SIBLING_GUARD_COUNT_SQL,
+                        params={"aid": authorization_id, "kind": intent_kind},
+                        param_types={
+                            "aid": self._pt.STRING,
+                            "kind": self._pt.STRING,
+                        },
+                    )
                 )
+                outstanding_siblings = int(sibling_rows[0][0]) if sibling_rows else 0
                 # The PK is (authorization_id, intent_kind): settle and refund
                 # coexist by design, so shared records must outlive the last
                 # pending/dead intent, not merely the first one to finish.
@@ -492,12 +518,14 @@ class SpannerSettleOutbox:
         next_at = _iso_after_seconds(retry_after_seconds)
 
         def txn(transaction: Any) -> bool:
-            rows = list(transaction.execute_sql(
-                "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
-                "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
-                params={"aid": authorization_id, "kind": intent_kind},
-                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
-            ))
+            rows = list(
+                transaction.execute_sql(
+                    "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
+                    "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'",
+                    params={"aid": authorization_id, "kind": intent_kind},
+                    param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+                )
+            )
             if not rows:
                 return False
             attempts, cur_owner = int(rows[0][0] or 0), rows[0][1]
@@ -517,15 +545,21 @@ class SpannerSettleOutbox:
                 "AND ((@lease_owner IS NULL AND lease_owner IS NULL) OR "
                 "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner))",
                 params={
-                    "attempts": attempts, "err": note[:1000],
-                    "next_at": next_at, "now": now,
-                    "aid": authorization_id, "kind": intent_kind,
+                    "attempts": attempts,
+                    "err": note[:1000],
+                    "next_at": next_at,
+                    "now": now,
+                    "aid": authorization_id,
+                    "kind": intent_kind,
                     "lease_owner": lease_owner,
                 },
                 param_types={
-                    "attempts": self._pt.INT64, "err": self._pt.STRING,
-                    "next_at": self._pt.TIMESTAMP, "now": self._pt.TIMESTAMP,
-                    "aid": self._pt.STRING, "kind": self._pt.STRING,
+                    "attempts": self._pt.INT64,
+                    "err": self._pt.STRING,
+                    "next_at": self._pt.TIMESTAMP,
+                    "now": self._pt.TIMESTAMP,
+                    "aid": self._pt.STRING,
+                    "kind": self._pt.STRING,
                     "lease_owner": self._pt.STRING,
                 },
             )
@@ -546,21 +580,25 @@ class SpannerSettleOutbox:
         reservation. Read on a snapshot for the advisory pre-scan; the reaper
         also re-checks in-transaction (Increment 2) for the real interlock."""
         with self._database.snapshot() as snapshot:
-            rows = list(snapshot.execute_sql(
-                GUARD_COUNT_SQL,
-                params={"aid": authorization_id},
-                param_types={"aid": self._pt.STRING},
-            ))
+            rows = list(
+                snapshot.execute_sql(
+                    GUARD_COUNT_SQL,
+                    params={"aid": authorization_id},
+                    param_types={"aid": self._pt.STRING},
+                )
+            )
         return bool(rows) and int(rows[0][0]) > 0
 
     def get(self, authorization_id: str, intent_kind: str) -> SettleOutboxRow | None:
         with self._database.snapshot() as snapshot:
-            rows = list(snapshot.execute_sql(
-                f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608 - fixed column list
-                "WHERE authorization_id=@aid AND intent_kind=@kind",
-                params={"aid": authorization_id, "kind": intent_kind},
-                param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
-            ))
+            rows = list(
+                snapshot.execute_sql(
+                    f"SELECT {', '.join(OUTBOX_COLUMNS)} FROM tr_settle_outbox "  # noqa: S608 - fixed column list
+                    "WHERE authorization_id=@aid AND intent_kind=@kind",
+                    params={"aid": authorization_id, "kind": intent_kind},
+                    param_types={"aid": self._pt.STRING, "kind": self._pt.STRING},
+                )
+            )
         return _row_from_tuple(rows[0]) if rows else None
 
     def purge_done(self, *, older_than_days: int = 30) -> int:

--- a/src/trusted_router/storage_gcp_synthetic_rollups.py
+++ b/src/trusted_router/storage_gcp_synthetic_rollups.py
@@ -90,7 +90,11 @@ def _rollup_key(rollup: SyntheticRollup) -> bytes:
 
 
 def _seen_key(rollup: SyntheticRollup, sample_id: str) -> bytes:
-    return _rollup_key(rollup).replace(b"synthetic_rollup#", b"synthetic_rollup_seen#", 1) + b"#" + sample_id.encode("utf-8")
+    return (
+        _rollup_key(rollup).replace(b"synthetic_rollup#", b"synthetic_rollup_seen#", 1)
+        + b"#"
+        + sample_id.encode("utf-8")
+    )
 
 
 def _row_exists(table: Any, family: FamilyNames, key: bytes) -> bool:
@@ -134,7 +138,11 @@ def _rollups_from_rows(
             continue
         try:
             payload = json.loads(cells[0].value.decode("utf-8"))
-            if not isinstance(payload, dict) or payload.get("period") not in {"hour", "day", "month"}:
+            if not isinstance(payload, dict) or payload.get("period") not in {
+                "hour",
+                "day",
+                "month",
+            }:
                 continue
             if not include_histograms:
                 payload["latency_histogram"] = {}

--- a/src/trusted_router/synthetic/alerts.py
+++ b/src/trusted_router/synthetic/alerts.py
@@ -39,7 +39,7 @@ def alert_on_failure_streak(
         recent = store.synthetic_probe_samples(
             probe_type=sample.probe_type,
             target=sample.target,
-            limit=threshold + 1,
+            limit=threshold + 2,
         )
     except Exception:  # noqa: BLE001 - alerting must never break ingestion
         logger.exception("synthetic alert streak query failed")
@@ -52,9 +52,14 @@ def alert_on_failure_streak(
         if row.status == "up":
             break
         streak += 1
-    # Fire only at the exact transition into the streak: the (threshold+1)-th
-    # failure and beyond stay silent until the probe recovers and breaks again.
-    if streak != threshold:
+    # Fire at the transition into the streak. The window is TWO values, not
+    # one: some probe series have two concurrent writers (GCP's two monitor
+    # regions both record peer_monitor samples), and if both record a down
+    # before either runs this check, the observed streak jumps 2 -> 4 and an
+    # exact `== threshold` match would suppress the alert forever. A double
+    # fire at 3 and 4 folds into one Sentry issue via the fingerprint; past
+    # threshold+1 the streak stays silent until the probe recovers.
+    if not (threshold <= streak <= threshold + 1):
         return False
 
     message = (
@@ -75,5 +80,40 @@ def alert_on_failure_streak(
             sentry_sdk.capture_message(message, level="error")
     except Exception:  # noqa: BLE001 - Sentry unavailable must not break ingestion
         logger.exception("synthetic alert capture failed")
+        return False
+    return True
+
+
+def ops_alert(
+    message: str,
+    *,
+    fingerprint: list[str],
+    tags: dict[str, str] | None = None,
+) -> bool:
+    """A page-worthy operational alarm: logged AND captured as a Sentry issue.
+
+    Exists because ``LoggingIntegration(event_level=None)`` deliberately keeps
+    logger output out of Sentry issues (INFO->Axiom, WARNING+->Sentry logs) —
+    which meant every ``logger.error("ALERT ...")`` money alarm in the outbox
+    and dead-letter paths shipped to a log store nobody watches. Sites that
+    mean "a human must look at this" call ops_alert instead of logger.error;
+    the rendered message stays byte-identical so runbook greps keep working.
+
+    Fingerprinted per alarm class so a recurring condition folds into one
+    issue that re-opens, and exception-swallowed so alerting can never break
+    the money path it is reporting on. Returns True when the capture reached
+    the Sentry SDK.
+    """
+    logger.error(message)
+    try:
+        import sentry_sdk
+
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["ops-alert", *fingerprint]
+            for key, value in (tags or {}).items():
+                scope.set_tag(key, value)
+            sentry_sdk.capture_message(message, level="error")
+    except Exception:  # noqa: BLE001 - Sentry unavailable must not break the caller
+        logger.exception("ops alert capture failed")
         return False
     return True

--- a/src/trusted_router/synthetic/backfill_rollups.py
+++ b/src/trusted_router/synthetic/backfill_rollups.py
@@ -20,9 +20,13 @@ from trusted_router.synthetic.rollups import (
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Backfill synthetic status rollups from raw samples.")
+    parser = argparse.ArgumentParser(
+        description="Backfill synthetic status rollups from raw samples."
+    )
     parser.add_argument("--date", action="append", dest="dates", help="UTC date YYYY-MM-DD.")
-    parser.add_argument("--days", type=int, default=14, help="Recent UTC days to backfill when --date is omitted.")
+    parser.add_argument(
+        "--days", type=int, default=14, help="Recent UTC days to backfill when --date is omitted."
+    )
     parser.add_argument("--limit-per-day", type=int, default=35_000)
     args = parser.parse_args(argv)
 
@@ -43,7 +47,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         print(f"{date}: read {len(samples)} raw samples", flush=True)
         all_samples.extend(samples)
     rollups = _recompute_rollups(all_samples)
-    print(f"writing {len(rollups)} recomputed rollup rows from {len(all_samples)} samples", flush=True)
+    print(
+        f"writing {len(rollups)} recomputed rollup rows from {len(all_samples)} samples", flush=True
+    )
     for index, rollup in enumerate(rollups, 1):
         _write_rollup(table, "m", rollup)
         if index % 500 == 0:
@@ -93,8 +99,7 @@ def _write_rollup(table: Any, family: str, rollup: SyntheticRollup) -> None:
 def _recent_dates(days: int) -> list[str]:
     today = dt.datetime.now(dt.UTC).date()
     return [
-        (today - dt.timedelta(days=offset)).isoformat()
-        for offset in reversed(range(max(days, 1)))
+        (today - dt.timedelta(days=offset)).isoformat() for offset in reversed(range(max(days, 1)))
     ]
 
 

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -297,9 +297,7 @@ async def _throughput_pass(
         ).completion_seconds,
     )
     target = SyntheticTarget("throughput", settings.api_base_url, monitor_region)
-    async with httpx.AsyncClient(
-        timeout=httpx.Timeout(effective_timeout_seconds)
-    ) as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(effective_timeout_seconds)) as client:
         return [
             await provider_throughput_probe(
                 client,

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -33,6 +33,13 @@ MONITOR_CONFIGURATION_ERROR_TYPES = frozenset(
         "monitor_workspace_paused",
     }
 )
+# Liveness/ops probe types (synthetic/fleet.py): scheduler heartbeats and
+# cross-cloud peer policing. They ride the synthetic-sample pipeline for
+# storage and streak alerts but are NOT evidence about this deployment's
+# service, so they must stay out of every component, every SLO, and — most
+# importantly — the monitor-freshness clock: a heartbeat from a loop that is
+# not the probe fleet must never make a dead probe fleet look fresh.
+OPS_PROBE_TYPES = frozenset({"heartbeat", "peer_monitor"})
 # Deep end-to-end model calls: a real OpenAI-SDK chat completion and a real
 # Responses round-trip, output-verified. These probes previously fed NO
 # component: they could fail 100% (as they did on AWS and Azure on

--- a/src/trusted_router/synthetic/fleet.py
+++ b/src/trusted_router/synthetic/fleet.py
@@ -1,0 +1,385 @@
+"""Fleet view + peer policing: the command-center substrate.
+
+Every deployment publishes an honest self-portrait at /status.json, but until
+this module nobody assembled the fleet: an operator had to open four status
+pages to know whether TrustedRouter was healthy, and a cloud whose monitor
+silently died told the truth ("Monitor Data Stale") to nobody in particular.
+
+Two jobs, deliberately in one module because they share the peer list:
+
+* ``fleet_peer_probes`` — the WATCHER-WATCHING half. Each synthetic pass
+  fetches every peer's /status.json (the deployment's own public URL
+  included — proving our own public serving path end to end) and records a
+  ``peer_monitor`` sample per peer. Those samples ride the existing pipeline:
+  three consecutive failures fire the streak alert, and the fleet page shows
+  the freshness. The dead-man's switch is cross-cloud peer pressure — no new
+  scheduler, no external service, no single point of failure.
+
+* ``fleet_snapshot`` — the SEEING half, served at /fleet.json and /fleet.
+  A compact merge of every peer's banner, components, and monitor freshness,
+  plus this deployment's scheduler heartbeats. It deliberately extracts a
+  small summary instead of embedding full payloads: the fleet view is for
+  "where do I look next", not a second copy of every status page.
+
+``peer_monitor`` samples map to no public component (see components.py), so
+peer trouble never repaints THIS deployment's banner — policing the watchers
+must not let a peer outage masquerade as local unavailability.
+
+Heartbeats are ordinary synthetic samples too (``probe_type="heartbeat"``,
+target = job name): recording them through the existing store means zero new
+storage surface and the same retention, and the fleet page derives "this
+scheduler is alive" from sample age alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Any
+
+import httpx
+
+from trusted_router.config import Settings
+from trusted_router.storage_models import SyntheticProbeSample, utcnow
+
+logger = logging.getLogger(__name__)
+
+PEER_MONITOR_PROBE = "peer_monitor"
+HEARTBEAT_PROBE = "heartbeat"
+# One fetch per peer per synthetic pass (1-3 min cadence). Keep the timeout
+# well under the pass budget so a black-holed peer cannot stall the pass.
+PEER_FETCH_TIMEOUT_SECONDS = 10.0
+# A heartbeat older than this is a dead scheduler as far as the fleet page is
+# concerned. Two synthetic cadences plus scheduling allowance, mirroring
+# SILENT_PROBE_TTL_SECONDS in status.py.
+HEARTBEAT_STALE_SECONDS = 11 * 60
+
+
+def fleet_peers(settings: Settings) -> list[tuple[str, str]]:
+    """Parse ``synthetic_fleet_peers`` ("name=base_url,...") into pairs."""
+    peers: list[tuple[str, str]] = []
+    for entry in (settings.synthetic_fleet_peers or "").split(","):
+        entry = entry.strip()
+        if not entry or "=" not in entry:
+            continue
+        name, _, base_url = entry.partition("=")
+        name = name.strip()
+        base_url = base_url.strip().rstrip("/")
+        if name and base_url:
+            peers.append((name, base_url))
+    return peers
+
+
+def _peer_sample(
+    *,
+    name: str,
+    url: str,
+    monitor_region: str,
+    status: str,
+    latency_ms: int | None,
+    error_type: str | None,
+    http_status: int | None,
+) -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=f"syn_peer_{name}_{uuid.uuid4().hex[:12]}",
+        probe_type=PEER_MONITOR_PROBE,
+        target=name,
+        target_url=url,
+        monitor_region=monitor_region,
+        status=status,
+        latency_milliseconds=latency_ms,
+        http_status=http_status,
+        error_type=error_type,
+    )
+
+
+async def _probe_peer(
+    client: httpx.AsyncClient,
+    name: str,
+    base_url: str,
+    *,
+    monitor_region: str,
+) -> SyntheticProbeSample:
+    """One peer_monitor sample: up iff the peer serves a parseable status.json
+    whose OWN monitor is fresh. A reachable page with a stale monitor is DOWN
+    here — "serving but blind" is exactly the state this probe exists to catch.
+    """
+    url = f"{base_url}/status.json"
+    started = time.perf_counter()
+    try:
+        # Per-request timeout: the production caller hands us the shared
+        # monitor client (20s budget); a black-holed peer must not eat the
+        # whole pass, so the peer budget is enforced here, not on the client.
+        response = await client.get(url, timeout=PEER_FETCH_TIMEOUT_SECONDS)
+    except httpx.HTTPError as exc:
+        return _peer_sample(
+            name=name,
+            url=url,
+            monitor_region=monitor_region,
+            status="down",
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            error_type=f"peer_unreachable:{exc.__class__.__name__}",
+            http_status=None,
+        )
+    latency_ms = int((time.perf_counter() - started) * 1000)
+    if response.status_code != 200:
+        return _peer_sample(
+            name=name,
+            url=url,
+            monitor_region=monitor_region,
+            status="down",
+            latency_ms=latency_ms,
+            error_type="peer_bad_status",
+            http_status=response.status_code,
+        )
+    try:
+        data = response.json()["data"]
+        freshness = data.get("monitor_freshness") or {}
+        is_stale = bool(freshness.get("is_stale"))
+    except Exception:  # noqa: BLE001 - malformed peer payload is a DOWN, not a crash
+        return _peer_sample(
+            name=name,
+            url=url,
+            monitor_region=monitor_region,
+            status="down",
+            latency_ms=latency_ms,
+            error_type="peer_bad_payload",
+            http_status=response.status_code,
+        )
+    if is_stale:
+        return _peer_sample(
+            name=name,
+            url=url,
+            monitor_region=monitor_region,
+            status="down",
+            latency_ms=latency_ms,
+            error_type="peer_monitor_stale",
+            http_status=response.status_code,
+        )
+    return _peer_sample(
+        name=name,
+        url=url,
+        monitor_region=monitor_region,
+        status="up",
+        latency_ms=latency_ms,
+        error_type=None,
+        http_status=response.status_code,
+    )
+
+
+async def fleet_peer_probes(
+    settings: Settings,
+    *,
+    monitor_region: str,
+    client: httpx.AsyncClient | None = None,
+) -> list[SyntheticProbeSample]:
+    peers = fleet_peers(settings)
+    if not peers:
+        return []
+    owns_client = client is None
+    active = client or httpx.AsyncClient(timeout=httpx.Timeout(PEER_FETCH_TIMEOUT_SECONDS))
+    try:
+        return list(
+            await asyncio.gather(
+                *(
+                    _probe_peer(active, name, base_url, monitor_region=monitor_region)
+                    for name, base_url in peers
+                )
+            )
+        )
+    finally:
+        if owns_client:
+            await active.aclose()
+
+
+# Heartbeats are bucketed to one row per (job, 5 minutes): liveness needs
+# "recent beat exists", not a row per iteration — per-iteration rows from a
+# 30s loop would both bloat stores with no synthetic-row deletion (Postgres)
+# and let one chatty job crowd older jobs out of bounded newest-N queries,
+# making a dead scheduler VANISH from /fleet instead of rendering stale.
+HEARTBEAT_BUCKET_SECONDS = 5 * 60
+# (job name -> last bucket recorded by THIS process); purely a write saver,
+# the deterministic id is what keeps concurrent replicas to one row.
+_HEARTBEAT_MARKS: dict[str, int] = {}
+
+
+def record_heartbeat(name: str, *, settings: Settings) -> None:
+    """Record one liveness sample for a background job. Never raises: a
+    heartbeat that can kill its own loop would be worse than no heartbeat."""
+    try:
+        bucket = int(time.time() // HEARTBEAT_BUCKET_SECONDS)
+        if _HEARTBEAT_MARKS.get(name) == bucket:
+            return
+        from trusted_router.storage import STORE
+
+        STORE.record_synthetic_probe_sample(
+            SyntheticProbeSample(
+                id=f"syn_hb_{name.replace(':', '_')}_{bucket}",
+                probe_type=HEARTBEAT_PROBE,
+                target=name,
+                target_url="",
+                monitor_region=settings.synthetic_monitor_region or settings.primary_region,
+                status="up",
+            )
+        )
+        _HEARTBEAT_MARKS[name] = bucket
+    except Exception:  # noqa: BLE001 - liveness reporting must not break the job
+        logger.exception("heartbeat record failed for %s", name)
+
+
+def reset_for_tests() -> None:
+    _HEARTBEAT_MARKS.clear()
+
+
+def _age_seconds(created_at: str) -> float | None:
+    import datetime as dt
+
+    try:
+        created = dt.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (utcnow() - created).total_seconds())
+
+
+def _heartbeat_rows() -> list[dict[str, Any]]:
+    from trusted_router.storage import STORE
+
+    samples = STORE.synthetic_probe_samples(probe_type=HEARTBEAT_PROBE, limit=500)
+    latest: dict[str, SyntheticProbeSample] = {}
+    for sample in samples:
+        current = latest.get(sample.target)
+        if current is None or sample.created_at > current.created_at:
+            latest[sample.target] = sample
+    rows = []
+    for name in sorted(latest):
+        sample = latest[name]
+        age = _age_seconds(sample.created_at)
+        rows.append(
+            {
+                "name": name,
+                "last_beat_at": sample.created_at,
+                "age_seconds": round(age) if age is not None else None,
+                "stale": age is None or age > HEARTBEAT_STALE_SECONDS,
+            }
+        )
+    return rows
+
+
+def _peer_summary(name: str, base_url: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {
+            "name": name,
+            "url": f"{base_url}/status.json",
+            "reachable": False,
+            "overall_status": "unreachable",
+            "headline": "Unreachable",
+            "components": {},
+            "monitor_stale": None,
+            "generated_at": None,
+        }
+    # A peer payload is REMOTE input: one deployment shipping a malformed
+    # status.json must degrade to one weird row on everyone's fleet page,
+    # never a 500 of the fleet page itself.
+    try:
+        freshness = payload.get("monitor_freshness")
+        summary = payload.get("summary")
+        components = payload.get("components")
+        return {
+            "name": name,
+            "url": f"{base_url}/status.json",
+            "reachable": True,
+            "overall_status": str(payload.get("overall_status") or "unknown"),
+            "headline": str((summary.get("headline") if isinstance(summary, dict) else None) or ""),
+            "components": {
+                str(row.get("id")): str(row.get("status"))
+                for row in (components if isinstance(components, list) else [])
+                if isinstance(row, dict)
+            },
+            "monitor_stale": bool(freshness.get("is_stale"))
+            if isinstance(freshness, dict)
+            else None,
+            "generated_at": payload.get("generated_at"),
+        }
+    except Exception:  # noqa: BLE001 - malformed peer data renders, not raises
+        logger.exception("unparseable peer status payload from %s", name)
+        return {
+            "name": name,
+            "url": f"{base_url}/status.json",
+            "reachable": True,
+            "overall_status": "unknown",
+            "headline": "Unparseable status payload",
+            "components": {},
+            "monitor_stale": None,
+            "generated_at": None,
+        }
+
+
+_FLEET_SEVERITY = {
+    "up": 0,
+    "degraded": 1,
+    "routing_degraded": 1,
+    "trust_degraded": 2,
+    "down": 3,
+    "unreachable": 3,
+    "unknown": 1,
+}
+
+
+def _fleet_overall(summaries: list[dict[str, Any]]) -> str:
+    worst = "up"
+    for row in summaries:
+        status = str(row["overall_status"])
+        if row.get("monitor_stale"):
+            status = "degraded" if _FLEET_SEVERITY.get(status, 0) < 1 else status
+        if _FLEET_SEVERITY.get(status, 1) > _FLEET_SEVERITY.get(worst, 0):
+            worst = status
+    return worst
+
+
+async def fleet_snapshot(
+    settings: Settings,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """The merged fleet view served at /fleet.json.
+
+    In the test environment peers are only fetched through an explicitly
+    injected client (tests pass a MockTransport-backed one); without it the
+    peer list is treated as empty so no test ever touches the network.
+    """
+    peers = fleet_peers(settings)
+    if settings.environment == "test" and client is None:
+        peers = []
+    payloads: dict[str, dict[str, Any] | None] = {}
+    if peers:
+        owns_client = client is None
+        active = client or httpx.AsyncClient(timeout=httpx.Timeout(PEER_FETCH_TIMEOUT_SECONDS))
+
+        async def fetch(name: str, base_url: str) -> None:
+            try:
+                response = await active.get(
+                    f"{base_url}/status.json", timeout=PEER_FETCH_TIMEOUT_SECONDS
+                )
+                data = response.json()["data"] if response.status_code == 200 else None
+                payloads[name] = data if isinstance(data, dict) else None
+            except Exception:  # noqa: BLE001 - a down peer is data, not an error
+                payloads[name] = None
+
+        try:
+            await asyncio.gather(*(fetch(name, url) for name, url in peers))
+        finally:
+            if owns_client:
+                await active.aclose()
+    summaries = [_peer_summary(name, url, payloads.get(name)) for name, url in peers]
+    from trusted_router.storage_models import iso_now
+
+    return {
+        "generated_at": iso_now(),
+        "fleet_overall_status": _fleet_overall(summaries) if summaries else "unknown",
+        "deployments": summaries,
+        # Blocking storage read — off the event loop, same rule as every
+        # other sync store call on a request path (head-of-line blocking).
+        "heartbeats": await asyncio.to_thread(_heartbeat_rows),
+    }

--- a/src/trusted_router/synthetic/image_generation.py
+++ b/src/trusted_router/synthetic/image_generation.py
@@ -95,9 +95,7 @@ async def run() -> int:
                 "generation_id": sample.generation_id,
                 "cost_microdollars": sample.cost_microdollars,
                 "attempts": len(samples),
-                "total_cost_microdollars": sum(
-                    item.cost_microdollars or 0 for item in samples
-                ),
+                "total_cost_microdollars": sum(item.cost_microdollars or 0 for item in samples),
                 "ingest_status": response.status_code,
             },
             separators=(",", ":"),

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -159,30 +159,22 @@ class ProviderModelStats:
             "error_rate": round(self.error_rate, 4),
             "effective_attempt_count": self.effective_attempt_count,
             "completion_rate": (
-                round(self.completion_rate, 4)
-                if self.effective_attempt_count
-                else None
+                round(self.completion_rate, 4) if self.effective_attempt_count else None
             ),
             "provider_sample_count": self.provider_sample_count,
             "provider_availability": (
-                round(self.provider_availability, 4)
-                if self.provider_sample_count
-                else None
+                round(self.provider_availability, 4) if self.provider_sample_count else None
             ),
             "deadline_sample_count": self.deadline_sample_count,
             "availability_within_deadline": (
-                round(self.availability_within_deadline, 4)
-                if self.deadline_sample_count
-                else None
+                round(self.availability_within_deadline, 4) if self.deadline_sample_count else None
             ),
             "first_token_deadline_ms": int(
                 model_deadlines(self.model, provider=self.provider).first_token_seconds * 1000
             ),
             "capacity_attempt_count": self.capacity_attempt_count,
             "capacity_acceptance_rate": (
-                round(self.capacity_acceptance_rate, 4)
-                if self.capacity_attempt_count
-                else None
+                round(self.capacity_acceptance_rate, 4) if self.capacity_attempt_count else None
             ),
             "excluded_count": self.excluded_count,
             "ttft_sample_count": self.ttft_sample_count,
@@ -297,27 +289,19 @@ class ProviderStats:
             "error_rate": round(self.error_rate, 4),
             "effective_attempt_count": self.effective_attempt_count,
             "completion_rate": (
-                round(self.completion_rate, 4)
-                if self.effective_attempt_count
-                else None
+                round(self.completion_rate, 4) if self.effective_attempt_count else None
             ),
             "provider_sample_count": self.provider_sample_count,
             "provider_availability": (
-                round(self.provider_availability, 4)
-                if self.provider_sample_count
-                else None
+                round(self.provider_availability, 4) if self.provider_sample_count else None
             ),
             "deadline_sample_count": self.deadline_sample_count,
             "availability_within_deadline": (
-                round(self.availability_within_deadline, 4)
-                if self.deadline_sample_count
-                else None
+                round(self.availability_within_deadline, 4) if self.deadline_sample_count else None
             ),
             "capacity_attempt_count": self.capacity_attempt_count,
             "capacity_acceptance_rate": (
-                round(self.capacity_acceptance_rate, 4)
-                if self.capacity_attempt_count
-                else None
+                round(self.capacity_acceptance_rate, 4) if self.capacity_attempt_count else None
             ),
             "excluded_count": self.excluded_count,
             "ttft_sample_count": self.ttft_sample_count,
@@ -533,14 +517,10 @@ def _aggregate_providers(
         agg.failure_classes.update(model_stat.failure_classes)
         # Weight each model's p50 by its sample count for the provider median.
         if model_stat.p50_ttft_ms is not None:
-            ttft[model_stat.provider].extend(
-                [model_stat.p50_ttft_ms] * model_stat.sample_count
-            )
+            ttft[model_stat.provider].extend([model_stat.p50_ttft_ms] * model_stat.sample_count)
         if model_stat.p50_tokens_per_second is not None:
             weight = model_stat.throughput_sample_count
-            tps[model_stat.provider].extend(
-                [model_stat.p50_tokens_per_second] * weight
-            )
+            tps[model_stat.provider].extend([model_stat.p50_tokens_per_second] * weight)
     providers = list(by_provider.values())
     for agg in providers:
         agg.p50_ttft_ms = _percentile(ttft[agg.provider], 50)

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -303,6 +303,18 @@ async def run_synthetic_once(
                     billing_semaphore=limiter,
                 )
             )
+        # Peer policing rides the same pass: every deployment fetches every
+        # deployment's public status.json (itself included) and records a
+        # peer_monitor sample, so a cloud whose monitor silently dies is
+        # caught by its PEERS within three cadences (streak alert), not by a
+        # human opening four status pages. Gated off in tests, which build
+        # Settings(environment="test") and must not touch the network.
+        if settings.synthetic_fleet_peers and settings.environment != "test":
+            from trusted_router.synthetic.fleet import fleet_peer_probes
+
+            probe_tasks.append(
+                fleet_peer_probes(settings, monitor_region=region, client=default_client)
+            )
         target_results = await asyncio.gather(*probe_tasks)
     for target_samples in target_results:
         samples.extend(target_samples)

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -171,7 +171,9 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
         )
         error_counts.update(rollup.error_counts)
         cost_microdollars += rollup.cost_microdollars
-        if rollup.last_checked_at and (last_checked_at is None or rollup.last_checked_at > last_checked_at):
+        if rollup.last_checked_at and (
+            last_checked_at is None or rollup.last_checked_at > last_checked_at
+        ):
             last_checked_at = rollup.last_checked_at
     return {
         "sample_count": sample_count,
@@ -182,18 +184,10 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
         "p95_ttfb_milliseconds": percentile_from_histogram(ttfb_histogram, 95),
         "p50_dns_milliseconds": percentile_from_histogram(dns_histogram, 50),
         "p95_dns_milliseconds": percentile_from_histogram(dns_histogram, 95),
-        "p50_tcp_connect_milliseconds": percentile_from_histogram(
-            tcp_connect_histogram, 50
-        ),
-        "p95_tcp_connect_milliseconds": percentile_from_histogram(
-            tcp_connect_histogram, 95
-        ),
-        "p50_tls_handshake_milliseconds": percentile_from_histogram(
-            tls_handshake_histogram, 50
-        ),
-        "p95_tls_handshake_milliseconds": percentile_from_histogram(
-            tls_handshake_histogram, 95
-        ),
+        "p50_tcp_connect_milliseconds": percentile_from_histogram(tcp_connect_histogram, 50),
+        "p95_tcp_connect_milliseconds": percentile_from_histogram(tcp_connect_histogram, 95),
+        "p50_tls_handshake_milliseconds": percentile_from_histogram(tls_handshake_histogram, 50),
+        "p95_tls_handshake_milliseconds": percentile_from_histogram(tls_handshake_histogram, 95),
         "p50_gateway_processing_milliseconds": percentile_from_histogram(
             gateway_processing_histogram, 50
         ),

--- a/src/trusted_router/synthetic/route_health.py
+++ b/src/trusted_router/synthetic/route_health.py
@@ -129,9 +129,10 @@ def report_route_health(flags: list[RouteHealthFlag]) -> None:
         return
 
     for flag in flags:
-        latest = " ".join(
-            part for part in (flag.newest_error_type, flag.newest_error_message) if part
-        ) or "unknown error"
+        latest = (
+            " ".join(part for part in (flag.newest_error_type, flag.newest_error_message) if part)
+            or "unknown error"
+        )
         message = (
             f"route-health: {flag.provider}/{flag.model} {flag.failure_rate:.0%} failure "
             f"over {flag.samples} samples (latest: {latest})"

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -18,6 +18,7 @@ from trusted_router.synthetic.components import (
     COMPONENT_DEFINITIONS,
     COMPONENT_PROBE_TARGETS,
     GATEWAY_REGION_TARGET_NAMES,
+    OPS_PROBE_TYPES,
     REGIONAL_GATEWAY_PROBES,
     SLO_DEFINITIONS,
     UNCATEGORIZED_COMPONENT,
@@ -211,7 +212,12 @@ def status_snapshot(
         },
         "daily": daily,
         "monthly": monthly,
-        "samples": [sample.public_dict() for sample in ordered[:100]],
+        # Ops/liveness samples stay off the public live feed: they would
+        # crowd real probes out of the bounded window and leak internal job
+        # names; /fleet is their surface.
+        "samples": [
+            sample.public_dict() for sample in ordered if sample.probe_type not in OPS_PROBE_TYPES
+        ][:100],
     }
 
 
@@ -229,12 +235,19 @@ def _monitor_freshness(
     # worse than none: it reports "fresh" through a total monitor outage.
     # Small negative ages are ordinary clock skew between the monitor and
     # this host, so only samples beyond the skew budget are excluded.
+    #
+    # Ops/liveness samples (heartbeats, peer policing) are excluded for the
+    # same reason from the other direction: a background loop's heartbeat is
+    # not the probe fleet reporting, and counting it would keep this clock
+    # "fresh" straight through a dead monitor — the masking failure this
+    # detector exists to catch.
+    probe_samples = [sample for sample in samples if sample.probe_type not in OPS_PROBE_TYPES]
     dateable = [
         sample
-        for sample in samples
+        for sample in probe_samples
         if (now - _parse_time(sample.created_at)).total_seconds() >= -FUTURE_SAMPLE_SKEW_SECONDS
     ]
-    future_dated = len(samples) - len(dateable)
+    future_dated = len(probe_samples) - len(dateable)
     if not dateable:
         return {
             "latest_sample_at": None,

--- a/src/trusted_router/synthetic/video_leaderboard.py
+++ b/src/trusted_router/synthetic/video_leaderboard.py
@@ -120,11 +120,7 @@ def aggregate_video_leaderboard(
         {
             **_aggregate_group(provider=provider, model=None, samples=group),
             "model_count": len(
-                {
-                    model
-                    for route_provider, model in by_model
-                    if route_provider == provider
-                }
+                {model for route_provider, model in by_model if route_provider == provider}
             ),
         }
         for provider, group in by_provider.items()

--- a/tests/test_fleet_command_center.py
+++ b/tests/test_fleet_command_center.py
@@ -1,0 +1,359 @@
+"""Tests for the fleet command-center substrate (see synthetic/fleet.py).
+
+Covers the two halves plus the alert plumbing they rely on:
+- peer policing: peer_monitor samples up/down for fresh, stale, broken,
+  and unreachable peers, and the run_synthetic_once gating;
+- fleet view: /fleet.json + /fleet merge, heartbeat liveness rows;
+- ops_alert: money alarms become fingerprinted Sentry issues and can
+  never break their caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.storage import STORE
+from trusted_router.storage_models import iso_now, utcnow
+from trusted_router.synthetic import fleet
+from trusted_router.synthetic.alerts import ops_alert
+from trusted_router.synthetic.fleet import (
+    fleet_peer_probes,
+    fleet_peers,
+    fleet_snapshot,
+    record_heartbeat,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_heartbeat_marks() -> None:
+    fleet.reset_for_tests()
+
+
+def _settings(**kwargs: object) -> Settings:
+    return Settings(environment="test", **kwargs)  # type: ignore[arg-type]
+
+
+def _peer_transport(responses: dict[str, object]) -> httpx.MockTransport:
+    """Map host -> response spec: dict payload => 200 status.json body,
+    int => that HTTP status, Exception => raised as a connect error."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        spec = responses.get(request.url.host)
+        if isinstance(spec, Exception):
+            raise httpx.ConnectError("boom", request=request)
+        if isinstance(spec, int):
+            return httpx.Response(spec)
+        return httpx.Response(200, json={"data": spec})
+
+    return httpx.MockTransport(handler)
+
+
+def test_fleet_peers_parsing_skips_junk() -> None:
+    settings = _settings(
+        synthetic_fleet_peers="gcp=https://trustedrouter.com/, junk, =nope,aws=https://aws.trustedrouter.com"
+    )
+    assert fleet_peers(settings) == [
+        ("gcp", "https://trustedrouter.com"),
+        ("aws", "https://aws.trustedrouter.com"),
+    ]
+
+
+def test_peer_probes_classify_fresh_stale_broken_unreachable() -> None:
+    settings = _settings(
+        synthetic_fleet_peers=(
+            "fresh=https://fresh.example,stale=https://stale.example,"
+            "broken=https://broken.example,gone=https://gone.example"
+        )
+    )
+    transport = _peer_transport(
+        {
+            "fresh.example": {"monitor_freshness": {"is_stale": False}, "overall_status": "up"},
+            "stale.example": {"monitor_freshness": {"is_stale": True}, "overall_status": "up"},
+            "broken.example": 500,
+            "gone.example": httpx.ConnectError("x", request=None),  # type: ignore[arg-type]
+        }
+    )
+
+    async def run() -> dict[str, object]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            samples = await fleet_peer_probes(settings, monitor_region="test-1", client=client)
+        return {s.target: s for s in samples}
+
+    by_target = asyncio.run(run())
+    assert by_target["fresh"].status == "up"  # type: ignore[union-attr]
+    assert by_target["stale"].status == "down"  # type: ignore[union-attr]
+    assert by_target["stale"].error_type == "peer_monitor_stale"  # type: ignore[union-attr]
+    assert by_target["broken"].status == "down"  # type: ignore[union-attr]
+    assert by_target["broken"].error_type == "peer_bad_status"  # type: ignore[union-attr]
+    assert by_target["gone"].status == "down"  # type: ignore[union-attr]
+    assert str(by_target["gone"].error_type).startswith("peer_unreachable")  # type: ignore[union-attr]
+    for sample in by_target.values():
+        assert sample.probe_type == "peer_monitor"  # type: ignore[union-attr]
+
+
+def test_peer_probe_bad_payload_is_down() -> None:
+    settings = _settings(synthetic_fleet_peers="odd=https://odd.example")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not json")
+
+    async def run() -> list[object]:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            return list(await fleet_peer_probes(settings, monitor_region="test-1", client=client))
+
+    (sample,) = asyncio.run(run())
+    assert sample.status == "down"  # type: ignore[union-attr]
+    assert sample.error_type == "peer_bad_payload"  # type: ignore[union-attr]
+
+
+def test_run_synthetic_once_gates_peer_probes_off_in_test_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import probes as probes_module
+
+    called: list[str] = []
+
+    async def spy(*args: object, **kwargs: object) -> list[object]:
+        called.append("fleet")
+        return []
+
+    monkeypatch.setattr(fleet, "fleet_peer_probes", spy)
+    monkeypatch.setattr(probes_module, "configured_targets", lambda settings: [])
+
+    from trusted_router.synthetic.probes import run_synthetic_once
+
+    # environment="test": the peers stay configured but the branch is off.
+    asyncio.run(run_synthetic_once(_settings()))
+    assert called == []
+
+    # any non-test environment with peers configured: the branch runs.
+    canary = Settings(environment="canary")
+    assert canary.synthetic_fleet_peers  # default-on config
+    asyncio.run(run_synthetic_once(canary))
+    assert called == ["fleet"]
+
+
+def test_record_heartbeat_and_liveness_rows() -> None:
+    settings = _settings()
+    record_heartbeat("scheduler:test-loop", settings=settings)
+    snapshot = asyncio.run(fleet_snapshot(settings))
+    beats = {row["name"]: row for row in snapshot["heartbeats"]}
+    assert "scheduler:test-loop" in beats
+    assert beats["scheduler:test-loop"]["stale"] is False
+    assert beats["scheduler:test-loop"]["age_seconds"] is not None
+
+    # An old heartbeat renders as stale — the fleet page's dead-loop signal.
+    old = (utcnow() - dt.timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    from trusted_router.storage_models import SyntheticProbeSample
+
+    STORE.record_synthetic_probe_sample(
+        SyntheticProbeSample(
+            id="syn_hb_dead_loop_test",
+            probe_type="heartbeat",
+            target="scheduler:dead-loop",
+            target_url="",
+            monitor_region="test-1",
+            status="up",
+            created_at=old,
+        )
+    )
+    snapshot = asyncio.run(fleet_snapshot(settings))
+    beats = {row["name"]: row for row in snapshot["heartbeats"]}
+    assert beats["scheduler:dead-loop"]["stale"] is True
+
+
+def test_fleet_snapshot_merges_peers_and_ranks_overall() -> None:
+    settings = _settings(synthetic_fleet_peers="good=https://good.example,bad=https://bad.example")
+    transport = _peer_transport(
+        {
+            "good.example": {
+                "overall_status": "up",
+                "summary": {"headline": "All Systems Operational"},
+                "components": [{"id": "model_inference", "status": "up"}],
+                "monitor_freshness": {"is_stale": False},
+                "generated_at": iso_now(),
+            },
+            "bad.example": httpx.ConnectError("x", request=None),  # type: ignore[arg-type]
+        }
+    )
+
+    async def run() -> dict[str, object]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            return await fleet_snapshot(settings, client=client)
+
+    snapshot = asyncio.run(run())
+    rows = {row["name"]: row for row in snapshot["deployments"]}  # type: ignore[union-attr,index]
+    assert rows["good"]["reachable"] is True
+    assert rows["good"]["overall_status"] == "up"
+    assert rows["good"]["components"] == {"model_inference": "up"}
+    assert rows["bad"]["reachable"] is False
+    assert rows["bad"]["overall_status"] == "unreachable"
+    # One unreachable deployment pulls the fleet banner all the way down:
+    # a cloud you cannot see is a cloud you cannot vouch for.
+    assert snapshot["fleet_overall_status"] == "unreachable"
+
+
+def test_fleet_routes_serve_json_and_html(client: TestClient) -> None:
+    record_heartbeat("scheduler:route-test", settings=_settings())
+    response = client.get("/fleet.json")
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert "fleet_overall_status" in data
+    assert isinstance(data["deployments"], list)
+    names = {row["name"] for row in data["heartbeats"]}
+    assert "scheduler:route-test" in names
+
+    page = client.get("/fleet")
+    assert page.status_code == 200
+    assert "TrustedRouter Fleet" in page.text
+    assert "scheduler:route-test" in page.text
+    # Ops page: keep it out of search indexes.
+    assert 'name="robots" content="noindex"' in page.text
+
+
+def test_ops_alert_fires_fingerprinted_sentry_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sentry_sdk
+
+    events: list[str] = []
+    fingerprints: list[list[str]] = []
+
+    class _Scope:
+        def __enter__(self) -> _Scope:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def __setattr__(self, name: str, value: object) -> None:
+            if name == "fingerprint":
+                fingerprints.append(list(value))  # type: ignore[arg-type]
+            object.__setattr__(self, name, value)
+
+        def set_tag(self, key: str, value: str) -> None:
+            return None
+
+    monkeypatch.setattr(sentry_sdk, "new_scope", lambda: _Scope())
+    monkeypatch.setattr(
+        sentry_sdk,
+        "capture_message",
+        lambda message, level=None: events.append(message),
+    )
+
+    assert (
+        ops_alert(
+            "ALERT settle outbox lost charge authorization_id=auth_x actual_cost_micro=5",
+            fingerprint=["settle-outbox", "lost-charge"],
+            tags={"authorization_id": "auth_x"},
+        )
+        is True
+    )
+    assert events and "lost charge" in events[0]
+    assert fingerprints == [["ops-alert", "settle-outbox", "lost-charge"]]
+
+
+def test_ops_alert_survives_sentry_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sentry_sdk
+
+    def explode() -> object:
+        raise RuntimeError("sentry down")
+
+    monkeypatch.setattr(sentry_sdk, "new_scope", explode)
+    assert ops_alert("ALERT test message", fingerprint=["test"], tags=None) is False
+
+
+def test_peer_samples_stay_out_of_components_and_slo() -> None:
+    from trusted_router.storage_models import SyntheticProbeSample
+    from trusted_router.synthetic.components import (
+        sample_component_ids,
+        sample_slo_class_ids,
+    )
+
+    for probe_type in ("peer_monitor", "heartbeat"):
+        sample = SyntheticProbeSample(
+            id=f"syn_{probe_type}_scope",
+            probe_type=probe_type,
+            target="aws",
+            target_url="https://aws.trustedrouter.com/status.json",
+            monitor_region="test-1",
+            status="down",
+        )
+        # Policing the watchers must never repaint THIS deployment's banner.
+        assert sample_component_ids(sample) == []
+        assert sample_slo_class_ids(sample) == []
+
+
+def test_heartbeats_never_keep_the_freshness_clock_alive() -> None:
+    # The masking failure: the probe fleet dies but a background loop keeps
+    # heartbeating. monitor_freshness must report STALE — a heartbeat is not
+    # the probe fleet reporting.
+    from trusted_router.storage_models import SyntheticProbeSample
+    from trusted_router.synthetic.status import status_snapshot
+
+    now = utcnow()
+    old = (now - dt.timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+    fresh = (now - dt.timedelta(seconds=20)).isoformat().replace("+00:00", "Z")
+    samples = [
+        SyntheticProbeSample(
+            id="syn_tls_old",
+            probe_type="tls_health",
+            target="canonical",
+            target_url="https://api.trustedrouter.com/v1",
+            monitor_region="test-1",
+            status="up",
+            created_at=old,
+        ),
+        SyntheticProbeSample(
+            id="syn_hb_fresh",
+            probe_type="heartbeat",
+            target="scheduler:home-settlement",
+            target_url="",
+            monitor_region="test-1",
+            status="up",
+            created_at=fresh,
+        ),
+        SyntheticProbeSample(
+            id="syn_peer_fresh",
+            probe_type="peer_monitor",
+            target="aws",
+            target_url="https://aws.trustedrouter.com/status.json",
+            monitor_region="test-1",
+            status="up",
+            created_at=fresh,
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_settings())
+
+    assert snapshot["monitor_freshness"]["is_stale"] is True
+    assert snapshot["monitor_freshness"]["latest_sample_at"] == old
+
+
+def test_fleet_probe_constants_stay_in_the_ops_set() -> None:
+    # OPS_PROBE_TYPES (components.py) is what keeps liveness samples out of
+    # the freshness clock; fleet.py's constants must never drift out of it.
+    from trusted_router.synthetic.components import OPS_PROBE_TYPES
+
+    assert {fleet.PEER_MONITOR_PROBE, fleet.HEARTBEAT_PROBE} <= OPS_PROBE_TYPES
+
+
+def test_fleet_json_shape_is_stable() -> None:
+    # The fleet feed is a machine surface (future remediation loops read it):
+    # lock the top-level keys the same way status.json's shape is locked.
+    settings = _settings()
+    snapshot = asyncio.run(fleet_snapshot(settings))
+    assert set(snapshot) == {
+        "generated_at",
+        "fleet_overall_status",
+        "deployments",
+        "heartbeats",
+    }
+    json.dumps(snapshot)  # must be JSON-serializable as-is

--- a/tests/test_synthetic_visibility_and_funding.py
+++ b/tests/test_synthetic_visibility_and_funding.py
@@ -331,10 +331,24 @@ def test_alert_stays_silent_below_threshold(sentry_events: list[str]) -> None:
     assert sentry_events == []
 
 
-def test_alert_does_not_refire_past_threshold(sentry_events: list[str]) -> None:
-    # 4th consecutive failure: the issue already exists; stay silent until
+def test_alert_fires_in_the_two_sample_transition_window(
+    sentry_events: list[str],
+) -> None:
+    # streak == threshold + 1 still fires: with two concurrent writers (GCP's
+    # two monitor regions) the observed streak can jump 2 -> 4, and an exact
+    # == threshold match would suppress the alert forever. The Sentry
+    # fingerprint folds a double fire at 3 and 4 into one issue.
+    store = _StreakStore(["down", "down", "down", "down", "up"])
+    assert alert_on_failure_streak(store, store.rows[0]) is True
+    assert len(sentry_events) == 1
+
+
+def test_alert_does_not_refire_past_the_transition_window(
+    sentry_events: list[str],
+) -> None:
+    # 5th consecutive failure: the issue already exists; stay silent until
     # the probe recovers and a fresh streak forms.
-    store = _StreakStore(["down", "down", "down", "down"])
+    store = _StreakStore(["down", "down", "down", "down", "down"])
     assert alert_on_failure_streak(store, store.rows[0]) is False
     assert sentry_events == []
 


### PR DESCRIPTION
Command-center Increments 1+2 (see the roadmap discussion). Three gaps from the two-repo recon, closed:

## 1. See — `/fleet.json` + `/fleet` on every control plane
Compact merge of every deployment's banner, components, and monitor freshness + this deployment's scheduler heartbeats. Served by **all** clouds (any healthy deployment is the command center). Single-flight + 30s cache; ops page is `noindex`.

## 2. Watch the watchers — cross-cloud peer pressure
`peer_monitor` probes ride every synthetic pass on every cloud (one insertion point in `run_synthetic_once` covers GCP Cloud Run Jobs, AWS EventBridge, Azure in-process). Each cloud fetches each cloud's public status.json — itself included. Unreachable / unparseable / **stale-monitor** peers record down samples → 3 consecutive fire the existing streak alert. Silent scheduler death (the recon's canonical failure shape) is now caught by peers within three cadences, with zero new infrastructure. Scheduler heartbeats (bucketed 1/5min per job) render as liveness rows on `/fleet`.

## 3. Money alarms reach a human — `ops_alert`
`LoggingIntegration(event_level=None)` deliberately keeps `logger.error` out of Sentry issues — which meant settle-outbox lost-charge/dead-row alarms went only to a log store. `ops_alert()` = same grep-identical log line + fingerprinted Sentry issue; wired into the 5 outbox ALERT sites + home-settlement dead-letter.

## Guard rails (adversarial review: 12 findings, 10 confirmed, all addressed)
- Ops probe types excluded from the **freshness clock** (heartbeat must never make a dead probe fleet look fresh), all components/SLO, and the public samples feed.
- Streak fire window widened to `threshold..threshold+1` (limit `threshold+2`): two concurrent monitor regions can jump the streak 2→4 and an exact match would suppress forever; fingerprint folds double fires.
- Peer payloads treated as remote input: malformed → one weird row, never a 500. Per-request 10s peer timeout on both the probe and fleet paths.
- `/fleet` storage reads off the event loop; heartbeat bucketing caps write volume and prevents newest-N crowd-out.

Config: `synthetic_fleet_peers` default-on in config.py (gcp/aws/azure) — reaches every cloud on its next image roll, no env churn; `environment=test` gates all network.

**Verification:** 15 new tests; full suite **3251 passed / 0 failed**; ruff + mypy clean.
**Follow-ups (remediator increment):** heartbeat staleness should alert (render-only today); Postgres synthetic-row retention sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)