### PR TITLE
Refine Quill Cowork billing title

### DIFF
--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -62,7 +62,7 @@ BLOG_POSTS: tuple[BlogPost, ...] = (
     ),
     BlogPost(
         slug="an-agent-that-hides-the-bill",
-        title="Quill Cowork has confidential mode and shows you the bill",
+        title="Quill Cowork has confidential mode and trusts you with the bill",
         description=(
             "Quill Cowork puts a live token meter in the top bar and a /confidential "
             "mode that forgets the conversation but keeps the receipt. Private "

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1289,7 +1289,7 @@ def test_blog_post_og_image_uses_first_image_else_default(client: TestClient) ->
         ("native-swift-harness-no-electron", "Open Source all native Swift harness (NO Electron!)"),
         (
             "an-agent-that-hides-the-bill",
-            "Quill Cowork has confidential mode and shows you the bill",
+            "Quill Cowork has confidential mode and trusts you with the bill",
         ),
         (
             "sre-agent-on-three-clouds",
@@ -1325,4 +1325,4 @@ def test_blog_index_uses_recent_product_images(client: TestClient) -> None:
         "sre-agent-on-three-clouds",
     ):
         assert f'src="https://trustedrouter.com/static/og/blog/{slug}.png"' in response.text
-    assert "Quill Cowork has confidential mode and shows you the bill" in response.text
+    assert "Quill Cowork has confidential mode and trusts you with the bill" in response.text


### PR DESCRIPTION
## Summary
- change the Quill Cowork article title to emphasize that it trusts users with visible billing
- update public SEO regression assertions

## Test
- .................................................                        [100%]
=============================== warnings summary ===============================
src/trusted_router/main.py:220: 1 warning
tests/test_public_seo_pages.py: 46 warnings
  /private/tmp/quill-router-blog-og/src/trusted_router/main.py:220: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

.venv/lib/python3.12/site-packages/fastapi/applications.py:4598: 1 warning
tests/test_public_seo_pages.py: 46 warnings
  /private/tmp/quill-router-blog-og/.venv/lib/python3.12/site-packages/fastapi/applications.py:4598: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)  # ty: ignore[deprecated]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
49 passed, 94 warnings in 8.78s (49 passed)