### PR TITLE
Activate Databricks routes per model canary

### DIFF
--- a/scripts/pricing/manifest.py
+++ b/scripts/pricing/manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Collection
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -227,6 +228,46 @@ def set_manifest_canary_state(
                 continue
             row["routable"] = False
             row["routable_reason"] = failure_reason
+    manifest_path.write_text(
+        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def set_manifest_model_canary_states(
+    manifest_path: Path,
+    *,
+    checked_model_ids: Collection[str],
+    healthy_model_ids: Collection[str],
+    failure_reason: str = "provider-canary-failed",
+) -> None:
+    """Apply authenticated canary state per model without disturbing holds."""
+
+    checked = set(checked_model_ids)
+    healthy = set(healthy_model_ids)
+    if not healthy <= checked:
+        raise ValueError("healthy model ids must be a subset of checked model ids")
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = raw.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError(f"{manifest_path.name} has no models list")
+    for row in rows:
+        if not isinstance(row, dict) or row.get("id") not in checked:
+            continue
+        if row["id"] in healthy:
+            if row.get("routable_reason") == failure_reason:
+                row.pop("routable", None)
+                row.pop("routable_reason", None)
+            continue
+        existing_reason = row.get("routable_reason")
+        if row.get("routable") is False and existing_reason not in {
+            None,
+            failure_reason,
+        }:
+            continue
+        row["routable"] = False
+        row["routable_reason"] = failure_reason
     manifest_path.write_text(
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",

--- a/scripts/pricing/providers/databricks.py
+++ b/scripts/pricing/providers/databricks.py
@@ -20,7 +20,7 @@ from scripts.pricing.base import (
     validate,
 )
 from scripts.pricing.manifest import (
-    set_manifest_canary_state,
+    set_manifest_model_canary_states,
     write_discovered_chat_manifest,
 )
 from scripts.pricing.openai_catalog import probe_openai_chat
@@ -136,7 +136,8 @@ UPSTREAM_ID_MAP = {
     str(row["id"]): str(row["upstream_id"]) for row in MODEL_CONFIG.values()
 }
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
-_LIVE_CANARY_OK = False
+_LIVE_CANARY_CHECKED_MODEL_IDS: set[str] = set()
+_LIVE_CANARY_HEALTHY_MODEL_IDS: set[str] = set()
 
 
 class _TableRows(HTMLParser):
@@ -280,7 +281,9 @@ def normalize_workspace_host(value: str) -> str:
 
 
 def fetch() -> ProviderPricingResult:
-    global _DISCOVERED_MANIFEST_ROWS, _LIVE_CANARY_OK  # noqa: PLW0603
+    global _DISCOVERED_MANIFEST_ROWS  # noqa: PLW0603
+    global _LIVE_CANARY_CHECKED_MODEL_IDS  # noqa: PLW0603
+    global _LIVE_CANARY_HEALTHY_MODEL_IDS  # noqa: PLW0603
 
     transport = httpx.HTTPTransport(retries=PROVIDER_FETCH_TRANSPORT_RETRIES)
     with httpx.Client(
@@ -307,15 +310,19 @@ def fetch() -> ProviderPricingResult:
     host = (os.environ.get("DATABRICKS_HOST") or "").strip()
     if bool(token) != bool(host):
         raise RuntimeError("databricks: DATABRICKS_HOST and DATABRICKS_TOKEN must be set together")
-    _LIVE_CANARY_OK = False
+    _LIVE_CANARY_CHECKED_MODEL_IDS = set()
+    _LIVE_CANARY_HEALTHY_MODEL_IDS = set()
     if token and host:
         base_url = f"{normalize_workspace_host(host)}/serving-endpoints"
-        _LIVE_CANARY_OK = probe_openai_chat(
-            base_url=base_url,
-            api_key=token,
-            model="databricks-gpt-oss-20b",
-            max_tokens=16,
-        )
+        for model_id, row in discovered.items():
+            _LIVE_CANARY_CHECKED_MODEL_IDS.add(model_id)
+            if probe_openai_chat(
+                base_url=base_url,
+                api_key=token,
+                model=str(row["upstream_id"]),
+                max_tokens=4,
+            ):
+                _LIVE_CANARY_HEALTHY_MODEL_IDS.add(model_id)
 
     return ProviderPricingResult(
         slug=SLUG,
@@ -325,7 +332,13 @@ def fetch() -> ProviderPricingResult:
         notes=[
             f"matched {len(discovered)} documented pay-per-token endpoints",
             f"converted DBU prices at ${_dbu_usd()}/DBU",
-            f"account canary {'passed' if _LIVE_CANARY_OK else 'not configured or failed'}",
+            "account canary "
+            + (
+                f"passed {len(_LIVE_CANARY_HEALTHY_MODEL_IDS)}/"
+                f"{len(_LIVE_CANARY_CHECKED_MODEL_IDS)} models"
+                if _LIVE_CANARY_CHECKED_MODEL_IDS
+                else "not configured"
+            ),
         ],
     )
 
@@ -341,5 +354,9 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     # Databricks credentials. Preserve the last private canary state unless
     # this process was explicitly configured to run an authenticated check.
     if os.environ.get("DATABRICKS_TOKEN") and os.environ.get("DATABRICKS_HOST"):
-        set_manifest_canary_state(MANIFEST_PATH, healthy=_LIVE_CANARY_OK)
+        set_manifest_model_canary_states(
+            MANIFEST_PATH,
+            checked_model_ids=_LIVE_CANARY_CHECKED_MODEL_IDS,
+            healthy_model_ids=_LIVE_CANARY_HEALTHY_MODEL_IDS,
+        )
     return notes

--- a/src/trusted_router/data/provider_models/databricks.json
+++ b/src/trusted_router/data/provider_models/databricks.json
@@ -26,10 +26,9 @@
         "chat",
         "completion"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 150000,
-      "output_token_price_per_m": 500000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 500000
     },
     {
       "display_name": "Llama 3.1 8B Instruct",
@@ -52,10 +51,9 @@
         "chat",
         "completion"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 150000,
-      "output_token_price_per_m": 450000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 450000
     },
     {
       "display_name": "Llama 3.3 70B Instruct",
@@ -78,10 +76,9 @@
         "chat",
         "completion"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 500000,
-      "output_token_price_per_m": 1500000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 1500000
     },
     {
       "display_name": "Llama 4 Maverick",
@@ -105,10 +102,9 @@
         "chat",
         "completion"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 500000,
-      "output_token_price_per_m": 1500000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 1500000
     },
     {
       "display_name": "Kimi K3",
@@ -162,10 +158,9 @@
         "completion",
         "reasoning"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 150000,
-      "output_token_price_per_m": 600000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 600000
     },
     {
       "display_name": "GPT OSS 20B",
@@ -189,10 +184,9 @@
         "completion",
         "reasoning"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 70000,
-      "output_token_price_per_m": 300000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 300000
     },
     {
       "display_name": "Qwen3 Next 80B A3B Instruct",
@@ -215,10 +209,9 @@
         "chat",
         "completion"
       ],
-      "routable": false,
+      "routable": true,
       "input_token_price_per_m": 150000,
-      "output_token_price_per_m": 1200000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 1200000
     },
     {
       "display_name": "Qwen 3.5 122B A10B",
@@ -242,11 +235,10 @@
         "completion",
         "reasoning"
       ],
-      "routable": false,
+      "routable": true,
       "max_output_tokens": 25000,
       "input_token_price_per_m": 220000,
-      "output_token_price_per_m": 2200000,
-      "routable_reason": "provider-canary-failed"
+      "output_token_price_per_m": 2200000
     },
     {
       "display_name": "Inkling",
@@ -308,6 +300,6 @@
       "routable_reason": "provider-canary-failed"
     }
   ],
-  "generated_at": "2026-08-10T15:43:41Z",
+  "generated_at": "2026-08-10T19:19:12Z",
   "model_count": 11
 }

--- a/tests/test_databricks_provider.py
+++ b/tests/test_databricks_provider.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import copy
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from scripts.pricing.base import ProviderPricingResult
 from scripts.pricing.providers import databricks
 from scripts.pricing.refresh import PROVIDER_SLUGS
 from trusted_router.catalog import PROVIDERS
@@ -137,12 +140,14 @@ def test_databricks_fetch_uses_public_sources_without_operator_credentials(
     monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
     monkeypatch.delenv("DATABRICKS_HOST", raising=False)
     monkeypatch.setattr(databricks, "_DISCOVERED_MANIFEST_ROWS", {})
-    monkeypatch.setattr(databricks, "_LIVE_CANARY_OK", True)
+    monkeypatch.setattr(databricks, "_LIVE_CANARY_CHECKED_MODEL_IDS", {"old"})
+    monkeypatch.setattr(databricks, "_LIVE_CANARY_HEALTHY_MODEL_IDS", {"old"})
 
     result = databricks.fetch()
 
     assert set(result.prices) == set(databricks.EXPECTED_MODELS)
-    assert databricks._LIVE_CANARY_OK is False
+    assert databricks._LIVE_CANARY_CHECKED_MODEL_IDS == set()
+    assert databricks._LIVE_CANARY_HEALTHY_MODEL_IDS == set()
     assert len(databricks._DISCOVERED_MANIFEST_ROWS) == len(databricks.EXPECTED_MODELS)
 
 
@@ -176,10 +181,15 @@ def test_databricks_fetch_runs_private_canary_when_pair_is_configured(
     monkeypatch.setenv("DATABRICKS_TOKEN", "token")
     monkeypatch.setenv("DATABRICKS_HOST", "dbc-1234.cloud.databricks.com")
     calls: list[dict[str, Any]] = []
+
+    def fake_probe(**kwargs: Any) -> bool:
+        calls.append(copy.deepcopy(kwargs))
+        return kwargs["model"] != "databricks-glm-5-2"
+
     monkeypatch.setattr(
         databricks,
         "probe_openai_chat",
-        lambda **kwargs: calls.append(copy.deepcopy(kwargs)) is None,
+        fake_probe,
     )
 
     databricks.fetch()
@@ -188,11 +198,15 @@ def test_databricks_fetch_runs_private_canary_when_pair_is_configured(
         {
             "base_url": "https://dbc-1234.cloud.databricks.com/serving-endpoints",
             "api_key": "token",
-            "model": "databricks-gpt-oss-20b",
-            "max_tokens": 16,
+            "model": databricks.UPSTREAM_ID_MAP[model_id],
+            "max_tokens": 4,
         }
+        for model_id in databricks.EXPECTED_MODELS
     ]
-    assert databricks._LIVE_CANARY_OK is True
+    assert databricks._LIVE_CANARY_CHECKED_MODEL_IDS == set(databricks.EXPECTED_MODELS)
+    assert databricks._LIVE_CANARY_HEALTHY_MODEL_IDS == {
+        model_id for model_id in databricks.EXPECTED_MODELS if model_id != "z-ai/glm-5.2"
+    }
 
 
 def test_databricks_fetch_rejects_partial_private_configuration(
@@ -226,6 +240,47 @@ def test_databricks_fetch_rejects_partial_private_configuration(
     monkeypatch.delenv("DATABRICKS_HOST", raising=False)
     with pytest.raises(RuntimeError, match="must be set together"):
         databricks.fetch()
+
+
+def test_databricks_manifest_activates_only_models_with_passing_canaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "databricks.json"
+    manifest_path.write_text(
+        databricks.MANIFEST_PATH.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    prices, discovered = databricks._parse_catalog(
+        _pricing_html(),
+        _supported_models_html(),
+    )
+    checked = set(discovered)
+    healthy = {"openai/gpt-oss-20b", "meta-llama/llama-3.1-8b-instruct"}
+    monkeypatch.setattr(databricks, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(databricks, "_DISCOVERED_MANIFEST_ROWS", discovered)
+    monkeypatch.setattr(databricks, "_LIVE_CANARY_CHECKED_MODEL_IDS", checked)
+    monkeypatch.setattr(databricks, "_LIVE_CANARY_HEALTHY_MODEL_IDS", healthy)
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token")
+    monkeypatch.setenv("DATABRICKS_HOST", "dbc-1234.cloud.databricks.com")
+
+    databricks.write_provider_manifest(
+        ProviderPricingResult(
+            slug="databricks",
+            prices=prices,
+            source="api",
+            fetched_url=databricks.PRICING_URL,
+        )
+    )
+
+    by_id = {
+        row["id"]: row for row in json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    }
+    for model_id in healthy:
+        assert "routable_reason" not in by_id[model_id]
+    for model_id in checked - healthy:
+        assert by_id[model_id]["routable"] is False
+        assert by_id[model_id]["routable_reason"] == "provider-canary-failed"
 
 
 def test_databricks_is_prepaid_standard_privacy_and_not_byok() -> None:

--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pytest
 
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
-from scripts.pricing.manifest import set_manifest_canary_state
+from scripts.pricing.manifest import (
+    set_manifest_canary_state,
+    set_manifest_model_canary_states,
+)
 from scripts.pricing.openai_catalog import discover_openai_chat_catalog
 from scripts.pricing.parsers import morph as morph_parser
 from scripts.pricing.parsers import streamlake as streamlake_parser
@@ -253,6 +256,57 @@ def test_canary_state_preserves_unrelated_operator_holds(tmp_path: Path) -> None
     row = json.loads(manifest_path.read_text())["models"][0]
     assert row["routable"] is False
     assert row["routable_reason"] == "operator-hold"
+
+
+def test_model_canary_state_is_scoped_and_preserves_operator_holds(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "provider.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "example",
+                "models": [
+                    {
+                        "id": "example/healthy",
+                        "routable": False,
+                        "routable_reason": "provider-canary-failed",
+                    },
+                    {"id": "example/failed"},
+                    {"id": "example/held", "routable": False, "routable_reason": "operator-hold"},
+                    {"id": "example/unchecked"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    set_manifest_model_canary_states(
+        manifest_path,
+        checked_model_ids={"example/healthy", "example/failed", "example/held"},
+        healthy_model_ids={"example/healthy"},
+    )
+
+    by_id = {
+        row["id"]: row for row in json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    }
+    assert "routable" not in by_id["example/healthy"]
+    assert by_id["example/failed"]["routable_reason"] == "provider-canary-failed"
+    assert by_id["example/held"]["routable_reason"] == "operator-hold"
+    assert "routable" not in by_id["example/unchecked"]
+
+
+def test_model_canary_state_rejects_unchecked_healthy_models(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "provider.json"
+    manifest_path.write_text('{"models": []}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="subset"):
+        set_manifest_model_canary_states(
+            manifest_path,
+            checked_model_ids={"example/checked"},
+            healthy_model_ids={"example/unchecked"},
+        )
 
 
 def test_wave2_hourly_refresh_and_secret_wiring_are_complete() -> None:


### PR DESCRIPTION
## Summary
- probe every documented Databricks endpoint with the private account before activation
- publish only the 8 endpoints that pass their own authenticated canary
- keep Kimi K3, Inkling, and GLM 5.2 dark while Databricks reports a rate limit of zero
- preserve public hourly refresh behavior and unrelated operator holds

## Verification
- direct Databricks full-catalog probe: 8/11 endpoints healthy
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (3254 passed, 253 skipped, 10 xfailed)
- focused provider tests: 31 passed