### PR TITLE
Handle Wafer August 17 model retirements

### DIFF
--- a/scripts/pricing/providers/wafer.py
+++ b/scripts/pricing/providers/wafer.py
@@ -32,6 +32,7 @@ from scripts.pricing.model_ids import (
     mapped_or_canonical_model_id,
     remember_upstream_id,
 )
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "wafer"
 URL = "https://pass.wafer.ai/v1/models"
@@ -45,7 +46,6 @@ MANIFEST_PATH = (
 )
 
 EXPECTED_MODELS = [
-    "z-ai/glm-5.1",
     "z-ai/glm-5.2",
     "z-ai/glm-5.2-fast",
     # Pinning a model Wafer might delist deadlocks manifest rebuilds
@@ -193,6 +193,8 @@ def fetch() -> ProviderPricingResult:
         if or_id is None:
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
+        if provider_model_retired(SLUG, or_id, native_id):
+            continue
         # Feed presence is authoritative even when Wafer renames a pricing
         # key. Record it before parsing so a schema drift cannot look like a
         # delisting and destroy the route's committed price.

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -61,7 +61,10 @@
       "output_token_price_per_m": 3200000,
       "zdr_supported": true,
       "context_length": 202752,
-      "cached_input_token_price_per_m": 100000
+      "cached_input_token_price_per_m": 100000,
+      "deprecation_at": "2026-08-10T00:00:00Z",
+      "retirement_at": "2026-08-17T00:00:00Z",
+      "replacement_model_id": "z-ai/glm-5.2"
     },
     {
       "id": "z-ai/glm-5.2",
@@ -159,7 +162,10 @@
       ],
       "input_token_price_per_m": 4500000,
       "output_token_price_per_m": 22500000,
-      "cached_input_token_price_per_m": 450000
+      "cached_input_token_price_per_m": 450000,
+      "deprecation_at": "2026-08-10T00:00:00Z",
+      "retirement_at": "2026-08-17T00:00:00Z",
+      "replacement_model_id": "moonshotai/kimi-k3"
     }
   ]
 }

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -18,6 +18,7 @@ PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
+WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 
 
 @dataclass(frozen=True)
@@ -35,6 +36,27 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Wafer announced that GLM 5.1 and Kimi K3 Fast retire on 2026-08-17,
+    # with GLM 5.2 and Kimi K3 Standard as their respective replacements.
+    # The notice did not specify a time zone, so use 00:00 UTC as the
+    # conservative cutover. Other providers serving these models are
+    # unaffected.
+    _Retirement(
+        provider="wafer",
+        model_ids=frozenset(
+            {
+                "z-ai/glm-5.1",
+                "moonshotai/kimi-k3-fast",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "GLM-5.1",
+                "kimi-k3-fast",
+            }
+        ),
+        effective_at=WAFER_AUGUST_2026_RETIREMENT_AT,
+    ),
     # Crusoe announced that Nemotron 3 Ultra retires from its Serverless
     # offering at 2026-07-28 11:00 PT, which is 2026-07-28 18:00 UTC.
     # Other providers serving Nemotron 3 Ultra are unaffected.

--- a/tests/test_wafer_august_2026_lifecycle.py
+++ b/tests/test_wafer_august_2026_lifecycle.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import wafer
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
+_RETIRING = {
+    "z-ai/glm-5.1": "GLM-5.1",
+    "moonshotai/kimi-k3-fast": "kimi-k3-fast",
+}
+_REPLACEMENTS = {
+    "z-ai/glm-5.2": "GLM-5.2",
+    "moonshotai/kimi-k3": "Kimi-K3",
+}
+
+
+def test_wafer_routes_retire_at_announced_date() -> None:
+    for model_id, upstream_id in _RETIRING.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "wafer",
+            model_id,
+            upstream_id,
+            at=_CUTOFF - timedelta(microseconds=1),
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "wafer",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+    for model_id, upstream_id in _REPLACEMENTS.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "wafer",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+
+def test_wafer_retirements_are_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    for model_id in _RETIRING:
+        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+        assert "wafer" not in providers
+        assert not provider_lifecycle.provider_model_retired(
+            "another-provider",
+            model_id,
+            _RETIRING[model_id],
+            at=_CUTOFF,
+        )
+
+    for model_id in _REPLACEMENTS:
+        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+        assert "wafer" in providers
+
+
+def test_hourly_refresh_cannot_restore_retired_wafer_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prices = {
+        model_id: ModelPrice(1_000_000, 3_000_000)
+        for model_id in {*_RETIRING, *_REPLACEMENTS}
+    }
+    result = ProviderPricingResult(
+        slug="wafer",
+        prices=prices,
+        source="api",
+        fetched_url=wafer.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"wafer": result})
+    for model_id in _RETIRING:
+        assert "wafer" in before[model_id]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"wafer": result})
+    for model_id in _RETIRING:
+        assert model_id not in after
+    for model_id in _REPLACEMENTS:
+        assert "wafer" in after[model_id]
+
+
+def test_wafer_parser_filters_retired_rows_from_stale_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def row(native_id: str) -> dict[str, object]:
+        return {
+            "id": native_id,
+            "wafer": {
+                "pricing": {
+                    "input_cents_per_million": 100,
+                    "output_cents_per_million": 300,
+                }
+            },
+        }
+
+    payload = {
+        "data": [
+            row("GLM-5.1"),
+            row("GLM-5.2"),
+            row("glm5.2-fast"),
+            row("MiniMax-M3"),
+            row("Kimi-K3"),
+            row("kimi-k3-fast"),
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(wafer.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = wafer.fetch()
+    assert set(_RETIRING).issubset(before.prices)
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = wafer.fetch()
+    assert set(_RETIRING).isdisjoint(after.prices)
+    assert set(_RETIRING).isdisjoint(wafer._DISCOVERED_MANIFEST_ROWS)
+    assert set(_REPLACEMENTS).issubset(after.prices)
+
+
+def test_wafer_manifest_records_announced_replacements() -> None:
+    rows = {
+        row["id"]: row
+        for row in json.loads(wafer.MANIFEST_PATH.read_text())["models"]
+    }
+
+    assert rows["z-ai/glm-5.1"]["retirement_at"] == "2026-08-17T00:00:00Z"
+    assert rows["z-ai/glm-5.1"]["replacement_model_id"] == "z-ai/glm-5.2"
+    assert (
+        rows["moonshotai/kimi-k3-fast"]["retirement_at"]
+        == "2026-08-17T00:00:00Z"
+    )
+    assert (
+        rows["moonshotai/kimi-k3-fast"]["replacement_model_id"]
+        == "moonshotai/kimi-k3"
+    )


### PR DESCRIPTION
## Summary
- retire Wafer GLM 5.1 and Kimi K3 Fast at 2026-08-17 00:00 UTC
- preserve Wafer GLM 5.2 and Kimi K3 Standard as replacement routes
- filter stale hourly Wafer catalog data so retired routes cannot reappear
- record replacement metadata in the provider manifest

## Verification
- regression tests failed on the previous code
- uv run ruff check .
- uv run mypy
- uv run pytest -q (3284 passed, 253 skipped, 10 xfailed)