### PR TITLE
Prove the two privacy claims the product sells

### DIFF
--- a/tests/test_catalog_privacy_coherence_property.py
+++ b/tests/test_catalog_privacy_coherence_property.py
@@ -1,0 +1,339 @@
+"""Exhaustive coherence proof for the catalog's privacy tiers.
+
+Three things describe a route's privacy posture, and customers see all three:
+
+  * `endpoint_privacy_tier` — the rank the router enforces a `min_privacy`
+    floor against
+  * the boolean claims — `endpoint_stores_content`,
+    `endpoint_zero_data_retention`, and the confidential-compute pair, which
+    are what the catalog UI and the `/models` API publish
+  * the override table, which lets a specific (model, provider) route depart
+    from its provider's default posture
+
+If those disagree, one of two things happens, and both are bad in the way that
+matters most for this product: a route is advertised as more private than the
+router will actually enforce (overclaiming retention posture to a paying
+customer), or less (silently excluding a route the customer paid for).
+
+The law, quantified over the whole catalog:
+
+    for every ModelEndpoint e,
+        tier(e) >= ZERO_RETENTION      <=>  zero_data_retention(e) is True
+        tier(e) == CONFIDENTIAL         =>  confidential compute AND e2ee
+        tier(e) >= NO_STORE             =>  some explicit flag justifies it
+        stores_content(e)               <=> tier(e) < NO_STORE
+
+The catalog is finite — 51 providers, ~1500 endpoints — so this enumerates
+rather than samples. That makes it a genuine proof *for the shipped catalog*,
+re-established on every CI run, rather than evidence from a sample. Hypothesis
+covers the part enumeration cannot: that the laws are consequences of the
+CODE and not accidents of today's DATA, by generating synthetic providers and
+override entries the real catalog does not currently contain.
+
+The distinction matters. An exhaustive pass over real data proves today's
+catalog is coherent. It does not stop someone adding a provider tomorrow whose
+flags are contradictory. The synthetic half is what covers tomorrow.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from trusted_router.catalog import MODEL_ENDPOINTS, PROVIDERS
+from trusted_router.catalog_data import (
+    PRIVACY_TIER_CONFIDENTIAL,
+    PRIVACY_TIER_NO_STORE,
+    PRIVACY_TIER_STANDARD,
+    PRIVACY_TIER_ZERO_RETENTION,
+)
+from trusted_router.catalog_privacy import (
+    endpoint_privacy_tier,
+    endpoint_stores_content,
+    endpoint_zero_data_retention,
+    provider_privacy_tier,
+)
+
+# MODEL_ENDPOINTS is a dict keyed by "model@provider/usage"; the VALUES are the
+# ModelEndpoint records. Iterating the mapping directly yields keys.
+ALL_ENDPOINTS = list(MODEL_ENDPOINTS.values())
+
+
+def _describe(endpoint: object) -> str:
+    model = getattr(endpoint, "model_id", "?")
+    provider = getattr(endpoint, "provider", "?")
+    return f"{model} @ {provider}"
+
+
+# ---------------------------------------------------------------------------
+# Exhaustive over the shipped catalog.
+# ---------------------------------------------------------------------------
+
+
+def test_the_catalog_is_large_enough_that_enumeration_is_the_point() -> None:
+    """Guard the guard: if the catalog ever collapses to a handful of entries,
+    the exhaustive tests below stop being meaningful and someone should know."""
+    assert len(ALL_ENDPOINTS) > 100, (
+        f"only {len(ALL_ENDPOINTS)} endpoints; exhaustive coverage is no longer "
+        "a meaningful claim and these tests need rethinking"
+    )
+
+
+def test_zero_data_retention_is_exactly_the_zdr_tier() -> None:
+    """The biconditional. This is the law customers rely on most directly:
+    the ZDR badge and the zdr routing floor must mean the same thing."""
+    disagreements = [
+        (
+            _describe(endpoint),
+            endpoint_privacy_tier(endpoint),
+            endpoint_zero_data_retention(endpoint),
+        )
+        for endpoint in ALL_ENDPOINTS
+        if (endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION)
+        != (endpoint_zero_data_retention(endpoint) is True)
+    ]
+    assert not disagreements, (
+        "tier and the published ZDR claim disagree for "
+        f"{len(disagreements)} route(s): {disagreements[:5]}"
+    )
+
+
+def test_confidential_tier_requires_both_confidential_flags() -> None:
+    """CONFIDENTIAL is the strongest claim the catalog makes. It must never be
+    reachable without both underlying flags actually being set."""
+    for endpoint in ALL_ENDPOINTS:
+        if endpoint_privacy_tier(endpoint) != PRIVACY_TIER_CONFIDENTIAL:
+            continue
+        provider = PROVIDERS[endpoint.provider]
+        from trusted_router.catalog_privacy import _model_provider_privacy_override
+
+        override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)
+        if override is not None and override.privacy_tier == PRIVACY_TIER_CONFIDENTIAL:
+            assert override.provider_confidential_compute is True, (
+                f"{_describe(endpoint)}: override claims CONFIDENTIAL without "
+                "provider_confidential_compute"
+            )
+            assert override.provider_e2ee is True, (
+                f"{_describe(endpoint)}: override claims CONFIDENTIAL without provider_e2ee"
+            )
+        else:
+            assert provider.provider_confidential_compute and provider.provider_e2ee, (
+                f"{_describe(endpoint)}: CONFIDENTIAL tier without both provider flags"
+            )
+
+
+def test_stores_content_is_the_complement_of_the_no_store_tier() -> None:
+    for endpoint in ALL_ENDPOINTS:
+        assert endpoint_stores_content(endpoint) == (
+            endpoint_privacy_tier(endpoint) < PRIVACY_TIER_NO_STORE
+        ), f"{_describe(endpoint)}: stores_content disagrees with its tier"
+
+
+def test_no_endpoint_clears_a_bar_without_an_explicit_flag() -> None:
+    """A tier above STANDARD must be justified by something a human wrote —
+    an override, a provider flag, or the prepaid-ZDR upgrade. Never by a
+    default."""
+    from trusted_router.catalog_privacy import _model_provider_privacy_override
+
+    for endpoint in ALL_ENDPOINTS:
+        tier = endpoint_privacy_tier(endpoint)
+        if tier <= PRIVACY_TIER_STANDARD:
+            continue
+        provider = PROVIDERS[endpoint.provider]
+        override = _model_provider_privacy_override(endpoint.model_id, endpoint.provider)
+        justified = (
+            override is not None
+            or provider.stores_content is False
+            or bool(provider.provider_zero_data_retention)
+            or bool(provider.provider_confidential_compute and provider.provider_e2ee)
+            or (endpoint.usage_type == "Credits" and provider.prepaid_zero_data_retention)
+        )
+        assert justified, (
+            f"{_describe(endpoint)} sits at tier {tier} with no flag justifying it"
+        )
+
+
+def test_every_endpoint_provider_exists_and_tiers_are_in_range() -> None:
+    """Totality: the tier function is defined everywhere and never returns a
+    rank outside the declared ladder."""
+    valid = {
+        PRIVACY_TIER_STANDARD,
+        PRIVACY_TIER_NO_STORE,
+        PRIVACY_TIER_ZERO_RETENTION,
+        PRIVACY_TIER_CONFIDENTIAL,
+    }
+    for endpoint in ALL_ENDPOINTS:
+        assert endpoint.provider in PROVIDERS, f"{_describe(endpoint)}: unknown provider"
+        assert endpoint_privacy_tier(endpoint) in valid, _describe(endpoint)
+
+
+def test_the_prepaid_upgrade_only_ever_raises_a_tier() -> None:
+    """The Credits/prepaid path is the one place a tier is computed rather than
+    declared. It must be monotone: an upgrade rule that could LOWER a tier
+    would silently downgrade a route whose provider posture already qualified."""
+    for endpoint in ALL_ENDPOINTS:
+        provider = PROVIDERS[endpoint.provider]
+        if not (endpoint.usage_type == "Credits" and provider.prepaid_zero_data_retention):
+            continue
+        from trusted_router.catalog_privacy import _model_provider_privacy_override
+
+        if _model_provider_privacy_override(endpoint.model_id, endpoint.provider) is not None:
+            continue  # override wins; not the computed path
+        assert endpoint_privacy_tier(endpoint) >= provider_privacy_tier(provider), (
+            f"{_describe(endpoint)}: prepaid upgrade lowered the tier"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic providers: the laws must follow from the CODE, not from the
+# accident that today's data happens to be consistent.
+# ---------------------------------------------------------------------------
+
+_PROVIDER_TEMPLATE = next(iter(PROVIDERS.values()))
+
+
+@st.composite
+def synthetic_providers(draw: object) -> object:
+    """Every combination of the four posture flags, including contradictory
+    ones a careless catalog edit could introduce."""
+    return dataclasses.replace(
+        _PROVIDER_TEMPLATE,
+        stores_content=draw(st.booleans()),
+        provider_zero_data_retention=draw(st.one_of(st.none(), st.booleans())),
+        provider_confidential_compute=draw(st.one_of(st.none(), st.booleans())),
+        provider_e2ee=draw(st.one_of(st.none(), st.booleans())),
+        prepaid_zero_data_retention=draw(st.booleans()),
+    )
+
+
+@given(provider=synthetic_providers())
+@settings(max_examples=500)
+def test_provider_tier_is_monotone_in_its_flags(provider: object) -> None:
+    """Turning a posture flag ON must never LOWER the resulting tier.
+
+    This is the property that stops a future edit from creating a provider
+    whose stronger guarantees compute to a weaker rank — the failure that no
+    amount of exhaustive checking over today's data would catch.
+    """
+    base = provider_privacy_tier(provider)
+
+    stronger = dataclasses.replace(provider, stores_content=False)
+    assert provider_privacy_tier(stronger) >= base or provider.stores_content is False
+
+    zdr = dataclasses.replace(provider, provider_zero_data_retention=True)
+    assert provider_privacy_tier(zdr) >= PRIVACY_TIER_ZERO_RETENTION
+
+    confidential = dataclasses.replace(
+        provider, provider_confidential_compute=True, provider_e2ee=True
+    )
+    assert provider_privacy_tier(confidential) == PRIVACY_TIER_CONFIDENTIAL
+
+
+@given(provider=synthetic_providers())
+@settings(max_examples=500)
+def test_confidential_requires_both_flags_by_construction(provider: object) -> None:
+    """One flag alone must never reach CONFIDENTIAL — the pair is the claim."""
+    if provider_privacy_tier(provider) == PRIVACY_TIER_CONFIDENTIAL:
+        assert provider.provider_confidential_compute and provider.provider_e2ee
+
+
+@given(provider=synthetic_providers())
+@settings(max_examples=500)
+def test_tier_is_always_within_the_declared_ladder(provider: object) -> None:
+    assert PRIVACY_TIER_STANDARD <= provider_privacy_tier(provider) <= PRIVACY_TIER_CONFIDENTIAL
+
+
+@pytest.mark.parametrize(
+    "flags,expected",
+    [
+        ({"stores_content": True}, PRIVACY_TIER_STANDARD),
+        ({"stores_content": False}, PRIVACY_TIER_NO_STORE),
+        ({"provider_zero_data_retention": True}, PRIVACY_TIER_ZERO_RETENTION),
+        (
+            {"provider_confidential_compute": True, "provider_e2ee": True},
+            PRIVACY_TIER_CONFIDENTIAL,
+        ),
+        # One confidential flag alone is NOT confidential.
+        ({"provider_confidential_compute": True}, PRIVACY_TIER_STANDARD),
+        ({"provider_e2ee": True}, PRIVACY_TIER_STANDARD),
+    ],
+)
+def test_the_flag_ladder_is_pinned(flags: dict[str, object], expected: int) -> None:
+    """The exact rung each flag buys. Pinned so a refactor of the if-chain
+    cannot quietly re-order the ladder."""
+    cleared = {
+        "stores_content": True,
+        "provider_zero_data_retention": None,
+        "provider_confidential_compute": None,
+        "provider_e2ee": None,
+        "prepaid_zero_data_retention": False,
+    }
+    provider = dataclasses.replace(_PROVIDER_TEMPLATE, **{**cleared, **flags})
+    assert provider_privacy_tier(provider) == expected
+
+
+# ---------------------------------------------------------------------------
+# A latent incoherence the code permits and the data currently avoids.
+# ---------------------------------------------------------------------------
+
+
+def test_confidential_without_the_zdr_flag_is_a_known_latent_incoherence() -> None:
+    """Standing record of a gap the shipped catalog does not currently hit.
+
+    A provider with `provider_confidential_compute` and `provider_e2ee` set but
+    `provider_zero_data_retention=False` resolves to tier CONFIDENTIAL (3),
+    which is above ZERO_RETENTION (2) — so the router would admit it for a
+    `min_privacy=zdr` request. But `endpoint_zero_data_retention` reads the raw
+    flag and returns False, so `/models` would publish "no ZDR" for a route the
+    router treats as satisfying ZDR.
+
+    The two would disagree, which is exactly what
+    `test_zero_data_retention_is_exactly_the_zdr_tier` forbids across the real
+    catalog. No shipped provider has that flag combination, so the biconditional
+    holds today — this test exists so the gap is recorded rather than
+    rediscovered.
+
+    Deliberately NOT fixed here. The repair is a product decision about what
+    the ZDR badge means (does confidential compute imply zero retention?), and
+    it changes a value published on a customer-visible API. If this test starts
+    failing, the ladder was changed and this note should be revisited.
+    """
+    template = next(iter(PROVIDERS.values()))
+    contradictory = dataclasses.replace(
+        template,
+        stores_content=True,
+        provider_zero_data_retention=False,
+        provider_confidential_compute=True,
+        provider_e2ee=True,
+        prepaid_zero_data_retention=False,
+    )
+
+    tier = provider_privacy_tier(contradictory)
+    assert tier == PRIVACY_TIER_CONFIDENTIAL
+    assert tier >= PRIVACY_TIER_ZERO_RETENTION, (
+        "the router would admit this provider for a zdr floor..."
+    )
+    assert contradictory.provider_zero_data_retention is False, (
+        "...while the published ZDR claim would say False. Coherent only because "
+        "no real provider is configured this way."
+    )
+
+
+def test_no_shipped_provider_has_the_contradictory_flag_combination() -> None:
+    """The reason the gap above is latent rather than live. If a future catalog
+    edit introduces this combination, this fails before the biconditional does,
+    and points at the cause rather than the symptom."""
+    offenders = [
+        slug
+        for slug, provider in PROVIDERS.items()
+        if provider.provider_confidential_compute
+        and provider.provider_e2ee
+        and provider.provider_zero_data_retention is False
+    ]
+    assert not offenders, (
+        f"providers {offenders} claim confidential compute + e2ee but explicitly "
+        "deny zero data retention; the router and the published claim will disagree"
+    )

--- a/tests/test_egress_projection_closure_property.py
+++ b/tests/test_egress_projection_closure_property.py
@@ -1,0 +1,363 @@
+"""Property tests for egress projection closure.
+
+The product's central claim is that prompt and output content never enters the
+control plane's logs, analytics, or third-party sinks. That claim is enforced
+structurally: every surface that leaves the process goes through a *projection*
+function that names its fields explicitly. The law:
+
+    for every Generation g, and every egress projection P,
+        keys(P(g)) == a frozen, declared key set
+        and no content-bearing field of g appears anywhere in serialize(P(g))
+
+Example tests cannot hold this, and the reason is worth being precise about.
+The failure mode is not "someone writes a projection that leaks" — it is
+"someone adds a field to Generation and a projection picks it up." Every
+existing test asserts on a projection's *value* for a fixed input, so a new
+content-bearing field flows through the day it is added and every test still
+passes.
+
+So the load-bearing test here is `test_every_generation_field_is_classified`:
+it partitions `fields(Generation)` into projected / deliberately-excluded, and
+fails CI when a new field belongs to neither. That converts "remember not to
+leak" into "the build stops until you decide."
+
+The canary technique: every string-typed position in the generated Generation
+is planted with a unique marker, including nested tool-call arguments and tag
+values. The assertion is over the *serialized* image, because that is what
+actually leaves — a field that survives only inside an object's repr still
+counts as leaked.
+
+Scope, stated plainly: this proves projections are closed over their declared
+key sets and exclude the declared content fields. It does not prove the
+declared classification is morally correct — that `user` and `session_id` are
+acceptable to export is a product decision, pinned here so it cannot change
+silently, not derived.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from trusted_router.analytics_sink import _row_from_sample
+from trusted_router.storage_activity import generation_events
+from trusted_router.storage_gcp_generation_records import generation_record_body
+from trusted_router.storage_models import Generation, ProviderBenchmarkSample
+from trusted_router.storage_operational_analytics import activity_payload
+from trusted_router.types import UsageType
+
+CANARY = "CANARY-7f3a2b9c"
+
+# ---------------------------------------------------------------------------
+# The classification. Adding a field to Generation and not listing it here is a
+# CI failure, which is the entire point of this module.
+# ---------------------------------------------------------------------------
+
+# Fields that are model-produced or internal and must NEVER reach an analytics
+# or third-party surface.
+CONTENT_OR_INTERNAL_FIELDS = frozenset(
+    {
+        # Model-produced: tool-call arguments are free-form model output and are
+        # the one place raw generated content can hide inside a "metadata" row.
+        "tool_calls",
+        # Internal provider COGS. Not content, but deliberately not published:
+        # exporting it would leak per-provider margin.
+        "operator_cost_microdollars",
+    }
+)
+
+# Raw tenant identifiers. These may appear in the Spanner system of record, but
+# must be surrogated before reaching ClickHouse or any external sink.
+RAW_TENANT_FIELDS = frozenset({"workspace_id", "key_hash"})
+
+# Everything else on Generation is metadata that projections may carry.
+EXPECTED_ACTIVITY_KEYS = frozenset(
+    {
+        "generation_id", "request_id", "tenant_id", "key_id", "model", "provider",
+        "provider_name", "app", "tokens_prompt", "tokens_completion",
+        "cached_input_tokens", "reasoning_tokens", "total_cost_microdollars",
+        "usage_type", "speed_tokens_per_second", "finish_reason", "status",
+        "streamed", "usage_estimated", "elapsed_milliseconds",
+        "first_token_milliseconds", "ttfb_milliseconds", "region", "user",
+        "session_id", "http_referer", "app_categories", "tags", "created_at",
+    }
+)
+
+EXPECTED_EVENT_KEYS = frozenset(
+    {
+        "id", "request_id", "created_at", "date", "model", "provider_name", "app",
+        "user", "session_id", "http_referer", "app_categories", "tags",
+        "input_tokens", "output_tokens", "cost", "cost_microdollars", "usage_type",
+        "speed_tokens_per_second", "finish_reason", "status", "streamed",
+        "content_stored",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Generators. Every string position carries a distinct canary so the assertion
+# can name which field leaked, not merely that something did.
+# ---------------------------------------------------------------------------
+
+
+def _marked(field_name: str) -> str:
+    return f"{CANARY}-{field_name}"
+
+
+@st.composite
+def generations(draw: Any) -> Generation:
+    """A Generation with a canary in every string-typed position."""
+    return Generation(
+        id=_marked("id"),
+        request_id=_marked("request_id"),
+        workspace_id=_marked("workspace_id"),
+        key_hash=_marked("key_hash"),
+        model=_marked("model"),
+        provider_name=_marked("provider_name"),
+        app=_marked("app"),
+        tokens_prompt=draw(st.integers(min_value=0, max_value=10**6)),
+        tokens_completion=draw(st.integers(min_value=0, max_value=10**6)),
+        total_cost_microdollars=draw(st.integers(min_value=0, max_value=10**9)),
+        usage_type=draw(st.sampled_from(list(UsageType))),
+        speed_tokens_per_second=draw(
+            st.floats(min_value=0, max_value=1e4, allow_nan=False, allow_infinity=False)
+        ),
+        finish_reason=_marked("finish_reason"),
+        status=_marked("status"),
+        streamed=draw(st.booleans()),
+        # The dangerous one: free-form model output nested inside metadata.
+        tool_calls=[
+            {
+                "id": _marked("tool_call_id"),
+                "type": "function",
+                "function": {
+                    "name": _marked("tool_name"),
+                    "arguments": _marked("tool_arguments"),
+                },
+            }
+        ],
+        provider=_marked("provider"),
+        region=_marked("region"),
+        user=_marked("user"),
+        session_id=_marked("session_id"),
+        http_referer=_marked("http_referer"),
+        app_categories=[_marked("app_category")],
+        tags={_marked("tag_key"): _marked("tag_value")},
+        operator_cost_microdollars=draw(st.integers(min_value=0, max_value=10**9)),
+        route_type=_marked("route_type"),
+    )
+
+
+def _leaked_markers(payload: Any) -> set[str]:
+    """Which canaries survived into the serialized image.
+
+    `default=str` is the faithful check: it is what a shipper does with a value
+    it does not natively understand, so a secret surviving only inside an
+    object's string form still counts.
+    """
+    blob = json.dumps(payload, default=str, ensure_ascii=False)
+    return {
+        marker
+        for marker in (_marked(f.name) for f in dataclasses.fields(Generation))
+        if marker in blob
+    } | ({_marked("tool_arguments")} if _marked("tool_arguments") in blob else set())
+
+
+# ---------------------------------------------------------------------------
+# The meta-law: every field is classified.
+# ---------------------------------------------------------------------------
+
+
+def test_every_generation_field_is_classified() -> None:
+    """A new field on Generation fails CI until someone decides where it goes.
+
+    This is the test that actually prevents the defect class. Everything below
+    checks today's projections; this one checks tomorrow's.
+    """
+    declared = {f.name for f in dataclasses.fields(Generation)}
+    activity_sourced = {
+        "id", "request_id", "workspace_id", "key_hash", "model", "provider",
+        "provider_name", "app", "tokens_prompt", "tokens_completion",
+        "cached_input_tokens", "reasoning_tokens", "total_cost_microdollars",
+        "usage_type", "speed_tokens_per_second", "finish_reason", "status",
+        "streamed", "usage_estimated", "elapsed_milliseconds",
+        "first_token_milliseconds", "ttfb_milliseconds", "region", "user",
+        "session_id", "http_referer", "app_categories", "tags", "created_at",
+    }
+    # Fields carried only on the system-of-record or video surfaces.
+    other_metadata = {
+        "route_type", "video_input_mode", "video_duration_seconds",
+        "video_resolution", "video_aspect_ratio", "video_generate_audio",
+    }
+
+    classified = activity_sourced | other_metadata | CONTENT_OR_INTERNAL_FIELDS
+    unclassified = declared - classified
+
+    assert not unclassified, (
+        f"Generation gained field(s) {sorted(unclassified)} that no egress "
+        "classification covers. Decide whether each is metadata (add it to the "
+        "appropriate set here and to the projections that should carry it) or "
+        "content/internal (add it to CONTENT_OR_INTERNAL_FIELDS and make sure "
+        "every projection excludes it). Do not simply add it to make this pass."
+    )
+    # And nothing may be classified that no longer exists.
+    assert not (classified - declared), (
+        f"classification names fields not on Generation: {sorted(classified - declared)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse-bound / dashboard projections: closed key sets, no content.
+# ---------------------------------------------------------------------------
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_activity_payload_key_set_is_frozen(generation: Generation) -> None:
+    payload = activity_payload(generation)
+    assert set(payload) == EXPECTED_ACTIVITY_KEYS, (
+        "activity_payload key set drifted; update EXPECTED_ACTIVITY_KEYS only "
+        "after confirming the new field is content-free"
+    )
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_activity_payload_carries_no_content_and_no_raw_tenant_ids(
+    generation: Generation,
+) -> None:
+    leaked = _leaked_markers(activity_payload(generation))
+    forbidden = leaked & (CONTENT_OR_INTERNAL_FIELDS | RAW_TENANT_FIELDS)
+    assert not forbidden, f"activity_payload leaked {sorted(forbidden)}"
+    assert _marked("tool_arguments") not in leaked, (
+        "tool-call arguments are free-form model output and must never reach analytics"
+    )
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_activity_payload_surrogates_tenant_identifiers(generation: Generation) -> None:
+    """Tenant ids must be surrogated, not merely absent by accident."""
+    payload = activity_payload(generation)
+    assert payload["tenant_id"] != generation.workspace_id
+    assert payload["key_id"] != generation.key_hash
+    assert payload["tenant_id"], "surrogate must not be empty"
+    assert payload["key_id"], "surrogate must not be empty"
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_generation_events_key_set_is_frozen_and_content_free(
+    generation: Generation,
+) -> None:
+    events = generation_events([generation])
+    assert len(events) == 1
+    assert set(events[0]) == EXPECTED_EVENT_KEYS
+
+    leaked = _leaked_markers(events[0])
+    forbidden = leaked & (CONTENT_OR_INTERNAL_FIELDS | RAW_TENANT_FIELDS)
+    assert not forbidden, f"generation_events leaked {sorted(forbidden)}"
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_generation_events_never_claims_content_is_stored(
+    generation: Generation,
+) -> None:
+    """`content_stored` is a promise to the dashboard. It is a constant false,
+    and a projection that ever made it dynamic would be a product-claim change
+    rather than a refactor."""
+    assert generation_events([generation])[0]["content_stored"] is False
+
+
+# ---------------------------------------------------------------------------
+# The Spanner system of record is a DIFFERENT surface with different rules.
+# ---------------------------------------------------------------------------
+
+
+@given(generation=generations())
+@settings(max_examples=200)
+def test_generation_record_excludes_tool_calls_but_keeps_raw_ids(
+    generation: Generation,
+) -> None:
+    """The system of record legitimately holds raw tenant ids — it is not an
+    egress surface. It must still exclude model-produced content.
+
+    Asserting both directions matters: a well-meaning change that surrogated
+    ids here would break lookups, and one that kept tool_calls would put model
+    output in durable storage.
+    """
+    body = json.loads(generation_record_body(generation))
+
+    assert "tool_calls" not in body, "model-produced tool arguments must not be persisted"
+    assert _marked("tool_arguments") not in json.dumps(body, default=str)
+    assert body["workspace_id"] == generation.workspace_id
+    assert body["key_hash"] == generation.key_hash
+
+
+# ---------------------------------------------------------------------------
+# Benchmark samples: a separate surface, same closure requirement.
+# ---------------------------------------------------------------------------
+
+
+@given(
+    provider=st.text(min_size=1, max_size=12),
+    model=st.text(min_size=1, max_size=12),
+    tokens=st.integers(min_value=0, max_value=10**6),
+)
+@settings(max_examples=100)
+def test_benchmark_row_never_carries_free_text(
+    provider: str, model: str, tokens: int
+) -> None:
+    """The public leaderboard row is built from a benchmark sample. Its key set
+    is closed, and every value is a scalar — no nested structure that could
+    carry a payload."""
+    sample = ProviderBenchmarkSample(
+        id="bench-1",
+        provider=provider,
+        model=model,
+        provider_name=provider,
+        status="ok",
+        usage_type=UsageType.CREDITS,
+        source="synthetic",
+        streamed=False,
+        input_tokens=tokens,
+        output_tokens=tokens,
+        total_cost_microdollars=0,
+        speed_tokens_per_second=1.0,
+    )
+    row = _row_from_sample(sample)
+
+    for key, value in row.items():
+        assert not isinstance(value, (dict, list)), (
+            f"benchmark row field {key!r} is a container; leaderboard rows must be "
+            "flat scalars so no structured payload can ride along"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression pins for the specific fields that motivated this module.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("excluded", sorted(CONTENT_OR_INTERNAL_FIELDS))
+def test_excluded_fields_are_absent_from_every_analytics_projection(
+    excluded: str,
+) -> None:
+    generation = Generation(
+        id="g", request_id="r", workspace_id="w", key_hash="k", model="m",
+        provider_name="p", app="a", tokens_prompt=1, tokens_completion=1,
+        total_cost_microdollars=1, usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=1.0, finish_reason="stop", status="ok",
+        streamed=False,
+        tool_calls=[{"function": {"arguments": CANARY}}],
+        operator_cost_microdollars=999,
+    )
+
+    assert excluded not in activity_payload(generation)
+    assert excluded not in generation_events([generation])[0]


### PR DESCRIPTION
Two properties that turn customer-facing privacy claims from *asserted* into *mechanically checked*. No production code changes — these are proofs about existing behaviour, plus one latent gap recorded.

## 1. Egress projection closure

The claim is that prompt and output content never enters logs, analytics, or third-party sinks. It is enforced structurally: every surface that leaves the process goes through a projection that names its fields explicitly.

**Example tests cannot hold that claim**, and the reason is worth being precise about. The failure mode is not *"someone writes a leaky projection"* — it is *"someone adds a field to `Generation` and a projection picks it up."* Every existing test asserts on a projection's **value** for a fixed input, so a new content-bearing field flows through the day it is added and every test still passes.

So the load-bearing test is `test_every_generation_field_is_classified`: it partitions `fields(Generation)` into projected / deliberately-excluded and fails CI when a field belongs to neither. That converts *"remember not to leak"* into *"the build stops until you decide."*

**Verified it fires.** Adding a `system_prompt_preview: str | None` field to `Generation`:

```
AssertionError: Generation gained field(s) ['system_prompt_preview'] that no
egress classification covers. Decide whether each is metadata ... or
content/internal ... Do not simply add it to make this pass.
```

The rest plant a unique canary in every string position — including **nested tool-call arguments**, the one place raw model output can hide inside a "metadata" row — and assert over the *serialized* image, because that is what actually leaves.

Both directions are pinned, which matters: analytics surfaces must surrogate tenant ids and drop `tool_calls`, while the Spanner **system of record must keep raw ids** (it is not an egress surface) and still drop `tool_calls`. A well-meaning change in either direction breaks something real.

## 2. Catalog privacy coherence

Three things describe a route's posture, and customers see all three: the tier the router enforces a `min_privacy` floor against, the booleans the catalog UI and `/models` publish, and the override table. If they disagree, a route is either **advertised as more private than the router enforces**, or less.

The catalog is finite — 51 providers, **1517 endpoints** — so this *enumerates* rather than samples. That makes it a genuine proof for the shipped catalog, re-established on every CI run. **All 1517 are coherent today.**

Hypothesis covers what enumeration cannot: that the laws follow from the **code** rather than from the accident that today's **data** happens to be consistent. It generates synthetic providers across every combination of the four posture flags, including contradictory ones.

### A latent incoherence, recorded and deliberately not fixed

That synthetic half surfaced something real. A provider with `provider_confidential_compute` and `provider_e2ee` set but `provider_zero_data_retention=False` resolves to tier `CONFIDENTIAL` (3), which is above `ZERO_RETENTION` (2) — so the router would admit it for a `min_privacy=zdr` request — while `endpoint_zero_data_retention` reads the raw flag and returns `False`, so `/models` would publish "no ZDR" for it.

**No shipped provider is configured that way**, so the biconditional holds today. I have not fixed it: the repair is a product decision about what the ZDR badge means (does confidential compute imply zero retention?) and it changes a value published on a customer-visible API. Two tests pin it — one documents the gap so it is not rediscovered, one fails loudly if a catalog edit ever introduces the combination, pointing at the cause rather than the symptom.

**This is yours to decide, not mine.**

## Verification

- `pytest`: 3499 passed, 254 skipped, 10 xfailed (3407 before)
- `ruff check .` and `mypy`: clean
- No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)