### PR TITLE
SEO: connect topic hubs and expose route evidence

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -2669,6 +2669,7 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
     test_mode = settings.environment == "test"
     seo_name = _seo_model_name(model)
     site_url = f"https://{settings.trusted_domain}/models/{model_id}"
+    model_view = _model_detail_view(model, test_mode=test_mode)
     return (
         _env()
         .get_template("public/model_detail.html")
@@ -2681,7 +2682,9 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
                 f"Compare every TrustedRouter route for {seo_name}, including token pricing, context "
                 "limits, privacy policy, regional availability, measured uptime, and API support."
             ),
-            model=_model_detail_view(model, test_mode=test_mode),
+            model=model_view,
+            route_evidence=_model_route_evidence(model, test_mode=test_mode),
+            related_comparisons=_related_model_comparison_rows(model.id, limit=6),
             # Service/Offer JSON-LD. The page sells API access to a hosted
             # routing service, not a retail product with customer ratings.
             # Avoid Product schema so Search Console doesn't expect review
@@ -2704,7 +2707,7 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
     test_mode = settings.environment == "test"
     site_path = canonical_model_comparison_path(left.id, right.id)
     assert site_path is not None
-    comparison = _comparison_view(left, right)
+    comparison = _comparison_view(left, right, test_mode=test_mode)
     faq_items = _model_comparison_faq_items(left, right, comparison=comparison)
     return (
         _env()
@@ -2729,6 +2732,12 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                 include_section_links=False,
             ),
             comparison=comparison,
+            related_comparisons=_related_model_comparison_rows(
+                left.id,
+                right.id,
+                exclude_path=site_path,
+                limit=8,
+            ),
             faq_items=faq_items,
             json_ld_blob=_json_ld_graph(
                 _breadcrumb_node(
@@ -3649,6 +3658,12 @@ def _model_detail_view(
             str(view["provider"]),
         )
     )
+    section_links = _model_section_links(
+        model.id,
+        active_section=active_section,
+        include_sections=not is_meta and include_section_links,
+        test_mode=test_mode,
+    )
     return {
         "id": model.id,
         "name": model.name,
@@ -3676,11 +3691,22 @@ def _model_detail_view(
         "pricing_href": (
             f"/models/{model.id}/pricing" if not is_meta and len(endpoints) >= 2 else None
         ),
-        "section_links": _model_section_links(
-            model.id,
-            active_section=active_section,
-            include_sections=not is_meta and include_section_links,
-            test_mode=test_mode,
+        "section_links": section_links,
+        "performance_href": next(
+            (
+                str(link["href"])
+                for link in section_links
+                if link["label"] == MODEL_SEO_SECTION_LABELS["performance"]
+            ),
+            None,
+        ),
+        "uptime_href": next(
+            (
+                str(link["href"])
+                for link in section_links
+                if link["label"] == MODEL_SEO_SECTION_LABELS["uptime"]
+            ),
+            None,
         ),
         "ai_iq": ai_iq,
         "is_meta": is_meta,
@@ -3890,20 +3916,51 @@ def _llms_model_rows(*, test_mode: bool = False) -> list[dict[str, object]]:
     return [_model_view(model, test_mode=test_mode) for model in models]
 
 
-def _model_comparison_pairs() -> list[tuple[Model, Model]]:
-    candidates = sorted(
+@lru_cache(maxsize=1)
+def _model_comparison_pairs() -> tuple[tuple[Model, Model], ...]:
+    all_models = sorted(
         _public_models_for_seo(),
         key=lambda model: (
             -len(endpoints_for_model(model.id)),
             -(model.context_length or 0),
             model.id.lower(),
         ),
-    )[:MODEL_COMPARE_MODEL_LIMIT]
-    pairs = [
+    )
+    core_models = all_models[:MODEL_COMPARE_MODEL_LIMIT]
+    core_pairs = [
         tuple(sorted(pair, key=lambda model: model.id.casefold()))
-        for pair in combinations(candidates, 2)
+        for pair in combinations(core_models, 2)
+        if pair[0].id.casefold() != pair[1].id.casefold()
     ]
-    return cast(list[tuple[Model, Model]], pairs[:MODEL_COMPARE_URL_LIMIT])
+    core_budget = max(0, MODEL_COMPARE_URL_LIMIT - len(all_models))
+    pairs = cast(list[tuple[Model, Model]], core_pairs[:core_budget])
+    seen = {frozenset((left.id.casefold(), right.id.casefold())) for left, right in pairs}
+    covered = {model.id for pair in pairs for model in pair}
+    anchors = core_models[: min(12, len(core_models))]
+
+    for index, model in enumerate(all_models):
+        if model.id in covered or not anchors:
+            continue
+        anchor = anchors[index % len(anchors)]
+        if anchor.id.casefold() == model.id.casefold():
+            anchor = anchors[(index + 1) % len(anchors)]
+        pair = tuple(sorted((model, anchor), key=lambda item: item.id.casefold()))
+        key = frozenset((pair[0].id.casefold(), pair[1].id.casefold()))
+        if len(key) != 2 or key in seen:
+            continue
+        pairs.append((pair[0], pair[1]))
+        seen.add(key)
+        covered.update((pair[0].id, pair[1].id))
+
+    for left, right in core_pairs[core_budget:]:
+        key = frozenset((left.id.casefold(), right.id.casefold()))
+        if key in seen:
+            continue
+        pairs.append((left, right))
+        seen.add(key)
+        if len(pairs) >= MODEL_COMPARE_URL_LIMIT:
+            break
+    return tuple(pairs[:MODEL_COMPARE_URL_LIMIT])
 
 
 def _canonical_model_comparison_pair(
@@ -3918,6 +3975,7 @@ def _canonical_model_comparison_pair(
         or left.id in META_MODEL_IDS
         or right.id in META_MODEL_IDS
         or left.id == right.id
+        or left.id.casefold() == right.id.casefold()
     ):
         return None
     ordered = sorted((left, right), key=lambda model: model.id.casefold())
@@ -3937,13 +3995,164 @@ def _seo_model_rows(*, test_mode: bool = False) -> list[dict[str, object]]:
     return [_model_view(model, test_mode=test_mode) for model in _public_models_for_seo()]
 
 
-def _comparison_view(left: Model, right: Model) -> dict[str, object]:
+def _model_route_evidence(
+    model: Model,
+    *,
+    test_mode: bool = False,
+) -> dict[str, object]:
+    endpoints = endpoints_for_model(model.id)
+    measured = measured_for_model(model.id, test_mode=test_mode)
+    priced_endpoints = [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+    prompt_prices = [
+        endpoint.prompt_price_microdollars_per_million_tokens for endpoint in priced_endpoints
+    ]
+    completion_prices = [
+        endpoint.completion_price_microdollars_per_million_tokens for endpoint in priced_endpoints
+    ]
+    lowest_prompt = min(prompt_prices) if prompt_prices else None
+    lowest_completion = min(completion_prices) if completion_prices else None
+
+    ttft_rows = [
+        row
+        for row in measured
+        if row.get("p50_ttft_ms") is not None and int(row.get("sample_count") or 0) >= 2
+    ]
+    fastest_ttft_row = min(
+        ttft_rows,
+        key=lambda row: int(row["p50_ttft_ms"]),
+        default=None,
+    )
+    throughput_rows = [
+        row
+        for row in measured
+        if row.get("p50_tokens_per_second") is not None
+        and int(row.get("throughput_sample_count") or 0) >= 2
+    ]
+    fastest_throughput_row = max(
+        throughput_rows,
+        key=lambda row: float(row["p50_tokens_per_second"]),
+        default=None,
+    )
+    uptime_rows = [
+        row
+        for row in measured
+        if row.get("uptime") is not None and int(row.get("sample_count") or 0) > 0
+    ]
+    uptime_values = [float(row["uptime"]) * 100 for row in uptime_rows]
+    if uptime_values:
+        lowest_uptime = min(uptime_values)
+        highest_uptime = max(uptime_values)
+        uptime_range = (
+            f"{lowest_uptime:.2f}%"
+            if abs(highest_uptime - lowest_uptime) < 0.005
+            else f"{lowest_uptime:.2f}% to {highest_uptime:.2f}%"
+        )
+    else:
+        uptime_range = "not enough data"
+
+    fastest_ttft_ms = int(fastest_ttft_row["p50_ttft_ms"]) if fastest_ttft_row is not None else None
+    fastest_throughput = (
+        float(fastest_throughput_row["p50_tokens_per_second"])
+        if fastest_throughput_row is not None
+        else None
+    )
+    return {
+        "lowest_prompt_price": _price(lowest_prompt) if lowest_prompt is not None else "BYOK only",
+        "lowest_completion_price": (
+            _price(lowest_completion) if lowest_completion is not None else "BYOK only"
+        ),
+        "fastest_ttft_ms": fastest_ttft_ms,
+        "fastest_ttft": (
+            f"{fastest_ttft_ms} ms" if fastest_ttft_ms is not None else "not enough data"
+        ),
+        "fastest_ttft_provider": (
+            str(fastest_ttft_row.get("provider") or "") if fastest_ttft_row is not None else ""
+        ),
+        "fastest_throughput": (
+            f"{fastest_throughput:.0f} tok/s"
+            if fastest_throughput is not None
+            else "not enough data"
+        ),
+        "fastest_throughput_provider": (
+            str(fastest_throughput_row.get("provider") or "")
+            if fastest_throughput_row is not None
+            else ""
+        ),
+        "uptime_range": uptime_range,
+        "route_count": len(endpoints),
+        "provider_count": len(
+            _endpoint_provider_views(endpoints, fallback_provider=model.provider)
+        ),
+    }
+
+
+@lru_cache(maxsize=1)
+def _model_comparison_index() -> dict[
+    str,
+    tuple[tuple[str, str, str, str, int], ...],
+]:
+    indexed: dict[str, list[tuple[str, str, str, str, int]]] = {}
+    for left, right in _model_comparison_pairs():
+        path = f"/compare/models/{left.id}/vs/{right.id}"
+        row = (
+            path,
+            f"{left.name} vs {right.name}",
+            left.id,
+            right.id,
+            len(endpoints_for_model(left.id)) + len(endpoints_for_model(right.id)),
+        )
+        for model_id in {left.id.casefold(), right.id.casefold()}:
+            indexed.setdefault(model_id, []).append(row)
+    return {
+        model_id: tuple(sorted(rows, key=lambda row: (-row[4], row[0].casefold())))
+        for model_id, rows in indexed.items()
+    }
+
+
+def _related_model_comparison_rows(
+    *model_ids: str,
+    exclude_path: str | None = None,
+    limit: int = 6,
+) -> list[dict[str, object]]:
+    target_ids = {model_id.casefold() for model_id in model_ids}
+    candidates: dict[str, tuple[str, str, str, str, int]] = {}
+    comparison_index = _model_comparison_index()
+    for model_id in target_ids:
+        for indexed_row in comparison_index.get(model_id, ()):
+            candidates[indexed_row[0]] = indexed_row
+
+    ranked: list[tuple[int, int, str, dict[str, object]]] = []
+    for path, label, left_id, right_id, route_count in candidates.values():
+        pair_ids = {left_id.casefold(), right_id.casefold()}
+        shared = len(target_ids & pair_ids)
+        if path == exclude_path:
+            continue
+        result_row: dict[str, object] = {
+            "href": path,
+            "label": label,
+            "left_id": left_id,
+            "right_id": right_id,
+            "route_count": route_count,
+        }
+        ranked.append((-shared, -route_count, path.casefold(), result_row))
+    ranked.sort(key=lambda item: item[:3])
+    return [item[3] for item in ranked[:limit]]
+
+
+def _comparison_view(
+    left: Model,
+    right: Model,
+    *,
+    test_mode: bool = False,
+) -> dict[str, object]:
     left_total = _cheapest_total_microdollars(left)
     right_total = _cheapest_total_microdollars(right)
     left_routes = len(endpoints_for_model(left.id))
     right_routes = len(endpoints_for_model(right.id))
-    left_measured = _best_measured_ttft(left.id)
-    right_measured = _best_measured_ttft(right.id)
+    left_evidence = _model_route_evidence(left, test_mode=test_mode)
+    right_evidence = _model_route_evidence(right, test_mode=test_mode)
+    left_measured = cast(int | None, left_evidence["fastest_ttft_ms"])
+    right_measured = cast(int | None, right_evidence["fastest_ttft_ms"])
     return {
         "summary": _comparison_summary(
             left,
@@ -3961,8 +4170,16 @@ def _comparison_view(left: Model, right: Model) -> dict[str, object]:
         "right_routes": right_routes,
         "left_privacy": _privacy_summary(left),
         "right_privacy": _privacy_summary(right),
-        "left_ttft": f"{left_measured} ms" if left_measured is not None else "not enough data",
-        "right_ttft": f"{right_measured} ms" if right_measured is not None else "not enough data",
+        "left_ttft": left_evidence["fastest_ttft"],
+        "right_ttft": right_evidence["fastest_ttft"],
+        "left_ttft_provider": left_evidence["fastest_ttft_provider"],
+        "right_ttft_provider": right_evidence["fastest_ttft_provider"],
+        "left_throughput": left_evidence["fastest_throughput"],
+        "right_throughput": right_evidence["fastest_throughput"],
+        "left_throughput_provider": left_evidence["fastest_throughput_provider"],
+        "right_throughput_provider": right_evidence["fastest_throughput_provider"],
+        "left_uptime": left_evidence["uptime_range"],
+        "right_uptime": right_evidence["uptime_range"],
     }
 
 
@@ -4030,10 +4247,13 @@ def _comparison_summary(
 
 def _cheapest_total_microdollars(model: Model) -> int:
     endpoints = endpoints_for_model(model.id)
+    priced_endpoints = [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+    if not priced_endpoints:
+        priced_endpoints = endpoints
     totals = [
         endpoint.prompt_price_microdollars_per_million_tokens
         + endpoint.completion_price_microdollars_per_million_tokens
-        for endpoint in endpoints
+        for endpoint in priced_endpoints
         if endpoint.prompt_price_microdollars_per_million_tokens
         or endpoint.completion_price_microdollars_per_million_tokens
     ]
@@ -4043,16 +4263,6 @@ def _cheapest_total_microdollars(model: Model) -> int:
         model.prompt_price_microdollars_per_million_tokens
         + model.completion_price_microdollars_per_million_tokens
     )
-
-
-def _best_measured_ttft(model_id: str) -> int | None:
-    rows = measured_for_model(model_id)
-    values = [
-        int(row["p50_ttft_ms"])
-        for row in rows
-        if row.get("p50_ttft_ms") is not None and int(row.get("sample_count") or 0) >= 2
-    ]
-    return min(values) if values else None
 
 
 def _privacy_summary(model: Model) -> str:

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -191,6 +191,10 @@ blockquote { margin:0 0 12px; padding-left:14px; border-left:3px solid var(--gre
 .public-proof-strip strong { display:block; color:var(--ink); font-size:16px; line-height:1.25; }
 .public-proof-strip span { display:block; color:var(--muted); font-size:13px; line-height:1.35; margin-top:8px; }
 .public-proof-strip .mono, .panel-body .mono, .marketing-copy .mono { overflow-wrap:anywhere; word-break:break-word; }
+.home-topic-links { display:flex; align-items:center; justify-content:center; flex-wrap:wrap; gap:12px 22px; padding:18px clamp(20px, 4vw, 64px); border-top:1px solid var(--line); border-bottom:1px solid var(--line); background:var(--panel); }
+.home-topic-links > span { color:var(--muted); font:600 13px/1.2 var(--mono); text-transform:uppercase; }
+.home-topic-links a { color:var(--ink); font-size:15px; line-height:1.35; text-decoration:none; }
+.home-topic-links a:hover { color:var(--accent); text-decoration:underline; text-underline-offset:4px; }
 .marketing-split { display:grid; grid-template-columns:minmax(0,1fr) minmax(320px,.82fr); gap:18px; align-items:stretch; }
 .marketing-copy, .quote-feature, .limitation-band, .model-catalog { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:24px; box-shadow:0 12px 40px var(--shadow); }
 .marketing-copy h2, .quote-feature h2, .model-catalog h2 { margin:12px 0 14px; font-size:30px; line-height:1.12; letter-spacing:0; }

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -92,6 +92,15 @@
       <div class="charter-stat"><strong>Public</strong><span>Source and status</span></div>
     </section>
 
+    <nav class="home-topic-links" aria-label="TrustedRouter developer resources">
+      <span>Explore</span>
+      <a href="/compare/models">Model comparisons</a>
+      <a href="/private-llm-api">Private and ZDR APIs</a>
+      <a href="/eu">EU AI infrastructure</a>
+      <a href="/openrouter-alternative">OpenRouter migration</a>
+      <a href="/docs/agent-setup">Agent setup</a>
+    </nav>
+
     <section class="home-section band-dim" aria-label="Customer story">
       <div class="home-wrap quote-feature">
         <div>

--- a/src/trusted_router/templates/public/agent_setup.html
+++ b/src/trusted_router/templates/public/agent_setup.html
@@ -165,8 +165,12 @@ Read the full behavior at https://trustedrouter.com/docs/synth.</code></pre>
       <a class="pill" href="#codex-skill">Agent skill</a>
       <a class="pill" href="/docs/synth">Synth</a>
       <a class="pill" href="/models">Models</a>
+      <a class="pill" href="/compare/models">Model comparisons</a>
       <a class="pill" href="/providers">Providers</a>
       <a class="pill" href="/leaderboard">Leaderboard</a>
+      <a class="pill" href="/private-llm-api">Private API</a>
+      <a class="pill" href="/eu">EU setup</a>
+      <a class="pill" href="/docs/migrate-from-openrouter">Migration guide</a>
     </div>
   </section>
 </section>

--- a/src/trusted_router/templates/public/eu.html
+++ b/src/trusted_router/templates/public/eu.html
@@ -78,4 +78,17 @@ response = client.chat.completions.create(
     </div>
   </div>
 </section>
+
+<section class="panel" aria-label="EU AI infrastructure resources">
+  <div class="panel-head"><h2>EU AI infrastructure resources</h2><a href="/resources">All resources</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      <li><a href="/llm-data-residency">LLM data residency</a><span>Separate gateway, provider, and storage regions</span></li>
+      <li><a href="/gdpr-compliant-llm-api">GDPR-compliant LLM API</a><span>DPA, subprocessors, and routing evidence</span></li>
+      <li><a href="/eu-ai-act-llm-compliance">EU AI Act</a><span>Evidence for deployers and procurement teams</span></li>
+      <li><a href="/private-llm-api">Private LLM API</a><span>Attestation, ZDR, and confidential provider routes</span></li>
+      <li><a href="/providers">Provider directory</a><span>Privacy posture and policy sources by provider</span></li>
+    </ul>
+  </div>
+</section>
 {% endblock %}

--- a/src/trusted_router/templates/public/model_compare.html
+++ b/src/trusted_router/templates/public/model_compare.html
@@ -14,8 +14,8 @@
     <div class="public-proof-strip">
       <div><strong>{{ comparison.left_price }}</strong><span>{{ left.name }} cheapest route</span></div>
       <div><strong>{{ comparison.right_price }}</strong><span>{{ right.name }} cheapest route</span></div>
-      <div><strong>{{ comparison.left_ttft }}</strong><span>{{ left.name }} measured p50 TTFT</span></div>
-      <div><strong>{{ comparison.right_ttft }}</strong><span>{{ right.name }} measured p50 TTFT</span></div>
+      <div><strong>{{ comparison.left_ttft }}</strong><span>{{ left.name }} fastest measured p50 TTFT{% if comparison.left_ttft_provider %} via {{ comparison.left_ttft_provider }}{% endif %}</span></div>
+      <div><strong>{{ comparison.right_ttft }}</strong><span>{{ right.name }} fastest measured p50 TTFT{% if comparison.right_ttft_provider %} via {{ comparison.right_ttft_provider }}{% endif %}</span></div>
     </div>
   </div>
 </section>
@@ -56,6 +56,15 @@
     <span>Privacy posture</span><span>{{ comparison.left_privacy }}</span><span>{{ comparison.right_privacy }}</span>
   </div>
   <div class="matrix-row">
+    <span>Fastest measured p50 TTFT</span><span>{{ comparison.left_ttft }}{% if comparison.left_ttft_provider %} via <a href="/providers/{{ comparison.left_ttft_provider }}">{{ comparison.left_ttft_provider }}</a>{% endif %}</span><span>{{ comparison.right_ttft }}{% if comparison.right_ttft_provider %} via <a href="/providers/{{ comparison.right_ttft_provider }}">{{ comparison.right_ttft_provider }}</a>{% endif %}</span>
+  </div>
+  <div class="matrix-row">
+    <span>Highest measured throughput</span><span>{{ comparison.left_throughput }}{% if comparison.left_throughput_provider %} via <a href="/providers/{{ comparison.left_throughput_provider }}">{{ comparison.left_throughput_provider }}</a>{% endif %}</span><span>{{ comparison.right_throughput }}{% if comparison.right_throughput_provider %} via <a href="/providers/{{ comparison.right_throughput_provider }}">{{ comparison.right_throughput_provider }}</a>{% endif %}</span>
+  </div>
+  <div class="matrix-row">
+    <span>Recent route uptime range</span><span>{{ comparison.left_uptime }}</span><span>{{ comparison.right_uptime }}</span>
+  </div>
+  <div class="matrix-row">
     <span>Modes</span>
     <span>
       {% if left.supports_chat %}<span class="pill">chat</span>{% endif %}
@@ -94,6 +103,19 @@
     </div>
   </div>
 </section>
+
+{% if related_comparisons %}
+<section class="panel" aria-label="Related model comparisons">
+  <div class="panel-head"><h2>Related comparisons</h2><a href="/compare/models">Browse every comparison</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      {% for related in related_comparisons %}
+      <li><a href="{{ related.href }}">{{ related.label }}</a><span>{{ related.route_count }} combined provider routes</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endif %}
 
 <section class="marketing-split">
   <div class="marketing-copy">

--- a/src/trusted_router/templates/public/model_compare_index.html
+++ b/src/trusted_router/templates/public/model_compare_index.html
@@ -1,5 +1,11 @@
 {% extends "public/_base.html" %}
 {% block body %}
+<section class="marketing-grid three" aria-label="Model selection resources">
+  <a class="marketing-card card-as-link" href="/leaderboard"><span class="card-label">Measured speed</span><h3>Find the fastest routes.</h3><p>Compare provider TTFT, throughput, and uptime from routed probes.</p><span class="card-link">Open leaderboard →</span></a>
+  <a class="marketing-card card-as-link" href="/models?filter=open"><span class="card-label">Open weights</span><h3>Compare open models.</h3><p>Browse DeepSeek, GLM, Gemma, Kimi, MiniMax, Qwen, and other open routes.</p><span class="card-link">Browse models →</span></a>
+  <a class="marketing-card card-as-link" href="/private-llm-api"><span class="card-label">Privacy</span><h3>Require ZDR or confidential routes.</h3><p>Separate gateway attestation from each downstream provider's privacy posture.</p><span class="card-link">Review privacy →</span></a>
+</section>
+
 <section class="model-catalog">
   <div class="model-catalog-head">
     <div>

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -86,6 +86,27 @@
   </div>
 </section>
 
+{% if not model.is_meta %}
+<section class="panel" aria-label="Current {{ model.name }} route evidence">
+  <div class="panel-head"><h2>Current route evidence</h2><a href="/leaderboard">Live leaderboard</a></div>
+  <div class="panel-body">
+    <div class="public-proof-strip">
+      <div><strong>{{ route_evidence.lowest_prompt_price }}</strong><span>Lowest prepaid input price</span></div>
+      <div><strong>{{ route_evidence.lowest_completion_price }}</strong><span>Lowest prepaid output price</span></div>
+      <div><strong>{{ route_evidence.fastest_ttft }}</strong><span>Fastest measured p50 TTFT{% if route_evidence.fastest_ttft_provider %} via <a href="/providers/{{ route_evidence.fastest_ttft_provider }}">{{ route_evidence.fastest_ttft_provider }}</a>{% endif %}</span></div>
+      <div><strong>{{ route_evidence.fastest_throughput }}</strong><span>Highest measured throughput{% if route_evidence.fastest_throughput_provider %} via <a href="/providers/{{ route_evidence.fastest_throughput_provider }}">{{ route_evidence.fastest_throughput_provider }}</a>{% endif %}</span></div>
+    </div>
+    <p class="muted-copy">Recent provider-route uptime spans {{ route_evidence.uptime_range }} across {{ route_evidence.route_count }} route{{ '' if route_evidence.route_count == 1 else 's' }} and {{ route_evidence.provider_count }} provider{{ '' if route_evidence.provider_count == 1 else 's' }}. Price comes from the current prepaid catalog. Speed and uptime come from routed probes rather than vendor claims.</p>
+    <div class="mini-links">
+      {% if model.pricing_href %}<a href="{{ model.pricing_href }}">All route prices</a>{% endif %}
+      {% if model.providers_href %}<a href="{{ model.providers_href }}">All providers</a>{% endif %}
+      {% if model.performance_href %}<a href="{{ model.performance_href }}">Performance details</a>{% endif %}
+      {% if model.uptime_href %}<a href="{{ model.uptime_href }}">Uptime details</a>{% endif %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
 <section class="panel">
   <div class="panel-head"><h2>{% if model.is_meta and model.configuration_hidden %}Configuration{% elif model.is_meta %}Models used by this orchestration{% else %}Providers serving this model{% endif %}</h2></div>
   <div class="panel-body">
@@ -100,6 +121,7 @@
       through the component models below inside the attested prompt path, using
       the preset's worker, advisor, judge, or synthesizer roles.
     </p>
+    <div class="model-table-wrap">
     <table data-sortable="true">
       <thead>
         <tr>
@@ -120,6 +142,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
     {% else %}
     <p style="color:var(--muted);font-size:14px">
       Sorted by lowest combined prompt and completion price. Use
@@ -132,6 +155,7 @@
       TrustedRouter gateway only. Provider policy separately describes the
       upstream model host's retention, confidential compute, and E2EE posture.
     </p>
+    <div class="model-table-wrap">
     <table data-sortable="true">
       <thead>
         <tr>
@@ -158,10 +182,24 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
     <p class="signup-foot">
       Endpoint JSON: <span class="mono">{{ api_base_url }}/models/{{ model.id }}/endpoints</span>
     </p>
     {% endif %}
   </div>
 </section>
+
+{% if related_comparisons %}
+<section class="panel" aria-label="Compare {{ model.name }} with other models">
+  <div class="panel-head"><h2>Compare {{ model.name }}</h2><a href="/compare/models">All comparisons</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      {% for related in related_comparisons %}
+      <li><a href="{{ related.href }}">{{ related.label }}</a><span>{{ related.route_count }} combined provider routes</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endif %}
 {% endblock %}

--- a/src/trusted_router/templates/public/resources.html
+++ b/src/trusted_router/templates/public/resources.html
@@ -1,5 +1,14 @@
 {% extends "public/_base.html" %}
 {% block body %}
+<section class="marketing-grid three" aria-label="TrustedRouter topic hubs">
+  <a class="marketing-card card-as-link" href="/compare/models"><span class="card-label">Choose</span><h3>Models and comparisons</h3><p>Compare price, context, provider routes, privacy, latency, throughput, and uptime.</p><span class="card-link">Compare models →</span></a>
+  <a class="marketing-card card-as-link" href="/private-llm-api"><span class="card-label">Protect</span><h3>Private and ZDR APIs</h3><p>Understand attestation, provider retention, confidential compute, and fail-closed filters.</p><span class="card-link">Review privacy →</span></a>
+  <a class="marketing-card card-as-link" href="/eu"><span class="card-label">Localize</span><h3>EU AI infrastructure</h3><p>Use a European gateway, EU-focused routes, provider controls, and procurement evidence.</p><span class="card-link">Open EU hub →</span></a>
+  <a class="marketing-card card-as-link" href="/openrouter-alternative"><span class="card-label">Migrate</span><h3>OpenRouter migration</h3><p>Keep the OpenAI SDK, change one base URL, then add privacy and fallback policies.</p><span class="card-link">Start migration →</span></a>
+  <a class="marketing-card card-as-link" href="/docs/agent-setup"><span class="card-label">Build</span><h3>Agents and coding tools</h3><p>Connect Codex, Claude Code, Cursor, Cline, eval runners, and other compatible clients.</p><span class="card-link">Open agent setup →</span></a>
+  <a class="marketing-card card-as-link" href="/customers/robot-robot-human"><span class="card-label">Deploy</span><h3>Production use cases</h3><p>See how legal document workflows route billions of tokens through one private API.</p><span class="card-link">Read customer story →</span></a>
+</section>
+
 <section class="seo-two-col">
   <div class="panel">
     <div class="panel-head"><h2>Build</h2></div>

--- a/src/trusted_router/templates/public/seo_openrouter_alternative.html
+++ b/src/trusted_router/templates/public/seo_openrouter_alternative.html
@@ -91,4 +91,17 @@ client = OpenAI(
   <span class="microcopy">No card required.</span>
 </section>
 
+<section class="panel" aria-label="OpenRouter migration resources">
+  <div class="panel-head"><h2>OpenRouter migration resources</h2><a href="/resources">All resources</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      <li><a href="/docs/migrate-from-openrouter">Migration guide</a><span>Endpoints, headers, provider controls, and compatibility</span></li>
+      <li><a href="/compare/openrouter">Detailed gateway comparison</a><span>Trust, pricing, deployment, and API surface</span></li>
+      <li><a href="/docs/agent-setup">Agent setup</a><span>Codex, Claude Code, Cursor, and eval runners</span></li>
+      <li><a href="/compare/models">Model comparisons</a><span>Current price, latency, throughput, privacy, and provider routes</span></li>
+      <li><a href="/leaderboard">Provider leaderboard</a><span>Measured route performance and availability</span></li>
+    </ul>
+  </div>
+</section>
+
 {% endblock %}

--- a/src/trusted_router/templates/public/seo_private_llm_api.html
+++ b/src/trusted_router/templates/public/seo_private_llm_api.html
@@ -83,4 +83,17 @@ resp = client.chat.completions.create(
   </div>
 </section>
 
+<section class="panel" aria-label="Private LLM API resources">
+  <div class="panel-head"><h2>Build a private routing policy</h2><a href="/resources">All resources</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      <li><a href="/providers">Provider privacy directory</a><span>ZDR, confidential compute, E2EE, and policy sources</span></li>
+      <li><a href="/deepseek-api-privacy">DeepSeek API privacy</a><span>Hosting boundaries and fail-closed ZDR filters</span></li>
+      <li><a href="/claude-api-privacy">Claude API privacy</a><span>Route-specific retention and provider controls</span></li>
+      <li><a href="/confidential-computing-llm">Confidential computing for LLMs</a><span>Hardware attestation and trust boundaries</span></li>
+      <li><a href="/legal">Legal and procurement packet</a><span>DPA, BAA, subprocessors, and readiness evidence</span></li>
+    </ul>
+  </div>
+</section>
+
 {% endblock %}

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -815,6 +815,85 @@ def test_model_overview_only_links_subpages_with_indexable_content(
     assert 'href="/models/minimax/minimax-m3/api"' not in response.text
 
 
+def test_model_overview_surfaces_cached_route_evidence(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import dashboard
+
+    measured = [
+        {
+            "model": "minimax/minimax-m3",
+            "provider": "novita",
+            "sample_count": 12,
+            "p50_ttft_ms": 140,
+            "p50_tokens_per_second": 52.0,
+            "throughput_sample_count": 8,
+            "uptime": 0.99,
+        },
+        {
+            "model": "minimax/minimax-m3",
+            "provider": "minimax",
+            "sample_count": 10,
+            "p50_ttft_ms": 220,
+            "p50_tokens_per_second": 91.0,
+            "throughput_sample_count": 7,
+            "uptime": 1.0,
+        },
+    ]
+    monkeypatch.setattr(dashboard, "measured_for_model", lambda *_args, **_kwargs: measured)
+
+    response = client.get("/models/minimax/minimax-m3")
+
+    assert response.status_code == 200
+    assert "Current route evidence" in response.text
+    assert "Lowest prepaid input price" in response.text
+    assert "140 ms" in response.text
+    assert "91 tok/s" in response.text
+    assert "99.00% to 100.00%" in response.text
+    assert 'href="/providers/novita"' in response.text
+    assert 'href="/providers/minimax"' in response.text
+    assert 'href="/models/minimax/minimax-m3/performance"' in response.text
+    assert 'href="/models/minimax/minimax-m3/uptime"' not in response.text
+    assert "n=12" not in response.text
+    assert "n=10" not in response.text
+
+
+def test_model_route_evidence_does_not_invent_a_prepaid_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import dashboard
+
+    monkeypatch.setattr(dashboard, "endpoints_for_model", lambda _model_id: [])
+    monkeypatch.setattr(dashboard, "measured_for_model", lambda *_args, **_kwargs: [])
+
+    evidence = dashboard._model_route_evidence(
+        dashboard.MODELS["minimax/minimax-m3"],
+        test_mode=True,
+    )
+
+    assert evidence["lowest_prompt_price"] == "BYOK only"
+    assert evidence["lowest_completion_price"] == "BYOK only"
+
+
+def test_model_overview_links_canonical_related_comparisons(client: TestClient) -> None:
+    response = client.get("/models/minimax/minimax-m3")
+
+    assert response.status_code == 200
+    assert "Compare MiniMax: MiniMax M3" in response.text
+    related_paths = re.findall(
+        r'href="(/compare/models/[^\"]+/vs/[^\"]+)"',
+        response.text,
+    )
+    assert related_paths
+    assert all("minimax/minimax-m3" in path for path in related_paths)
+    assert all(
+        left.casefold() < right.casefold()
+        for path in related_paths
+        for left, right in [path.removeprefix("/compare/models/").split("/vs/", 1)]
+    )
+
+
 def test_model_seo_cluster_pages_are_public_and_not_openrouter_links(
     client: TestClient,
 ) -> None:
@@ -869,6 +948,49 @@ def test_model_comparison_pages_are_public(client: TestClient) -> None:
     assert "Can I test MoonshotAI: Kimi K2.6 and Z.ai: GLM 5.1 with the same API?" in response.text
     comparison_schema = _json_ld(response.text)
     assert "FAQPage" in json.dumps(comparison_schema)
+
+
+def test_model_comparison_surfaces_distinct_measured_route_metrics(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router import dashboard
+
+    def measured(model_id: str, **_kwargs: object) -> list[dict[str, object]]:
+        if model_id == "moonshotai/kimi-k2.6":
+            return [
+                {
+                    "provider": "together",
+                    "sample_count": 9,
+                    "p50_ttft_ms": 180,
+                    "p50_tokens_per_second": 75.0,
+                    "throughput_sample_count": 6,
+                    "uptime": 0.995,
+                }
+            ]
+        return [
+            {
+                "provider": "zai",
+                "sample_count": 11,
+                "p50_ttft_ms": 120,
+                "p50_tokens_per_second": 48.0,
+                "throughput_sample_count": 7,
+                "uptime": 1.0,
+            }
+        ]
+
+    monkeypatch.setattr(dashboard, "measured_for_model", measured)
+    response = client.get("/compare/models/moonshotai/kimi-k2.6/vs/z-ai/glm-5.1")
+
+    assert response.status_code == 200
+    assert "Highest measured throughput" in response.text
+    assert "75 tok/s" in response.text
+    assert "48 tok/s" in response.text
+    assert "Recent route uptime range" in response.text
+    assert "99.50%" in response.text
+    assert "100.00%" in response.text
+    assert "Related comparisons" in response.text
+    assert "Browse every comparison" in response.text
 
 
 def test_reversed_model_comparison_redirects_to_stable_canonical(
@@ -927,6 +1049,15 @@ def test_model_comparison_directory_links_every_sitemap_pair(client: TestClient)
     )
 
 
+def test_model_comparison_graph_covers_every_public_model() -> None:
+    from trusted_router.dashboard import _model_comparison_pairs, _public_models_for_seo
+
+    represented = {
+        model.id.casefold() for left, right in _model_comparison_pairs() for model in (left, right)
+    }
+    assert {model.id.casefold() for model in _public_models_for_seo()} <= represented
+
+
 def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> None:
     response = client.get("/resources")
     assert response.status_code == 200
@@ -972,6 +1103,43 @@ def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> 
     assert 'href="/resources"' in footer.text
     assert 'href="/customers/robot-robot-human"' in footer.text
     assert 'href="/careers"' in footer.text
+
+
+def test_high_authority_pages_link_the_primary_intent_hubs(client: TestClient) -> None:
+    primary_hubs = {
+        "/compare/models",
+        "/private-llm-api",
+        "/eu",
+        "/openrouter-alternative",
+        "/docs/agent-setup",
+    }
+    homepage = client.get("/")
+    resources = client.get("/resources")
+    assert homepage.status_code == resources.status_code == 200
+    for path in primary_hubs:
+        assert f'href="{path}"' in homepage.text, path
+        assert f'href="{path}"' in resources.text, path
+
+    for heading in [
+        "Models and comparisons",
+        "Private and ZDR APIs",
+        "EU AI infrastructure",
+        "OpenRouter migration",
+        "Agents and coding tools",
+        "Production use cases",
+    ]:
+        assert heading in resources.text
+
+    eu = client.get("/eu")
+    private = client.get("/private-llm-api")
+    migration = client.get("/openrouter-alternative")
+    agents = client.get("/docs/agent-setup")
+    comparisons = client.get("/compare/models")
+    assert 'href="/llm-data-residency"' in eu.text
+    assert 'href="/providers"' in private.text
+    assert 'href="/docs/migrate-from-openrouter"' in migration.text
+    assert 'href="/compare/models"' in agents.text
+    assert 'href="/leaderboard"' in comparisons.text
 
 
 def test_exact_intent_search_landings_are_message_matched(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- connect the homepage, resources directory, and intent pages into clear SEO topic hubs
- add cached price, TTFT, throughput, uptime, and provider-route evidence to model and comparison pages
- make all public model concepts discoverable through the canonical comparison graph
- add regression coverage for evidence accuracy, canonical links, model coverage, and mobile table containment

## Compute posture
- reuses the existing five-minute benchmark snapshot
- builds the comparison relationship index once per process
- adds no continuous page-refresh worker or new database scan loop

## Verification
- 3,257 passed, 253 skipped, 10 xfailed
- ruff and mypy clean
- TypeScript, ESLint, and Stylelint clean
- desktop/mobile browser QA across homepage, resources, model, comparison, and EU pages