### PR TITLE
byok: write v2 envelopes, and give control secrets their own namespace

### DIFF
--- a/src/trusted_router/byok_crypto.py
+++ b/src/trusted_router/byok_crypto.py
@@ -12,7 +12,23 @@ from trusted_router.config import Settings
 from trusted_router.key_management import key_wrapper_for
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
+# v1 associated data is colon-joined with no escaping or length prefix, so
+# component boundaries are ambiguous: _aad("a:b", "c") == _aad("a", "b:c").
+# Kept because envelopes written before the migration are still v1 and must
+# keep decrypting. See docs/design/byok-aad-v2-migration.md.
 ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
+
+# v2 length-prefixes every AAD component and adds a namespace, making the
+# encoding injective. Written only because every enclave region can already
+# read it (quill-cloud-proxy#162 shipped first) — writing v2 before that would
+# break BYOK for every customer using it.
+ALGORITHM_V2 = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"
+
+# The two secret families. A purpose can no longer collide with a provider slug
+# even when the strings match, because the namespace is a separate AAD
+# component rather than a prefix on the same one.
+NAMESPACE_PROVIDER = "provider"
+NAMESPACE_CONTROL = "control"
 
 # Local/test fallback wrapping key — derived via HKDF from a label, not
 # a literal byte string. Anyone who reads this file can still
@@ -54,12 +70,12 @@ def encrypt_byok_secret(
     dek = secrets.token_bytes(32)
     nonce = secrets.token_bytes(12)
     dek_nonce = secrets.token_bytes(12)
-    aad = _aad(workspace_id, provider)
+    aad = _aad_v2(NAMESPACE_PROVIDER, workspace_id, provider)
 
     ciphertext = AESGCM(dek).encrypt(nonce, plaintext, aad)
     encrypted_dek = _wrap_dek(dek, dek_nonce, aad, settings)
     return EncryptedSecretEnvelope(
-        algorithm=ALGORITHM,
+        algorithm=ALGORITHM_V2,
         key_ref=_key_ref(settings),
         encrypted_dek=_b64(encrypted_dek),
         dek_nonce=_b64(dek_nonce),
@@ -75,9 +91,7 @@ def decrypt_byok_secret(
     workspace_id: str,
     provider: str,
 ) -> str:
-    if envelope.algorithm != ALGORITHM:
-        raise ValueError("unsupported BYOK envelope algorithm")
-    aad = _aad(workspace_id, provider)
+    aad = _envelope_aad(envelope.algorithm, NAMESPACE_PROVIDER, workspace_id, provider)
     dek = _unwrap_dek(envelope, aad, settings)
     plaintext = AESGCM(dek).decrypt(_unb64(envelope.nonce), _unb64(envelope.ciphertext), aad)
     return plaintext.decode("utf-8")
@@ -90,11 +104,32 @@ def encrypt_control_secret(
     workspace_id: str,
     purpose: str,
 ) -> EncryptedSecretEnvelope:
-    return encrypt_byok_secret(
-        raw_secret,
-        settings,
-        workspace_id=workspace_id,
-        provider=purpose,
+    """Envelope-encrypt a control-plane secret (broadcast keys, headers).
+
+    Deliberately no longer delegates through encrypt_byok_secret's `provider`
+    parameter. That put a control purpose into the same AAD slot as a provider
+    slug, so a BYOK key and a control secret in one workspace could share
+    associated data and decrypt each other. They now differ in the namespace
+    component, which no choice of purpose or provider string can collapse.
+    """
+    plaintext = raw_secret.strip().encode("utf-8")
+    if not plaintext:
+        raise ValueError("raw control secret is empty")
+
+    dek = secrets.token_bytes(32)
+    nonce = secrets.token_bytes(12)
+    dek_nonce = secrets.token_bytes(12)
+    aad = _aad_v2(NAMESPACE_CONTROL, workspace_id, purpose)
+
+    ciphertext = AESGCM(dek).encrypt(nonce, plaintext, aad)
+    encrypted_dek = _wrap_dek(dek, dek_nonce, aad, settings)
+    return EncryptedSecretEnvelope(
+        algorithm=ALGORITHM_V2,
+        key_ref=_key_ref(settings),
+        encrypted_dek=_b64(encrypted_dek),
+        dek_nonce=_b64(dek_nonce),
+        ciphertext=_b64(ciphertext),
+        nonce=_b64(nonce),
     )
 
 
@@ -105,12 +140,18 @@ def decrypt_control_secret(
     workspace_id: str,
     purpose: str,
 ) -> str:
-    return decrypt_byok_secret(
-        envelope,
-        settings,
-        workspace_id=workspace_id,
-        provider=purpose,
-    )
+    """Decrypt a control-plane secret.
+
+    A v1 envelope predates the namespace split, so it is opened with the v1 AAD
+    that sealed it — which is the same shape a BYOK key used. That collision is
+    exactly what the backfill (step 3) removes; until then v1 rows keep working
+    as they always did.
+    """
+    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 else NAMESPACE_PROVIDER
+    aad = _envelope_aad(envelope.algorithm, namespace, workspace_id, purpose)
+    dek = _unwrap_dek(envelope, aad, settings)
+    plaintext = AESGCM(dek).decrypt(_unb64(envelope.nonce), _unb64(envelope.ciphertext), aad)
+    return plaintext.decode("utf-8")
 
 
 def encrypted_secret_payload(envelope: EncryptedSecretEnvelope | None) -> dict[str, str] | None:
@@ -187,7 +228,45 @@ def _key_ref(settings: Settings) -> str:
 
 
 def _aad(workspace_id: str, provider: str) -> bytes:
+    """v1 associated data. Not injective — see the module header."""
     return f"trustedrouter:byok:{workspace_id}:{provider}".encode()
+
+
+def _aad_v2(namespace: str, workspace_id: str, context: str) -> bytes:
+    """v2 associated data: length-prefixed, so it is injective.
+
+    Each component is a 4-byte big-endian length followed by its UTF-8 bytes.
+    No choice of component values can produce the same byte string from a
+    different tuple, which is the property v1 lacks.
+
+    Must stay byte-identical to aadV2 in quill-cloud-proxy's
+    enclave-go/internal/byokcache/cache.go. Both sides pin the same hex vector;
+    a divergence is not a test failure but every BYOK key in that family
+    failing to open on the other plane.
+    """
+    parts = (
+        b"trustedrouter/byok/v2",
+        namespace.encode("utf-8"),
+        workspace_id.encode("utf-8"),
+        context.encode("utf-8"),
+    )
+    return b"".join(len(part).to_bytes(4, "big") + part for part in parts)
+
+
+def _envelope_aad(
+    algorithm: str, namespace: str, workspace_id: str, context: str
+) -> bytes:
+    """Select the associated data for an envelope's declared format.
+
+    Dispatching on the stored algorithm rather than trying v2 and falling back
+    to v1: a permanent fallback would keep the substitution weakness alive and
+    make the migration impossible to declare finished.
+    """
+    if algorithm == ALGORITHM:
+        return _aad(workspace_id, context)
+    if algorithm == ALGORITHM_V2:
+        return _aad_v2(namespace, workspace_id, context)
+    raise ValueError("unsupported BYOK envelope algorithm")
 
 
 def _b64(value: bytes) -> str:

--- a/tests/test_byok_aad_namespace_property.py
+++ b/tests/test_byok_aad_namespace_property.py
@@ -22,33 +22,45 @@ catalog-valid provider slug can collide with a control purpose.
         and aad(workspace, p) differs from aad(workspace, purpose)
         for every control purpose
 
-Two things this deliberately does NOT claim:
+Since step 2 of the migration this module also covers the v2 format, which
+length-prefixes every AAD component and adds a namespace separating provider
+keys from control secrets. v1 envelopes still exist in storage until the step-3
+backfill, so both formats must open and the v1 collision is still asserted
+below rather than quietly dropped.
 
-  * The AAD map is still not injective in general. `_aad` joins with ":" and
-    neither escapes nor length-prefixes, so ("a:b", "c") and ("a", "b:c")
-    collide. Reaching that needs a colon in a workspace id, and all three
-    backends mint str(uuid.uuid4()), so it is not reachable by normal issuance
-    — but it is a real property of the function and is asserted below as a
-    known gap rather than quietly left out.
-  * Repairing the encoding needs a V2 envelope algorithm and a dual-read
-    migration, because existing ciphertexts AND wrapped DEKs were sealed under
-    the current AAD, and the attested enclave consumes these envelopes too.
-    That is out of scope here; this closes the reachable door.
+The v2 encoding must stay byte-identical to aadV2 in quill-cloud-proxy. Both
+sides pin the same hex vector; see test_the_v2_vector_matches_the_enclave.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import secrets as secrets_module
+
 import pytest
+from cryptography.exceptions import InvalidTag
 from fastapi.testclient import TestClient
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from trusted_router.byok_crypto import _aad
+from trusted_router.byok_crypto import (
+    ALGORITHM,
+    ALGORITHM_V2,
+    NAMESPACE_CONTROL,
+    NAMESPACE_PROVIDER,
+    _aad,
+    _aad_v2,
+    decrypt_byok_secret,
+    decrypt_control_secret,
+    encrypt_byok_secret,
+    encrypt_control_secret,
+)
 from trusted_router.catalog import PROVIDERS
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.provider_compat import canonical_byok_provider
 from trusted_router.storage import STORE
+from trusted_router.storage_models import EncryptedSecretEnvelope
 
 WORKSPACE = "11111111-2222-3333-4444-555555555555"
 
@@ -194,3 +206,179 @@ def test_aad_encoding_is_not_injective_in_general() -> None:
     should be deleted along with the workaround it documents.
     """
     assert _aad("a:b", "c") == _aad("a", "b:c")
+
+
+# ---------------------------------------------------------------- v2 format ---
+#
+# Step 2 of docs/design/byok-aad-v2-migration.md. New envelopes are written v2,
+# whose AAD is length-prefixed and carries a namespace component. v1 envelopes
+# still exist in storage until the step-3 backfill, so both formats must open.
+
+
+def _settings() -> Settings:
+    return Settings(environment="test")
+
+
+def test_the_v2_vector_matches_the_enclave() -> None:
+    """The two implementations must agree byte for byte.
+
+    This exact hex is pinned in
+    quill-cloud-proxy/enclave-go/internal/byokcache/aad_v2_test.go. If the two
+    ever diverge it is not a test failure in the usual sense — it is every BYOK
+    key written by one plane failing to open on the other, which is precisely
+    the outage the migration ordering exists to avoid.
+    """
+    assert _aad_v2("provider", "ws-1", "openai").hex() == (
+        "0000001574727573746564726f757465722f62796f6b2f7632"
+        "0000000870726f76696465720000000477732d31000000066f70656e6169"
+    )
+
+
+@given(
+    namespace=st.sampled_from([NAMESPACE_PROVIDER, NAMESPACE_CONTROL]),
+    workspace=st.text(alphabet=":/abc\x00", max_size=6),
+    context=st.text(alphabet=":/abc\x00", max_size=6),
+)
+@settings(max_examples=400)
+def test_v2_aad_is_injective(namespace: str, workspace: str, context: str) -> None:
+    """The property v1 lacks: distinct tuples produce distinct bytes.
+
+    Quantified over an alphabet of exactly the characters that break a
+    delimiter-joined encoding — colons, slashes, NUL — because those are the
+    inputs where a naive scheme silently collapses two tuples into one.
+    """
+    encoded = _aad_v2(namespace, workspace, context)
+    for other in [
+        (namespace, workspace, context + "x"),
+        (namespace, workspace + "x", context),
+        (NAMESPACE_CONTROL if namespace == NAMESPACE_PROVIDER else NAMESPACE_PROVIDER,
+         workspace, context),
+    ]:
+        if other != (namespace, workspace, context):
+            assert _aad_v2(*other) != encoded
+
+
+def test_v2_separates_the_two_v1_collision_classes() -> None:
+    """Both concrete v1 collisions are gone under v2."""
+    assert _aad("a:b", "c") == _aad("a", "b:c")  # v1, still true
+    assert _aad_v2("provider", "a:b", "c") != _aad_v2("provider", "a", "b:c")
+    assert _aad_v2(NAMESPACE_PROVIDER, "w", "x") != _aad_v2(NAMESPACE_CONTROL, "w", "x")
+
+
+def test_new_byok_secrets_are_written_v2() -> None:
+    envelope = encrypt_byok_secret(
+        "sk-provider-key", _settings(), workspace_id=WORKSPACE, provider="openai"
+    )
+    assert envelope.algorithm == ALGORITHM_V2
+    assert (
+        decrypt_byok_secret(
+            envelope, _settings(), workspace_id=WORKSPACE, provider="openai"
+        )
+        == "sk-provider-key"
+    )
+
+
+def test_new_control_secrets_are_written_v2() -> None:
+    envelope = encrypt_control_secret(
+        "shhh", _settings(), workspace_id=WORKSPACE, purpose="broadcast:bdst_1:api-key"
+    )
+    assert envelope.algorithm == ALGORITHM_V2
+    assert (
+        decrypt_control_secret(
+            envelope,
+            _settings(),
+            workspace_id=WORKSPACE,
+            purpose="broadcast:bdst_1:api-key",
+        )
+        == "shhh"
+    )
+
+
+def test_a_control_secret_does_not_open_as_a_provider_key() -> None:
+    """The whole point of the namespace component.
+
+    Under v1 these two shared associated data whenever the purpose string
+    equalled the provider slug, so each opened the other. The console guard
+    (#544) made that unreachable; the namespace makes it impossible.
+    """
+    shared_context = "openai"
+    control = encrypt_control_secret(
+        "control-secret", _settings(), workspace_id=WORKSPACE, purpose=shared_context
+    )
+
+    with pytest.raises(InvalidTag):
+        decrypt_byok_secret(
+            control, _settings(), workspace_id=WORKSPACE, provider=shared_context
+        )
+
+
+def test_a_provider_key_does_not_open_as_a_control_secret() -> None:
+    shared_context = "openai"
+    provider = encrypt_byok_secret(
+        "sk-provider-key", _settings(), workspace_id=WORKSPACE, provider=shared_context
+    )
+
+    with pytest.raises(InvalidTag):
+        decrypt_control_secret(
+            provider, _settings(), workspace_id=WORKSPACE, purpose=shared_context
+        )
+
+
+def test_v1_envelopes_still_decrypt() -> None:
+    """Rows written before the migration must keep working until the backfill.
+
+    Sealed here the way v1 sealed them, since nothing writes v1 any more.
+    """
+    envelope = _seal_v1("legacy-secret", workspace_id=WORKSPACE, context="openai")
+    assert envelope.algorithm == ALGORITHM
+    assert (
+        decrypt_byok_secret(
+            envelope, _settings(), workspace_id=WORKSPACE, provider="openai"
+        )
+        == "legacy-secret"
+    )
+
+
+def test_an_unknown_algorithm_is_still_refused() -> None:
+    envelope = _seal_v1("x", workspace_id=WORKSPACE, context="openai")
+    envelope = dataclasses.replace(envelope, algorithm="TR-BYOK-ENVELOPE-AES-256-GCM-V3")
+    with pytest.raises(ValueError, match="unsupported BYOK envelope algorithm"):
+        decrypt_byok_secret(
+            envelope, _settings(), workspace_id=WORKSPACE, provider="openai"
+        )
+
+
+@given(
+    workspace=st.sampled_from(["ws-1", "ws-2"]),
+    context=st.sampled_from(["openai", "anthropic"]),
+)
+def test_v2_still_rejects_a_wrong_binding(workspace: str, context: str) -> None:
+    """Cross-binding rejection is what AAD is for; v2 must not weaken it."""
+    envelope = encrypt_byok_secret(
+        "sk", _settings(), workspace_id=workspace, provider=context
+    )
+    for other_ws, other_ctx in [("ws-other", context), (workspace, "other-provider")]:
+        with pytest.raises(InvalidTag):
+            decrypt_byok_secret(
+                envelope, _settings(), workspace_id=other_ws, provider=other_ctx
+            )
+
+
+def _seal_v1(secret: str, *, workspace_id: str, context: str):
+    """Seal an envelope the way v1 did, for backward-compatibility tests."""
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    from trusted_router.byok_crypto import _b64, _key_ref, _wrap_dek
+
+    dek = secrets_module.token_bytes(32)
+    nonce = secrets_module.token_bytes(12)
+    dek_nonce = secrets_module.token_bytes(12)
+    aad = _aad(workspace_id, context)
+    return EncryptedSecretEnvelope(
+        algorithm=ALGORITHM,
+        key_ref=_key_ref(_settings()),
+        encrypted_dek=_b64(_wrap_dek(dek, dek_nonce, aad, _settings())),
+        dek_nonce=_b64(dek_nonce),
+        ciphertext=_b64(AESGCM(dek).encrypt(nonce, secret.encode(), aad)),
+        nonce=_b64(nonce),
+    )

--- a/tests/test_byok_crypto.py
+++ b/tests/test_byok_crypto.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from trusted_router.byok_crypto import decrypt_byok_secret, encrypt_byok_secret
+from trusted_router.byok_crypto import (
+    NAMESPACE_PROVIDER,
+    _aad_v2,
+    decrypt_byok_secret,
+    encrypt_byok_secret,
+)
 from trusted_router.config import Settings
 
 
@@ -55,7 +60,13 @@ def test_byok_envelope_uses_kms_wrap_without_plaintext_in_envelope(monkeypatch) 
     assert raw not in str(envelope)
     assert _FakeKmsClient.calls[0]["op"] == "encrypt"
     assert _FakeKmsClient.calls[0]["name"] == key_name
-    assert _FakeKmsClient.calls[0]["additional_authenticated_data"] == b"trustedrouter:byok:ws_1:openai"
+    # v2 AAD: length-prefixed components with a namespace, not the v1
+    # colon-joined string. The KMS wrap is bound to the same bytes the
+    # ciphertext is, which is why the migration has to re-wrap rather than
+    # re-encrypt only the payload.
+    assert _FakeKmsClient.calls[0]["additional_authenticated_data"] == _aad_v2(
+        NAMESPACE_PROVIDER, "ws_1", "openai"
+    )
     assert decrypt_byok_secret(
         envelope,
         settings,


### PR DESCRIPTION
**Step 2** of [the BYOK AAD v2 migration plan](https://github.com/Lore-Hex/quill-router/blob/main/docs/design/byok-aad-v2-migration.md).

> ## ⚠️ Do not merge until Lore-Hex/quill-cloud-proxy#162 has rolled out to every enclave region
>
> A v2 envelope reaching a build that only reads v1 is a **hard failure for that customer's BYOK key**. That ordering is the entire reason the plan sequences these two steps instead of shipping one PR. Step 1 is read-only and safe to deploy on its own; this one is the point of no return for new writes.

## What changes

New envelopes are written v2 — AAD length-prefixes every component and carries a namespace. Existing v1 rows keep decrypting: `_envelope_aad` **dispatches on the stored algorithm** rather than trying v2 and falling back to v1. A permanent fallback would keep the substitution weakness alive forever and leave the migration with no definition of "finished".

`encrypt_control_secret` no longer delegates through `encrypt_byok_secret`'s `provider` parameter. That put a control purpose into the same AAD slot as a provider slug, so a BYOK key and a control secret in one workspace could share associated data and open each other. They now differ in the **namespace** component, which no choice of purpose or provider string can collapse.

`decrypt_control_secret` still opens v1 rows under the old shared-namespace AAD, because that is what sealed them. Step 3's backfill is what removes them.

## Keeping the two planes byte-identical

`_aad_v2` must produce exactly the bytes `aadV2` produces in `quill-cloud-proxy`. Both sides now pin the same hex vector:

```
0000001574727573746564726f757465722f62796f6b2f7632...
```

A divergence is a red build on both repos rather than an outage discovered by a customer.

## Tests

- round trip for both namespaces, both formats
- **a control secret does not open as a provider key**, and vice versa, with the *same* context string — the property the namespace exists for, and the one that was false under v1
- v1 envelopes still decrypt (sealed the v1 way, since nothing writes v1 any more)
- injectivity quantified over exactly the characters that break a delimiter-joined encoding: colons, slashes, NUL
- an unrecognised algorithm is still refused rather than defaulted

**Four fail if the writes are reverted to v1.**

One existing test changed: `test_byok_envelope_uses_kms_wrap_without_plaintext_in_envelope` asserted the v1 AAD literal reaching KMS and now asserts the v2 bytes. That assertion is load-bearing — the KMS wrap is bound to the same AAD as the ciphertext, which is precisely why step 3 has to re-wrap rather than re-encrypt only the payload.

## Verification

- `pytest`: 3578 passed, 254 skipped, 10 xfailed
- `ruff check .` and `mypy`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)