### PR TITLE
Keep public snapshot worker imports lightweight

### DIFF
--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from trusted_router.config import Settings
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
+
+if TYPE_CHECKING:
+    from trusted_router.config import Settings
 
 # Target name of the billing/settlement and provider-fallback probes. Unlike
 # the gateway targets these do not come from the region topology — every

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 
 from clickhouse.build_public_snapshots import _clickhouse_string_array, build_snapshots
 from trusted_router.config import Settings
@@ -11,6 +16,38 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     SyntheticRollup,
 )
+
+
+def test_snapshot_worker_imports_without_control_plane_dependencies() -> None:
+    root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join((str(root), str(root / "src")))
+    code = textwrap.dedent(
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def import_without_pydantic(name, *args, **kwargs):
+            if name == "pydantic" or name.startswith("pydantic."):
+                raise ModuleNotFoundError("pydantic is intentionally absent")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = import_without_pydantic
+        import clickhouse.build_public_snapshots
+        """
+    )
+
+    result = subprocess.run(  # noqa: S603 - interpreter and test program are fixed
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_current_public_analytics_snapshot_accepts_fresh_utc_payload() -> None:


### PR DESCRIPTION
## Summary
- keep the lightweight ClickHouse snapshot worker from importing the control-plane configuration stack at runtime
- add a subprocess regression test that imports the deployed worker with Pydantic intentionally unavailable

## Root cause
The snapshot worker imported `Settings` only for annotations, but the runtime import pulled in Pydantic. The ClickHouse snapshot venv intentionally does not carry control-plane dependencies, so the deployment service failed and rolled back.

## Verification
- regression test fails on previous code with `ModuleNotFoundError: pydantic`
- `uv run pytest -q tests/test_public_analytics_snapshots.py tests/test_status_component_scope.py`
- `uv run ruff check src/trusted_router/synthetic/components.py tests/test_public_analytics_snapshots.py`
- `uv run mypy`