### PR TITLE
Keep alert reconciliation independent of metric IAM

### DIFF
--- a/scripts/deploy/gateway_reliability.sh
+++ b/scripts/deploy/gateway_reliability.sh
@@ -103,7 +103,11 @@ ensure_policies() {
   done
 }
 
-ensure_slow_metric
+if ! ensure_slow_metric; then
+  # Log-metric administration is a separate IAM capability from alert-policy
+  # administration. Do not let that optional metric block urgent policy fixes.
+  log "WARN: unable to reconcile the optional slow billing-path metric; continuing with alert policies"
+fi
 channel="$(ensure_channel)"
 ensure_policies "$channel"
 log "Gateway billing-path alerting is configured"

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -71,6 +71,8 @@ def test_gateway_alert_deploy_is_idempotent_and_dry_run_by_default() -> None:
     assert "TrustedRouter Spanner on-call" in script
     assert 'httpRequest.status < 500' in script
     assert 'httpRequest.latency >= "10s"' in script
+    assert "if ! ensure_slow_metric; then" in script
+    assert "continuing with alert policies" in script
 
 
 def test_gateway_alert_workflow_requires_explicit_apply() -> None:


### PR DESCRIPTION
The production reliability workflow currently stops on an optional log-metric update because log metric and alert policy administration use separate IAM capabilities. Continue to reconcile customer-facing policies when that optional metric update is denied; policy failures remain fatal. Includes a focused regression and shell syntax validation.