### PR TITLE
Canonicalize all mirror-domain public pages

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -58,6 +58,7 @@ from trusted_router.content.legal import (
     subprocessor_packet,
 )
 from trusted_router.content_handling import CONTENT_HANDLING_CLAIM
+from trusted_router.domains import canonical_public_url
 from trusted_router.measured import measured_for_model, measured_for_provider
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR, format_money_precise
 from trusted_router.og import OG_DESCRIPTION, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, OG_TITLE
@@ -1542,7 +1543,7 @@ def dashboard_html(
     domain = settings.trusted_domain
     resolved_api_base_url = api_base_url or settings.api_base_url
     environment = settings.environment.lower()
-    canonical_site_url = f"https://{domain}/"
+    canonical_site_url = canonical_public_url(settings)
     site_url = site_url or canonical_site_url
     alternate_brand = brand_name != "TrustedRouter"
     page_title = f"{brand_name} | Every model. Privacy with proof." if alternate_brand else OG_TITLE
@@ -1862,7 +1863,8 @@ def _render_public_page(
     site_url: str | None = None,
     robots_meta: str | None = None,
 ) -> str:
-    resolved_site_url = site_url or f"https://{settings.trusted_domain}{path}"
+    canonical_url = canonical_public_url(settings, path)
+    resolved_site_url = site_url or canonical_url
     catalog_evidence = (
         seo_catalog_evidence(page_key, test_mode=settings.environment == "test")
         if page_key is not None and page.template.startswith("public/seo_")
@@ -1875,6 +1877,7 @@ def _render_public_page(
             api_base_url=settings.api_base_url,
             control_plane_api_base_url=f"https://{settings.trusted_domain}/v1",
             site_url=resolved_site_url,
+            canonical_url=canonical_url,
             title=f"{page.title} | TrustedRouter",
             heading=page.title,
             description=page.description,

--- a/src/trusted_router/domains.py
+++ b/src/trusted_router/domains.py
@@ -72,6 +72,28 @@ def request_control_origin(request: Request, settings: Settings) -> str:
     return f"https://{request_control_domain(request, settings)}"
 
 
+def canonical_public_url(
+    settings: Settings,
+    path: str = "/",
+    *,
+    query: str | None = None,
+) -> str:
+    """Build a public URL on the one search-canonical control-plane host.
+
+    Alias domains intentionally remain usable, but their crawlable content is
+    the same publication. Keeping canonical URL construction request-agnostic
+    prevents an alias or hostile Host header from creating a second SEO origin.
+    """
+    if not path.startswith("/") or path.startswith("//") or any(
+        separator in path for separator in ("?", "#")
+    ):
+        raise ValueError("canonical public paths must be absolute paths without query data")
+    if query is not None and (not query or query.startswith("?") or "#" in query):
+        raise ValueError("canonical public queries must omit '?' and fragments")
+    origin = f"https://{configured_control_domains(settings)[0]}"
+    return f"{origin}{path}{f'?{query}' if query else ''}"
+
+
 def api_base_url_for_domain(settings: Settings, domain: str) -> str:
     canonical = configured_control_domains(settings)[0]
     normalized = _normalized_domain(domain)

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -94,6 +94,7 @@ from trusted_router.dashboard import (
     subprocessors_json,
 )
 from trusted_router.domains import (
+    canonical_public_url,
     control_domain_for_hostname,
     is_status_hostname,
     is_trust_hostname,
@@ -520,6 +521,12 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     def trust_response_status(status: str) -> int:
         return 200 if status in {"live", "embedded"} else 503
+
+    def public_document_headers(path: str) -> dict[str, str]:
+        return {
+            "cache-control": "public, max-age=300, s-maxage=3600",
+            "link": f'<{canonical_public_url(settings, path)}>; rel="canonical"',
+        }
 
     def public_html_route(
         path: str, *, include_slash: bool = True
@@ -1168,14 +1175,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def llms() -> PlainTextResponse:
         return PlainTextResponse(
             llms_txt(settings),
-            headers={"cache-control": "public, max-age=300, s-maxage=3600"},
+            headers=public_document_headers("/llms.txt"),
         )
 
     @app.api_route("/docs/llms.txt", methods=["GET", "HEAD"], response_class=PlainTextResponse)
     async def docs_llms() -> PlainTextResponse:
         return PlainTextResponse(
             docs_llms_txt(settings),
-            headers={"cache-control": "public, max-age=300, s-maxage=3600"},
+            headers=public_document_headers("/docs/llms.txt"),
         )
 
     @app.api_route(
@@ -1186,7 +1193,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def docs_llms_full() -> PlainTextResponse:
         return PlainTextResponse(
             docs_llms_full_txt(settings),
-            headers={"cache-control": "public, max-age=300, s-maxage=3600"},
+            headers=public_document_headers("/docs/llms-full.txt"),
         )
 
     @public_html_route("/status")
@@ -1703,6 +1710,11 @@ def _status_history_page_html(
         "public/status_history.html",
         api_base_url=settings.api_base_url,
         site_url=site_url,
+        canonical_url=canonical_public_url(
+            settings,
+            "/status/history",
+            query=f"window={window}",
+        ),
         title=title,
         heading=heading,
         description=(
@@ -2120,6 +2132,7 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
             else settings.api_base_url
         ),
         site_url=site_url,
+        canonical_url=canonical_public_url(settings, "/status"),
         title="Status | TrustedRouter",
         heading="TrustedRouter Status",
         description=(

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -18,7 +18,7 @@
   <meta name="description" content="{{ meta_description }}">
   {% include "_favicon.html" %}
   {% if robots_meta %}<meta name="robots" content="{{ robots_meta }}">{% endif %}
-  <link rel="canonical" href="{{ site_url }}">
+  <link rel="canonical" href="{{ canonical_url|default(site_url, true) }}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="TrustedRouter">
   <meta property="og:title" content="{{ meta_title }}">

--- a/tests/test_domain_aliases.py
+++ b/tests/test_domain_aliases.py
@@ -62,6 +62,81 @@ def test_alias_homepage_uses_attested_api_alias(
 
 
 @pytest.mark.parametrize("domain", ["allyrouter.com", "uptimerouter.com"])
+@pytest.mark.parametrize(
+    ("path", "canonical_path"),
+    [
+        ("/docs", "/docs"),
+        ("/openrouter-alternative", "/openrouter-alternative"),
+        ("/models/minimax/minimax-m3", "/models/minimax/minimax-m3"),
+        ("/providers/minimax", "/providers/minimax"),
+        ("/blog", "/blog"),
+        ("/api/reference?group=models&utm_source=mirror", "/api/reference"),
+    ],
+)
+def test_alias_public_pages_use_primary_canonical(
+    client: TestClient,
+    domain: str,
+    path: str,
+    canonical_path: str,
+) -> None:
+    response = client.get(path, headers={"host": domain})
+
+    assert response.status_code == 200
+    assert response.text.count('rel="canonical"') == 1
+    assert (
+        f'<link rel="canonical" href="https://trustedrouter.com{canonical_path}">'
+        in response.text
+    )
+
+
+@pytest.mark.parametrize("domain", ["allyrouter.com", "uptimerouter.com"])
+def test_alias_status_pages_use_primary_status_canonical(
+    client: TestClient,
+    domain: str,
+) -> None:
+    status = client.get("/", headers={"host": f"status.{domain}"})
+    history = client.get(
+        "/status/history?window=48h&format=html",
+        headers={"host": f"status.{domain}"},
+    )
+
+    assert status.status_code == 200
+    assert (
+        '<link rel="canonical" href="https://trustedrouter.com/status">'
+        in status.text
+    )
+    assert history.status_code == 200
+    assert (
+        '<link rel="canonical" '
+        'href="https://trustedrouter.com/status/history?window=48h">'
+        in history.text
+    )
+
+
+def test_eu_mirror_homepage_uses_primary_eu_canonical(client: TestClient) -> None:
+    response = client.get("/", headers={"host": "eu.trustedrouter.com"})
+
+    assert response.status_code == 200
+    assert '<link rel="canonical" href="https://trustedrouter.com/eu">' in response.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/llms.txt", "/docs/llms.txt", "/docs/llms-full.txt"],
+)
+def test_alias_plaintext_docs_publish_primary_canonical_link(
+    client: TestClient,
+    path: str,
+) -> None:
+    response = client.get(path, headers={"host": "allyrouter.com"})
+
+    assert response.status_code == 200
+    assert response.headers["link"] == (
+        f'<https://trustedrouter.com{path}>; rel="canonical"'
+    )
+
+
+@pytest.mark.parametrize("domain", ["allyrouter.com", "uptimerouter.com"])
 def test_alias_status_and_trust_hosts_render(
     client: TestClient,
     domain: str,


### PR DESCRIPTION
## Summary
- centralize public canonical URL construction on the primary TrustedRouter domain
- canonicalize UptimeRouter, AllyRouter, EU, and status mirror pages to trustedrouter.com
- publish canonical Link headers for llms.txt and agent documentation
- add host-level regression coverage across homepage, docs, SEO, model, provider, blog, API reference, status, and EU pages

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q
- 3344 passed, 254 skipped, 10 xfailed