### PR TITLE
Record cache reads on attested generations

### DIFF
--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -688,8 +688,18 @@ class Generation:
             status=str(body.get("status") or "success"),
             streamed=bool(body.get("streamed", False)),
             usage_estimated=bool(body.get("usage_estimated", False)),
+            # `cache_read_input_tokens` is the canonical settle-body field: it is
+            # what the attested gateway sends, what SettleRequest declares, and
+            # what billing reads via `cache_read_count`. Reading only the two
+            # legacy aliases meant this metric was silently 0 on every attested
+            # generation. Billing was never affected — the cost is computed
+            # upstream and passed in as `actual_cost_microdollars`; only this
+            # activity-index field was blank.
             cached_input_tokens=int(
-                body.get("cached_input_tokens") or body.get("cached_tokens") or 0
+                body.get("cache_read_input_tokens")
+                or body.get("cached_input_tokens")
+                or body.get("cached_tokens")
+                or 0
             ),
             reasoning_tokens=int(body.get("reasoning_tokens") or 0),
             # Tool-call arguments are model output content, not activity

--- a/tests/test_gateway_cache_billing.py
+++ b/tests/test_gateway_cache_billing.py
@@ -214,3 +214,39 @@ def test_settle_without_cache_fields_is_unchanged() -> None:
     generation = STORE.get_generation(data["generation_id"])
     assert generation is not None
     assert generation.tokens_prompt == 500
+    assert generation.cached_input_tokens == 0
+
+
+def test_settle_records_cache_reads_on_the_generation() -> None:
+    """The generation's cached_input_tokens must reflect the settle body.
+
+    Regression: `from_settle_body` only read the legacy `cached_input_tokens`
+    / `cached_tokens` aliases, but the attested gateway sends
+    `cache_read_input_tokens` (the name SettleRequest declares and billing
+    reads). Every attested generation therefore recorded 0 cached tokens —
+    across ~700k rows in production — making prompt-cache usage look
+    nonexistent. Billing was always correct; only this metric was blank.
+    """
+    client, key = _client_and_key()
+    auth = _authorize(
+        client,
+        key,
+        "z-ai/glm-5.2",
+        provider={"only": ["tinfoil"]},
+    )
+
+    settle = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth["authorization_id"],
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 50,
+            "cache_read_input_tokens": 900,
+            "request_id": "gw-cache-metric",
+            "elapsed_seconds": 1.0,
+        },
+    )
+    assert settle.status_code == 200, settle.text
+    generation = STORE.get_generation(settle.json()["data"]["generation_id"])
+    assert generation is not None
+    assert generation.cached_input_tokens == 900


### PR DESCRIPTION
## The bug
`Generation.from_settle_body` read only the legacy `cached_input_tokens` / `cached_tokens` aliases:

```python
cached_input_tokens=int(body.get("cached_input_tokens") or body.get("cached_tokens") or 0)
```

But the attested gateway sends **`cache_read_input_tokens`** ([`client.go`](https://github.com/Lore-Hex/quill-cloud-proxy) → `body["cache_read_input_tokens"]`) — the same canonical name that `SettleRequest` declares (`schemas.py`), that billing reads via `cache_read_count`, and that `_SETTLE_REPAIR_FIELDS` lists. Neither alias is ever sent by anything.

**Result:** every attested generation recorded 0 cached input tokens. Verified in production — across **705,475 rows the field is never once non-zero**, including 355k OpenAI requests where automatic prompt caching makes that implausible. Prompt-cache usage looks nonexistent in activity and analytics.

## Money was never affected
The cost is computed upstream from the correctly-named schema field and passed into `from_settle_body` as `actual_cost_microdollars`. Only this activity-index metric was blank. `tests/test_gateway_cache_billing.py` already pinned the billing behaviour and still passes unchanged.

## The fix
Read the canonical name first, keep both legacy aliases as fallbacks.

## Test
New `test_settle_records_cache_reads_on_the_generation` settles with `cache_read_input_tokens: 900` and asserts the generation records it. **Verified it fails against the old code** and passes with the fix. Also added `cached_input_tokens == 0` to the existing no-cache-fields test so the default stays pinned.

Full suite green: **3297 passed, 253 skipped, 10 xfailed**.

## Note
The enclave also sends `cache_creation_input_tokens`, which `Generation` has no field for. Billing handles it (`cache_creation_count`); it's simply not carried on the activity record. Left alone here — separate change if you want it surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)