### PR TITLE
Filter untrusted HTTP 405 events from Sentry

### DIFF
--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import hashlib
-import ipaddress
 import json
 import logging
 import os
 import sys
 import time
-from collections.abc import Callable, MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
 from threading import Lock
 from typing import Any, cast
@@ -204,11 +203,11 @@ def init_sentry(settings: Settings) -> None:
             # alert: Starlette answers 405 from the router without an exception
             # for Sentry to catch.
             #
-            # 405 is worth the exception to "don't alert on 4xx" because it is
-            # never a client mistake we can't fix — it means a path exists but
-            # not for that method, i.e. our own form or client targets a route
-            # we did not implement. Low volume, high signal. Other 4xx stay
-            # unreported: 401/402/404 are routine and would drown the signal.
+            # 405 is retained for same-origin UI requests and authenticated
+            # internal workers because those indicate a route contract we can
+            # fix. before_send drops bare public wrong-method traffic before it
+            # can consume the Sentry budget. Other 4xx stay unreported:
+            # 401/402/404 are routine and would drown the signal.
             StarletteIntegration(
                 transaction_style="endpoint",
                 failed_request_status_codes=SENTRY_FAILED_REQUEST_STATUS_CODES,
@@ -255,6 +254,7 @@ def before_send(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
     if _is_dropped_noise(event):
         return None
     event = _scrub(event)
+    _fingerprint_method_not_allowed(event)
     request = event.get("request")
     if isinstance(request, MutableMapping):
         request.pop("data", None)
@@ -291,48 +291,94 @@ def _is_dropped_noise(event: dict[str, Any]) -> bool:
         and "missing (instance_id)" in text
     ):
         return True
-    return _is_public_scanner_405(event)
+    return _is_untrusted_405(event)
 
 
-def _is_public_scanner_405(event: dict[str, Any]) -> bool:
-    """Drop only unmistakable CMS reconnaissance, not application 405s."""
-    exception = event.get("exception")
-    values = exception.get("values") if isinstance(exception, dict) else None
-    if not isinstance(values, list) or not values:
-        return False
-    latest = values[-1]
-    if not isinstance(latest, dict):
-        return False
-    if latest.get("type") != "HTTPException" or latest.get("value") != "Method Not Allowed":
+def _is_untrusted_405(event: dict[str, Any]) -> bool:
+    """Keep actionable first-party 405s without reporting public probes.
+
+    Public endpoints receive wrong-method requests continuously. A 405 is a
+    product signal only when it came from one of our rendered pages or an
+    authenticated internal worker. SDK/API callers can choose arbitrary HTTP
+    methods, so a bare 405 from the public internet is not a server regression.
+    """
+    if not _is_method_not_allowed_event(event):
         return False
 
     request = event.get("request")
-    if not isinstance(request, dict):
-        return False
-    target = " ".join(
-        str(request.get(field) or "") for field in ("url", "query_string", "path")
-    ).lower()
-    scanner_markers = (
-        "rest_route=%2fbatch%2fv1",
-        "rest_route=/batch/v1",
-        "/wp-admin",
-        "/wp-login.php",
-        "/xmlrpc.php",
-    )
-    if any(marker in target for marker in scanner_markers):
+    if not isinstance(request, Mapping):
         return True
-
-    # Internet scanners also probe the load balancer's numeric address with a
-    # bare POST. This cannot be a supported product route, while the equivalent
-    # request on a named host remains visible as a potentially broken client.
-    method = str(request.get("method") or "").upper()
-    url = str(request.get("url") or "")
-    try:
-        parsed = urlsplit(url)
-        ipaddress.ip_address(parsed.hostname or "")
-    except (ValueError, TypeError):
+    headers = _request_headers(request)
+    if "x-trustedrouter-internal-token" in headers:
         return False
-    return method == "POST" and parsed.path in {"", "/"} and not parsed.query
+
+    request_host = _url_hostname(request.get("url"))
+    if request_host is None:
+        return True
+    for name in ("origin", "referer"):
+        if _url_hostname(headers.get(name)) == request_host:
+            return False
+    return True
+
+
+def _is_method_not_allowed_event(event: Mapping[str, Any]) -> bool:
+    contexts = event.get("contexts")
+    if isinstance(contexts, Mapping):
+        response = contexts.get("response")
+        if isinstance(response, Mapping) and str(response.get("status_code")) == "405":
+            return True
+
+    exception = event.get("exception")
+    values = exception.get("values") if isinstance(exception, Mapping) else None
+    if not isinstance(values, list):
+        return False
+    for value in values:
+        if not isinstance(value, Mapping):
+            continue
+        exception_type = str(value.get("type") or "").lower()
+        exception_value = str(value.get("value") or "").lower()
+        if "httpexception" in exception_type and "method not allowed" in exception_value:
+            return True
+    return False
+
+
+def _request_headers(request: Mapping[str, Any]) -> dict[str, str]:
+    raw_headers = request.get("headers")
+    if isinstance(raw_headers, Mapping):
+        return {str(name).lower(): str(value) for name, value in raw_headers.items()}
+    if isinstance(raw_headers, list):
+        headers: dict[str, str] = {}
+        for item in raw_headers:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                headers[str(item[0]).lower()] = str(item[1])
+        return headers
+    return {}
+
+
+def _url_hostname(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return urlsplit(value).hostname
+    except ValueError:
+        return None
+
+
+def _fingerprint_method_not_allowed(event: dict[str, Any]) -> None:
+    if not _is_method_not_allowed_event(event) or event.get("fingerprint"):
+        return
+    request = event.get("request")
+    if not isinstance(request, Mapping):
+        return
+    method = str(request.get("method") or "UNKNOWN").upper()
+    url = request.get("url")
+    path = "/"
+    if isinstance(url, str):
+        try:
+            path = urlsplit(url).path or "/"
+        except ValueError:
+            pass
+    event["fingerprint"] = ["http-405", method, path]
 
 
 def configure_sentry_floodgate(settings: Settings) -> None:

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -327,33 +327,117 @@ def test_sentry_failed_request_statuses_exclude_expected_compatibility_501() -> 
     assert 599 in SENTRY_FAILED_REQUEST_STATUS_CODES
 
 
-def test_sentry_drops_wordpress_scanner_405_but_keeps_application_405() -> None:
-    def event(url: str, *, method: str = "POST") -> dict:
-        return {
-            "level": "error",
-            "request": {"method": method, "url": url},
-            "exception": {
-                "values": [
-                    {
-                        "type": "HTTPException",
-                        "value": "Method Not Allowed",
-                    }
-                ]
-            },
-        }
+def _method_not_allowed_event(
+    url: str,
+    *,
+    method: str = "POST",
+    headers: dict[str, str] | list[list[str]] | None = None,
+) -> dict[str, object]:
+    return {
+        "level": "error",
+        "request": {"method": method, "url": url, "headers": headers or {}},
+        "exception": {
+            "values": [
+                {
+                    "type": "HTTPException",
+                    "value": "Method Not Allowed",
+                }
+            ]
+        },
+    }
 
-    assert (
-        before_send(
-            event("https://trustedrouter.com/?rest_route=%2Fbatch%2Fv1"),
-            {},
-        )
-        is None
+
+@pytest.mark.parametrize(
+    ("method", "url", "headers"),
+    [
+        (
+            "GET",
+            "https://trustedrouter.com/v1/internal/synthetic/route-health",
+            {"User-Agent": "meta-externalagent/1.1"},
+        ),
+        ("POST", "https://35.241.14.18/", {"User-Agent": "scanner"}),
+        (
+            "POST",
+            "https://trustedrouter.com/?rest_route=%2Fbatch%2Fv1",
+            {"User-Agent": "wp2shell"},
+        ),
+        (
+            "POST",
+            "https://trustedrouter.com/console/credits",
+            {"Origin": "https://attacker.example"},
+        ),
+    ],
+)
+def test_sentry_drops_untrusted_method_not_allowed_noise(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+) -> None:
+    reset_sentry_floodgate_for_tests()
+    assert before_send(
+        _method_not_allowed_event(url, method=method, headers=headers),
+        {},
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Referer": "https://trustedrouter.com/console/settings"},
+        [["Origin", "https://trustedrouter.com"]],
+        {"X-TrustedRouter-Internal-Token": "filtered-secret"},
+    ],
+)
+def test_sentry_keeps_trusted_405_and_fingerprints_method_and_path(
+    headers: dict[str, str] | list[list[str]],
+) -> None:
+    reset_sentry_floodgate_for_tests()
+    event = _method_not_allowed_event(
+        "https://trustedrouter.com/console/settings?source=console",
+        headers=headers,
     )
-    assert before_send(event("http://35.241.14.18/"), {}) is None
-    assert before_send(event("http://[2001:db8::1]/"), {}) is None
-    assert before_send(event("http://35.241.14.18/health"), {}) is not None
-    assert before_send(event("https://trustedrouter.com/"), {}) is not None
-    assert before_send(event("https://trustedrouter.com/console/credits"), {}) is not None
+
+    captured = before_send(event, {})
+
+    assert captured is not None
+    assert captured["fingerprint"] == ["http-405", "POST", "/console/settings"]
+    assert "fingerprint" not in event
+
+
+def test_sentry_recognizes_context_only_405_as_untrusted() -> None:
+    reset_sentry_floodgate_for_tests()
+    event = {
+        "request": {
+            "method": "GET",
+            "url": "https://trustedrouter.com/mcp",
+            "headers": {"User-Agent": "Infrawatch/1.0"},
+        },
+        "contexts": {"response": {"status_code": 405}},
+    }
+
+    assert before_send(event, {}) is None
+
+
+def test_sentry_keeps_non_405_server_errors_without_origin() -> None:
+    reset_sentry_floodgate_for_tests()
+    event = {
+        "level": "error",
+        "request": {"method": "POST", "url": "https://trustedrouter.com/v1/keys"},
+        "exception": {"values": [{"type": "RuntimeError", "value": "database failed"}]},
+    }
+
+    assert before_send(event, {}) is not None
+
+
+def test_sentry_does_not_mutate_dropped_scanner_event() -> None:
+    event = _method_not_allowed_event(
+        "https://trustedrouter.com/",
+        headers={"User-Agent": "scanner"},
+    )
+    original = json.loads(json.dumps(event))
+
+    assert before_send(event, {}) is None
+    assert event == original
 
 
 def test_sentry_floodgate_drops_repeated_issue_after_per_fingerprint_limit() -> None:


### PR DESCRIPTION
## Summary
- classify HTTP 405 events as actionable only for same-origin browser requests or authenticated internal workers
- drop crawler, scanner, cross-origin, and headerless 405 traffic before the Sentry floodgate
- fingerprint retained 405s by method and path

## Root cause
QUILL-ROUTER-3V grouped public wrong-method traffic under one FastAPI HTTPException. The last reported event was Meta externalagent issuing GET /v1/internal/synthetic/route-health; nearby events were direct-IP, /mcp, and WordPress exploit probes. Release a0a8be0 did not introduce a route regression.

## Verification
- uv run ruff check src/trusted_router/sentry_config.py tests/test_security_contracts.py
- uv run mypy src/trusted_router/sentry_config.py
- uv run pytest -q tests/test_security_contracts.py (35 passed)