### PR TITLE
Filter same-origin crawler 405s from Sentry

### DIFF
--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -91,6 +91,20 @@ SENTRY_FAILED_REQUEST_STATUS_CODES = {
     *range(502, 600),
 }
 
+# Same-origin Referer is normally evidence that a 405 came from our UI, but
+# crawlers synthesize it while walking forms and script-discovered URLs. Keep
+# this list deliberately limited to unambiguous crawler identifiers so browser
+# and SDK contract regressions still reach Sentry.
+CRAWLER_USER_AGENT_MARKERS: tuple[str, ...] = (
+    "bot",
+    "crawler",
+    "externalagent",
+    "facebookexternalhit",
+    "heritrix",
+    "slurp",
+    "spider",
+)
+
 
 @dataclass(frozen=True)
 class SentryFloodgateConfig:
@@ -315,6 +329,8 @@ def _is_untrusted_405(event: dict[str, Any]) -> bool:
     headers = _request_headers(request)
     if "x-trustedrouter-internal-token" in headers:
         return False
+    if _is_crawler_user_agent(headers.get("user-agent")):
+        return True
 
     request_host = _url_hostname(request.get("url"))
     if request_host is None:
@@ -357,6 +373,13 @@ def _request_headers(request: Mapping[str, Any]) -> dict[str, str]:
                 headers[str(item[0]).lower()] = str(item[1])
         return headers
     return {}
+
+
+def _is_crawler_user_agent(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = value.casefold()
+    return any(marker in normalized for marker in CRAWLER_USER_AGENT_MARKERS)
 
 
 def _url_hostname(value: Any) -> str | None:

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -404,6 +404,84 @@ def test_sentry_keeps_trusted_405_and_fingerprints_method_and_path(
     assert "fingerprint" not in event
 
 
+@pytest.mark.parametrize(
+    ("url", "referer", "user_agent"),
+    [
+        (
+            "https://uptimerouter.com/support/inquiry",
+            "https://uptimerouter.com/support",
+            (
+                "Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT "
+                "+https://www.image-meta.com)"
+            ),
+        ),
+        (
+            "https://uptimerouter.com/analytics/events",
+            "https://uptimerouter.com/static/dashboard.js",
+            (
+                "Mozilla/5.0 (compatible; heritrix/3.14.2-SNAPSHOT "
+                "+https://www.image-meta.com)"
+            ),
+        ),
+        (
+            "https://uptimerouter.com/",
+            "https://uptimerouter.com/docs",
+            "Mozilla/5.0 (compatible; Amzn-SearchBot/1.0)",
+        ),
+    ],
+)
+def test_sentry_drops_crawler_405_even_with_same_origin_referer(
+    url: str,
+    referer: str,
+    user_agent: str,
+) -> None:
+    reset_sentry_floodgate_for_tests()
+    event = _method_not_allowed_event(
+        url,
+        method="GET",
+        headers={
+            "Referer": referer,
+            "User-Agent": user_agent,
+        },
+    )
+
+    assert before_send(event, {}) is None
+
+
+def test_sentry_keeps_internal_worker_405_with_crawler_shaped_user_agent() -> None:
+    reset_sentry_floodgate_for_tests()
+    event = _method_not_allowed_event(
+        "https://trustedrouter.com/v1/internal/synthetic/route-health",
+        method="GET",
+        headers={
+            "User-Agent": "trustedrouter-synthetic-bot/1.0",
+            "X-TrustedRouter-Internal-Token": "private-token",
+        },
+    )
+
+    assert before_send(event, {}) is not None
+
+
+def test_sentry_keeps_crawler_originated_server_error() -> None:
+    reset_sentry_floodgate_for_tests()
+    event = {
+        "level": "error",
+        "request": {
+            "method": "GET",
+            "url": "https://uptimerouter.com/support",
+            "headers": {
+                "Referer": "https://uptimerouter.com/",
+                "User-Agent": "heritrix/3.14.2",
+            },
+        },
+        "exception": {
+            "values": [{"type": "RuntimeError", "value": "database failed"}]
+        },
+    }
+
+    assert before_send(event, {}) is not None
+
+
 def test_sentry_recognizes_context_only_405_as_untrusted() -> None:
     reset_sentry_floodgate_for_tests()
     event = {


### PR DESCRIPTION
## Summary
- drop 405 Sentry events from unambiguous crawler user agents even when they synthesize a same-origin Referer
- preserve internal-worker 405s, normal first-party browser 405s, and all 5xx events
- add regressions for the two production Heritrix alerts and a generic search bot

## Production root cause
At 2026-08-14 12:23:15-16 UTC, Heritrix requested GET /support/inquiry and GET /analytics/events on uptimerouter.com. Both endpoints are POST-only and correctly returned 405. No authenticated user or billing/inference request was involved.

## Verification
- regression failed twice before the filter change
- ruff clean
- mypy clean for sentry_config.py
- tests/test_security_contracts.py: 40 passed