### PR TITLE
Guard Alibaba October 2026 model retirements

### DIFF
--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -20,6 +20,7 @@ FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
+ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,119 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Alibaba Cloud Model Studio is consolidating its previously announced
+    # retirements at 2026-10-10 00:00 UTC+08. Keep this provider-scoped: the
+    # same open-weight models remain routable through other healthy providers.
+    # Alibaba explicitly canceled retirement for qwen-vl-ocr, qwen-mt-image,
+    # and the named ASR/live-translation routes, so none appear here.
+    _Retirement(
+        provider="alibaba",
+        model_ids=frozenset(
+            {
+                "deepseek/deepseek-r1",
+                "deepseek/deepseek-r1-0528",
+                "deepseek/deepseek-r1-distill-qwen-7b",
+                "deepseek/deepseek-r1-distill-qwen-14b",
+                "deepseek/deepseek-r1-distill-qwen-32b",
+                "deepseek/deepseek-v3",
+                "deepseek/deepseek-v3.1",
+                "deepseek/deepseek-v3.2",
+                "deepseek/deepseek-v3.2-exp",
+                "minimax/minimax-m2.1",
+                "moonshotai/kimi-k2-instruct",
+                "moonshotai/kimi-k2-thinking",
+                "qwen/qwen3-8b",
+                "qwen/qwen3-14b",
+                "qwen/qwen3-30b-a3b",
+                "qwen/qwen3-30b-a3b-instruct-2507",
+                "qwen/qwen3-30b-a3b-thinking-2507",
+                "qwen/qwen3-32b",
+                "qwen/qwen3-235b-a22b",
+                "qwen/qwen3-235b-a22b-instruct-2507",
+                "qwen/qwen3-235b-a22b-thinking-2507",
+                "qwen/qwen3-coder-30b-a3b-instruct",
+                "qwen/qwen3-coder-480b-a35b-instruct",
+                "qwen/qwen3-coder-next",
+                "qwen/qwen3-coder-plus",
+                "qwen/qwen3-coder-plus-2025-07-22",
+                "qwen/qwen3-coder-plus-2025-09-23",
+                "qwen/qwen3-max",
+                "qwen/qwen3-max-2025-09-23",
+                "qwen/qwen3-max-2026-01-23",
+                "qwen/qwen3-max-preview",
+                "qwen/qwen3-next-80b-a3b-instruct",
+                "qwen/qwen3-next-80b-a3b-thinking",
+                "qwen/qwen3-vl-8b-instruct",
+                "qwen/qwen3-vl-8b-thinking",
+                "qwen/qwen3-vl-30b-a3b-instruct",
+                "qwen/qwen3-vl-30b-a3b-thinking",
+                "qwen/qwen3-vl-32b-instruct",
+                "qwen/qwen3-vl-32b-thinking",
+                "qwen/qwen3-vl-235b-a22b-instruct",
+                "qwen/qwen3-vl-235b-a22b-thinking",
+                "qwen/qwen3-vl-flash",
+                "qwen/qwen3-vl-flash-2025-10-15",
+                "qwen/qwen3-vl-flash-2026-01-22",
+                "qwen/qwen3.6-max-preview",
+                "qwen/qwen-mt-turbo",
+                "z-ai/glm-4.6",
+                "z-ai/glm-4.7",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "deepseek-r1",
+                "deepseek-r1-0528",
+                "deepseek-r1-distill-qwen-7b",
+                "deepseek-r1-distill-qwen-14b",
+                "deepseek-r1-distill-qwen-32b",
+                "deepseek-v3",
+                "deepseek-v3.1",
+                "deepseek-v3.2",
+                "deepseek-v3.2-exp",
+                "MiniMax-M2.1",
+                "Moonshot-Kimi-K2-Instruct",
+                "kimi-k2-thinking",
+                "qwen3-8b",
+                "qwen3-14b",
+                "qwen3-30b-a3b",
+                "qwen3-30b-a3b-instruct-2507",
+                "qwen3-30b-a3b-thinking-2507",
+                "qwen3-32b",
+                "qwen3-235b-a22b",
+                "qwen3-235b-a22b-instruct-2507",
+                "qwen3-235b-a22b-thinking-2507",
+                "qwen3-coder-30b-a3b-instruct",
+                "qwen3-coder-480b-a35b-instruct",
+                "qwen3-coder-next",
+                "qwen3-coder-plus",
+                "qwen3-coder-plus-2025-07-22",
+                "qwen3-coder-plus-2025-09-23",
+                "qwen3-max",
+                "qwen3-max-2025-09-23",
+                "qwen3-max-2026-01-23",
+                "qwen3-max-preview",
+                "qwen3-next-80b-a3b-instruct",
+                "qwen3-next-80b-a3b-thinking",
+                "qwen3-vl-8b-instruct",
+                "qwen3-vl-8b-thinking",
+                "qwen3-vl-30b-a3b-instruct",
+                "qwen3-vl-30b-a3b-thinking",
+                "qwen3-vl-32b-instruct",
+                "qwen3-vl-32b-thinking",
+                "qwen3-vl-235b-a22b-instruct",
+                "qwen3-vl-235b-a22b-thinking",
+                "qwen3-vl-flash",
+                "qwen3-vl-flash-2025-10-15",
+                "qwen3-vl-flash-2026-01-22",
+                "qwen3.6-max-preview",
+                "qwen-mt-turbo",
+                "glm-4.6",
+                "glm-4.7",
+            }
+        ),
+        effective_at=ALIBABA_OCTOBER_2026_RETIREMENT_AT,
+    ),
     # Novita's time-limited free-trial Ling 3.0 Tiny route retired at the
     # provider's exact announced UTC cutover. There is no replacement model.
     _Retirement(

--- a/tests/test_alibaba_october_2026_lifecycle.py
+++ b/tests/test_alibaba_october_2026_lifecycle.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from trusted_router import provider_lifecycle
+
+_BEFORE_CUTOFF = datetime(2026, 10, 9, 15, 59, 59, tzinfo=UTC)
+_CUTOFF = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
+
+
+def test_alibaba_october_retirements_are_effective_at_announced_cutoff() -> None:
+    affected = (
+        ("qwen/qwen3-max", "qwen3-max"),
+        ("qwen/qwen3-vl-flash", "qwen3-vl-flash"),
+        ("qwen/qwen3-coder-next", "qwen3-coder-next"),
+        ("qwen/qwen3-235b-a22b-instruct-2507", "qwen3-235b-a22b-instruct-2507"),
+        ("qwen/qwen-mt-turbo", "qwen-mt-turbo"),
+        ("deepseek/deepseek-v3.2", "deepseek-v3.2"),
+        ("z-ai/glm-4.7", "glm-4.7"),
+    )
+
+    for model_id, upstream_id in affected:
+        assert not provider_lifecycle.provider_model_retired(
+            "alibaba", model_id, upstream_id, at=_BEFORE_CUTOFF
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "alibaba", model_id, upstream_id, at=_CUTOFF
+        )
+
+
+def test_alibaba_canceled_retirements_remain_available() -> None:
+    canceled = (
+        ("qwen/qwen-vl-ocr", "qwen-vl-ocr"),
+        ("qwen/qwen-mt-image", "qwen-mt-image"),
+        ("qwen/qwen3-asr-flash-us", "qwen3-asr-flash-us"),
+        (
+            "qwen/qwen3-asr-flash-2025-09-08-us",
+            "qwen3-asr-flash-2025-09-08-us",
+        ),
+        ("qwen/qwen3-livetranslate-flash", "qwen3-livetranslate-flash"),
+        (
+            "qwen/qwen3-livetranslate-flash-2025-12-01",
+            "qwen3-livetranslate-flash-2025-12-01",
+        ),
+    )
+
+    for model_id, upstream_id in canceled:
+        assert not provider_lifecycle.provider_model_retired(
+            "alibaba", model_id, upstream_id, at=_CUTOFF
+        )
+
+
+def test_alibaba_retirement_does_not_disable_other_providers() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "novita",
+        "qwen/qwen3-32b",
+        "qwen/qwen3-32b",
+        at=_CUTOFF,
+    )


### PR DESCRIPTION
Adds an effective-dated, Alibaba-only retirement guard for the models now unified under the October 10, 2026 Model Studio cutoff. Explicitly preserves the canceled qwen-vl-ocr, qwen-mt-image, ASR, and live-translation retirements. Other providers serving the same open-weight models remain unaffected.\n\nVerification:\n- uv run pytest -q tests/test_*lifecycle.py (50 passed)\n- uv run ruff check src/trusted_router/provider_lifecycle.py tests/test_alibaba_october_2026_lifecycle.py\n- uv run mypy