### PR TITLE
Install alert workflow beta commands explicitly

### DIFF
--- a/.github/workflows/gateway-reliability.yml
+++ b/.github/workflows/gateway-reliability.yml
@@ -36,5 +36,7 @@ jobs:
           workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
       - uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: beta
       - name: Reconcile gateway reliability alerts
         run: bash scripts/deploy/gateway_reliability.sh --apply

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -83,4 +83,5 @@ def test_gateway_alert_workflow_requires_explicit_apply() -> None:
     assert 'if [ "${CONFIRMATION}" != "APPLY" ]' in workflow
     assert "id-token: write" in workflow
     assert "tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com" in workflow
+    assert "install_components: beta" in workflow
     assert "gateway_reliability.sh --apply" in workflow


### PR DESCRIPTION
The current GitHub runner no longer bundles the gcloud beta notification-channel command group. Install the required component during setup so the production alert reconciler is deterministic and noninteractive. Focused workflow regression passes.