### PR TITLE
Gate the provider-check contract against production drift

### DIFF
--- a/scripts/export_provider_check_contract.py
+++ b/scripts/export_provider_check_contract.py
@@ -1,0 +1,1017 @@
+#!/usr/bin/env python3
+"""Export the production-derived provider-check contract snapshot."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import hashlib
+import importlib.util
+import inspect
+import json
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "src/trusted_router/data/provider_check_contract.json"
+
+
+class _CatalogFreeProvider(str):
+    """Keep leaderboard deadline fallback coverage out of the catalog branch."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def _load_script_module(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    root_text = str(ROOT)
+    inserted_root = root_text not in sys.path
+    if inserted_root:
+        sys.path.insert(0, root_text)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if inserted_root:
+            sys.path.remove(root_text)
+    return module
+
+
+def _normalized_source(fn: Any) -> str:
+    """Return stable source text while ignoring docstrings and comment-only churn."""
+    source = textwrap.dedent(inspect.getsource(fn))
+    parsed = ast.parse(source)
+    definition = parsed.body[0]
+    ignored_lines: set[int] = set()
+    if isinstance(definition, (ast.AsyncFunctionDef, ast.FunctionDef)) and definition.body:
+        first_statement = definition.body[0]
+        if (
+            isinstance(first_statement, ast.Expr)
+            and isinstance(first_statement.value, ast.Constant)
+            and isinstance(first_statement.value.value, str)
+        ):
+            ignored_lines.update(
+                range(first_statement.lineno, (first_statement.end_lineno or first_statement.lineno) + 1)
+            )
+    lines = []
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        stripped = line.strip()
+        if line_number in ignored_lines or not stripped or stripped.startswith("#"):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines)
+
+
+def _source_hashes(
+    probes: ModuleType,
+    provider_reliability: ModuleType,
+    components: ModuleType,
+    leaderboard: ModuleType,
+    route_classifier: ModuleType,
+    catalog: ModuleType,
+) -> dict[str, str]:
+    functions = {
+        "catalog._decimal": catalog._decimal,
+        "components.is_router_origin_error": components.is_router_origin_error,
+        "leaderboard._effective_throughput": leaderboard._effective_throughput,
+        "leaderboard._excluded_from_uptime": leaderboard._excluded_from_uptime,
+        "leaderboard._percentile": leaderboard._percentile,
+        "leaderboard._sort_key": leaderboard._sort_key,
+        "leaderboard.aggregate_leaderboard": leaderboard.aggregate_leaderboard,
+        "provider_reliability.classify_provider_failure": (
+            provider_reliability.classify_provider_failure
+        ),
+        "provider_reliability.model_deadlines": provider_reliability.model_deadlines,
+        "probes._chat_text": probes._chat_text,
+        "probes._first_int": probes._first_int,
+        "probes._observe_provider_stream": probes._observe_provider_stream,
+        "probes._pong_matches": probes._pong_matches,
+        "probes._response_error": probes._response_error,
+        "probes._responses_text": probes._responses_text,
+        "probes._rotation_error_type": probes._rotation_error_type,
+        "probes._rotation_max_tokens": probes._rotation_max_tokens,
+        "probes._rotation_omits_temperature": probes._rotation_omits_temperature,
+        "probes._sse_line_error": probes._sse_line_error,
+        "probes._sse_line_finish_reason": probes._sse_line_finish_reason,
+        "probes._sse_line_has_content": probes._sse_line_has_content,
+        "probes._sse_line_payload": probes._sse_line_payload,
+        "probes._sse_line_usage": probes._sse_line_usage,
+        "routes._classify": route_classifier._classify,
+    }
+    return {
+        name: hashlib.sha256(_normalized_source(fn).encode()).hexdigest()
+        for name, fn in sorted(functions.items())
+    }
+
+
+def _catalog_contract(catalog: ModuleType) -> dict[str, Any]:
+    frozensets = {
+        name: sorted(value)
+        for name, value in vars(catalog).items()
+        if isinstance(value, frozenset)
+    }
+    decimal_inputs: list[tuple[str, object, bool]] = [
+        ("valid_decimal", "12.340", False),
+        ("leading_zero", "01.5", False),
+        ("missing_fraction", "1.", False),
+        ("missing_integer", ".5", False),
+        ("negative", "-1", False),
+        ("non_string", 7, False),
+        ("empty", "", False),
+        ("nullable_none", None, True),
+        ("non_nullable_none", None, False),
+        ("junk", "not-a-decimal", False),
+    ]
+    decimal_behavior: list[dict[str, Any]] = []
+    for name, value, nullable in decimal_inputs:
+        row: dict[str, Any] = {"name": name, "input": value, "nullable": nullable}
+        try:
+            parsed = catalog._decimal(value, label="provider_check", nullable=nullable)
+        except Exception as exc:  # noqa: BLE001 - exception type is the contract.
+            row["exception"] = type(exc).__name__
+        else:
+            row["result"] = str(parsed) if parsed is not None else None
+        decimal_behavior.append(row)
+    return {
+        "decimal_behavior": decimal_behavior,
+        "frozensets": frozensets,
+        "model_id_pattern": catalog._MODEL_ID_RE.pattern,
+        "owner_pattern": catalog._OWNER_RE.pattern,
+        "invariants": {
+            "error_contract": {
+                "rate_limit_status": 429,
+                "overload_status": 503,
+                "retry_after_header": "Retry-After",
+            },
+            "pricing": {
+                "currency": "USD",
+                "unit": "per_1m_tokens",
+                "minimum_request": 0,
+                "cache_write_allowed_values": [None, 0],
+                "prompt_caching_matches_cached_input_presence": True,
+            },
+        },
+    }
+
+
+def _decision_tables(probes: ModuleType) -> list[dict[str, Any]]:
+    # This literal grid pins every marker and provider branch in both policies.
+    grid = [
+        ("openai", "vendor/o1-preview"),
+        ("openai", "vendor/o3-mini"),
+        ("openai", "vendor/o4-mini"),
+        ("openai", "vendor/gpt-5.4"),
+        ("generic", "google/gemini-2.5-pro"),
+        ("generic", "google/gemini-3-pro"),
+        ("generic", "openai/gpt-oss-120b"),
+        ("generic", "zai/glm-4.6"),
+        ("generic", "zai/glm-4.7"),
+        ("generic", "zai/glm-5"),
+        ("generic", "nvidia/nemotron-3"),
+        ("generic", "anthropic/claude-fable-5"),
+        ("generic", "anthropic/claude-sonnet-5"),
+        ("generic", "acme/reasoning-model"),
+        ("generic", "acme/thinking-model"),
+        ("kimi", "moonshotai/kimi-k2.5"),
+        ("generic", "x-ai/grok-4"),
+        ("anthropic", "anthropic/claude-opus-4.7"),
+        ("anthropic", "anthropic/claude-opus-4.8"),
+        ("generic", "openai/gpt-5.1"),
+        ("openai", "openai/gpt-4.1"),
+        ("novita", "moonshotai/kimi-k2.5"),
+        ("kimi", "moonshotai/kimi-latest"),
+        ("generic", "anthropic/claude-opus-4.7"),
+        ("anthropic", "anthropic/claude-haiku-5"),
+        ("generic", "acme/plain-model"),
+    ]
+    return [
+        {
+            "provider": provider,
+            "model": model,
+            "max_tokens": probes._rotation_max_tokens(provider, model),
+            "omits_temperature": probes._rotation_omits_temperature(provider, model),
+        }
+        for provider, model in grid
+    ]
+
+
+def _attribution_dict(attribution: Any) -> dict[str, Any]:
+    return {
+        "owner": attribution.owner.value,
+        "failure_class": attribution.failure_class.value,
+        "counts_toward_provider_availability": (
+            attribution.counts_toward_provider_availability
+        ),
+        "capacity_rejected": attribution.capacity_rejected,
+    }
+
+
+def _failure_classification(
+    markers: dict[str, list[Any]],
+    classify_provider_failure: Any,
+) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+
+    def add_case(
+        name: str,
+        *,
+        status: str = "error",
+        error_type: str | None = None,
+        error_status: int | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        inputs = {
+            "status": status,
+            "error_type": error_type,
+            "error_status": error_status,
+            "error_message": error_message,
+        }
+        cases.append(
+            {
+                "name": name,
+                "input": inputs,
+                "attribution": _attribution_dict(classify_provider_failure(**inputs)),
+            }
+        )
+
+    error_type_groups = [
+        "unsupported_route_error_types",
+        "probe_config_error_types",
+        "customer_quota_types",
+        "config_types",
+        "monitor_configuration_error_types",
+    ]
+    substring_type_groups = [
+        "timeout_markers",
+        "stream_markers",
+        "slow_reasoning_markers",
+        "fast_markers",
+    ]
+    message_groups = [
+        "unsupported_route_message_markers",
+        "probe_config_message_markers",
+        "dead_markers",
+    ]
+    for group in error_type_groups:
+        for marker in markers[group]:
+            add_case(f"{group}:{marker}", error_type=str(marker))
+    for group in substring_type_groups:
+        for marker in markers[group]:
+            add_case(f"{group}:{marker}", error_type=f"synthetic_{marker}_failure")
+    for group in message_groups:
+        for marker in markers[group]:
+            add_case(
+                f"{group}:{marker}",
+                error_type="provider_error",
+                error_message=f"upstream reported {marker} for this request",
+            )
+    for marker in markers["account_quota_markers"]:
+        add_case(
+            f"account_quota_markers:{marker}",
+            error_type="rate_limit_error",
+            error_status=429,
+            error_message=f"upstream reported {marker}",
+        )
+    for marker in markers["dead_statuses"]:
+        add_case(
+            f"dead_statuses:{marker}",
+            error_type="provider_error",
+            error_status=int(marker),
+        )
+
+    add_case("generic:plain_500", error_status=500)
+    add_case("generic:plain_402", error_status=402)
+    add_case("generic:plain_503", error_status=503)
+    add_case("generic:plain_529", error_status=529)
+    add_case("generic:plain_429", error_status=429)
+    add_case("generic:overloaded_type", error_type="overloaded")
+    add_case("generic:capacity_type", error_type="capacity_exceeded")
+    add_case(
+        "generic:unsupported_status_only",
+        status="unsupported",
+        error_type="unmapped_failure",
+    )
+    add_case(
+        "generic:not_found_with_401",
+        error_type="not_found",
+        error_status=401,
+    )
+    add_case("generic:timeout_type", error_type="ReadTimeout")
+    add_case("generic:unknown_type", error_type="unmapped_failure")
+    add_case(
+        "generic:success_shaped",
+        status="success",
+        error_type="router_error",
+        error_status=500,
+        error_message="account quota",
+    )
+    add_case("generic:router_prefix", error_type="router_database_contention")
+    return sorted(cases, key=lambda row: row["name"])
+
+
+def _deadline_behavior(model_deadlines: Any) -> list[dict[str, Any]]:
+    cases = [
+        ("vendor/plain-default", None, 20.0),
+        ("vendor/reasoning-pro", None, 20.0),
+        ("vendor/reasoning-high-default", None, 60.0),
+        ("vendor/reasoning-haiku", None, 20.0),
+        ("anthropic/haiku", None, 20.0),
+        ("vendor/plain-low-clamp", None, 1.0),
+        ("vendor/plain-completion-floor", None, 6.0),
+        ("vendor/plain-completion-ceiling", None, 80.0),
+        ("vendor/plain-high-clamp", None, 400.0),
+        ("vendor/fast-low-clamp", None, 1.0),
+        ("vendor/fast-high-clamp", None, 400.0),
+        ("vendor/invalid-default", None, 0.0),
+    ]
+
+    catalog_name = "trusted_router.catalog"
+    missing = object()
+    previous_catalog = sys.modules.pop(catalog_name, missing)
+    catalog_stub = ModuleType(catalog_name)
+    catalog_stub.MODEL_ENDPOINTS = {
+        "floor": SimpleNamespace(
+            model_id="catalog/first-floor",
+            provider="catalog-provider",
+            usage_type="Credits",
+            first_token_timeout_seconds=1.0,
+            completion_timeout_seconds=40.0,
+        ),
+        "ceiling": SimpleNamespace(
+            model_id="catalog/first-ceiling",
+            provider="catalog-provider",
+            usage_type="Credits",
+            first_token_timeout_seconds=400.0,
+            completion_timeout_seconds=400.0,
+        ),
+        "completion_floor": SimpleNamespace(
+            model_id="catalog/completion-floor",
+            provider="catalog-provider",
+            usage_type="Credits",
+            first_token_timeout_seconds=5.0,
+            completion_timeout_seconds=10.0,
+        ),
+        "completion_ceiling": SimpleNamespace(
+            model_id="catalog/completion-ceiling",
+            provider="catalog-provider",
+            usage_type="Credits",
+            first_token_timeout_seconds=100.0,
+            completion_timeout_seconds=1_000.0,
+        ),
+        "completion_fallback": SimpleNamespace(
+            model_id="catalog/completion-fallback",
+            provider="catalog-provider",
+            usage_type="Credits",
+            first_token_timeout_seconds=20.0,
+            completion_timeout_seconds=None,
+        ),
+        "usage_filter": SimpleNamespace(
+            model_id="catalog/usage-filter",
+            provider="catalog-provider",
+            usage_type="BYOK",
+            first_token_timeout_seconds=77.0,
+            completion_timeout_seconds=88.0,
+        ),
+    }
+    sys.modules[catalog_name] = catalog_stub
+    cases.extend(
+        [
+            ("catalog/first-floor", "catalog-provider", 20.0),
+            ("catalog/first-ceiling", "catalog-provider", 20.0),
+            ("catalog/completion-floor", "catalog-provider", 20.0),
+            ("catalog/completion-ceiling", "catalog-provider", 20.0),
+            ("catalog/completion-fallback", "catalog-provider", 20.0),
+            ("catalog/usage-filter", "catalog-provider", 20.0),
+        ]
+    )
+    rows: list[dict[str, Any]] = []
+    try:
+        for model, provider, default_first_token_seconds in cases:
+            row: dict[str, Any] = {
+                "model": model,
+                "provider": provider,
+                "default_first_token_seconds": default_first_token_seconds,
+            }
+            try:
+                deadlines = model_deadlines(
+                    model,
+                    provider=provider,
+                    default_first_token_seconds=default_first_token_seconds,
+                )
+            except Exception as exc:  # noqa: BLE001 - exception type is the contract.
+                row["exception"] = type(exc).__name__
+            else:
+                row["first_token_seconds"] = deadlines.first_token_seconds
+                row["completion_seconds"] = deadlines.completion_seconds
+            rows.append(row)
+    finally:
+        if sys.modules.get(catalog_name) is not catalog_stub:
+            raise RuntimeError("synthetic trusted_router.catalog module was replaced")
+        del sys.modules[catalog_name]
+        if previous_catalog is not missing:
+            sys.modules[catalog_name] = previous_catalog  # type: ignore[assignment]
+    if previous_catalog is missing and catalog_name in sys.modules:
+        raise RuntimeError("synthetic trusted_router.catalog module leaked")
+    return sorted(rows, key=lambda row: (row["model"], row["provider"] or ""))
+
+
+def _stable_result(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _stable_result(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _stable_result(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_stable_result(item) for item in value]
+    if value is None or isinstance(value, (bool, float, int, str)):
+        return value
+    return repr(value)
+
+
+def _extractor_behavior(probes: ModuleType) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+
+    def record(name: str, input_value: Any, call: Any) -> None:
+        try:
+            result = call()
+        except Exception as exc:  # noqa: BLE001 - exception type is the contract.
+            stable_result: Any = type(exc).__name__
+        else:
+            stable_result = _stable_result(result)
+        rows.append({"name": name, "input": input_value, "result": stable_result})
+
+    pong_cases: list[tuple[str, Any]] = [
+        ("exact", "PONG"),
+        ("lowercase", "pong"),
+        ("embedded_sentence", "The answer is PONG today."),
+        ("markdown", "**PONG**"),
+        ("empty", ""),
+        ("none", None),
+        ("nonmatching", "PING"),
+    ]
+    for case_name, text in pong_cases:
+        record(
+            f"pong_matches:{case_name}",
+            {"text": text},
+            lambda text=text: probes._pong_matches(text),
+        )
+
+    chat_cases: list[tuple[str, dict[str, Any]]] = [
+        ("string_content", {"choices": [{"message": {"content": "PONG"}}]}),
+        (
+            "list_text_parts",
+            {"choices": [{"message": {"content": [{"type": "text", "text": "PONG"}]}}]},
+        ),
+        (
+            "list_content_parts",
+            {"choices": [{"message": {"content": [{"content": "PONG"}]}}]},
+        ),
+        (
+            "reasoning_content_string",
+            {"choices": [{"message": {"content": "", "reasoning_content": "PONG"}}]},
+        ),
+        (
+            "reasoning_list",
+            {"choices": [{"message": {"reasoning": [{"text": "PONG"}]}}]},
+        ),
+        ("empty_choices", {"choices": []}),
+        ("missing_keys", {}),
+    ]
+    for case_name, body in chat_cases:
+        input_value = {"status_code": 200, "json": body}
+        record(
+            f"chat_text:{case_name}",
+            input_value,
+            lambda body=body: probes._chat_text(httpx.Response(200, json=body)),
+        )
+    record(
+        "chat_text:non_200",
+        {"status_code": 503, "json": chat_cases[0][1]},
+        lambda: probes._chat_text(httpx.Response(503, json=chat_cases[0][1])),
+    )
+    record(
+        "chat_text:malformed_json",
+        {"status_code": 200, "text": "not-json"},
+        lambda: probes._chat_text(httpx.Response(200, text="not-json")),
+    )
+
+    responses_cases: list[tuple[str, dict[str, Any]]] = [
+        ("string_content", {"output": [{"content": "PONG"}]}),
+        ("list_text_parts", {"output": [{"content": [{"text": "PONG"}]}]}),
+        (
+            "full_output_walk",
+            {
+                "output": [
+                    {"type": "reasoning", "summary": [{"text": "THINK"}]},
+                    {"type": "message", "content": [{"text": "PONG"}]},
+                ]
+            },
+        ),
+        ("reasoning_summary", {"output": [{"summary": [{"text": "PONG"}]}]}),
+        ("non_dict_output_item", {"output": ["ignored"]}),
+        ("missing_keys", {}),
+    ]
+    for case_name, body in responses_cases:
+        record(
+            f"responses_text:{case_name}",
+            {"status_code": 200, "json": body},
+            lambda body=body: probes._responses_text(httpx.Response(200, json=body)),
+        )
+    record(
+        "responses_text:non_200",
+        {"status_code": 503, "json": responses_cases[0][1]},
+        lambda: probes._responses_text(httpx.Response(503, json=responses_cases[0][1])),
+    )
+    record(
+        "responses_text:malformed_json",
+        {"status_code": 200, "text": "not-json"},
+        lambda: probes._responses_text(httpx.Response(200, text="not-json")),
+    )
+
+    payload_lines = [
+        ("data_space", 'data: {"value":1}'),
+        ("data_no_space", 'data:{"value":1}'),
+        ("done", "data: [DONE]"),
+        ("comment", ": ping"),
+        ("non_dict", "data: [1,2]"),
+        ("malformed", "data: {oops"),
+        ("empty", ""),
+    ]
+    for case_name, line in payload_lines:
+        record(
+            f"sse_line_payload:{case_name}",
+            {"line": line},
+            lambda line=line: probes._sse_line_payload(line),
+        )
+
+    def sse_line(payload: dict[str, Any]) -> str:
+        return f"data: {json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
+
+    for key in (
+        "content",
+        "reasoning_content",
+        "reasoning",
+        "thinking",
+        "text",
+        "output_text",
+    ):
+        line = sse_line({"choices": [{"delta": {key: "PONG"}}]})
+        record(
+            f"sse_line_has_content:delta_{key}",
+            {"line": line},
+            lambda line=line: probes._sse_line_has_content(line),
+        )
+    for key in ("content", "reasoning_content", "reasoning", "thinking", "text"):
+        line = sse_line({"choices": [{"message": {key: "PONG"}}]})
+        record(
+            f"sse_line_has_content:message_{key}",
+            {"line": line},
+            lambda line=line: probes._sse_line_has_content(line),
+        )
+    content_cases = [
+        ("choice_text", {"choices": [{"text": "PONG"}]}),
+        ("role_only", {"choices": [{"delta": {"role": "assistant"}}]}),
+        ("empty_content", {"choices": [{"delta": {"content": ""}}]}),
+        ("unrecognized_audio", {"choices": [{"delta": {"audio": "PONG"}}]}),
+    ]
+    for case_name, payload in content_cases:
+        line = sse_line(payload)
+        record(
+            f"sse_line_has_content:{case_name}",
+            {"line": line},
+            lambda line=line: probes._sse_line_has_content(line),
+        )
+
+    error_cases = [
+        ("default_type", {"error": {"message": "boom"}}),
+        (
+            "status_precedence",
+            {"error": {"type": "upstream", "status": 409, "code": 410, "status_code": 411}},
+        ),
+        ("code_precedence", {"error": {"type": "upstream", "code": 410, "status_code": 411}}),
+        ("status_code", {"error": {"type": "upstream", "status_code": 411}}),
+    ]
+    for case_name, payload in error_cases:
+        line = sse_line(payload)
+        record(
+            f"sse_line_error:{case_name}",
+            {"line": line},
+            lambda line=line: probes._sse_line_error(line),
+        )
+
+    for reason in ("stop", "length", "tool_calls", "content_filter", "function_call", "future"):
+        line = sse_line({"choices": [{"finish_reason": reason}]})
+        record(
+            f"sse_line_finish_reason:{reason}",
+            {"line": line},
+            lambda line=line: probes._sse_line_finish_reason(line),
+        )
+
+    usage_cases = [
+        (
+            "canonical_precedence",
+            {
+                "usage": {
+                    "prompt_tokens": 1,
+                    "input_tokens": 2,
+                    "completion_tokens": 3,
+                    "output_tokens": 4,
+                    "completion_tokens_details": {"reasoning_tokens": 5},
+                }
+            },
+        ),
+        ("alias_fallback", {"usage": {"input_tokens": 6, "output_tokens": 7}}),
+        (
+            "negative_clamp",
+            {
+                "usage": {
+                    "prompt_tokens": -1,
+                    "completion_tokens": -2,
+                    "completion_tokens_details": {"reasoning_tokens": -3},
+                }
+            },
+        ),
+        ("missing_keys", {"usage": {}}),
+        (
+            "non_int_values",
+            {
+                "usage": {
+                    "prompt_tokens": "bad",
+                    "input_tokens": "8",
+                    "completion_tokens": [],
+                    "output_tokens": "9",
+                    "completion_tokens_details": {"reasoning_tokens": "bad"},
+                }
+            },
+        ),
+        ("missing_usage", {}),
+    ]
+    for case_name, payload in usage_cases:
+        line = sse_line(payload)
+        record(
+            f"sse_line_usage:{case_name}",
+            {"line": line},
+            lambda line=line: probes._sse_line_usage(line),
+        )
+
+    first_int_cases = [
+        ("first_key_precedence", {"values": {"a": 1, "b": 2}, "keys": ["a", "b"]}),
+        ("second_key_fallback", {"values": {"a": None, "b": 2}, "keys": ["a", "b"]}),
+        ("negative_clamp", {"values": {"a": -7}, "keys": ["a"]}),
+        ("invalid_then_valid", {"values": {"a": "bad", "b": "3"}, "keys": ["a", "b"]}),
+        ("missing", {"values": {}, "keys": ["a", "b"]}),
+        ("non_int", {"values": {"a": []}, "keys": ["a"]}),
+    ]
+    for case_name, input_value in first_int_cases:
+        values = input_value["values"]
+        keys = input_value["keys"]
+        record(
+            f"first_int:{case_name}",
+            input_value,
+            lambda values=values, keys=keys: probes._first_int(values, *keys),
+        )
+
+    response_error_cases: list[tuple[str, int, str | dict[str, Any]]] = [
+        (
+            "json_error",
+            503,
+            {"error": {"type": "overloaded", "message": "busy", "status": 529}},
+        ),
+        (
+            "nested_detail",
+            422,
+            {"detail": {"error": {"type": "invalid_request", "message": "bad"}}},
+        ),
+        ("html_body", 502, "<html>bad gateway</html>"),
+        ("empty_body", 504, ""),
+        ("success_200", 200, {}),
+        ("json_error_on_200", 200, {"error": {"type": "provider_error"}}),
+    ]
+    for case_name, status_code, body in response_error_cases:
+        input_value: dict[str, Any] = {"status_code": status_code}
+        if isinstance(body, dict):
+            input_value["json"] = body
+            response = httpx.Response(status_code, json=body)
+        else:
+            input_value["text"] = body
+            response = httpx.Response(status_code, text=body)
+        record(
+            f"response_error:{case_name}",
+            input_value,
+            lambda response=response: probes._response_error(response),
+        )
+
+    return sorted(rows, key=lambda row: row["name"])
+
+
+def _rotation_error_behavior(probes: ModuleType) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+
+    def add(
+        name: str,
+        *,
+        error_type: str = "provider_error",
+        status: int | None = None,
+        message: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        inputs = {
+            "error_type": error_type,
+            "status": status,
+            "message": message,
+            "source": source,
+        }
+        rows.append(
+            {
+                "name": name,
+                "input": inputs,
+                "result": probes._rotation_error_type(**inputs),
+            }
+        )
+
+    add("message:workspace_billing_paused", message="workspace billing is paused")
+    add("message:database_contention", message="database contention")
+    add("message:deadlock", message="deadlock")
+    add("message:read_only_mode", message="read-only mode")
+    add("message:planned_maintenance", message="planned maintenance")
+    for marker in (
+        "insufficient credits",
+        "api key is disabled",
+        "api key expired",
+        "invalid api key",
+        "api key not found",
+    ):
+        add(f"router_account:{marker}", message=marker, source="router")
+    for marker in sorted(probes._UNSUPPORTED_ROUTE_ERROR_TYPES):
+        add(f"unsupported_type:{marker}", error_type=marker)
+    for marker in probes._UNSUPPORTED_ROUTE_MESSAGE_MARKERS:
+        add(f"unsupported_message:{marker}", message=marker)
+    for marker in sorted(probes._PROBE_CONFIG_ERROR_TYPES):
+        add(f"probe_config_type:{marker}", error_type=marker)
+    for status in (400, 422):
+        for marker in probes._PROBE_CONFIG_MESSAGE_MARKERS:
+            add(f"probe_config_message:{status}:{marker}", status=status, message=marker)
+    add("router:fallback", source="router")
+    add("auth:401", status=401)
+    add("auth:403", status=403)
+    add("fallback:unchanged", error_type="custom_provider_error", status=500)
+    add(
+        "precedence:workspace_before_contention",
+        message="workspace billing is paused after database contention",
+    )
+    add(
+        "precedence:router_account_before_unsupported",
+        error_type="unsupported_route",
+        message="insufficient credits",
+        source="router",
+    )
+    add(
+        "precedence:unsupported_before_auth",
+        error_type="unsupported_route",
+        status=401,
+    )
+    return sorted(rows, key=lambda row: row["name"])
+
+
+def _rotation_error_exclusions(
+    probes: ModuleType,
+    *,
+    failure_classification: list[dict[str, Any]],
+    extractor_behavior: list[dict[str, Any]],
+    rotation_error_behavior: list[dict[str, Any]],
+    marker_error_types: list[Any],
+) -> list[dict[str, Any]]:
+    error_types: set[str | None] = {
+        None,
+        "unsupported_route",
+        "probe_config_error",
+        "provider_auth_config",
+        "insufficient_throughput_sample",
+    }
+    error_types.update(str(value) for value in marker_error_types)
+    for row in failure_classification:
+        value = row["input"]["error_type"]
+        error_types.add(value)
+    for row in rotation_error_behavior:
+        error_types.add(row["input"]["error_type"])
+        error_types.add(row["result"])
+    for row in extractor_behavior:
+        if row["name"].startswith(("response_error:", "sse_line_error:")):
+            result = row["result"]
+            if isinstance(result, list) and result:
+                error_types.add(str(result[0]))
+    return [
+        {"input": error_type, "result": probes._rotation_error_excluded_from_uptime(error_type)}
+        for error_type in sorted(error_types, key=lambda value: (value is not None, value or ""))
+    ]
+
+
+SAMPLE_FIELDS = sorted(
+    [
+        "provider",
+        "model",
+        "source",
+        "status",
+        "error_type",
+        "error_status",
+        "error_message",
+        "created_at",
+        "output_tokens",
+        "elapsed_milliseconds",
+        "speed_tokens_per_second",
+        "first_token_milliseconds",
+        "ttfb_milliseconds",
+    ]
+)
+
+
+def _leaderboard_behavior(aggregate_leaderboard: Any) -> dict[str, Any]:
+    alpha = _CatalogFreeProvider("alpha")
+    beta = _CatalogFreeProvider("beta")
+
+    def sample(
+        provider: str,
+        model: str,
+        created_at: str,
+        **overrides: Any,
+    ) -> SimpleNamespace:
+        values: dict[str, Any] = {
+            "provider": provider,
+            "model": model,
+            "source": "synthetic",
+            "status": "success",
+            "error_type": None,
+            "error_status": None,
+            "error_message": None,
+            "created_at": created_at,
+            "output_tokens": 0,
+            "elapsed_milliseconds": None,
+            "speed_tokens_per_second": None,
+            "first_token_milliseconds": None,
+            "ttfb_milliseconds": None,
+        }
+        values.update(overrides)
+        if sorted(values) != SAMPLE_FIELDS:
+            raise RuntimeError("leaderboard sample fields drifted")
+        return SimpleNamespace(**values)
+
+    # The aggregator does not bucket by wall clock; these fixed values only
+    # exercise deterministic last-seen selection.
+    samples = [
+        sample(alpha, "alpha/steady", "2026-01-01T00:00:00Z", first_token_milliseconds=100, ttfb_milliseconds=80),
+        sample(alpha, "alpha/steady", "2026-01-01T01:00:00Z", first_token_milliseconds=140, ttfb_milliseconds=100),
+        sample(alpha, "alpha/steady", "2026-01-01T02:00:00Z", first_token_milliseconds=18_000, ttfb_milliseconds=120),
+        sample(alpha, "alpha/steady", "2026-01-01T03:00:00Z", status="error", error_type="ReadTimeout"),
+        sample(alpha, "alpha/steady", "2026-01-01T04:00:00Z", source="synthetic_throughput", output_tokens=200, elapsed_milliseconds=10_000, speed_tokens_per_second=999.0),
+        sample(alpha, "alpha/steady", "2026-01-01T05:00:00Z", source="synthetic_throughput", speed_tokens_per_second=30.0),
+        sample(alpha, "alpha/thin", "2026-01-01T06:00:00Z", status="unsupported", error_type="unsupported_route", error_status=404),
+        sample(alpha, "alpha/thin", "2026-01-01T07:00:00Z"),
+        sample(alpha, "alpha/challenger", "2026-01-01T07:10:00Z", first_token_milliseconds=500, ttfb_milliseconds=400),
+        sample(alpha, "alpha/challenger", "2026-01-01T07:20:00Z", first_token_milliseconds=600, ttfb_milliseconds=450),
+        sample(alpha, "alpha/challenger", "2026-01-01T07:30:00Z", first_token_milliseconds=700, ttfb_milliseconds=500),
+        sample(alpha, "alpha/challenger", "2026-01-01T07:40:00Z", first_token_milliseconds=800, ttfb_milliseconds=550),
+        sample(alpha, "alpha/throughput-only", "2026-01-01T07:50:00Z", source="synthetic_throughput", output_tokens=300, elapsed_milliseconds=10_000),
+        sample(beta, "beta/stable", "2026-01-01T08:00:00Z", first_token_milliseconds=200, ttfb_milliseconds=150),
+        sample(beta, "beta/stable", "2026-01-01T09:00:00Z", first_token_milliseconds=250, ttfb_milliseconds=175),
+        sample(beta, "beta/stable", "2026-01-01T10:00:00Z", status="error", error_type="rate_limit_error", error_status=429),
+        sample(beta, "beta/stable", "2026-01-01T10:30:00Z", first_token_milliseconds=225, ttfb_milliseconds=160),
+        sample(beta, "beta/thin", "2026-01-01T11:00:00Z", first_token_milliseconds=30_000, ttfb_milliseconds=200),
+        sample(beta, "beta/thin", "2026-01-01T12:00:00Z", status="error", error_type="router_error", error_status=503),
+        sample(beta, "beta/thin", "2026-01-01T13:00:00Z", status="error", error_type="rate_limit_exceeded", error_status=429),
+        sample(beta, "beta/thin", "2026-01-01T14:00:00Z", status="error", error_type="provider_auth_config", error_status=401),
+        sample(beta, "beta/thin", "2026-01-01T15:00:00Z", status="error", error_type=None, error_status=500),
+        sample(beta, "beta/thin", "2026-01-01T16:00:00Z", status="error", error_type=None, error_status=None),
+    ]
+    result = aggregate_leaderboard(
+        samples,
+        min_samples=1,
+        model_rank_min_samples=4,
+        provider_rank_min_samples=5,
+        rank_min_ttft_samples=3,
+    )
+    result["models_order"] = [
+        f"{row['provider']}/{row['model']}" for row in result["models"]
+    ]
+    result["providers_order"] = [row["provider"] for row in result["providers"]]
+    result["models"] = sorted(
+        result["models"], key=lambda row: (row["provider"], row["model"])
+    )
+    result["providers"] = sorted(result["providers"], key=lambda row: row["provider"])
+    return json.loads(json.dumps(result, sort_keys=True))
+
+
+def build_contract() -> dict[str, Any]:
+    """Build the deterministic provider-check contract without writing it."""
+    from trusted_router import provider_reliability
+    from trusted_router.synthetic import components, leaderboard, probes
+
+    route_classifier = _load_script_module(
+        ROOT / "scripts/classify_provider_routes.py",
+        "_provider_check_route_classifier",
+    )
+    catalog = _load_script_module(
+        ROOT / "scripts/pricing/provider_contract_catalog.py",
+        "_provider_check_catalog_contract",
+    )
+    markers: dict[str, list[Any]] = {
+        "account_quota_markers": sorted(provider_reliability._ACCOUNT_QUOTA_MARKERS),
+        "config_types": sorted(provider_reliability._CONFIG_TYPES),
+        "customer_quota_types": sorted(provider_reliability._CUSTOMER_QUOTA_TYPES),
+        "dead_markers": sorted(route_classifier._DEAD_MARKERS),
+        "dead_statuses": sorted(route_classifier._DEAD_STATUSES),
+        "fast_markers": sorted(provider_reliability._FAST_MARKERS),
+        "monitor_configuration_error_types": sorted(
+            components.MONITOR_CONFIGURATION_ERROR_TYPES
+        ),
+        "probe_config_error_types": sorted(probes._PROBE_CONFIG_ERROR_TYPES),
+        "probe_config_message_markers": sorted(probes._PROBE_CONFIG_MESSAGE_MARKERS),
+        "slow_reasoning_markers": sorted(provider_reliability._SLOW_REASONING_MARKERS),
+        "stream_markers": sorted(provider_reliability._STREAM_MARKERS),
+        "timeout_markers": sorted(provider_reliability._TIMEOUT_MARKERS),
+        "unsupported_route_error_types": sorted(probes._UNSUPPORTED_ROUTE_ERROR_TYPES),
+        "unsupported_route_message_markers": sorted(
+            probes._UNSUPPORTED_ROUTE_MESSAGE_MARKERS
+        ),
+    }
+    router_origin_inputs = [
+        None,
+        "",
+        *markers["monitor_configuration_error_types"],
+        "router_database_contention",
+        "provider_timeout",
+        "Router_error",
+    ]
+    markers["router_origin_behavior"] = [
+        {"input": value, "result": components.is_router_origin_error(value)}
+        for value in router_origin_inputs
+    ]
+
+    failure_classification = _failure_classification(
+        markers,
+        provider_reliability.classify_provider_failure,
+    )
+    extractor_behavior = _extractor_behavior(probes)
+    rotation_error_behavior = _rotation_error_behavior(probes)
+    marker_error_types = [
+        *markers["config_types"],
+        *markers["customer_quota_types"],
+        *markers["monitor_configuration_error_types"],
+        *markers["probe_config_error_types"],
+        *markers["unsupported_route_error_types"],
+        *router_origin_inputs,
+    ]
+
+    contract: dict[str, Any] = {
+        "prompts": {
+            "pong": probes.PONG_PROMPT,
+            "throughput": probes._THROUGHPUT_PROMPT,
+        },
+        "markers": markers,
+        "catalog_contract": _catalog_contract(catalog),
+        "decision_tables": _decision_tables(probes),
+        "failure_classification": failure_classification,
+        "model_deadlines": _deadline_behavior(provider_reliability.model_deadlines),
+        "leaderboard": _leaderboard_behavior(leaderboard.aggregate_leaderboard),
+        "extractors": extractor_behavior,
+        "rotation_errors": {
+            "classification": rotation_error_behavior,
+            "excluded_from_uptime": _rotation_error_exclusions(
+                probes,
+                failure_classification=failure_classification,
+                extractor_behavior=extractor_behavior,
+                rotation_error_behavior=rotation_error_behavior,
+                marker_error_types=marker_error_types,
+            ),
+        },
+        "source_hashes": _source_hashes(
+            probes,
+            provider_reliability,
+            components,
+            leaderboard,
+            route_classifier,
+            catalog,
+        ),
+        "sample_fields": SAMPLE_FIELDS,
+    }
+    canonical = json.dumps(contract, sort_keys=True, separators=(",", ":"))
+    contract["contract_version"] = hashlib.sha256(canonical.encode()).hexdigest()
+    return contract
+
+
+def main() -> int:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(build_contract(), indent=2, sort_keys=True) + "\n"
+    OUTPUT_PATH.write_text(payload, encoding="utf-8")
+    print(OUTPUT_PATH.relative_to(ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/data/provider_check_contract.json
+++ b/src/trusted_router/data/provider_check_contract.json
@@ -1,0 +1,4315 @@
+{
+  "catalog_contract": {
+    "decimal_behavior": [
+      {
+        "input": "12.340",
+        "name": "valid_decimal",
+        "nullable": false,
+        "result": "12.340"
+      },
+      {
+        "exception": "RuntimeError",
+        "input": "01.5",
+        "name": "leading_zero",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": "1.",
+        "name": "missing_fraction",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": ".5",
+        "name": "missing_integer",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": "-1",
+        "name": "negative",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": 7,
+        "name": "non_string",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": "",
+        "name": "empty",
+        "nullable": false
+      },
+      {
+        "input": null,
+        "name": "nullable_none",
+        "nullable": true,
+        "result": null
+      },
+      {
+        "exception": "RuntimeError",
+        "input": null,
+        "name": "non_nullable_none",
+        "nullable": false
+      },
+      {
+        "exception": "RuntimeError",
+        "input": "not-a-decimal",
+        "name": "junk",
+        "nullable": false
+      }
+    ],
+    "frozensets": {
+      "_CAPABILITY_FIELDS": [
+        "prompt_caching",
+        "reasoning",
+        "streaming",
+        "structured_output",
+        "tools"
+      ],
+      "_CAPACITY_SCOPES": [
+        "global",
+        "model",
+        "model_region",
+        "region"
+      ],
+      "_ENDPOINTS": [
+        "chat/completions",
+        "responses"
+      ],
+      "_ERROR_CONTRACT_FIELDS": [
+        "account_quota_error_codes",
+        "overload_status",
+        "rate_limit_status",
+        "retry_after_header"
+      ],
+      "_INPUT_MODALITIES": [
+        "audio",
+        "file",
+        "image",
+        "text",
+        "video"
+      ],
+      "_LIFECYCLE_FIELDS": [
+        "deprecation_at",
+        "replacement_model_id",
+        "retirement_at",
+        "status"
+      ],
+      "_LIFECYCLE_STATUSES": [
+        "active",
+        "deprecated",
+        "retired"
+      ],
+      "_MODEL_FIELDS": [
+        "capabilities",
+        "context_length",
+        "endpoints",
+        "id",
+        "input_modalities",
+        "lifecycle",
+        "max_output_tokens",
+        "name",
+        "object",
+        "output_modalities",
+        "owned_by",
+        "pricing",
+        "type"
+      ],
+      "_MODEL_V2_FIELDS": [
+        "capabilities",
+        "context_length",
+        "endpoints",
+        "id",
+        "input_modalities",
+        "lifecycle",
+        "max_output_tokens",
+        "name",
+        "object",
+        "output_modalities",
+        "owned_by",
+        "pricing",
+        "reliability",
+        "type"
+      ],
+      "_OUTPUT_MODALITIES": [
+        "audio",
+        "image",
+        "text"
+      ],
+      "_PRICING_FIELDS": [
+        "cache_write",
+        "cached_input",
+        "currency",
+        "input",
+        "minimum_request",
+        "output",
+        "unit"
+      ],
+      "_PROVIDER_V2_FIELDS": [
+        "error_contract",
+        "id",
+        "incident_contact",
+        "regions",
+        "request_id_header",
+        "status_url",
+        "support_contact"
+      ],
+      "_RELIABILITY_FIELDS": [
+        "capacity_scope",
+        "completion_timeout_seconds",
+        "first_token_timeout_seconds",
+        "stream_idle_timeout_seconds"
+      ],
+      "_TOP_LEVEL_FIELDS": [
+        "data",
+        "object"
+      ],
+      "_TOP_LEVEL_V2_FIELDS": [
+        "contract_version",
+        "data",
+        "object",
+        "provider"
+      ]
+    },
+    "invariants": {
+      "error_contract": {
+        "overload_status": 503,
+        "rate_limit_status": 429,
+        "retry_after_header": "Retry-After"
+      },
+      "pricing": {
+        "cache_write_allowed_values": [
+          null,
+          0
+        ],
+        "currency": "USD",
+        "minimum_request": 0,
+        "prompt_caching_matches_cached_input_presence": true,
+        "unit": "per_1m_tokens"
+      }
+    },
+    "model_id_pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+    "owner_pattern": "^[a-z0-9][a-z0-9._-]*$"
+  },
+  "contract_version": "c811d765b89f44f542c127e5d546439b3fea9953d4cf42b620861cfc278d741e",
+  "decision_tables": [
+    {
+      "max_tokens": 512,
+      "model": "vendor/o1-preview",
+      "omits_temperature": true,
+      "provider": "openai"
+    },
+    {
+      "max_tokens": 512,
+      "model": "vendor/o3-mini",
+      "omits_temperature": true,
+      "provider": "openai"
+    },
+    {
+      "max_tokens": 512,
+      "model": "vendor/o4-mini",
+      "omits_temperature": true,
+      "provider": "openai"
+    },
+    {
+      "max_tokens": 512,
+      "model": "vendor/gpt-5.4",
+      "omits_temperature": true,
+      "provider": "openai"
+    },
+    {
+      "max_tokens": 2048,
+      "model": "google/gemini-2.5-pro",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 2048,
+      "model": "google/gemini-3-pro",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "openai/gpt-oss-120b",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "zai/glm-4.6",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "zai/glm-4.7",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "zai/glm-5",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "nvidia/nemotron-3",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "anthropic/claude-fable-5",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "anthropic/claude-sonnet-5",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "acme/reasoning-model",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 512,
+      "model": "acme/thinking-model",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 128,
+      "model": "moonshotai/kimi-k2.5",
+      "omits_temperature": true,
+      "provider": "kimi"
+    },
+    {
+      "max_tokens": 128,
+      "model": "x-ai/grok-4",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 128,
+      "model": "anthropic/claude-opus-4.7",
+      "omits_temperature": true,
+      "provider": "anthropic"
+    },
+    {
+      "max_tokens": 128,
+      "model": "anthropic/claude-opus-4.8",
+      "omits_temperature": true,
+      "provider": "anthropic"
+    },
+    {
+      "max_tokens": 16,
+      "model": "openai/gpt-5.1",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 16,
+      "model": "openai/gpt-4.1",
+      "omits_temperature": false,
+      "provider": "openai"
+    },
+    {
+      "max_tokens": 128,
+      "model": "moonshotai/kimi-k2.5",
+      "omits_temperature": false,
+      "provider": "novita"
+    },
+    {
+      "max_tokens": 16,
+      "model": "moonshotai/kimi-latest",
+      "omits_temperature": false,
+      "provider": "kimi"
+    },
+    {
+      "max_tokens": 128,
+      "model": "anthropic/claude-opus-4.7",
+      "omits_temperature": false,
+      "provider": "generic"
+    },
+    {
+      "max_tokens": 16,
+      "model": "anthropic/claude-haiku-5",
+      "omits_temperature": false,
+      "provider": "anthropic"
+    },
+    {
+      "max_tokens": 16,
+      "model": "acme/plain-model",
+      "omits_temperature": false,
+      "provider": "generic"
+    }
+  ],
+  "extractors": [
+    {
+      "input": {
+        "json": {
+          "choices": []
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:empty_choices",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "content": [
+                  {
+                    "content": "PONG"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:list_content_parts",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "content": [
+                  {
+                    "text": "PONG",
+                    "type": "text"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:list_text_parts",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "status_code": 200,
+        "text": "not-json"
+      },
+      "name": "chat_text:malformed_json",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {},
+        "status_code": 200
+      },
+      "name": "chat_text:missing_keys",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "content": "PONG"
+              }
+            }
+          ]
+        },
+        "status_code": 503
+      },
+      "name": "chat_text:non_200",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "content": "",
+                "reasoning_content": "PONG"
+              }
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:reasoning_content_string",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "reasoning": [
+                  {
+                    "text": "PONG"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:reasoning_list",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "json": {
+          "choices": [
+            {
+              "message": {
+                "content": "PONG"
+              }
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "chat_text:string_content",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "keys": [
+          "a",
+          "b"
+        ],
+        "values": {
+          "a": 1,
+          "b": 2
+        }
+      },
+      "name": "first_int:first_key_precedence",
+      "result": 1
+    },
+    {
+      "input": {
+        "keys": [
+          "a",
+          "b"
+        ],
+        "values": {
+          "a": "bad",
+          "b": "3"
+        }
+      },
+      "name": "first_int:invalid_then_valid",
+      "result": 3
+    },
+    {
+      "input": {
+        "keys": [
+          "a",
+          "b"
+        ],
+        "values": {}
+      },
+      "name": "first_int:missing",
+      "result": 0
+    },
+    {
+      "input": {
+        "keys": [
+          "a"
+        ],
+        "values": {
+          "a": -7
+        }
+      },
+      "name": "first_int:negative_clamp",
+      "result": 0
+    },
+    {
+      "input": {
+        "keys": [
+          "a"
+        ],
+        "values": {
+          "a": []
+        }
+      },
+      "name": "first_int:non_int",
+      "result": 0
+    },
+    {
+      "input": {
+        "keys": [
+          "a",
+          "b"
+        ],
+        "values": {
+          "a": null,
+          "b": 2
+        }
+      },
+      "name": "first_int:second_key_fallback",
+      "result": 2
+    },
+    {
+      "input": {
+        "text": "The answer is PONG today."
+      },
+      "name": "pong_matches:embedded_sentence",
+      "result": true
+    },
+    {
+      "input": {
+        "text": ""
+      },
+      "name": "pong_matches:empty",
+      "result": false
+    },
+    {
+      "input": {
+        "text": "PONG"
+      },
+      "name": "pong_matches:exact",
+      "result": true
+    },
+    {
+      "input": {
+        "text": "pong"
+      },
+      "name": "pong_matches:lowercase",
+      "result": true
+    },
+    {
+      "input": {
+        "text": "**PONG**"
+      },
+      "name": "pong_matches:markdown",
+      "result": true
+    },
+    {
+      "input": {
+        "text": null
+      },
+      "name": "pong_matches:none",
+      "result": "AttributeError"
+    },
+    {
+      "input": {
+        "text": "PING"
+      },
+      "name": "pong_matches:nonmatching",
+      "result": false
+    },
+    {
+      "input": {
+        "status_code": 504,
+        "text": ""
+      },
+      "name": "response_error:empty_body",
+      "result": [
+        "http_504",
+        504,
+        null
+      ]
+    },
+    {
+      "input": {
+        "status_code": 502,
+        "text": "<html>bad gateway</html>"
+      },
+      "name": "response_error:html_body",
+      "result": [
+        "http_502",
+        502,
+        null
+      ]
+    },
+    {
+      "input": {
+        "json": {
+          "error": {
+            "message": "busy",
+            "status": 529,
+            "type": "overloaded"
+          }
+        },
+        "status_code": 503
+      },
+      "name": "response_error:json_error",
+      "result": [
+        "overloaded",
+        529,
+        "busy"
+      ]
+    },
+    {
+      "input": {
+        "json": {
+          "error": {
+            "type": "provider_error"
+          }
+        },
+        "status_code": 200
+      },
+      "name": "response_error:json_error_on_200",
+      "result": [
+        "provider_error",
+        200,
+        null
+      ]
+    },
+    {
+      "input": {
+        "json": {
+          "detail": {
+            "error": {
+              "message": "bad",
+              "type": "invalid_request"
+            }
+          }
+        },
+        "status_code": 422
+      },
+      "name": "response_error:nested_detail",
+      "result": [
+        "probe_config_error",
+        422,
+        "bad"
+      ]
+    },
+    {
+      "input": {
+        "json": {},
+        "status_code": 200
+      },
+      "name": "response_error:success_200",
+      "result": [
+        "http_200",
+        200,
+        null
+      ]
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            {
+              "summary": [
+                {
+                  "text": "THINK"
+                }
+              ],
+              "type": "reasoning"
+            },
+            {
+              "content": [
+                {
+                  "text": "PONG"
+                }
+              ],
+              "type": "message"
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "responses_text:full_output_walk",
+      "result": "THINK PONG"
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            {
+              "content": [
+                {
+                  "text": "PONG"
+                }
+              ]
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "responses_text:list_text_parts",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "status_code": 200,
+        "text": "not-json"
+      },
+      "name": "responses_text:malformed_json",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {},
+        "status_code": 200
+      },
+      "name": "responses_text:missing_keys",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            {
+              "content": "PONG"
+            }
+          ]
+        },
+        "status_code": 503
+      },
+      "name": "responses_text:non_200",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            "ignored"
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "responses_text:non_dict_output_item",
+      "result": ""
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            {
+              "summary": [
+                {
+                  "text": "PONG"
+                }
+              ]
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "responses_text:reasoning_summary",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "json": {
+          "output": [
+            {
+              "content": "PONG"
+            }
+          ]
+        },
+        "status_code": 200
+      },
+      "name": "responses_text:string_content",
+      "result": "PONG"
+    },
+    {
+      "input": {
+        "line": "data: {\"error\":{\"code\":410,\"status_code\":411,\"type\":\"upstream\"}}"
+      },
+      "name": "sse_line_error:code_precedence",
+      "result": [
+        "upstream",
+        410,
+        null
+      ]
+    },
+    {
+      "input": {
+        "line": "data: {\"error\":{\"message\":\"boom\"}}"
+      },
+      "name": "sse_line_error:default_type",
+      "result": [
+        "provider_error",
+        null,
+        "boom"
+      ]
+    },
+    {
+      "input": {
+        "line": "data: {\"error\":{\"status_code\":411,\"type\":\"upstream\"}}"
+      },
+      "name": "sse_line_error:status_code",
+      "result": [
+        "upstream",
+        411,
+        null
+      ]
+    },
+    {
+      "input": {
+        "line": "data: {\"error\":{\"code\":410,\"status\":409,\"status_code\":411,\"type\":\"upstream\"}}"
+      },
+      "name": "sse_line_error:status_precedence",
+      "result": [
+        "upstream",
+        409,
+        null
+      ]
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"content_filter\"}]}"
+      },
+      "name": "sse_line_finish_reason:content_filter",
+      "result": "content_filter"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"function_call\"}]}"
+      },
+      "name": "sse_line_finish_reason:function_call",
+      "result": "function_call"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"future\"}]}"
+      },
+      "name": "sse_line_finish_reason:future",
+      "result": "future"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"length\"}]}"
+      },
+      "name": "sse_line_finish_reason:length",
+      "result": "length"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"stop\"}]}"
+      },
+      "name": "sse_line_finish_reason:stop",
+      "result": "stop"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"finish_reason\":\"tool_calls\"}]}"
+      },
+      "name": "sse_line_finish_reason:tool_calls",
+      "result": "tool_calls"
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"text\":\"PONG\"}]}"
+      },
+      "name": "sse_line_has_content:choice_text",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"content\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_content",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"output_text\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_output_text",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"reasoning\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_reasoning",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_reasoning_content",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"text\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_text",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"thinking\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:delta_thinking",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"content\":\"\"}}]}"
+      },
+      "name": "sse_line_has_content:empty_content",
+      "result": false
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"message\":{\"content\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:message_content",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"message\":{\"reasoning\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:message_reasoning",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"message\":{\"reasoning_content\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:message_reasoning_content",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"message\":{\"text\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:message_text",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"message\":{\"thinking\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:message_thinking",
+      "result": true
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}"
+      },
+      "name": "sse_line_has_content:role_only",
+      "result": false
+    },
+    {
+      "input": {
+        "line": "data: {\"choices\":[{\"delta\":{\"audio\":\"PONG\"}}]}"
+      },
+      "name": "sse_line_has_content:unrecognized_audio",
+      "result": false
+    },
+    {
+      "input": {
+        "line": ": ping"
+      },
+      "name": "sse_line_payload:comment",
+      "result": null
+    },
+    {
+      "input": {
+        "line": "data:{\"value\":1}"
+      },
+      "name": "sse_line_payload:data_no_space",
+      "result": {
+        "value": 1
+      }
+    },
+    {
+      "input": {
+        "line": "data: {\"value\":1}"
+      },
+      "name": "sse_line_payload:data_space",
+      "result": {
+        "value": 1
+      }
+    },
+    {
+      "input": {
+        "line": "data: [DONE]"
+      },
+      "name": "sse_line_payload:done",
+      "result": null
+    },
+    {
+      "input": {
+        "line": ""
+      },
+      "name": "sse_line_payload:empty",
+      "result": null
+    },
+    {
+      "input": {
+        "line": "data: {oops"
+      },
+      "name": "sse_line_payload:malformed",
+      "result": null
+    },
+    {
+      "input": {
+        "line": "data: [1,2]"
+      },
+      "name": "sse_line_payload:non_dict",
+      "result": null
+    },
+    {
+      "input": {
+        "line": "data: {\"usage\":{\"input_tokens\":6,\"output_tokens\":7}}"
+      },
+      "name": "sse_line_usage:alias_fallback",
+      "result": {
+        "input_tokens": 6,
+        "output_tokens": 7,
+        "reasoning_tokens": 0
+      }
+    },
+    {
+      "input": {
+        "line": "data: {\"usage\":{\"completion_tokens\":3,\"completion_tokens_details\":{\"reasoning_tokens\":5},\"input_tokens\":2,\"output_tokens\":4,\"prompt_tokens\":1}}"
+      },
+      "name": "sse_line_usage:canonical_precedence",
+      "result": {
+        "input_tokens": 1,
+        "output_tokens": 3,
+        "reasoning_tokens": 5
+      }
+    },
+    {
+      "input": {
+        "line": "data: {\"usage\":{}}"
+      },
+      "name": "sse_line_usage:missing_keys",
+      "result": {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0
+      }
+    },
+    {
+      "input": {
+        "line": "data: {}"
+      },
+      "name": "sse_line_usage:missing_usage",
+      "result": null
+    },
+    {
+      "input": {
+        "line": "data: {\"usage\":{\"completion_tokens\":-2,\"completion_tokens_details\":{\"reasoning_tokens\":-3},\"prompt_tokens\":-1}}"
+      },
+      "name": "sse_line_usage:negative_clamp",
+      "result": {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0
+      }
+    },
+    {
+      "input": {
+        "line": "data: {\"usage\":{\"completion_tokens\":[],\"completion_tokens_details\":{\"reasoning_tokens\":\"bad\"},\"input_tokens\":\"8\",\"output_tokens\":\"9\",\"prompt_tokens\":\"bad\"}}"
+      },
+      "name": "sse_line_usage:non_int_values",
+      "result": {
+        "input_tokens": 8,
+        "output_tokens": 9,
+        "reasoning_tokens": 0
+      }
+    }
+  ],
+  "failure_classification": [
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported account quota",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:account quota"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported billing quota",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:billing quota"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported credit balance",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:credit balance"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported credits exhausted",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:credits exhausted"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported insufficient credit",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:insufficient credit"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported insufficient funds",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:insufficient funds"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported monthly spend",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:monthly spend"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported payment required",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:payment required"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": "upstream reported quota exceeded for quota metric",
+        "error_status": 429,
+        "error_type": "rate_limit_error",
+        "status": "error"
+      },
+      "name": "account_quota_markers:quota exceeded for quota metric"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "bad_request",
+        "status": "error"
+      },
+      "name": "config_types:bad_request"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "invalid_request",
+        "status": "error"
+      },
+      "name": "config_types:invalid_request"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "invalid_request_error",
+        "status": "error"
+      },
+      "name": "config_types:invalid_request_error"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "model_not_available",
+        "status": "error"
+      },
+      "name": "config_types:model_not_available"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "model_not_found",
+        "status": "error"
+      },
+      "name": "config_types:model_not_found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "not_found",
+        "status": "error"
+      },
+      "name": "config_types:not_found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "not_supported",
+        "status": "error"
+      },
+      "name": "config_types:not_supported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "probe_config_error",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "probe_config_error",
+        "status": "error"
+      },
+      "name": "config_types:probe_config_error"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "provider_auth_config",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "provider_auth_config",
+        "status": "error"
+      },
+      "name": "config_types:provider_auth_config"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported",
+        "status": "error"
+      },
+      "name": "config_types:unsupported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_model",
+        "status": "error"
+      },
+      "name": "config_types:unsupported_model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_provider",
+        "status": "error"
+      },
+      "name": "config_types:unsupported_provider"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_route",
+        "status": "error"
+      },
+      "name": "config_types:unsupported_route"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "customer_quota",
+        "owner": "customer"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "credit_limit_exceeded",
+        "status": "error"
+      },
+      "name": "customer_quota_types:credit_limit_exceeded"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "customer_quota",
+        "owner": "customer"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "insufficient_credits",
+        "status": "error"
+      },
+      "name": "customer_quota_types:insufficient_credits"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "customer_quota",
+        "owner": "customer"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "key_limit_exceeded",
+        "status": "error"
+      },
+      "name": "customer_quota_types:key_limit_exceeded"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "customer_quota",
+        "owner": "customer"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "rate_limit_exceeded",
+        "status": "error"
+      },
+      "name": "customer_quota_types:rate_limit_exceeded"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "customer_quota",
+        "owner": "customer"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "workspace_limit_exceeded",
+        "status": "error"
+      },
+      "name": "customer_quota_types:workspace_limit_exceeded"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported deployment for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:deployment"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported does not exist for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:does not exist"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported no endpoint for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:no endpoint"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not available for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:not available"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not found for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:not found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not supported for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:not supported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported unavailable for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:unavailable"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported unknown model for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_markers:unknown model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 400,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_statuses:400"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "provider_auth_config",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 401,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_statuses:401"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "provider_auth_config",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 403,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_statuses:403"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 404,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_statuses:404"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 422,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "dead_statuses:422"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_cerebras/_failure",
+        "status": "error"
+      },
+      "name": "fast_markers:cerebras/"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_fast_failure",
+        "status": "error"
+      },
+      "name": "fast_markers:fast"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_flash-lite_failure",
+        "status": "error"
+      },
+      "name": "fast_markers:flash-lite"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_groq/_failure",
+        "status": "error"
+      },
+      "name": "fast_markers:groq/"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_haiku_failure",
+        "status": "error"
+      },
+      "name": "fast_markers:haiku"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_capacity",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "capacity_exceeded",
+        "status": "error"
+      },
+      "name": "generic:capacity_type"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "provider_auth_config",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 401,
+        "error_type": "not_found",
+        "status": "error"
+      },
+      "name": "generic:not_found_with_401"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_capacity",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "overloaded",
+        "status": "error"
+      },
+      "name": "generic:overloaded_type"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": false,
+        "failure_class": "trustedrouter_capacity",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 402,
+        "error_type": null,
+        "status": "error"
+      },
+      "name": "generic:plain_402"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_capacity",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 429,
+        "error_type": null,
+        "status": "error"
+      },
+      "name": "generic:plain_429"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_internal",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 500,
+        "error_type": null,
+        "status": "error"
+      },
+      "name": "generic:plain_500"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_capacity",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 503,
+        "error_type": null,
+        "status": "error"
+      },
+      "name": "generic:plain_503"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": true,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_capacity",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": 529,
+        "error_type": null,
+        "status": "error"
+      },
+      "name": "generic:plain_529"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "router_fault",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "router_database_contention",
+        "status": "error"
+      },
+      "name": "generic:router_prefix"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "success",
+        "owner": "none"
+      },
+      "input": {
+        "error_message": "account quota",
+        "error_status": 500,
+        "error_type": "router_error",
+        "status": "success"
+      },
+      "name": "generic:success_shaped"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "ReadTimeout",
+        "status": "error"
+      },
+      "name": "generic:timeout_type"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unmapped_failure",
+        "status": "error"
+      },
+      "name": "generic:unknown_type"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unmapped_failure",
+        "status": "unsupported"
+      },
+      "name": "generic:unsupported_status_only"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "router_fault",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "monitor_account_unavailable",
+        "status": "error"
+      },
+      "name": "monitor_configuration_error_types:monitor_account_unavailable"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "router_fault",
+        "owner": "trustedrouter"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "monitor_workspace_paused",
+        "status": "error"
+      },
+      "name": "monitor_configuration_error_types:monitor_workspace_paused"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "bad_request",
+        "status": "error"
+      },
+      "name": "probe_config_error_types:bad_request"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "invalid_request",
+        "status": "error"
+      },
+      "name": "probe_config_error_types:invalid_request"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "invalid_request_error",
+        "status": "error"
+      },
+      "name": "probe_config_error_types:invalid_request_error"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "invalid_request_error_type",
+        "status": "error"
+      },
+      "name": "probe_config_error_types:invalid_request_error_type"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported max_completion_tokens for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "probe_config_message_markers:max_completion_tokens"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported max_tokens for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "probe_config_message_markers:max_tokens"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported temperature for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "probe_config_message_markers:temperature"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported top_p for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "probe_config_message_markers:top_p"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_/o1_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:/o1"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_/o3_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:/o3"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_/o4_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:/o4"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_deep-research_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:deep-research"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_deepseek-r_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:deepseek-r"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_glm-5_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:glm-5"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_gpt-5.5_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:gpt-5.5"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_gpt-5.6_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:gpt-5.6"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_opus_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:opus"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_reasoning_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:reasoning"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_thinking_failure",
+        "status": "error"
+      },
+      "name": "slow_reasoning_markers:thinking"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_stream",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_empty_stream_failure",
+        "status": "error"
+      },
+      "name": "stream_markers:empty_stream"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_stream",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_incomplete_stream_failure",
+        "status": "error"
+      },
+      "name": "stream_markers:incomplete_stream"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_stream",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_stream_error_failure",
+        "status": "error"
+      },
+      "name": "stream_markers:stream_error"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_stream",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_stream_interrupted_failure",
+        "status": "error"
+      },
+      "name": "stream_markers:stream_interrupted"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_connecttimeout_failure",
+        "status": "error"
+      },
+      "name": "timeout_markers:connecttimeout"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_deadline_failure",
+        "status": "error"
+      },
+      "name": "timeout_markers:deadline"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_readtimeout_failure",
+        "status": "error"
+      },
+      "name": "timeout_markers:readtimeout"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_timed_out_failure",
+        "status": "error"
+      },
+      "name": "timeout_markers:timed_out"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": true,
+        "failure_class": "provider_timeout",
+        "owner": "provider"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "synthetic_timeout_failure",
+        "status": "error"
+      },
+      "name": "timeout_markers:timeout"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "model_not_available",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:model_not_available"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "model_not_found",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:model_not_found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "not_found",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:not_found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "not_supported",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:not_supported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:unsupported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_model",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:unsupported_model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_provider",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:unsupported_provider"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unsupported_route",
+        "owner": "configuration"
+      },
+      "input": {
+        "error_message": null,
+        "error_status": null,
+        "error_type": "unsupported_route",
+        "status": "error"
+      },
+      "name": "unsupported_route_error_types:unsupported_route"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported does not exist for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:does not exist"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported does not support for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:does not support"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported invalid model for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:invalid model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported model does not exist for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:model does not exist"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported model not found for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:model not found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported model_not_found for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:model_not_found"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported no endpoint for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:no endpoint"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported no route for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:no route"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported no such model for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:no such model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not authorized for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:not authorized"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not available for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:not available"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not enabled for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:not enabled"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not permitted for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:not permitted"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported not supported for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:not supported"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported unavailable for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:unavailable"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported unknown model for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:unknown model"
+    },
+    {
+      "attribution": {
+        "capacity_rejected": false,
+        "counts_toward_provider_availability": false,
+        "failure_class": "unknown",
+        "owner": "unknown"
+      },
+      "input": {
+        "error_message": "upstream reported unsupported for this request",
+        "error_status": null,
+        "error_type": "provider_error",
+        "status": "error"
+      },
+      "name": "unsupported_route_message_markers:unsupported"
+    }
+  ],
+  "leaderboard": {
+    "excluded_samples": 4,
+    "model_count": 6,
+    "models": [
+      {
+        "availability_within_deadline": 1.0,
+        "capacity_acceptance_rate": 1.0,
+        "capacity_attempt_count": 4,
+        "completion_rate": 1.0,
+        "deadline_sample_count": 4,
+        "effective_attempt_count": 4,
+        "error_rate": 0.0,
+        "errors": {},
+        "excluded_count": 0,
+        "excluded_reasons": {},
+        "failure_classes": {},
+        "failure_owners": {},
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T07:40:00Z",
+        "model": "alpha/challenger",
+        "p50_tokens_per_second": null,
+        "p50_ttfb_ms": 450,
+        "p50_ttft_ms": 600,
+        "p95_ttfb_ms": 550,
+        "p95_ttft_ms": 800,
+        "provider": "alpha",
+        "provider_availability": 1.0,
+        "provider_sample_count": 4,
+        "rank": 1,
+        "rank_eligible": true,
+        "sample_count": 4,
+        "throughput_sample_count": 0,
+        "top_error": null,
+        "top_excluded": null,
+        "ttft_sample_count": 4,
+        "uptime": 1.0
+      },
+      {
+        "availability_within_deadline": 0.75,
+        "capacity_acceptance_rate": 1.0,
+        "capacity_attempt_count": 4,
+        "completion_rate": 0.75,
+        "deadline_sample_count": 4,
+        "effective_attempt_count": 4,
+        "error_rate": 0.25,
+        "errors": {
+          "ReadTimeout": 1
+        },
+        "excluded_count": 0,
+        "excluded_reasons": {},
+        "failure_classes": {
+          "provider_timeout": 1
+        },
+        "failure_owners": {
+          "provider": 1
+        },
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T05:00:00Z",
+        "model": "alpha/steady",
+        "p50_tokens_per_second": 25.0,
+        "p50_ttfb_ms": 100,
+        "p50_ttft_ms": 140,
+        "p95_ttfb_ms": 120,
+        "p95_ttft_ms": 18000,
+        "provider": "alpha",
+        "provider_availability": 0.75,
+        "provider_sample_count": 4,
+        "rank": 2,
+        "rank_eligible": true,
+        "sample_count": 4,
+        "throughput_sample_count": 2,
+        "top_error": "ReadTimeout",
+        "top_excluded": null,
+        "ttft_sample_count": 3,
+        "uptime": 0.75
+      },
+      {
+        "availability_within_deadline": null,
+        "capacity_acceptance_rate": 1.0,
+        "capacity_attempt_count": 1,
+        "completion_rate": 1.0,
+        "deadline_sample_count": 0,
+        "effective_attempt_count": 1,
+        "error_rate": 0.0,
+        "errors": {},
+        "excluded_count": 1,
+        "excluded_reasons": {
+          "unsupported_route": 1
+        },
+        "failure_classes": {},
+        "failure_owners": {},
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T07:00:00Z",
+        "model": "alpha/thin",
+        "p50_tokens_per_second": null,
+        "p50_ttfb_ms": null,
+        "p50_ttft_ms": null,
+        "p95_ttfb_ms": null,
+        "p95_ttft_ms": null,
+        "provider": "alpha",
+        "provider_availability": 1.0,
+        "provider_sample_count": 1,
+        "rank": null,
+        "rank_eligible": false,
+        "sample_count": 1,
+        "throughput_sample_count": 0,
+        "top_error": null,
+        "top_excluded": "unsupported_route",
+        "ttft_sample_count": 0,
+        "uptime": 1.0
+      },
+      {
+        "availability_within_deadline": null,
+        "capacity_acceptance_rate": null,
+        "capacity_attempt_count": 0,
+        "completion_rate": null,
+        "deadline_sample_count": 0,
+        "effective_attempt_count": 0,
+        "error_rate": 0.0,
+        "errors": {},
+        "excluded_count": 0,
+        "excluded_reasons": {},
+        "failure_classes": {},
+        "failure_owners": {},
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T07:50:00Z",
+        "model": "alpha/throughput-only",
+        "p50_tokens_per_second": 30.0,
+        "p50_ttfb_ms": null,
+        "p50_ttft_ms": null,
+        "p95_ttfb_ms": null,
+        "p95_ttft_ms": null,
+        "provider": "alpha",
+        "provider_availability": null,
+        "provider_sample_count": 0,
+        "rank": null,
+        "rank_eligible": false,
+        "sample_count": 0,
+        "throughput_sample_count": 1,
+        "top_error": null,
+        "top_excluded": null,
+        "ttft_sample_count": 0,
+        "uptime": null
+      },
+      {
+        "availability_within_deadline": 0.75,
+        "capacity_acceptance_rate": 0.75,
+        "capacity_attempt_count": 4,
+        "completion_rate": 0.75,
+        "deadline_sample_count": 4,
+        "effective_attempt_count": 4,
+        "error_rate": 0.25,
+        "errors": {
+          "rate_limit_error": 1
+        },
+        "excluded_count": 0,
+        "excluded_reasons": {},
+        "failure_classes": {
+          "provider_capacity": 1
+        },
+        "failure_owners": {
+          "provider": 1
+        },
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T10:30:00Z",
+        "model": "beta/stable",
+        "p50_tokens_per_second": null,
+        "p50_ttfb_ms": 160,
+        "p50_ttft_ms": 225,
+        "p95_ttfb_ms": 175,
+        "p95_ttft_ms": 250,
+        "provider": "beta",
+        "provider_availability": 0.75,
+        "provider_sample_count": 4,
+        "rank": 3,
+        "rank_eligible": true,
+        "sample_count": 4,
+        "throughput_sample_count": 0,
+        "top_error": "rate_limit_error",
+        "top_excluded": null,
+        "ttft_sample_count": 3,
+        "uptime": 0.75
+      },
+      {
+        "availability_within_deadline": 0.0,
+        "capacity_acceptance_rate": 1.0,
+        "capacity_attempt_count": 2,
+        "completion_rate": 0.25,
+        "deadline_sample_count": 2,
+        "effective_attempt_count": 4,
+        "error_rate": 0.6667,
+        "errors": {
+          "error": 1,
+          "http_500": 1
+        },
+        "excluded_count": 3,
+        "excluded_reasons": {
+          "provider_auth_config": 1,
+          "rate_limit_exceeded": 1,
+          "router_error": 1
+        },
+        "failure_classes": {
+          "customer_quota": 1,
+          "provider_internal": 1,
+          "router_fault": 1,
+          "unknown": 1
+        },
+        "failure_owners": {
+          "customer": 1,
+          "provider": 1,
+          "trustedrouter": 1,
+          "unknown": 1
+        },
+        "first_token_deadline_ms": 20000,
+        "last_seen": "2026-01-01T16:00:00Z",
+        "model": "beta/thin",
+        "p50_tokens_per_second": null,
+        "p50_ttfb_ms": 200,
+        "p50_ttft_ms": 30000,
+        "p95_ttfb_ms": 200,
+        "p95_ttft_ms": 30000,
+        "provider": "beta",
+        "provider_availability": 0.5,
+        "provider_sample_count": 2,
+        "rank": null,
+        "rank_eligible": false,
+        "sample_count": 3,
+        "throughput_sample_count": 0,
+        "top_error": "http_500",
+        "top_excluded": "router_error",
+        "ttft_sample_count": 1,
+        "uptime": 0.3333
+      }
+    ],
+    "models_order": [
+      "alpha/alpha/challenger",
+      "alpha/alpha/steady",
+      "beta/beta/stable",
+      "alpha/alpha/thin",
+      "beta/beta/thin",
+      "alpha/alpha/throughput-only"
+    ],
+    "provider_count": 2,
+    "providers": [
+      {
+        "availability_within_deadline": 0.875,
+        "capacity_acceptance_rate": 1.0,
+        "capacity_attempt_count": 9,
+        "completion_rate": 0.8889,
+        "deadline_sample_count": 8,
+        "effective_attempt_count": 9,
+        "error_rate": 0.1111,
+        "errors": {
+          "ReadTimeout": 1
+        },
+        "excluded_count": 1,
+        "excluded_reasons": {
+          "unsupported_route": 1
+        },
+        "failure_classes": {
+          "provider_timeout": 1
+        },
+        "failure_owners": {
+          "provider": 1
+        },
+        "model_count": 4,
+        "p50_tokens_per_second": 25.0,
+        "p50_ttfb_ms": 400,
+        "p50_ttft_ms": 140,
+        "p95_ttfb_ms": 550,
+        "p95_ttft_ms": 18000,
+        "provider": "alpha",
+        "provider_availability": 0.8889,
+        "provider_sample_count": 9,
+        "rank": 1,
+        "rank_eligible": true,
+        "sample_count": 9,
+        "throughput_sample_count": 3,
+        "top_error": "ReadTimeout",
+        "top_excluded": "unsupported_route",
+        "ttft_sample_count": 7,
+        "uptime": 0.8889
+      },
+      {
+        "availability_within_deadline": 0.5,
+        "capacity_acceptance_rate": 0.8333,
+        "capacity_attempt_count": 6,
+        "completion_rate": 0.5,
+        "deadline_sample_count": 6,
+        "effective_attempt_count": 8,
+        "error_rate": 0.4286,
+        "errors": {
+          "error": 1,
+          "http_500": 1,
+          "rate_limit_error": 1
+        },
+        "excluded_count": 3,
+        "excluded_reasons": {
+          "provider_auth_config": 1,
+          "rate_limit_exceeded": 1,
+          "router_error": 1
+        },
+        "failure_classes": {
+          "customer_quota": 1,
+          "provider_capacity": 1,
+          "provider_internal": 1,
+          "router_fault": 1,
+          "unknown": 1
+        },
+        "failure_owners": {
+          "customer": 1,
+          "provider": 2,
+          "trustedrouter": 1,
+          "unknown": 1
+        },
+        "model_count": 2,
+        "p50_tokens_per_second": null,
+        "p50_ttfb_ms": 160,
+        "p50_ttft_ms": 225,
+        "p95_ttfb_ms": 200,
+        "p95_ttft_ms": 30000,
+        "provider": "beta",
+        "provider_availability": 0.6667,
+        "provider_sample_count": 6,
+        "rank": 2,
+        "rank_eligible": true,
+        "sample_count": 7,
+        "throughput_sample_count": 0,
+        "top_error": "rate_limit_error",
+        "top_excluded": "router_error",
+        "ttft_sample_count": 4,
+        "uptime": 0.5714
+      }
+    ],
+    "providers_order": [
+      "alpha",
+      "beta"
+    ],
+    "total_samples": 16,
+    "total_throughput_samples": 3
+  },
+  "markers": {
+    "account_quota_markers": [
+      "account quota",
+      "billing quota",
+      "credit balance",
+      "credits exhausted",
+      "insufficient credit",
+      "insufficient funds",
+      "monthly spend",
+      "payment required",
+      "quota exceeded for quota metric"
+    ],
+    "config_types": [
+      "bad_request",
+      "invalid_request",
+      "invalid_request_error",
+      "model_not_available",
+      "model_not_found",
+      "not_found",
+      "not_supported",
+      "probe_config_error",
+      "provider_auth_config",
+      "unsupported",
+      "unsupported_model",
+      "unsupported_provider",
+      "unsupported_route"
+    ],
+    "customer_quota_types": [
+      "credit_limit_exceeded",
+      "insufficient_credits",
+      "key_limit_exceeded",
+      "rate_limit_exceeded",
+      "workspace_limit_exceeded"
+    ],
+    "dead_markers": [
+      "deployment",
+      "does not exist",
+      "no endpoint",
+      "not available",
+      "not found",
+      "not supported",
+      "unavailable",
+      "unknown model"
+    ],
+    "dead_statuses": [
+      400,
+      401,
+      403,
+      404,
+      422
+    ],
+    "fast_markers": [
+      "cerebras/",
+      "fast",
+      "flash-lite",
+      "groq/",
+      "haiku"
+    ],
+    "monitor_configuration_error_types": [
+      "monitor_account_unavailable",
+      "monitor_workspace_paused"
+    ],
+    "probe_config_error_types": [
+      "bad_request",
+      "invalid_request",
+      "invalid_request_error",
+      "invalid_request_error_type"
+    ],
+    "probe_config_message_markers": [
+      "max_completion_tokens",
+      "max_tokens",
+      "temperature",
+      "top_p"
+    ],
+    "router_origin_behavior": [
+      {
+        "input": null,
+        "result": false
+      },
+      {
+        "input": "",
+        "result": false
+      },
+      {
+        "input": "monitor_account_unavailable",
+        "result": true
+      },
+      {
+        "input": "monitor_workspace_paused",
+        "result": true
+      },
+      {
+        "input": "router_database_contention",
+        "result": true
+      },
+      {
+        "input": "provider_timeout",
+        "result": false
+      },
+      {
+        "input": "Router_error",
+        "result": false
+      }
+    ],
+    "slow_reasoning_markers": [
+      "/o1",
+      "/o3",
+      "/o4",
+      "deep-research",
+      "deepseek-r",
+      "glm-5",
+      "gpt-5.5",
+      "gpt-5.6",
+      "opus",
+      "reasoning",
+      "thinking"
+    ],
+    "stream_markers": [
+      "empty_stream",
+      "incomplete_stream",
+      "stream_error",
+      "stream_interrupted"
+    ],
+    "timeout_markers": [
+      "connecttimeout",
+      "deadline",
+      "readtimeout",
+      "timed_out",
+      "timeout"
+    ],
+    "unsupported_route_error_types": [
+      "model_not_available",
+      "model_not_found",
+      "not_found",
+      "not_supported",
+      "unsupported",
+      "unsupported_model",
+      "unsupported_provider",
+      "unsupported_route"
+    ],
+    "unsupported_route_message_markers": [
+      "does not exist",
+      "does not support",
+      "invalid model",
+      "model does not exist",
+      "model not found",
+      "model_not_found",
+      "no endpoint",
+      "no route",
+      "no such model",
+      "not authorized",
+      "not available",
+      "not enabled",
+      "not permitted",
+      "not supported",
+      "unavailable",
+      "unknown model",
+      "unsupported"
+    ]
+  },
+  "model_deadlines": [
+    {
+      "completion_seconds": 60.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 15.0,
+      "model": "anthropic/haiku",
+      "provider": null
+    },
+    {
+      "completion_seconds": 900.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 100.0,
+      "model": "catalog/completion-ceiling",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 80.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 20.0,
+      "model": "catalog/completion-fallback",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 30.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 5.0,
+      "model": "catalog/completion-floor",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 400.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 300.0,
+      "model": "catalog/first-ceiling",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 40.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 5.0,
+      "model": "catalog/first-floor",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 80.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 20.0,
+      "model": "catalog/usage-filter",
+      "provider": "catalog-provider"
+    },
+    {
+      "completion_seconds": 60.0,
+      "default_first_token_seconds": 400.0,
+      "first_token_seconds": 15.0,
+      "model": "vendor/fast-high-clamp",
+      "provider": null
+    },
+    {
+      "completion_seconds": 30.0,
+      "default_first_token_seconds": 1.0,
+      "first_token_seconds": 5.0,
+      "model": "vendor/fast-low-clamp",
+      "provider": null
+    },
+    {
+      "default_first_token_seconds": 0.0,
+      "exception": "ValueError",
+      "model": "vendor/invalid-default",
+      "provider": null
+    },
+    {
+      "completion_seconds": 300.0,
+      "default_first_token_seconds": 80.0,
+      "first_token_seconds": 80.0,
+      "model": "vendor/plain-completion-ceiling",
+      "provider": null
+    },
+    {
+      "completion_seconds": 30.0,
+      "default_first_token_seconds": 6.0,
+      "first_token_seconds": 6.0,
+      "model": "vendor/plain-completion-floor",
+      "provider": null
+    },
+    {
+      "completion_seconds": 80.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 20.0,
+      "model": "vendor/plain-default",
+      "provider": null
+    },
+    {
+      "completion_seconds": 300.0,
+      "default_first_token_seconds": 400.0,
+      "first_token_seconds": 90.0,
+      "model": "vendor/plain-high-clamp",
+      "provider": null
+    },
+    {
+      "completion_seconds": 30.0,
+      "default_first_token_seconds": 1.0,
+      "first_token_seconds": 5.0,
+      "model": "vendor/plain-low-clamp",
+      "provider": null
+    },
+    {
+      "completion_seconds": 180.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 45.0,
+      "model": "vendor/reasoning-haiku",
+      "provider": null
+    },
+    {
+      "completion_seconds": 240.0,
+      "default_first_token_seconds": 60.0,
+      "first_token_seconds": 60.0,
+      "model": "vendor/reasoning-high-default",
+      "provider": null
+    },
+    {
+      "completion_seconds": 180.0,
+      "default_first_token_seconds": 20.0,
+      "first_token_seconds": 45.0,
+      "model": "vendor/reasoning-pro",
+      "provider": null
+    }
+  ],
+  "prompts": {
+    "pong": "reply exactly PONG",
+    "throughput": "Continue writing the lowercase word benchmark separated by single spaces until the response token limit stops you. Do not count, explain, use punctuation, or stop early."
+  },
+  "rotation_errors": {
+    "classification": [
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": null,
+          "source": null,
+          "status": 401
+        },
+        "name": "auth:401",
+        "result": "provider_auth_config"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": null,
+          "source": null,
+          "status": 403
+        },
+        "name": "auth:403",
+        "result": "provider_auth_config"
+      },
+      {
+        "input": {
+          "error_type": "custom_provider_error",
+          "message": null,
+          "source": null,
+          "status": 500
+        },
+        "name": "fallback:unchanged",
+        "result": "custom_provider_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "database contention",
+          "source": null,
+          "status": null
+        },
+        "name": "message:database_contention",
+        "result": "router_database_contention"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "deadlock",
+          "source": null,
+          "status": null
+        },
+        "name": "message:deadlock",
+        "result": "router_database_contention"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "planned maintenance",
+          "source": null,
+          "status": null
+        },
+        "name": "message:planned_maintenance",
+        "result": "router_maintenance"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "read-only mode",
+          "source": null,
+          "status": null
+        },
+        "name": "message:read_only_mode",
+        "result": "router_maintenance"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "workspace billing is paused",
+          "source": null,
+          "status": null
+        },
+        "name": "message:workspace_billing_paused",
+        "result": "monitor_workspace_paused"
+      },
+      {
+        "input": {
+          "error_type": "unsupported_route",
+          "message": "insufficient credits",
+          "source": "router",
+          "status": null
+        },
+        "name": "precedence:router_account_before_unsupported",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "unsupported_route",
+          "message": null,
+          "source": null,
+          "status": 401
+        },
+        "name": "precedence:unsupported_before_auth",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "workspace billing is paused after database contention",
+          "source": null,
+          "status": null
+        },
+        "name": "precedence:workspace_before_contention",
+        "result": "monitor_workspace_paused"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "max_completion_tokens",
+          "source": null,
+          "status": 400
+        },
+        "name": "probe_config_message:400:max_completion_tokens",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "max_tokens",
+          "source": null,
+          "status": 400
+        },
+        "name": "probe_config_message:400:max_tokens",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "temperature",
+          "source": null,
+          "status": 400
+        },
+        "name": "probe_config_message:400:temperature",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "top_p",
+          "source": null,
+          "status": 400
+        },
+        "name": "probe_config_message:400:top_p",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "max_completion_tokens",
+          "source": null,
+          "status": 422
+        },
+        "name": "probe_config_message:422:max_completion_tokens",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "max_tokens",
+          "source": null,
+          "status": 422
+        },
+        "name": "probe_config_message:422:max_tokens",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "temperature",
+          "source": null,
+          "status": 422
+        },
+        "name": "probe_config_message:422:temperature",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "top_p",
+          "source": null,
+          "status": 422
+        },
+        "name": "probe_config_message:422:top_p",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "bad_request",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "probe_config_type:bad_request",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "invalid_request",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "probe_config_type:invalid_request",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "invalid_request_error",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "probe_config_type:invalid_request_error",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "invalid_request_error_type",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "probe_config_type:invalid_request_error_type",
+        "result": "probe_config_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": null,
+          "source": "router",
+          "status": null
+        },
+        "name": "router:fallback",
+        "result": "router_error"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "api key expired",
+          "source": "router",
+          "status": null
+        },
+        "name": "router_account:api key expired",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "api key is disabled",
+          "source": "router",
+          "status": null
+        },
+        "name": "router_account:api key is disabled",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "api key not found",
+          "source": "router",
+          "status": null
+        },
+        "name": "router_account:api key not found",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "insufficient credits",
+          "source": "router",
+          "status": null
+        },
+        "name": "router_account:insufficient credits",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "invalid api key",
+          "source": "router",
+          "status": null
+        },
+        "name": "router_account:invalid api key",
+        "result": "monitor_account_unavailable"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "does not exist",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:does not exist",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "does not support",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:does not support",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "invalid model",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:invalid model",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "model does not exist",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:model does not exist",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "model not found",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:model not found",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "model_not_found",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:model_not_found",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "no endpoint",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:no endpoint",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "no route",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:no route",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "no such model",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:no such model",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "not authorized",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:not authorized",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "not available",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:not available",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "not enabled",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:not enabled",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "not permitted",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:not permitted",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "not supported",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:not supported",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "unavailable",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:unavailable",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "unknown model",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:unknown model",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "provider_error",
+          "message": "unsupported",
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_message:unsupported",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "model_not_available",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:model_not_available",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "model_not_found",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:model_not_found",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "not_found",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:not_found",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "not_supported",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:not_supported",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "unsupported",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:unsupported",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "unsupported_model",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:unsupported_model",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "unsupported_provider",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:unsupported_provider",
+        "result": "unsupported_route"
+      },
+      {
+        "input": {
+          "error_type": "unsupported_route",
+          "message": null,
+          "source": null,
+          "status": null
+        },
+        "name": "unsupported_type:unsupported_route",
+        "result": "unsupported_route"
+      }
+    ],
+    "excluded_from_uptime": [
+      {
+        "input": null,
+        "result": false
+      },
+      {
+        "input": "",
+        "result": false
+      },
+      {
+        "input": "None",
+        "result": false
+      },
+      {
+        "input": "ReadTimeout",
+        "result": false
+      },
+      {
+        "input": "Router_error",
+        "result": false
+      },
+      {
+        "input": "bad_request",
+        "result": false
+      },
+      {
+        "input": "capacity_exceeded",
+        "result": false
+      },
+      {
+        "input": "credit_limit_exceeded",
+        "result": false
+      },
+      {
+        "input": "custom_provider_error",
+        "result": false
+      },
+      {
+        "input": "http_200",
+        "result": false
+      },
+      {
+        "input": "http_502",
+        "result": false
+      },
+      {
+        "input": "http_504",
+        "result": false
+      },
+      {
+        "input": "insufficient_credits",
+        "result": false
+      },
+      {
+        "input": "insufficient_throughput_sample",
+        "result": true
+      },
+      {
+        "input": "invalid_request",
+        "result": false
+      },
+      {
+        "input": "invalid_request_error",
+        "result": false
+      },
+      {
+        "input": "invalid_request_error_type",
+        "result": false
+      },
+      {
+        "input": "key_limit_exceeded",
+        "result": false
+      },
+      {
+        "input": "model_not_available",
+        "result": false
+      },
+      {
+        "input": "model_not_found",
+        "result": false
+      },
+      {
+        "input": "monitor_account_unavailable",
+        "result": true
+      },
+      {
+        "input": "monitor_workspace_paused",
+        "result": true
+      },
+      {
+        "input": "not_found",
+        "result": false
+      },
+      {
+        "input": "not_supported",
+        "result": false
+      },
+      {
+        "input": "overloaded",
+        "result": false
+      },
+      {
+        "input": "probe_config_error",
+        "result": true
+      },
+      {
+        "input": "provider_auth_config",
+        "result": true
+      },
+      {
+        "input": "provider_error",
+        "result": false
+      },
+      {
+        "input": "provider_timeout",
+        "result": false
+      },
+      {
+        "input": "rate_limit_error",
+        "result": false
+      },
+      {
+        "input": "rate_limit_exceeded",
+        "result": false
+      },
+      {
+        "input": "router_database_contention",
+        "result": true
+      },
+      {
+        "input": "router_error",
+        "result": true
+      },
+      {
+        "input": "router_maintenance",
+        "result": true
+      },
+      {
+        "input": "synthetic_/o1_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_/o3_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_/o4_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_cerebras/_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_connecttimeout_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_deadline_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_deep-research_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_deepseek-r_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_empty_stream_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_fast_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_flash-lite_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_glm-5_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_gpt-5.5_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_gpt-5.6_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_groq/_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_haiku_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_incomplete_stream_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_opus_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_readtimeout_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_reasoning_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_stream_error_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_stream_interrupted_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_thinking_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_timed_out_failure",
+        "result": false
+      },
+      {
+        "input": "synthetic_timeout_failure",
+        "result": false
+      },
+      {
+        "input": "unmapped_failure",
+        "result": false
+      },
+      {
+        "input": "unsupported",
+        "result": false
+      },
+      {
+        "input": "unsupported_model",
+        "result": false
+      },
+      {
+        "input": "unsupported_provider",
+        "result": false
+      },
+      {
+        "input": "unsupported_route",
+        "result": true
+      },
+      {
+        "input": "upstream",
+        "result": false
+      },
+      {
+        "input": "workspace_limit_exceeded",
+        "result": false
+      }
+    ]
+  },
+  "sample_fields": [
+    "created_at",
+    "elapsed_milliseconds",
+    "error_message",
+    "error_status",
+    "error_type",
+    "first_token_milliseconds",
+    "model",
+    "output_tokens",
+    "provider",
+    "source",
+    "speed_tokens_per_second",
+    "status",
+    "ttfb_milliseconds"
+  ],
+  "source_hashes": {
+    "catalog._decimal": "2c1bf5587a4d60d56b65cdece79937608e43a35661df24b4d1f087de5abfb4ce",
+    "components.is_router_origin_error": "ce3a226b41f03957f4ef43d2bdb51a1d5750db7ae2ad96b5b7c5fb1efee6f134",
+    "leaderboard._effective_throughput": "8d2a0df175cb0a7b986b0900f44f75fbe42e6b604e45127a2bdb0007d2b5e020",
+    "leaderboard._excluded_from_uptime": "6e673fe96aa8f6e317a2db774aa9f46de1a3c38ba958245e3d4e1527f2eb61a5",
+    "leaderboard._percentile": "f400388aa9334b49eef0e7005a79478c39c5c7868c2b0a6a3909b1f443f95742",
+    "leaderboard._sort_key": "ce505ca4b7d577416f080b19c67feb6791f7f3e446374677e402f5f8a10891b4",
+    "leaderboard.aggregate_leaderboard": "1ae336252e85afbe0181b55ed8c37288c8f144d01ad8c6db4888eb739bf20601",
+    "probes._chat_text": "d93e2345277c7fc9f2f201a308768f3cc42b2d53a9715a5cfe7801e3a0f2a3bb",
+    "probes._first_int": "29a2c84649a74c53afb4bfe4d017f9b799908bcd08704a26d1e4d2b7ac46c64a",
+    "probes._observe_provider_stream": "eb68ab6008853ff16e7930e20f151de978bf6b498bffd55dcce2023a50542c58",
+    "probes._pong_matches": "998237bb5709cb6804b12310face8e43876dd189fa179eed2802df8871716b0b",
+    "probes._response_error": "b99b11a62e9d331e655f65b612fb6dbab94885c3accb3dd30989311baa469d13",
+    "probes._responses_text": "99429cf72be3c5cd8dadd9569a08bfe1c17a6c42318309a376f4bf12d31bf1fa",
+    "probes._rotation_error_type": "54584b9ec26edb80f372d63f7b3a08916b1947b99b632e009a6b46e442ff3a76",
+    "probes._rotation_max_tokens": "99b68643eeec2f398dae3a920eea77bdf04644884e015c61ae01e57d0a19653e",
+    "probes._rotation_omits_temperature": "cd342f2c4d36ce49f57acad9b8a21b7515ebbbdeec42e53b7cc514b827c04980",
+    "probes._sse_line_error": "bc5e36f9addbf54b9f4045d0817d41e4818a9e78de53769be58e36cc3eee5b33",
+    "probes._sse_line_finish_reason": "90dfa40b8825eb4346522c1537f4a118feaa8c80e7f7b163883933748d096144",
+    "probes._sse_line_has_content": "5e5e660c7a34a0f8ab529fc0462b9972a2b973723c05e4025c45bfa4c0201d64",
+    "probes._sse_line_payload": "b1c471040fa210f1fafb8653c207989707ae0cdd014e9e31ed03cbc931d70e6e",
+    "probes._sse_line_usage": "03d596eaae4e6875f2e58789d477987617c72f87ba23120503c101374d4063bc",
+    "provider_reliability.classify_provider_failure": "f8e1b14099827858028ec415bf78272616bc81f3aeafc04a0b83117efd2c9e37",
+    "provider_reliability.model_deadlines": "61436cfe1e43f1aeb34ada0539a284de2a1c9ea4f871118db1ea80e6039dee08",
+    "routes._classify": "e28308b685513256d3d6441d429e1896796f68cc1d131bb78832fad4633bf7f0"
+  }
+}

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -42,6 +42,16 @@ VIDEO_GENERATION_MODEL = "x-ai/grok-imagine-video"
 VIDEO_GENERATION_PROVIDER = "grok"
 VIDEO_GENERATION_DURATION_SECONDS = 1
 VIDEO_GENERATION_RESOLUTION = "480p"
+# Reverted from "Respond with only the word PONG." back to
+# "reply exactly PONG" — the original phrasing worked at
+# 99.97% uptime for ~24h on the same monitor pool, then the
+# rephrase coincided with a surge to 100% pong_mismatch at
+# 06:00Z 2026-06-02. DeepSeek V4 Flash (current pool leader)
+# appears to interpret the new phrasing differently — maybe
+# refusing, maybe wrapping in markdown the extractor doesn't
+# reach. Reverting to the known-good prompt while we
+# investigate the underlying response shape.
+PONG_PROMPT = "reply exactly PONG"
 _IMAGE_CANARY_PROMPT = (
     "Generate and return an actual square image now, not a textual description. "
     "Show one solid red circle centered on a white background."
@@ -975,16 +985,7 @@ async def openai_chat_pong_probe(
     url = _api_url(target.api_base_url, "/chat/completions")
     body = {
         "model": model,
-        # Reverted from "Respond with only the word PONG." back to
-        # "reply exactly PONG" — the original phrasing worked at
-        # 99.97% uptime for ~24h on the same monitor pool, then the
-        # rephrase coincided with a surge to 100% pong_mismatch at
-        # 06:00Z 2026-06-02. DeepSeek V4 Flash (current pool leader)
-        # appears to interpret the new phrasing differently — maybe
-        # refusing, maybe wrapping in markdown the extractor doesn't
-        # reach. Reverting to the known-good prompt while we
-        # investigate the underlying response shape.
-        "messages": [{"role": "user", "content": "reply exactly PONG"}],
+        "messages": [{"role": "user", "content": PONG_PROMPT}],
         # max_tokens stays at 128 so reasoning models (kimi-k2.6,
         # glm-4.6) in the rollover tail still finish their thinking
         # phase if they're ever reached.
@@ -1042,10 +1043,10 @@ async def responses_pong_probe(
     url = _api_url(target.api_base_url, "/responses")
     body = {
         "model": model,
-        # Same prompt as chat-completions — see that probe's revert
-        # comment. Original phrasing worked, rephrase coincided with
+        # Same prompt as chat-completions — see PONG_PROMPT's warning
+        # comment. Original phrasing worked; rephrasing coincided with a
         # 100% failure surge on 2026-06-02.
-        "input": "reply exactly PONG",
+        "input": PONG_PROMPT,
         # See chat-completions probe — same reason: reasoning models in
         # the monitor pool need headroom past their thinking phase.
         "max_output_tokens": 128,
@@ -2143,7 +2144,7 @@ async def provider_rotation_probe(
     url = _api_url(target.api_base_url, "/chat/completions")
     body = {
         "model": model,
-        "messages": [{"role": "user", "content": "reply exactly PONG"}],
+        "messages": [{"role": "user", "content": PONG_PROMPT}],
         "max_tokens": _rotation_max_tokens(provider, model),
         "stream": True,
         "provider": {"only": [provider]},

--- a/tests/test_provider_check_contract_parity.py
+++ b/tests/test_provider_check_contract_parity.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORTER_PATH = ROOT / "scripts/export_provider_check_contract.py"
+SNAPSHOT_PATH = ROOT / "src/trusted_router/data/provider_check_contract.json"
+PARITY_MESSAGE = (
+    "Production contract symbols changed. Re-run "
+    "scripts/export_provider_check_contract.py, review the diff, and open a sync PR to "
+    "Lore-Hex/trustedrouter-provider-check. Do NOT relax this assertion."
+)
+EXPECTED_KEYS = {
+    "prompts",
+    "markers",
+    "catalog_contract",
+    "decision_tables",
+    "failure_classification",
+    "model_deadlines",
+    "leaderboard",
+    "extractors",
+    "rotation_errors",
+    "source_hashes",
+    "sample_fields",
+    "contract_version",
+}
+
+
+def _load_builder() -> Callable[[], dict[str, Any]]:
+    spec = importlib.util.spec_from_file_location(
+        "provider_check_contract_exporter",
+        EXPORTER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not import {EXPORTER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build_contract
+
+
+def _committed_contract() -> dict[str, Any]:
+    return json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+
+def test_production_contract_matches_snapshot() -> None:
+    assert _load_builder()() == _committed_contract(), PARITY_MESSAGE
+
+
+def test_contract_guards_are_nonempty_and_deterministic() -> None:
+    build_contract = _load_builder()
+    previous_catalog = sys.modules.pop("trusted_router.catalog", None)
+    try:
+        first = build_contract()
+        second = build_contract()
+
+        assert first == second
+        assert set(first) == EXPECTED_KEYS
+        assert all(isinstance(values, list) and values for values in first["markers"].values())
+        assert len(first["decision_tables"]) >= 15
+        assert len(first["failure_classification"]) >= 20
+        assert len(first["extractors"]) >= 40
+        assert first["rotation_errors"]["classification"]
+        assert first["rotation_errors"]["excluded_from_uptime"]
+        assert len(first["source_hashes"]) >= 20
+        assert all(
+            isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+            for value in first["source_hashes"].values()
+        )
+        assert hashlib.sha256(b"").hexdigest() not in first["source_hashes"].values()
+        # Distinct bodies must hash distinctly. The empty-digest check above
+        # only catches a normalizer that strips everything; one that collapses
+        # every function to the same non-empty text would still pass it while
+        # pinning nothing.
+        assert len(set(first["source_hashes"].values())) == len(first["source_hashes"])
+        assert first["leaderboard"]["models"]
+        assert first["leaderboard"]["providers"]
+        assert "trusted_router.catalog" not in sys.modules
+    finally:
+        if previous_catalog is not None:
+            sys.modules["trusted_router.catalog"] = previous_catalog
+
+
+def test_optional_public_provider_check_snapshot() -> None:
+    provider_check_repo = os.environ.get("PROVIDER_CHECK_REPO_PATH")
+    if not provider_check_repo:
+        pytest.skip("PROVIDER_CHECK_REPO_PATH is not set")
+    public_snapshot = Path(provider_check_repo) / "contract_snapshot.json"
+    public_contract = json.loads(public_snapshot.read_text(encoding="utf-8"))
+    assert public_contract == _committed_contract(), PARITY_MESSAGE


### PR DESCRIPTION
## Why

A public suite (`Lore-Hex/trustedrouter-provider-check`) will let inference providers test their own endpoint against the attested gateway's wire contract before applying to the marketplace. To predict production, it has to assert what production asserts — so it vendors the PONG prompt, the SSE/response extractors, the rotation error taxonomy, the failure-ownership model, the deadline policy, and the leaderboard scorer.

Vendored copies rot silently. This adds the gate that stops it: an exporter, a committed snapshot, and a CI test that recomputes the snapshot from the live symbols.

## Two pinning mechanisms, because either alone fails open

**Behavioral tables** pin semantics, but only at sampled inputs. An adversarial review mutation-proved the gap: inserting a new `if "minimax" in model_l: return 1024` branch into `_rotation_max_tokens` — a new model family, the likeliest real change — left the snapshot byte-identical and CI green.

**Normalized source hashes** of all 24 vendored functions close that. Normalization strips docstrings, blank lines, full-line comments and indentation, so comment churn stays quiet while any semantic edit trips the gate. Hashes alone would only say "something changed"; the behavioral tables say what the contract *is*, which is what the public repo replays against its copies.

## Coverage holes the review found (all mutation-proved green before this PR)

| Symbol | Hole |
| --- | --- |
| `classify_provider_failure` | no case reached 402, 503, 529, `overload`/`capacity` kinds, bare `status="unsupported"`, or the in-branch 401/403 disjunct |
| `_rotation_max_tokens` / `_rotation_omits_temperature` | grid never crossed a provider gate with a model marker, so deleting `provider_l == "openai" and` changed no row |
| `model_deadlines` | no case exceeded the slow-marker floor, so flattening `max(first_token, 45.0)` was invisible; slow-vs-fast precedence and the `ValueError` guard unpinned |
| `aggregate_leaderboard` | exactly one rank-eligible model and provider, so the comparator was unobservable and reversing the sort passed; the exporter also re-sorted the output, discarding production ordering |
| extractors | `_pong_matches`, `_chat_text`, `_responses_text`, `_sse_line_*`, `_first_int`, `_response_error` were absent entirely |
| `_rotation_error_type` | never called; its inline literals and precedence unpinned |

Now: 74 extractor rows, 113 classification cases, 26 grid rows, 18 deadline cases, and a leaderboard fixture that records the aggregator's own ordering instead of sorting it away.

The catalog branch of `model_deadlines` is pinned through an injected stub module, and the test asserts `trusted_router.catalog` never lands in `sys.modules` — the branch stays cold while its clamps stay pinned.

## Production change

One: `PONG_PROMPT` is hoisted out of three call sites so parity can import it rather than scrape the literal. Pure refactor — the comment recording why the phrasing is load-bearing (the 2026-06-02 rephrase caused 100% `pong_mismatch`) moves with it.

## Verification

Mutation table — 9 must be red, 1 must be green:

| Mutation | Result |
| --- | --- |
| Add a new `minimax` branch | RED |
| Delete the OpenAI provider gate | RED |
| Remove 503 from the capacity set | RED |
| Delete the 402 leg | RED |
| Make PONG matching exact | RED |
| Accept a new SSE delta key | RED |
| Reverse the leaderboard availability sort | RED |
| Flatten the slow-marker `max()` | RED |
| Alter a `_rotation_error_type` literal | RED |
| Add a pure comment | GREEN |

I independently re-ran the three load-bearing ones (new branch, exact-match PONG, comment-only) rather than trusting the agent's table; all three matched.

Guards against a gate that pins nothing: every marker list non-empty, floors on every section's row count, all 24 hashes 64-char hex, none equal to the empty digest, and all 24 distinct (a normalizer collapsing every function to the same non-empty text would otherwise pass).

`build_contract()` is deterministic across runs and re-export is byte-identical. `ruff`, `ruff format --check`, `mypy` (236 files) clean. The parity test plus the loopback-binding suites (`test_gateway_reuse_probe`, `test_per_enclave_probes`) pass unsandboxed: 65 passed.

## Sequencing

[#523](https://github.com/Lore-Hex/quill-router/pull/523) removes a dead leg from `classify_provider_failure`, which is hashed here. If it lands first this branch needs a rebase and one re-export — the gate doing its job. I'll handle that before merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
