### PR TITLE
Support DeepSeek time-of-day pricing

### DIFF
--- a/scripts/pricing/parsers/deepseek.py
+++ b/scripts/pricing/parsers/deepseek.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
 from bs4 import BeautifulSoup
 
@@ -14,17 +15,19 @@ _NAME_TO_OR_ID = {
     "deepseek-reasoner": "deepseek/deepseek-reasoner",
 }
 
-# Known public DeepSeek pricing as of late-2025 / 2026 for the current
-# model lineup. Used as a fallback when the fetched page does not include
+# Known public DeepSeek pricing for the current model lineup. V4 entries use
+# the announced off-peak baseline effective 2026-08-16 16:00 UTC; the runtime
+# pricing schedule keeps the old rate before that instant and doubles these
+# rates during the two daily peak windows. Used as a fallback when the page does not include
 # a machine-parseable pricing table (e.g. when the refresh scraper lands
 # on the "Your First API Call" page instead of "Models & Pricing"), so
 # downstream validation doesn't see an empty dict.
-# Values are USD per 1M tokens (cache-miss input, standard output).
+# Values are USD per 1M tokens (cache-miss input, output, cached input).
 _FALLBACK_PRICES = {
-    "deepseek-v4-flash": (0.14, 0.28),
-    "deepseek-v4-pro": (0.56, 1.68),
-    "deepseek-chat": (0.27, 1.10),
-    "deepseek-reasoner": (0.55, 2.19),
+    "deepseek-v4-flash": ("0.22", "0.66", "0.007"),
+    "deepseek-v4-pro": ("0.66", "1.98", "0.022"),
+    "deepseek-chat": ("0.27", "1.10", None),
+    "deepseek-reasoner": ("0.55", "2.19", None),
 }
 
 _DOLLAR_RE = re.compile(r"\$\s*([\d]+(?:\.[\d]+)?)")
@@ -32,16 +35,23 @@ _FOOTNOTE_RE = re.compile(r"\s*\(\d+\)\s*$")
 _MODEL_TOKEN_RE = re.compile(r"deepseek-[a-z0-9]+(?:-[a-z0-9]+)*", re.IGNORECASE)
 
 
-def _to_micro_per_m(text):
+def _decimal_to_micro_per_m(value: str) -> int | None:
+    try:
+        parsed = Decimal(value)
+    except (InvalidOperation, ValueError):
+        return None
+    if not parsed.is_finite() or parsed <= 0 or parsed > 1000:
+        return None
+    return int((parsed * 1_000_000).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _to_micro_per_m(text: str) -> int | None:
     if not text:
         return None
     match = _DOLLAR_RE.search(text)
     if not match:
         return None
-    try:
-        return int(round(float(match.group(1)) * 1_000_000))
-    except (TypeError, ValueError):
-        return None
+    return _decimal_to_micro_per_m(match.group(1))
 
 
 def _strip_footnote(name: str) -> str:
@@ -67,9 +77,9 @@ def _parse_pricing_tables(soup) -> dict:
         if not header_models:
             continue
 
-        input_prices = None
-        cached_prices = None
-        output_prices = None
+        input_prices_by_period: dict[str, list[str]] = {}
+        cached_prices_by_period: dict[str, list[str]] = {}
+        output_prices_by_period: dict[str, list[str]] = {}
         for row in rows[header_idx + 1 :]:
             cells = [td.get_text(" ", strip=True) for td in row.find_all(["td", "th"])]
             if not cells:
@@ -78,14 +88,40 @@ def _parse_pricing_tables(soup) -> dict:
             if len(cells) < len(header_models):
                 continue
             value_cells = cells[-len(header_models) :]
+            # The scheduled-pricing table contains both OFF-PEAK and PEAK
+            # rows. The generated provider manifest needs one stable baseline;
+            # runtime billing overlays the exact UTC period independently.
+            # Prefer off-peak here so a later peak row cannot silently replace
+            # the baseline simply because of table order.
+            period = (
+                "off_peak"
+                if "OFF-PEAK" in label_text or "OFF PEAK" in label_text
+                else "peak"
+                if "PEAK" in label_text
+                else "standard"
+            )
             if "INPUT" in label_text and "CACHE MISS" in label_text:
-                input_prices = value_cells
+                input_prices_by_period[period] = value_cells
             elif "INPUT" in label_text and "CACHE HIT" in label_text:
-                cached_prices = value_cells
-            elif "INPUT" in label_text and input_prices is None and "TOKEN" in label_text:
-                input_prices = value_cells
+                cached_prices_by_period[period] = value_cells
+            elif (
+                "INPUT" in label_text
+                and "TOKEN" in label_text
+                and period not in input_prices_by_period
+            ):
+                input_prices_by_period[period] = value_cells
             elif "OUTPUT" in label_text and "TOKEN" in label_text:
-                output_prices = value_cells
+                output_prices_by_period[period] = value_cells
+
+        input_prices = input_prices_by_period.get("off_peak") or input_prices_by_period.get(
+            "standard"
+        )
+        cached_prices = cached_prices_by_period.get(
+            "off_peak"
+        ) or cached_prices_by_period.get("standard")
+        output_prices = output_prices_by_period.get("off_peak") or output_prices_by_period.get(
+            "standard"
+        )
 
         if input_prices is None or output_prices is None:
             continue
@@ -126,19 +162,13 @@ def _parse_inline_prices(text: str) -> dict:
         dollars = _DOLLAR_RE.findall(window)
         if len(dollars) < 2:
             continue
-        try:
-            prompt_v = float(dollars[0])
-            completion_v = float(dollars[-1])
-        except (TypeError, ValueError):
-            continue
-        # Guard against tiny/huge numbers.
-        if prompt_v <= 0 or completion_v <= 0:
-            continue
-        if prompt_v > 1000 or completion_v > 1000:
+        prompt = _decimal_to_micro_per_m(dollars[0])
+        completion = _decimal_to_micro_per_m(dollars[-1])
+        if prompt is None or completion is None:
             continue
         out[or_id] = {
-            "prompt_micro_per_m": int(round(prompt_v * 1_000_000)),
-            "completion_micro_per_m": int(round(completion_v * 1_000_000)),
+            "prompt_micro_per_m": prompt,
+            "completion_micro_per_m": completion,
         }
     return out
 
@@ -178,9 +208,18 @@ def parse(html: str) -> dict:
         prices = _FALLBACK_PRICES.get(native)
         if or_id is None or prices is None:
             continue
-        prompt_v, completion_v = prices
-        result[or_id] = {
-            "prompt_micro_per_m": int(round(prompt_v * 1_000_000)),
-            "completion_micro_per_m": int(round(completion_v * 1_000_000)),
+        prompt_v, completion_v, cached_v = prices
+        prompt = _decimal_to_micro_per_m(prompt_v)
+        completion = _decimal_to_micro_per_m(completion_v)
+        if prompt is None or completion is None:
+            continue
+        row = {
+            "prompt_micro_per_m": prompt,
+            "completion_micro_per_m": completion,
         }
+        if cached_v is not None:
+            cached = _decimal_to_micro_per_m(cached_v)
+            if cached is not None:
+                row["prompt_cached_micro_per_m"] = cached
+        result[or_id] = row
     return result

--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -320,7 +320,16 @@ def effective_endpoint(
         return endpoint
     prompt_price = _customer_price(provider_price.prompt_microdollars_per_million_tokens)
     completion_price = _customer_price(provider_price.completion_microdollars_per_million_tokens)
-    tiers = _flat_tier(prompt_price, completion_price)
+    cached_prompt_price = (
+        _customer_price(provider_price.prompt_cached_microdollars_per_million_tokens)
+        if provider_price.prompt_cached_microdollars_per_million_tokens is not None
+        else None
+    )
+    tiers = _flat_tier(
+        prompt_price,
+        completion_price,
+        prompt_cached=cached_prompt_price,
+    )
     return replace(
         endpoint,
         prompt_price_microdollars_per_million_tokens=prompt_price,

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -71,6 +71,7 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_EXAMPLE,
     PROVIDER_CATALOG_V2_EXAMPLE,
 )
+from trusted_router.provider_lifecycle import provider_pricing_schedule
 from trusted_router.regions import configured_regions, region_map_payload
 from trusted_router.seo_catalog import seo_catalog_evidence
 from trusted_router.seo_meta import (
@@ -3635,6 +3636,10 @@ def _model_detail_view(
                 ),
                 "prompt_microdollars_per_million_tokens": endpoint.prompt_price_microdollars_per_million_tokens,
                 "completion_microdollars_per_million_tokens": endpoint.completion_price_microdollars_per_million_tokens,
+                "pricing_schedule": provider_pricing_schedule(
+                    endpoint.provider,
+                    endpoint.model_id,
+                ),
                 "attested_gateway": ep_provider.attested_gateway if ep_provider else False,
                 "provider_zero_data_retention": (
                     endpoint_zero_data_retention(endpoint) if ep_provider else None

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -21,12 +21,44 @@ CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
+DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
+
+# DeepSeek prices direct V4 traffic at twice the off-peak rate during these
+# half-open UTC windows. Keep them as seconds since midnight so boundary
+# behavior is independent of locale, daylight-saving time, and date.
+DEEPSEEK_V4_PEAK_WINDOWS_UTC = (
+    (1 * 60 * 60, 4 * 60 * 60),
+    (6 * 60 * 60, 10 * 60 * 60),
+)
 
 
 @dataclass(frozen=True)
 class ProviderPrice:
     prompt_microdollars_per_million_tokens: int
     completion_microdollars_per_million_tokens: int
+    prompt_cached_microdollars_per_million_tokens: int | None = None
+
+
+_DEEPSEEK_V4_FLASH_MODEL_IDS = frozenset(
+    {
+        "deepseek/deepseek-v4-flash",
+        # This TrustedRouter alias resolves to the same first-party
+        # `deepseek-v4-flash` upstream id and therefore the same bill.
+        "deepseek/deepseek-v4-flash-0731",
+    }
+)
+_DEEPSEEK_V4_PRICES = {
+    "flash": {
+        "legacy": ProviderPrice(140_000, 280_000, 2_800),
+        "off_peak": ProviderPrice(220_000, 660_000, 7_000),
+        "peak": ProviderPrice(440_000, 1_320_000, 14_000),
+    },
+    "pro": {
+        "legacy": ProviderPrice(435_000, 870_000, 3_625),
+        "off_peak": ProviderPrice(660_000, 1_980_000, 22_000),
+        "peak": ProviderPrice(1_320_000, 3_960_000, 44_000),
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -334,6 +366,60 @@ def provider_model_retired(
     return False
 
 
+def _deepseek_v4_family(provider_slug: str, model_id: str) -> str | None:
+    if provider_slug != "deepseek":
+        return None
+    if model_id in _DEEPSEEK_V4_FLASH_MODEL_IDS:
+        return "flash"
+    if model_id == "deepseek/deepseek-v4-pro":
+        return "pro"
+    return None
+
+
+def _deepseek_v4_period(effective_at: datetime) -> str:
+    if effective_at < DEEPSEEK_V4_PRICING_EFFECTIVE_AT:
+        return "legacy"
+    seconds_since_midnight = (
+        effective_at.hour * 60 * 60 + effective_at.minute * 60 + effective_at.second
+    )
+    if any(
+        start <= seconds_since_midnight < end
+        for start, end in DEEPSEEK_V4_PEAK_WINDOWS_UTC
+    ):
+        return "peak"
+    return "off_peak"
+
+
+def provider_pricing_schedule(
+    provider_slug: str,
+    model_id: str,
+    *,
+    at: datetime | str | None = None,
+) -> dict[str, object] | None:
+    """Public timing metadata for a provider's variable token pricing."""
+    if _deepseek_v4_family(provider_slug, model_id) is None:
+        return None
+    effective_at = _effective_time(at)
+
+    def clock(seconds: int) -> str:
+        return f"{seconds // 3600:02d}:{seconds % 3600 // 60:02d}"
+
+    return {
+        "kind": "time_of_day",
+        "timezone": "UTC",
+        "effective_at": DEEPSEEK_V4_PRICING_EFFECTIVE_AT.isoformat().replace("+00:00", "Z"),
+        "current_period": _deepseek_v4_period(effective_at),
+        "peak_multiplier": 2,
+        "peak_windows": [
+            {"start": clock(start), "end": clock(end)}
+            for start, end in DEEPSEEK_V4_PEAK_WINDOWS_UTC
+        ],
+        # Authorization time, not settlement time, selects the period so a
+        # long stream cannot change price midway through the request.
+        "rate_locked_at": "authorization",
+    }
+
+
 def provider_price_microdollars(
     provider_slug: str,
     model_id: str,
@@ -345,8 +431,13 @@ def provider_price_microdollars(
     Pinning both sides prevents a provider API from publishing the new price
     early and makes the exact advertised transition deterministic.
     """
-    if provider_slug != "phala" or model_id != "qwen/qwen-2.5-7b-instruct":
-        return None
-    if _effective_time(at) < PHALA_JULY_2026_EFFECTIVE_AT:
-        return ProviderPrice(40_000, 100_000)
-    return ProviderPrice(100_000, 200_000)
+    effective_at = _effective_time(at)
+    family = _deepseek_v4_family(provider_slug, model_id)
+    if family is not None:
+        return _DEEPSEEK_V4_PRICES[family][_deepseek_v4_period(effective_at)]
+
+    if provider_slug == "phala" and model_id == "qwen/qwen-2.5-7b-instruct":
+        if effective_at < PHALA_JULY_2026_EFFECTIVE_AT:
+            return ProviderPrice(40_000, 100_000)
+        return ProviderPrice(100_000, 200_000)
+    return None

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -11,6 +11,7 @@ from trusted_router.catalog import (
     PRIVACY_TIER_LABELS,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
+    ModelEndpoint,
     endpoint_confidential_compute,
     endpoint_e2ee,
     endpoint_privacy_tier,
@@ -28,6 +29,7 @@ from trusted_router.openai_service_tiers import (
     OPENAI_SERVICE_TIERS,
     openai_priority_pricing,
 )
+from trusted_router.provider_lifecycle import provider_pricing_schedule
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.routing import catalog_endpoint_candidates, provider_route_preferences
 
@@ -86,6 +88,26 @@ def _openai_service_tier_metadata(
             "priority_pricing": pricing.public_payload(),
         }
     return {"service_tiers": ["default"]}
+
+
+def _endpoint_pricing_payload(endpoint: ModelEndpoint) -> dict[str, str]:
+    payload = {
+        "prompt": microdollars_per_million_tokens_to_token_decimal(
+            endpoint.prompt_price_microdollars_per_million_tokens
+        ),
+        "completion": microdollars_per_million_tokens_to_token_decimal(
+            endpoint.completion_price_microdollars_per_million_tokens
+        ),
+    }
+    tiers = getattr(endpoint, "price_tiers", ()) or ()
+    cached_price = (
+        tiers[0].prompt_cached_price_microdollars_per_million_tokens if tiers else None
+    )
+    if cached_price is not None:
+        payload["input_cache_read"] = microdollars_per_million_tokens_to_token_decimal(
+            cached_price
+        )
+    return payload
 
 
 def _public_model_matches_filters(shape: dict[str, Any], request: Request) -> bool:
@@ -179,14 +201,7 @@ def register_catalog_routes(router: APIRouter) -> None:
                     "endpoint_id": endpoint.id,
                     "provider": endpoint.provider,
                     "context_length": model.context_length,
-                    "pricing": {
-                        "prompt": microdollars_per_million_tokens_to_token_decimal(
-                            endpoint.prompt_price_microdollars_per_million_tokens
-                        ),
-                        "completion": microdollars_per_million_tokens_to_token_decimal(
-                            endpoint.completion_price_microdollars_per_million_tokens
-                        ),
-                    },
+                    "pricing": _endpoint_pricing_payload(endpoint),
                     "usage_type": endpoint.usage_type,
                     "upstream_id": endpoint.upstream_id,
                     "prompt_price_microdollars_per_million_tokens": (
@@ -227,6 +242,10 @@ def register_catalog_routes(router: APIRouter) -> None:
                         "prepaid_available": endpoint.usage_type == "Credits",
                         "byok_available": endpoint.usage_type == "BYOK",
                         **_openai_service_tier_metadata(
+                            endpoint.provider,
+                            endpoint.model_id,
+                        ),
+                        "pricing_schedule": provider_pricing_schedule(
                             endpoint.provider,
                             endpoint.model_id,
                         ),

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -147,6 +147,7 @@
           <th>Usage</th>
           <th>Prompt</th>
           <th>Completion</th>
+          <th>Schedule</th>
         </tr>
       </thead>
       <tbody>
@@ -156,6 +157,13 @@
           <td>{{ endpoint.usage_type }}</td>
           <td>{{ endpoint.prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
+          <td>
+            {% if endpoint.pricing_schedule %}
+            DeepSeek direct authorization-time pricing. New rates begin 2026-08-16 16:00 UTC. Peak 01:00–04:00 UTC and 06:00–10:00 UTC.
+            {% else %}
+            Flat
+            {% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_deepseek_time_pricing.py
+++ b/tests/test_deepseek_time_pricing.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.pricing.parsers import deepseek as deepseek_parser
+from trusted_router.catalog import MODEL_ENDPOINTS, effective_endpoint
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.provider_lifecycle import (
+    DEEPSEEK_V4_PRICING_EFFECTIVE_AT,
+    ProviderPrice,
+    provider_price_microdollars,
+    provider_pricing_schedule,
+)
+from trusted_router.routes.internal.gateway import _endpoint_cost_microdollars
+from trusted_router.storage import STORE
+
+_FLASH = "deepseek/deepseek-v4-flash"
+_FLASH_DATED = "deepseek/deepseek-v4-flash-0731"
+_PRO = "deepseek/deepseek-v4-pro"
+
+
+def test_deepseek_parser_uses_off_peak_as_static_schedule_baseline() -> None:
+    html = """
+    <table>
+      <tr><th>MODEL</th><th>deepseek-v4-flash</th><th>deepseek-v4-pro</th></tr>
+      <tr><td>OFF-PEAK 1M INPUT TOKENS (CACHE HIT)</td><td>$0.007</td><td>$0.022</td></tr>
+      <tr><td>OFF-PEAK 1M INPUT TOKENS (CACHE MISS)</td><td>$0.22</td><td>$0.66</td></tr>
+      <tr><td>OFF-PEAK 1M OUTPUT TOKENS</td><td>$0.66</td><td>$1.98</td></tr>
+      <tr><td>PEAK 1M INPUT TOKENS (CACHE HIT)</td><td>$0.014</td><td>$0.044</td></tr>
+      <tr><td>PEAK 1M INPUT TOKENS (CACHE MISS)</td><td>$0.44</td><td>$1.32</td></tr>
+      <tr><td>PEAK 1M OUTPUT TOKENS</td><td>$1.32</td><td>$3.96</td></tr>
+    </table>
+    """
+
+    assert deepseek_parser.parse(html) == {
+        _FLASH: {
+            "prompt_micro_per_m": 220_000,
+            "completion_micro_per_m": 660_000,
+            "prompt_cached_micro_per_m": 7_000,
+        },
+        _PRO: {
+            "prompt_micro_per_m": 660_000,
+            "completion_micro_per_m": 1_980_000,
+            "prompt_cached_micro_per_m": 22_000,
+        },
+    }
+
+
+def test_deepseek_parser_fallback_keeps_announced_off_peak_baseline() -> None:
+    assert deepseek_parser.parse(
+        "<p>Available models: deepseek-v4-flash and deepseek-v4-pro</p>"
+    ) == {
+        _FLASH: {
+            "prompt_micro_per_m": 220_000,
+            "completion_micro_per_m": 660_000,
+            "prompt_cached_micro_per_m": 7_000,
+        },
+        _PRO: {
+            "prompt_micro_per_m": 660_000,
+            "completion_micro_per_m": 1_980_000,
+            "prompt_cached_micro_per_m": 22_000,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        (_FLASH, ProviderPrice(140_000, 280_000, 2_800)),
+        (_FLASH_DATED, ProviderPrice(140_000, 280_000, 2_800)),
+        (_PRO, ProviderPrice(435_000, 870_000, 3_625)),
+    ],
+)
+def test_deepseek_direct_prices_stay_flat_before_announced_cutover(
+    model_id: str,
+    expected: ProviderPrice,
+) -> None:
+    assert provider_price_microdollars(
+        "deepseek",
+        model_id,
+        at=DEEPSEEK_V4_PRICING_EFFECTIVE_AT - timedelta(seconds=1),
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("at", "is_peak"),
+    [
+        (datetime(2026, 8, 16, 16, 0, tzinfo=UTC), False),
+        (datetime(2026, 8, 17, 0, 59, 59, tzinfo=UTC), False),
+        (datetime(2026, 8, 17, 1, 0, tzinfo=UTC), True),
+        (datetime(2026, 8, 17, 3, 59, 59, tzinfo=UTC), True),
+        (datetime(2026, 8, 17, 4, 0, tzinfo=UTC), False),
+        (datetime(2026, 8, 17, 5, 59, 59, tzinfo=UTC), False),
+        (datetime(2026, 8, 17, 6, 0, tzinfo=UTC), True),
+        (datetime(2026, 8, 17, 9, 59, 59, tzinfo=UTC), True),
+        (datetime(2026, 8, 17, 10, 0, tzinfo=UTC), False),
+        (datetime(2026, 8, 17, 23, 59, 59, tzinfo=UTC), False),
+    ],
+)
+def test_deepseek_v4_flash_uses_half_open_utc_peak_windows(
+    at: datetime,
+    is_peak: bool,
+) -> None:
+    expected = ProviderPrice(440_000, 1_320_000, 14_000) if is_peak else ProviderPrice(
+        220_000,
+        660_000,
+        7_000,
+    )
+    assert provider_price_microdollars("deepseek", _FLASH, at=at) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_id", "off_peak", "peak"),
+    [
+        (
+            _FLASH,
+            ProviderPrice(220_000, 660_000, 7_000),
+            ProviderPrice(440_000, 1_320_000, 14_000),
+        ),
+        (
+            _PRO,
+            ProviderPrice(660_000, 1_980_000, 22_000),
+            ProviderPrice(1_320_000, 3_960_000, 44_000),
+        ),
+    ],
+)
+def test_deepseek_v4_new_rates_cover_input_output_and_cache(
+    model_id: str,
+    off_peak: ProviderPrice,
+    peak: ProviderPrice,
+) -> None:
+    assert provider_price_microdollars(
+        "deepseek", model_id, at=datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    ) == off_peak
+    assert provider_price_microdollars(
+        "deepseek", model_id, at=datetime(2026, 8, 17, 2, 0, tzinfo=UTC)
+    ) == peak
+
+
+def test_deepseek_schedule_metadata_is_explicit_and_authorization_scoped() -> None:
+    assert provider_pricing_schedule(
+        "deepseek",
+        _PRO,
+        at=datetime(2026, 8, 17, 2, 0, tzinfo=UTC),
+    ) == {
+        "kind": "time_of_day",
+        "timezone": "UTC",
+        "effective_at": "2026-08-16T16:00:00Z",
+        "current_period": "peak",
+        "peak_multiplier": 2,
+        "peak_windows": [
+            {"start": "01:00", "end": "04:00"},
+            {"start": "06:00", "end": "10:00"},
+        ],
+        "rate_locked_at": "authorization",
+    }
+    assert provider_pricing_schedule(
+        "novita",
+        _PRO,
+        at=datetime(2026, 8, 17, 2, 0, tzinfo=UTC),
+    ) is None
+
+
+def test_deepseek_schedule_does_not_change_third_party_route_prices() -> None:
+    assert provider_price_microdollars(
+        "novita",
+        _FLASH,
+        at=datetime(2026, 8, 17, 2, 0, tzinfo=UTC),
+    ) is None
+
+
+def test_model_endpoints_publish_direct_deepseek_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trusted_router.provider_lifecycle._utc_now",
+        lambda: datetime(2026, 8, 17, 2, 0, tzinfo=UTC),
+    )
+    client = TestClient(create_app(Settings(environment="test"), init_observability=False))
+    response = client.get("/v1/models/deepseek/deepseek-v4-pro/endpoints")
+    assert response.status_code == 200, response.text
+    direct = next(row for row in response.json()["data"] if row["provider"] == "deepseek")
+
+    assert direct["pricing"] == {
+        "prompt": "0.000001386",
+        "completion": "0.000004158",
+        "input_cache_read": "0.0000000462",
+    }
+    assert direct["trustedrouter"]["pricing_schedule"]["current_period"] == "peak"
+    assert direct["trustedrouter"]["pricing_schedule"]["rate_locked_at"] == "authorization"
+
+
+def test_deepseek_pricing_page_explains_variable_direct_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trusted_router.provider_lifecycle._utc_now",
+        lambda: datetime(2026, 8, 17, 12, 0, tzinfo=UTC),
+    )
+    client = TestClient(create_app(Settings(environment="test"), init_observability=False))
+    response = client.get("/models/deepseek/deepseek-v4-pro/pricing")
+
+    assert response.status_code == 200, response.text
+    assert "authorization-time pricing" in response.text
+    assert "01:00–04:00 UTC" in response.text
+    assert "06:00–10:00 UTC" in response.text
+
+
+@pytest.mark.parametrize(
+    ("model_id", "period", "prompt", "completion", "cached"),
+    [
+        (_FLASH, "off_peak", 231_000, 693_000, 10_000),
+        (_FLASH, "peak", 462_000, 1_386_000, 14_700),
+        (_PRO, "off_peak", 693_000, 2_079_000, 23_100),
+        (_PRO, "peak", 1_386_000, 4_158_000, 46_200),
+    ],
+)
+def test_effective_endpoint_applies_markup_and_real_cached_rate(
+    model_id: str,
+    period: str,
+    prompt: int,
+    completion: int,
+    cached: int,
+) -> None:
+    endpoint = MODEL_ENDPOINTS[f"{model_id}@deepseek/prepaid"]
+    hour = 2 if period == "peak" else 12
+    priced = effective_endpoint(endpoint, at=datetime(2026, 8, 17, hour, 0, tzinfo=UTC))
+
+    assert priced.prompt_price_microdollars_per_million_tokens == prompt
+    assert priced.completion_price_microdollars_per_million_tokens == completion
+    assert priced.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == cached
+
+
+def test_deepseek_cached_tokens_are_billed_at_announced_cache_rate() -> None:
+    endpoint = MODEL_ENDPOINTS[f"{_PRO}@deepseek/prepaid"]
+    actual = _endpoint_cost_microdollars(
+        endpoint,
+        100_000,
+        200_000,
+        cache_read_tokens=900_000,
+        effective_at=datetime(2026, 8, 17, 2, 0, tzinfo=UTC),
+    )
+
+    assert actual == (
+        100_000 * 1_386_000 // 1_000_000
+        + 900_000 * 46_200 // 1_000_000
+        + 200_000 * 4_158_000 // 1_000_000
+    )
+
+
+def test_gateway_settlement_uses_authorization_time_for_deepseek_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    peak_time = datetime(2026, 8, 17, 2, 0, tzinfo=UTC)
+    off_peak_time = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "trusted_router.provider_lifecycle._utc_now",
+        lambda: peak_time,
+    )
+    client = TestClient(create_app(Settings(environment="test"), init_observability=False))
+    created = client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "deepseek-pricing@example.com"},
+        json={"name": "DeepSeek pricing"},
+    )
+    assert created.status_code == 201, created.text
+    key = created.json()["data"]
+
+    authorized = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": _FLASH,
+            "estimated_input_tokens": 100_000,
+            "max_output_tokens": 10_000,
+            "provider": {"only": ["deepseek"]},
+        },
+    )
+    assert authorized.status_code == 200, authorized.text
+    authorization_id = authorized.json()["data"]["authorization_id"]
+    authorization = STORE.get_gateway_authorization(authorization_id)
+    assert authorization is not None
+    authorization.created_at = peak_time.isoformat().replace("+00:00", "Z")
+
+    # Settlement happens during another period. Billing must continue to use
+    # the authorization's peak-time quote rather than the wall clock now.
+    monkeypatch.setattr(
+        "trusted_router.provider_lifecycle._utc_now",
+        lambda: off_peak_time,
+    )
+    settled = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": authorization_id,
+            "actual_input_tokens": 100_000,
+            "actual_output_tokens": 10_000,
+            "cache_read_input_tokens": 90_000,
+            "request_id": "deepseek-peak-price",
+            "elapsed_seconds": 1,
+        },
+    )
+    assert settled.status_code == 200, settled.text
+    assert settled.json()["data"]["cost_microdollars"] == 19_803


### PR DESCRIPTION
## Summary
- add effective-dated direct DeepSeek V4 Flash and V4 Pro pricing with UTC peak windows
- lock rates at gateway authorization time and expose schedule metadata in the model endpoint API and pricing UI
- fix the DeepSeek parser so static manifests use announced off-peak rates instead of silently selecting peak rows
- bill cached input with the announced provider rate while preserving the customer pricing floor

## Effective time
`2026-08-16T16:00:00Z`

Peak windows are `[01:00, 04:00)` and `[06:00, 10:00)` UTC. Existing flat rates remain active until the effective timestamp.

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (`3490 passed, 254 skipped, 10 xfailed`)
- `uv run pytest -q tests/test_deepseek_time_pricing.py` (`27 passed`)
- `uv run pytest -q tests/test_alibaba_october_2026_lifecycle.py` (`3 passed`)

The new regression tests were run against the previous implementation first and failed for the missing schedule, cached-input pricing, API metadata, pricing-page disclosure, and parser peak-row selection.