### PR TITLE
Fix alert reconciler IAM and add payment fee floor

### DIFF
--- a/scripts/deploy/gateway_reliability.sh
+++ b/scripts/deploy/gateway_reliability.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Provision early, customer-facing billing-path alerts.
+# IAM bootstrap (project IAM administrator only):
+#   bash scripts/deploy/gateway_reliability_iam.sh --apply
 
 set -euo pipefail
 

--- a/scripts/deploy/gateway_reliability_iam.sh
+++ b/scripts/deploy/gateway_reliability_iam.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Bootstrap the least-privilege role used by gateway-reliability.yml.
+#
+# This must be run by a project IAM administrator. The workflow identity must
+# never receive project-IAM mutation rights merely so it can grant itself this
+# role.
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-quill-cloud-proxy}"
+RECONCILER_SERVICE_ACCOUNT="${TR_ALERT_RECONCILER_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+ROLE_ID="${TR_ALERT_RECONCILER_ROLE_ID:-trustedRouterAlertReconciler}"
+ROLE_NAME="projects/${PROJECT_ID}/roles/${ROLE_ID}"
+# Monitoring replaces the associated Logging notification rule when a
+# log-matched policy is updated. Google therefore requires rule create/delete
+# in addition to alertPolicies.update; neither permission grants log access.
+PERMISSIONS="logging.logMetrics.create,logging.logMetrics.get,logging.logMetrics.list,logging.logMetrics.update,logging.notificationRules.create,logging.notificationRules.delete,monitoring.alertPolicies.create,monitoring.alertPolicies.get,monitoring.alertPolicies.list,monitoring.alertPolicies.update,monitoring.notificationChannelDescriptors.get,monitoring.notificationChannelDescriptors.list,monitoring.notificationChannels.create,monitoring.notificationChannels.get,monitoring.notificationChannels.list"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+gc() {
+  gcloud --project "$PROJECT_ID" "$@"
+}
+
+if gc iam roles describe "$ROLE_ID" >/dev/null 2>&1; then
+  run gc iam roles update "$ROLE_ID" \
+    --title="TrustedRouter Alert Reconciler" \
+    --description="Reconciles TrustedRouter-owned log metrics and alerts; cannot delete metrics or policies, read logs, or change IAM." \
+    --permissions="$PERMISSIONS" \
+    --stage=GA \
+    --quiet
+else
+  run gc iam roles create "$ROLE_ID" \
+    --title="TrustedRouter Alert Reconciler" \
+    --description="Reconciles TrustedRouter-owned log metrics and alerts; cannot delete metrics or policies, read logs, or change IAM." \
+    --permissions="$PERMISSIONS" \
+    --stage=GA \
+    --quiet
+fi
+
+member="serviceAccount:${RECONCILER_SERVICE_ACCOUNT}"
+bound_role="$(gc projects get-iam-policy "$PROJECT_ID" \
+  --flatten='bindings[].members' \
+  --filter="bindings.role=${ROLE_NAME} AND bindings.members=${member}" \
+  --format='value(bindings.role)' 2>/dev/null || true)"
+if [ "$bound_role" != "$ROLE_NAME" ]; then
+  run gc projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="$member" \
+    --role="$ROLE_NAME" \
+    --quiet
+fi
+
+echo "Gateway alert reconciler IAM is configured for ${RECONCILER_SERVICE_ACCOUNT}"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -359,6 +359,7 @@ ENV_VARS=(
   # Replace these zeros with the signed Adyen commercial terms before launch.
   "TR_ADYEN_CARD_FEE_BASIS_POINTS=0"
   "TR_ADYEN_CARD_FEE_FIXED_CENTS=0"
+  "TR_CHECKOUT_CARD_FEE_MINIMUM_CENTS=80"
   "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com,https://b.trustedrouter.com,https://c.allyrouter.com"
   # /trustedos partner-inquiry form leads. Plain env (an address, not a
   # secret); without it the handler falls back to TR_SES_FROM_EMAIL, which

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -353,6 +353,9 @@ class Settings(BaseSettings):
     # They are explicit config because negotiated Stripe pricing can differ.
     stripe_card_fee_basis_points: int = 290
     stripe_card_fee_fixed_cents: int = 30
+    # Card-style rails have a purchase-fee floor. ACH and stablecoin retain
+    # their lower rail-specific schedules and deliberately do not use it.
+    checkout_card_fee_minimum_cents: int = 80
     stripe_stablecoin_fee_basis_points: int = 150
     stripe_stablecoin_fee_fixed_cents: int = 0
     stripe_ach_fee_basis_points: int = 80
@@ -765,6 +768,10 @@ class Settings(BaseSettings):
                 raise ValueError(f"{name} must be between 0 and 9999")
         for name, value in (
             ("TR_STRIPE_CARD_FEE_FIXED_CENTS", self.stripe_card_fee_fixed_cents),
+            (
+                "TR_CHECKOUT_CARD_FEE_MINIMUM_CENTS",
+                self.checkout_card_fee_minimum_cents,
+            ),
             (
                 "TR_STRIPE_STABLECOIN_FEE_FIXED_CENTS",
                 self.stripe_stablecoin_fee_fixed_cents,

--- a/src/trusted_router/services/adyen_billing.py
+++ b/src/trusted_router/services/adyen_billing.py
@@ -99,6 +99,7 @@ def create_adyen_checkout_session(
         credit_amount_cents=credit_amount_cents,
         variable_basis_points=settings.adyen_card_fee_basis_points,
         fixed_fee_cents=settings.adyen_card_fee_fixed_cents,
+        minimum_fee_cents=settings.checkout_card_fee_minimum_cents,
     )
     merchant_reference = _new_checkout_reference(
         workspace_id=workspace_id,

--- a/src/trusted_router/services/auto_refill.py
+++ b/src/trusted_router/services/auto_refill.py
@@ -101,6 +101,7 @@ def maybe_charge_after_settle(
         credit_amount_cents=credit_amount_cents,
         variable_basis_points=settings.stripe_card_fee_basis_points,
         fixed_fee_cents=settings.stripe_card_fee_fixed_cents,
+        minimum_fee_cents=settings.checkout_card_fee_minimum_cents,
     )
     idempotency_key = (
         f"auto-refill:{workspace_id}:{fee.charge_amount_cents}:"

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -67,6 +67,7 @@ def create_paypal_checkout_session(
         credit_amount_cents=credit_amount_cents,
         variable_basis_points=settings.stripe_card_fee_basis_points,
         fixed_fee_cents=settings.stripe_card_fee_fixed_cents,
+        minimum_fee_cents=settings.checkout_card_fee_minimum_cents,
     )
     workspace = STORE.get_workspace(workspace_id)
     if workspace is None:

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -51,12 +51,16 @@ def create_checkout_session(
     else:
         fee_basis_points = settings.stripe_card_fee_basis_points
         fee_fixed_cents = settings.stripe_card_fee_fixed_cents
+        fee_minimum_cents = settings.checkout_card_fee_minimum_cents
         fee_max_cents = None
         payment_method = "card"
+    if ach_requested or stablecoin_requested:
+        fee_minimum_cents = 0
     fee = stripe_processing_fee(
         credit_amount_cents=amount_cents,
         variable_basis_points=fee_basis_points,
         fixed_fee_cents=fee_fixed_cents,
+        minimum_fee_cents=fee_minimum_cents,
         max_fee_cents=fee_max_cents,
     )
     payment_metadata = fee.metadata(

--- a/src/trusted_router/services/stripe_fees.py
+++ b/src/trusted_router/services/stripe_fees.py
@@ -20,6 +20,7 @@ class ProcessingFee:
     charge_amount_cents: int
     variable_basis_points: int
     fixed_fee_cents: int
+    minimum_fee_cents: int = 0
     max_fee_cents: int | None = None
 
     @property
@@ -100,6 +101,7 @@ class ProcessingFee:
             "charge_amount_cents": str(self.charge_amount_cents),
             "fee_variable_basis_points": str(self.variable_basis_points),
             "fee_fixed_cents": str(self.fixed_fee_cents),
+            "fee_minimum_cents": str(self.minimum_fee_cents),
         }
         if self.max_fee_cents is not None:
             metadata["fee_max_cents"] = str(self.max_fee_cents)
@@ -111,6 +113,7 @@ def processing_fee(
     credit_amount_cents: int,
     variable_basis_points: int,
     fixed_fee_cents: int,
+    minimum_fee_cents: int = 0,
     max_fee_cents: int | None = None,
 ) -> ProcessingFee:
     """Gross up a USD-cent principal so it survives the configured fee.
@@ -126,8 +129,12 @@ def processing_fee(
         raise ValueError("variable_basis_points must be between 0 and 9999")
     if fixed_fee_cents < 0:
         raise ValueError("fixed_fee_cents cannot be negative")
+    if minimum_fee_cents < 0:
+        raise ValueError("minimum_fee_cents cannot be negative")
     if max_fee_cents is not None and max_fee_cents < 0:
         raise ValueError("max_fee_cents cannot be negative")
+    if max_fee_cents is not None and minimum_fee_cents > max_fee_cents:
+        raise ValueError("minimum_fee_cents cannot exceed max_fee_cents")
 
     denominator = 10_000 - variable_basis_points
     uncapped_charge_amount_cents = _ceil_div(
@@ -141,13 +148,18 @@ def processing_fee(
         charge_amount_cents = credit_amount_cents + max_fee_cents
     else:
         charge_amount_cents = uncapped_charge_amount_cents
-    processing_fee_cents = charge_amount_cents - credit_amount_cents
+    processing_fee_cents = max(
+        charge_amount_cents - credit_amount_cents,
+        minimum_fee_cents,
+    )
+    charge_amount_cents = credit_amount_cents + processing_fee_cents
     return ProcessingFee(
         credit_amount_cents=credit_amount_cents,
         processing_fee_cents=processing_fee_cents,
         charge_amount_cents=charge_amount_cents,
         variable_basis_points=variable_basis_points,
         fixed_fee_cents=fixed_fee_cents,
+        minimum_fee_cents=minimum_fee_cents,
         max_fee_cents=max_fee_cents,
     )
 

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -30,7 +30,8 @@
       <button class="btn primary" type="submit">Continue to checkout</button>
       <p class="form-help">
         Card and PayPal checkouts show your credits and the same payment
-        processing fee as separate line items before you pay. ACH and
+        processing fee as separate line items before you pay, with an $0.80
+        minimum fee. ACH and
         stablecoin keep their lower rail-specific fees. ACH is 0.8%, capped
         at $5, and can take up to four business days. Bank-funded credits
         appear only after settlement.

--- a/tests/test_adyen_billing.py
+++ b/tests/test_adyen_billing.py
@@ -208,6 +208,37 @@ def test_adyen_checkout_session_has_exact_money_and_no_balance_side_effect(
     assert sum(item["amountIncludingTax"] for item in payload["lineItems"]) == 2609
 
 
+def test_small_adyen_checkout_applies_card_fee_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(201, json={"id": "CS_FLOOR", "sessionData": "opaque"})
+
+    monkeypatch.setattr(
+        adyen_billing.httpx,
+        "Client",
+        _http_client_factory(handler),
+    )
+    app = create_app(
+        _settings(adyen_card_fee_basis_points=300, adyen_card_fee_fixed_cents=30),
+        init_observability=False,
+    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"x-trustedrouter-user": "adyen@example.com"},
+            json={"amount": "3.00", "payment_method": "adyen"},
+        )
+
+    assert response.status_code == 201, response.text
+    payload = captured["payload"]
+    assert payload["amount"] == {"currency": "USD", "value": 380}
+    assert [item["amountIncludingTax"] for item in payload["lineItems"]] == [300, 80]
+
+
 def test_adyen_inactive_merchant_is_a_retryable_checkout_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_auto_refill.py
+++ b/tests/test_auto_refill.py
@@ -179,6 +179,33 @@ def test_auto_refill_fires_below_threshold(
     assert account.last_auto_refill_status == "pending"
 
 
+def test_small_auto_refill_applies_card_fee_floor(stripe_settings: Settings) -> None:
+    user = STORE.ensure_user("small-refill@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.set_stripe_customer(
+        workspace.id,
+        customer_id="cus_small",
+        payment_method_id="pm_small",
+    )
+    STORE.update_auto_refill_settings(
+        workspace.id,
+        enabled=True,
+        threshold_microdollars=2_000_000,
+        amount_microdollars=3_000_000,
+    )
+    STORE.settle(STORE.reserve(workspace.id, "small-key", 9_000_000).id, 9_000_000)
+
+    fake_intent = MagicMock(id="pi_small")
+    with patch("stripe.PaymentIntent.create", return_value=fake_intent) as create:
+        outcome = maybe_charge_after_settle(workspace.id, settings=stripe_settings)
+
+    assert outcome.fired is True
+    kwargs = create.call_args.kwargs
+    assert kwargs["amount"] == 380
+    assert kwargs["metadata"]["processing_fee_cents"] == "80"
+    assert kwargs["metadata"]["fee_minimum_cents"] == "80"
+
+
 def test_auto_refill_records_card_error(
     configured_workspace: str, stripe_settings: Settings
 ) -> None:

--- a/tests/test_gateway_reliability_deploy.py
+++ b/tests/test_gateway_reliability_deploy.py
@@ -85,3 +85,34 @@ def test_gateway_alert_workflow_requires_explicit_apply() -> None:
     assert "tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com" in workflow
     assert "install_components: beta" in workflow
     assert "gateway_reliability.sh --apply" in workflow
+
+
+def test_gateway_alert_iam_is_least_privilege_and_dry_run_by_default() -> None:
+    script = (DEPLOY / "gateway_reliability_iam.sh").read_text(encoding="utf-8")
+
+    assert 'if [ "${1:-}" = "--apply" ]' in script
+    assert "trustedRouterAlertReconciler" in script
+    for permission in (
+        "logging.logMetrics.create",
+        "logging.logMetrics.get",
+        "logging.logMetrics.list",
+        "logging.logMetrics.update",
+        # Cloud Monitoring replaces this associated Logging object whenever a
+        # log-matched policy is updated.
+        "logging.notificationRules.create",
+        "logging.notificationRules.delete",
+        "monitoring.alertPolicies.create",
+        "monitoring.alertPolicies.get",
+        "monitoring.alertPolicies.list",
+        "monitoring.alertPolicies.update",
+        "monitoring.notificationChannels.create",
+        "monitoring.notificationChannels.get",
+        "monitoring.notificationChannels.list",
+    ):
+        assert permission in script
+    assert "logging.logEntries.list" not in script
+    assert "logging.logMetrics.delete" not in script
+    assert "monitoring.alertPolicies.delete" not in script
+    assert "resourcemanager.projects.setIamPolicy" not in script
+    assert "roles/logging.admin" not in script
+    assert "roles/monitoring.admin" not in script

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -1157,6 +1157,10 @@ def test_console_workspace_selector_persists_session_workspace(
         assert f'<option value="{org.id}" selected>' in workspace_page.text, path
         assert f'<option value="{personal.id}" selected>' not in workspace_page.text, path
 
+    credits_page = client.get("/console/credits")
+    normalized_credits = " ".join(credits_page.text.split())
+    assert "with an $0.80 minimum fee" in normalized_credits
+
     created = client.post(
         "/console/api-keys",
         data={"name": "org-key", "limit": ""},

--- a/tests/test_paypal_processing_fees.py
+++ b/tests/test_paypal_processing_fees.py
@@ -240,6 +240,23 @@ def test_mock_paypal_checkout_reports_same_fee_breakdown(
     assert data["total_microdollars"] == 26_060_000
 
 
+def test_small_paypal_checkout_applies_eighty_cent_fee_floor(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    response = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": 3, "payment_method": "paypal"},
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()["data"]
+    assert data["amount_microdollars"] == 3_000_000
+    assert data["processing_fee_microdollars"] == 800_000
+    assert data["total_microdollars"] == 3_800_000
+
+
 def test_paypal_capture_rejects_cross_workspace_reference(
     client: TestClient,
     user_headers: dict[str, str],

--- a/tests/test_stripe_processing_fees.py
+++ b/tests/test_stripe_processing_fees.py
@@ -40,6 +40,34 @@ def test_stablecoin_fee_grosses_up_principal_without_fixed_fee() -> None:
     assert fee.estimated_processor_cost_cents() <= fee.processing_fee_cents
 
 
+def test_card_purchase_fee_honors_eighty_cent_floor() -> None:
+    fee = stripe_processing_fee(
+        credit_amount_cents=300,
+        variable_basis_points=290,
+        fixed_fee_cents=30,
+        minimum_fee_cents=80,
+    )
+
+    assert fee.credit_amount_cents == 300
+    assert fee.processing_fee_cents == 80
+    assert fee.charge_amount_cents == 380
+    assert fee.estimated_processor_cost_cents() <= fee.processing_fee_cents
+    assert fee.metadata(workspace_id="ws_test", payment_method="card")[
+        "fee_minimum_cents"
+    ] == "80"
+
+
+def test_processing_fee_rejects_minimum_above_cap() -> None:
+    with pytest.raises(ValueError, match="minimum_fee_cents cannot exceed"):
+        stripe_processing_fee(
+            credit_amount_cents=300,
+            variable_basis_points=80,
+            fixed_fee_cents=0,
+            minimum_fee_cents=80,
+            max_fee_cents=50,
+        )
+
+
 def test_ach_fee_is_integer_only_and_caps_at_five_dollars() -> None:
     small = stripe_processing_fee(
         credit_amount_cents=2_500,
@@ -63,7 +91,7 @@ def test_ach_fee_is_integer_only_and_caps_at_five_dollars() -> None:
 
 
 @given(
-    credit_amount_cents=st.integers(min_value=100, max_value=1_000_000),
+    credit_amount_cents=st.integers(min_value=1, max_value=1_000_000),
     variable_basis_points=st.integers(min_value=0, max_value=900),
     fixed_fee_cents=st.integers(min_value=0, max_value=100),
 )
@@ -86,6 +114,40 @@ def test_processing_fee_is_minimal_and_always_preserves_principal(
             lower_charge * variable_basis_points + 9_999
         ) // 10_000 + fixed_fee_cents
         assert lower_charge - lower_cost < credit_amount_cents
+
+
+@given(
+    credit_amount_cents=st.integers(min_value=1, max_value=1_000_000),
+    variable_basis_points=st.integers(min_value=0, max_value=900),
+    fixed_fee_cents=st.integers(min_value=0, max_value=100),
+    minimum_fee_cents=st.integers(min_value=0, max_value=200),
+)
+def test_processing_fee_floor_is_exact_and_preserves_principal(
+    credit_amount_cents: int,
+    variable_basis_points: int,
+    fixed_fee_cents: int,
+    minimum_fee_cents: int,
+) -> None:
+    without_floor = stripe_processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=variable_basis_points,
+        fixed_fee_cents=fixed_fee_cents,
+    )
+    with_floor = stripe_processing_fee(
+        credit_amount_cents=credit_amount_cents,
+        variable_basis_points=variable_basis_points,
+        fixed_fee_cents=fixed_fee_cents,
+        minimum_fee_cents=minimum_fee_cents,
+    )
+
+    assert with_floor.processing_fee_cents == max(
+        without_floor.processing_fee_cents,
+        minimum_fee_cents,
+    )
+    assert with_floor.charge_amount_cents == (
+        credit_amount_cents + with_floor.processing_fee_cents
+    )
+    assert with_floor.estimated_processor_cost_cents() <= with_floor.processing_fee_cents
 
 
 def test_checkout_rejects_subcent_credit_amount() -> None:
@@ -135,6 +197,75 @@ def test_card_checkout_uses_separate_credit_and_processing_fee_line_items(
     assert data["amount_microdollars"] == 25_000_000
     assert data["processing_fee_microdollars"] == 1_060_000
     assert data["total_microdollars"] == 26_060_000
+
+
+def test_small_card_checkout_applies_fee_floor(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_floor"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_floor", "url": "https://checkout.stripe.test/floor"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 3, "payment_method": "card"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert [item["price_data"]["unit_amount"] for item in captured["line_items"]] == [
+        300,
+        80,
+    ]
+    assert captured["metadata"]["fee_minimum_cents"] == "80"
+    assert response.json()["data"]["processing_fee_microdollars"] == 800_000
+
+
+def test_small_stablecoin_checkout_keeps_lower_rail_fee(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    app = create_app(
+        Settings(environment="test", stripe_secret_key="sk_test_crypto_floor"),  # noqa: S106
+        init_observability=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_crypto_floor", "url": "https://checkout.stripe.test/crypto"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 3, "payment_method": "stablecoin"},
+        )
+
+    assert response.status_code == 201, response.text
+    assert [item["price_data"]["unit_amount"] for item in captured["line_items"]] == [
+        300,
+        5,
+    ]
+    assert captured["metadata"]["fee_minimum_cents"] == "0"
 
 
 def test_explicit_card_checkout_saves_only_a_reusable_card(


### PR DESCRIPTION
## Summary
- add a least-privilege custom IAM bootstrap for gateway alert reconciliation
- apply a configurable /bin/zsh.80 minimum fee to card, PayPal, Adyen, and card auto-refill checkouts
- preserve lower ACH and stablecoin fee schedules
- add exact integer-math, checkout, UI, and IAM regression tests

## Production verification
- custom role applied to tr-deploy
- production gateway alert reconciler completed successfully with the deployment identity

## Tests
- mypy
- ruff
- pytest: 3362 passed, 254 skipped, 10 xfailed
- focused payment/IAM tests: 142 passed
- shell syntax and diff checks