### PR TITLE
Fix remaining Ahrefs crawl errors

### DIFF
--- a/docs/marketing/ahrefs-seo-execution-2026-08-15.md
+++ b/docs/marketing/ahrefs-seo-execution-2026-08-15.md
@@ -42,6 +42,37 @@ destination.
 6. Add complete social metadata and WebPage structured data to the standalone
    trust page.
 
+## Same-day recrawl
+
+The completed Ahrefs crawl at 10:10 AM covered 4,597 internal URLs and reported
+a 100 Health Score. It found three errors, 443 warnings, and 4,485 notices.
+
+The three errors were narrow crawl-graph defects:
+
+1. The independently published trust site still linked to the authenticated API
+   root, which correctly returns 401 to a crawler. Link to the public API
+   reference instead.
+2. `/trust` was self-canonical but had no ordinary internal href. Link the
+   shared public footer to `/trust`, then let that page link to the live trust
+   evidence.
+3. `/api/reference` had no server-rendered outgoing links. Add a compact
+   server-rendered reference header with an H1, explanatory text, language
+   declaration, and links to docs, models, security, and the homepage.
+
+The remaining warning queue should be handled by value, not by raw count:
+
+1. Investigate the 19 slow public pages and fix only repeatable origin latency;
+   do not optimize one-off crawl noise.
+2. Replace internal links to the final destinations behind the 83 redirects.
+   Keep intentional compatibility redirects themselves.
+3. Review the two remaining missing-H1 pages and the one low-word-count page
+   after the API-reference fix is deployed and recrawled.
+4. Treat the 337 noindex pages as an allowlist audit. Console, authentication,
+   and filtered/empty catalog pages should stay noindex and out of sitemaps.
+5. Submit changed public URLs through IndexNow after releases. Ahrefs identified
+   3,919 currently eligible URLs; submit only new or materially changed URLs,
+   not the full catalog on every deploy.
+
 ## Rank Tracker groups
 
 Track the United States and United Kingdom on desktop. Add Germany as the first

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -582,9 +582,30 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             '<meta property="og:image" content="https://trustedrouter.com/og.png">\n'
             '<meta name="twitter:card" content="summary_large_image">\n'
         )
+        reference_header = (
+            '<header style="padding:16px 24px;background:#101820;color:#fff;font-family:'
+            'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif">'
+            '<h1 style="font-size:18px;line-height:1.2;margin:0 0 6px;color:#fff">'
+            "TrustedRouter API reference</h1>"
+            '<p style="max-width:900px;margin:0 0 10px;color:#d7e6f5;font-size:14px;line-height:1.45">'
+            "Explore the OpenAI-compatible endpoints, request schemas, authentication, model "
+            "routing, billing, observability, and stable compatibility errors used by "
+            "TrustedRouter clients. Start with the integration guide, browse the live model "
+            "catalog, and review how the attested gateway keeps prompt traffic separate from "
+            "the control plane. Requests use one base URL and standard bearer authentication."
+            "</p>"
+            '<nav aria-label="TrustedRouter API reference links" '
+            'style="display:flex;align-items:center;gap:18px;flex-wrap:wrap">'
+            '<a href="/docs" style="color:#fff;font-weight:700;text-decoration:none">Docs</a>'
+            '<a href="/models" style="color:#d7e6f5;text-decoration:none">Models</a>'
+            '<a href="/security" style="color:#d7e6f5;text-decoration:none">Security</a>'
+            '<a href="/" style="color:#d7e6f5;text-decoration:none">TrustedRouter</a>'
+            "</nav></header>"
+        )
         body = (
             bytes(response.body)
             .decode()
+            .replace("<html>", '<html lang="en">', 1)
             .replace(
                 f"<title>{html.escape(app.title)} API reference</title>",
                 f"<title>{html.escape(title)}</title>",
@@ -595,6 +616,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 f"{metadata}</head>",
                 1,
             )
+            .replace("<body>", f"<body>{reference_header}", 1)
         )
         return HTMLResponse(body)
 

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -28,7 +28,7 @@
       <h3>Trust</h3>
       <a href="/security">Security</a>
       <a href="/status">Status</a>
-      <a href="https://trust.trustedrouter.com">Attestation</a>
+      <a href="/trust">Attestation</a>
       <a href="/badge">Confidential AI badge</a>
       <a href="/privacy">Privacy</a>
       <a href="/legal/dpa">DPA</a>

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -160,6 +160,20 @@ def test_api_reference_declares_one_query_independent_canonical(
     assert "<title>TrustedRouter API Reference: Endpoints and Schemas</title>" in response.text
     assert '<meta name="description"' in response.text
     assert 'property="og:title"' in response.text
+    assert '<html lang="en">' in response.text
+    assert 'aria-label="TrustedRouter API reference links"' in response.text
+    assert "<h1" in response.text
+    assert "TrustedRouter API reference</h1>" in response.text
+    for path in ["/docs", "/models", "/security", "/"]:
+        assert f'href="{path}"' in response.text
+
+
+def test_public_footer_links_to_canonical_trust_page(client: TestClient) -> None:
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert '<a href="/trust">Attestation</a>' in response.text
+    assert '<a href="https://trust.trustedrouter.com">Attestation</a>' not in response.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- link the shared footer to the canonical `/trust` page
- add a server-rendered API reference header with an H1, language declaration, useful copy, and internal links
- record the completed Ahrefs recrawl and prioritized warning queue

## Why

The August 15 Ahrefs crawl reached a 100 Health Score but still found a canonical page with no incoming links and an API reference with no outgoing links. The API reference also relied on client-side rendering for its page structure.

## Validation

- `uv run ruff check src/trusted_router/routes/public.py tests/test_public_seo_pages.py`
- `uv run mypy`
- `uv run pytest -q tests/test_public_seo_pages.py tests/test_sitemap_seo_hygiene.py` (54 passed)
- local browser rendering verified
