### PR TITLE
Make log scrubbing total over container shapes, and scrub the message text

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -42,7 +42,7 @@ from urllib.parse import urlparse
 from urllib3.util.retry import Retry
 
 from trusted_router.config import Settings
-from trusted_router.sentry_config import _scrub
+from trusted_router.sentry_config import _scrub, _scrub_string
 
 log = logging.getLogger(__name__)
 HTTPAdapter: Any = importlib.import_module("requests.adapters").HTTPAdapter
@@ -255,9 +255,16 @@ class _AxiomScrubFilter(logging.Filter):
             # Collapsing args means Axiom loses structured args fields and gets
             # the final formatted message only. That is the point: nothing
             # unscrubbed can leave the process.
-            record.msg = _AXIOM_EMAIL_VALUE_RE.sub(
-                "[Filtered-email]",
-                _AXIOM_SECRET_VALUE_RE.sub(r"\1=[Filtered]", collapsed),
+            # _scrub_string last: the two regexes above only catch secrets in
+            # `key=value` shape and e-mail addresses, so a bare `sk-tr-v1-…` in
+            # an ordinary message ("rotating sk-tr-v1-ABC…") passed straight
+            # through to the shipper. _scrub_string applies the same declared
+            # fragment/prefix blocklist the structured fields already get.
+            record.msg = _scrub_string(
+                _AXIOM_EMAIL_VALUE_RE.sub(
+                    "[Filtered-email]",
+                    _AXIOM_SECRET_VALUE_RE.sub(r"\1=[Filtered]", collapsed),
+                )
             )
             if len(record.msg) > self._MAX_MESSAGE_CHARS:
                 record.msg = (

--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -6,11 +6,15 @@ import logging
 import os
 import sys
 import time
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from datetime import time as _dt_time
+from decimal import Decimal
 from threading import Lock
 from typing import Any, cast
 from urllib.parse import urlsplit
+from uuid import UUID
 
 from trusted_router.config import Settings
 
@@ -470,20 +474,101 @@ def _hash_identity(identity: str) -> str:
     return hashlib.sha256(identity.encode()).hexdigest()
 
 
-def _scrub(value: Any) -> Any:
-    if isinstance(value, dict):
-        out: dict[str, Any] = {}
-        for key, item in value.items():
+# Walk limits. A log extra is not a data structure we control, so the scrubber
+# has to terminate on a cyclic or pathological one rather than recursing until
+# the interpreter gives up *inside a logging filter*.
+_SCRUB_MAX_DEPTH = 12
+_SCRUB_MAX_ITEMS = 500
+
+# Types whose str() is structurally incapable of carrying a secret (hex and
+# dashes, digits, ISO timestamps) and which appear constantly in log extras.
+# Everything outside this set is replaced by its type name rather than
+# stringified: calling repr() on an arbitrary object can execute application
+# code, raise, recurse, be enormous, or expose a value in a format the
+# blocklist does not recognise.
+_SAFE_REPR_TYPES = (UUID, datetime, date, _dt_time, timedelta, Decimal)
+
+
+def _scrub(value: Any, *, _depth: int = 0, _seen: frozenset[int] = frozenset()) -> Any:
+    """Redact secrets from an arbitrary logging value.
+
+    Totality matters here because this is the last barrier on the Axiom path:
+    `_AxiomScrubFilter` runs every log-record attribute through it and hands
+    the record straight to the shipper. It previously recursed into dict, list
+    and str only and returned everything else untouched, so a secret inside a
+    tuple extra was serialised and shipped verbatim.
+
+    The contract is now a whitelist rather than a blacklist: a value is only
+    returned unchanged if it is a scalar that cannot hold a string.
+    """
+    if _depth > _SCRUB_MAX_DEPTH:
+        return "[Filtered-depth]"
+
+    if isinstance(value, str):
+        return _scrub_string(value)
+
+    # Scalars that cannot carry a string secret. bool is checked implicitly —
+    # it is an int subclass and equally safe.
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    # Bytes are redacted wholesale rather than decoded and blocklist-scrubbed:
+    # a key can reach a log as base64, hex, or some framing the fragment list
+    # does not know, and there is no diagnostic value in the payload anyway.
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return "[Filtered-bytes]"
+
+    # Cycle guard, keyed on the path rather than globally so that a value
+    # legitimately repeated across sibling branches is still scrubbed in each.
+    marker = id(value)
+    if marker in _seen:
+        return "[Filtered-cycle]"
+    seen = _seen | {marker}
+    child_depth = _depth + 1
+
+    if isinstance(value, Mapping):
+        out: dict[Any, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= _SCRUB_MAX_ITEMS:
+                out["[truncated]"] = f"{len(value) - _SCRUB_MAX_ITEMS} more"
+                break
             if _is_sensitive_key(str(key)):
                 out[key] = "[Filtered]"
             else:
-                out[key] = _scrub(item)
+                out[key] = _scrub(item, _depth=child_depth, _seen=seen)
         return out
-    if isinstance(value, list):
-        return [_scrub(item) for item in value]
-    if isinstance(value, str):
-        return _scrub_string(value)
-    return value
+
+    if isinstance(value, (set, frozenset)):
+        # Deterministically ordered so two runs of the same event produce the
+        # same record; sorted on the scrubbed text since the members may not be
+        # mutually comparable.
+        return sorted(
+            (str(_scrub(item, _depth=child_depth, _seen=seen)) for item in _limited(value)),
+        )
+
+    if isinstance(value, (list, tuple)):
+        scrubbed = [_scrub(item, _depth=child_depth, _seen=seen) for item in _limited(value)]
+        if len(value) > _SCRUB_MAX_ITEMS:
+            scrubbed.append(f"[truncated {len(value) - _SCRUB_MAX_ITEMS} more]")
+        return tuple(scrubbed) if isinstance(value, tuple) else scrubbed
+
+    if isinstance(value, _SAFE_REPR_TYPES):
+        return _scrub_string(str(value))
+
+    # Unknown object: name the type so the log still says what was there, but
+    # never call repr() on it.
+    return f"[Filtered-{type(value).__name__}]"
+
+
+def _limited(items: Iterable[Any]) -> list[Any]:
+    """First _SCRUB_MAX_ITEMS elements, so one enormous extra cannot stall the
+    logging filter it is being scrubbed inside."""
+    out: list[Any] = []
+    for item in items:
+        if len(out) >= _SCRUB_MAX_ITEMS:
+            break
+        out.append(item)
+    return out
 
 
 def _is_sensitive_key(key: str) -> bool:

--- a/tests/test_scrub_totality_property.py
+++ b/tests/test_scrub_totality_property.py
@@ -1,0 +1,216 @@
+"""Property tests for scrub totality.
+
+`_scrub` is the last barrier on the Axiom path: `_AxiomScrubFilter` runs every
+log-record attribute through it and hands the record straight to the shipper.
+The law:
+
+    for every value v built from any Python container shape,
+        no declared secret fragment or prefix survives in the scrubbed output
+
+It was false. `_scrub` recursed into dict, list and str and returned everything
+else unchanged, so:
+
+    _scrub(("a", "sk-tr-v1-SECRET"))  ->  ('a', 'sk-tr-v1-SECRET')
+
+and a tuple is serialised by Axiom's ujson as a JSON array, preserving the
+string. The old tests all passed because every one of them embedded the secret
+in a str inside a dict or list — the two branches that already worked.
+
+The property generates *shapes*, not values: canaries are planted at random
+leaf positions inside recursively-built containers, and the assertion is over
+the serialised image. That is what makes it able to find a container type
+nobody thought to write a test for, which is exactly how the tuple hole
+survived.
+
+Scope limit worth stating plainly: this quantifies only over the declared
+SENSITIVE_* sets and the key blocklist. A secret in a format the blocklist does
+not recognise is out of scope for any blocklist scrubber, here or anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from trusted_router.axiom_config import _AxiomScrubFilter
+from trusted_router.sentry_config import (
+    SENSITIVE_KEYS,
+    SENSITIVE_STRING_FRAGMENTS,
+    SENSITIVE_STRING_PREFIXES,
+    _scrub,
+)
+
+CANARY_SUFFIX = "CANARY9f3a2b"
+SECRETS = [f"{fragment}{CANARY_SUFFIX}" for fragment in SENSITIVE_STRING_FRAGMENTS] + [
+    f"{prefix}{CANARY_SUFFIX}" for prefix in SENSITIVE_STRING_PREFIXES
+]
+
+
+def _leaked(scrubbed: Any) -> bool:
+    """Did a canary survive into the serialised image?
+
+    Serialising with default=str is the faithful check: it is what a shipper
+    does to a value it does not natively understand, so a secret that survives
+    only inside an object's string form still counts as leaked.
+    """
+    return CANARY_SUFFIX in json.dumps(scrubbed, default=str, ensure_ascii=False)
+
+
+# A recursive strategy over every container shape a log extra can take. The
+# tuple/set/frozenset/bytes arms are the ones that used to pass secrets through.
+leaves = st.one_of(
+    st.sampled_from(SECRETS),
+    st.sampled_from(SECRETS).map(lambda s: f"context {s} trailing"),
+    st.sampled_from(SECRETS).map(str.encode),
+    st.text(max_size=8),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.booleans(),
+    st.none(),
+)
+
+values = st.recursive(
+    leaves,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.lists(children, max_size=4).map(tuple),
+        st.dictionaries(st.text(max_size=6), children, max_size=4),
+        st.frozensets(st.sampled_from(SECRETS) | st.text(max_size=6), max_size=3),
+    ),
+    max_leaves=12,
+)
+
+
+# ----------------------------------------------------------------- the law ---
+
+
+@given(value=values)
+@settings(max_examples=1500)
+def test_no_declared_secret_survives_any_container_shape(value: Any) -> None:
+    assert not _leaked(_scrub(value)), f"secret survived _scrub of {value!r}"
+
+
+@given(value=values)
+@settings(max_examples=500)
+def test_scrubbing_is_idempotent(value: Any) -> None:
+    """A second pass must be a no-op, or the output is not a fixed point and a
+    re-scrubbed record could differ from the one that shipped."""
+    once = _scrub(value)
+    assert _scrub(once) == once
+
+
+@given(
+    key=st.sampled_from(sorted(SENSITIVE_KEYS)),
+    payload=values,
+)
+@settings(max_examples=300)
+def test_a_sensitive_key_redacts_its_whole_subtree(key: str, payload: Any) -> None:
+    """Key-based redaction must not depend on the shape of what is under it."""
+    scrubbed = _scrub({key: payload})
+    assert scrubbed[key] == "[Filtered]"
+
+
+# ------------------------------------------------- termination and limits ---
+
+
+def test_a_cycle_terminates() -> None:
+    cyclic: dict[str, Any] = {"secret_holder": "sk-tr-v1-" + CANARY_SUFFIX}
+    cyclic["self"] = cyclic
+    scrubbed = _scrub(cyclic)
+    assert scrubbed["self"] == "[Filtered-cycle]"
+    assert not _leaked(scrubbed)
+
+
+def test_deep_nesting_terminates() -> None:
+    deep: Any = "sk-tr-v1-" + CANARY_SUFFIX
+    for _ in range(200):
+        deep = {"n": deep}
+    scrubbed = _scrub(deep)
+    assert not _leaked(scrubbed)
+
+
+def test_a_huge_container_is_truncated_not_walked_forever() -> None:
+    scrubbed = _scrub(list(range(5_000)))
+    assert len(scrubbed) <= 501
+
+
+# -------------------------------------------------------- unknown objects ---
+
+
+def test_an_unknown_object_is_named_not_repred() -> None:
+    """repr() on an arbitrary object can execute application code, raise,
+    recurse, or expose a value the blocklist does not recognise. The type name
+    keeps the diagnostic signal without any of that."""
+
+    class Custom:
+        def __repr__(self) -> str:  # pragma: no cover - must never be called
+            raise AssertionError("_scrub must not call repr on unknown objects")
+
+    assert _scrub(Custom()) == "[Filtered-Custom]"
+
+
+def test_structurally_safe_types_survive_for_diagnostics() -> None:
+    """UUIDs and timestamps cannot carry a secret and are common in extras, so
+    they keep their value rather than being replaced by a type name."""
+    import datetime
+    import uuid
+
+    identifier = uuid.uuid4()
+    assert _scrub(identifier) == str(identifier)
+    assert _scrub(datetime.date(2026, 8, 13)) == "2026-08-13"
+
+
+def test_bytes_are_redacted_wholesale() -> None:
+    """Decoding and blocklist-scrubbing bytes would still ship a key that
+    arrived base64'd, hex'd, or in an unrecognised framing."""
+    assert _scrub(b"sk-tr-v1-" + CANARY_SUFFIX.encode()) == "[Filtered-bytes]"
+    assert _scrub(b"harmless") == "[Filtered-bytes]"
+
+
+# ------------------------------------------------------ the Axiom filter ---
+
+
+@given(value=values)
+@settings(max_examples=400)
+def test_the_axiom_filter_ships_no_canary_in_an_extra(value: Any) -> None:
+    """End to end at the boundary that actually ships: the filter mutates the
+    record in place and axiom-py serialises it immediately afterwards."""
+    record = logging.LogRecord(
+        name="trusted_router.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="event happened",
+        args=(),
+        exc_info=None,
+    )
+    record.context = value  # type: ignore[attr-defined]
+
+    assert _AxiomScrubFilter().filter(record) is True
+    assert not _leaked(
+        {k: v for k, v in record.__dict__.items() if not k.startswith("_")}
+    )
+
+
+@pytest.mark.parametrize("secret", SECRETS)
+def test_a_bare_secret_in_the_message_is_scrubbed(secret: str) -> None:
+    """The message path applied only the `key=value` and e-mail regexes, so a
+    bare token in ordinary prose — "rotating sk-tr-v1-…" — shipped verbatim.
+    It now goes through the same declared blocklist as the structured fields."""
+    record = logging.LogRecord(
+        name="trusted_router.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="rotating %s now",
+        args=(secret,),
+        exc_info=None,
+    )
+
+    assert _AxiomScrubFilter().filter(record) is True
+    assert CANARY_SUFFIX not in record.getMessage()


### PR DESCRIPTION
## The defect

`_scrub` is the last barrier on the Axiom path — `_AxiomScrubFilter` runs every log-record attribute through it and hands the record straight to the shipper. It recursed into `dict`, `list` and `str`, and returned everything else unchanged:

```python
_scrub({"note": "sk-tr-v1-…"})   -> {'note': '[Filtered]'}          scrubbed
_scrub(("a", "sk-tr-v1-…"))      -> ('a', 'sk-tr-v1-SECRET…')       LEAKS
_scrub({"sk-tr-v1-…"})           -> {'sk-tr-v1-SECRET…'}            LEAKS
_scrub(b"sk-tr-v1-…")            -> b'sk-tr-v1-SECRET…'             LEAKS
```

An independent review narrowed which of these actually reach a sink, and it is worth being precise: **tuples are the live leak** — axiom-py's `ujson` serialises them as JSON arrays, preserving the contained string. Sets hit axiom-py's unsupported-object branch and become JSON `null`; bytes make `ujson` raise, and our wrapper then drops the whole batch. On the Sentry side, error events are pre-serialised before `before_send`, so `_scrub` already catches those shapes — but standalone Sentry Logs run `before_send_log` *before* attribute serialisation, so they can still leak.

So: one confirmed exfiltration path, one silent data-loss path, and a sink-dependent third. All three are the same missing branch.

The existing tests all passed because every one of them embedded its secret in a `str` inside a `dict` or `list` — the two branches that already worked.

## The fix

Invert the contract. A value is returned unchanged **only** if it is a scalar that cannot hold a string:

- Mappings (not just `dict`), lists, tuples, sets and frozensets are walked. Sets become deterministically ordered lists.
- **Bytes are redacted wholesale**, not decoded and blocklist-scrubbed — a key can arrive base64'd, hex'd, or in a framing the fragment list does not know, and there is no diagnostic value in the payload.
- **Unknown objects become their type name**, never `repr()`. Calling `repr` on an arbitrary object can execute application code, raise, recurse, be enormous, or expose a value in a format the blocklist does not recognise. A test asserts `repr` is not called.
- UUIDs, timestamps and Decimals keep their value: structurally unable to carry a secret, and common enough in log extras to be worth the diagnostic signal.
- Depth, breadth and cycle limits. This runs *inside a logging filter*, where recursing until the interpreter gives up takes the process with it.

### A more direct leak, fixed in the same pass

The message path applied only the `key=value` and e-mail regexes and never `_scrub_string`. So a bare token in ordinary prose — `log.info("rotating %s now", key)` — shipped verbatim, because it is not in `key=value` shape. It now goes through the same declared blocklist as the structured fields.

## The proof

`tests/test_scrub_totality_property.py` generates container **shapes**, with canaries planted at random leaf positions inside recursively-built containers, and asserts over the *serialised* image (`json.dumps(..., default=str)` — what a shipper does to a value it does not natively understand).

Generating shapes rather than values is the point: it is what lets the test find a container type nobody thought to write a case for, which is exactly how the tuple hole survived a suite that looked thorough.

**32 of its 35 cases fail against the unfixed code.**

It also pins idempotence, whole-subtree redaction under a sensitive key, termination on cycles and deep nesting, and the end-to-end path through `_AxiomScrubFilter` itself.

**Scope limit, stated in the module docstring:** this quantifies only over the declared `SENSITIVE_*` sets and key blocklist. A secret in a format the blocklist does not recognise is out of scope for any blocklist scrubber.

## Verification

- `pytest`: 3407 passed, 254 skipped, 10 xfailed
- `ruff check .`: clean
- `mypy`: no issues in 236 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)