### PR TITLE
Fix Spanner API failure alert status matching

### DIFF
--- a/scripts/deploy/spanner-alerts/api-failures.yaml
+++ b/scripts/deploy/spanner-alerts/api-failures.yaml
@@ -11,7 +11,10 @@ documentation:
 conditions:
   - displayName: "Unexpected API failures exceed one per minute for 5 minutes"
     conditionThreshold:
-      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/api/api_request_count" AND metric.labels.status != "OK" AND metric.labels.status != "aborted" AND metric.labels.status != "already_exists"'
+      # Spanner currently emits both title-case and lowercase retry statuses.
+      # Exclude every observed spelling so expected transaction retries do not
+      # page as API failures.
+      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/api/api_request_count" AND metric.labels.status != "OK" AND metric.labels.status != "Aborted" AND metric.labels.status != "aborted" AND metric.labels.status != "AlreadyExists" AND metric.labels.status != "already_exists"'
       aggregations:
         - alignmentPeriod: 300s
           perSeriesAligner: ALIGN_RATE

--- a/tests/test_spanner_reliability_deploy.py
+++ b/tests/test_spanner_reliability_deploy.py
@@ -26,6 +26,15 @@ def test_every_spanner_alert_reduces_cross_series_fanout() -> None:
         display_names.add(display_name)
 
 
+def test_api_failure_alert_excludes_retry_status_case_variants() -> None:
+    policy = (DEPLOY / "spanner-alerts" / "api-failures.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for status in ("Aborted", "aborted", "AlreadyExists", "already_exists"):
+        assert f'metric.labels.status != "{status}"' in policy
+
+
 def test_high_priority_cpu_alert_keeps_short_spikes_visible() -> None:
     policy = (DEPLOY / "spanner-alerts" / "high-priority-cpu.yaml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- exclude both title-case and lowercase Spanner retry status labels from the API-failure alert
- preserve genuine non-retry failure paging
- add a regression test for all observed status spellings

## Production evidence
The 2026-08-14 alert was caused by expected `Aborted` transaction retries. Cloud Monitoring emitted both `Aborted` and `aborted`, while the policy excluded only lowercase. The incident auto-closed after 68 seconds and customer endpoints remained healthy.

## Verification
- `uv run pytest tests/test_spanner_reliability_deploy.py -q` (6 passed)
- live policy updated and read back with all four notification channels preserved