### PR TITLE
Fix automatic provider launch discovery

### DIFF
--- a/scripts/pricing/providers/gemini.py
+++ b/scripts/pricing/providers/gemini.py
@@ -26,7 +26,11 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
+import httpx
+
 from scripts.pricing.base import (
+    PROVIDER_FETCH_TIMEOUT,
+    PROVIDER_FETCH_UA,
     ProviderPricingResult,
     fetch_json,
     fetch_provider,
@@ -34,6 +38,7 @@ from scripts.pricing.base import (
     reconcile_manifest_tombstones,
     validate,
 )
+from scripts.pricing.manifest import apply_canary_results, models_requiring_canary
 
 SLUG = "gemini"
 URL = "https://ai.google.dev/gemini-api/docs/pricing"
@@ -54,6 +59,7 @@ EXPECTED_MODELS = [
     "google/gemini-2.5-flash-lite",
     "google/gemini-3.5-flash",
     "google/gemini-3.6-flash",
+    "google/gemini-3.7-flash",
 ]
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 _STANDARD_TEXT_MODEL_RE = re.compile(r"^google/gemini-\d+(?:\.\d+)?-(?:pro|flash|flash-lite)$")
@@ -163,6 +169,55 @@ def _new_required_price_ids(live_rows: dict[str, dict[str, Any]]) -> frozenset[s
     )
 
 
+def _probe_generate_content(*, api_key: str | None, native_id: str) -> bool:
+    """Run a minimal paid-path Gemini canary without retaining its content."""
+
+    if not api_key:
+        return False
+    try:
+        response = httpx.post(
+            f"https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{native_id}:generateContent",
+            headers={
+                "x-goog-api-key": api_key,
+                "Content-Type": "application/json",
+                "User-Agent": PROVIDER_FETCH_UA,
+            },
+            json={
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": "Reply exactly PONG"}],
+                    }
+                ],
+                "generationConfig": {"maxOutputTokens": 64},
+            },
+            timeout=PROVIDER_FETCH_TIMEOUT,
+        )
+    except httpx.HTTPError:
+        return False
+    if response.status_code != 200:
+        return False
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        return False
+    candidates = payload.get("candidates") if isinstance(payload, dict) else None
+    if not isinstance(candidates, list) or not candidates:
+        return False
+    first = candidates[0]
+    content = first.get("content") if isinstance(first, dict) else None
+    parts = content.get("parts") if isinstance(content, dict) else None
+    if not isinstance(parts, list):
+        return False
+    visible = "".join(
+        str(part.get("text") or "")
+        for part in parts
+        if isinstance(part, dict) and part.get("thought") is not True
+    )
+    return visible.strip() == "PONG"
+
+
 def _refresh_price(row: dict[str, Any], result: ProviderPricingResult, model_id: str) -> bool:
     price = result.prices.get(model_id)
     if price is None:
@@ -232,17 +287,35 @@ def fetch() -> ProviderPricingResult:
         expected_models=EXPECTED_MODELS,
         required_models=required_price_ids,
     )
-    _DISCOVERED_MANIFEST_ROWS = live_rows
     result.prices = {
         model_id: price for model_id, price in result.prices.items() if model_id in live_rows
     }
     errors = validate(result.prices, EXPECTED_MODELS)
     if errors:
         raise RuntimeError("; ".join(errors))
+    api_key = os.environ.get("GEMINI_API_KEY")
+    checked = models_requiring_canary(MANIFEST_PATH, result.prices)
+    healthy = {
+        model_id
+        for model_id in checked
+        if _probe_generate_content(
+            api_key=api_key,
+            native_id=str(live_rows[model_id]["upstream_id"]),
+        )
+    }
+    apply_canary_results(
+        live_rows,
+        checked_model_ids=checked,
+        healthy_model_ids=healthy,
+    )
+    _DISCOVERED_MANIFEST_ROWS = live_rows
     if result.source != "stale_snapshot":
         # The manifest's availability view came from a complete live API feed;
         # use that freshness marker for consecutive-miss accounting.
         result.source = "api"
+    result.notes.append(
+        f"canaried {len(checked)} new/held routes ({len(healthy)} healthy)"
+    )
     return result
 
 

--- a/scripts/pricing/refresh.py
+++ b/scripts/pricing/refresh.py
@@ -286,7 +286,12 @@ def _latest_model_created(snapshot: dict[str, Any]) -> int:
 def _is_launch_candidate(model_id: str) -> bool:
     """Exclude catalog aliases that do not represent independently priced launches."""
 
-    return not model_id.startswith("~") and not model_id.endswith(":free")
+    # OpenRouter-style suffixes describe routing or billing modes for an
+    # existing model (for example ``:batch``, ``:free``, or ``:nitro``). They
+    # are not independently launched provider SKUs and therefore must not
+    # become parser requirements. Provider-native discovery is responsible
+    # for publishing actual provider model IDs.
+    return not model_id.startswith("~") and ":" not in model_id
 
 
 def _new_parser_requirements(

--- a/tests/test_automatic_provider_discovery.py
+++ b/tests/test_automatic_provider_discovery.py
@@ -8,7 +8,7 @@ import pytest
 from scripts.pricing.base import ModelPrice, PriceTier, ProviderPricingResult
 from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.parsers import openai as openai_parser
-from scripts.pricing.providers import grok, openai
+from scripts.pricing.providers import gemini, grok, openai
 from scripts.pricing.refresh import PROVIDER_SLUGS
 from trusted_router.catalog_ingest import _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS
 
@@ -251,6 +251,121 @@ def test_grok_api_discovers_new_model_with_exact_tiered_prices(
             "cached_input_token_price_per_m": 200_000,
         },
     ]
+
+
+def test_gemini_canaries_new_priced_models_before_publication(
+    tmp_path,  # noqa: ANN001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "google-ai-studio.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "provider": "google-ai-studio",
+                "models": [
+                    {
+                        "id": "google/gemini-3.6-flash",
+                        "upstream_id": "gemini-3.6-flash",
+                        "input_token_price_per_m": 1,
+                        "output_token_price_per_m": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gemini, "MANIFEST_PATH", manifest)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        gemini,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="gemini",
+            prices={
+                "google/gemini-3.6-flash": ModelPrice(1_500_000, 7_500_000),
+                "google/gemini-3.7-flash": ModelPrice(750_000, 3_750_000),
+            },
+            source="deterministic",
+            fetched_url=gemini.URL,
+        ),
+    )
+    monkeypatch.setattr(
+        gemini,
+        "fetch_json",
+        lambda *_args, **_kwargs: {
+            "models": [
+                {
+                    "name": "models/gemini-3.6-flash",
+                    "supportedGenerationMethods": ["generateContent"],
+                },
+                {
+                    "name": "models/gemini-3.7-flash",
+                    "supportedGenerationMethods": ["generateContent"],
+                },
+            ]
+        },
+    )
+    probed: list[tuple[str | None, str]] = []
+    monkeypatch.setattr(
+        gemini,
+        "_probe_generate_content",
+        lambda **kwargs: probed.append(
+            (kwargs.get("api_key"), str(kwargs["native_id"]))
+        )
+        or True,
+    )
+
+    result = gemini.fetch()
+    gemini.write_provider_manifest(result)
+
+    raw = json.loads(manifest.read_text(encoding="utf-8"))
+    by_id = {row["id"]: row for row in raw["models"]}
+    assert probed == [("test-key", "gemini-3.7-flash")]
+    assert by_id["google/gemini-3.7-flash"]["routable"] is True
+    assert by_id["google/gemini-3.7-flash"]["input_token_price_per_m"] == 750_000
+
+
+def test_gemini_canary_requires_exact_visible_pong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"thought": True, "text": "internal"},
+                                {"text": "PONG"},
+                            ]
+                        }
+                    }
+                ]
+            }
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        gemini.httpx,
+        "post",
+        lambda *_args, **kwargs: calls.append(kwargs) or Response(),
+    )
+
+    assert gemini._probe_generate_content(  # noqa: SLF001
+        api_key="test-key",
+        native_id="gemini-3.7-flash",
+    )
+    assert calls[0]["json"] == {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": "Reply exactly PONG"}],
+            }
+        ],
+        "generationConfig": {"maxOutputTokens": 64},
+    }
 
 
 def test_grok_failed_new_model_canary_is_published_dark(

--- a/tests/test_pricing_self_heal.py
+++ b/tests/test_pricing_self_heal.py
@@ -558,6 +558,12 @@ def test_new_parser_requirements_are_provider_specific_and_text_only(
                     "architecture": {"output_modalities": ["text"]},
                     "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
                 },
+                {
+                    "id": "google/gemini-3.8-flash:batch",
+                    "created": 104,
+                    "architecture": {"output_modalities": ["text"]},
+                    "endpoints": [{"tr_provider_slug": "google-ai-studio"}],
+                },
         ]
     }
 


### PR DESCRIPTION
## Summary

- stop treating OpenRouter routing suffixes such as `:batch` as independently priced model launches
- require an exact paid-path Gemini PONG before newly discovered Google routes become routable
- add Gemini 3.7 Flash to the provider pricing floor and cover the failed hourly-refresh regression

## Verification

- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (3372 passed, 254 skipped, 10 xfailed)
- live official Gemini pricing parse: 0.75 input / 3.75 output / 0.075 cached input per million
- live authenticated Gemini 3.7 catalog and exact PONG canary passed
