### PR TITLE
BYOK: add guarded AAD v2 backfill

### DIFF
--- a/scripts/backfill_byok_aad_v2.py
+++ b/scripts/backfill_byok_aad_v2.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Audit or backfill BYOK/control-secret envelopes from AAD v1 to v2.
+
+The default is a read-only audit. Applying requires an exact expected count,
+which prevents an operator from accidentally migrating a larger or different
+dataset than the one they reviewed.
+
+Examples:
+  uv run python scripts/backfill_byok_aad_v2.py --backend spanner
+  uv run python scripts/backfill_byok_aad_v2.py --backend spanner \
+    --apply --expected-v1 7
+  uv run python scripts/backfill_byok_aad_v2.py --backend postgres
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+from trusted_router.byok_aad_backfill import (
+    BackfillRunner,
+    EntityStore,
+    PostgresEntityStore,
+    SpannerEntityStore,
+)
+from trusted_router.config import Settings
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=("spanner", "postgres"), required=True)
+    parser.add_argument("--apply", action="store_true", help="Rewrite v1 envelopes to v2")
+    parser.add_argument(
+        "--expected-v1",
+        type=int,
+        help="Required with --apply; mutation is refused unless the audit count matches exactly",
+    )
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--kms-operations-per-second", type=float, default=5.0)
+    parser.add_argument("--after-kind")
+    parser.add_argument("--after-id")
+    parser.add_argument(
+        "--project",
+        default=os.environ.get("TR_GCP_PROJECT_ID", "quill-cloud-proxy"),
+    )
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6"),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("TR_SPANNER_DATABASE_ID", "trusted-router"),
+    )
+    parser.add_argument("--postgres-dsn", default=os.environ.get("TR_POSTGRES_DSN", ""))
+    return parser
+
+
+def _spanner_store(args: argparse.Namespace) -> EntityStore:
+    from google.cloud import spanner
+
+    client = spanner.Client(project=args.project, disable_builtin_metrics=True)
+    database = client.instance(args.spanner_instance).database(args.spanner_database)
+    return SpannerEntityStore(database, spanner.param_types)
+
+
+def _store(args: argparse.Namespace) -> EntityStore:
+    if args.backend == "spanner":
+        return _spanner_store(args)
+    return PostgresEntityStore(args.postgres_dsn)
+
+
+def _summary(label: str, stats: Any) -> None:
+    print(f"{label}={json.dumps(stats.as_dict(), sort_keys=True)}")
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if (args.after_kind is None) != (args.after_id is None):
+        raise SystemExit("--after-kind and --after-id must be supplied together")
+    if args.apply and args.expected_v1 is None:
+        raise SystemExit("--expected-v1 is required with --apply")
+    if args.expected_v1 is not None and args.expected_v1 < 0:
+        raise SystemExit("--expected-v1 cannot be negative")
+    after = None
+    if args.after_kind is not None and args.after_id is not None:
+        after = (args.after_kind, args.after_id)
+
+    store = _store(args)
+    audit = BackfillRunner(store, apply=False).run(batch_size=args.batch_size, after=after)
+    _summary("preflight", audit)
+    if audit.failures or audit.unsupported_algorithms:
+        print("REFUSED: preflight found malformed or unsupported envelopes")
+        return 2
+    if not args.apply:
+        return 0
+    if audit.v1_envelopes != args.expected_v1:
+        print(
+            "REFUSED: expected-v1 gate did not match "
+            f"expected={args.expected_v1} actual={audit.v1_envelopes}"
+        )
+        return 2
+    if audit.v1_envelopes == 0:
+        print("nothing to migrate")
+        return 0
+
+    migrated = BackfillRunner(
+        store,
+        settings=Settings(),
+        apply=True,
+        kms_operations_per_second=args.kms_operations_per_second,
+    ).run(batch_size=args.batch_size, after=after)
+    _summary("migration", migrated)
+
+    verification = BackfillRunner(store, apply=False).run(batch_size=args.batch_size)
+    _summary("verification", verification)
+    if (
+        verification.v1_envelopes
+        or verification.failures
+        or verification.unsupported_algorithms
+    ):
+        print("FAILED: post-write audit is not clean")
+        return 3
+    print("complete: every discovered envelope is v2")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -1,0 +1,422 @@
+"""Resumable BYOK envelope AAD v1-to-v2 backfill primitives.
+
+The migration touches secret-bearing rows, so the storage adapters expose only
+the generic entity body and an optimistic compare-and-swap. KMS work happens
+outside database transactions; the final write succeeds only when the row is
+still byte-for-byte (Spanner) or JSON-equivalent (Postgres) to the version that
+was decrypted. A concurrent key rotation therefore wins and is never
+overwritten by the backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from trusted_router.byok_crypto import (
+    ALGORITHM,
+    ALGORITHM_V2,
+    decrypt_byok_secret,
+    decrypt_control_secret,
+    encrypt_byok_secret,
+    encrypt_control_secret,
+)
+from trusted_router.config import Settings
+from trusted_router.storage_models import EncryptedSecretEnvelope
+
+_MIGRATED_KINDS = ("broadcast_destination", "byok")
+
+
+@dataclass(frozen=True)
+class EntityRow:
+    kind: str
+    entity_id: str
+    body: dict[str, Any]
+    original_body: Any
+
+
+class EntityStore(Protocol):
+    def scan(
+        self,
+        *,
+        after: tuple[str, str] | None,
+        limit: int,
+    ) -> list[EntityRow]: ...
+
+    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool: ...
+
+
+@dataclass
+class BackfillStats:
+    rows_scanned: int = 0
+    envelopes_seen: int = 0
+    v1_envelopes: int = 0
+    v2_envelopes: int = 0
+    missing_envelopes: int = 0
+    rows_updated: int = 0
+    envelopes_migrated: int = 0
+    conflicts: int = 0
+    failures: int = 0
+    unsupported_algorithms: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+class KmsOperationRateLimiter:
+    """Bound the average KMS operation rate without introducing concurrency."""
+
+    def __init__(
+        self,
+        operations_per_second: float,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if operations_per_second <= 0:
+            raise ValueError("KMS operations per second must be positive")
+        self._operations_per_second = operations_per_second
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._next_operation_at = 0.0
+
+    def acquire(self, operations: int) -> None:
+        if operations <= 0:
+            return
+        now = self._monotonic()
+        start = max(now, self._next_operation_at)
+        if start > now:
+            self._sleep(start - now)
+        self._next_operation_at = start + operations / self._operations_per_second
+
+
+class BackfillRunner:
+    """Audit or migrate every known encrypted field in stable key order."""
+
+    def __init__(
+        self,
+        store: EntityStore,
+        *,
+        settings: Settings | None = None,
+        apply: bool = False,
+        kms_operations_per_second: float = 5.0,
+        reporter: Callable[[str], None] = print,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if apply and settings is None:
+            raise ValueError("settings are required when applying the backfill")
+        self._store = store
+        self._settings = settings
+        self._apply = apply
+        self._report = reporter
+        self._limiter = KmsOperationRateLimiter(
+            kms_operations_per_second,
+            monotonic=monotonic,
+            sleep=sleep,
+        )
+
+    def run(
+        self,
+        *,
+        batch_size: int = 100,
+        after: tuple[str, str] | None = None,
+    ) -> BackfillStats:
+        if not 1 <= batch_size <= 1000:
+            raise ValueError("batch size must be between 1 and 1000")
+        stats = BackfillStats()
+        cursor = after
+        while True:
+            rows = self._store.scan(after=cursor, limit=batch_size)
+            if not rows:
+                return stats
+            for row in rows:
+                self._process_row(row, stats)
+                cursor = (row.kind, row.entity_id)
+            last_row = rows[-1]
+            self._report(
+                "checkpoint "
+                f"kind={last_row.kind} row={_row_ref(last_row.kind, last_row.entity_id)} "
+                f"rows_scanned={stats.rows_scanned}"
+            )
+
+    def _process_row(self, row: EntityRow, stats: BackfillStats) -> None:
+        stats.rows_scanned += 1
+        new_body = copy.deepcopy(row.body)
+        migrations = 0
+        row_failed = False
+        for field, envelope_family in _fields_for_kind(row.kind):
+            raw_envelope = row.body.get(field)
+            if raw_envelope is None:
+                stats.missing_envelopes += 1
+                continue
+            stats.envelopes_seen += 1
+            if not isinstance(raw_envelope, dict):
+                stats.failures += 1
+                row_failed = True
+                self._error(row, field, "invalid_envelope_shape")
+                continue
+            algorithm = raw_envelope.get("algorithm")
+            if algorithm == ALGORITHM_V2:
+                stats.v2_envelopes += 1
+                continue
+            if algorithm != ALGORITHM:
+                stats.unsupported_algorithms += 1
+                row_failed = True
+                self._error(row, field, "unsupported_algorithm")
+                continue
+            stats.v1_envelopes += 1
+            if not self._apply:
+                continue
+            try:
+                # One v1 unwrap, one v2 wrap, and one v2 verification unwrap.
+                self._limiter.acquire(3)
+                new_body[field] = self._migrate_envelope(
+                    row,
+                    field=field,
+                    envelope_family=envelope_family,
+                    raw_envelope=raw_envelope,
+                )
+                migrations += 1
+            except Exception as exc:  # fail closed; never expose secret material
+                stats.failures += 1
+                row_failed = True
+                self._error(row, field, type(exc).__name__)
+
+        if not self._apply or row_failed or migrations == 0:
+            return
+        if self._store.compare_and_swap(row, new_body):
+            stats.rows_updated += 1
+            stats.envelopes_migrated += migrations
+            return
+        stats.conflicts += 1
+        self._error(row, "*", "concurrent_change")
+
+    def _migrate_envelope(
+        self,
+        row: EntityRow,
+        *,
+        field: str,
+        envelope_family: str,
+        raw_envelope: dict[str, Any],
+    ) -> dict[str, str]:
+        assert self._settings is not None
+        workspace_id = _required_string(row.body, "workspace_id")
+        envelope = EncryptedSecretEnvelope(**raw_envelope)
+        if envelope_family == "provider":
+            provider = _required_string(row.body, "provider")
+            plaintext = decrypt_byok_secret(
+                envelope,
+                self._settings,
+                workspace_id=workspace_id,
+                provider=provider,
+            )
+            migrated = encrypt_byok_secret(
+                plaintext,
+                self._settings,
+                workspace_id=workspace_id,
+                provider=provider,
+            )
+            verified = decrypt_byok_secret(
+                migrated,
+                self._settings,
+                workspace_id=workspace_id,
+                provider=provider,
+            )
+        else:
+            purpose = _broadcast_context(row.entity_id, field)
+            plaintext = decrypt_control_secret(
+                envelope,
+                self._settings,
+                workspace_id=workspace_id,
+                purpose=purpose,
+            )
+            migrated = encrypt_control_secret(
+                plaintext,
+                self._settings,
+                workspace_id=workspace_id,
+                purpose=purpose,
+            )
+            verified = decrypt_control_secret(
+                migrated,
+                self._settings,
+                workspace_id=workspace_id,
+                purpose=purpose,
+            )
+        if verified != plaintext or migrated.algorithm != ALGORITHM_V2:
+            raise ValueError("v2 verification failed")
+        return asdict(migrated)
+
+    def _error(self, row: EntityRow, field: str, reason: str) -> None:
+        self._report(
+            "ERROR "
+            f"kind={row.kind} row={_row_ref(row.kind, row.entity_id)} "
+            f"field={field} reason={reason}"
+        )
+
+
+class SpannerEntityStore:
+    def __init__(self, database: Any, param_types: Any) -> None:
+        self._database = database
+        self._param_types = param_types
+
+    def scan(
+        self,
+        *,
+        after: tuple[str, str] | None,
+        limit: int,
+    ) -> list[EntityRow]:
+        after_kind, after_id = after or ("", "")
+        sql = (
+            "SELECT kind, id, body FROM tr_entities "
+            "WHERE kind IN ('broadcast_destination', 'byok') "
+            "AND (kind > @after_kind OR (kind = @after_kind AND id > @after_id)) "
+            "ORDER BY kind, id LIMIT @limit"
+        )
+        with self._database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                sql,
+                params={
+                    "after_kind": after_kind,
+                    "after_id": after_id,
+                    "limit": limit,
+                },
+                param_types={
+                    "after_kind": self._param_types.STRING,
+                    "after_id": self._param_types.STRING,
+                    "limit": self._param_types.INT64,
+                },
+            )
+            return [
+                EntityRow(
+                    kind=kind,
+                    entity_id=entity_id,
+                    body=json.loads(body),
+                    original_body=body,
+                )
+                for kind, entity_id, body in rows
+            ]
+
+    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
+        new_body_json = _json_body(new_body)
+
+        def update(transaction: Any) -> bool:
+            changed = transaction.execute_update(
+                "UPDATE tr_entities SET body=@new_body, "
+                "updated_at=PENDING_COMMIT_TIMESTAMP() "
+                "WHERE kind=@kind AND id=@id AND body=@old_body",
+                params={
+                    "new_body": new_body_json,
+                    "kind": row.kind,
+                    "id": row.entity_id,
+                    "old_body": row.original_body,
+                },
+                param_types={
+                    "new_body": self._param_types.STRING,
+                    "kind": self._param_types.STRING,
+                    "id": self._param_types.STRING,
+                    "old_body": self._param_types.STRING,
+                },
+            )
+            return changed == 1
+
+        return bool(self._database.run_in_transaction(update))
+
+
+class PostgresEntityStore:
+    def __init__(self, dsn: str) -> None:
+        if not dsn.strip():
+            raise ValueError("Postgres DSN is required")
+        self._dsn = dsn
+
+    def scan(
+        self,
+        *,
+        after: tuple[str, str] | None,
+        limit: int,
+    ) -> list[EntityRow]:
+        import psycopg
+
+        after_kind, after_id = after or ("", "")
+        with psycopg.connect(self._dsn) as conn:
+            rows = conn.execute(
+                "SELECT kind, id, body FROM tr_entities "
+                "WHERE kind IN (%s, %s) "
+                "AND (kind > %s OR (kind = %s AND id > %s)) "
+                "ORDER BY kind, id LIMIT %s",
+                (
+                    _MIGRATED_KINDS[0],
+                    _MIGRATED_KINDS[1],
+                    after_kind,
+                    after_kind,
+                    after_id,
+                    limit,
+                ),
+            ).fetchall()
+        result: list[EntityRow] = []
+        for kind, entity_id, raw_body in rows:
+            body = json.loads(raw_body) if isinstance(raw_body, str) else dict(raw_body)
+            result.append(
+                EntityRow(
+                    kind=kind,
+                    entity_id=entity_id,
+                    body=body,
+                    original_body=copy.deepcopy(body),
+                )
+            )
+        return result
+
+    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            changed = conn.execute(
+                "UPDATE tr_entities SET body=%s::jsonb, updated_at=CURRENT_TIMESTAMP "
+                "WHERE kind=%s AND id=%s AND body=%s::jsonb",
+                (
+                    _json_body(new_body),
+                    row.kind,
+                    row.entity_id,
+                    _json_body(row.original_body),
+                ),
+            ).rowcount
+        return changed == 1
+
+
+def _fields_for_kind(kind: str) -> tuple[tuple[str, str], ...]:
+    if kind == "byok":
+        return (("encrypted_secret", "provider"),)
+    if kind == "broadcast_destination":
+        return (
+            ("encrypted_api_key", "control"),
+            ("encrypted_headers", "control"),
+        )
+    raise ValueError(f"unsupported entity kind: {kind}")
+
+
+def _broadcast_context(destination_id: str, field: str) -> str:
+    suffix = {"encrypted_api_key": "api_key", "encrypted_headers": "headers"}[field]
+    # Byte-identical to services.broadcast.broadcast_secret_context. Keeping
+    # this tiny helper here avoids importing the application-global STORE into
+    # an offline secret migration process.
+    return f"broadcast:{destination_id}:{suffix}"
+
+
+def _required_string(body: dict[str, Any], field: str) -> str:
+    value = body.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"missing {field}")
+    return value
+
+
+def _row_ref(kind: str, entity_id: str) -> str:
+    return hashlib.sha256(f"{kind}\x00{entity_id}".encode()).hexdigest()[:12]
+
+
+def _json_body(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)

--- a/tests/test_byok_aad_backfill.py
+++ b/tests/test_byok_aad_backfill.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import base64
+import copy
+import secrets
+from dataclasses import asdict
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from trusted_router.byok_aad_backfill import (
+    BackfillRunner,
+    EntityRow,
+    KmsOperationRateLimiter,
+)
+from trusted_router.byok_crypto import (
+    ALGORITHM,
+    ALGORITHM_V2,
+    _aad,
+    decrypt_byok_secret,
+    decrypt_control_secret,
+)
+from trusted_router.config import Settings
+from trusted_router.key_management import key_wrapper_for
+from trusted_router.storage_models import EncryptedSecretEnvelope
+
+
+class MemoryEntityStore:
+    def __init__(self, rows: dict[tuple[str, str], dict[str, Any]]) -> None:
+        self.rows = copy.deepcopy(rows)
+        self.force_conflict = False
+
+    def scan(
+        self,
+        *,
+        after: tuple[str, str] | None,
+        limit: int,
+    ) -> list[EntityRow]:
+        keys = sorted(key for key in self.rows if after is None or key > after)[:limit]
+        return [
+            EntityRow(
+                kind=kind,
+                entity_id=entity_id,
+                body=copy.deepcopy(self.rows[(kind, entity_id)]),
+                original_body=copy.deepcopy(self.rows[(kind, entity_id)]),
+            )
+            for kind, entity_id in keys
+        ]
+
+    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
+        key = (row.kind, row.entity_id)
+        if self.force_conflict:
+            self.rows[key]["concurrent_rotation"] = True
+            self.force_conflict = False
+        if self.rows[key] != row.original_body:
+            return False
+        self.rows[key] = copy.deepcopy(new_body)
+        return True
+
+
+def _settings() -> Settings:
+    return Settings(environment="test")
+
+
+def _v1_envelope(
+    plaintext: str,
+    settings: Settings,
+    *,
+    workspace_id: str,
+    context: str,
+) -> dict[str, str]:
+    dek = secrets.token_bytes(32)
+    nonce = secrets.token_bytes(12)
+    dek_nonce = secrets.token_bytes(12)
+    aad = _aad(workspace_id, context)
+    wrapper = key_wrapper_for(settings)
+    envelope = EncryptedSecretEnvelope(
+        algorithm=ALGORITHM,
+        key_ref=wrapper.key_ref,
+        encrypted_dek=base64.urlsafe_b64encode(
+            wrapper.wrap(dek, nonce=dek_nonce, aad=aad)
+        ).decode("ascii"),
+        dek_nonce=base64.urlsafe_b64encode(dek_nonce).decode("ascii"),
+        ciphertext=base64.urlsafe_b64encode(
+            AESGCM(dek).encrypt(nonce, plaintext.encode(), aad)
+        ).decode("ascii"),
+        nonce=base64.urlsafe_b64encode(nonce).decode("ascii"),
+    )
+    return asdict(envelope)
+
+
+def _apply(store: MemoryEntityStore, settings: Settings, logs: list[str] | None = None):
+    return BackfillRunner(
+        store,
+        settings=settings,
+        apply=True,
+        kms_operations_per_second=1000,
+        reporter=(logs.append if logs is not None else lambda _message: None),
+        sleep=lambda _seconds: None,
+    ).run(batch_size=1)
+
+
+def test_provider_backfill_is_verified_resumable_and_idempotent() -> None:
+    settings = _settings()
+    token_value = "provider-secret-never-log"  # noqa: S105 - synthetic crypto fixture
+    body = {
+        "workspace_id": "workspace-1",
+        "provider": "anthropic",
+        "secret_ref": "encrypted://anthropic",
+        "encrypted_secret": _v1_envelope(
+            token_value,
+            settings,
+            workspace_id="workspace-1",
+            context="anthropic",
+        ),
+    }
+    store = MemoryEntityStore({("byok", "workspace-1#anthropic"): body})
+
+    audit = BackfillRunner(store, reporter=lambda _message: None).run()
+    assert audit.v1_envelopes == 1
+    assert audit.rows_updated == 0
+
+    migrated = _apply(store, settings)
+    assert migrated.envelopes_migrated == 1
+    assert migrated.rows_updated == 1
+    raw = store.rows[("byok", "workspace-1#anthropic")]["encrypted_secret"]
+    assert raw["algorithm"] == ALGORITHM_V2
+    assert (
+        decrypt_byok_secret(
+            EncryptedSecretEnvelope(**raw),
+            settings,
+            workspace_id="workspace-1",
+            provider="anthropic",
+        )
+        == token_value
+    )
+
+    repeated = _apply(store, settings)
+    assert repeated.v1_envelopes == 0
+    assert repeated.v2_envelopes == 1
+    assert repeated.rows_updated == 0
+
+
+def test_broadcast_backfill_migrates_both_secret_fields_atomically() -> None:
+    settings = _settings()
+    destination_id = "bdst_123"
+    workspace_id = "workspace-2"
+    api_key = "posthog-project-token"
+    headers = '{"Authorization":"Bearer private"}'
+    body = {
+        "id": destination_id,
+        "workspace_id": workspace_id,
+        "type": "webhook",
+        "encrypted_api_key": _v1_envelope(
+            api_key,
+            settings,
+            workspace_id=workspace_id,
+            context=f"broadcast:{destination_id}:api_key",
+        ),
+        "encrypted_headers": _v1_envelope(
+            headers,
+            settings,
+            workspace_id=workspace_id,
+            context=f"broadcast:{destination_id}:headers",
+        ),
+    }
+    store = MemoryEntityStore({("broadcast_destination", destination_id): body})
+
+    migrated = _apply(store, settings)
+    assert migrated.envelopes_migrated == 2
+    assert migrated.rows_updated == 1
+    current = store.rows[("broadcast_destination", destination_id)]
+    assert current["encrypted_api_key"]["algorithm"] == ALGORITHM_V2
+    assert current["encrypted_headers"]["algorithm"] == ALGORITHM_V2
+    assert (
+        decrypt_control_secret(
+            EncryptedSecretEnvelope(**current["encrypted_api_key"]),
+            settings,
+            workspace_id=workspace_id,
+            purpose=f"broadcast:{destination_id}:api_key",
+        )
+        == api_key
+    )
+    assert (
+        decrypt_control_secret(
+            EncryptedSecretEnvelope(**current["encrypted_headers"]),
+            settings,
+            workspace_id=workspace_id,
+            purpose=f"broadcast:{destination_id}:headers",
+        )
+        == headers
+    )
+
+
+def test_decrypt_failure_never_writes_or_logs_secret_material() -> None:
+    settings = _settings()
+    token_value = "must-not-appear-anywhere"  # noqa: S105 - synthetic crypto fixture
+    envelope = _v1_envelope(
+        token_value,
+        settings,
+        workspace_id="workspace-3",
+        context="openai",
+    )
+    envelope["ciphertext"] = "corrupt"
+    body = {
+        "workspace_id": "workspace-3",
+        "provider": "openai",
+        "encrypted_secret": envelope,
+    }
+    store = MemoryEntityStore({("byok", "workspace-3#openai"): body})
+    logs: list[str] = []
+
+    result = _apply(store, settings, logs)
+
+    assert result.failures == 1
+    assert result.rows_updated == 0
+    assert store.rows[("byok", "workspace-3#openai")] == body
+    assert token_value not in "\n".join(logs)
+    assert envelope["ciphertext"] not in "\n".join(logs)
+
+
+def test_concurrent_rotation_wins_compare_and_swap() -> None:
+    settings = _settings()
+    body = {
+        "workspace_id": "workspace-4",
+        "provider": "anthropic",
+        "encrypted_secret": _v1_envelope(
+            "old-key",
+            settings,
+            workspace_id="workspace-4",
+            context="anthropic",
+        ),
+    }
+    store = MemoryEntityStore({("byok", "workspace-4#anthropic"): body})
+    store.force_conflict = True
+
+    result = _apply(store, settings)
+
+    assert result.conflicts == 1
+    assert result.rows_updated == 0
+    assert store.rows[("byok", "workspace-4#anthropic")]["concurrent_rotation"] is True
+    assert (
+        store.rows[("byok", "workspace-4#anthropic")]["encrypted_secret"]["algorithm"]
+        == ALGORITHM
+    )
+
+
+def test_unknown_algorithm_is_reported_and_never_rewritten() -> None:
+    body = {
+        "workspace_id": "workspace-5",
+        "provider": "anthropic",
+        "encrypted_secret": {"algorithm": "future-v99"},
+    }
+    store = MemoryEntityStore({("byok", "workspace-5#anthropic"): body})
+
+    result = BackfillRunner(store, reporter=lambda _message: None).run()
+
+    assert result.unsupported_algorithms == 1
+    assert result.rows_updated == 0
+    assert store.rows[("byok", "workspace-5#anthropic")] == body
+
+
+def test_resume_cursor_and_small_batches_do_not_repeat_rows() -> None:
+    store = MemoryEntityStore(
+        {
+            ("broadcast_destination", "a"): {"workspace_id": "w"},
+            ("byok", "a"): {"workspace_id": "w", "provider": "a"},
+            ("byok", "b"): {"workspace_id": "w", "provider": "b"},
+        }
+    )
+
+    result = BackfillRunner(store, reporter=lambda _message: None).run(
+        batch_size=1,
+        after=("broadcast_destination", "a"),
+    )
+
+    assert result.rows_scanned == 2
+    assert result.missing_envelopes == 2
+
+
+def test_kms_rate_limiter_accounts_for_multiple_operations() -> None:
+    now = [10.0]
+    sleeps: list[float] = []
+
+    def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    limiter = KmsOperationRateLimiter(
+        5.0,
+        monotonic=lambda: now[0],
+        sleep=sleep,
+    )
+    limiter.acquire(3)
+    limiter.acquire(3)
+
+    assert sleeps == [pytest.approx(0.6)]


### PR DESCRIPTION
## Summary
- add resumable AAD v1 to v2 backfill for BYOK and Broadcast envelopes
- require exact expected-v1 count before mutation
- use per-row compare-and-swap so concurrent rotations always win
- verify every v2 envelope before commit and require a zero-v1 post-audit
- support Spanner and Postgres peer-plane databases

## Production inventory
- GCP: 7 v1 BYOK envelopes, 0 Broadcast envelopes
- AWS: 0 envelopes
- Azure: 0 envelopes

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q (3627 passed, 254 skipped, 10 xfailed)
- read-only GCP audit matched 7 v1 envelopes
