### PR TITLE
Make the control plane a mirror of three records, not the author of two

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -23,15 +23,6 @@ if [ -n "$TRUST_JSON" ]; then
   TRUST_IMAGE_DIGEST="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_digest", ""))' <<<"$TRUST_JSON")"
 fi
 
-# AWS and Azure serving-plane measurements. Unlike the GCP record above there is
-# no published release file to read them from, so they are pinned here and
-# checked against live attestations by scripts/verify_trust_measurements.py.
-# Verified against live attestations on 2026-08-15.
-TRUST_AWS_PCR0="${TRUST_AWS_PCR0:-aef48a453944b35a6cdf472c51a704c1cce185feba75e54538f62f9a0ec54243a1a55fb2c4bddde23b4ea0d0e5e855e1}"
-TRUST_AWS_ACCEPTED_PCR0S="${TRUST_AWS_ACCEPTED_PCR0S:-}"
-TRUST_AZURE_HOSTDATA="${TRUST_AZURE_HOSTDATA:-44e44a55fa76e7e970319777f0e0814c3757908c8fc2a4165ff586d9ef4b1334}"
-TRUST_AZURE_ACCEPTED_HOSTDATA="${TRUST_AZURE_ACCEPTED_HOSTDATA:-}"
-TRUST_AZURE_ATTESTATION_ISSUERS="${TRUST_AZURE_ATTESTATION_ISSUERS:-https://trquilluaen.uaen.attest.azure.net}"
 
 SECRET_ENVS=(
   "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
@@ -345,22 +336,15 @@ ENV_VARS=(
   "TR_TRUST_GCP_IMAGE_DIGEST=${TRUST_IMAGE_DIGEST}"
   "TR_TRUST_GCP_RELEASE_URL=${TRUST_FILE_URL}"
   "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=https://raw.githubusercontent.com/Lore-Hex/quill-cloud-proxy/main/trust-page/gcp-release.json"
-  # AWS and Azure measurements are deploy-time values, not resolved live. They
-  # change when those enclaves are rebuilt, NOT when the control plane deploys,
-  # so a stale value here is silent by construction. Before changing either one,
-  # and periodically regardless, run:
-  #
-  #   uv run python scripts/verify_trust_measurements.py
-  #
-  # which fetches a live attestation from each plane and fails if what we
-  # publish is not what is running. During a bind window put both the outgoing
-  # and incoming measurement in the ACCEPTED list and the incoming one in the
-  # primary; drop the outgoing value only after the old enclave is retired.
-  "TR_TRUST_AWS_PCR0=${TRUST_AWS_PCR0}"
-  "TR_TRUST_AWS_ACCEPTED_PCR0S=${TRUST_AWS_ACCEPTED_PCR0S}"
-  "TR_TRUST_AZURE_HOSTDATA=${TRUST_AZURE_HOSTDATA}"
-  "TR_TRUST_AZURE_ACCEPTED_HOSTDATA=${TRUST_AZURE_ACCEPTED_HOSTDATA}"
-  "TR_TRUST_AZURE_ATTESTATION_ISSUERS=${TRUST_AZURE_ATTESTATION_ISSUERS}"
+  # AWS and Azure measurements are NOT injected here any more. Each plane
+  # publishes its own record, produced from a live attestation by
+  # quill-cloud-proxy's tools/capture-plane-measurements.py, and the control
+  # plane mirrors it from the URL below. Pinning them here made this one
+  # GCP-region rollout script the authority for what three independent planes
+  # were running — one place to falsify, one place to fail, and one more value
+  # to remember to update on every enclave rebuild.
+  "TR_TRUST_AWS_RELEASE_URL=https://trust.trustedrouter.com/trust/aws-release.json"
+  "TR_TRUST_AZURE_RELEASE_URL=https://trust.trustedrouter.com/trust/azure-release.json"
   "TR_GOOGLE_OAUTH_REDIRECT_URL=https://trustedrouter.com/google_oauth_callback"
   "TR_GITHUB_OAUTH_REDIRECT_URL=https://trustedrouter.com/github_oauth_callback"
   "TR_SIWE_DOMAIN=trustedrouter.com"

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -36,6 +36,7 @@ from typing import Any
 
 import cbor2
 
+GCP_ATTESTATION_URL = "https://api.trustedrouter.com/attestation"
 AWS_ATTESTATION_URL = "https://api-aws.trustedrouter.com/attestation"
 AZURE_ATTESTATION_URL = "https://api-azure.trustedrouter.com/attestation"
 DEFAULT_CONTROL_PLANE = "https://trustedrouter.com"
@@ -121,15 +122,80 @@ def live_azure_hostdata() -> tuple[str, str]:
     return hostdata, issuer
 
 
+# 503 is what the control plane returns for a record it has no measurement for.
+# Static origins say the same thing differently: S3 returns 403 for a missing
+# object on a bucket that denies listing, GCS and GitHub Pages return 404.
+# Treating only 503 as "unpublished" made this script CRASH against exactly the
+# mirrors the records are moving to — a stack trace where the honest answer is
+# "that plane publishes nothing here".
+NOT_PUBLISHED_STATUSES = frozenset({403, 404, 503})
+
+
 def _published(control_plane: str, path: str) -> dict[str, Any] | None:
-    """Published release record, or None when the plane reports unconfigured."""
+    """Published release record, or None when nothing is published there."""
     url = f"{control_plane.rstrip('/')}{path}"
     try:
         return json.loads(_fetch(url))
     except urllib.error.HTTPError as exc:  # noqa: UP041 - urllib error hierarchy
-        if exc.code == 503:
+        if exc.code in NOT_PUBLISHED_STATUSES:
             return None
         raise
+    except ValueError as exc:
+        # A 200 carrying something that is not a record is a different failure
+        # from an absent record, and must not be silently read as "unpublished"
+        # — that is how a broken mirror looks identical to an honest one.
+        raise ValueError(f"{url} returned a non-JSON body: {exc}") from exc
+
+
+def live_gcp_digest() -> str:
+    """Container image digest from the running Confidential Space workload."""
+    token = _fetch(GCP_ATTESTATION_URL).decode("ascii").strip()
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("GCP attestation is not a three-part JWT")
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(padded))
+    if claims.get("iss") != "https://confidentialcomputing.googleapis.com":
+        raise ValueError(f"unexpected attestation issuer {claims.get('iss')!r}")
+    digest = claims.get("submods", {}).get("container", {}).get("image_digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError("GCP attestation has no container image digest")
+    return digest
+
+
+def check_gcp(control_plane: str) -> Result:
+    """Compare the running GCP workload against the published accepted set.
+
+    Against the SET, never the scalar. A rolling deploy legitimately serves the
+    outgoing digest while the record already names the incoming one — observed
+    exactly that mid-roll on 2026-08-15 — so a scalar comparison would report
+    drift on every deploy and train the reader to ignore it.
+
+    GCP went longest without this check, which is the wrong way round: it is the
+    plane that carries every prompt.
+    """
+    record = _published(control_plane, "/trust/gcp-release.json")
+    if record is None:
+        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
+    accepted = [
+        value
+        for value in record.get("accepted_image_digests") or [record.get("image_digest")]
+        if isinstance(value, str) and value != NOT_CONFIGURED
+    ]
+    if not accepted:
+        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
+    running = live_gcp_digest()
+    if running not in accepted:
+        return Result(
+            "gcp",
+            ok=False,
+            detail="running image digest is not in the published accepted set",
+            extra=[f"running:   {running}", *(f"published: {v}" for v in accepted)],
+        )
+    note = "" if running == record.get("image_digest") else " (rolling; matches accepted set)"
+    return Result(
+        "gcp", ok=True, detail=f"image digest matches{note}", extra=[f"running: {running}"]
+    )
 
 
 def check_aws(control_plane: str) -> Result:
@@ -183,7 +249,7 @@ def main() -> int:
     args = parser.parse_args()
 
     results: list[Result] = []
-    for name, check in (("aws", check_aws), ("azure", check_azure)):
+    for name, check in (("gcp", check_gcp), ("aws", check_aws), ("azure", check_azure)):
         try:
             results.append(check(args.control_plane))
         except Exception as exc:  # noqa: BLE001 - any failure is a failed check
@@ -199,7 +265,10 @@ def main() -> int:
     if failed:
         print(
             f"\n{len(failed)} plane(s) publish a measurement that is not what is running.\n"
-            "Update the TR_TRUST_* values in scripts/deploy/rollout.sh and redeploy, or\n"
+            "Republish from the plane that drifted — in quill-cloud-proxy run\n"
+            "`python3 tools/capture-plane-measurements.py --write` and commit\n"
+            "trust-page/, adding --keep-accepted if a roll is still in progress. The\n"
+            "control plane mirrors those records, so there is nothing to change here.\n"
             "widen the accepted set if a bind window is in progress.",
             file=sys.stderr,
         )

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -383,6 +383,14 @@ class Settings(BaseSettings):
     # instance, so the issuer a verifier sees depends on which region answered.
     # Comma-separated; a verifier should accept any of them.
     trust_azure_attestation_issuers: str = ""
+    # Where each plane's AUTHORITATIVE record lives. The control plane mirrors
+    # these; the values above are only the offline fallback for when the
+    # authoritative source cannot be reached. Keeping the fallback means a
+    # Sigstore or Pages outage degrades to a stale-but-verified measurement
+    # rather than to no measurement, and the scheduled drift check catches it
+    # either way.
+    trust_aws_release_url: str = ""
+    trust_azure_release_url: str = ""
 
     rate_limit_enabled: bool = True
     rate_limit_window_seconds: int = 60
@@ -1021,6 +1029,12 @@ class Settings(BaseSettings):
             missing.append("TR_BYOK_KMS_KEY_NAME")
         if not self.trust_gcp_release_url:
             self.trust_gcp_release_url = "https://trust.trustedrouter.com/trust/gcp-release.json"
+        if not self.trust_aws_release_url:
+            self.trust_aws_release_url = "https://trust.trustedrouter.com/trust/aws-release.json"
+        if not self.trust_azure_release_url:
+            self.trust_azure_release_url = (
+                "https://trust.trustedrouter.com/trust/azure-release.json"
+            )
         elif not self.trust_gcp_release_url.startswith("https://"):
             missing.append("TR_TRUST_GCP_RELEASE_URL=https://...")
         invalid_release_fallbacks = [

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -10,7 +10,7 @@ import threading
 import time
 import uuid
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -116,7 +116,11 @@ from trusted_router.services.trust_release import (
     ResolvedTrustRelease,
     TrustReleaseResolver,
     TrustReleaseUnavailable,
+    embedded_aws_metadata,
+    embedded_azure_metadata,
     unavailable_trust_release,
+    validated_aws_metadata,
+    validated_azure_metadata,
 )
 from trusted_router.storage import STORE
 from trusted_router.storage_custom_models import normalize_custom_model_id
@@ -505,6 +509,35 @@ async def _handle_support_inquiry(settings: Settings, request: Request) -> JSONR
 def register_public_routes(app: FastAPI, settings: Settings) -> None:
     app.mount("/static", _CachedStaticFiles(directory=STATIC_DIR), name="static")
     trust_release_resolver = TrustReleaseResolver(settings)
+    # One resolver per plane. The control plane mirrors three independently
+    # published records rather than authoring two of them from its own config.
+    aws_release_resolver = TrustReleaseResolver(
+        settings,
+        urls=[settings.trust_aws_release_url],
+        validator=validated_aws_metadata,
+        embedded=embedded_aws_metadata,
+    )
+    azure_release_resolver = TrustReleaseResolver(
+        settings,
+        urls=[settings.trust_azure_release_url],
+        validator=validated_azure_metadata,
+        embedded=embedded_azure_metadata,
+    )
+
+    async def _mirrored(
+        resolver: TrustReleaseResolver, embedded: Callable[[Settings], Mapping[str, Any]]
+    ) -> tuple[Mapping[str, Any], str]:
+        """Authoritative record if reachable, else the offline fallback.
+
+        Falling back to config keeps a verified measurement available during an
+        upstream outage. It is labelled 'embedded' rather than 'live' so the
+        response never implies it was just confirmed from the source.
+        """
+        try:
+            resolved = await resolver.resolve()
+            return resolved.metadata, resolved.status
+        except TrustReleaseUnavailable:
+            return embedded(settings), "embedded"
 
     async def resolved_trust_release() -> ResolvedTrustRelease:
         try:
@@ -1519,25 +1552,28 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     # IS is an unconfigured state, and that must not render as a measurement:
     # serve 503 so a verifier treats it as "no answer" rather than reading
     # "not-configured" as the value it should expect.
-    def _static_release_response(payload: dict[str, Any]) -> JSONResponse:
+    def _static_release_response(payload: dict[str, Any], status: str = "embedded") -> JSONResponse:
         configured = payload["release_metadata_status"] != "not-configured"
         return JSONResponse(
             payload,
             status_code=200 if configured else 503,
-            headers=trust_response_headers("embedded" if configured else "unavailable"),
+            headers=trust_response_headers(status if configured else "unavailable"),
         )
 
     @app.get("/trust/aws-release.json")
     async def trust_release_aws() -> JSONResponse:
-        return _static_release_response(aws_release(settings))
+        metadata, status = await _mirrored(aws_release_resolver, embedded_aws_metadata)
+        return _static_release_response(aws_release(settings, metadata=metadata), status)
 
     @app.get("/trust/azure-release.json")
     async def trust_release_azure() -> JSONResponse:
-        return _static_release_response(azure_release(settings))
+        metadata, status = await _mirrored(azure_release_resolver, embedded_azure_metadata)
+        return _static_release_response(azure_release(settings, metadata=metadata), status)
 
     @app.get("/trust/pcr0-aws.txt")
     async def trust_pcr0_aws() -> PlainTextResponse:
-        payload = aws_release(settings)
+        metadata, _ = await _mirrored(aws_release_resolver, embedded_aws_metadata)
+        payload = aws_release(settings, metadata=metadata)
         configured = payload["release_metadata_status"] != "not-configured"
         return PlainTextResponse(
             "".join(f"{value}\n" for value in payload["accepted_pcr0s"]),
@@ -1547,7 +1583,8 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @app.get("/trust/hostdata-azure.txt")
     async def trust_hostdata_azure() -> PlainTextResponse:
-        payload = azure_release(settings)
+        metadata, _ = await _mirrored(azure_release_resolver, embedded_azure_metadata)
+        payload = azure_release(settings, metadata=metadata)
         configured = payload["release_metadata_status"] != "not-configured"
         return PlainTextResponse(
             "".join(f"{value}\n" for value in payload["accepted_hostdata"]),

--- a/src/trusted_router/services/trust_release.py
+++ b/src/trusted_router/services/trust_release.py
@@ -4,8 +4,9 @@ import asyncio
 import json
 import re
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 
@@ -31,7 +32,7 @@ class TrustReleaseUnavailable(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class ResolvedTrustRelease:
-    metadata: Mapping[str, str]
+    metadata: Mapping[str, Any]
     status: str
 
 
@@ -51,6 +52,9 @@ class TrustReleaseResolver:
         *,
         monotonic: Callable[[], float] = time.monotonic,
         wall_clock: Callable[[], float] = time.time,
+        urls: Sequence[str] | None = None,
+        validator: Callable[[object], Mapping[str, Any]] | None = None,
+        embedded: Callable[[Settings], Mapping[str, Any]] | None = None,
     ) -> None:
         self._settings = settings
         self._monotonic = monotonic
@@ -58,9 +62,18 @@ class TrustReleaseResolver:
         self._entry: _CacheEntry | None = None
         self._retry_after = 0.0
         self._refresh_lock = asyncio.Lock()
+        # Which record, how to validate it, and what to fall back to are inputs
+        # rather than hardcoded GCP. The control plane's job is to MIRROR each
+        # plane's authoritative record — it is not the author of any of them,
+        # and hardcoding one plane's shape is what made it look like one.
+        self._urls = tuple(urls) if urls is not None else None
+        self._validator = validator or _validated_metadata
+        self._embedded = embedded or _embedded_metadata
 
-    async def resolve(self) -> ResolvedTrustRelease:
-        release_urls = tuple(
+    def _release_urls(self) -> tuple[str, ...]:
+        if self._urls is not None:
+            return tuple(url.strip() for url in self._urls if url.strip())
+        return tuple(
             dict.fromkeys(
                 [
                     self._settings.trust_gcp_release_url.strip(),
@@ -68,10 +81,12 @@ class TrustReleaseResolver:
                 ]
             )
         )
-        release_urls = tuple(url for url in release_urls if url)
+
+    async def resolve(self) -> ResolvedTrustRelease:
+        release_urls = tuple(url for url in self._release_urls() if url)
         if not release_urls:
             return ResolvedTrustRelease(
-                metadata=_embedded_metadata(self._settings),
+                metadata=self._embedded(self._settings),
                 status="embedded",
             )
 
@@ -88,7 +103,7 @@ class TrustReleaseResolver:
             if now < self._retry_after:
                 return self._stale_or_raise(now)
             last_error: Exception | None = None
-            metadata: Mapping[str, str] | None = None
+            metadata: Mapping[str, Any] | None = None
             for release_url in release_urls:
                 try:
                     metadata = await self._fetch(release_url)
@@ -115,7 +130,7 @@ class TrustReleaseResolver:
             return ResolvedTrustRelease(metadata=self._entry.metadata, status="stale")
         raise TrustReleaseUnavailable("live gateway release record unavailable")
 
-    async def _fetch(self, release_url: str) -> Mapping[str, str]:
+    async def _fetch(self, release_url: str) -> Mapping[str, Any]:
         url = httpx.URL(release_url)
         if url.scheme != "https" or not url.host:
             raise ValueError("trust release URL must be absolute HTTPS")
@@ -140,7 +155,7 @@ class TrustReleaseResolver:
                         raise ValueError("trust release record exceeds size limit")
                     content.extend(chunk)
         payload = json.loads(content)
-        return _validated_metadata(payload)
+        return self._validator(payload)
 
 
 def unavailable_trust_release() -> ResolvedTrustRelease:
@@ -149,20 +164,28 @@ def unavailable_trust_release() -> ResolvedTrustRelease:
             "source_commit": "live-release-unavailable",
             "image_reference": "live-release-unavailable",
             "image_digest": "live-release-unavailable",
+            "accepted_image_digests": ["live-release-unavailable"],
+            "accepted_image_references": ["live-release-unavailable"],
+            "release_state": "unavailable",
         },
         status="unavailable",
     )
 
 
-def _embedded_metadata(settings: Settings) -> Mapping[str, str]:
+def _embedded_metadata(settings: Settings) -> Mapping[str, Any]:
+    digest = settings.trust_gcp_image_digest or "not-configured"
+    reference = settings.trust_gcp_image_reference or "not-configured"
     return {
         "source_commit": settings.trust_gcp_source_commit or "not-configured",
-        "image_reference": settings.trust_gcp_image_reference or "not-configured",
-        "image_digest": settings.trust_gcp_image_digest or "not-configured",
+        "image_reference": reference,
+        "image_digest": digest,
+        "accepted_image_digests": [digest],
+        "accepted_image_references": [reference],
+        "release_state": "current",
     }
 
 
-def _validated_metadata(payload: object) -> Mapping[str, str]:
+def _validated_metadata(payload: object) -> Mapping[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("trust release record must be an object")
     if payload.get("platform") != _EXPECTED_PLATFORM:
@@ -187,8 +210,139 @@ def _validated_metadata(payload: object) -> Mapping[str, str]:
         raise ValueError("trust release image reference does not match source commit")
     if not isinstance(image_digest, str) or _DIGEST_RE.fullmatch(image_digest) is None:
         raise ValueError("invalid trust release image digest")
+    # The accepted SETS must survive the trip. Dropping them is not a cosmetic
+    # loss: during a rolling deploy the record names the incoming digest while
+    # the fleet still serves the outgoing one, so a record carrying only the
+    # scalar tells a verifier that the enclave answering them does not match its
+    # published measurement. Observed live on 2026-08-15 — trust.trustedrouter.com
+    # correctly published both digests and trustedrouter.com republished one.
+    #
+    # A mirror serves a record. Narrowing a pin in transit makes it an author,
+    # and a careless one.
+    accepted_digests = _validated_set(payload, "accepted_image_digests", image_digest, _DIGEST_RE)
+    accepted_references = _validated_set(
+        payload, "accepted_image_references", image_reference, None
+    )
     return {
         "source_commit": source_commit,
         "image_reference": image_reference,
         "image_digest": image_digest,
+        "accepted_image_digests": accepted_digests,
+        "accepted_image_references": accepted_references,
+        "release_state": (
+            "current"
+            if accepted_digests == [image_digest] and accepted_references == [image_reference]
+            else "rolling"
+        ),
+    }
+
+
+def _validated_set(
+    payload: dict[str, object],
+    key: str,
+    primary: str,
+    pattern: re.Pattern[str] | None,
+) -> list[str]:
+    """The accepted set from an upstream record, primary always included.
+
+    An upstream that omits the set, or publishes one missing the value it also
+    calls current, must not produce a published set that rejects the running
+    enclave — so the primary is unconditionally a member.
+    """
+    raw = payload.get(key)
+    values = [primary]
+    if isinstance(raw, list):
+        for value in raw:
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"invalid entry in {key}")
+            if pattern is not None and pattern.fullmatch(value) is None:
+                raise ValueError(f"invalid entry in {key}")
+            if value not in values:
+                values.append(value)
+    elif raw is not None:
+        raise ValueError(f"{key} must be a list when present")
+    return values
+
+
+# --- Mirroring the AWS and Azure records ------------------------------------
+#
+# These planes publish their own records, produced from live attestations by
+# quill-cloud-proxy's tools/capture-plane-measurements.py and signed under a
+# per-plane identity. The control plane fetches and republishes them; it does
+# not compute them. Embedding a measurement here would make one deployment the
+# authority for what three independent planes are running — a single place to
+# falsify and a single place to fail, which is precisely what the three-plane
+# arrangement exists to avoid.
+
+_PCR0_RE = re.compile(r"[0-9a-f]{96}")
+_HOSTDATA_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def _validated_set_of(payload: dict[str, object], key: str, pattern: re.Pattern[str]) -> list[str]:
+    raw = payload.get(key)
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"{key} must be a non-empty list")
+    values: list[str] = []
+    for value in raw:
+        if not isinstance(value, str) or pattern.fullmatch(value) is None:
+            raise ValueError(f"invalid entry in {key}")
+        if value not in values:
+            values.append(value)
+    return values
+
+
+def validated_aws_metadata(payload: object) -> Mapping[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("AWS trust record must be an object")
+    if payload.get("platform") != "aws-nitro-enclaves":
+        raise ValueError("unexpected AWS trust record platform")
+    accepted = _validated_set_of(payload, "accepted_pcr0s", _PCR0_RE)
+    pcr0 = payload.get("pcr0")
+    if not isinstance(pcr0, str) or _PCR0_RE.fullmatch(pcr0) is None:
+        raise ValueError("invalid AWS PCR0")
+    if pcr0 not in accepted:
+        # A record whose accepted set excludes its own current measurement would
+        # have a verifier reject the enclave that is answering them.
+        raise ValueError("AWS pcr0 is absent from its own accepted set")
+    return {"pcr0": pcr0, "accepted_pcr0s": accepted}
+
+
+def validated_azure_metadata(payload: object) -> Mapping[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("Azure trust record must be an object")
+    if payload.get("platform") != "azure-confidential-containers-sev-snp":
+        raise ValueError("unexpected Azure trust record platform")
+    accepted = _validated_set_of(payload, "accepted_hostdata", _HOSTDATA_RE)
+    hostdata = payload.get("hostdata")
+    if not isinstance(hostdata, str) or _HOSTDATA_RE.fullmatch(hostdata) is None:
+        raise ValueError("invalid Azure hostdata")
+    if hostdata not in accepted:
+        raise ValueError("Azure hostdata is absent from its own accepted set")
+    issuers = payload.get("attestation_issuers")
+    if not isinstance(issuers, list) or not issuers:
+        raise ValueError("Azure record must name at least one MAA issuer")
+    for issuer in issuers:
+        if not isinstance(issuer, str) or not issuer.startswith("https://"):
+            raise ValueError("invalid MAA issuer")
+    return {
+        "hostdata": hostdata,
+        "accepted_hostdata": accepted,
+        "attestation_issuers": list(issuers),
+    }
+
+
+def embedded_aws_metadata(settings: Settings) -> Mapping[str, Any]:
+    accepted = list(settings.trust_aws_accepted_pcr0_list)
+    return {
+        "pcr0": settings.trust_aws_pcr0 or "not-configured",
+        "accepted_pcr0s": accepted or ["not-configured"],
+    }
+
+
+def embedded_azure_metadata(settings: Settings) -> Mapping[str, Any]:
+    accepted = list(settings.trust_azure_accepted_hostdata_list)
+    return {
+        "hostdata": settings.trust_azure_hostdata or "not-configured",
+        "accepted_hostdata": accepted or ["not-configured"],
+        "attestation_issuers": list(settings.trust_azure_attestation_issuer_list),
     }

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -32,6 +32,19 @@ AZURE_API_HOSTNAME = "api-azure.trustedrouter.com"
 AWS_ATTESTATION_ROOT = "https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip"
 
 
+def gcp_api_hostname(settings: Settings) -> str:
+    """The hostname that terminates the GCP prompt path.
+
+    A property of the plane, not of whoever is serving the record. Any control
+    plane — GCP, AWS or Azure hosted — describing the GCP plane must name this.
+    """
+    return f"api.{configured_control_domains(settings)[0]}"
+
+
+def gcp_api_base_url(settings: Settings) -> str:
+    return f"https://{gcp_api_hostname(settings)}/v1"
+
+
 def _source_repositories() -> dict[str, str]:
     return {
         "control_plane": CONTROL_PLANE_REPO,
@@ -47,13 +60,18 @@ def _source_repositories() -> dict[str, str]:
 def gcp_release(
     settings: Settings,
     *,
-    release_metadata: Mapping[str, str] | None = None,
+    release_metadata: Mapping[str, Any] | None = None,
     release_metadata_status: str = "embedded",
 ) -> dict[str, Any]:
+    digest = settings.trust_gcp_image_digest or NOT_CONFIGURED
+    reference = settings.trust_gcp_image_reference or NOT_CONFIGURED
     metadata = release_metadata or {
         "source_commit": settings.trust_gcp_source_commit or NOT_CONFIGURED,
-        "image_reference": settings.trust_gcp_image_reference or NOT_CONFIGURED,
-        "image_digest": settings.trust_gcp_image_digest or NOT_CONFIGURED,
+        "image_reference": reference,
+        "image_digest": digest,
+        "accepted_image_digests": [digest],
+        "accepted_image_references": [reference],
+        "release_state": "current",
     }
     api_hostnames = [f"api.{domain}" for domain in configured_control_domains(settings)]
     return {
@@ -63,17 +81,44 @@ def gcp_release(
         "source_commit": metadata["source_commit"],
         "image_reference": metadata["image_reference"],
         "image_digest": metadata["image_digest"],
+        # Published as SETS. During a roll the fleet still serves the outgoing
+        # digest while this record already names the incoming one, so a verifier
+        # given only the scalar concludes the enclave answering them does not
+        # match its measurement. Carried through from upstream rather than
+        # recomputed here — a mirror serves a record, it does not narrow it.
+        "accepted_image_digests": list(
+            metadata.get("accepted_image_digests") or [metadata["image_digest"]]
+        ),
+        "accepted_image_references": list(
+            metadata.get("accepted_image_references") or [metadata["image_reference"]]
+        ),
+        "release_state": metadata.get("release_state", "current"),
         "release_metadata_status": release_metadata_status,
         "attestation_issuer": "https://confidentialcomputing.googleapis.com",
         "attestation_audience": "quill-cloud",
-        "api_base_url": settings.api_base_url,
+        # Describes the GCP PLANE, never the deployment that happens to serve
+        # this record. settings.api_base_url is per-deployment, so the AWS- and
+        # Azure-hosted control planes were serving a gcp-confidential-space
+        # record — Google issuer and audience intact — whose api_base_url
+        # pointed at their own gateway. Verified live on 2026-08-15:
+        # aws.trustedrouter.com advertised api-aws.trustedrouter.com. A verifier
+        # following that would fetch COSE_Sign1 CBOR over a self-signed cert
+        # while expecting a Confidential Space JWT, and correctly conclude the
+        # measurement did not match — an accusation of tampering manufactured
+        # entirely by us.
+        #
+        # A mirror serves a record; it does not rewrite it. Every field here is
+        # a property of the plane.
+        "api_base_url": gcp_api_base_url(settings),
         "api_base_urls": [
             api_base_url_for_domain(settings, domain)
             for domain in configured_control_domains(settings)
         ],
         "tls": {
             "mode": "acme-inside-confidential-space",
-            "hostname": "api.trustedrouter.com",
+            # Derived from the same source as api_base_url so the two cannot
+            # drift into disagreeing about which host terminates the prompt path.
+            "hostname": gcp_api_hostname(settings),
             "hostnames": api_hostnames,
         },
         "data_policy": {
@@ -87,7 +132,7 @@ def gcp_release_json(settings: Settings) -> str:
     return json.dumps(gcp_release(settings), indent=2, sort_keys=True) + "\n"
 
 
-def aws_release(settings: Settings) -> dict[str, Any]:
+def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
     """Publish the AWS Nitro serving plane's measurement.
 
     Deploy-time configured rather than resolved live: the enclave answers
@@ -96,7 +141,15 @@ def aws_release(settings: Settings) -> dict[str, Any]:
     CBOR on a public route. The staleness that trade buys is checked out of band
     by scripts/verify_trust_measurements.py instead.
     """
-    accepted = settings.trust_aws_accepted_pcr0_list
+    # Mirrored from the plane's own published record when available. The
+    # settings are only the offline fallback — the control plane is not the
+    # author of what the AWS enclave is running.
+    if metadata is not None:
+        pcr0 = str(metadata.get("pcr0") or NOT_CONFIGURED)
+        accepted = tuple(str(v) for v in metadata.get("accepted_pcr0s", []) if v != NOT_CONFIGURED)
+    else:
+        pcr0 = settings.trust_aws_pcr0 or NOT_CONFIGURED
+        accepted = settings.trust_aws_accepted_pcr0_list
     return {
         "platform": "aws-nitro-enclaves",
         "source_repo": ATTESTED_GATEWAY_REPO,
@@ -106,7 +159,7 @@ def aws_release(settings: Settings) -> dict[str, Any]:
         # PCR0 measures the enclave image file: kernel, ramdisk, and
         # application, as built by nitro-cli build-enclave.
         "measurement_type": "nitro-pcr0-sha384",
-        "pcr0": settings.trust_aws_pcr0 or NOT_CONFIGURED,
+        "pcr0": pcr0,
         "accepted_pcr0s": list(accepted),
         "release_metadata_status": ("configured" if accepted else NOT_CONFIGURED),
         "attestation_format": "cose-sign1-nitro-attestation-document",
@@ -130,14 +183,25 @@ def aws_release(settings: Settings) -> dict[str, Any]:
     }
 
 
-def azure_release(settings: Settings) -> dict[str, Any]:
+def azure_release(
+    settings: Settings, *, metadata: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     """Publish the Azure SEV-SNP serving plane's measurement.
 
     hostdata is sha256 over the decoded CCE policy, which is what the released
     key is bound to; it is the value a verifier compares against
     x-ms-sevsnpvm-hostdata in an MAA token.
     """
-    accepted = settings.trust_azure_accepted_hostdata_list
+    if metadata is not None:
+        hostdata = str(metadata.get("hostdata") or NOT_CONFIGURED)
+        accepted = tuple(
+            str(v) for v in metadata.get("accepted_hostdata", []) if v != NOT_CONFIGURED
+        )
+        issuers = tuple(str(v) for v in metadata.get("attestation_issuers", []))
+    else:
+        hostdata = settings.trust_azure_hostdata or NOT_CONFIGURED
+        accepted = settings.trust_azure_accepted_hostdata_list
+        issuers = settings.trust_azure_attestation_issuer_list
     return {
         "platform": "azure-confidential-containers-sev-snp",
         "source_repo": ATTESTED_GATEWAY_REPO,
@@ -145,14 +209,14 @@ def azure_release(settings: Settings) -> dict[str, Any]:
         "source_commit": settings.trust_azure_source_commit or NOT_CONFIGURED,
         "image_reference": settings.trust_azure_image_reference or NOT_CONFIGURED,
         "measurement_type": "sev-snp-hostdata-sha256",
-        "hostdata": settings.trust_azure_hostdata or NOT_CONFIGURED,
+        "hostdata": hostdata,
         "accepted_hostdata": list(accepted),
         "release_metadata_status": ("configured" if accepted else NOT_CONFIGURED),
         "attestation_format": "microsoft-azure-attestation-jwt",
         "attestation_type": "sevsnpvm",
         # One MAA instance per serving region, so which issuer signs depends on
         # which region answered. A verifier should accept any of them.
-        "attestation_issuers": list(settings.trust_azure_attestation_issuer_list),
+        "attestation_issuers": list(issuers),
         "api_base_url": f"https://{AZURE_API_HOSTNAME}/v1",
         "tls": {
             "mode": "acme-inside-confidential-container",
@@ -178,7 +242,7 @@ def trust_html(
     *,
     public_domain: str | None = None,
     api_base_url: str | None = None,
-    release_metadata: Mapping[str, str] | None = None,
+    release_metadata: Mapping[str, Any] | None = None,
     release_metadata_status: str = "embedded",
 ) -> str:
     release = gcp_release(

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -377,3 +377,257 @@ def test_trust_page_shows_every_plane_and_flags_the_ones_without_a_measurement()
         bare_page = client.get("/trust").text
     # Absence has to be legible on the page too, not just in the JSON.
     assert bare_page.count("No measurement published for this plane yet") == 2
+
+
+# --- A mirror serves a record; it does not rewrite it ------------------------
+
+
+def test_gcp_record_describes_the_gcp_plane_from_every_deployment() -> None:
+    # Shipped live for some time: the AWS- and Azure-hosted control planes each
+    # served a gcp-confidential-space record, Google issuer and audience intact,
+    # whose api_base_url pointed at their OWN gateway — because api_base_url came
+    # from per-deployment settings. Verified on production 2026-08-15:
+    # aws.trustedrouter.com advertised https://api-aws.trustedrouter.com/v1.
+    #
+    # A verifier following that record fetches COSE_Sign1 CBOR over a self-signed
+    # certificate while expecting a Confidential Space JWT, and correctly
+    # concludes the running code does not match the published measurement. The
+    # accusation of tampering is manufactured entirely by us, which makes this
+    # worse than serving nothing.
+    from trusted_router.trust import gcp_release
+
+    canonical = Settings(environment="test", trust_gcp_image_digest="sha256:" + "11" * 32)
+    aws_hosted = Settings(
+        environment="test",
+        trust_gcp_image_digest="sha256:" + "11" * 32,
+        api_base_url="https://api-aws.trustedrouter.com/v1",
+    )
+    azure_hosted = Settings(
+        environment="test",
+        trust_gcp_image_digest="sha256:" + "11" * 32,
+        api_base_url="https://api-azure.trustedrouter.com/v1",
+    )
+
+    for settings in (canonical, aws_hosted, azure_hosted):
+        record = gcp_release(settings)
+        assert record["platform"] == "gcp-confidential-space"
+        assert record["api_base_url"] == "https://api.trustedrouter.com/v1", (
+            "a GCP record must name the GCP plane no matter which deployment mirrors it"
+        )
+        assert record["tls"]["hostname"] == "api.trustedrouter.com"
+        # The two fields must never disagree about which host terminates the
+        # prompt path; that disagreement is what makes the record unverifiable.
+        assert record["api_base_url"] == f"https://{record['tls']['hostname']}/v1"
+
+
+def test_gcp_endpoint_fields_are_derived_from_the_domain_not_hardcoded() -> None:
+    # Without this case the assertions above pass against a hardcoded
+    # "api.trustedrouter.com", because the default domain makes the literal and
+    # the derived value identical. Exercising a different canonical domain is
+    # what proves the value is computed rather than coincidentally right — the
+    # difference matters the day the record is served under another domain.
+    from trusted_router.trust import gcp_release
+
+    settings = Settings(
+        environment="test",
+        trusted_domain="allyrouter.com",
+        trust_gcp_image_digest="sha256:" + "22" * 32,
+    )
+    record = gcp_release(settings)
+    assert record["tls"]["hostname"] == "api.allyrouter.com"
+    assert record["api_base_url"] == "https://api.allyrouter.com/v1"
+
+
+def test_every_plane_record_is_self_consistent_about_its_own_endpoint() -> None:
+    from trusted_router.trust import aws_release, azure_release, gcp_release
+
+    settings = configured_multicloud_settings(
+        trust_gcp_image_digest="sha256:" + "11" * 32,
+        api_base_url="https://api-aws.trustedrouter.com/v1",
+    )
+    for record in (gcp_release(settings), aws_release(settings), azure_release(settings)):
+        assert record["api_base_url"] == f"https://{record['tls']['hostname']}/v1", (
+            f"{record['platform']} points a verifier at {record['api_base_url']} while "
+            f"claiming TLS terminates at {record['tls']['hostname']}"
+        )
+
+
+def test_rolling_accepted_set_survives_the_mirror(httpx_mock: HTTPXMock) -> None:
+    # Live on 2026-08-15: trust.trustedrouter.com correctly published BOTH
+    # digests mid-roll, and trustedrouter.com republished only the incoming one
+    # because the resolver kept just three scalar fields. The fleet was still
+    # serving the outgoing digest, so anyone verifying against the control
+    # plane's copy would have concluded the enclave did not match its published
+    # measurement. Narrowing a pin in transit turns a mirror into an author.
+    outgoing = "sha256:" + "a7" * 32
+    incoming = "sha256:" + "7a" * 32
+    payload = release_payload()
+    payload["image_digest"] = incoming
+    payload["accepted_image_digests"] = [outgoing, incoming]
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/release\.json\?tr_cache_bucket=\d+"),
+        json=payload,
+    )
+    settings = Settings(
+        environment="test", trust_gcp_release_url="https://trust.example/release.json"
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/gcp-release.json").json()
+
+    assert record["image_digest"] == incoming
+    assert outgoing in record["accepted_image_digests"], (
+        "the still-serving digest was dropped; a verifier hitting an enclave that "
+        "has not rolled yet would read this record as a measurement mismatch"
+    )
+    assert record["release_state"] == "rolling"
+
+
+def test_primary_digest_is_always_in_its_own_accepted_set(httpx_mock: HTTPXMock) -> None:
+    # An upstream record whose accepted set omits its own current digest must
+    # not produce a published set that rejects the running enclave.
+    payload = release_payload()
+    payload["accepted_image_digests"] = ["sha256:" + "cc" * 32]
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/release\.json\?tr_cache_bucket=\d+"),
+        json=payload,
+    )
+    settings = Settings(
+        environment="test", trust_gcp_release_url="https://trust.example/release.json"
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/gcp-release.json").json()
+    assert record["image_digest"] in record["accepted_image_digests"]
+
+
+# --- The control plane mirrors; it does not author ---------------------------
+
+
+def _aws_upstream(pcr0: str, accepted: list[str]) -> dict[str, object]:
+    return {"platform": "aws-nitro-enclaves", "pcr0": pcr0, "accepted_pcr0s": accepted}
+
+
+def test_aws_record_is_mirrored_from_the_plane_not_control_plane_config(
+    httpx_mock: HTTPXMock,
+) -> None:
+    # The point of the change: what the AWS enclave runs is published by AWS's
+    # own pipeline. If the control plane computed it from its own settings, one
+    # deployment would be the authority for three independent planes — a single
+    # place to falsify and a single place to fail.
+    upstream = "ab" * 48
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/aws\.json\?tr_cache_bucket=\d+"),
+        json=_aws_upstream(upstream, [upstream]),
+    )
+    settings = Settings(
+        environment="test",
+        trust_aws_release_url="https://trust.example/aws.json",
+        trust_aws_pcr0="cd" * 48,  # stale local config, deliberately different
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/aws-release.json").json()
+
+    assert record["pcr0"] == upstream, "the mirrored record must win over local config"
+    assert record["accepted_pcr0s"] == [upstream]
+
+
+def test_unreachable_upstream_falls_back_without_claiming_it_is_live(
+    httpx_mock: HTTPXMock,
+) -> None:
+    # An upstream outage should degrade to a stale-but-verified measurement
+    # rather than to none — but the response must not imply it was just
+    # confirmed from the source.
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/aws\.json\?tr_cache_bucket=\d+"), status_code=503
+    )
+    configured = "ef" * 48
+    settings = Settings(
+        environment="test",
+        trust_aws_release_url="https://trust.example/aws.json",
+        trust_aws_pcr0=configured,
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        response = client.get("/trust/aws-release.json")
+
+    assert response.status_code == 200
+    assert response.json()["pcr0"] == configured
+    assert response.headers["x-trustedrouter-release-status"] == "embedded"
+
+
+def test_a_poisoned_upstream_record_is_rejected_not_republished(
+    httpx_mock: HTTPXMock,
+) -> None:
+    # Mirroring must not mean repeating whatever arrives. A record whose
+    # accepted set excludes its own current measurement would have a verifier
+    # reject the very enclave answering them, so it is refused and the verified
+    # local fallback is served instead.
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/aws\.json\?tr_cache_bucket=\d+"),
+        json=_aws_upstream("ab" * 48, ["cd" * 48]),
+    )
+    configured = "ef" * 48
+    settings = Settings(
+        environment="test",
+        trust_aws_release_url="https://trust.example/aws.json",
+        trust_aws_pcr0=configured,
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/aws-release.json").json()
+
+    assert record["pcr0"] == configured, "a self-inconsistent upstream record was republished"
+
+
+def test_azure_mirror_requires_an_issuer_and_carries_every_region(
+    httpx_mock: HTTPXMock,
+) -> None:
+    uaen, sea = "44" * 32, "26" * 32
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/azure\.json\?tr_cache_bucket=\d+"),
+        json={
+            "platform": "azure-confidential-containers-sev-snp",
+            "hostdata": uaen,
+            "accepted_hostdata": [uaen, sea],
+            "attestation_issuers": [
+                "https://trquilluaen.uaen.attest.azure.net",
+                "https://trquillsea.sasia.attest.azure.net",
+            ],
+        },
+    )
+    settings = Settings(
+        environment="test", trust_azure_release_url="https://trust.example/azure.json"
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/azure-release.json").json()
+
+    # Both regions run different CCE policies, so both hostdata values are
+    # permanently correct. Dropping either makes a verifier routed to that
+    # region conclude tampering.
+    assert record["accepted_hostdata"] == [uaen, sea]
+    assert len(record["attestation_issuers"]) == 2
+
+
+def test_azure_record_without_an_issuer_is_rejected(httpx_mock: HTTPXMock) -> None:
+    # An MAA record naming no issuer is unverifiable: the reader has no way to
+    # know which attestation service's signature to trust, so "hostdata is X"
+    # is an unsupported assertion. Republishing it would look like a measurement
+    # while carrying none of the evidence that makes one meaningful.
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/azure\.json\?tr_cache_bucket=\d+"),
+        json={
+            "platform": "azure-confidential-containers-sev-snp",
+            "hostdata": "44" * 32,
+            "accepted_hostdata": ["44" * 32],
+            "attestation_issuers": [],
+        },
+    )
+    configured = "99" * 32
+    settings = Settings(
+        environment="test",
+        trust_azure_release_url="https://trust.example/azure.json",
+        trust_azure_hostdata=configured,
+        trust_azure_attestation_issuers="https://trquilluaen.uaen.attest.azure.net",
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/azure-release.json").json()
+
+    assert record["hostdata"] == configured, "an issuer-less upstream record was republished"
+    assert record["attestation_issuers"] == ["https://trquilluaen.uaen.attest.azure.net"]


### PR DESCRIPTION
Follows [quill-cloud-proxy#164](https://github.com/Lore-Hex/quill-cloud-proxy/pull/164), which gives each plane a producer for its own measurement.

## Two defects that were live on main

Both the same shape — **a mirror rewriting a record instead of serving it.**

**The accepted set was narrowed in transit.** `trust.trustedrouter.com` correctly published both digests during a roll; `trustedrouter.com` republished only the incoming one, because the resolver kept three scalar fields and dropped `accepted_image_digests`. Caught live, mid-roll: the record named `7a32069…` while the fleet still served `a781e99…`. Anyone verifying GCP against the control plane was told the enclave didn't match its published measurement.

**A GCP record pointed at the Nitro gateway.** `api_base_url` came from per-deployment settings, so the AWS- and Azure-hosted control planes served a `gcp-confidential-space` record — Google issuer and audience intact — advertising their own gateway. Verified live: `aws.trustedrouter.com` advertised `api-aws.trustedrouter.com`. A verifier following that fetches COSE/CBOR over a self-signed cert while expecting a Confidential Space JWT, and correctly concludes tampering. The accusation is manufactured entirely by us, which is worse than publishing nothing.

## Mirroring, not authoring

`TrustReleaseResolver` now takes URLs, validator and fallback as inputs, so AWS and Azure records are **fetched from the planes that produce them** rather than computed from control-plane config. The five `TR_TRUST_*` pins and their `rollout.sh` block are gone — pinning them made one GCP-region rollout script the authority for what three independent planes were running.

Mirroring isn't repeating, though. A record whose accepted set excludes its own current measurement, or an MAA record naming no issuer, is **refused** and the verified local fallback served instead. An unreachable upstream degrades to that fallback labelled `embedded`, never `live`.

## Testing

Full suite green (3619 passed). Every new guarantee is mutation-tested. Two mutations initially slipped through and both revealed genuinely weak tests:

- the hardcoded-hostname mutation passed because the default domain makes literal and derived values identical — fixed by exercising a different canonical domain, so the test proves derivation rather than coincidence
- the missing-MAA-issuer mutation passed because no test covered an issuer-less record at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)