### PR TITLE
Validate BYOK provider names in the console, as the API route already does

### DIFF
--- a/src/trusted_router/routes/console/byok.py
+++ b/src/trusted_router/routes/console/byok.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from trusted_router.auth import SettingsDep
 from trusted_router.byok_crypto import encrypt_byok_secret
 from trusted_router.catalog import PROVIDERS
+from trusted_router.provider_compat import canonical_byok_provider
 from trusted_router.routes.console._shared import ConsoleDep, render
 from trusted_router.storage import STORE
 
@@ -52,7 +53,19 @@ def register(app: FastAPI) -> None:
         # may send `secret_ref` + `key_hint`. Mirror PUT /v1/byok/providers/...
         # so both paths land on the same storage shape.
         api_key = api_key.strip()
-        provider_slug = provider.strip().lower()
+        # Validate against the catalog exactly as PUT /v1/byok/providers/... does
+        # (_require_byok_provider). This route previously accepted any lowercased
+        # string up to 64 chars and passed it straight into encrypt_byok_secret
+        # as the `provider` component of the AEAD associated data. Control
+        # secrets are sealed in the SAME namespace with their `purpose` in that
+        # slot, so a tenant could register a BYOK entry whose provider equalled
+        # a control purpose (e.g. a broadcast destination key) and produce two
+        # envelopes in one workspace that share associated data — exactly the
+        # substitution the AAD exists to prevent.
+        provider_slug = canonical_byok_provider(provider)
+        catalog_provider = PROVIDERS.get(provider_slug)
+        if catalog_provider is None or not catalog_provider.supports_byok:
+            return RedirectResponse(url="/console/byok?error=provider", status_code=303)
         secret_ref = secret_ref.strip()
         explicit_hint = key_hint.strip() or None
         stored_hint: str | None

--- a/tests/test_byok_aad_namespace_property.py
+++ b/tests/test_byok_aad_namespace_property.py
@@ -1,0 +1,196 @@
+"""Property tests for BYOK associated-data separation.
+
+AES-GCM gives cross-binding rejection — an envelope sealed for one context
+failing to open in another — only if the associated data map is injective.
+The BYOK AAD is
+
+    f"trustedrouter:byok:{workspace_id}:{provider}"
+
+and `encrypt_control_secret` seals control secrets in the SAME namespace with
+its `purpose` in the `provider` slot. So a BYOK entry whose provider string
+equals a control purpose produces two envelopes in one workspace under
+identical associated data, and each opens the other.
+
+The console POST route accepted any lowercased string up to 64 characters as
+`provider` and passed it straight into `encrypt_byok_secret`, so a tenant could
+create that collision through the ordinary UI. The API route already validated
+against the catalog. This module pins that both doors agree, and that no
+catalog-valid provider slug can collide with a control purpose.
+
+    for every accepted provider string p,
+        p is a catalog provider supporting BYOK,
+        and aad(workspace, p) differs from aad(workspace, purpose)
+        for every control purpose
+
+Two things this deliberately does NOT claim:
+
+  * The AAD map is still not injective in general. `_aad` joins with ":" and
+    neither escapes nor length-prefixes, so ("a:b", "c") and ("a", "b:c")
+    collide. Reaching that needs a colon in a workspace id, and all three
+    backends mint str(uuid.uuid4()), so it is not reachable by normal issuance
+    — but it is a real property of the function and is asserted below as a
+    known gap rather than quietly left out.
+  * Repairing the encoding needs a V2 envelope algorithm and a dual-read
+    migration, because existing ciphertexts AND wrapped DEKs were sealed under
+    the current AAD, and the attested enclave consumes these envelopes too.
+    That is out of scope here; this closes the reachable door.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from trusted_router.byok_crypto import _aad
+from trusted_router.catalog import PROVIDERS
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.provider_compat import canonical_byok_provider
+from trusted_router.storage import STORE
+
+WORKSPACE = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(name="console")
+def _console() -> TestClient:
+    """Authenticated console client. The guard under test lives in the route,
+    so these drive the real endpoint rather than a reimplementation of it."""
+    # Rate limiting off: the property drives hundreds of POSTs at one endpoint,
+    # and a 429 would report as a namespace failure rather than what it is.
+    settings = Settings(environment="local", rate_limit_enabled=False)
+    client = TestClient(create_app(settings, init_observability=False))
+    user = STORE.ensure_user("byok-namespace@example.com")
+    raw_token, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label=user.email,
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+    return client
+
+
+def _post_provider(console: TestClient, provider: str) -> str:
+    """POST the console form and return the redirect target."""
+    response = console.post(
+        "/console/byok",
+        data={"provider": provider, "api_key": "sk-test-namespace-key-0001"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    return response.headers["location"]
+
+# The control-secret purposes that share the BYOK namespace. Broadcast
+# destination keys are the reachable family: their ids are short enough to fit
+# inside the console form's 64-character limit.
+CONTROL_PURPOSES = [
+    "broadcast:bdst_abc123:api-key",
+    "broadcast:bdst_abc123:signing-key",
+    "smtp:password",
+    "webhook:signing-secret",
+]
+
+BYOK_PROVIDERS = sorted(slug for slug, p in PROVIDERS.items() if p.supports_byok)
+
+
+# ---------------------------------------------------- namespace separation ---
+
+
+@given(
+    provider=st.text(
+        alphabet=st.characters(blacklist_categories=("Cs", "Cc")), min_size=1, max_size=64
+    )
+)
+@settings(
+    max_examples=300,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_whatever_the_console_stores_never_collides_with_a_control_purpose(
+    console: TestClient, provider: str
+) -> None:
+    """Anything the route actually stores has AAD distinct from every control
+    purpose.
+
+    Driven through the real endpoint, and asserted on what landed in storage,
+    so the property cannot pass by agreeing with a copy of the guard. Quantified
+    over arbitrary text because the input is a free-form form field and the
+    interesting values are the ones nobody thought to enumerate.
+    """
+    location = _post_provider(console, provider)
+    workspace_id = next(iter(STORE.workspaces))
+    slug = canonical_byok_provider(provider)
+    stored = STORE.get_byok_provider(workspace_id, slug)
+
+    if location.endswith("error=provider"):
+        assert stored is None, f"rejected {provider!r} but still stored a row"
+        return
+
+    assert stored is not None
+    byok_aad = _aad(workspace_id, stored.provider)
+    for purpose in CONTROL_PURPOSES:
+        assert byok_aad != _aad(workspace_id, purpose), (
+            f"stored provider {stored.provider!r} shares associated data with "
+            f"control purpose {purpose!r}"
+        )
+
+
+@pytest.mark.parametrize("purpose", CONTROL_PURPOSES)
+def test_a_control_purpose_cannot_be_registered_as_a_provider(
+    console: TestClient, purpose: str
+) -> None:
+    """The direct attempt: register a BYOK entry named after a control secret.
+
+    This is the reachable path — broadcast destination keys are sealed with
+    their purpose in the same AAD slot, and those purposes fit inside the
+    form's 64-character limit.
+    """
+    assert _post_provider(console, purpose).endswith("error=provider")
+    workspace_id = next(iter(STORE.workspaces))
+    assert STORE.get_byok_provider(workspace_id, purpose) is None
+
+
+@pytest.mark.parametrize("provider", BYOK_PROVIDERS[:8])
+def test_every_catalog_byok_provider_is_still_accepted(
+    console: TestClient, provider: str
+) -> None:
+    """The guard must not have narrowed the legitimate set."""
+    assert _post_provider(console, provider) == "/console/byok"
+
+
+def test_console_and_api_agree_on_which_providers_are_acceptable(
+    console: TestClient,
+) -> None:
+    """Both doors, one rule. The console used to accept a superset."""
+    from trusted_router.routes.byok import _require_byok_provider
+
+    for provider in [*BYOK_PROVIDERS[:8], *CONTROL_PURPOSES, "nonsense", "OpenAI"]:
+        console_ok = not _post_provider(console, provider).endswith("error=provider")
+        try:
+            _require_byok_provider(provider)
+            api_ok = True
+        except Exception:
+            api_ok = False
+        assert console_ok == api_ok, f"routes disagree about provider {provider!r}"
+
+
+# --------------------------------------------- known gap, asserted not hidden ---
+
+
+def test_aad_encoding_is_not_injective_in_general() -> None:
+    """A standing record of the unfixed half.
+
+    `_aad` joins with ":" without escaping or length-prefixing, so component
+    boundaries are ambiguous. Reaching this needs a colon inside a workspace
+    id, and all three backends mint str(uuid.uuid4()), so it is not reachable
+    by normal issuance — but the encoding is still wrong, and repairing it
+    needs a V2 envelope algorithm plus a dual-read migration because existing
+    ciphertexts and wrapped DEKs were sealed under the current AAD.
+
+    If this test ever starts FAILING, the encoding was fixed and this test
+    should be deleted along with the workaround it documents.
+    """
+    assert _aad("a:b", "c") == _aad("a", "b:c")


### PR DESCRIPTION
## The defect

AES-GCM gives you cross-binding rejection — an envelope sealed for one context failing to open in another — **only if the associated-data map is injective**. The BYOK AAD is:

```python
def _aad(workspace_id: str, provider: str) -> bytes:
    return f"trustedrouter:byok:{workspace_id}:{provider}".encode()
```

and `encrypt_control_secret` seals control secrets in the **same namespace**, passing its `purpose` into the `provider` slot. So a BYOK entry whose provider string equals a control purpose produces two envelopes in one workspace under identical associated data, and each decrypts the other.

`PUT /v1/byok/providers/{provider}` validated the provider against the catalog (`_require_byok_provider`). The console POST accepted **any lowercased string up to 64 characters** and passed it straight into `encrypt_byok_secret`. Broadcast destination purposes (`broadcast:bdst_…:api-key`) fit inside that limit, so a tenant could create the collision through the ordinary UI.

Apply the same catalog check on the console path. Both doors, one rule.

## What this does *not* fix

The encoding is still not injective: `_aad` joins with `":"` without escaping or length-prefixing, so `("a:b", "c")` and `("a", "b:c")` collide. Reaching that needs a colon inside a workspace id, and all three backends mint `str(uuid.uuid4())` with no caller-supplied id — so it is not reachable by normal issuance. It is still wrong, and `test_aad_encoding_is_not_injective_in_general` asserts it as a **standing record** rather than leaving it unmentioned. If that test ever starts failing, the encoding was fixed and the test should be deleted with it.

**Repairing it properly is deliberately out of scope here**, and should not be done in this repository alone:

- Both the ciphertext *and* the wrapped DEK were sealed under the current AAD, so re-wrapping the DEK is not enough — it needs a **V2 envelope algorithm** dispatched on the stored `algorithm` field, with dual-read / single-write and a backfill.
- **The attested enclave consumes these envelopes too.** Changing the AAD contract here alone would make every new envelope unreadable there, taking BYOK down in production. That sequencing is enclave-first, and it is a cross-repository change.

A permanent legacy-AAD fallback is *not* an acceptable shortcut either: it would preserve the substitution weakness forever.

## The proof

`tests/test_byok_aad_namespace_property.py` drives the **real endpoint** and asserts on what reached storage:

> for every provider string the route accepts and stores, its AAD differs from every control-secret purpose's AAD

An earlier draft of this test asserted against a *copy* of the guard written inside the test file, and consequently **passed against the unfixed code** — precisely the failure mode a proof is supposed not to have. Rewritten to POST through the route and read back from the store, **6 of its cases fail without the fix**.

It also pins that the two routes agree on the accepted set, and that no catalog BYOK provider was excluded by the new check.

## Verification

- `pytest`: 3396 passed, 254 skipped, 10 xfailed
- `ruff check .`: clean
- `mypy`: no issues in 236 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)