### PR TITLE
Publish AWS and Azure serving-plane measurements on /trust

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -23,6 +23,16 @@ if [ -n "$TRUST_JSON" ]; then
   TRUST_IMAGE_DIGEST="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_digest", ""))' <<<"$TRUST_JSON")"
 fi
 
+# AWS and Azure serving-plane measurements. Unlike the GCP record above there is
+# no published release file to read them from, so they are pinned here and
+# checked against live attestations by scripts/verify_trust_measurements.py.
+# Verified against live attestations on 2026-08-15.
+TRUST_AWS_PCR0="${TRUST_AWS_PCR0:-aef48a453944b35a6cdf472c51a704c1cce185feba75e54538f62f9a0ec54243a1a55fb2c4bddde23b4ea0d0e5e855e1}"
+TRUST_AWS_ACCEPTED_PCR0S="${TRUST_AWS_ACCEPTED_PCR0S:-}"
+TRUST_AZURE_HOSTDATA="${TRUST_AZURE_HOSTDATA:-44e44a55fa76e7e970319777f0e0814c3757908c8fc2a4165ff586d9ef4b1334}"
+TRUST_AZURE_ACCEPTED_HOSTDATA="${TRUST_AZURE_ACCEPTED_HOSTDATA:-}"
+TRUST_AZURE_ATTESTATION_ISSUERS="${TRUST_AZURE_ATTESTATION_ISSUERS:-https://trquilluaen.uaen.attest.azure.net}"
+
 SECRET_ENVS=(
   "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
   "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
@@ -335,6 +345,22 @@ ENV_VARS=(
   "TR_TRUST_GCP_IMAGE_DIGEST=${TRUST_IMAGE_DIGEST}"
   "TR_TRUST_GCP_RELEASE_URL=${TRUST_FILE_URL}"
   "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=https://raw.githubusercontent.com/Lore-Hex/quill-cloud-proxy/main/trust-page/gcp-release.json"
+  # AWS and Azure measurements are deploy-time values, not resolved live. They
+  # change when those enclaves are rebuilt, NOT when the control plane deploys,
+  # so a stale value here is silent by construction. Before changing either one,
+  # and periodically regardless, run:
+  #
+  #   uv run python scripts/verify_trust_measurements.py
+  #
+  # which fetches a live attestation from each plane and fails if what we
+  # publish is not what is running. During a bind window put both the outgoing
+  # and incoming measurement in the ACCEPTED list and the incoming one in the
+  # primary; drop the outgoing value only after the old enclave is retired.
+  "TR_TRUST_AWS_PCR0=${TRUST_AWS_PCR0}"
+  "TR_TRUST_AWS_ACCEPTED_PCR0S=${TRUST_AWS_ACCEPTED_PCR0S}"
+  "TR_TRUST_AZURE_HOSTDATA=${TRUST_AZURE_HOSTDATA}"
+  "TR_TRUST_AZURE_ACCEPTED_HOSTDATA=${TRUST_AZURE_ACCEPTED_HOSTDATA}"
+  "TR_TRUST_AZURE_ATTESTATION_ISSUERS=${TRUST_AZURE_ATTESTATION_ISSUERS}"
   "TR_GOOGLE_OAUTH_REDIRECT_URL=https://trustedrouter.com/google_oauth_callback"
   "TR_GITHUB_OAUTH_REDIRECT_URL=https://trustedrouter.com/github_oauth_callback"
   "TR_SIWE_DOMAIN=trustedrouter.com"

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Check every measurement we publish against a live attestation from that plane.
+
+This exists because the failure it catches already happened. The Quill trust
+bucket published a PCR0 from the initial commit onward, and it matched no
+running enclave — the file was correct once, the enclave was rebuilt, and
+nothing anywhere compared the two. A published measurement that has drifted is
+worse than no measurement: it invites a verifier to conclude the gateway has
+been tampered with, or worse, teaches them to ignore a mismatch.
+
+Fetching happens against the live serving planes. Nothing here is billed and no
+prompt is sent; every endpoint used is an unauthenticated attestation route.
+
+    uv run python scripts/verify_trust_measurements.py
+    uv run python scripts/verify_trust_measurements.py --control-plane https://…
+
+Exit status is 0 only if every configured measurement matches what is running.
+Unconfigured planes are reported and do NOT fail the run; drift does.
+
+The canonical, cryptographically complete verifier is quill-cloud-proxy's
+tools/verify-attestation.py, which checks signatures and certificate chains.
+This script deliberately does less: it answers "is what we publish what is
+running", which is the question a signature check does not ask.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import ssl
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+import cbor2
+
+AWS_ATTESTATION_URL = "https://api-aws.trustedrouter.com/attestation"
+AZURE_ATTESTATION_URL = "https://api-azure.trustedrouter.com/attestation"
+DEFAULT_CONTROL_PLANE = "https://trustedrouter.com"
+TIMEOUT_SECONDS = 25
+NOT_CONFIGURED = "not-configured"
+
+
+@dataclass
+class Result:
+    plane: str
+    ok: bool
+    detail: str
+    skipped: bool = False
+    extra: list[str] = field(default_factory=list)
+
+
+def _fetch(url: str, *, verify_tls: bool = True) -> bytes:
+    context: ssl.SSLContext | None = None
+    if not verify_tls:
+        # The AWS enclave serves a certificate it generated itself, so there is
+        # no chain to validate — that is the design, not a defect. The binding
+        # that replaces chain validation lives in the attestation's user_data.
+        # This script does not check that binding, so treat what it returns as
+        # an unauthenticated read: good enough to detect our own drift, not
+        # good enough to authenticate the enclave. Use verify-attestation.py
+        # for the latter.
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    if not url.startswith(("https://", "http://127.0.0.1:")):
+        # Scheme is fixed by construction; assert it anyway so a future
+        # caller cannot turn this into a file:// read.
+        raise ValueError(f"refusing to fetch non-HTTP(S) URL {url!r}")
+    request = urllib.request.Request(url, headers={"accept": "*/*"})  # noqa: S310
+    with urllib.request.urlopen(  # noqa: S310 - scheme checked above
+        request, timeout=TIMEOUT_SECONDS, context=context
+    ) as response:
+        return response.read()
+
+
+def live_aws_pcr0() -> str:
+    """PCR0 from the running Nitro enclave.
+
+    Fails closed: anything unexpected in the document shape raises rather than
+    returning a value that might silently be the wrong 48 bytes.
+    """
+    envelope = cbor2.loads(_fetch(AWS_ATTESTATION_URL, verify_tls=False))
+    if not isinstance(envelope, list) or len(envelope) != 4:
+        raise ValueError("AWS attestation is not a 4-element COSE_Sign1 envelope")
+    document = cbor2.loads(envelope[2])
+    if not isinstance(document, dict):
+        raise ValueError("AWS attestation payload is not a map")
+    if document.get("digest") != "SHA384":
+        raise ValueError(f"unexpected PCR digest algorithm {document.get('digest')!r}")
+    pcrs = document.get("pcrs")
+    if not isinstance(pcrs, dict) or 0 not in pcrs:
+        raise ValueError("AWS attestation has no PCR0")
+    pcr0 = pcrs[0]
+    if not isinstance(pcr0, bytes) or len(pcr0) != 48:
+        raise ValueError(f"PCR0 is {len(pcr0) if isinstance(pcr0, bytes) else '?'} bytes, want 48")
+    return pcr0.hex()
+
+
+def live_azure_hostdata() -> tuple[str, str]:
+    """(hostdata, MAA issuer) from the running confidential container.
+
+    The token's signature is not checked here; see the module docstring.
+    """
+    token = _fetch(AZURE_ATTESTATION_URL).decode("ascii").strip()
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Azure attestation is not a three-part JWT")
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(padded))
+    if claims.get("x-ms-attestation-type") != "sevsnpvm":
+        raise ValueError(f"unexpected attestation type {claims.get('x-ms-attestation-type')!r}")
+    hostdata = claims.get("x-ms-sevsnpvm-hostdata")
+    issuer = claims.get("iss")
+    if not isinstance(hostdata, str) or len(hostdata) != 64:
+        raise ValueError("Azure attestation has no 32-byte hostdata")
+    if not isinstance(issuer, str) or not issuer:
+        raise ValueError("Azure attestation has no issuer")
+    return hostdata, issuer
+
+
+def _published(control_plane: str, path: str) -> dict[str, Any] | None:
+    """Published release record, or None when the plane reports unconfigured."""
+    url = f"{control_plane.rstrip('/')}{path}"
+    try:
+        return json.loads(_fetch(url))
+    except urllib.error.HTTPError as exc:  # noqa: UP041 - urllib error hierarchy
+        if exc.code == 503:
+            return None
+        raise
+
+
+def check_aws(control_plane: str) -> Result:
+    record = _published(control_plane, "/trust/aws-release.json")
+    if record is None:
+        return Result("aws", ok=True, detail="no measurement published (503)", skipped=True)
+    accepted = [value for value in record.get("accepted_pcr0s", []) if value != NOT_CONFIGURED]
+    if not accepted:
+        return Result("aws", ok=True, detail="no measurement published", skipped=True)
+    running = live_aws_pcr0()
+    if running not in accepted:
+        return Result(
+            "aws",
+            ok=False,
+            detail="running PCR0 is not in the published accepted set",
+            extra=[f"running:   {running}", *(f"published: {value}" for value in accepted)],
+        )
+    note = "" if running == record.get("pcr0") else " (matches accepted set, not the primary)"
+    return Result("aws", ok=True, detail=f"PCR0 matches{note}", extra=[f"running: {running}"])
+
+
+def check_azure(control_plane: str) -> Result:
+    record = _published(control_plane, "/trust/azure-release.json")
+    if record is None:
+        return Result("azure", ok=True, detail="no measurement published (503)", skipped=True)
+    accepted = [value for value in record.get("accepted_hostdata", []) if value != NOT_CONFIGURED]
+    if not accepted:
+        return Result("azure", ok=True, detail="no measurement published", skipped=True)
+    running, issuer = live_azure_hostdata()
+    problems: list[str] = []
+    if running not in accepted:
+        problems.append("running hostdata is not in the published accepted set")
+    issuers = record.get("attestation_issuers", [])
+    if issuers and issuer not in issuers:
+        # A region we serve from but never listed. A verifier following our
+        # record would reject a token that is in fact genuine.
+        problems.append(f"live MAA issuer {issuer} is not in the published issuer list")
+    detail_extra = [
+        f"running:   {running}",
+        *(f"published: {value}" for value in accepted),
+        f"issuer:    {issuer}",
+    ]
+    if problems:
+        return Result("azure", ok=False, detail="; ".join(problems), extra=detail_extra)
+    return Result("azure", ok=True, detail="hostdata and issuer match", extra=detail_extra)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control-plane", default=DEFAULT_CONTROL_PLANE)
+    args = parser.parse_args()
+
+    results: list[Result] = []
+    for name, check in (("aws", check_aws), ("azure", check_azure)):
+        try:
+            results.append(check(args.control_plane))
+        except Exception as exc:  # noqa: BLE001 - any failure is a failed check
+            results.append(Result(name, ok=False, detail=f"check failed: {exc}"))
+
+    for result in results:
+        mark = "SKIP" if result.skipped else ("ok" if result.ok else "DRIFT")
+        print(f"[{mark}] {result.plane}: {result.detail}")
+        for line in result.extra:
+            print(f"       {line}")
+
+    failed = [result for result in results if not result.ok]
+    if failed:
+        print(
+            f"\n{len(failed)} plane(s) publish a measurement that is not what is running.\n"
+            "Update the TR_TRUST_* values in scripts/deploy/rollout.sh and redeploy, or\n"
+            "widen the accepted set if a bind window is in progress.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nEvery published measurement matches a live attestation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -202,6 +202,17 @@ def parse_gateway_region_targets(raw: str) -> tuple[GatewayRegionTarget, ...]:
     return tuple(entries)
 
 
+def _comma_set(raw: str, *, primary: str | None = None) -> tuple[str, ...]:
+    """Parse a comma-separated setting into a de-duplicated ordered tuple.
+
+    ``primary`` is prepended when given, so the value that should be serving
+    leads the set regardless of where it appears in the configured string.
+    """
+    values = [primary.strip()] if primary and primary.strip() else []
+    values.extend(value.strip() for value in raw.split(",") if value.strip())
+    return tuple(dict.fromkeys(values))
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="TR_", env_file=".env", extra="ignore")
 
@@ -338,6 +349,40 @@ class Settings(BaseSettings):
     # the canonical DNS zone is unavailable. Every fetched record is subjected
     # to the same strict release validation before it enters the cache.
     trust_gcp_release_fallback_urls: str = ""
+
+    # AWS and Azure measure a different artifact than GCP does. AWS Nitro
+    # measures the enclave image file into PCR0 (SHA-384); Azure Confidential
+    # Containers measure the SEV-SNP hostdata, which is sha256 over the decoded
+    # CCE policy. Neither plane publishes a release record the control plane can
+    # fetch the way it fetches the GCP gateway's, so both are supplied at deploy
+    # time.
+    #
+    # An unset measurement publishes "not-configured" and serves 503 rather than
+    # a number that may no longer be running. That failure mode is not
+    # hypothetical: trust.trustedrouter.com/pcr0.txt has served the same PCR0
+    # since the initial commit and it matches no running enclave. Nothing caught
+    # it because no code ever compared the published value to a live
+    # attestation. scripts/verify_trust_measurements.py is that comparison.
+    #
+    # Both are SETS, not scalars. During a bind window the released key is bound
+    # to the old and the new measurement at once — quill-cloud-proxy's
+    # tools/deploy-azure-aci.sh emits an anyOf over BOTH hostdata values so the
+    # outgoing enclave keeps serving while the incoming one comes up. A verifier
+    # pinned to a single value fails exactly when a rollout is in flight, which
+    # is when it is least helpful to fail. The primary is what should be
+    # serving; the accepted set is what a verifier should tolerate.
+    trust_aws_source_commit: str | None = None
+    trust_aws_image_reference: str | None = None
+    trust_aws_pcr0: str | None = None
+    trust_aws_accepted_pcr0s: str = ""
+    trust_azure_source_commit: str | None = None
+    trust_azure_image_reference: str | None = None
+    trust_azure_hostdata: str | None = None
+    trust_azure_accepted_hostdata: str = ""
+    # Azure serves from more than one region and each region has its own MAA
+    # instance, so the issuer a verifier sees depends on which region answered.
+    # Comma-separated; a verifier should accept any of them.
+    trust_azure_attestation_issuers: str = ""
 
     rate_limit_enabled: bool = True
     rate_limit_window_seconds: int = 60
@@ -1052,13 +1097,25 @@ class Settings(BaseSettings):
 
     @property
     def trust_gcp_release_fallback_url_list(self) -> tuple[str, ...]:
-        return tuple(
-            dict.fromkeys(
-                value.strip()
-                for value in self.trust_gcp_release_fallback_urls.split(",")
-                if value.strip()
-            )
-        )
+        return _comma_set(self.trust_gcp_release_fallback_urls)
+
+    @property
+    def trust_aws_accepted_pcr0_list(self) -> tuple[str, ...]:
+        """Every PCR0 a verifier should accept, primary first.
+
+        The primary is always a member. A bind window that widened the accepted
+        set but forgot the currently-serving value would otherwise publish a set
+        that rejects the enclave answering the request.
+        """
+        return _comma_set(self.trust_aws_accepted_pcr0s, primary=self.trust_aws_pcr0)
+
+    @property
+    def trust_azure_accepted_hostdata_list(self) -> tuple[str, ...]:
+        return _comma_set(self.trust_azure_accepted_hostdata, primary=self.trust_azure_hostdata)
+
+    @property
+    def trust_azure_attestation_issuer_list(self) -> tuple[str, ...]:
+        return _comma_set(self.trust_azure_attestation_issuers)
 
     @property
     def google_alias_credentials(self) -> dict[str, tuple[str, str]]:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -124,7 +124,7 @@ from trusted_router.synthetic.fleet import fleet_snapshot
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 from trusted_router.synthetic.status import history_payload, status_snapshot
 from trusted_router.synthetic.video_leaderboard import aggregate_video_leaderboard
-from trusted_router.trust import gcp_release, trust_html
+from trusted_router.trust import aws_release, azure_release, gcp_release, trust_html
 from trusted_router.views import render_template
 
 STATUS_SNAPSHOT_CACHE_SECONDS = 15
@@ -1507,6 +1507,47 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             ),
             status_code=trust_response_status(release.status),
             headers=trust_response_headers(release.status),
+        )
+
+    # AWS and Azure are deploy-time configured, so unlike the GCP record there
+    # is nothing to resolve and no stale/live distinction to report. What there
+    # IS is an unconfigured state, and that must not render as a measurement:
+    # serve 503 so a verifier treats it as "no answer" rather than reading
+    # "not-configured" as the value it should expect.
+    def _static_release_response(payload: dict[str, Any]) -> JSONResponse:
+        configured = payload["release_metadata_status"] != "not-configured"
+        return JSONResponse(
+            payload,
+            status_code=200 if configured else 503,
+            headers=trust_response_headers("embedded" if configured else "unavailable"),
+        )
+
+    @app.get("/trust/aws-release.json")
+    async def trust_release_aws() -> JSONResponse:
+        return _static_release_response(aws_release(settings))
+
+    @app.get("/trust/azure-release.json")
+    async def trust_release_azure() -> JSONResponse:
+        return _static_release_response(azure_release(settings))
+
+    @app.get("/trust/pcr0-aws.txt")
+    async def trust_pcr0_aws() -> PlainTextResponse:
+        payload = aws_release(settings)
+        configured = payload["release_metadata_status"] != "not-configured"
+        return PlainTextResponse(
+            "".join(f"{value}\n" for value in payload["accepted_pcr0s"]),
+            status_code=200 if configured else 503,
+            headers=trust_response_headers("embedded" if configured else "unavailable"),
+        )
+
+    @app.get("/trust/hostdata-azure.txt")
+    async def trust_hostdata_azure() -> PlainTextResponse:
+        payload = azure_release(settings)
+        configured = payload["release_metadata_status"] != "not-configured"
+        return PlainTextResponse(
+            "".join(f"{value}\n" for value in payload["accepted_hostdata"]),
+            status_code=200 if configured else 503,
+            headers=trust_response_headers("embedded" if configured else "unavailable"),
         )
 
     @app.get("/trust/image-digest-gcp.txt")

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -21,6 +21,29 @@ JAVASCRIPT_SDK_REPO = "https://github.com/Lore-Hex/trusted-router-js"
 PROVIDER_CHECK_REPO = "https://github.com/Lore-Hex/trustedrouter-provider-check"
 
 
+NOT_CONFIGURED = "not-configured"
+
+AWS_API_HOSTNAME = "api-aws.trustedrouter.com"
+AZURE_API_HOSTNAME = "api-azure.trustedrouter.com"
+
+# Nitro attestation documents are COSE_Sign1 signed by AWS's own PKI. There is
+# no issuer URL to compare the way GCP's JWT has one; the check is a chain to
+# this published root.
+AWS_ATTESTATION_ROOT = "https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip"
+
+
+def _source_repositories() -> dict[str, str]:
+    return {
+        "control_plane": CONTROL_PLANE_REPO,
+        "attested_gateway": ATTESTED_GATEWAY_REPO,
+        "cloud_infra": CLOUD_INFRA_REPO,
+        "quill": QUILL_REPO,
+        "python_sdk": PYTHON_SDK_REPO,
+        "javascript_sdk": JAVASCRIPT_SDK_REPO,
+        "provider_check": PROVIDER_CHECK_REPO,
+    }
+
+
 def gcp_release(
     settings: Settings,
     *,
@@ -28,23 +51,15 @@ def gcp_release(
     release_metadata_status: str = "embedded",
 ) -> dict[str, Any]:
     metadata = release_metadata or {
-        "source_commit": settings.trust_gcp_source_commit or "not-configured",
-        "image_reference": settings.trust_gcp_image_reference or "not-configured",
-        "image_digest": settings.trust_gcp_image_digest or "not-configured",
+        "source_commit": settings.trust_gcp_source_commit or NOT_CONFIGURED,
+        "image_reference": settings.trust_gcp_image_reference or NOT_CONFIGURED,
+        "image_digest": settings.trust_gcp_image_digest or NOT_CONFIGURED,
     }
     api_hostnames = [f"api.{domain}" for domain in configured_control_domains(settings)]
     return {
         "platform": "gcp-confidential-space",
         "source_repo": ATTESTED_GATEWAY_REPO,
-        "source_repositories": {
-            "control_plane": CONTROL_PLANE_REPO,
-            "attested_gateway": ATTESTED_GATEWAY_REPO,
-            "cloud_infra": CLOUD_INFRA_REPO,
-            "quill": QUILL_REPO,
-            "python_sdk": PYTHON_SDK_REPO,
-            "javascript_sdk": JAVASCRIPT_SDK_REPO,
-            "provider_check": PROVIDER_CHECK_REPO,
-        },
+        "source_repositories": _source_repositories(),
         "source_commit": metadata["source_commit"],
         "image_reference": metadata["image_reference"],
         "image_digest": metadata["image_digest"],
@@ -70,6 +85,92 @@ def gcp_release(
 
 def gcp_release_json(settings: Settings) -> str:
     return json.dumps(gcp_release(settings), indent=2, sort_keys=True) + "\n"
+
+
+def aws_release(settings: Settings) -> dict[str, Any]:
+    """Publish the AWS Nitro serving plane's measurement.
+
+    Deploy-time configured rather than resolved live: the enclave answers
+    attestation over a self-signed certificate, so fetching it from here would
+    mean the control plane making an unauthenticated TLS connection and parsing
+    CBOR on a public route. The staleness that trade buys is checked out of band
+    by scripts/verify_trust_measurements.py instead.
+    """
+    accepted = settings.trust_aws_accepted_pcr0_list
+    return {
+        "platform": "aws-nitro-enclaves",
+        "source_repo": ATTESTED_GATEWAY_REPO,
+        "source_repositories": _source_repositories(),
+        "source_commit": settings.trust_aws_source_commit or NOT_CONFIGURED,
+        "image_reference": settings.trust_aws_image_reference or NOT_CONFIGURED,
+        # PCR0 measures the enclave image file: kernel, ramdisk, and
+        # application, as built by nitro-cli build-enclave.
+        "measurement_type": "nitro-pcr0-sha384",
+        "pcr0": settings.trust_aws_pcr0 or NOT_CONFIGURED,
+        "accepted_pcr0s": list(accepted),
+        "release_metadata_status": ("configured" if accepted else NOT_CONFIGURED),
+        "attestation_format": "cose-sign1-nitro-attestation-document",
+        "attestation_root": AWS_ATTESTATION_ROOT,
+        "api_base_url": f"https://{AWS_API_HOSTNAME}/v1",
+        "tls": {
+            # Deliberately not a public-CA certificate. The enclave generates
+            # its own key, and binds the certificate fingerprint and the TLS
+            # exporter value into the attestation's user_data, so the connection
+            # you are on is the connection that was attested. Chain validation
+            # is replaced by that binding, not dropped.
+            "mode": "attested-self-signed-inside-enclave",
+            "hostname": AWS_API_HOSTNAME,
+            "certificate_binding": "user_data[0:64]=certificate fingerprint, "
+            "user_data[64:96]=TLS exporter channel binding",
+        },
+        "data_policy": {
+            "prompt_output_storage": False,
+            "control_plane_prompt_access": False,
+        },
+    }
+
+
+def azure_release(settings: Settings) -> dict[str, Any]:
+    """Publish the Azure SEV-SNP serving plane's measurement.
+
+    hostdata is sha256 over the decoded CCE policy, which is what the released
+    key is bound to; it is the value a verifier compares against
+    x-ms-sevsnpvm-hostdata in an MAA token.
+    """
+    accepted = settings.trust_azure_accepted_hostdata_list
+    return {
+        "platform": "azure-confidential-containers-sev-snp",
+        "source_repo": ATTESTED_GATEWAY_REPO,
+        "source_repositories": _source_repositories(),
+        "source_commit": settings.trust_azure_source_commit or NOT_CONFIGURED,
+        "image_reference": settings.trust_azure_image_reference or NOT_CONFIGURED,
+        "measurement_type": "sev-snp-hostdata-sha256",
+        "hostdata": settings.trust_azure_hostdata or NOT_CONFIGURED,
+        "accepted_hostdata": list(accepted),
+        "release_metadata_status": ("configured" if accepted else NOT_CONFIGURED),
+        "attestation_format": "microsoft-azure-attestation-jwt",
+        "attestation_type": "sevsnpvm",
+        # One MAA instance per serving region, so which issuer signs depends on
+        # which region answered. A verifier should accept any of them.
+        "attestation_issuers": list(settings.trust_azure_attestation_issuer_list),
+        "api_base_url": f"https://{AZURE_API_HOSTNAME}/v1",
+        "tls": {
+            "mode": "acme-inside-confidential-container",
+            "hostname": AZURE_API_HOSTNAME,
+        },
+        "data_policy": {
+            "prompt_output_storage": False,
+            "control_plane_prompt_access": False,
+        },
+    }
+
+
+def aws_release_json(settings: Settings) -> str:
+    return json.dumps(aws_release(settings), indent=2, sort_keys=True) + "\n"
+
+
+def azure_release_json(settings: Settings) -> str:
+    return json.dumps(azure_release(settings), indent=2, sort_keys=True) + "\n"
 
 
 def trust_html(
@@ -127,18 +228,38 @@ def trust_html(
     if release_metadata_status == "stale":
         release_warning = (
             '<section class="panel warn"><h2>Release record temporarily stale</h2>'
-            '<p>This page is showing the last validated gateway release record and returns '
-            'HTTP 503. Verify the canonical trust record before sending sensitive data.</p></section>'
+            "<p>This page is showing the last validated gateway release record and returns "
+            "HTTP 503. Verify the canonical trust record before sending sensitive data.</p></section>"
         )
     elif release_metadata_status == "unavailable":
         release_warning = (
             '<section class="panel warn"><h2>Live release record unavailable</h2>'
-            '<p>This page cannot currently verify the running gateway digest and returns '
-            'HTTP 503. Do not rely on an older embedded digest.</p></section>'
+            "<p>This page cannot currently verify the running gateway digest and returns "
+            "HTTP 503. Do not rely on an older embedded digest.</p></section>"
         )
     else:
         release_warning = ""
     release_json = html.escape(json.dumps(release, indent=2, sort_keys=True) + "\n")
+
+    aws = aws_release(settings)
+    azure = azure_release(settings)
+    aws_pcr0 = html.escape(str(aws["pcr0"]))
+    aws_api = html.escape(str(aws["api_base_url"]))
+    azure_hostdata = html.escape(str(azure["hostdata"]))
+    azure_api = html.escape(str(azure["api_base_url"]))
+    azure_issuers = html.escape(", ".join(azure["attestation_issuers"]) or NOT_CONFIGURED)
+
+    def _plane_note(payload: Mapping[str, Any]) -> str:
+        if payload["release_metadata_status"] == NOT_CONFIGURED:
+            return (
+                "<p><strong>No measurement published for this plane yet.</strong> "
+                "Do not treat its absence as a measurement of zero — verify against a "
+                "live attestation before sending sensitive data.</p>"
+            )
+        return ""
+
+    aws_note = _plane_note(aws)
+    azure_note = _plane_note(azure)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -243,11 +364,54 @@ def trust_html(
         <p><a href="/trust/image-digest-gcp.txt">image-digest-gcp.txt</a></p>
         <p><a href="/trust/image-reference-gcp.txt">image-reference-gcp.txt</a></p>
         <p><a href="/trust/gcp-release.json">gcp-release.json</a></p>
+        <p><a href="/trust/aws-release.json">aws-release.json</a></p>
+        <p><a href="/trust/azure-release.json">azure-release.json</a></p>
       </div>
       <div class="panel warn">
         <h2>DNS Requirement</h2>
         <p><code>{api_hostname}</code> must remain DNS-only or TCP-passthrough. TLS termination by a CDN would break the hosted-code trust claim because the prompt path certificate key must remain inside the measured workload.</p>
       </div>
+    </section>
+    <section class="grid" aria-label="Attested serving planes">
+      <div class="panel">
+        <h2>GCP · Confidential Space</h2>
+        <div class="kv">
+          <div><div class="label">Measures</div><div class="value">Container image digest</div></div>
+          <div><div class="label">Image digest</div><div class="value">{digest}</div></div>
+          <div><div class="label">Attestation issuer</div><div class="value">confidentialcomputing.googleapis.com</div></div>
+          <div><div class="label">API base</div><div class="value">{api}</div></div>
+          <div><div class="label">Release record</div><div class="value"><a href="/trust/gcp-release.json">gcp-release.json</a></div></div>
+        </div>
+      </div>
+      <div class="panel">
+        <h2>AWS · Nitro Enclaves</h2>
+        {aws_note}
+        <div class="kv">
+          <div><div class="label">Measures</div><div class="value">PCR0 over the enclave image file (SHA-384)</div></div>
+          <div><div class="label">PCR0</div><div class="value">{aws_pcr0}</div></div>
+          <div><div class="label">Attestation</div><div class="value">COSE_Sign1, AWS Nitro PKI</div></div>
+          <div><div class="label">API base</div><div class="value">{aws_api}</div></div>
+          <div><div class="label">Release record</div><div class="value"><a href="/trust/aws-release.json">aws-release.json</a></div></div>
+        </div>
+        <p>This plane serves a certificate generated inside the enclave rather than one from a public CA. Its fingerprint and the TLS exporter value are bound into the attestation, so the connection you are on is the connection that was attested. Verify with <code>--attested-cert-only</code>; chain validation is replaced by that binding, not dropped.</p>
+      </div>
+      <div class="panel">
+        <h2>Azure · Confidential Containers</h2>
+        {azure_note}
+        <div class="kv">
+          <div><div class="label">Measures</div><div class="value">SEV-SNP hostdata, sha256 over the CCE policy</div></div>
+          <div><div class="label">hostdata</div><div class="value">{azure_hostdata}</div></div>
+          <div><div class="label">MAA issuers</div><div class="value">{azure_issuers}</div></div>
+          <div><div class="label">API base</div><div class="value">{azure_api}</div></div>
+          <div><div class="label">Release record</div><div class="value"><a href="/trust/azure-release.json">azure-release.json</a></div></div>
+        </div>
+        <p>Compare <code>hostdata</code> against <code>x-ms-sevsnpvm-hostdata</code> in a live MAA token. Each serving region runs its own MAA instance, so accept any issuer listed above.</p>
+      </div>
+    </section>
+    <section class="panel">
+      <h2>Why the three measurements look different</h2>
+      <p>Each platform measures the artifact its own hardware can attest to, so there is no single number to compare across all three. GCP measures the container image; AWS measures the enclave image file into PCR0; Azure measures the policy that constrains what the container is allowed to be. A verifier checks one plane at a time, against that plane's own record.</p>
+      <p>Measurements published here are a <strong>set</strong>, not a single value. During a rollout the released key is deliberately bound to both the outgoing and incoming measurement so the old enclave keeps serving while the new one starts. A verifier pinned to exactly one value would fail during precisely that window, which is why each record carries the full accepted set alongside the value expected to be serving.</p>
     </section>
     <section class="grid">
       <div class="panel"><h2>No Prompt Logs</h2><p>Ordinary synchronous and streaming prompt/output storage is disabled. The opt-in Batch API uses separately documented encrypted retention. Generation content endpoint returns a compatible <code>content_not_stored</code> response.</p></div>

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -382,6 +382,7 @@ def trust_html(
           <div><div class="label">API base</div><div class="value">{api}</div></div>
           <div><div class="label">Release record</div><div class="value"><a href="/trust/gcp-release.json">gcp-release.json</a></div></div>
         </div>
+        <p>Compare <code>image_digest</code> against the digest in a live attestation JWT from the issuer above, checking its audience is <code>quill-cloud</code>. The certificate fingerprint is bound into the attestation nonce, so the connection you are on is the connection that was attested.</p>
       </div>
       <div class="panel">
         <h2>AWS · Nitro Enclaves</h2>

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -16,8 +16,7 @@ from trusted_router.services.trust_release import (
 SOURCE_COMMIT = "5e7c096"
 IMAGE_DIGEST = "sha256:" + "7f" * 32
 IMAGE_REFERENCE = (
-    "us-central1-docker.pkg.dev/quill-cloud-proxy/quill/"
-    f"enclave-multi:gcp-release-{SOURCE_COMMIT}"
+    f"us-central1-docker.pkg.dev/quill-cloud-proxy/quill/enclave-multi:gcp-release-{SOURCE_COMMIT}"
 )
 
 
@@ -72,9 +71,7 @@ async def test_release_uses_independent_validated_fallback(
     resolver = TrustReleaseResolver(
         Settings(
             trust_gcp_release_url="https://trust.trustedrouter.com/release.json",
-            trust_gcp_release_fallback_urls=(
-                "https://trust.backup.example/release.json"
-            ),
+            trust_gcp_release_fallback_urls=("https://trust.backup.example/release.json"),
         ),
         monotonic=lambda: 100.0,
         wall_clock=lambda: 600.0,
@@ -203,13 +200,10 @@ def test_alias_trust_routes_render_live_release(httpx_mock: HTTPXMock) -> None:
     )
     settings = Settings(
         environment="test",
-        trust_gcp_release_url=(
-            "https://trust.trustedrouter.com/trust/gcp-release.json"
-        ),
+        trust_gcp_release_url=("https://trust.trustedrouter.com/trust/gcp-release.json"),
         trust_gcp_source_commit="stale000",
         trust_gcp_image_reference=(
-            "us-central1-docker.pkg.dev/quill-cloud-proxy/quill/"
-            "enclave-multi:gcp-release-stale000"
+            "us-central1-docker.pkg.dev/quill-cloud-proxy/quill/enclave-multi:gcp-release-stale000"
         ),
         trust_gcp_image_digest="sha256:" + "00" * 32,
     )
@@ -266,3 +260,120 @@ def test_alias_trust_route_fails_closed_without_live_or_cached_release(
     assert digest.text.strip() == "live-release-unavailable"
     assert digest.headers["cache-control"] == "no-store"
     assert len(httpx_mock.get_requests()) == 1
+
+
+# --- AWS and Azure serving planes -------------------------------------------
+#
+# These are deploy-time configured rather than resolved live, so the risk they
+# carry is the opposite of the GCP record's: not a fetch that fails, but a
+# value that quietly stops being true. The tests below pin the two behaviours
+# that keep that survivable — an unconfigured plane must not render as a
+# measurement, and the accepted set must always contain what should be serving.
+
+AWS_PCR0 = "ae" + "f4" * 23 + "8a"
+AWS_PCR0_PREVIOUS = "bb" + "c1" * 23 + "9d"
+AZURE_HOSTDATA = "44" + "e4" * 31
+AZURE_HOSTDATA_PREVIOUS = "77" + "a2" * 31
+
+
+def configured_multicloud_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "environment": "test",
+        "trust_aws_pcr0": AWS_PCR0,
+        "trust_azure_hostdata": AZURE_HOSTDATA,
+        "trust_azure_attestation_issuers": "https://trquilluaen.uaen.attest.azure.net",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_aws_and_azure_release_records_publish_configured_measurements() -> None:
+    settings = configured_multicloud_settings()
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        aws = client.get("/trust/aws-release.json")
+        azure = client.get("/trust/azure-release.json")
+
+    assert aws.status_code == 200
+    assert aws.json()["platform"] == "aws-nitro-enclaves"
+    assert aws.json()["pcr0"] == AWS_PCR0
+    assert aws.json()["accepted_pcr0s"] == [AWS_PCR0]
+    assert aws.json()["measurement_type"] == "nitro-pcr0-sha384"
+    # The self-signed certificate is the design; the page must say what stands
+    # in for chain validation rather than leaving it looking like a weakness.
+    assert aws.json()["tls"]["mode"] == "attested-self-signed-inside-enclave"
+    assert "exporter" in aws.json()["tls"]["certificate_binding"]
+
+    assert azure.status_code == 200
+    assert azure.json()["platform"] == "azure-confidential-containers-sev-snp"
+    assert azure.json()["hostdata"] == AZURE_HOSTDATA
+    assert azure.json()["accepted_hostdata"] == [AZURE_HOSTDATA]
+    assert azure.json()["attestation_issuers"] == ["https://trquilluaen.uaen.attest.azure.net"]
+    # Same repo set as GCP, so a reader comparing planes sees one source of code.
+    assert azure.json()["source_repositories"] == aws.json()["source_repositories"]
+
+
+def test_unconfigured_plane_fails_closed_rather_than_publishing_a_placeholder() -> None:
+    # The bug this prevents shipped once already on the Quill trust bucket: a
+    # measurement file that outlived the enclave it described. Serving 200 with
+    # "not-configured" would be the same mistake in a new costume — a verifier
+    # scripting against this must get "no answer", not a string to compare.
+    settings = Settings(environment="test")
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        aws = client.get("/trust/aws-release.json")
+        azure = client.get("/trust/azure-release.json")
+        pcr0 = client.get("/trust/pcr0-aws.txt")
+        hostdata = client.get("/trust/hostdata-azure.txt")
+
+    assert aws.status_code == 503
+    assert azure.status_code == 503
+    assert aws.json()["release_metadata_status"] == "not-configured"
+    assert azure.json()["release_metadata_status"] == "not-configured"
+    assert aws.json()["accepted_pcr0s"] == []
+    assert azure.json()["accepted_hostdata"] == []
+    assert aws.headers["cache-control"] == "no-store"
+    assert azure.headers["cache-control"] == "no-store"
+    assert pcr0.status_code == 503
+    assert hostdata.status_code == 503
+    assert pcr0.text == ""
+    assert hostdata.text == ""
+
+
+def test_bind_window_publishes_both_measurements_with_the_incoming_one_primary() -> None:
+    # During a rollout the released key is bound to both measurements at once,
+    # so a verifier that accepts only one fails exactly while a deploy is in
+    # flight. Both values must be published, and the primary must survive being
+    # omitted from the accepted list — a set that rejects the enclave currently
+    # answering is worse than no set at all.
+    settings = configured_multicloud_settings(
+        trust_aws_accepted_pcr0s=AWS_PCR0_PREVIOUS,
+        trust_azure_accepted_hostdata=f"{AZURE_HOSTDATA_PREVIOUS},{AZURE_HOSTDATA}",
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        aws = client.get("/trust/aws-release.json").json()
+        azure = client.get("/trust/azure-release.json").json()
+        pcr0 = client.get("/trust/pcr0-aws.txt")
+
+    assert aws["pcr0"] == AWS_PCR0
+    assert aws["accepted_pcr0s"] == [AWS_PCR0, AWS_PCR0_PREVIOUS]
+    assert azure["hostdata"] == AZURE_HOSTDATA
+    # Configured twice (primary plus the accepted list); published once.
+    assert azure["accepted_hostdata"] == [AZURE_HOSTDATA, AZURE_HOSTDATA_PREVIOUS]
+    assert pcr0.status_code == 200
+    assert pcr0.text.split() == [AWS_PCR0, AWS_PCR0_PREVIOUS]
+
+
+def test_trust_page_shows_every_plane_and_flags_the_ones_without_a_measurement() -> None:
+    configured = configured_multicloud_settings(trust_gcp_image_digest="sha256:" + "00" * 32)
+    with TestClient(create_app(configured, init_observability=False)) as client:
+        page = client.get("/trust").text
+    assert AWS_PCR0 in page
+    assert AZURE_HOSTDATA in page
+    assert "aws-release.json" in page
+    assert "azure-release.json" in page
+    assert "No measurement published for this plane yet" not in page
+
+    bare = Settings(environment="test", trust_gcp_image_digest="sha256:" + "00" * 32)
+    with TestClient(create_app(bare, init_observability=False)) as client:
+        bare_page = client.get("/trust").text
+    # Absence has to be legible on the page too, not just in the JSON.
+    assert bare_page.count("No measurement published for this plane yet") == 2


### PR DESCRIPTION
## What

`/trust` told customers to verify three attested planes and published one. `trust/aws-release.json` and `trust/azure-release.json` returned 404, so the two clouds a reader was pointed at had nothing to check against.

This adds both records, the plain-text measurement files, and a three-plane section on the page explaining why the measurements are not comparable to each other.

## The bug this found on the way

`https://trust.trustedrouter.com/pcr0.txt` has served `9b4ca566…` since its initial commit. The running AWS enclave measures `aef48a45…`. The file was correct once, the enclave was rebuilt, and nothing anywhere compared the two.

That is the failure mode of a published measurement — worse than publishing none, because a verifier who checks it concludes the gateway was tampered with. `scripts/verify_trust_measurements.py` fetches a live attestation from each plane and fails if what we publish is not what is running. Verified in both directions: it passes on the correct values and exits 1 on that exact stale one.

**Not fixed here** — `pcr0.txt` lives in quill-cloud-proxy, where pushing to main redeploys the production enclave. Flagged for a deliberate change.

## Design notes

- **Deploy-time configured, not resolved live.** The AWS enclave answers attestation over a certificate it generated itself; fetching that from the control plane would mean an unauthenticated TLS connection and CBOR parsing on a public route. Out-of-band checking is the better trade.
- **Measurements are sets.** During a bind window the released key is bound to the outgoing and incoming measurement at once (`deploy-azure-aci.sh` emits an `anyOf` over both). A verifier pinned to one value fails precisely while a rollout is in flight, so each record carries the accepted set alongside the value expected to be serving. The primary is always a member of its own set.
- **Unconfigured serves 503, not 200.** A verifier scripting against these routes gets "no answer" rather than the string `not-configured` to compare against.

## Verified against live attestations, 2026-08-15

| Plane | Measurement | Value |
| --- | --- | --- |
| AWS Nitro | PCR0 (SHA-384) | `aef48a453944b35a6cdf472c51a704c1cce185feba75e54538f62f9a0ec54243…` |
| Azure SEV-SNP | hostdata | `44e44a55fa76e7e970319777f0e0814c3757908c8fc2a4165ff586d9ef4b1334` |
| Azure MAA | issuer | `https://trquilluaen.uaen.attest.azure.net` |

## Testing

Full suite green (3588 passed). The four new tests are mutation-verified — serving 200 when unconfigured, dropping the primary from the accepted set, and dropping the unmeasured-plane warning each make a test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)