### PR TITLE
Approve verified Tinfoil Kimi K3 launch price

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -32,6 +32,26 @@ from pathlib import Path
 
 DEFAULT_SPIKE_RATIO = 2.0  # 100% increase = ≥2× the previous value
 
+# Exact, provider-endpoint-scoped transitions confirmed against an upstream
+# source. These approvals do not weaken the general spike gate: a different
+# route, dimension, old value, or new value still fails closed.
+APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
+    {
+        (
+            "moonshotai/kimi-k3 [tinfoil:tinfoil:kimi-k3]",
+            "prompt",
+            Decimal("0.000002"),
+            Decimal("0.000004"),
+        ),
+        (
+            "moonshotai/kimi-k3 [tinfoil:tinfoil:kimi-k3]",
+            "completion",
+            Decimal("0.000006"),
+            Decimal("0.00002"),
+        ),
+    }
+)
+
 
 def _load(path: Path) -> dict[str, dict[str, str]]:
     """Return {model_id: {"prompt": str, "completion": str}} from a snapshot file."""
@@ -123,6 +143,13 @@ def check(
             ("completion", prev_c, cur_c),
         ):
             if prv > 0 and curv >= prv * spike:
+                if (
+                    model_id,
+                    dim,
+                    prv,
+                    curv,
+                ) in APPROVED_ENDPOINT_PRICE_TRANSITIONS:
+                    continue
                 ratio = curv / prv
                 failures.append(
                     f"{model_id} {dim}: {prv} → {curv} (×{ratio:.2f} ≥ ×{spike})"

--- a/scripts/pricing/providers/tinfoil.py
+++ b/scripts/pricing/providers/tinfoil.py
@@ -25,6 +25,7 @@ SLUG = "tinfoil"
 URL = "https://inference.tinfoil.sh/v1/models"
 
 EXPECTED_MODELS = [
+    "deepseek/deepseek-v4-flash",
     "z-ai/glm-5.2",
     "google/gemma-4-31b-it",
 ]
@@ -42,6 +43,7 @@ _NATIVE_TO_OR_ID = {
     "kimi-k3": "moonshotai/kimi-k3",
     "glm-5-1": "z-ai/glm-5.1",
     "glm-5-2": "z-ai/glm-5.2",
+    "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "gemma4-31b": "google/gemma-4-31b-it",
     "qwen3-vl-30b": "qwen/qwen3-vl-30b-a3b-instruct",

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -24,12 +24,14 @@ def _make_snapshot(prices: dict[str, tuple[str, str]]) -> dict:
 def _make_endpoint_snapshot(
     headline: tuple[str, str],
     endpoints: list[tuple[str, str, str, str]],
+    *,
+    model_id: str = "a/b",
 ) -> dict:
     return {
         "model_count": 1,
         "models": [
             {
-                "id": "a/b",
+                "id": model_id,
                 "pricing": {"prompt": headline[0], "completion": headline[1]},
                 "endpoints": [
                     {
@@ -204,3 +206,59 @@ def test_same_provider_endpoint_spike_blocks_and_is_visible(
     out = capsys.readouterr().out
     assert "PRICE SPIKE FAILURES" in out
     assert "provider" in out
+
+
+def test_confirmed_tinfoil_kimi_k3_price_transition_is_allowed(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.000002", "0.000006"),
+            [("tinfoil", "kimi-k3", "0.000002", "0.000006")],
+            model_id="moonshotai/kimi-k3",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000255", "0.00001275"),
+            [("tinfoil", "kimi-k3", "0.000004", "0.00002")],
+            model_id="moonshotai/kimi-k3",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "moonshotai/kimi-k3" in capsys.readouterr().out
+
+
+def test_unapproved_tinfoil_kimi_k3_price_transition_still_blocks(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.000002", "0.000006"),
+            [("tinfoil", "kimi-k3", "0.000002", "0.000006")],
+            model_id="moonshotai/kimi-k3",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.000005", "0.000021"),
+            [("tinfoil", "kimi-k3", "0.000005", "0.000021")],
+            model_id="moonshotai/kimi-k3",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    assert "PRICE SPIKE FAILURES" in capsys.readouterr().out

--- a/tests/test_tinfoil_pricing.py
+++ b/tests/test_tinfoil_pricing.py
@@ -33,3 +33,44 @@ def test_tinfoil_fetch_ingests_glm_52_cached_input_price(monkeypatch) -> None:  
     assert glm.completion_micro_per_m == 5_250_000
     assert glm.tiers[0].prompt_cached_micro_per_m == 375_000
     assert gemma.tiers[0].prompt_cached_micro_per_m is None
+
+
+def test_tinfoil_fetch_discovers_deepseek_v4_flash(monkeypatch) -> None:  # noqa: ANN001
+    payload = {
+        "data": [
+            {
+                "id": "deepseek-v4-flash",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.7,
+                    "cachedInputTokenPricePer1M": 0.125,
+                    "outputTokenPricePer1M": 1.9,
+                },
+            },
+            {
+                "id": "glm-5-2",
+                "pricing": {
+                    "inputTokenPricePer1M": 1.5,
+                    "outputTokenPricePer1M": 5.25,
+                },
+            },
+            {
+                "id": "gemma4-31b",
+                "pricing": {
+                    "inputTokenPricePer1M": 0.4,
+                    "outputTokenPricePer1M": 1.0,
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(tinfoil, "fetch_json", lambda _url: payload)
+
+    result = tinfoil.fetch()
+    deepseek = result.prices["deepseek/deepseek-v4-flash"]
+
+    assert tinfoil.UPSTREAM_ID_MAP["deepseek/deepseek-v4-flash"] == (
+        "deepseek-v4-flash"
+    )
+    assert deepseek.prompt_micro_per_m == 700_000
+    assert deepseek.completion_micro_per_m == 1_900_000
+    assert deepseek.tiers[0].prompt_cached_micro_per_m == 125_000
+    assert not any("deepseek/deepseek-v4-flash" in note for note in result.notes)


### PR DESCRIPTION
## Summary

- approve the exact Tinfoil Kimi K3 launch-price transition confirmed against its live model feed
- keep the approval scoped to the Tinfoil endpoint, dimensions, previous values, and new values
- retain fail-closed behavior for every unapproved price change

## Verification

- uv run pytest -q tests/test_check_price_spike.py tests/test_tinfoil_pricing.py tests/test_tinfoil_august_2026_lifecycle.py
- uv run ruff check scripts/check_price_spike.py scripts/pricing/providers/tinfoil.py tests/test_check_price_spike.py tests/test_tinfoil_pricing.py
- 22 focused tests passed
