### PR TITLE
Remove the unreachable monitor_account_unavailable capacity leg

### DIFF
--- a/src/trusted_router/provider_reliability.py
+++ b/src/trusted_router/provider_reliability.py
@@ -140,11 +140,7 @@ def classify_provider_failure(
             FailureClass.PROVIDER_AUTH_CONFIG,
             False,
         )
-    if (
-        error_status == 402
-        or kind == "monitor_account_unavailable"
-        or any(marker in message for marker in _ACCOUNT_QUOTA_MARKERS)
-    ):
+    if error_status == 402 or any(marker in message for marker in _ACCOUNT_QUOTA_MARKERS):
         return FailureAttribution(
             FailureOwner.TRUSTEDROUTER,
             FailureClass.TRUSTEDROUTER_CAPACITY,

--- a/tests/test_provider_reliability.py
+++ b/tests/test_provider_reliability.py
@@ -45,6 +45,32 @@ def test_provider_account_quota_is_owned_by_trustedrouter() -> None:
     assert result.capacity_rejected is True
 
 
+def test_monitor_account_unavailable_is_a_router_fault_not_a_capacity_rejection() -> None:
+    # The probe never reached the provider: this type is only emitted when the
+    # MONITOR's own router account is unusable (probes.py, source == "router"
+    # plus an "insufficient credits"/"invalid api key" message). It is monitor
+    # trouble, so it must not read as an upstream capacity rejection — a bare
+    # 402 still does, and that path is asserted alongside it here so removing
+    # the redundant leg cannot quietly take the real one with it.
+    monitor = classify_provider_failure(
+        status="error",
+        error_type="monitor_account_unavailable",
+        error_status=None,
+    )
+    upstream_payment_required = classify_provider_failure(
+        status="error",
+        error_type="provider_error",
+        error_status=402,
+    )
+
+    assert monitor.owner is FailureOwner.TRUSTEDROUTER
+    assert monitor.failure_class is FailureClass.ROUTER_FAULT
+    assert monitor.counts_toward_provider_availability is False
+    assert monitor.capacity_rejected is False
+    assert upstream_payment_required.failure_class is FailureClass.TRUSTEDROUTER_CAPACITY
+    assert upstream_payment_required.capacity_rejected is True
+
+
 def test_ambiguous_error_is_not_charged_to_provider() -> None:
     result = classify_provider_failure(
         status="error",


### PR DESCRIPTION
## What

`classify_provider_failure` tested `kind == "monitor_account_unavailable"` inside the TrustedRouter-capacity branch, but `is_router_origin_error()` already returns `True` for that type (it is a member of `MONITOR_CONFIGURATION_ERROR_TYPES`) and is consulted first. For the canonical spelling, control never reached the leg.

Found while building the provider-check contract-export parity gate; deliberately kept out of that PR.

## Is it actually dead?

Not quite — and the "not quite" is the interesting part. `is_router_origin_error` matches the **raw** `error_type`, while this branch matched the **stripped + casefolded** `kind`. Measured on `origin/main`:

| `error_type` | `is_router_origin_error` | attribution |
| --- | --- | --- |
| `monitor_account_unavailable` | `True` | `trustedrouter` / `router_fault`, `capacity_rejected=False` |
| `Monitor_Account_Unavailable` | `False` | `trustedrouter` / `trustedrouter_capacity`, `capacity_rejected=True` |
| `' monitor_account_unavailable '` | `False` | `trustedrouter` / `trustedrouter_capacity`, `capacity_rejected=True` |

So one logical condition had two classifications, chosen by casing. The only producer (`probes.py:2109`) emits the canonical lowercase form, so no variant occurs in practice.

## Delete, not reorder

`router_fault` is the correct attribution, and it is already the one that wins:

- The type is emitted only when the **monitor's own** router account is unusable — `probes.py` requires `source == "router"` plus an insufficient-credits / disabled-or-invalid-key message. The probe never reached the provider, which is verbatim what `is_router_origin_error` documents ("failure happened before provider invocation").
- `TRUSTEDROUTER_CAPACITY` means an **upstream provider account quota** per the classifier's own docstring — a different condition, where the provider was in the picture.
- `tests/test_synthetic_visibility_and_funding.py` already states the intent for this type: "monitor trouble, not a public outage."

Reordering would have promoted the wrong answer, so the leg is deleted.

## Blast radius: none measurable

Both candidate attributions set `counts_toward_provider_availability=False`, and `capacity_rejected` is only read inside `if attribution.counts_toward_provider_availability:` (`leaderboard.py:402-408`). No published availability, capacity-acceptance, or uptime number moves. Variant spellings now classify `unknown` (also `counts=False`) instead of `trustedrouter_capacity`.

## What I deliberately did *not* fix

Normalizing inside `is_router_origin_error` would close the raw-vs-casefolded gap for all three call sites, but casefolding the `startswith("router_")` prefix would extend TrustedRouter's error namespace over provider-supplied strings: an upstream returning `"Router_Error"` would be reattributed to us and silently dropped out of that provider's availability. Hiding a real provider failure is a worse outcome than the unreachable branch this removes. Left alone on purpose.

## Verification

- New regression test pins `router_fault` / `capacity_rejected=False` for the canonical type, and asserts the bare-402 path alongside it so removing the redundant leg cannot quietly take the real one with it.
- **Mutation-verified**: restoring the leg and reordering it ahead of the router-origin check turns the new test red (and the pre-existing router-fault test with it). Reverted, green again.
- `uv run ruff check .` clean, `ruff format --check` clean, `uv run mypy` clean (236 files).
- `pytest -k "reliability or leaderboard or provider or synthetic or status or portal"` → 660 passed, 16 skipped, 1 xfailed.

## Note for the in-flight contract-export PR

`scripts/export_provider_check_contract.py` (branch `codex/provider-check-contract-20260812`) hashes and fingerprints `classify_provider_failure`. If that PR lands first, this change requires a snapshot re-export — which is the parity gate doing its job. Sequencing it first avoids the re-export entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
