### PR TITLE
Schedule Wafer GLM 5.2 Fast retirement

### DIFF
--- a/scripts/pricing/providers/wafer.py
+++ b/scripts/pricing/providers/wafer.py
@@ -47,10 +47,9 @@ MANIFEST_PATH = (
 
 EXPECTED_MODELS = [
     "z-ai/glm-5.2",
-    "z-ai/glm-5.2-fast",
     # Pinning a model Wafer might delist deadlocks manifest rebuilds
     # (validate raises -> stale fallback -> prune skipped); kimi-k2.6 already
-    # flipped non-ZDR once.
+    # flipped non-ZDR once. Retiring models must not be pinned here either.
     "minimax/minimax-m3",
 ]
 

--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -90,7 +90,10 @@
       "output_token_price_per_m": 6600000,
       "zdr_supported": true,
       "context_length": 1048576,
-      "cached_input_token_price_per_m": 210000
+      "cached_input_token_price_per_m": 210000,
+      "deprecation_at": "2026-08-12T00:00:00Z",
+      "retirement_at": "2026-08-17T00:00:00Z",
+      "replacement_model_id": "z-ai/glm-5.2"
     },
     {
       "id": "qwen/qwen3.5-397b-a17b",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -36,8 +36,9 @@ class _Retirement:
 
 
 _RETIREMENTS = (
-    # Wafer announced that GLM 5.1 and Kimi K3 Fast retire on 2026-08-17,
-    # with GLM 5.2 and Kimi K3 Standard as their respective replacements.
+    # Wafer announced that GLM 5.1, GLM 5.2 Fast, and Kimi K3 Fast retire on
+    # 2026-08-17. Standard GLM 5.2 replaces both GLM routes, while Kimi K3
+    # Standard replaces Kimi K3 Fast.
     # The notice did not specify a time zone, so use 00:00 UTC as the
     # conservative cutover. Other providers serving these models are
     # unaffected.
@@ -46,12 +47,15 @@ _RETIREMENTS = (
         model_ids=frozenset(
             {
                 "z-ai/glm-5.1",
+                "z-ai/glm-5.2-fast",
                 "moonshotai/kimi-k3-fast",
             }
         ),
         upstream_ids=frozenset(
             {
                 "GLM-5.1",
+                "GLM-5.2-Fast",
+                "glm5.2-fast",
                 "kimi-k3-fast",
             }
         ),

--- a/tests/test_wafer_august_2026_lifecycle.py
+++ b/tests/test_wafer_august_2026_lifecycle.py
@@ -14,6 +14,7 @@ from trusted_router.catalog import endpoints_for_model
 _CUTOFF = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 _RETIRING = {
     "z-ai/glm-5.1": "GLM-5.1",
+    "z-ai/glm-5.2-fast": "glm5.2-fast",
     "moonshotai/kimi-k3-fast": "kimi-k3-fast",
 }
 _REPLACEMENTS = {
@@ -167,6 +168,8 @@ def test_wafer_manifest_records_announced_replacements() -> None:
 
     assert rows["z-ai/glm-5.1"]["retirement_at"] == "2026-08-17T00:00:00Z"
     assert rows["z-ai/glm-5.1"]["replacement_model_id"] == "z-ai/glm-5.2"
+    assert rows["z-ai/glm-5.2-fast"]["retirement_at"] == "2026-08-17T00:00:00Z"
+    assert rows["z-ai/glm-5.2-fast"]["replacement_model_id"] == "z-ai/glm-5.2"
     assert (
         rows["moonshotai/kimi-k3-fast"]["retirement_at"]
         == "2026-08-17T00:00:00Z"


### PR DESCRIPTION
## Summary
- retire only Wafer's GLM 5.2 Fast route at 2026-08-17 00:00 UTC
- preserve standard Wafer GLM 5.2 as the announced replacement
- prevent stale native catalog and hourly pricing refreshes from restoring the retired route
- record the cutoff and replacement in Wafer's provider manifest

## Regression proof
- the expanded five-test lifecycle suite failed 5/5 on the previous code
- the same suite passes after the implementation

## Validation
- `uv run pytest -q`: 3292 passed, 253 skipped, 10 xfailed
- 213 targeted pricing/catalog/lifecycle tests passed
- `uv run ruff check .`
- `uv run mypy`