### PR TITLE
Add the SMS clauses A2P campaign vetting requires

### DIFF
--- a/src/trusted_router/templates/public/privacy.html
+++ b/src/trusted_router/templates/public/privacy.html
@@ -44,6 +44,11 @@
   <h2>Children</h2>
   <p>The service is not directed to children under 13, and we do not knowingly collect their personal information. Users must be able to form a binding contract for the service in their jurisdiction.</p>
 
+  <h2>Mobile messaging</h2>
+  <p>If you add a mobile number to your account, we use it only to send you the messages you asked for: one-time codes that prove you control the number, and operational alerts about your own account and services. We send messages only to a number the account owner entered in their own account settings and confirmed with a one-time code. We do not accept phone numbers from third parties, and we do not buy, rent, or append phone numbers.</p>
+  <p><strong>No mobile information will be shared with third parties or affiliates for marketing or promotional purposes.</strong> Information sharing with subcontractors who support the service, such as our telecommunications carriers, is limited to what is necessary to deliver the message you requested. Text messaging originator opt-in data and consent are never shared with any third party for any other purpose, and are never sold.</p>
+  <p>Reply STOP to any message to stop them, or remove the number in your account settings. Reply HELP for help. Message frequency varies with your own alert configuration. Message and data rates may apply. Carriers are not liable for delayed or undelivered messages.</p>
+
   <h2>Changes</h2>
   <p>We may update this policy as the service changes. We will post the updated policy here and change the effective date. Material changes may also be communicated through the service or account email.</p>
 

--- a/src/trusted_router/templates/public/terms.html
+++ b/src/trusted_router/templates/public/terms.html
@@ -47,6 +47,11 @@
   <h2>Indemnity</h2>
   <p>You will defend and indemnify {{ entity.name }} and its personnel against third-party claims arising from your content, your unlawful or prohibited use, or your breach of these terms, to the extent permitted by law.</p>
 
+  <h2>SMS and voice notifications</h2>
+  <p>TrustedRouter offers an optional notification program. If you add a mobile number to your account and consent, we send one-time verification codes to confirm you control that number, and operational alerts about your own account and the services you monitor. Enrolment is per account and per number: messages go only to the account owner's own verified number, never to a number supplied by anyone else.</p>
+  <p>Message frequency varies and depends on the alerts you configure. <strong>Message and data rates may apply.</strong> Reply STOP to any message to unsubscribe, or remove the number in your account settings; reply HELP, or email <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>, for help. Mobile carriers are not liable for delayed or undelivered messages. Consent to receive these messages is not a condition of purchasing any goods or services.</p>
+  <p>Notifications are a convenience and not a guaranteed delivery channel. Carriers, handset settings, and network conditions can delay or drop messages, so notifications must not be relied upon as the sole safeguard where a missed alert could cause harm. See also the high-risk use section above.</p>
+
   <h2>Changes</h2>
   <p>We may update these terms as the service changes. We will post updated terms here and change the effective date. Continued use after updated terms take effect constitutes acceptance, except where law requires another form of consent.</p>
 

--- a/tests/test_legal_sms_clauses.py
+++ b/tests/test_legal_sms_clauses.py
@@ -1,0 +1,70 @@
+"""The SMS clauses carriers actually check for.
+
+A2P 10DLC campaign vetting fetches the brand's privacy policy and terms and
+looks for specific language. Both TrustedRouter campaigns were REJECTED for
+their absence — 30882 (terms) and 30908 (privacy) — so these are not
+decorative: dropping a sentence here silently un-registers our ability to send
+SMS, and the failure surfaces days later as a rejected campaign rather than as
+a broken page.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.dashboard import public_privacy_html, public_terms_html
+
+
+def _text(html: str) -> str:
+    return re.sub(r"<[^>]+>", " ", html).lower()
+
+
+@pytest.fixture
+def privacy() -> str:
+    return _text(public_privacy_html(Settings()))
+
+
+@pytest.fixture
+def terms() -> str:
+    return _text(public_terms_html(Settings()))
+
+
+class TestPrivacyPolicy:
+    def test_states_that_mobile_data_is_not_shared(self, privacy: str) -> None:
+        # The exact clause carrier vetting looks for. Error 30908 is raised
+        # when it cannot be found.
+        assert "no mobile information will be shared with third parties" in privacy
+        assert "marketing or promotional purposes" in privacy
+
+    def test_says_opt_in_data_is_never_sold(self, privacy: str) -> None:
+        assert "never sold" in privacy or "not be sold" in privacy
+
+    @pytest.mark.parametrize(
+        "clause",
+        ["reply stop", "reply help", "message frequency varies",
+         "message and data rates may apply"],
+    )
+    def test_carries_the_standard_disclosures(self, privacy: str, clause: str) -> None:
+        assert clause in privacy
+
+
+class TestTerms:
+    @pytest.mark.parametrize(
+        "clause",
+        ["reply stop", "reply help", "message frequency varies",
+         "message and data rates may apply", "not liable for delayed"],
+    )
+    def test_carries_the_sms_program_terms(self, terms: str, clause: str) -> None:
+        # Error 30882 is raised when the terms do not describe the program.
+        assert clause in terms
+
+    def test_consent_is_not_a_condition_of_purchase(self, terms: str) -> None:
+        assert "not a condition of purchas" in terms
+
+    def test_notifications_are_not_promised_as_reliable(self, terms: str) -> None:
+        # We page people about outages over networks that drop messages; saying
+        # so is both honest and what keeps this out of life-safety reliance.
+        assert "not a guaranteed delivery channel" in terms


### PR DESCRIPTION
Both TrustedRouter A2P 10DLC campaigns were submitted and **rejected**:

| Error | Field | Meaning |
|---|---|---|
| 30882 | `TERMS_AND_CONDITIONS_URL` | terms don't describe the SMS program |
| 30908 | `PRIVACY_POLICY_URL` | "a compliant privacy policy can not be verified" |

Neither failure was about the API. Campaign vetting fetches the brand's own
website and looks for specific language, and our privacy policy contained no
mobile or SMS wording at all. `/terms` and `/privacy` were both returning 200
the whole time, which is why nothing looked wrong.

**Privacy** now carries the clause vetting greps for — that no mobile
information is shared with third parties or affiliates for marketing, and that
opt-in data is never sold — plus the STOP/HELP, frequency, and rates
disclosures.

**Terms** now describe the program: what we send, that consent is not a
condition of purchase, and that carriers are not liable for undelivered
messages. They also state plainly that notifications are **not a guaranteed
delivery channel** — we page people about outages across networks that drop
messages, so saying so is both honest and what keeps this out of life-safety
reliance.

The tests are the point. An edit that drops one of these sentences does not
break a page — it silently un-registers our ability to send SMS, and the damage
surfaces days later as a rejected campaign. Each required clause is asserted,
with the error code that punishes its absence in the docstring.

Copy only: no route, config, or behaviour changes. 3584 tests pass; ruff and
mypy green.

Campaigns will be resubmitted only once these pages are live and verified —
each submission can incur a fee, so resubmitting against the current site would
just burn it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
