### PR TITLE
Wire Databricks manifest into production catalog

### DIFF
--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -745,6 +745,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
         "streamlake",
         "neurometric",
         "engy",
+        "databricks",
         "zero-g",
         "kimi",
         "zai",

--- a/tests/test_databricks_provider.py
+++ b/tests/test_databricks_provider.py
@@ -10,7 +10,7 @@ import pytest
 from scripts.pricing.base import ProviderPricingResult
 from scripts.pricing.providers import databricks
 from scripts.pricing.refresh import PROVIDER_SLUGS
-from trusted_router.catalog import PROVIDERS
+from trusted_router.catalog import MODEL_ENDPOINTS, PROVIDERS
 from trusted_router.providers import OPENAI_COMPATIBLE_PROVIDERS, ProviderClient
 from trusted_router.services.inference_errors import default_provider_secret_ref
 
@@ -294,6 +294,26 @@ def test_databricks_is_prepaid_standard_privacy_and_not_byok() -> None:
     assert OPENAI_COMPATIBLE_PROVIDERS["databricks"][0] == ("DATABRICKS_TOKEN",)
     assert default_provider_secret_ref("databricks") == "env://DATABRICKS_TOKEN"
     assert "databricks" in PROVIDER_SLUGS
+
+
+def test_databricks_canaried_manifest_routes_are_in_catalog() -> None:
+    active = {
+        row["id"]: row
+        for row in json.loads(databricks.MANIFEST_PATH.read_text(encoding="utf-8"))["models"]
+        if row.get("routable") is not False
+    }
+    dark = {
+        row["id"]
+        for row in json.loads(databricks.MANIFEST_PATH.read_text(encoding="utf-8"))["models"]
+        if row.get("routable") is False
+    }
+
+    for model_id, row in active.items():
+        endpoint = MODEL_ENDPOINTS[f"{model_id}@databricks/prepaid"]
+        assert endpoint.upstream_id == row["upstream_id"]
+        assert endpoint.usage_type == "Credits"
+    for model_id in dark:
+        assert f"{model_id}@databricks/prepaid" not in MODEL_ENDPOINTS
 
 
 def test_provider_client_requires_workspace_host() -> None:


### PR DESCRIPTION
## Summary
- include Databricks in the supplemental provider manifest loader
- assert all canary-passing Databricks routes reach MODEL_ENDPOINTS
- assert failed canaries remain dark

## Verification
- regression test failed before the loader fix
- `uv run pytest -q tests/test_databricks_provider.py`
- `uv run pytest -q tests/test_catalog_prepaid_display.py tests/test_catalog_routing_contracts.py tests/test_databricks_provider.py`
- `uv run ruff check src/trusted_router/catalog_ingest.py tests/test_databricks_provider.py`