### PR TITLE
Discover Tinfoil DeepSeek V4 Flash

### DIFF
--- a/scripts/pricing/providers/tinfoil.py
+++ b/scripts/pricing/providers/tinfoil.py
@@ -25,6 +25,7 @@ SLUG = "tinfoil"
 URL = "https://inference.tinfoil.sh/v1/models"
 
 EXPECTED_MODELS = [
+    "deepseek/deepseek-v4-flash",
     "z-ai/glm-5.2",
     "google/gemma-4-31b-it",
 ]
@@ -42,6 +43,7 @@ _NATIVE_TO_OR_ID = {
     "kimi-k3": "moonshotai/kimi-k3",
     "glm-5-1": "z-ai/glm-5.1",
     "glm-5-2": "z-ai/glm-5.2",
+    "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "gemma4-31b": "google/gemma-4-31b-it",
     "qwen3-vl-30b": "qwen/qwen3-vl-30b-a3b-instruct",

--- a/tests/test_tinfoil_pricing.py
+++ b/tests/test_tinfoil_pricing.py
@@ -33,3 +33,44 @@ def test_tinfoil_fetch_ingests_glm_52_cached_input_price(monkeypatch) -> None:  
     assert glm.completion_micro_per_m == 5_250_000
     assert glm.tiers[0].prompt_cached_micro_per_m == 375_000
     assert gemma.tiers[0].prompt_cached_micro_per_m is None
+
+
+def test_tinfoil_fetch_discovers_deepseek_v4_flash(monkeypatch) -> None:  # noqa: ANN001
+    payload = {
+        "data": [
+            {
+                "id": "deepseek-v4-flash",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.7,
+                    "cachedInputTokenPricePer1M": 0.125,
+                    "outputTokenPricePer1M": 1.9,
+                },
+            },
+            {
+                "id": "glm-5-2",
+                "pricing": {
+                    "inputTokenPricePer1M": 1.5,
+                    "outputTokenPricePer1M": 5.25,
+                },
+            },
+            {
+                "id": "gemma4-31b",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.4,
+                    "outputTokenPricePer1M": 1.0,
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(tinfoil, "fetch_json", lambda _url: payload)
+
+    result = tinfoil.fetch()
+    deepseek = result.prices["deepseek/deepseek-v4-flash"]
+
+    assert tinfoil.UPSTREAM_ID_MAP["deepseek/deepseek-v4-flash"] == (
+        "deepseek-v4-flash"
+    )
+    assert deepseek.prompt_micro_per_m == 700_000
+    assert deepseek.completion_micro_per_m == 1_900_000
+    assert deepseek.tiers[0].prompt_cached_micro_per_m == 125_000
+    assert not any("deepseek/deepseek-v4-flash" in note for note in result.notes)


### PR DESCRIPTION
## Summary

- map Tinfoil's native deepseek-v4-flash ID to the canonical TrustedRouter model
- require the route in Tinfoil pricing validation so future disappearance is visible
- cover live input, cached-input, and output pricing with a regression test

## Verification

- uv run pytest -q tests/test_tinfoil_pricing.py tests/test_tinfoil_august_2026_lifecycle.py
- uv run ruff check scripts/pricing/providers/tinfoil.py tests/test_tinfoil_pricing.py
- live Tinfoil feed maps to 700000 / 125000 cached / 1900000 microdollars per million tokens
