### PR TITLE
Filter direct-IP scanner 405s from Sentry

### DIFF
--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 from threading import Lock
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 from trusted_router.config import Settings
 
@@ -317,7 +319,20 @@ def _is_public_scanner_405(event: dict[str, Any]) -> bool:
         "/wp-login.php",
         "/xmlrpc.php",
     )
-    return any(marker in target for marker in scanner_markers)
+    if any(marker in target for marker in scanner_markers):
+        return True
+
+    # Internet scanners also probe the load balancer's numeric address with a
+    # bare POST. This cannot be a supported product route, while the equivalent
+    # request on a named host remains visible as a potentially broken client.
+    method = str(request.get("method") or "").upper()
+    url = str(request.get("url") or "")
+    try:
+        parsed = urlsplit(url)
+        ipaddress.ip_address(parsed.hostname or "")
+    except (ValueError, TypeError):
+        return False
+    return method == "POST" and parsed.path in {"", "/"} and not parsed.query
 
 
 def configure_sentry_floodgate(settings: Settings) -> None:

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -328,10 +328,10 @@ def test_sentry_failed_request_statuses_exclude_expected_compatibility_501() -> 
 
 
 def test_sentry_drops_wordpress_scanner_405_but_keeps_application_405() -> None:
-    def event(url: str) -> dict:
+    def event(url: str, *, method: str = "POST") -> dict:
         return {
             "level": "error",
-            "request": {"url": url},
+            "request": {"method": method, "url": url},
             "exception": {
                 "values": [
                     {
@@ -349,6 +349,10 @@ def test_sentry_drops_wordpress_scanner_405_but_keeps_application_405() -> None:
         )
         is None
     )
+    assert before_send(event("http://35.241.14.18/"), {}) is None
+    assert before_send(event("http://[2001:db8::1]/"), {}) is None
+    assert before_send(event("http://35.241.14.18/health"), {}) is not None
+    assert before_send(event("https://trustedrouter.com/"), {}) is not None
     assert before_send(event("https://trustedrouter.com/console/credits"), {}) is not None
 
 


### PR DESCRIPTION
## Summary
- drop only bare POST 405 events sent to a numeric load-balancer address
- preserve named-domain and application-route 405 reporting
- add IPv4/IPv6 and negative regression coverage

## Verification
- `uv run pytest -q tests/test_security_contracts.py -k "sentry_drops_wordpress_scanner_405 or sentry_failed_request_statuses"`
- `uv run ruff check src/trusted_router/sentry_config.py tests/test_security_contracts.py`
- `uv run mypy src/trusted_router/sentry_config.py`