### PR TITLE
Scrub mapping keys, not just values

### DIFF
--- a/src/trusted_router/sentry_config.py
+++ b/src/trusted_router/sentry_config.py
@@ -555,10 +555,16 @@ def _scrub(value: Any, *, _depth: int = 0, _seen: frozenset[int] = frozenset()) 
             if index >= _SCRUB_MAX_ITEMS:
                 out["[truncated]"] = f"{len(value) - _SCRUB_MAX_ITEMS} more"
                 break
+            # The KEY is a string that leaves the process too. A secret can be
+            # the key rather than the value — {"sk-tr-v1-...": 3} is what a
+            # per-key counter or cache-hit tally looks like — and scrubbing only
+            # values left it intact. Scrub the key with the same string rules
+            # before deciding anything about the value under it.
+            safe_key = _scrub_string(key) if isinstance(key, str) else key
             if _is_sensitive_key(str(key)):
-                out[key] = "[Filtered]"
+                out[safe_key] = "[Filtered]"
             else:
-                out[key] = _scrub(item, _depth=child_depth, _seen=seen)
+                out[safe_key] = _scrub(item, _depth=child_depth, _seen=seen)
         return out
 
     if isinstance(value, (set, frozenset)):

--- a/tests/test_scrub_totality_property.py
+++ b/tests/test_scrub_totality_property.py
@@ -74,12 +74,19 @@ leaves = st.one_of(
     st.none(),
 )
 
+# Mapping KEYS carry secrets too. The first version of this module generated
+# keys only from st.text(), so every canary lived in a value — and a real leak
+# through {"sk-tr-v1-...": 3} survived the whole suite until an external review
+# pointed at it. That shape is not exotic: a per-key counter or a cache-hit
+# tally is exactly a dict keyed by the credential.
+keys = st.one_of(st.text(max_size=6), st.sampled_from(SECRETS))
+
 values = st.recursive(
     leaves,
     lambda children: st.one_of(
         st.lists(children, max_size=4),
         st.lists(children, max_size=4).map(tuple),
-        st.dictionaries(st.text(max_size=6), children, max_size=4),
+        st.dictionaries(keys, children, max_size=4),
         st.frozensets(st.sampled_from(SECRETS) | st.text(max_size=6), max_size=3),
     ),
     max_leaves=12,
@@ -214,3 +221,25 @@ def test_a_bare_secret_in_the_message_is_scrubbed(secret: str) -> None:
 
     assert _AxiomScrubFilter().filter(record) is True
     assert CANARY_SUFFIX not in record.getMessage()
+
+
+def test_a_secret_used_as_a_mapping_key_is_scrubbed() -> None:
+    """The concrete shape the generator missed.
+
+    `_scrub` checked whether a key NAME was sensitive ("api_key") but never
+    scrubbed the key's own text, so a credential used as a key survived intact
+    while the value beside it was filtered. Found by external review, not by
+    this module — which is why the generator above now produces secret keys.
+    """
+    secret = f"sk-tr-v1-{CANARY_SUFFIX}"
+    assert not _leaked(_scrub({secret: 1}))
+    assert not _leaked(_scrub({"nested": {secret: 1}}))
+    assert not _leaked(_scrub([{secret: 1}]))
+    assert not _leaked(_scrub({secret: secret}))
+
+
+def test_scrubbing_a_key_does_not_disturb_a_harmless_one() -> None:
+    """The bound must not rename ordinary keys, or every structured log field
+    changes name and dashboards break."""
+    scrubbed = _scrub({"request_id": "abc", "count": 3})
+    assert scrubbed == {"request_id": "abc", "count": 3}


### PR DESCRIPTION
## The defect

A credential used as a dict **key** survived scrubbing intact:

```python
_scrub({"sk-tr-v1-SECRET": 1})   ->  {'sk-tr-v1-SECRET': 1}      LEAKS
_scrub({"nested": {"sk-tr-v1-SECRET": 1}})                        LEAKS
_scrub([{"sk-tr-v1-SECRET": 1}])                                  LEAKS
```

`_scrub` asked whether a key *name* was sensitive (`"api_key"`, `"token"`) but never scrubbed the key's own text. So the value beside it was filtered while the key itself shipped to Axiom.

The shape is not exotic. A per-key counter or a cache-hit tally is exactly a dict keyed by the credential.

## The more useful half of the finding

**This was found by external review, not by the property module that exists to cover it.**

`test_scrub_totality_property.py` generated mapping keys only from `st.text()`, so every canary it planted lived in a *value*. It searched a large space thoroughly and never looked at half the shape. A property test is only as good as the positions its generator can reach, and "I generated containers" is not the same as "I generated every position a string can occupy in a container."

The generator now draws keys from the secret corpus too. **Three of its cases fail without this fix**, including the general `test_no_declared_secret_survives_any_container_shape`.

## The fix

Scrub the key with the same string rules before deciding anything about the value under it. Deliberately narrow: an ordinary key keeps its name, since renaming every structured log field would break dashboards — pinned by a test.

## Verification

- `pytest`: 3564 passed, 254 skipped, 10 xfailed
- `ruff check .` and `mypy`: clean
- Three property cases verified to fail without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)