### PR TITLE
Keep public pages available during analytics outages

### DIFF
--- a/src/trusted_router/measured.py
+++ b/src/trusted_router/measured.py
@@ -11,7 +11,9 @@ per-test STORE reset isn't masked by a stale snapshot.
 
 from __future__ import annotations
 
+import logging
 import time
+from threading import Lock
 from typing import Any
 
 from trusted_router.benchmark_samples import (
@@ -19,11 +21,22 @@ from trusted_router.benchmark_samples import (
     PUBLIC_BENCHMARK_SAMPLE_LIMIT,
     public_benchmark_samples,
 )
+from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
+from trusted_router.storage import STORE
 from trusted_router.storage_models import utcnow
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 
 _TTL_SECONDS = 300
 _CACHE: tuple[float, dict[str, Any]] | None = None
+_CACHE_LOCK = Lock()
+
+logger = logging.getLogger(__name__)
+
+
+def _empty_snapshot() -> dict[str, Any]:
+    payload = aggregate_leaderboard([], min_samples=1)
+    payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
+    return payload
 
 
 def measured_snapshot(*, test_mode: bool = False) -> dict[str, Any]:
@@ -31,15 +44,42 @@ def measured_snapshot(*, test_mode: bool = False) -> dict[str, Any]:
     now = time.monotonic()
     if not test_mode and _CACHE is not None and now - _CACHE[0] < _TTL_SECONDS:
         return _CACHE[1]
-    samples = public_benchmark_samples(
-        limit=PUBLIC_BENCHMARK_SAMPLE_LIMIT,
-        recent_minutes=PUBLIC_BENCHMARK_RECENT_MINUTES,
-    )
-    payload = aggregate_leaderboard(samples, min_samples=1)
-    payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
-    if not test_mode:
-        _CACHE = (now, payload)
-    return payload
+
+    with _CACHE_LOCK:
+        now = time.monotonic()
+        if not test_mode and _CACHE is not None and now - _CACHE[0] < _TTL_SECONDS:
+            return _CACHE[1]
+
+        stale_payload = _CACHE[1] if _CACHE is not None else None
+        try:
+            if test_mode:
+                samples = public_benchmark_samples(
+                    limit=PUBLIC_BENCHMARK_SAMPLE_LIMIT,
+                    recent_minutes=PUBLIC_BENCHMARK_RECENT_MINUTES,
+                )
+                payload = aggregate_leaderboard(samples, min_samples=1)
+                payload["generated_at"] = utcnow().isoformat().replace("+00:00", "Z")
+            else:
+                reader = getattr(STORE, "public_analytics_snapshot", None)
+                precomputed = (
+                    current_public_analytics_snapshot("leaderboard", reader=reader)
+                    if callable(reader)
+                    else None
+                )
+                payload = precomputed or stale_payload or _empty_snapshot()
+        except Exception as exc:
+            payload = stale_payload or _empty_snapshot()
+            logger.warning(
+                "Measured analytics refresh failed; serving %s snapshot (%s)",
+                "stale" if stale_payload is not None else "empty",
+                type(exc).__name__,
+            )
+
+        if not test_mode:
+            # Cache failures too so a backend incident cannot turn public page
+            # traffic into a retry storm. The next normal TTL refresh retries.
+            _CACHE = (now, payload)
+        return payload
 
 
 def measured_for_model(model_id: str, *, test_mode: bool = False) -> list[dict[str, Any]]:

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -25,6 +25,7 @@ from trusted_router.types import UsageType
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 T = TypeVar("T")
+PUBLIC_SNAPSHOT_QUERY_TIMEOUT_SECONDS = 2.0
 
 
 def _identifier(value: str, *, label: str) -> str:
@@ -65,13 +66,14 @@ class OperationalAnalyticsClient:
         sql: str,
         *,
         params: dict[str, str | int] | None = None,
+        timeout_seconds: float = 20.0,
     ) -> list[dict[str, Any]]:
         query_params: dict[str, str] = {"database": self._database}
         for key, value in (params or {}).items():
             query_params[f"param_{key}"] = str(value)
         with httpx.Client(
             auth=(self._user, self._password),
-            timeout=httpx.Timeout(20.0),
+            timeout=httpx.Timeout(timeout_seconds),
             transport=self._transport,
         ) as client:
             response = client.post(
@@ -311,6 +313,7 @@ LIMIT 1
 FORMAT JSON
 """,
             params={"name": name},
+            timeout_seconds=PUBLIC_SNAPSHOT_QUERY_TIMEOUT_SECONDS,
         )
         if not rows:
             return None

--- a/src/trusted_router/public_analytics_snapshots.py
+++ b/src/trusted_router/public_analytics_snapshots.py
@@ -1,0 +1,37 @@
+"""Validation shared by public consumers of precomputed analytics snapshots."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable
+from typing import Any
+
+PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS = 600
+
+
+def current_public_analytics_snapshot(
+    name: str,
+    *,
+    reader: Callable[[str], dict[str, Any] | None],
+    now: dt.datetime | None = None,
+    max_age_seconds: int = PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS,
+) -> dict[str, Any] | None:
+    payload = reader(name)
+    if not isinstance(payload, dict):
+        return None
+    generated_at = payload.get("generated_at")
+    if not isinstance(generated_at, str):
+        return None
+    try:
+        generated = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if generated.tzinfo is None:
+        generated = generated.replace(tzinfo=dt.UTC)
+    current = now or dt.datetime.now(dt.UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.UTC)
+    age = (current.astimezone(dt.UTC) - generated.astimezone(dt.UTC)).total_seconds()
+    if age < 0 or age > max_age_seconds:
+        return None
+    return payload

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -107,6 +107,7 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_SCHEMA,
     PROVIDER_CATALOG_V2_SCHEMA,
 )
+from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
 from trusted_router.services.email import EmailMessage, get_email_service
 from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
 from trusted_router.services.trust_release import (
@@ -155,7 +156,6 @@ LEADERBOARD_RECENT_WINDOW_MINUTES = PUBLIC_BENCHMARK_RECENT_MINUTES
 LEADERBOARD_SNAPSHOT_CACHE_SECONDS = 300
 LEADERBOARD_RESPONSE_CACHE_SECONDS = 60
 LEADERBOARD_RESPONSE_STALE_SECONDS = 600
-PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS = 600
 VIDEO_LEADERBOARD_SAMPLE_LIMIT = 5_000
 VIDEO_LEADERBOARD_RECENT_WINDOW_MINUTES = 30 * 24 * 60
 CHOOSE_PAGE_CACHE_SECONDS = 300
@@ -1837,22 +1837,7 @@ def _precomputed_public_analytics_snapshot(name: str) -> dict[str, Any] | None:
     reader = getattr(STORE, "public_analytics_snapshot", None)
     if not callable(reader):
         return None
-    payload = reader(name)
-    if not isinstance(payload, dict):
-        return None
-    generated_at = payload.get("generated_at")
-    if not isinstance(generated_at, str):
-        return None
-    try:
-        generated = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if generated.tzinfo is None:
-        generated = generated.replace(tzinfo=dt.UTC)
-    age = (dt.datetime.now(dt.UTC) - generated.astimezone(dt.UTC)).total_seconds()
-    if age < 0 or age > PUBLIC_ANALYTICS_SNAPSHOT_MAX_AGE_SECONDS:
-        return None
-    return payload
+    return current_public_analytics_snapshot(name, reader=reader)
 
 
 def _status_snapshot(settings: Settings) -> dict[str, Any]:

--- a/tests/test_measured.py
+++ b/tests/test_measured.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+
+from trusted_router import measured
+
+
+def test_measured_snapshot_returns_empty_data_when_analytics_is_unavailable(
+    monkeypatch,
+    caplog,
+) -> None:
+    monkeypatch.setattr(measured, "_CACHE", None)
+
+    def fail_read(_name):
+        raise TimeoutError("analytics unavailable")
+
+    monkeypatch.setattr(
+        measured.STORE,
+        "public_analytics_snapshot",
+        fail_read,
+        raising=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="trusted_router.measured"):
+        snapshot = measured.measured_snapshot()
+
+    assert snapshot["models"] == []
+    assert snapshot["providers"] == []
+    assert snapshot["total_samples"] == 0
+    assert snapshot["generated_at"].endswith("Z")
+    assert "serving empty snapshot (TimeoutError)" in caplog.text
+    assert "analytics unavailable" not in caplog.text
+
+
+def test_measured_snapshot_uses_stale_data_when_refresh_fails(
+    monkeypatch,
+) -> None:
+    stale = {
+        "models": [{"model": "minimax/minimax-m3", "provider": "minimax"}],
+        "providers": [{"provider": "minimax"}],
+        "total_samples": 11,
+        "generated_at": "2026-08-10T18:00:00Z",
+    }
+    monkeypatch.setattr(measured, "_CACHE", (1.0, stale))
+    monkeypatch.setattr(measured.time, "monotonic", lambda: 1.0 + measured._TTL_SECONDS + 1)
+
+    def fail_read(_name):
+        raise ConnectionError("analytics unavailable")
+
+    monkeypatch.setattr(
+        measured.STORE,
+        "public_analytics_snapshot",
+        fail_read,
+        raising=False,
+    )
+
+    assert measured.measured_snapshot() is stale
+
+
+def test_measured_snapshot_caches_a_failed_refresh(
+    monkeypatch,
+) -> None:
+    calls = 0
+    now = 100.0
+    monkeypatch.setattr(measured, "_CACHE", None)
+    monkeypatch.setattr(measured.time, "monotonic", lambda: now)
+
+    def fail_read(_name):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        measured.STORE,
+        "public_analytics_snapshot",
+        fail_read,
+        raising=False,
+    )
+
+    first = measured.measured_snapshot()
+    second = measured.measured_snapshot()
+
+    assert second is first
+    assert calls == 1
+
+
+def test_measured_snapshot_uses_precomputed_data_without_raw_sample_scan(
+    monkeypatch,
+) -> None:
+    snapshot = {
+        "models": [],
+        "providers": [],
+        "total_samples": 17,
+        "generated_at": "2026-08-10T19:00:00Z",
+    }
+    monkeypatch.setattr(measured, "_CACHE", None)
+    monkeypatch.setattr(
+        measured,
+        "current_public_analytics_snapshot",
+        lambda *_args, **_kwargs: snapshot,
+    )
+    monkeypatch.setattr(
+        measured.STORE,
+        "public_analytics_snapshot",
+        lambda _name: snapshot,
+        raising=False,
+    )
+
+    def fail_raw_scan(**_kwargs):
+        raise AssertionError("raw benchmark scan should not run in production")
+
+    monkeypatch.setattr(measured, "public_benchmark_samples", fail_raw_scan)
+
+    assert measured.measured_snapshot() is snapshot

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -241,6 +241,25 @@ def test_public_snapshot_reads_newest_revision_across_month_partitions() -> None
     }
 
 
+def test_public_snapshot_uses_a_short_optional_read_timeout(monkeypatch) -> None:
+    client = OperationalAnalyticsClient(
+        base_url="http://clickhouse",
+        user="reader",
+        password="secret",  # noqa: S106 - inert test credential.
+    )
+    observed: dict[str, float] = {}
+
+    def query(_sql, *, params=None, timeout_seconds=20.0):
+        _ = params
+        observed["timeout_seconds"] = timeout_seconds
+        return []
+
+    monkeypatch.setattr(client, "_query", query)
+
+    assert client.public_snapshot("leaderboard") is None
+    assert observed == {"timeout_seconds": 2.0}
+
+
 def _outbox_row() -> OperationalOutboxRow:
     return OperationalOutboxRow(
         shard=2,

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
+
+
+def test_current_public_analytics_snapshot_accepts_fresh_utc_payload() -> None:
+    payload = {"generated_at": "2026-08-10T19:00:00Z", "total_samples": 7}
+
+    assert (
+        current_public_analytics_snapshot(
+            "leaderboard",
+            reader=lambda _name: payload,
+            now=dt.datetime(2026, 8, 10, 19, 9, tzinfo=dt.UTC),
+        )
+        is payload
+    )
+
+
+def test_current_public_analytics_snapshot_rejects_stale_future_and_malformed_payloads() -> None:
+    now = dt.datetime(2026, 8, 10, 19, 20, tzinfo=dt.UTC)
+    invalid = [
+        {"generated_at": "2026-08-10T19:00:00Z"},
+        {"generated_at": "2026-08-10T19:21:00Z"},
+        {"generated_at": "not-a-date"},
+        {"total_samples": 1},
+    ]
+
+    for payload in invalid:
+        assert (
+            current_public_analytics_snapshot(
+                "leaderboard",
+                reader=lambda _name, value=payload: value,
+                now=now,
+            )
+            is None
+        )


### PR DESCRIPTION
## Summary

- Read precomputed leaderboard evidence instead of scanning raw ClickHouse rows from SEO page requests.
- Fail open to stale or empty optional measurements when analytics is unavailable.
- Cap optional public snapshot reads at two seconds and share snapshot freshness validation.

## Production root cause

A cold SEO page request to `/chinese-ai-models-us-hosted` waited on a raw ClickHouse query for 20 seconds, raised `httpx.ConnectTimeout`, and returned 500. This removes that raw query from the production render path.

## Verification

- `uv run pytest -q` (3,271 passed, 253 skipped, 10 xfailed)
- `uv run mypy`
- `uv run ruff check ...`
