### PR TITLE
Canonicalize trust page to TrustedRouter

### DIFF
--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -8,6 +8,7 @@ from typing import Any
 from trusted_router.config import Settings
 from trusted_router.domains import (
     api_base_url_for_domain,
+    canonical_public_url,
     configured_control_domains,
 )
 
@@ -117,7 +118,7 @@ def trust_html(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TrustedRouter Trust</title>
-  <link rel="canonical" href="https://trust.trustedrouter.com/">
+  <link rel="canonical" href="{html.escape(canonical_public_url(settings, '/trust'))}">
   <style>
     :root {{
       color-scheme: light;

--- a/tests/test_domain_aliases.py
+++ b/tests/test_domain_aliases.py
@@ -150,7 +150,7 @@ def test_alias_status_and_trust_hosts_render(
     assert trust.status_code == 200
     assert f"https://api.{domain}/v1" in trust.text
     assert f"https://api.{domain}/attestation" in trust.text
-    assert '<link rel="canonical" href="https://trust.trustedrouter.com/">' in trust.text
+    assert '<link rel="canonical" href="https://trustedrouter.com/trust">' in trust.text
 
 
 def test_alias_www_and_status_redirects_stay_on_alias(client: TestClient) -> None:

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -189,7 +189,7 @@ def test_duplicate_api_reference_surfaces_redirect_to_canonical(
         assert response.headers["location"] == "/api/reference"
 
 
-def test_trust_page_declares_dedicated_trust_host_as_canonical(
+def test_trust_page_declares_primary_trust_path_as_canonical(
     client: TestClient,
 ) -> None:
     for path, headers in [
@@ -199,7 +199,7 @@ def test_trust_page_declares_dedicated_trust_host_as_canonical(
         response = client.get(path, headers=headers)
         assert response.status_code == 200
         assert response.text.count('rel="canonical"') == 1
-        assert '<link rel="canonical" href="https://trust.trustedrouter.com/">' in response.text
+        assert '<link rel="canonical" href="https://trustedrouter.com/trust">' in response.text
 
 
 def test_indexnow_key_file_is_public(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- make both /trust and trust subdomains canonicalize to https://trustedrouter.com/trust
- remove the final public HTML exception to the single primary-domain canonical policy
- update primary and mirror-domain regressions

## Verification
- uv run pytest -q tests/test_domain_aliases.py tests/test_public_seo_pages.py -k 'trust_page or alias_status_and_trust_hosts_render'
- uv run ruff check src/trusted_router/trust.py tests/test_public_seo_pages.py tests/test_domain_aliases.py
- uv run mypy