### PR TITLE
Retire DeepInfra Terminus route on August 17

### DIFF
--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -19,6 +19,7 @@ FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
+DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
@@ -190,6 +191,17 @@ _RETIREMENTS = (
         model_ids=frozenset({"inclusionai/ling-3.0-tiny"}),
         upstream_ids=frozenset({"inclusionai/ling-3.0-tiny"}),
         effective_at=NOVITA_LING_30_TINY_RETIREMENT_AT,
+    ),
+    # DeepInfra announced that its DeepSeek V3.1 Terminus route retires on
+    # 2026-08-17 and that subsequent requests will be redirected to DeepSeek
+    # V4 Flash 0731. TrustedRouter must not silently substitute a different
+    # model, so retire only DeepInfra's endpoint at the conservative 00:00 UTC
+    # boundary. Terminus routes on other providers remain eligible.
+    _Retirement(
+        provider="deepinfra",
+        model_ids=frozenset({"deepseek/deepseek-v3.1-terminus"}),
+        upstream_ids=frozenset({"deepseek-ai/DeepSeek-V3.1-Terminus"}),
+        effective_at=DEEPINFRA_TERMINUS_RETIREMENT_AT,
     ),
     # Wafer announced that GLM 5.1, GLM 5.2 Fast, and Kimi K3 Fast retire on
     # 2026-08-17. Standard GLM 5.2 replaces both GLM routes, while Kimi K3

--- a/tests/test_deepinfra_august_2026_lifecycle.py
+++ b/tests/test_deepinfra_august_2026_lifecycle.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
+_TERMINUS = "deepseek/deepseek-v3.1-terminus"
+_TERMINUS_UPSTREAM = "deepseek-ai/DeepSeek-V3.1-Terminus"
+_FLASH = "deepseek/deepseek-v4-flash-0731"
+_FLASH_UPSTREAM = "deepseek-ai/DeepSeek-V4-Flash-0731"
+
+
+def test_deepinfra_terminus_retires_at_announced_date() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _TERMINUS,
+        _TERMINUS_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _TERMINUS,
+        _TERMINUS_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _FLASH,
+        _FLASH_UPSTREAM,
+        at=_CUTOFF,
+    )
+
+
+def test_deepinfra_terminus_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = {endpoint.provider for endpoint in endpoints_for_model(_TERMINUS)}
+    assert "deepinfra" in before
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = {endpoint.provider for endpoint in endpoints_for_model(_TERMINUS)}
+
+    assert "deepinfra" not in after
+    assert after
+    assert after == before - {"deepinfra"}
+
+
+def test_hourly_refresh_cannot_restore_retired_deepinfra_terminus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="deepinfra",
+        prices={
+            _TERMINUS: ModelPrice(270_000, 950_000),
+            _FLASH: ModelPrice(80_000, 180_000),
+        },
+        source="api",
+        fetched_url="https://api.deepinfra.com/v1/openai/models",
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"deepinfra": result})
+    assert "deepinfra" in before[_TERMINUS]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"deepinfra": result})
+
+    assert _TERMINUS not in after
+    assert "deepinfra" in after[_FLASH]


### PR DESCRIPTION
## Summary
- schedule DeepInfra's `deepseek-ai/DeepSeek-V3.1-Terminus` route retirement for 2026-08-17 00:00 UTC
- preserve Terminus routes on other providers instead of accepting DeepInfra's announced silent redirect to V4 Flash 0731
- prevent hourly price refreshes from restoring the retired DeepInfra route

## Verification
- regression tests fail on the previous code
- direct DeepInfra PONG succeeds before the cutoff
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (`3568 passed, 254 skipped, 10 xfailed`)
