### PR TITLE
Decouple BYOK backfill from web settings

### DIFF
--- a/scripts/backfill_byok_aad_v2.py
+++ b/scripts/backfill_byok_aad_v2.py
@@ -26,7 +26,7 @@ from trusted_router.byok_aad_backfill import (
     PostgresEntityStore,
     SpannerEntityStore,
 )
-from trusted_router.config import Settings
+from trusted_router.key_management import KeyWrapperConfig
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -55,6 +55,11 @@ def _parser() -> argparse.ArgumentParser:
         default=os.environ.get("TR_SPANNER_DATABASE_ID", "trusted-router"),
     )
     parser.add_argument("--postgres-dsn", default=os.environ.get("TR_POSTGRES_DSN", ""))
+    parser.add_argument(
+        "--kms-key-name",
+        default=os.environ.get("TR_BYOK_KMS_KEY_NAME", ""),
+        help="Wrapping KMS key; required with --apply",
+    )
     return parser
 
 
@@ -84,6 +89,8 @@ def main() -> int:
         raise SystemExit("--expected-v1 is required with --apply")
     if args.expected_v1 is not None and args.expected_v1 < 0:
         raise SystemExit("--expected-v1 cannot be negative")
+    if args.apply and not args.kms_key_name.strip():
+        raise SystemExit("--kms-key-name or TR_BYOK_KMS_KEY_NAME is required with --apply")
     after = None
     if args.after_kind is not None and args.after_id is not None:
         after = (args.after_kind, args.after_id)
@@ -108,7 +115,7 @@ def main() -> int:
 
     migrated = BackfillRunner(
         store,
-        settings=Settings(),
+        settings=KeyWrapperConfig(byok_kms_key_name=args.kms_key_name.strip()),
         apply=True,
         kms_operations_per_second=args.kms_operations_per_second,
     ).run(batch_size=args.batch_size, after=after)

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -26,7 +26,7 @@ from trusted_router.byok_crypto import (
     encrypt_byok_secret,
     encrypt_control_secret,
 )
-from trusted_router.config import Settings
+from trusted_router.key_management import KeyWrapperSettings
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 _MIGRATED_KINDS = ("broadcast_destination", "byok")
@@ -102,7 +102,7 @@ class BackfillRunner:
         self,
         store: EntityStore,
         *,
-        settings: Settings | None = None,
+        settings: KeyWrapperSettings | None = None,
         apply: bool = False,
         kms_operations_per_second: float = 5.0,
         reporter: Callable[[str], None] = print,

--- a/src/trusted_router/byok_crypto.py
+++ b/src/trusted_router/byok_crypto.py
@@ -8,8 +8,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
-from trusted_router.config import Settings
-from trusted_router.key_management import key_wrapper_for
+from trusted_router.key_management import KeyWrapperSettings, key_wrapper_for
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 # v1 associated data is colon-joined with no escaping or length prefix, so
@@ -51,7 +50,7 @@ _DEV_WRAPPING_KEY = _derive_dev_wrapping_key()
 
 def encrypt_byok_secret(
     raw_secret: str,
-    settings: Settings,
+    settings: KeyWrapperSettings,
     *,
     workspace_id: str,
     provider: str,
@@ -86,7 +85,7 @@ def encrypt_byok_secret(
 
 def decrypt_byok_secret(
     envelope: EncryptedSecretEnvelope,
-    settings: Settings,
+    settings: KeyWrapperSettings,
     *,
     workspace_id: str,
     provider: str,
@@ -99,7 +98,7 @@ def decrypt_byok_secret(
 
 def encrypt_control_secret(
     raw_secret: str,
-    settings: Settings,
+    settings: KeyWrapperSettings,
     *,
     workspace_id: str,
     purpose: str,
@@ -135,7 +134,7 @@ def encrypt_control_secret(
 
 def decrypt_control_secret(
     envelope: EncryptedSecretEnvelope,
-    settings: Settings,
+    settings: KeyWrapperSettings,
     *,
     workspace_id: str,
     purpose: str,
@@ -197,7 +196,7 @@ def byok_cache_key(
     return "byokcache:v1:" + digest.hexdigest()
 
 
-def _wrapping_key(settings: Settings) -> bytes:
+def _wrapping_key(settings: KeyWrapperSettings) -> bytes:
     if settings.byok_envelope_key_b64:
         key = _unb64(settings.byok_envelope_key_b64)
         if len(key) != 32:
@@ -208,14 +207,19 @@ def _wrapping_key(settings: Settings) -> bytes:
     raise ValueError("TR_BYOK_ENVELOPE_KEY_B64 is required outside local/test")
 
 
-def _wrap_dek(dek: bytes, dek_nonce: bytes, aad: bytes, settings: Settings) -> bytes:
+def _wrap_dek(
+    dek: bytes,
+    dek_nonce: bytes,
+    aad: bytes,
+    settings: KeyWrapperSettings,
+) -> bytes:
     return key_wrapper_for(settings).wrap(dek, nonce=dek_nonce, aad=aad)
 
 
 def _unwrap_dek(
     envelope: EncryptedSecretEnvelope,
     aad: bytes,
-    settings: Settings,
+    settings: KeyWrapperSettings,
 ) -> bytes:
     encrypted_dek = _unb64(envelope.encrypted_dek)
     return key_wrapper_for(settings).unwrap(
@@ -223,7 +227,7 @@ def _unwrap_dek(
     )
 
 
-def _key_ref(settings: Settings) -> str:
+def _key_ref(settings: KeyWrapperSettings) -> str:
     return key_wrapper_for(settings).key_ref
 
 

--- a/src/trusted_router/key_management.py
+++ b/src/trusted_router/key_management.py
@@ -25,11 +25,10 @@ docs/storage-portability/README.md rather than smuggled in here.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
-from trusted_router.config import Settings
 
 
 class KeyManagementError(Exception):
@@ -60,6 +59,31 @@ class KeyWrapper(Protocol):
     def wrap(self, dek: bytes, *, nonce: bytes, aad: bytes) -> bytes: ...
 
     def unwrap(self, wrapped: bytes, *, nonce: bytes, aad: bytes) -> bytes: ...
+
+
+class KeyWrapperSettings(Protocol):
+    """The small configuration surface envelope wrapping actually needs."""
+
+    environment: str
+    byok_kms_key_name: str | None
+    byok_envelope_key_b64: str | None
+    byok_envelope_key_ref: str
+
+
+@dataclass(frozen=True)
+class KeyWrapperConfig:
+    """Standalone key configuration for offline operator tools.
+
+    Operator migrations must not instantiate the full web application settings
+    object: doing so couples a KMS-only job to OAuth, email, gateway, and every
+    other production startup validator. The explicit non-local environment also
+    keeps the development wrapping-key fallback unavailable.
+    """
+
+    environment: str = "production"
+    byok_kms_key_name: str | None = None
+    byok_envelope_key_b64: str | None = None
+    byok_envelope_key_ref: str = "trustedrouter/byok-envelope-key/v1"
 
 
 class LocalAesKeyWrapper:
@@ -153,7 +177,7 @@ def _translate_kms_error(exc: Exception) -> Exception:
     return exc
 
 
-def key_wrapper_for(settings: Settings) -> KeyWrapper:
+def key_wrapper_for(settings: KeyWrapperSettings) -> KeyWrapper:
     """Select the wrapper for this deployment.
 
     Precedence matches the behaviour this replaced: an explicit local key wins

--- a/tests/test_byok_aad_backfill.py
+++ b/tests/test_byok_aad_backfill.py
@@ -22,7 +22,7 @@ from trusted_router.byok_crypto import (
     decrypt_control_secret,
 )
 from trusted_router.config import Settings
-from trusted_router.key_management import key_wrapper_for
+from trusted_router.key_management import KeyWrapperConfig, key_wrapper_for
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 
@@ -99,6 +99,14 @@ def _apply(store: MemoryEntityStore, settings: Settings, logs: list[str] | None 
         reporter=(logs.append if logs is not None else lambda _message: None),
         sleep=lambda _seconds: None,
     ).run(batch_size=1)
+
+
+def test_operator_key_config_is_kms_only_and_fails_closed() -> None:
+    key_name = "projects/example/locations/global/keyRings/ring/cryptoKeys/byok"
+
+    assert key_wrapper_for(KeyWrapperConfig(byok_kms_key_name=key_name)).key_ref == key_name
+    with pytest.raises(ValueError, match="required outside local/test"):
+        key_wrapper_for(KeyWrapperConfig())
 
 
 def test_provider_backfill_is_verified_resumable_and_idempotent() -> None:


### PR DESCRIPTION
Summary:
- give the offline BYOK AAD backfill a minimal, production-only key wrapper configuration
- require an explicit KMS key before apply mode
- preserve fail-closed behavior without loading unrelated OAuth, mail, or gateway settings

Verification:
- focused BYOK tests: 34 passed
- full ruff check passed
- full mypy passed