### PR TITLE
Fix remaining chat H1 SEO warning

### DIFF
--- a/src/trusted_router/static/chat.css
+++ b/src/trusted_router/static/chat.css
@@ -164,6 +164,7 @@
 }
 
 .chat-header-chat-title {
+    margin: 0;
     font-size: 13px;
     font-weight: 600;
     color: var(--chat-text);

--- a/src/trusted_router/static/chat.js
+++ b/src/trusted_router/static/chat.js
@@ -840,7 +840,7 @@
         const costEl = document.querySelector("[data-chat-header-cost]");
         const chat = getActiveChat();
         if (titleEl) {
-            titleEl.textContent = (chat && chat.title) || "";
+            titleEl.textContent = (chat && chat.title) || "TrustedRouter Chat";
         }
         updateTabTitle();
         if (costEl) {

--- a/src/trusted_router/templates/public/chat.html
+++ b/src/trusted_router/templates/public/chat.html
@@ -43,7 +43,7 @@
     <header class="chat-header">
       <button class="chat-hamburger" type="button" aria-label="Toggle sidebar" data-action="toggle-sidebar">&#9776;</button>
       <div class="chat-header-title">
-        <span class="chat-header-chat-title" data-chat-header-title></span>
+        <h1 class="chat-header-chat-title" data-chat-header-title>TrustedRouter Chat</h1>
         <span class="chat-header-chat-cost" data-chat-header-cost></span>
       </div>
       <div class="chat-models-bar" data-chat-models-bar>

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -46,6 +46,8 @@ def test_chat_page_renders_without_auth() -> None:
     assert "data-chat-input" in body
     assert "data-chat-send" in body
     assert 'data-action="clear-chat"' in body
+    assert '<h1 class="chat-header-chat-title"' in body
+    assert "TrustedRouter Chat</h1>" in body
 
     # The marketing chrome's sign-in modal trigger is reachable
     # (this is what the Send-button gate fall back to when signed-out)


### PR DESCRIPTION
## Summary
- render the public chat title as a semantic H1
- preserve a meaningful server-rendered title before chat state loads
- add a regression assertion

## Verification
- uv run pytest -q tests/test_chat_page.py tests/test_public_seo_pages.py tests/test_sitemap_seo_hygiene.py
- uv run ruff check tests/test_chat_page.py
- npx eslint src/trusted_router/static/chat.js
- git diff --check