### PR TITLE
Fix synthetic heartbeat parity

### DIFF
--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -78,7 +78,7 @@ def build_raw_rollups(
     periods: set[str],
 ) -> list[SyntheticRollup]:
     rollups: dict[str, SyntheticRollup] = {}
-    for sample in samples:
+    for sample in _deduplicate_samples(samples):
         for period, component in sample_rollup_ids(sample):
             if period not in periods:
                 continue
@@ -93,6 +93,28 @@ def build_raw_rollups(
             else:
                 apply_sample_to_rollup(existing, sample)
     return list(rollups.values())
+
+
+def _deduplicate_samples(
+    samples: list[SyntheticProbeSample],
+) -> list[SyntheticProbeSample]:
+    """Keep one latest version for each logical synthetic sample.
+
+    Regional workers and at-least-once outbox delivery may emit the same sample
+    ID more than once. Bigtable rollup markers already treat the ID as the
+    identity, so ClickHouse rebuilds must do the same.
+    """
+    latest: dict[str, SyntheticProbeSample] = {}
+    for sample in samples:
+        existing = latest.get(sample.id)
+        if existing is None or _sample_created_at(sample) >= _sample_created_at(existing):
+            latest[sample.id] = sample
+    return list(latest.values())
+
+
+def _sample_created_at(sample: SyntheticProbeSample) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(sample.created_at.replace("Z", "+00:00"))
+    return _utc(parsed)
 
 
 def complete_window_rollups(

--- a/src/trusted_router/synthetic/fleet.py
+++ b/src/trusted_router/synthetic/fleet.py
@@ -34,6 +34,7 @@ scheduler is alive" from sample age alone.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import logging
 import time
 import uuid
@@ -214,6 +215,14 @@ def record_heartbeat(name: str, *, settings: Settings) -> None:
             return
         from trusted_router.storage import STORE
 
+        bucket_start = (
+            dt.datetime.fromtimestamp(
+                bucket * HEARTBEAT_BUCKET_SECONDS,
+                tz=dt.UTC,
+            )
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
         STORE.record_synthetic_probe_sample(
             SyntheticProbeSample(
                 id=f"syn_hb_{name.replace(':', '_')}_{bucket}",
@@ -222,6 +231,7 @@ def record_heartbeat(name: str, *, settings: Settings) -> None:
                 target_url="",
                 monitor_region=settings.synthetic_monitor_region or settings.primary_region,
                 status="up",
+                created_at=bucket_start,
             )
         )
         _HEARTBEAT_MARKS[name] = bucket

--- a/tests/test_clickhouse_operational_parity.py
+++ b/tests/test_clickhouse_operational_parity.py
@@ -142,6 +142,16 @@ def test_rollup_parity_rebuilds_from_bounded_raw_bigtable_samples() -> None:
         value=json.dumps(dataclasses.asdict(sample)).encode("utf-8")
     )
     row = SimpleNamespace(cells={"synthetic": {b"body": [cell]}})
+    duplicate = dataclasses.replace(
+        sample,
+        created_at=(created_at + dt.timedelta(minutes=2)).isoformat().replace(
+            "+00:00", "Z"
+        ),
+    )
+    duplicate_cell = SimpleNamespace(
+        value=json.dumps(dataclasses.asdict(duplicate)).encode("utf-8")
+    )
+    duplicate_row = SimpleNamespace(cells={"synthetic": {b"body": [duplicate_cell]}})
 
     class Table:
         start_key: bytes = b""
@@ -150,7 +160,7 @@ def test_rollup_parity_rebuilds_from_bounded_raw_bigtable_samples() -> None:
         def read_rows(self, *, start_key: bytes, end_key: bytes, filter_: object) -> list[object]:
             self.start_key = start_key
             self.end_key = end_key
-            return [row]
+            return [row, duplicate_row]
 
     table = Table()
     rollups = _source_rollups_from_raw(table, limit=10, grace_seconds=600)

--- a/tests/test_fleet_command_center.py
+++ b/tests/test_fleet_command_center.py
@@ -143,6 +143,18 @@ def test_run_synthetic_once_gates_peer_probes_off_in_test_env(
 def test_record_heartbeat_and_liveness_rows() -> None:
     settings = _settings()
     record_heartbeat("scheduler:test-loop", settings=settings)
+    stored = STORE.synthetic_probe_samples(
+        target="scheduler:test-loop",
+        probe_type="heartbeat",
+        limit=1,
+    )[0]
+    bucket = int(stored.id.rsplit("_", 1)[1])
+    created_at = dt.datetime.fromisoformat(stored.created_at.replace("Z", "+00:00"))
+    assert created_at == dt.datetime.fromtimestamp(
+        bucket * fleet.HEARTBEAT_BUCKET_SECONDS,
+        tz=dt.UTC,
+    )
+
     snapshot = asyncio.run(fleet_snapshot(settings))
     beats = {row["name"]: row for row in snapshot["heartbeats"]}
     assert "scheduler:test-loop" in beats

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -553,6 +553,33 @@ def test_synthetic_rollups_preserve_exact_counts_histograms_and_costs() -> None:
         assert rollup.cost_microdollars == 4
 
 
+def test_synthetic_rollups_count_repeated_sample_id_once() -> None:
+    first = _synthetic_sample(
+        "shared-heartbeat",
+        status="down",
+        created_at="2026-07-31T12:01:00Z",
+        latency=30,
+        error_type="timeout",
+    )
+    latest = _synthetic_sample(
+        "shared-heartbeat",
+        status="up",
+        created_at="2026-07-31T12:04:00Z",
+        latency=10,
+    )
+
+    rollups = build_raw_rollups([first, latest], periods={"hour", "day"})
+
+    assert rollups
+    for rollup in rollups:
+        assert rollup.sample_count == 1
+        assert rollup.up_count == 1
+        assert rollup.down_count == 0
+        assert rollup.latency_histogram == {"10": 1}
+        assert rollup.error_counts == {}
+        assert rollup.cost_microdollars == 2
+
+
 def test_synthetic_monthly_rollups_merge_daily_without_losing_dimensions() -> None:
     day_one = build_raw_rollups(
         [


### PR DESCRIPTION
## Summary
- anchor regional scheduler heartbeats to their deterministic five-minute bucket
- deduplicate repeated logical synthetic sample IDs while rebuilding ClickHouse rollups
- cover regional duplicate writes in fleet, rollup, and parity regression tests

## Verification
- 41 focused tests passed
- 3,630 broad-suite tests passed, 254 skipped, 10 expected failures
- 104 socket-dependent tests passed outside the restricted sandbox
- ruff and mypy passed