### PR TITLE
Record BYOK AAD v2 multi-cloud completion

### DIFF
--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -1,14 +1,28 @@
 # BYOK envelope AAD v2 — migration plan
 
-**Status:** proposed, not started
-**Owner:** unassigned
+**Status:** deployed through step 3 on GCP, AWS, and Azure; step 4 is not started
+**Owner:** TrustedRouter platform/security
 **Blocks on:** nothing. The reachable exploit path is already closed (#544).
 **Spans:** `quill-router` and `quill-cloud-proxy`. Ordering between them is the
 whole difficulty — **and it repeats per cloud deployment**, see §4.0.
 
-**Progress:** steps 1 and 2 are done **for the GCP deployment only**
-(quill-cloud-proxy#162, quill-router#560). AWS and Azure have not been
-sequenced. Steps 3 and 4 are not started anywhere.
+**Progress (2026-08-15):** the per-cloud sequence is complete through step 3.
+Step 4 remains deliberately undone, so every enclave and control plane still
+reads v1 envelopes during the retention window.
+
+| Cloud | Step 1: enclave reads v1/v2 | Step 2: control plane writes v2 | Step 3: database backfill |
+|---|---|---|---|
+| GCP | complete in every serving region | complete | 7 BYOK envelopes migrated; 7 v2, 0 v1 after an independent audit |
+| AWS | complete in Paris and Ireland | complete on both Fargate services and both App Runner services | clean audit: no BYOK or Broadcast secret rows existed |
+| Azure | complete in UAE North and Southeast Asia | complete | clean audit: no BYOK or Broadcast secret rows existed |
+
+The backfill implementation landed in quill-router#573. The standalone
+operator configuration and mandatory explicit-KMS apply gate landed in
+quill-router#576. The GCP migration temporarily granted the dedicated operator
+identity key-scoped encrypt/decrypt access, then removed it automatically; the
+post-migration IAM audit found no remaining operator binding. AWS and Azure
+were read-only audits because their independent databases contained nothing to
+rewrite.
 
 ---
 

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -27,6 +27,24 @@ cloud-local.
 An API key issued on AWS authenticates only on AWS. Credit bought on GCP is
 spendable only on GCP.
 
+### Cloud-local security migrations
+
+Schema and cryptographic-envelope migrations repeat independently in every
+cloud. A successful GCP migration says nothing about the AWS or Azure database
+or enclave. The canonical BYOK AAD v2 procedure and completion evidence live in
+[`docs/design/byok-aad-v2-migration.md`](../design/byok-aad-v2-migration.md).
+
+As of 2026-08-15, GCP, AWS, and Azure are complete through that plan's step 3:
+
+| Cloud | v1/v2 readers | v2 writers | Step 3 result |
+|---|---|---|---|
+| GCP | deployed | deployed | 7 BYOK envelopes migrated; 0 v1 remain |
+| AWS | deployed | deployed | 0 eligible rows; no write required |
+| Azure | deployed | deployed | 0 eligible rows; no write required |
+
+Step 4 is not complete. V1 read support remains in every cloud until the
+retention-window condition in the migration plan is satisfied.
+
 ---
 
 ## 2. Why identity federates and money does not


### PR DESCRIPTION
Records the verified per-cloud rollout and backfill state:
- GCP: 7 BYOK envelopes migrated, 7 v2 and 0 v1
- AWS: clean database audit, no eligible rows
- Azure: clean database audit, no eligible rows
- Step 4 remains explicitly unstarted

Also records the temporary key-scoped operator access and successful cleanup.