### PR TITLE
Restrict wallet-only billing to stablecoin

### DIFF
--- a/src/trusted_router/billing_policy.py
+++ b/src/trusted_router/billing_policy.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from trusted_router.auth import Principal
+from trusted_router.storage import STORE, User
+
+STABLECOIN_CHECKOUT_METHODS = frozenset({"stablecoin", "crypto", "usdc"})
+WALLET_ONLY_STABLECOIN_MESSAGE = (
+    "Wallet-only accounts can only fund with stablecoin. "
+    "Add and verify an email to use other payment methods."
+)
+
+
+def is_wallet_only_user(user: User | None) -> bool:
+    """Whether the identity is backed only by a wallet signature.
+
+    An unverified email does not change the account's authentication
+    properties, so card-like payment methods remain locked until verification.
+    """
+    return bool(user and user.wallet_address and not (user.email and user.email_verified))
+
+
+def principal_user(principal: Principal) -> User | None:
+    if principal.user is not None:
+        return principal.user
+    if principal.api_key is None or not principal.api_key.creator_user_id:
+        return None
+    return STORE.get_user(principal.api_key.creator_user_id)
+
+
+def is_wallet_only_principal(principal: Principal) -> bool:
+    return is_wallet_only_user(principal_user(principal))
+
+
+def is_stablecoin_checkout_method(payment_method: str) -> bool:
+    return payment_method.strip().lower() in STABLECOIN_CHECKOUT_METHODS

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -8,6 +8,11 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
+from trusted_router.billing_policy import (
+    WALLET_ONLY_STABLECOIN_MESSAGE,
+    is_stablecoin_checkout_method,
+    is_wallet_only_principal,
+)
 from trusted_router.config import Settings
 from trusted_router.domains import request_control_origin
 from trusted_router.errors import api_error, deprecated
@@ -63,6 +68,14 @@ def register_billing_routes(router: APIRouter) -> None:
         workspace_id = body.workspace_id or principal.workspace.id
         if workspace_id != principal.workspace.id:
             raise api_error(403, "Forbidden", ErrorType.FORBIDDEN)
+        if is_wallet_only_principal(principal) and not is_stablecoin_checkout_method(
+            body.payment_method
+        ):
+            raise api_error(
+                403,
+                WALLET_ONLY_STABLECOIN_MESSAGE,
+                ErrorType.FORBIDDEN,
+            )
         body = _checkout_body_with_first_party_returns(body, request, settings)
         account = STORE.get_credit_account(workspace_id)
         return JSONResponse(
@@ -100,6 +113,7 @@ def register_billing_routes(router: APIRouter) -> None:
         principal: ManagementPrincipal,
         settings: SettingsDep,
     ) -> dict[str, dict[str, Any]]:
+        _reject_wallet_only_traditional_billing(principal)
         result = capture_paypal_order_for_workspace(
             order_id=order_id,
             workspace_id=principal.workspace.id,
@@ -189,6 +203,7 @@ def register_billing_routes(router: APIRouter) -> None:
         principal: ManagementPrincipal,
         settings: SettingsDep,
     ) -> dict[str, dict[str, str]]:
+        _reject_wallet_only_traditional_billing(principal)
         body = await json_body(request)
         return_url = str(body.get("return_url") or f"{request_control_origin(request, settings)}/billing")
         account = STORE.get_credit_account(principal.workspace.id)
@@ -201,6 +216,7 @@ def register_billing_routes(router: APIRouter) -> None:
         principal: ManagementPrincipal,
         settings: SettingsDep,
     ) -> JSONResponse:
+        _reject_wallet_only_traditional_billing(principal)
         account = STORE.get_credit_account(principal.workspace.id)
         return JSONResponse(
             {
@@ -235,6 +251,15 @@ def _checkout_customer_email(principal: Any) -> str | None:
         if user is not None and user.email and "@" in user.email:
             return user.email
     return None
+
+
+def _reject_wallet_only_traditional_billing(principal: Any) -> None:
+    if is_wallet_only_principal(principal):
+        raise api_error(
+            403,
+            WALLET_ONLY_STABLECOIN_MESSAGE,
+            ErrorType.FORBIDDEN,
+        )
 
 
 def _checkout_body_with_first_party_returns(

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -14,6 +14,10 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from pydantic import ValidationError
 
 from trusted_router.auth import SettingsDep
+from trusted_router.billing_policy import (
+    is_stablecoin_checkout_method,
+    is_wallet_only_user,
+)
 from trusted_router.domains import request_control_origin
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.schemas import CheckoutRequest
@@ -44,6 +48,7 @@ def register(app: FastAPI) -> None:
     async def console_credits(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         credit = STORE.get_credit_account(ctx.workspace.id)
         summary = live_credit_summary(ctx.workspace.id)
+        wallet_only_billing = is_wallet_only_user(ctx.user)
         # Pull the last 20 Stripe checkout sessions tagged with this
         # workspace_id from Stripe's Search API. Returns [] if Stripe is
         # unreachable / not configured / there are no payments yet — all
@@ -88,6 +93,7 @@ def register(app: FastAPI) -> None:
             last_auto_refill_status=credit.last_auto_refill_status if credit else None,
             paypal_enabled=settings.paypal_enabled or settings.environment.lower() in {"local", "test"},
             adyen_enabled=settings.adyen_checkout_ready,
+            wallet_only_billing=wallet_only_billing,
             payments=payments,
             saved_payment_method=saved_payment_method,
             api_base_url=ctx.api_base_url,
@@ -105,6 +111,10 @@ def register(app: FastAPI) -> None:
         amount: str = Form(...),
         payment_method: str = Form("auto"),
     ) -> Response:
+        if is_wallet_only_user(ctx.user) and not is_stablecoin_checkout_method(
+            payment_method
+        ):
+            return _wallet_only_redirect()
         origin = request_control_origin(request, settings)
         if payment_method == "paypal":
             success_url = f"{origin}/console/credits/paypal/capture"
@@ -194,6 +204,8 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         token: str = "",
     ) -> Response:
+        if is_wallet_only_user(ctx.user):
+            return _wallet_only_redirect()
         if not token:
             return RedirectResponse(url="/console/credits?error=paypal_missing_order", status_code=303)
         try:
@@ -213,6 +225,8 @@ def register(app: FastAPI) -> None:
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:
+        if is_wallet_only_user(ctx.user):
+            return _wallet_only_redirect()
         credit = STORE.get_credit_account(ctx.workspace.id)
         origin = request_control_origin(request, settings)
         try:
@@ -236,6 +250,8 @@ def register(app: FastAPI) -> None:
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:
+        if is_wallet_only_user(ctx.user):
+            return _wallet_only_redirect()
         credit = STORE.get_credit_account(ctx.workspace.id)
         if not (credit and credit.stripe_customer_id):
             return RedirectResponse(url="/console/credits?error=no_payment_method", status_code=303)
@@ -275,6 +291,8 @@ def register(app: FastAPI) -> None:
         # Reject the enable toggle if there's no saved payment method —
         # otherwise the trigger fires every settle and silently fails.
         truly_enable = enabled == "1"
+        if truly_enable and is_wallet_only_user(ctx.user):
+            return _wallet_only_redirect()
         if truly_enable and not (credit and credit.stripe_customer_id and credit.stripe_payment_method_id):
             return RedirectResponse(url="/console/credits?error=no_payment_method", status_code=303)
         STORE.update_auto_refill_settings(
@@ -284,3 +302,10 @@ def register(app: FastAPI) -> None:
             amount_microdollars=amount * 1_000_000,
         )
         return RedirectResponse(url="/console/credits?saved=1", status_code=303)
+
+
+def _wallet_only_redirect() -> RedirectResponse:
+    return RedirectResponse(
+        url="/console/credits?error=stablecoin_only",
+        status_code=303,
+    )

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -10,10 +10,20 @@
     <div class="notice warn" style="margin-top:18px">
       Migration credits are available by approval for qualified design partners spending more than $100 per month on LLMs. This console does not grant them automatically. Apply credits manually after approval.
     </div>
+    {% if wallet_only_billing %}
+    <div class="notice" style="margin-top:18px">
+      Wallet-only accounts can fund with stablecoin. Add and verify an email in
+      <a href="/console/account/preferences">Preferences</a> to use cards or other payment methods.
+    </div>
+    {% endif %}
     <form class="form" method="post" action="/console/credits/checkout" style="margin-top:18px">
       <div class="row">
         <label>Amount (USD)<input name="amount" type="number" min="1" max="10000" step="1" value="25" required></label>
         <label>Payment method
+          {% if wallet_only_billing %}
+          <input type="hidden" name="payment_method" value="stablecoin">
+          <input type="text" value="Stablecoin (USDC)" readonly>
+          {% else %}
           <select name="payment_method">
             <option value="auto">Stripe card</option>
             <option value="ach">Bank account (ACH)</option>
@@ -25,21 +35,27 @@
             <option value="adyen">Adyen</option>
             {% endif %}
           </select>
+          {% endif %}
         </label>
       </div>
       <button class="btn primary" type="submit">Continue to checkout</button>
       <p class="form-help">
+        {% if wallet_only_billing %}
+        Stablecoin checkout adds prepaid credits without attaching a card or bank account.
+        {% else %}
         Card and PayPal checkouts show your credits and the same payment
         processing fee as separate line items before you pay, with an $0.80
         minimum fee. ACH and
         stablecoin keep their lower rail-specific fees. ACH is 0.8%, capped
         at $5, and can take up to four business days. Bank-funded credits
         appear only after settlement.
+        {% endif %}
       </p>
     </form>
   </div>
 </section>
 
+{% if not wallet_only_billing or saved_payment_method %}
 <section class="panel">
   <div class="panel-head">
     <h2>Payment methods</h2>
@@ -49,10 +65,14 @@
   </div>
   <div class="panel-body">
     <p style="color:var(--muted);font-size:14px;margin:0 0 14px">
+      {% if wallet_only_billing %}
+      Wallet-only accounts cannot add or charge a card. You can remove this previously saved card below.
+      {% else %}
       Save a Stripe card for auto refill. One-time credit purchases can use a
       card, ACH bank account, PayPal{% if adyen_enabled %}, Adyen{% endif %}, or USDC above.
       {% if payment_method_pending %}
       <br><strong>Stripe setup is pending. Auto-refill will unlock after Stripe confirms the card.</strong>
+      {% endif %}
       {% endif %}
     </p>
     {% if saved_payment_method %}
@@ -85,6 +105,7 @@
       </form>
     </div>
     {% endif %}
+    {% if not wallet_only_billing %}
     <div class="button-row">
       <form method="post" action="/console/credits/payment-methods/add">
         <button class="btn primary" type="submit">
@@ -97,9 +118,12 @@
       </form>
       {% endif %}
     </div>
+    {% endif %}
   </div>
 </section>
+{% endif %}
 
+{% if not wallet_only_billing %}
 <section class="panel">
   <div class="panel-head">
     <h2>Auto refill</h2>
@@ -139,6 +163,7 @@
     {% endif %}
   </div>
 </section>
+{% endif %}
 
 <section class="panel">
   <div class="panel-head">
@@ -215,8 +240,12 @@
     </p>
     {% else %}
     <p style="color:var(--muted);font-size:14px;margin:0">
+      {% if wallet_only_billing %}
+      No payments yet. Stablecoin payments appear after confirmation.
+      {% else %}
       No payments yet. Card payments appear after completion; ACH credits appear
       after Stripe confirms bank settlement.
+      {% endif %}
     </p>
     {% endif %}
   </div>

--- a/tests/test_wallet_only_billing.py
+++ b/tests/test_wallet_only_billing.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import STORE, User, Workspace
+
+
+@contextmanager
+def _wallet_client(
+    *,
+    email: str | None = None,
+    email_verified: bool = False,
+) -> Iterator[tuple[TestClient, User, Workspace, str]]:
+    app = create_app(Settings(environment="local"), init_observability=False)
+    with TestClient(app) as client:
+        user = STORE.create_wallet_user("0x1111111111111111111111111111111111111111")
+        if email:
+            updated = STORE.set_user_email(user.id, email)
+            assert updated is not None
+            user = updated
+        if email_verified:
+            verified = STORE.mark_user_email_verified(user.id)
+            assert verified is not None
+            user = verified
+        workspace = STORE.list_workspaces_for_user(user.id)[0]
+        raw_session, _ = STORE.create_auth_session(
+            user_id=user.id,
+            provider="metamask",
+            label=user.wallet_address or "wallet",
+            workspace_id=workspace.id,
+            ttl_seconds=3600,
+            state="active",
+        )
+        client.cookies.set("tr_session", raw_session)
+        yield client, user, workspace, raw_session
+
+
+@pytest.mark.parametrize(
+    "payment_method",
+    ["auto", "card", "ach", "bank", "us_bank_account", "paypal", "adyen"],
+)
+def test_wallet_only_api_checkout_rejects_every_non_stablecoin_rail(
+    payment_method: str,
+) -> None:
+    with _wallet_client() as (client, _user, _workspace, _session):
+        response = client.post(
+            "/v1/billing/checkout",
+            json={"amount": 25, "payment_method": payment_method},
+        )
+
+    assert response.status_code == 403
+    error = response.json()["error"]
+    assert error["message"] == (
+        "Wallet-only accounts can only fund with stablecoin. "
+        "Add and verify an email to use other payment methods."
+    )
+    assert error["type"] == "forbidden"
+    assert error["code"] == 403
+    assert error["source"] == "router"
+
+
+@pytest.mark.parametrize("payment_method", ["stablecoin", "crypto", "usdc"])
+def test_wallet_only_api_checkout_allows_stablecoin_aliases(
+    payment_method: str,
+) -> None:
+    with _wallet_client() as (client, _user, _workspace, _session):
+        response = client.post(
+            "/v1/billing/checkout",
+            json={"amount": 25, "payment_method": payment_method},
+        )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["data"]["mode"] == "mock_stablecoin"
+
+
+@pytest.mark.parametrize(
+    ("path", "json_body"),
+    [
+        ("/v1/billing/payment-methods/setup", None),
+        ("/v1/billing/portal", {}),
+        ("/v1/billing/paypal/orders/order-test/capture", None),
+    ],
+)
+def test_wallet_only_api_rejects_direct_traditional_billing_routes(
+    path: str,
+    json_body: dict[str, object] | None,
+) -> None:
+    with _wallet_client() as (client, _user, _workspace, _session):
+        response = client.post(path, json=json_body)
+
+    assert response.status_code == 403
+    assert response.json()["error"]["type"] == "forbidden"
+
+
+def test_wallet_only_management_key_inherits_creator_billing_restriction() -> None:
+    with _wallet_client() as (client, user, workspace, _session):
+        raw_key, _ = STORE.create_api_key(
+            workspace_id=workspace.id,
+            name="wallet-management",
+            creator_user_id=user.id,
+            management=True,
+        )
+        response = client.post(
+            "/v1/billing/checkout",
+            headers={"authorization": f"Bearer {raw_key}"},
+            json={"amount": 25, "payment_method": "card"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["type"] == "forbidden"
+
+
+def test_wallet_only_console_offers_stablecoin_without_card_controls() -> None:
+    with _wallet_client() as (client, _user, _workspace, _session):
+        response = client.get("/console/credits")
+
+    assert response.status_code == 200
+    assert 'name="payment_method" value="stablecoin"' in response.text
+    assert 'value="Stablecoin (USDC)"' in response.text
+    assert '<option value="auto">' not in response.text
+    assert '<option value="ach">' not in response.text
+    assert '<option value="paypal">' not in response.text
+    assert '<option value="adyen">' not in response.text
+    assert 'action="/console/credits/payment-methods/add"' not in response.text
+    assert 'action="/console/credits/payment-methods/manage"' not in response.text
+    assert 'action="/console/credits/auto-refill"' not in response.text
+    assert "Wallet-only accounts can fund with stablecoin" in response.text
+
+
+def test_wallet_only_console_rejects_direct_card_and_auto_refill_posts() -> None:
+    with _wallet_client() as (client, _user, workspace, _session):
+        checkout = client.post(
+            "/console/credits/checkout",
+            data={"amount": "25", "payment_method": "card"},
+            follow_redirects=False,
+        )
+        add_method = client.post(
+            "/console/credits/payment-methods/add",
+            follow_redirects=False,
+        )
+        manage_method = client.post(
+            "/console/credits/payment-methods/manage",
+            follow_redirects=False,
+        )
+        paypal_capture = client.get(
+            "/console/credits/paypal/capture?token=order-test",
+            follow_redirects=False,
+        )
+        auto_refill = client.post(
+            "/console/credits/auto-refill",
+            data={"enabled": "1", "threshold": "10", "amount": "25"},
+            follow_redirects=False,
+        )
+        account = STORE.get_credit_account(workspace.id)
+
+    for response in (
+        checkout,
+        add_method,
+        manage_method,
+        paypal_capture,
+        auto_refill,
+    ):
+        assert response.status_code == 303
+        assert response.headers["location"] == ("/console/credits?error=stablecoin_only")
+    assert account is not None
+    assert account.stripe_customer_id is None
+    assert account.stripe_payment_method_id is None
+    assert account.auto_refill_enabled is False
+
+
+def test_wallet_only_console_stablecoin_checkout_still_works() -> None:
+    with _wallet_client() as (client, _user, _workspace, _session):
+        response = client.post(
+            "/console/credits/checkout",
+            data={"amount": "25", "payment_method": "stablecoin"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/console/credits?checkout=mock"
+
+
+def test_wallet_only_console_can_remove_a_legacy_saved_card() -> None:
+    with _wallet_client() as (client, _user, workspace, _session):
+        STORE.set_stripe_customer(
+            workspace.id,
+            customer_id="cus_wallet_legacy",
+            payment_method_id="pm_wallet_legacy",
+        )
+        page = client.get("/console/credits")
+        response = client.post(
+            "/console/credits/payment-methods/remove",
+            follow_redirects=False,
+        )
+        account = STORE.get_credit_account(workspace.id)
+
+    assert 'action="/console/credits/payment-methods/remove"' in page.text
+    assert 'action="/console/credits/payment-methods/add"' not in page.text
+    assert response.status_code == 303
+    assert response.headers["location"] == ("/console/credits?payment_method=removed")
+    assert account is not None
+    assert account.stripe_payment_method_id is None
+    assert account.auto_refill_enabled is False
+
+
+def test_unverified_wallet_email_does_not_unlock_card_billing() -> None:
+    with _wallet_client(email="wallet@example.com") as (
+        client,
+        _user,
+        _workspace,
+        _session,
+    ):
+        response = client.post(
+            "/v1/billing/checkout",
+            json={"amount": 25, "payment_method": "card"},
+        )
+
+    assert response.status_code == 403
+
+
+def test_verified_wallet_email_unlocks_standard_billing_options() -> None:
+    with _wallet_client(
+        email="wallet@example.com",
+        email_verified=True,
+    ) as (client, _user, _workspace, _session):
+        checkout = client.post(
+            "/v1/billing/checkout",
+            json={"amount": 25, "payment_method": "card"},
+        )
+        page = client.get("/console/credits")
+
+    assert checkout.status_code == 201, checkout.text
+    assert '<option value="auto">Stripe card</option>' in page.text
+    assert 'action="/console/credits/payment-methods/add"' in page.text
+    assert 'action="/console/credits/auto-refill"' in page.text


### PR DESCRIPTION
## Summary
- identify accounts authenticated only by a wallet and without a verified email
- allow only stablecoin checkout for those accounts across console and management APIs
- block direct card, ACH, PayPal, Adyen, billing-portal, card-setup, and auto-refill bypasses
- preserve removal of any legacy saved card and unlock standard billing after email verification

## Verification
- 3,518 tests passed, 254 skipped, 10 expected failures
- 20 focused wallet-only billing tests
- 64 focused post-rebase tests
- ruff clean
- mypy clean