### PR TITLE
Unblock catalog refresh throughput validation

### DIFF
--- a/src/trusted_router/synthetic/throughput.py
+++ b/src/trusted_router/synthetic/throughput.py
@@ -15,6 +15,15 @@ from trusted_router.synthetic.probes import rotation_candidates
 _RECENT_MODEL_COUNT = 24
 _RECENT_MODEL_BONUS = 5_000
 _RECENT_MODEL_STEP = 50
+# Keep a small cross-family baseline in the sustained benchmark while each
+# model is callable. Catalog growth must not silently crowd these comparison
+# anchors out, and a real retirement must not freeze the whole refresh.
+THROUGHPUT_ANCHOR_MODELS = (
+    "anthropic/claude-opus-5",
+    "moonshotai/kimi-k3",
+    "z-ai/glm-5.2",
+    "google/gemini-3.6-flash",
+)
 THROUGHPUT_INTERVAL_SECONDS = 60
 
 
@@ -59,6 +68,16 @@ def throughput_candidates(*, limit: int = 200) -> list[tuple[str, str]]:
         provider_routes = [(provider, model) for model in pool[provider]]
         if provider_routes:
             selected.append(min(provider_routes, key=route_key))
+
+    # Preserve one route for each reviewed comparison anchor. Use the same
+    # deterministic scoring as the main selection so provider choice remains
+    # stable, and skip anchors that no longer have a callable Credits route.
+    for model in THROUGHPUT_ANCHOR_MODELS:
+        model_routes = [route for route in routes if route[1] == model]
+        if model_routes:
+            anchor = min(model_routes, key=route_key)
+            if anchor not in selected:
+                selected.append(anchor)
 
     for route in sorted(routes, key=route_key):
         if route not in selected:

--- a/tests/test_synthetic_throughput.py
+++ b/tests/test_synthetic_throughput.py
@@ -17,6 +17,7 @@ from trusted_router.synthetic.probes import (
     rotation_candidates,
 )
 from trusted_router.synthetic.throughput import (
+    THROUGHPUT_ANCHOR_MODELS,
     THROUGHPUT_INTERVAL_SECONDS,
     choose_throughput_target,
     projected_monthly_cost_microdollars,
@@ -42,10 +43,10 @@ def test_top_200_throughput_routes_are_deterministic_and_provider_complete() -> 
     assert len(first) == min(200, sum(len(models) for models in pool.values()))
     assert len(first) == len(set(first))
     assert {provider for provider, _ in first} == set(pool)
-    assert ("anthropic", "anthropic/claude-opus-5") in first
-    assert any(model == "moonshotai/kimi-k3" for _, model in first)
-    assert any(model == "z-ai/glm-5.2" for _, model in first)
-    assert any(model == "google/gemini-3.6-flash" for _, model in first)
+    available_models = {model for models in pool.values() for model in models}
+    for anchor in THROUGHPUT_ANCHOR_MODELS:
+        if anchor in available_models:
+            assert any(model == anchor for _, model in first)
     assert all(model in pool[provider] for provider, model in first)
 
 


### PR DESCRIPTION
## Summary
- preserve one deterministic callable route for each reviewed throughput benchmark anchor
- skip anchors after a legitimate retirement instead of freezing the catalog refresh
- keep provider breadth and the 200-route budget unchanged

## Verification
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q tests/test_synthetic_throughput.py`
- full suite: 3650 passed, 254 skipped, 10 xfailed

Follow-up to the live refresh failure in https://github.com/Lore-Hex/quill-router/actions/runs/31896685614.