### PR TITLE
Charge PayPal the existing card checkout fee

### DIFF
--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -113,6 +113,8 @@ def register_billing_routes(router: APIRouter) -> None:
                 "credited": result.credited,
                 "status": result.status,
                 **money_pair("amount", result.amount_microdollars),
+                **money_pair("processing_fee", result.processing_fee_microdollars),
+                **money_pair("total", result.charge_amount_microdollars),
             }
         }
 

--- a/src/trusted_router/routes/internal/paypal.py
+++ b/src/trusted_router/routes/internal/paypal.py
@@ -47,6 +47,8 @@ def register(router: APIRouter) -> None:
                     "credited": result.credited,
                     "status": result.status,
                     **money_pair("amount", result.amount_microdollars),
+                    **money_pair("processing_fee", result.processing_fee_microdollars),
+                    **money_pair("total", result.charge_amount_microdollars),
                 }
             }
         return {"data": {"ignored": True, "event_id": event_id}}

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -20,12 +20,19 @@ from trusted_router.money import (
     money_pair,
 )
 from trusted_router.schemas import CheckoutRequest
+from trusted_router.services.stripe_fees import (
+    CREDITS_LINE_ITEM_NAME,
+    PROCESSING_FEE_LINE_ITEM_NAME,
+    ProcessingFee,
+    stripe_processing_fee,
+)
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
 
 _TOKEN_CACHE_SECONDS_SKEW = 60
 _TOKEN_CACHE_LOCK = threading.Lock()
 _TOKEN_CACHE: dict[tuple[str, str], tuple[str, float]] = {}
+_CHECKOUT_REFERENCE_VERSION = "tr1"
 
 
 @dataclass(frozen=True)
@@ -36,6 +43,15 @@ class PayPalCaptureResult:
     amount_microdollars: int
     credited: bool
     status: str
+    processing_fee_microdollars: int = 0
+    charge_amount_microdollars: int = 0
+
+
+@dataclass(frozen=True)
+class _PayPalCreditReference:
+    workspace_id: str
+    credit_amount_cents: int | None = None
+    charge_amount_cents: int | None = None
 
 
 def create_paypal_checkout_session(
@@ -45,7 +61,13 @@ def create_paypal_checkout_session(
     customer_email: str | None,
     settings: Settings,
 ) -> dict[str, Any]:
+    credit_amount_cents = dollars_to_cents(body.amount)
     amount_microdollars = dollars_to_microdollars(body.amount)
+    fee = stripe_processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=settings.stripe_card_fee_basis_points,
+        fixed_fee_cents=settings.stripe_card_fee_fixed_cents,
+    )
     workspace = STORE.get_workspace(workspace_id)
     if workspace is None:
         raise api_error(404, "Workspace not found", ErrorType.NOT_FOUND)
@@ -62,6 +84,8 @@ def create_paypal_checkout_session(
                 "url": f"https://{settings.trusted_domain}/billing/mock-paypal-checkout",
                 "workspace_id": workspace_id,
                 **money_pair("amount", amount_microdollars),
+                **money_pair("processing_fee", fee.processing_fee_microdollars),
+                **money_pair("total", fee.charge_amount_microdollars),
                 "mode": "mock_paypal",
             }
         raise api_error(400, "PayPal checkout is not configured", ErrorType.BAD_REQUEST)
@@ -78,12 +102,19 @@ def create_paypal_checkout_session(
             "purchase_units": [
                 {
                     "reference_id": workspace_id,
-                    "custom_id": workspace_id,
+                    "custom_id": _paypal_checkout_reference(workspace_id, fee),
                     "description": "TrustedRouter prepaid credits",
                     "amount": {
                         "currency_code": "USD",
-                        "value": _paypal_amount_value(dollars_to_cents(body.amount)),
+                        "value": _paypal_amount_value(fee.charge_amount_cents),
+                        "breakdown": {
+                            "item_total": {
+                                "currency_code": "USD",
+                                "value": _paypal_amount_value(fee.charge_amount_cents),
+                            }
+                        },
                     },
+                    "items": _paypal_line_items(fee),
                 }
             ],
             "application_context": {
@@ -110,6 +141,8 @@ def create_paypal_checkout_session(
         "url": approval_url,
         "workspace_id": workspace_id,
         **money_pair("amount", amount_microdollars),
+        **money_pair("processing_fee", fee.processing_fee_microdollars),
+        **money_pair("total", fee.charge_amount_microdollars),
         "mode": "paypal",
     }
 
@@ -137,6 +170,8 @@ def capture_paypal_order_for_workspace(
             amount_microdollars=result.amount_microdollars,
             credited=result.credited,
             status=result.status,
+            processing_fee_microdollars=result.processing_fee_microdollars,
+            charge_amount_microdollars=result.charge_amount_microdollars,
         )
     return result
 
@@ -155,6 +190,8 @@ def credit_paypal_capture(
     if STORE.get_credit_account(workspace_id) is None:
         raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
     amount_microdollars = parsed["amount_microdollars"]
+    processing_fee_microdollars = parsed["processing_fee_microdollars"]
+    charge_amount_microdollars = parsed["charge_amount_microdollars"]
     capture_id = parsed["capture_id"]
     credited = STORE.credit_workspace_typed_direct(
         workspace_id,
@@ -174,6 +211,8 @@ def credit_paypal_capture(
         amount_microdollars=amount_microdollars,
         credited=credited,
         status=parsed["status"],
+        processing_fee_microdollars=processing_fee_microdollars,
+        charge_amount_microdollars=charge_amount_microdollars,
     )
 
 
@@ -282,6 +321,44 @@ def _paypal_amount_value(cents: int) -> str:
     return f"{sign}{cents // 100}.{cents % 100:02d}"
 
 
+def _paypal_checkout_reference(workspace_id: str, fee: ProcessingFee) -> str:
+    return "|".join(
+        (
+            _CHECKOUT_REFERENCE_VERSION,
+            workspace_id,
+            str(fee.credit_amount_cents),
+            str(fee.charge_amount_cents),
+        )
+    )
+
+
+def _paypal_line_items(fee: ProcessingFee) -> list[dict[str, Any]]:
+    items = [
+        {
+            "name": CREDITS_LINE_ITEM_NAME,
+            "unit_amount": {
+                "currency_code": "USD",
+                "value": _paypal_amount_value(fee.credit_amount_cents),
+            },
+            "quantity": "1",
+            "category": "DIGITAL_GOODS",
+        }
+    ]
+    if fee.processing_fee_cents:
+        items.append(
+            {
+                "name": PROCESSING_FEE_LINE_ITEM_NAME,
+                "unit_amount": {
+                    "currency_code": "USD",
+                    "value": _paypal_amount_value(fee.processing_fee_cents),
+                },
+                "quantity": "1",
+                "category": "DIGITAL_GOODS",
+            }
+        )
+    return items
+
+
 def _approval_url(order: Mapping[str, Any]) -> str | None:
     links = order.get("links")
     if not isinstance(links, list):
@@ -301,14 +378,10 @@ def _extract_capture(event_or_order: Mapping[str, Any]) -> dict[str, Any]:
         resource = event_or_order.get("resource")
         if not isinstance(resource, dict):
             raise api_error(400, "PayPal webhook has no capture resource", ErrorType.BAD_REQUEST)
-        capture_id = str(resource.get("id") or "")
-        return {
-            "order_id": _paypal_related_order_id(resource),
-            "capture_id": capture_id,
-            "workspace_id": _paypal_workspace_id(resource),
-            "amount_microdollars": _paypal_amount_microdollars(resource.get("amount")),
-            "status": str(resource.get("status") or ""),
-        }
+        return _paypal_capture_payload(
+            resource,
+            order_id=_paypal_related_order_id(resource),
+        )
 
     order_id = str(event_or_order.get("id") or "")
     purchase_units = event_or_order.get("purchase_units")
@@ -323,23 +396,68 @@ def _extract_capture(event_or_order: Mapping[str, Any]) -> dict[str, Any]:
     capture = captures[0]
     if not isinstance(capture, dict):
         raise api_error(400, "PayPal capture is invalid", ErrorType.BAD_REQUEST)
+    return _paypal_capture_payload(capture, order_id=order_id, fallback=unit)
+
+
+def _paypal_capture_payload(
+    capture: Mapping[str, Any],
+    *,
+    order_id: str,
+    fallback: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     capture_id = str(capture.get("id") or "")
+    if not capture_id:
+        raise api_error(400, "PayPal capture has no id", ErrorType.BAD_REQUEST)
+    reference = _paypal_credit_reference(capture, fallback=fallback)
+    charge_amount_microdollars = _paypal_amount_microdollars(capture.get("amount"))
+    amount_microdollars = charge_amount_microdollars
+    processing_fee_microdollars = 0
+    if reference.charge_amount_cents is not None:
+        expected_charge = reference.charge_amount_cents * 10_000
+        if charge_amount_microdollars != expected_charge:
+            raise api_error(400, "PayPal capture amount mismatch", ErrorType.BAD_REQUEST)
+        if reference.credit_amount_cents is None:
+            raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
+        amount_microdollars = reference.credit_amount_cents * 10_000
+        processing_fee_microdollars = charge_amount_microdollars - amount_microdollars
     return {
         "order_id": order_id,
         "capture_id": capture_id,
-        "workspace_id": _paypal_workspace_id(capture, fallback=unit),
-        "amount_microdollars": _paypal_amount_microdollars(capture.get("amount")),
+        "workspace_id": reference.workspace_id,
+        "amount_microdollars": amount_microdollars,
+        "processing_fee_microdollars": processing_fee_microdollars,
+        "charge_amount_microdollars": charge_amount_microdollars,
         "status": str(capture.get("status") or ""),
     }
 
 
-def _paypal_workspace_id(resource: Mapping[str, Any], *, fallback: Mapping[str, Any] | None = None) -> str:
-    workspace_id = resource.get("custom_id")
-    if not isinstance(workspace_id, str) and fallback is not None:
-        workspace_id = fallback.get("custom_id") or fallback.get("reference_id")
-    if not isinstance(workspace_id, str) or not workspace_id:
+def _paypal_credit_reference(
+    resource: Mapping[str, Any],
+    *,
+    fallback: Mapping[str, Any] | None = None,
+) -> _PayPalCreditReference:
+    raw_reference = resource.get("custom_id")
+    if not isinstance(raw_reference, str) and fallback is not None:
+        raw_reference = fallback.get("custom_id") or fallback.get("reference_id")
+    if not isinstance(raw_reference, str) or not raw_reference:
         raise api_error(400, "PayPal capture has no workspace reference", ErrorType.BAD_REQUEST)
-    return workspace_id
+    if not raw_reference.startswith(f"{_CHECKOUT_REFERENCE_VERSION}|"):
+        return _PayPalCreditReference(workspace_id=raw_reference)
+    parts = raw_reference.split("|")
+    if len(parts) != 4 or not parts[1]:
+        raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
+    try:
+        credit_amount_cents = int(parts[2])
+        charge_amount_cents = int(parts[3])
+    except ValueError as exc:
+        raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST) from exc
+    if credit_amount_cents <= 0 or charge_amount_cents < credit_amount_cents:
+        raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
+    return _PayPalCreditReference(
+        workspace_id=parts[1],
+        credit_amount_cents=credit_amount_cents,
+        charge_amount_cents=charge_amount_cents,
+    )
 
 
 def _paypal_related_order_id(resource: Mapping[str, Any]) -> str:
@@ -363,4 +481,7 @@ def _paypal_amount_microdollars(amount: Any) -> int:
         raise api_error(400, "PayPal capture amount is invalid", ErrorType.BAD_REQUEST) from exc
     if not decimal.is_finite() or decimal <= 0:
         raise api_error(400, "PayPal capture amount is invalid", ErrorType.BAD_REQUEST)
-    return int((decimal * MICRODOLLARS_PER_DOLLAR).to_integral_value())
+    microdollars = int((decimal * MICRODOLLARS_PER_DOLLAR).to_integral_value())
+    if microdollars % 10_000:
+        raise api_error(400, "PayPal capture amount is invalid", ErrorType.BAD_REQUEST)
+    return microdollars

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -29,9 +29,11 @@
       </div>
       <button class="btn primary" type="submit">Continue to checkout</button>
       <p class="form-help">
-        Stripe shows your credits and the payment processing fee as separate
-        line items before you pay. ACH costs 0.8%, capped at $5, and can take
-        up to four business days. Bank-funded credits appear only after settlement.
+        Card and PayPal checkouts show your credits and the same payment
+        processing fee as separate line items before you pay. ACH and
+        stablecoin keep their lower rail-specific fees. ACH is 0.8%, capped
+        at $5, and can take up to four business days. Bank-funded credits
+        appear only after settlement.
       </p>
     </form>
   </div>

--- a/tests/test_paypal_processing_fees.py
+++ b/tests/test_paypal_processing_fees.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services.paypal_billing import credit_paypal_capture
+from trusted_router.storage import STORE
+from trusted_router.typed_balance import live_credit_summary
+
+
+def _paypal_settings() -> Settings:
+    return Settings(
+        environment="test",
+        paypal_client_id="paypal-client",
+        paypal_client_secret="paypal-secret",  # noqa: S106
+        paypal_webhook_id=None,
+        stripe_card_fee_basis_points=290,
+        stripe_card_fee_fixed_cents=30,
+    )
+
+
+def _completed_order(
+    *,
+    workspace_id: str,
+    custom_id: str,
+    value: str = "26.06",
+    order_id: str = "ORDER-1",
+    capture_id: str = "CAPTURE-1",
+) -> dict[str, Any]:
+    return {
+        "id": order_id,
+        "status": "COMPLETED",
+        "purchase_units": [
+            {
+                "reference_id": workspace_id,
+                "custom_id": custom_id,
+                "payments": {
+                    "captures": [
+                        {
+                            "id": capture_id,
+                            "status": "COMPLETED",
+                            "amount": {"currency_code": "USD", "value": value},
+                        }
+                    ]
+                },
+            }
+        ],
+    }
+
+
+def test_paypal_checkout_uses_the_existing_stripe_card_fee_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(_paypal_settings(), init_observability=False)
+    captured: dict[str, Any] = {}
+
+    def paypal_post(
+        _settings: Settings,
+        path: str,
+        *,
+        request_id: str,
+        json_body: dict[str, Any],
+    ) -> dict[str, Any]:
+        assert path == "/v2/checkout/orders"
+        assert request_id.startswith("tr-paypal-order-")
+        captured.update(json_body)
+        return {
+            "id": "ORDER-FEE",
+            "links": [{"rel": "approve", "href": "https://paypal.test/approve"}],
+        }
+
+    monkeypatch.setattr(
+        "trusted_router.services.paypal_billing._paypal_post",
+        paypal_post,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 25, "payment_method": "paypal"},
+        )
+
+    assert response.status_code == 201, response.text
+    unit = captured["purchase_units"][0]
+    assert unit["amount"] == {
+        "currency_code": "USD",
+        "value": "26.06",
+        "breakdown": {"item_total": {"currency_code": "USD", "value": "26.06"}},
+    }
+    assert [(item["name"], item["unit_amount"]["value"]) for item in unit["items"]] == [
+        ("TrustedRouter credits", "25.00"),
+        ("Payment processing fee", "1.06"),
+    ]
+    assert unit["custom_id"].startswith("tr1|")
+    assert unit["custom_id"].endswith("|2500|2606")
+    data = response.json()["data"]
+    assert data["amount_microdollars"] == 25_000_000
+    assert data["processing_fee_microdollars"] == 1_060_000
+    assert data["total_microdollars"] == 26_060_000
+
+
+def test_paypal_capture_credits_only_principal_and_is_idempotent(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+    order = _completed_order(
+        workspace_id=workspace_id,
+        custom_id=f"tr1|{workspace_id}|2500|2606",
+    )
+
+    first = credit_paypal_capture(order, expected_workspace_id=workspace_id)
+    second = credit_paypal_capture(order, expected_workspace_id=workspace_id)
+
+    assert first.credited is True
+    assert second.credited is False
+    assert first.amount_microdollars == 25_000_000
+    assert first.processing_fee_microdollars == 1_060_000
+    assert first.charge_amount_microdollars == 26_060_000
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] - before["total_credits"] == 25_000_000
+
+
+def test_paypal_capture_rejects_charge_that_does_not_match_reference(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+    order = _completed_order(
+        workspace_id=workspace_id,
+        custom_id=f"tr1|{workspace_id}|2500|2606",
+        value="26.05",
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        credit_paypal_capture(order, expected_workspace_id=workspace_id)
+
+    assert raised.value.status_code == 400
+    after = live_credit_summary(workspace_id)
+    assert after == before
+
+
+def test_legacy_paypal_capture_still_credits_the_full_capture(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    before = live_credit_summary(workspace_id)
+    assert before is not None
+    order = _completed_order(
+        workspace_id=workspace_id,
+        custom_id=workspace_id,
+        value="3.00",
+        capture_id="CAPTURE-LEGACY",
+    )
+
+    result = credit_paypal_capture(order, expected_workspace_id=workspace_id)
+
+    assert result.amount_microdollars == 3_000_000
+    assert result.processing_fee_microdollars == 0
+    assert result.charge_amount_microdollars == 3_000_000
+    after = live_credit_summary(workspace_id)
+    assert after is not None
+    assert after["total_credits"] - before["total_credits"] == 3_000_000
+
+
+def test_paypal_webhook_credits_principal_and_returns_fee_breakdown(
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(_paypal_settings(), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+        event = {
+            "id": "WH-1",
+            "event_type": "PAYMENT.CAPTURE.COMPLETED",
+            "resource": {
+                "id": "CAPTURE-WEBHOOK",
+                "status": "COMPLETED",
+                "custom_id": f"tr1|{workspace_id}|2500|2606",
+                "amount": {"currency_code": "USD", "value": "26.06"},
+                "supplementary_data": {"related_ids": {"order_id": "ORDER-WEBHOOK"}},
+            },
+        }
+
+        response = client.post("/v1/internal/paypal/webhook", json=event)
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["credited"] is True
+    assert data["amount_microdollars"] == 25_000_000
+    assert data["processing_fee_microdollars"] == 1_060_000
+    assert data["total_microdollars"] == 26_060_000
+
+
+def test_paypal_capture_rejects_subcent_amount(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    order = _completed_order(
+        workspace_id=workspace_id,
+        custom_id=workspace_id,
+        value="3.001",
+        capture_id="CAPTURE-SUBCENT",
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        credit_paypal_capture(order, expected_workspace_id=workspace_id)
+
+    assert raised.value.status_code == 400
+
+
+def test_mock_paypal_checkout_reports_same_fee_breakdown(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": 25, "payment_method": "paypal"},
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()["data"]
+    assert data["mode"] == "mock_paypal"
+    assert data["amount_microdollars"] == 25_000_000
+    assert data["processing_fee_microdollars"] == 1_060_000
+    assert data["total_microdollars"] == 26_060_000
+
+
+def test_paypal_capture_rejects_cross_workspace_reference(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
+    other = STORE.create_workspace("other-owner", "Other")
+    order = _completed_order(
+        workspace_id=other.id,
+        custom_id=f"tr1|{other.id}|2500|2606",
+        capture_id="CAPTURE-OTHER",
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        credit_paypal_capture(order, expected_workspace_id=workspace_id)
+
+    assert raised.value.status_code == 403


### PR DESCRIPTION
## Summary
- show PayPal credits and the existing Stripe-card processing fee as separate line items
- bind principal and total into the PayPal checkout reference so captures credit only purchased credits
- preserve legacy PayPal captures and reject amount mismatches
- leave Stripe, ACH, stablecoin, and Adyen pricing unchanged

## Verification
- live PayPal order-schema smoke created an unapproved order with the correct two-line-item total
- ruff passed
- mypy passed
- full pytest: 3287 passed, 253 skipped, 10 xfailed
- focused PayPal and console tests: 80 passed