### PR TITLE
Improve SEO crawl graph and Ahrefs tracking

### DIFF
--- a/docs/marketing/ahrefs-seo-execution-2026-08-15.md
+++ b/docs/marketing/ahrefs-seo-execution-2026-08-15.md
@@ -1,0 +1,157 @@
+# Ahrefs SEO execution: 2026-08-15
+
+## Baseline
+
+The Ahrefs project and connected Google Search Console property disagree because
+TrustedRouter is a young site and Ahrefs has not yet modeled its search traffic.
+Use Search Console as the source of truth for clicks and Ahrefs for crawl,
+backlink, competitor, and rank-change research.
+
+| Metric | Observed value |
+| --- | ---: |
+| Ahrefs Site Audit health | 100 |
+| Crawled URLs | 4,454 |
+| Site Audit errors | 2 |
+| Site Audit warnings | 402 |
+| Indexable pages with one internal dofollow inlink | 1,925 |
+| Indexable pages absent from sitemap | 66 |
+| Referring domains | about 540 |
+| Referring domains with a dofollow link | 43 |
+| Search Console clicks, May 1 through August 12 | 585 |
+| Search Console impressions, May 1 through August 12 | 11,500 |
+| Search Console CTR | 5.1% |
+| Search Console average position | 12.1 |
+
+The authenticated API root was the only meaningful 4xx crawl finding. The trust
+page linked crawlers directly to it. The public API reference is the correct
+destination.
+
+## Changes shipped from this audit
+
+1. Give every public model comparison two deterministic neighboring comparison
+   links in addition to its directory and related-model links. This turns the
+   2,600-page comparison set into a complete crawl graph.
+2. Add `/trust`, `/api/reference`, and `/docs/x402` to the core sitemap.
+3. Replace the trust page's authenticated API-root link with the public API
+   reference.
+4. Add model-specific answer blocks for model ID, current providers, current
+   lowest route prices, and fail-closed ZDR selection. Emit matching FAQPage
+   structured data.
+5. Improve titles and descriptions for the docs, EU gateway, provider catalog,
+   and trust page without creating overlapping landing pages.
+6. Add complete social metadata and WebPage structured data to the standalone
+   trust page.
+
+## Rank Tracker groups
+
+Track the United States and United Kingdom on desktop. Add Germany as the first
+EU market once the initial set is stable. Tag each keyword by the group below.
+
+### Category
+
+- `ai router`
+- `llm router`
+- `best llm router`
+- `ai gateway`
+- `llm gateway`
+- `llm api gateway`
+- `model router api`
+- `multi provider llm api`
+- `openai compatible llm api`
+- `openrouter alternative`
+
+### Privacy and trust
+
+- `private llm api`
+- `no log llm api`
+- `zero data retention llm`
+- `zdr llm api`
+- `confidential ai inference`
+- `confidential computing llm`
+- `end to end encrypted llm api`
+- `secure ai proxy`
+- `ai prompt privacy`
+- `llm attestation`
+- `claude api privacy`
+- `deepseek api privacy`
+
+### Reliability and performance
+
+- `llm failover`
+- `ai provider failover`
+- `multi region llm api`
+- `llm provider uptime`
+- `llm latency benchmark`
+- `llm provider latency`
+- `ai model latency`
+- `llm throughput benchmark`
+
+### EU and compliance
+
+- `eu llm gateway`
+- `eu ai gateway`
+- `gdpr compliant llm api`
+- `llm data residency`
+- `eu ai act llm compliance`
+- `hipaa llm api`
+- `llm api for law firms`
+- `llm api for financial services`
+
+### Migration and model APIs
+
+- `litellm alternative`
+- `portkey alternative`
+- `vercel ai gateway alternative`
+- `azure openai alternative`
+- `aws bedrock alternative`
+- `groq alternative`
+- `vertex ai alternative`
+- `kimi k2 api`
+- `minimax m3 api`
+- `glm 5 api`
+- `gpt oss 120b api`
+- `gemini flash alternative`
+
+## Competitors
+
+Use the following domains for rank overlap and content-gap analysis:
+
+- `openrouter.ai`
+- `portkey.ai`
+- `helicone.ai`
+- `litellm.ai`
+- `tinfoil.sh`
+- `together.ai`
+
+Large platform domains such as Cloudflare and Vercel are useful for individual
+keyword checks but distort domain-level comparisons because most of their search
+traffic is unrelated to AI gateways.
+
+## Link earning priorities
+
+Ignore the spam-anchor volume in the backlink report. Prioritize relevant links
+that can send developers or validate the product:
+
+1. Keep TrustedRouter provider integrations current in `models.dev` and similar
+   model registries.
+2. Finish and maintain native setup paths in open-source AI clients and agent
+   frameworks, then ask maintainers to link the public integration guide.
+3. Offer measured provider latency and privacy data to developer newsletters and
+   framework documentation, starting with sources already sending credible links
+   such as Mastra and This Week in React.
+4. Publish one citable data release per month from first-party leaderboard data.
+   Include a methodology, observation window, sample count, and stable URL.
+
+## Weekly operating loop
+
+1. Review Search Console query and page deltas over 28 days and 90 days.
+2. Review Ahrefs new and lost dofollow referring domains.
+3. Review Rank Tracker by the groups above, not only aggregate visibility.
+4. Improve an existing earning URL when impressions rise but CTR is weak.
+5. Add a new page only when a distinct query intent cannot be answered by an
+   existing page.
+6. Re-run Site Audit after every large catalog or template change.
+
+Renew Ahrefs only if this loop is actively used. A focused month each quarter is
+enough for crawl and competitor research when weekly backlink outreach is not in
+progress.

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -141,6 +141,7 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/leaderboard/video",
     "/status",
     "/security",
+    "/trust",
     "/eu",
     "/trustedos",
     "/legal",
@@ -176,6 +177,8 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     "/llm-provider-latency-benchmarks",
     "/pricing",
     "/docs",
+    "/docs/x402",
+    "/api/reference",
     "/apps",
     "/resources",
     "/customers/robot-robot-human",
@@ -1030,7 +1033,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "eu": PublicPage(
         template="public/eu.html",
         og_card="eu.png",
-        title="EU LLM Gateway: Private AI Routing in Europe",
+        title="EU LLM Gateway: Private AI Routing",
         description=(
             "Route OpenAI-compatible LLM requests through an attested Europe West "
             "gateway, with EU-focused models, provider controls, and no prompt logs."
@@ -1335,11 +1338,10 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
     "docs": PublicPage(
         template="public/docs.html",
         og_card="docs.png",
-        title="Docs — Quickstart, SDKs, and API Reference",
+        title="API Docs: Quickstart and SDKs",
         description=(
-            "Point any OpenAI-compatible SDK at TrustedRouter with one base_url "
-            "change. Guides, Python / TypeScript / Swift SDKs, and the "
-            "OpenAI-compatible API reference."
+            "Use TrustedRouter with any OpenAI-compatible SDK after one base_url change. "
+            "Get quickstarts, Python and TypeScript SDKs, privacy controls, and API reference."
         ),
     ),
     "vibe-coders": PublicPage(
@@ -2519,11 +2521,11 @@ def public_providers_html(settings: Settings) -> str:
         .render(
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}/providers",
-            title="Providers | TrustedRouter",
+            title="AI Providers: Models, Privacy and Uptime | TrustedRouter",
             heading="Providers",
             description=(
-                "Compare AI providers by available models, token pricing, retention policies, "
-                "regional coverage, confidential compute, encrypted routes, and measured performance."
+                "Compare AI providers by model coverage, token pricing, zero-retention policy, "
+                "region, confidential compute, encrypted routes, live uptime, and throughput."
             ),
             providers=providers,
             json_ld_blob=_json_ld_graph(
@@ -2674,6 +2676,8 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
     seo_name = _seo_model_name(model)
     site_url = f"https://{settings.trusted_domain}/models/{model_id}"
     model_view = _model_detail_view(model, test_mode=test_mode)
+    route_evidence = _model_route_evidence(model, test_mode=test_mode)
+    faq_items = _model_faq_items(model, route_evidence=route_evidence)
     return (
         _env()
         .get_template("public/model_detail.html")
@@ -2687,13 +2691,19 @@ def public_model_detail_html(settings: Settings, model_id: str) -> str | None:
                 "limits, privacy policy, regional availability, measured uptime, and API support."
             ),
             model=model_view,
-            route_evidence=_model_route_evidence(model, test_mode=test_mode),
+            route_evidence=route_evidence,
             related_comparisons=_related_model_comparison_rows(model.id, limit=6),
             # Service/Offer JSON-LD. The page sells API access to a hosted
             # routing service, not a retail product with customer ratings.
             # Avoid Product schema so Search Console doesn't expect review
             # or aggregateRating fields that we cannot honestly provide yet.
-            json_ld_blob=_model_json_ld(settings, model, site_url),
+            faq_items=faq_items,
+            json_ld_blob=_model_json_ld(
+                settings,
+                model,
+                site_url,
+                faq_items=faq_items,
+            ),
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
             static_version=_static_version(settings),
@@ -2742,6 +2752,7 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
                 exclude_path=site_path,
                 limit=8,
             ),
+            comparison_neighbors=_model_comparison_neighbor_rows(left.id, right.id),
             faq_items=faq_items,
             json_ld_blob=_json_ld_graph(
                 _breadcrumb_node(
@@ -4094,6 +4105,49 @@ def _model_route_evidence(
     }
 
 
+def _model_faq_items(
+    model: Model,
+    *,
+    route_evidence: Mapping[str, object],
+) -> tuple[tuple[str, str], ...]:
+    provider_names = [
+        provider["name"]
+        for provider in _endpoint_provider_views(
+            endpoints_for_model(model.id),
+            fallback_provider=model.provider,
+        )
+    ]
+    if len(provider_names) == 1:
+        provider_answer = str(provider_names[0])
+    else:
+        provider_answer = ", ".join(str(name) for name in provider_names[:-1])
+        provider_answer = f"{provider_answer}, and {provider_names[-1]}"
+    return (
+        (
+            f"What model ID should I use for {model.name}?",
+            f"Use {model.id} as the model field with the TrustedRouter OpenAI-compatible "
+            "API. The same model ID works for prepaid and eligible BYOK routes.",
+        ),
+        (
+            f"Which providers serve {model.name}?",
+            f"TrustedRouter currently lists {provider_answer} for {model.name}. Provider "
+            "availability and routing eligibility can change as catalog and health data update.",
+        ),
+        (
+            f"How much does {model.name} cost through TrustedRouter?",
+            f"The current lowest prepaid input price is {route_evidence['lowest_prompt_price']} "
+            f"and the lowest output price is {route_evidence['lowest_completion_price']}. "
+            "Prices are per one million tokens and come from the current route catalog.",
+        ),
+        (
+            f"How do I require zero data retention for {model.name}?",
+            "Set provider.min_privacy to zdr on the request. TrustedRouter considers only "
+            "routes with a recorded zero-data-retention posture and fails closed if no "
+            "eligible route remains.",
+        ),
+    )
+
+
 @lru_cache(maxsize=1)
 def _model_comparison_index() -> dict[
     str,
@@ -4145,6 +4199,43 @@ def _related_model_comparison_rows(
         ranked.append((-shared, -route_count, path.casefold(), result_row))
     ranked.sort(key=lambda item: item[:3])
     return [item[3] for item in ranked[:limit]]
+
+
+@lru_cache(maxsize=1)
+def _model_comparison_neighbor_index() -> dict[
+    str,
+    tuple[tuple[str, str, str], ...],
+]:
+    pairs = _model_comparison_pairs()
+    if len(pairs) < 2:
+        return {}
+    rows = [
+        (
+            f"/compare/models/{left.id}/vs/{right.id}",
+            f"{left.name} vs {right.name}",
+        )
+        for left, right in pairs
+    ]
+    return {
+        path: (
+            (rows[(index - 1) % len(rows)][0], rows[(index - 1) % len(rows)][1], "Previous"),
+            (rows[(index + 1) % len(rows)][0], rows[(index + 1) % len(rows)][1], "Next"),
+        )
+        for index, (path, _label) in enumerate(rows)
+    }
+
+
+def _model_comparison_neighbor_rows(
+    left_id: str,
+    right_id: str,
+) -> list[dict[str, str]]:
+    path = canonical_model_comparison_path(left_id, right_id)
+    if path is None:
+        return []
+    return [
+        {"href": href, "label": label, "relation": relation}
+        for href, label, relation in _model_comparison_neighbor_index().get(path, ())
+    ]
 
 
 def _comparison_view(
@@ -4345,7 +4436,13 @@ _BRAND_DISPLAY_NAMES: dict[str, str] = {
 }
 
 
-def _model_json_ld(settings: Settings, model: Model, site_url: str) -> str:
+def _model_json_ld(
+    settings: Settings,
+    model: Model,
+    site_url: str,
+    *,
+    faq_items: Sequence[tuple[str, str]] = (),
+) -> str:
     """Build the Service/Offer JSON-LD blob for the model detail page.
 
     Returns a JSON string ready to be injected into a
@@ -4360,6 +4457,7 @@ def _model_json_ld(settings: Settings, model: Model, site_url: str) -> str:
             (("Home", "/"), ("Models", "/models"), (model.name, f"/models/{model.id}")),
         ),
         _model_service_node(settings, model, site_url),
+        _faq_node(faq_items),
     )
 
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -565,12 +565,33 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             f"https://{settings.trusted_domain}/api/reference",
             quote=True,
         )
+        title = "TrustedRouter API Reference: Endpoints and Schemas"
+        description = (
+            "Explore TrustedRouter's OpenAI-compatible API endpoints, request schemas, "
+            "authentication, models, keys, billing, observability, and stable compatibility errors."
+        )
+        escaped_description = html.escape(description, quote=True)
+        metadata = (
+            f'<meta name="description" content="{escaped_description}">\n'
+            f'<link rel="canonical" href="{canonical}">\n'
+            '<meta property="og:type" content="website">\n'
+            f'<meta property="og:title" content="{html.escape(title, quote=True)}">\n'
+            f'<meta property="og:description" content="{escaped_description}">\n'
+            f'<meta property="og:url" content="{canonical}">\n'
+            '<meta property="og:image" content="https://trustedrouter.com/og.png">\n'
+            '<meta name="twitter:card" content="summary_large_image">\n'
+        )
         body = (
             bytes(response.body)
             .decode()
             .replace(
+                f"<title>{html.escape(app.title)} API reference</title>",
+                f"<title>{html.escape(title)}</title>",
+                1,
+            )
+            .replace(
                 "</head>",
-                f'<link rel="canonical" href="{canonical}">\n</head>',
+                f"{metadata}</head>",
                 1,
             )
         )

--- a/src/trusted_router/templates/public/model_compare.html
+++ b/src/trusted_router/templates/public/model_compare.html
@@ -117,6 +117,19 @@
 </section>
 {% endif %}
 
+{% if comparison_neighbors %}
+<nav class="panel" aria-label="Browse adjacent model comparisons">
+  <div class="panel-head"><h2>Keep comparing</h2><a href="/compare/models">Comparison directory</a></div>
+  <div class="panel-body">
+    <ul class="link-list">
+      {% for neighbor in comparison_neighbors %}
+      <li><a href="{{ neighbor.href }}">{{ neighbor.label }}</a><span>{{ neighbor.relation }} comparison</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+</nav>
+{% endif %}
+
 <section class="marketing-split">
   <div class="marketing-copy">
     <span class="eyebrow">Production choice</span>

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -91,6 +91,30 @@ def trust_html(
     api = html.escape(resolved_api_base_url)
     api_hostname = html.escape(resolved_api_base_url.removeprefix("https://").split("/", 1)[0])
     control_origin = html.escape(f"https://{domain}")
+    canonical_url = html.escape(canonical_public_url(settings, "/trust"), quote=True)
+    docs_url = html.escape(canonical_public_url(settings, "/api/reference"), quote=True)
+    trust_title = "Verify TrustedRouter Attestation and Running Code"
+    trust_description = (
+        "Verify the live TrustedRouter gateway attestation, image digest, source commit, "
+        "TLS boundary, and open-source deployment before sending prompts."
+    )
+    og_image = html.escape(canonical_public_url(settings, "/og.png"), quote=True)
+    trust_json_ld = json.dumps(
+        {
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            "name": trust_title,
+            "description": trust_description,
+            "url": canonical_public_url(settings, "/trust"),
+            "about": {
+                "@type": "SoftwareApplication",
+                "name": "TrustedRouter",
+                "applicationCategory": "DeveloperApplication",
+                "codeRepository": ATTESTED_GATEWAY_REPO,
+            },
+        },
+        separators=(",", ":"),
+    ).replace("<", "\\u003c")
     control_repo = html.escape(CONTROL_PLANE_REPO)
     gateway_repo = html.escape(ATTESTED_GATEWAY_REPO)
     infra_repo = html.escape(CLOUD_INFRA_REPO)
@@ -117,8 +141,20 @@ def trust_html(
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>TrustedRouter Trust</title>
-  <link rel="canonical" href="{html.escape(canonical_public_url(settings, '/trust'))}">
+  <title>{trust_title}</title>
+  <meta name="description" content="{trust_description}">
+  <link rel="canonical" href="{canonical_url}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="TrustedRouter">
+  <meta property="og:title" content="{trust_title}">
+  <meta property="og:description" content="{trust_description}">
+  <meta property="og:url" content="{canonical_url}">
+  <meta property="og:image" content="{og_image}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{trust_title}">
+  <meta name="twitter:description" content="{trust_description}">
+  <meta name="twitter:image" content="{og_image}">
+  <script type="application/ld+json">{trust_json_ld}</script>
   <style>
     :root {{
       color-scheme: light;
@@ -165,7 +201,7 @@ def trust_html(
   <header>
     <nav>
       <a class="brand" href="{control_origin}"><span class="mark">TR</span><span>TrustedRouter</span></a>
-      <div class="links"><a href="{control_repo}">Control repo</a><a href="{gateway_repo}">Gateway repo</a><a href="{infra_repo}">Infra repo</a><a href="{quill_repo}">Quill repo</a><a href="/trust/gcp-release.json">gcp-release.json</a><a href="{api}">API</a><a href="{control_origin}">Console</a></div>
+      <div class="links"><a href="{control_repo}">Control repo</a><a href="{gateway_repo}">Gateway repo</a><a href="{infra_repo}">Infra repo</a><a href="{quill_repo}">Quill repo</a><a href="/trust/gcp-release.json">gcp-release.json</a><a href="{docs_url}">API docs</a><a href="{control_origin}">Console</a></div>
     </nav>
   </header>
   <main class="wrap">

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -611,6 +611,7 @@ def test_public_docs_explain_hard_confidential_e2ee_filter(client: TestClient) -
     agent_setup = client.get("/docs/agent-setup")
 
     assert docs.status_code == providers.status_code == agent_setup.status_code == 200
+    assert "<title>API Docs: Quickstart and SDKs | TrustedRouter</title>" in docs.text
     assert '"min_privacy": "confidential"' in docs.text
     assert "<code>e2e</code> and <code>e2ee</code>" in docs.text
     assert "requires both provider-side confidential compute and end-to-end encryption" in docs.text

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -36,6 +36,9 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
     assert core.status_code == 200
     assert "<urlset" in core.text
     assert "<loc>https://trustedrouter.com/eu</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/trust</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/api/reference</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/docs/x402</loc>" in core.text
     assert "<loc>https://trustedrouter.com/openai-compatible-llm-api</loc>" in core.text
     assert "<loc>https://trustedrouter.com/kimi-k2-api</loc>" in core.text
     assert "<loc>https://trustedrouter.com/gemini-flash-alternative</loc>" in core.text
@@ -153,6 +156,9 @@ def test_api_reference_declares_one_query_independent_canonical(
     assert response.status_code == 200
     assert response.text.count('rel="canonical"') == 1
     assert '<link rel="canonical" href="https://trustedrouter.com/api/reference">' in response.text
+    assert "<title>TrustedRouter API Reference: Endpoints and Schemas</title>" in response.text
+    assert '<meta name="description"' in response.text
+    assert 'property="og:title"' in response.text
 
 
 @pytest.mark.parametrize(
@@ -200,6 +206,12 @@ def test_trust_page_declares_primary_trust_path_as_canonical(
         assert response.status_code == 200
         assert response.text.count('rel="canonical"') == 1
         assert '<link rel="canonical" href="https://trustedrouter.com/trust">' in response.text
+        assert "<title>Verify TrustedRouter Attestation and Running Code</title>" in response.text
+        assert '<meta name="description"' in response.text
+        assert 'property="og:title"' in response.text
+        assert 'href="https://trustedrouter.com/api/reference">API docs</a>' in response.text
+        assert 'href="https://api.trustedrouter.com/v1">API</a>' not in response.text
+        assert '"@type":"WebPage"' in response.text
 
 
 def test_indexnow_key_file_is_public(client: TestClient) -> None:
@@ -276,7 +288,10 @@ def test_public_provider_route_defaults_to_html_for_link_checkers(client: TestCl
     response = client.get("/providers")
 
     assert response.status_code == 200
-    assert "<title>Providers | TrustedRouter</title>" in response.text
+    assert (
+        "<title>AI Providers: Models, Privacy and Uptime | TrustedRouter</title>"
+        in response.text
+    )
     assert "Provider transparency" in response.text
     assert "application/json" not in response.headers["content-type"]
 
@@ -290,7 +305,7 @@ def test_search_console_opportunity_pages_answer_observed_queries(
 ) -> None:
     eu = client.get("/eu")
     assert eu.status_code == 200
-    assert "<title>EU LLM Gateway: Private AI Routing in Europe | TrustedRouter</title>" in eu.text
+    assert "<title>EU LLM Gateway: Private AI Routing | TrustedRouter</title>" in eu.text
     assert "What the EU LLM gateway controls" in eu.text
     assert "https://api-europe-west4.quillrouter.com/v1" in eu.text
     assert "Does the EU gateway guarantee EU data residency?" in eu.text
@@ -859,6 +874,18 @@ def test_model_overview_surfaces_cached_route_evidence(
     assert "n=10" not in response.text
 
 
+def test_model_overview_answers_high_intent_questions(client: TestClient) -> None:
+    response = client.get("/models/minimax/minimax-m3")
+
+    assert response.status_code == 200
+    assert "What model ID should I use for MiniMax: MiniMax M3?" in response.text
+    assert "Which providers serve MiniMax: MiniMax M3?" in response.text
+    assert "How much does MiniMax: MiniMax M3 cost through TrustedRouter?" in response.text
+    assert "How do I require zero data retention for MiniMax: MiniMax M3?" in response.text
+    assert "provider.min_privacy" in response.text
+    assert "FAQPage" in json.dumps(_json_ld(response.text))
+
+
 def test_model_route_evidence_does_not_invent_a_prepaid_price(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -991,6 +1018,9 @@ def test_model_comparison_surfaces_distinct_measured_route_metrics(
     assert "100.00%" in response.text
     assert "Related comparisons" in response.text
     assert "Browse every comparison" in response.text
+    assert "Keep comparing" in response.text
+    assert "Previous comparison" in response.text
+    assert "Next comparison" in response.text
 
 
 def test_reversed_model_comparison_redirects_to_stable_canonical(
@@ -1056,6 +1086,31 @@ def test_model_comparison_graph_covers_every_public_model() -> None:
         model.id.casefold() for left, right in _model_comparison_pairs() for model in (left, right)
     }
     assert {model.id.casefold() for model in _public_models_for_seo()} <= represented
+
+
+def test_model_comparison_graph_gives_every_page_two_inbound_neighbors() -> None:
+    from trusted_router.dashboard import (
+        _model_comparison_neighbor_index,
+        _model_comparison_pairs,
+    )
+
+    neighbor_index = _model_comparison_neighbor_index()
+    expected_paths = {
+        f"/compare/models/{left.id}/vs/{right.id}"
+        for left, right in _model_comparison_pairs()
+    }
+    inbound_counts = {path: 0 for path in expected_paths}
+
+    assert set(neighbor_index) == expected_paths
+    for source, neighbors in neighbor_index.items():
+        assert len(neighbors) == 2
+        assert {relation for _href, _label, relation in neighbors} == {"Previous", "Next"}
+        for href, _label, _relation in neighbors:
+            assert href != source
+            assert href in inbound_counts
+            inbound_counts[href] += 1
+
+    assert set(inbound_counts.values()) == {2}
 
 
 def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- connect every model comparison page into a deterministic internal-link graph
- add trust, x402 docs, and API reference to the core sitemap and improve answer-ready metadata
- add model FAQs with structured data and document the Ahrefs baseline and operating loop

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q: 3,569 passed, 254 skipped, 10 xfailed; one pre-patch sitemap metadata failure was fixed and its exhaustive test rerun passed
- focused SEO/public tests: 82 passed
- exhaustive sitemap SEO hygiene: 2 passed across the generated sitemap
- git diff --check